### PR TITLE
Added createTimePicker

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -424,7 +424,7 @@ hqDefine('cloudcare/js/utils', [
 
         $el.on("focusout", $el.data("DateTimePicker").hide);
         $el.attr("placeholder", dateFormat);
-        $el.attr("pattern", "[0-9\-/]+");
+        $el.attr("pattern", "[0-9\-/]+");   // eslint-disable-line no-useless-escape
     };
 
     var initTimePicker = function ($el, selectedTime, timeFormat) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -424,7 +424,7 @@ hqDefine('cloudcare/js/utils', [
 
         $el.on("focusout", $el.data("DateTimePicker").hide);
         $el.attr("placeholder", dateFormat);
-        $el.attr("pattern", "[0-9-/]+");
+        $el.attr("pattern", "[0-9\-/]+");
     };
 
     var initTimePicker = function ($el, selectedTime, timeFormat) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
@@ -27,9 +27,9 @@ hqDefine("hqwebapp/js/tempus_dominus", [
                     clock: false,
                 },
             },
-            localization: {
+            localization: _.extend(defaultTranslations, {
                 format: 'yyyy-MM-dd',
-            },
+            }),
         }, extraOptions || {}));
     };
 
@@ -78,9 +78,9 @@ hqDefine("hqwebapp/js/tempus_dominus", [
                     calendar: false,
                 },
             },
-            localization: {
+            localization: _.extend(defaultTranslations, {
                 format: 'yyyy-MM-dd',
-            },
+            }),
         }, extraOptions || {}));
     };
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
@@ -30,7 +30,7 @@ hqDefine("hqwebapp/js/tempus_dominus", [
             localization: {
                 format: 'yyyy-MM-dd',
             },
-        }, extraOptions));
+        }, extraOptions || {}));
     };
 
     // This replaces createBootstrap3DefaultDateRangePicker in hqwebapp/js/daterangepicker.config
@@ -68,6 +68,20 @@ hqDefine("hqwebapp/js/tempus_dominus", [
                 picker.dates.setValue(picker.dates.picked[0], 1);
             }
         });
+    };
+
+    let createTimePicker = function (el, extraOptions) {
+        return new tempusDominus.TempusDominus(el, _.extend({
+            display: {
+                theme: 'light',
+                components: {
+                    calendar: false,
+                },
+            },
+            localization: {
+                format: 'yyyy-MM-dd',
+            },
+        }, extraOptions || {}));
     };
 
     let getDateRangeSeparator = function () {
@@ -108,6 +122,7 @@ hqDefine("hqwebapp/js/tempus_dominus", [
         createDatePicker: createDatePicker,
         createDateRangePicker: createDateRangePicker,
         createDefaultDateRangePicker: createDefaultDateRangePicker,
+        createTimePicker: createDatePicker,
         getDateRangeSeparator: getDateRangeSeparator,
     };
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
@@ -122,7 +122,7 @@ hqDefine("hqwebapp/js/tempus_dominus", [
         createDatePicker: createDatePicker,
         createDateRangePicker: createDateRangePicker,
         createDefaultDateRangePicker: createDefaultDateRangePicker,
-        createTimePicker: createDatePicker,
+        createTimePicker: createTimePicker,
         getDateRangeSeparator: getDateRangeSeparator,
     };
 });


### PR DESCRIPTION
## Technical Summary
Cherry pick from the web apps B5 migration.

Maybe useful for other migrations, though I don't know offhand of anywhere else in HQ where a user inputs a time.

## Safety Assurance

### Safety story
Quite safe. Adds a function that isn't yet called. Makes a trivial change to `createDatePicker`.

### Automated test coverage

no

### QA Plan

This will be QAed as part of the web apps migration.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
