### PR TITLE
Add a few tools to the support flag

### DIFF
--- a/corehq/apps/reports/view_helpers.py
+++ b/corehq/apps/reports/view_helpers.py
@@ -84,7 +84,7 @@ def _index_to_context(index, is_ancestor):
 
 def normalize_date(val):
     # Can't use isinstance since datetime is a subclass of date.
-    if type(val) == datetime.date:
+    if type(val) is datetime.date:
         return datetime.datetime.combine(val, datetime.time.min)
 
     return val

--- a/corehq/apps/reports/view_helpers.py
+++ b/corehq/apps/reports/view_helpers.py
@@ -20,7 +20,7 @@ def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=
     columns = wrapped_case.related_cases_columns
     type_info = wrapped_case.related_type_info
 
-    descendent_case_list = get_flat_descendant_case_list(
+    descendant_case_list = get_flat_descendant_case_list(
         case, get_case_url, type_info=type_info
     )
 
@@ -43,11 +43,11 @@ def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=
             else:
                 last_parent_id = None
 
-        for c in descendent_case_list:
+        for c in descendant_case_list:
             if not getattr(c, 'treetable_parent_node_id', None) and last_parent_id:
                 c.treetable_parent_node_id = last_parent_id
 
-    case_list = parent_cases + descendent_case_list
+    case_list = parent_cases + descendant_case_list
 
     for c in case_list:
         if not c:

--- a/corehq/apps/reports/view_helpers.py
+++ b/corehq/apps/reports/view_helpers.py
@@ -31,7 +31,9 @@ def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=
         # relationships)
         for idx in case.live_indices:
             try:
-                parent_cases.append(idx.referenced_case)
+                parent_case = idx.referenced_case
+                parent_case.index_info = _index_to_context(idx, is_ancestor=True)
+                parent_cases.append(parent_case)
             except ResourceNotFound:
                 parent_cases.append(None)
         for parent_case in parent_cases:
@@ -46,6 +48,11 @@ def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=
         for c in descendant_case_list:
             if not getattr(c, 'treetable_parent_node_id', None) and last_parent_id:
                 c.treetable_parent_node_id = last_parent_id
+
+    reverse_indices = {index.case_id: index for index in case.reverse_indices}
+    for descendant in descendant_case_list:
+        if idx := reverse_indices.get(descendant.case_id):
+            descendant.index_info = _index_to_context(idx, is_ancestor=False)
 
     case_list = parent_cases + descendant_case_list
 
@@ -63,8 +70,15 @@ def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=
         'domain': case.domain,
         'case_list': case_list,
         'columns': columns,
-        'num_columns': len(columns) + 1,
         'show_view_buttons': show_view_buttons,
+    }
+
+
+def _index_to_context(index, is_ancestor):
+    return {
+        'identifier': index.identifier,
+        'relationship': index.relationship,
+        'is_ancestor': is_ancestor,
     }
 
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1010,22 +1010,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         pass
 
     def __repr__(self):
