### PR TITLE
make all 'use_X' decorators support function and class-based views

### DIFF
--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -82,11 +82,7 @@ def use_nvd3(view_func):
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_nvd3 = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
+    return get_wrapped_view(view_func, set_request_attr('use_nvd3', True))
 
 
 def use_nvd3_v3(view_func):
@@ -251,12 +247,7 @@ def use_tempusdominus(view_func):
     """
     @wraps(view_func)
     def _wrapped(*args, **kwargs):
-        if hasattr(args[0], 'META'):
-            # function view
-            request = args[0]
-        else:
-            # class view
-            request = args[1]
+        request = _get_request_from_args(*args, **kwargs)
         request.use_tempusdominus = True
         return view_func(*args, **kwargs)
     return _wrapped
@@ -295,3 +286,29 @@ def waf_allow(kind, hard_code_pattern=None):
 
 
 waf_allow.views = defaultdict(set)
+
+
+def set_request_attr(attr_name, attr_value):
+    def _set_attr(request):
+        setattr(request, attr_name, attr_value)
+
+    return _set_attr
+
+
+def get_wrapped_view(view_func, request_modifier):
+    @wraps(view_func)
+    def _wrapped(*args, **kwargs):
+        request = _get_request_from_args(*args, **kwargs)
+        request_modifier(request)
+        return view_func(*args, **kwargs)
+
+    return _wrapped
+
+
+def _get_request_from_args(*args, **kwargs):
+    if hasattr(args[0], 'META'):
+        # function view
+        return args[0]
+    else:
+        # class view
+        return args[1]

--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -16,17 +16,7 @@ def use_daterangepicker(view_func):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
 
-    @wraps(view_func)
-    def _wrapped(*args, **kwargs):
-        if hasattr(args[0], 'META'):
-            # function view
-            request = args[0]
-        else:
-            # class view
-            request = args[1]
-        request.use_daterangepicker = True
-        return view_func(*args, **kwargs)
-    return _wrapped
+    return set_request_flag(view_func, 'use_daterangepicker')
 
 
 def use_jquery_ui(view_func):
@@ -40,11 +30,7 @@ def use_jquery_ui(view_func):
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_jquery_ui = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
+    return set_request_flag(view_func, 'use_jquery_ui')
 
 
 def use_multiselect(view_func):
@@ -58,17 +44,7 @@ def use_multiselect(view_func):
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
-    @wraps(view_func)
-    def _wrapped(*args, **kwargs):
-        if hasattr(args[0], 'META'):
-            # function view
-            request = args[0]
-        else:
-            # class view
-            request = args[1]
-        request.use_multiselect = True
-        return view_func(*args, **kwargs)
-    return _wrapped
+    return set_request_flag(view_func, 'use_multiselect')
 
 
 def use_nvd3(view_func):
@@ -82,7 +58,7 @@ def use_nvd3(view_func):
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
-    return get_wrapped_view(view_func, set_request_attr('use_nvd3', True))
+    return set_request_flag(view_func, 'use_nvd3')
 
 
 def use_nvd3_v3(view_func):
@@ -96,11 +72,7 @@ def use_nvd3_v3(view_func):
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_nvd3_v3 = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
+    return set_request_flag(view_func, 'use_nvd3_v3')
 
 
 def use_timeago(view_func):
@@ -114,11 +86,7 @@ def use_timeago(view_func):
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_timeago = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
+    return set_request_flag(view_func, 'use_timeago')
 
 
 def use_datatables(view_func):
@@ -132,11 +100,7 @@ def use_datatables(view_func):
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_datatables = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
+    return set_request_flag(view_func, 'use_datatables')
 
 
 def use_typeahead(view_func):
@@ -150,11 +114,7 @@ def use_typeahead(view_func):
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_typeahead = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
+    return set_request_flag(view_func, 'use_typeahead')
 
 
 def use_timepicker(view_func):
@@ -168,11 +128,7 @@ def use_timepicker(view_func):
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_timepicker = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
+    return set_request_flag(view_func, 'use_timepicker')
 
 
 def use_maps(view_func):
@@ -186,11 +142,7 @@ def use_maps(view_func):
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_maps = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
+    return set_request_flag(view_func, 'use_maps')
 
 
 def use_ko_validation(view_func):
@@ -202,11 +154,7 @@ def use_ko_validation(view_func):
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_ko_validation = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
+    return set_request_flag(view_func, 'use_ko_validation')
 
 
 def use_bootstrap5(view_func):
@@ -223,11 +171,7 @@ def use_bootstrap5(view_func):
         class MyViewClass(MyViewSubclass):
             ...
     """
