### PR TITLE
Make existing es migrations more tolerant to errors

### DIFF
--- a/corehq/apps/es/migration_operations.py
+++ b/corehq/apps/es/migration_operations.py
@@ -393,7 +393,7 @@ class DeleteOnlyIfIndexExists(DeleteIndex):
         from corehq.apps.es.client import manager
         if manager.index_exists(self.name):
             return super().run(*args, **kwargs)
-        log.info(f"ElasticSearch index {self.name} does not exists. Skipping delete index operation.")
+        log.info(f"ElasticSearch index {self.name} does not exist. Skipping delete index operation.")
 
     def reverse_run(self, *args, **kw):
         return None

--- a/corehq/apps/es/migration_operations.py
+++ b/corehq/apps/es/migration_operations.py
@@ -372,5 +372,32 @@ class CreateIndexIfNotExists(CreateIndex):
         return None
 
 
+class DeleteOnlyIfIndexExists(DeleteIndex):
+    """
+    The class will not error out if trying to delete the indices that don't exist.
+    The utility of this class would generally be in case of exceptions where a migration
+    has be rolled back which were already applied on some of the environments.
+
+    Because of the nature of the operation, this class is not integrated into `make_elastic_migration` command.
+
+    """
+    def __init__(self, name, es_versions=[]):
+        # To satisfy parent class signature adding dummy reverse params
+        # Reverse for this class would be no-op
+        dummy_reverse_params = ('type', {}, {}, 'setting_key')
+        super().__init__(name, dummy_reverse_params, es_versions)
+
+    def run(self, *args, **kwargs):
+        if self.es_versions and self._should_skip_operation(self.es_versions):
+            return
+        from corehq.apps.es.client import manager
+        if manager.index_exists(self.name):
+            return super().run(*args, **kwargs)
+        log.info(f"ElasticSearch index {self.name} does not exists. Skipping delete index operation.")
+
+    def reverse_run(self, *args, **kw):
+        return None
+
+
 class MappingUpdateFailed(Exception):
     """The mapping update operation failed."""

--- a/corehq/apps/es/migration_operations.py
+++ b/corehq/apps/es/migration_operations.py
@@ -376,7 +376,7 @@ class DeleteOnlyIfIndexExists(DeleteIndex):
     """
     The class will not error out if trying to delete the indices that don't exist.
     The utility of this class would generally be in case of exceptions where a migration
-    has be rolled back which were already applied on some of the environments.
+    has to be rolled back which were already applied on some of the environments.
 
     Because of the nature of the operation, this class is not integrated into `make_elastic_migration` command.
 

--- a/corehq/apps/es/migrations/0009_add_indices_for_reindex_in_es5.py
+++ b/corehq/apps/es/migrations/0009_add_indices_for_reindex_in_es5.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        corehq.apps.es.migration_operations.CreateIndex(
+        corehq.apps.es.migration_operations.CreateIndexIfNotExists(
             name=index_runtime_name('apps-2024-03-09'),
             type_='app',
             mapping={
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
             settings_key='hqapps',
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.CreateIndex(
+        corehq.apps.es.migration_operations.CreateIndexIfNotExists(
             name=index_runtime_name('case-search-2024-03-09'),
             type_='case',
             mapping={
@@ -49,7 +49,7 @@ class Migration(migrations.Migration):
             settings_key='case_search',
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.CreateIndex(
+        corehq.apps.es.migration_operations.CreateIndexIfNotExists(
             name=index_runtime_name('cases-2024-03-09'),
             type_='case',
             mapping={
@@ -64,7 +64,7 @@ class Migration(migrations.Migration):
             settings_key='hqcases',
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.CreateIndex(
+        corehq.apps.es.migration_operations.CreateIndexIfNotExists(
             name=index_runtime_name('domains-2024-03-09'),
             type_='hqdomain',
             mapping={
@@ -80,7 +80,7 @@ class Migration(migrations.Migration):
             settings_key='hqdomains',
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.CreateIndex(
+        corehq.apps.es.migration_operations.CreateIndexIfNotExists(
             name=index_runtime_name('forms-2024-03-09'),
             type_='xform',
             mapping={
@@ -95,7 +95,7 @@ class Migration(migrations.Migration):
             settings_key='xforms',
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.CreateIndex(
+        corehq.apps.es.migration_operations.CreateIndexIfNotExists(
             name=index_runtime_name('groups-2024-03-09'),
             type_='group',
             mapping={
@@ -110,7 +110,7 @@ class Migration(migrations.Migration):
             settings_key='hqgroups',
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.CreateIndex(
+        corehq.apps.es.migration_operations.CreateIndexIfNotExists(
             name=index_runtime_name('sms-2024-03-09'),
             type_='sms',
             mapping={
@@ -126,7 +126,7 @@ class Migration(migrations.Migration):
             settings_key='smslogs',
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.CreateIndex(
+        corehq.apps.es.migration_operations.CreateIndexIfNotExists(
             name=index_runtime_name('users-2024-03-09'),
             type_='user',
             mapping={

--- a/corehq/apps/es/migrations/0010_delete_reverted_indices.py
+++ b/corehq/apps/es/migrations/0010_delete_reverted_indices.py
@@ -13,35 +13,35 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        corehq.apps.es.migration_operations.DeleteIndex(
+        corehq.apps.es.migration_operations.DeleteOnlyIfIndexExists(
             name=index_runtime_name("apps-2024-03-09"),
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.DeleteIndex(
+        corehq.apps.es.migration_operations.DeleteOnlyIfIndexExists(
             name=index_runtime_name("case-search-2024-03-09"),
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.DeleteIndex(
+        corehq.apps.es.migration_operations.DeleteOnlyIfIndexExists(
             name=index_runtime_name("cases-2024-03-09"),
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.DeleteIndex(
+        corehq.apps.es.migration_operations.DeleteOnlyIfIndexExists(
             name=index_runtime_name("domains-2024-03-09"),
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.DeleteIndex(
+        corehq.apps.es.migration_operations.DeleteOnlyIfIndexExists(
             name=index_runtime_name("forms-2024-03-09"),
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.DeleteIndex(
+        corehq.apps.es.migration_operations.DeleteOnlyIfIndexExists(
             name=index_runtime_name("groups-2024-03-09"),
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.DeleteIndex(
+        corehq.apps.es.migration_operations.DeleteOnlyIfIndexExists(
             name=index_runtime_name("sms-2024-03-09"),
             es_versions=[5],
         ),
-        corehq.apps.es.migration_operations.DeleteIndex(
+        corehq.apps.es.migration_operations.DeleteOnlyIfIndexExists(
             name=index_runtime_name("users-2024-03-09"),
             es_versions=[5],
         ),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
After reverting the migrations we did not consider that how it would affect third party hosters and we have gotten two instances where third party hosters (https://forum.dimagi.com/t/unable-to-deploy-prod-stable-b23df94-25-apr-2024/10754/13?u=aphulera, https://forum.dimagi.com/t/unable-to-deploy-index-not-found/10820) had issues with the es migrations. 
So this PR should fix their issues. I have tested the migrations on local by reverting and then applying again and it worked perfectly fine.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Tested locally and added tests.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Should be safe and should not affect Dimagi envs, just for the third party hosters who are having issues with deploy.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
