### PR TITLE
Add user groups-locations fixtures to restore file for web users

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1161,6 +1161,18 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         })
         return session_data
 
+    def get_owner_ids(self, domain):
+        owner_ids = [self.user_id]
+        owner_ids.extend(g._id for g in self.get_case_sharing_groups(domain=domain))
+        return owner_ids
+
+    def _get_case_sharing_groups_for_locations(self, domain):
+        # get faked location group objects
+        return [
+            location.case_sharing_group_object(self._id)
+            for location in self._get_case_owning_locations(domain)
+        ]
+
     def _get_case_owning_locations(self, domain):
         """
         :return: queryset of case-owning locations either directly assigned to the
@@ -1865,11 +1877,6 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
     def _get_deleted_case_ids(self):
         return CommCareCase.objects.get_deleted_case_ids_by_owner(self.domain, self.user_id)
 
-    def get_owner_ids(self, domain):
-        owner_ids = [self.user_id]
-        owner_ids.extend(g._id for g in self.get_case_sharing_groups())
-        return owner_ids
-
     def unretire(self, unretired_by_domain, unretired_by, unretired_via=None):
         """
         This un-deletes a user, but does not fully restore the state to
@@ -1968,17 +1975,13 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         self.set_password(password)
         self.save()
 
-    def get_case_sharing_groups(self):
+    def get_case_sharing_groups(self, domain=None):
         from corehq.apps.groups.models import Group
         from corehq.apps.events.models import (
             get_user_case_sharing_groups_for_events,
         )
 
-        # get faked location group objects
-        groups = [
-            location.case_sharing_group_object(self._id)
-            for location in self._get_case_owning_locations(self.domain)
-        ]
+        groups = self._get_case_sharing_groups_for_locations(self.domain)
         groups += [group for group in Group.by_user_id(self._id) if group.case_sharing]
 
         has_at_privilege = domain_has_privilege(self.domain, privileges.ATTENDANCE_TRACKING)
@@ -2473,10 +2476,9 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
             request_user=request_user
         )
 
-    def get_owner_ids(self, domain):
-        owner_ids = [self.user_id]
-        owner_ids.extend(loc.location_id for loc in self._get_case_owning_locations(domain))
-        return owner_ids
+    def get_case_sharing_groups(self, domain=None):
+        assert domain  # fail loudly
+        return self._get_case_sharing_groups_for_locations(domain)
 
     @quickcache(['self._id', 'domain'], lambda _: settings.UNIT_TESTING)
     def get_usercase_id(self, domain):

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -143,7 +143,7 @@ class OTARestoreUser(object):
         raise NotImplementedError()
 
     def get_case_sharing_groups(self):
-        raise NotImplementedError()
+        return self._couch_user.get_case_sharing_groups(domain=self.domain)
 
     def get_fixture_last_modified(self):
         raise NotImplementedError()
@@ -177,9 +177,6 @@ class OTARestoreWebUser(OTARestoreUser):
 
     def get_call_center_indicators(self, config):
         return None
-
-    def get_case_sharing_groups(self):
-        return []
 
     def get_fixture_last_modified(self):
         from corehq.apps.fixtures.models import UserLookupTableStatus
@@ -222,9 +219,6 @@ class OTARestoreCommCareUser(OTARestoreUser):
             self._couch_user,
             indicator_config=config
         )
-
-    def get_case_sharing_groups(self):
-        return self._couch_user.get_case_sharing_groups()
 
     def get_fixture_last_modified(self):
         from corehq.apps.fixtures.models import UserLookupTableType


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Fixes P2, see [USH-4556](https://dimagi.atlassian.net/browse/USH-4556?atlOrigin=eyJpIjoiMWI1N2Y0NDQ0NzlhNGIxOGE4ZDhjNDlhNDE4ZTJjNjIiLCJwIjoiaiJ9).

Cases owned by a web user's locations were not showing up in a user's case DB, even though they were in the restore file. This fixes that.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

In #34330 we added location IDs as owner IDs for creating a web user's restore, causing the cases owned by a web user's locations to show in the restore. However, we did not add a user group fixture to the restore for each location like we do for mobile users. Formplayer [purges cases that do not have a user or user group owner](https://github.com/dimagi/commcare-core/blob/eca503b2fc1f70dc0c175959b01efd05908e6434/src/main/java/org/commcare/core/sandbox/SandboxUtils.java#L128), and so the cases didn't show in the case DB.

This PR adds a user group fixture for each location to a web user's restore as well.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Testing on staging. Hope to run a quick regression test before deploy.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Testing for regression should be pretty good. I added a test to make sure user groups are added for each location.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Hoping to do a quick regression test.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Rollback will cause location-owned cases to disappear from a web user's case DB again.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4556]: https://dimagi.atlassian.net/browse/USH-4556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