-        # copied from jsonobject/base.py
-        name = self.__class__.__name__
-        predefined_properties = set(self._properties_by_attr)
-        predefined_property_keys = set(self._properties_by_attr[p].name
-                                       for p in predefined_properties)
-        dynamic_properties = set(self._wrapped) - predefined_property_keys
-
-        # redact hashed password
-        properties = sorted(predefined_properties - {'password'}) + sorted(dynamic_properties - {'password'})
-
-        return '{name}({keyword_args})'.format(
-            name=name,
-            keyword_args=', '.join('{key}={value!r}'.format(
-                key=key,
-                value=getattr(self, key)
-            ) for key in properties),
+        return "{class_name}(username={self.username})".format(
+            class_name=self.__class__.__name__,
+            self=self,
         )
 
     @property
@@ -2315,12 +2302,6 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             user_fixture_sync.save()
         get_fixture_statuses.clear(self._id)
 
-    def __repr__(self):
-        return ("{class_name}(username={self.username!r})".format(
-            class_name=self.__class__.__name__,
-            self=self
-        ))
-
     @property
     @memoized
     def memoized_usercase(self):
@@ -2431,6 +2412,12 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     # such as those going through the recruiting pipeline
     # to better mark them in our analytics
     atypical_user = BooleanProperty(default=False)
+
+    def __repr__(self):
+        return "{class_name}(username={self.username}, domains={self.domains})".format(
+            class_name=self.__class__.__name__,
+            self=self,
+        )
 
     def is_global_admin(self):
         # override this function to pass global admin rights off to django

--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -68,6 +68,16 @@
             </a>
           {% endif %}
           {% include "users/partials/edit_commtrack_user_settings.html" %}
+          {% if support_info.locations %}
+            <h4>[Support only] Assigned Locations</h4>
+            <div class="list-group">
+              {% for location in support_info.locations %}
+                <a href="{% url "edit_location" domain location.location_id %}" class="list-group-item">
+                  {{ location.get_path_display }} <span class="badge">{{ location.location_type.name }}</span>
+                </a>
+              {% endfor %}
+            </div>
+          {% endif %}
         </div>
       </div>
     {% endif %}

--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -43,6 +43,9 @@
     {% if not is_currently_logged_in_user and not request.is_view_only %}
       <li><a href="#user-permanent" data-toggle="tab">{% trans "Actions" %}</a></li>
     {% endif %}
+    {% if request|toggle_enabled:"SUPPORT" %}
+      <li><a href="#user-support" data-toggle="tab">{% trans "Support" %}</a></li>
+    {% endif %}
   </ul>
   <div class="tab-content" id="settings">
     <div class="tab-pane" id="basic-info">
@@ -173,6 +176,46 @@
             </div>
           {% endif %}
           {% endif %}
+        </div>
+      </div>
+    {% endif %}
+    {% if request|toggle_enabled:"SUPPORT" %}
+      <div class="tab-pane" id="user-support">
+        <div class="panel-body">
+          <table class="table table-striped table-hover">
+            <tbody>
+              <tr>
+                <td>Created On</td>
+                <td>{{ couch_user.created_on }}</td>
+              </tr>
+              <tr>
+                <td>Last Modified</td>
+                <td>{{ couch_user.last_modified }}</td>
+              </tr>
+              <tr>
+                <td>Last Login</td>
+                <td>{{ couch_user.last_login }}</td>
+              </tr>
+              <tr>
+                <td>Devices</td>
+                <td>
+                  <ul class="list-unstyled">
+                    {% for device in couch_user.devices %}
+                      <li>{{ device.last_used }} - {{ device.device_id }}</li>
+                    {% endfor %}
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <td>Last Sync</td>
+                <td>{{ couch_user.reporting_metadata.last_sync_for_user.sync_date }}</td>
+              </tr>
+              <tr>
+                <td>Last Form Submission</td>
+                <td>{{ couch_user.reporting_metadata.last_submission_for_user.submission_date }}</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     {% endif %}

--- a/corehq/apps/users/templates/users/edit_web_user.html
+++ b/corehq/apps/users/templates/users/edit_web_user.html
@@ -100,6 +100,17 @@
         </div>
       {% endif %}
     </form>
+
+    {% if support_info.locations %}
+      <h4>[Support only] Assigned Locations</h4>
+      <div class="list-group">
+        {% for location in support_info.locations %}
+          <a href="{% url "edit_location" domain location.location_id %}" class="list-group-item">
+            {{ location.get_path_display }} <span class="badge">{{ location.location_type.name }}</span>
+          </a>
+        {% endfor %}
+      </div>
+    {% endif %}
   {% endif %}
 
   {% if tableau_form %}

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -464,7 +464,10 @@ class EditWebUserView(BaseEditUserView):
             ),
             'idp_name': idp.name if idp else '',
         })
-
+        if toggles.SUPPORT.enabled(self.request.couch_user.username):
+            ctx["support_info"] = {
+                'locations': self.editable_user.get_sql_locations(self.domain)
+            }
         return ctx
 
     @method_decorator(always_allow_project_access)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -338,6 +338,10 @@ class EditCommCareUserView(BaseEditUserView):
                     'update_form': self.commtrack_form,
                 },
             })
+        if toggles.SUPPORT.enabled(self.request.couch_user.username):
+            context["support_info"] = {
+                'locations': self.editable_user.get_sql_locations(self.domain)
+            }
         return context
 
     @property

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
@@ -43,6 +43,9 @@
   <thead>
     <tr>
       <th>{% trans "Name" %}</th>
+      {% if request|toggle_enabled:"SUPPORT" %}
+        <th>{% trans "Index" %}</th>
+      {% endif %}
       {% for column in columns %}
         <th>{{ column.name }}</th>
       {% endfor %}
@@ -124,7 +127,17 @@
             </div>
           {% endif %}
         </td>
-
+        {% if request|toggle_enabled:"SUPPORT" %}
+          <td>
+            {% if case.case_id == current_case.case_id %}
+              <em>(current case)</em>
+            {% elif case.index_info.is_ancestor %}
+              <strong>{{ case.index_info.identifier }}</strong> / {{ case.index_info.relationship }}
+            {% elif case.index_info %}
+              {{ case.index_info.identifier }} / <strong>{{ case.index_info.relationship }}</strong>
+            {% endif %}
+          </td>
+        {% endif %}
         {% for column in case.columns %}
           <td>{{ column.value }}</td>
         {% endfor %}


### PR DESCRIPTION
## Product Description

Everything is gated behind the SUPPORT feature flag.  Would be nice to release some of this fully, but that'd probably take more care to the UI than is warranted for the moment.

Adds index information to the case data page (identifier and relationship)
![image](https://github.com/dimagi/commcare-hq/assets/2367539/e4971527-ab8d-47da-8c23-3c9bb5419d97)

Adds a "Support" tab to the mobile workers page with some info useful for debugging various issues that you otherwise have to go to "raw data" for:

![image](https://github.com/dimagi/commcare-hq/assets/2367539/2785fc83-45ea-4a1d-8d4e-0d8233150f26)

Adds links to assigned locations and the location type info to both web and mobile workers:

![image](https://github.com/dimagi/commcare-hq/assets/2367539/bf7751b6-eb2c-4472-9045-1b7627528d5d)


## Technical Summary


## Feature Flag


## Safety Assurance
Will poke around on staging a bit

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
