### PR TITLE
Fix for Error When Checking Deprecated Case Properties in Advanced Modules

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
@@ -3,7 +3,8 @@ hqDefine('app_manager/js/forms/advanced/actions', function () {
     var caseConfigUtils = hqImport('app_manager/js/case_config_utils'),
         caseProperty = hqImport('app_manager/js/forms/advanced/case_properties').caseProperty,
         casePreloadProperty = hqImport('app_manager/js/forms/advanced/case_properties').casePreloadProperty,
-        toggles = hqImport("hqwebapp/js/toggles");
+        toggles = hqImport("hqwebapp/js/toggles"),
+        privileges = hqImport('hqwebapp/js/privileges');
 
     var caseIndex = {
         mapping: {
@@ -447,6 +448,17 @@ hqDefine('app_manager/js/forms/advanced/actions', function () {
                 return self.case_properties();
             });
             self.saveOnlyEditedFormFieldsEnabled = toggles.toggleEnabled("SAVE_ONLY_EDITED_FORM_FIELDS");
+
+            self.hasDeprecatedProperties = ko.computed(function () {
+                if (privileges.hasPrivilege('data_dictionary')) {
+                    for (const p of self.case_properties()) {
+                        if (p.isDeprecated()) {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            });
 
             return self;
         },

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
@@ -47,6 +47,7 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
             self.setPropertiesMap(params.propertiesMap);
 
             self.descriptionDict = params.propertyDescriptions;
+            self.deprecatedPropertiesDict = params.deprecatedProperties;
 
             self.saveButton = hqImport("hqwebapp/js/bootstrap3/main").initSaveButton({
                 unsavedMessage: "You have unchanged case settings",

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
@@ -31,6 +31,14 @@ hqDefine('app_manager/js/forms/advanced/case_properties', function () {
                     self.updatedDescription(value);
                 },
             });
+            self.isDeprecated = ko.computed(function () {
+                const config = self.action.caseConfig;
+                const depProps = config.deprecatedPropertiesDict[self.caseType()];
+                if (depProps && self.key() !== 'name') {
+                    return depProps.includes(self.key());
+                }
+                return false;
+            });
             return self;
         },
     };


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Advanced modules should function the same as normal modules where a deprecated warning will be given if there are form questions being saved to one or more deprecated case properties.
![Screenshot from 2024-05-20 13-18-52](https://github.com/dimagi/commcare-hq/assets/122617251/9b9ee651-5133-48ee-b6e5-3cd8a3a70bdb)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to support ticket [here](https://dimagi.atlassian.net/browse/SUPPORT-19653).

This PR addresses a bug that was introduced as part of [this](https://github.com/dimagi/commcare-hq/pull/34425) PR where a deprecated warning is shown when trying to save form questions to deprecated case properties. The HTML for saving to case properties is shared between both normal and advanced modules, however there isn't a `hasDeprecatedProperties()` KO function for advanced modules, hence causing a JS exception.

A possible future TODO would be to incorporate the same deprecate warning functionality when loading deprecated case properties into form questions.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing of advanced modules.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA was involved in original PR.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