-    @wraps(view_func)
-    def _inner(request, *args, **kwargs):
-        set_bootstrap_version5()
-        return view_func(request, *args, **kwargs)
-    return _inner
+    return get_wrapped_view(view_func, lambda r: set_bootstrap_version5())
 
 
 def use_tempusdominus(view_func):
@@ -245,12 +189,7 @@ def use_tempusdominus(view_func):
         class MyViewClass(MyViewSubclass):
             ...
     """
-    @wraps(view_func)
-    def _wrapped(*args, **kwargs):
-        request = _get_request_from_args(*args, **kwargs)
-        request.use_tempusdominus = True
-        return view_func(*args, **kwargs)
-    return _wrapped
+    return set_request_flag(view_func, 'use_tempusdominus')
 
 
 def waf_allow(kind, hard_code_pattern=None):
@@ -288,11 +227,11 @@ def waf_allow(kind, hard_code_pattern=None):
 waf_allow.views = defaultdict(set)
 
 
-def set_request_attr(attr_name, attr_value):
+def set_request_flag(view_func, attr_name, attr_value=True):
     def _set_attr(request):
         setattr(request, attr_name, attr_value)
 
-    return _set_attr
+    return get_wrapped_view(view_func, _set_attr)
 
 
 def get_wrapped_view(view_func, request_modifier):

--- a/corehq/apps/hqwebapp/tests/test_decorators.py
+++ b/corehq/apps/hqwebapp/tests/test_decorators.py
@@ -1,7 +1,8 @@
 from django.test import RequestFactory, SimpleTestCase
 
 from corehq.apps.hqwebapp import decorators
-from corehq.apps.hqwebapp.utils.bootstrap import BOOTSTRAP_3, BOOTSTRAP_5, get_bootstrap_version
+from corehq.apps.hqwebapp.utils.bootstrap import BOOTSTRAP_3, BOOTSTRAP_5, get_bootstrap_version, \
+    set_bootstrap_version3
 from corehq.util.test_utils import generate_cases
 from inspect import getmembers, isfunction
 
@@ -23,6 +24,7 @@ class TestDecorators(SimpleTestCase):
         def dummy_view(request):
             self.assertEqual(get_bootstrap_version(), BOOTSTRAP_5)
 
+        set_bootstrap_version3()
         self.assertEqual(get_bootstrap_version(), BOOTSTRAP_3)
         dummy_view(self.factory.get('/'))
 

--- a/corehq/apps/hqwebapp/tests/test_decorators.py
+++ b/corehq/apps/hqwebapp/tests/test_decorators.py
@@ -1,0 +1,49 @@
+from django.test import RequestFactory, SimpleTestCase
+
+from corehq.apps.hqwebapp import decorators
+from corehq.apps.hqwebapp.utils.bootstrap import BOOTSTRAP_3, BOOTSTRAP_5, get_bootstrap_version
+from corehq.util.test_utils import generate_cases
+from inspect import getmembers, isfunction
+
+
+def filter_decorators(obj):
+    return isfunction(obj) and obj.__name__.startswith("use_") and obj.__name__ != "use_bootstrap5"
+
+
+ALL_DECORATORS = [member[1] for member in getmembers(decorators, filter_decorators)]
+
+
+class TestDecorators(SimpleTestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_use_bootstrap5(self):
+        @decorators.use_bootstrap5
+        def dummy_view(request):
+            self.assertEqual(get_bootstrap_version(), BOOTSTRAP_5)
+
+        self.assertEqual(get_bootstrap_version(), BOOTSTRAP_3)
+        dummy_view(self.factory.get('/'))
+
+    @generate_cases([
+        (decorator,) for decorator in ALL_DECORATORS
+    ])
+    def test_flag_decorators__function_view(self, decorator):
+        def dummy_view(request):
+            return True
+
+        request = self.factory.get('/')
+        decorator(dummy_view)(request)
+        self.assertTrue(getattr(request, decorator.__name__))
+
+    @generate_cases([
+        (decorator,) for decorator in ALL_DECORATORS
+    ])
+    def test_flag_decorators__cls_view(self, decorator):
+        request = self.factory.get('/')
+        decorator(self._dummy_cls_view)(request)
+        self.assertTrue(getattr(request, decorator.__name__))
+
+    def _dummy_cls_view(self, request):
+        return True


### PR DESCRIPTION
## Technical Summary
During some recent work I had to modify one of these to support class based views so I decided to modify them all to support both. This also extracts some helper functions to reduce duplication.


## Safety Assurance

### Safety story
This is a pure refactor which I tested locally.

### Automated test coverage
Tests added in this PR

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
