### PR TITLE
Clear screen, but not scrollback history

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -651,7 +651,7 @@ class Command(BaseCommand):
         return bootstrap3_folder / file_path.name, bootstrap5_folder / file_path.name
 
     def clear_screen(self):
-        self.stdout.write("\033c")  # clear terminal screen
+        self.stdout.write("\033[2J\033[H")  # clear terminal screen
 
     @staticmethod
     def format_code(code_text, split_lines=False, break_length=80):


### PR DESCRIPTION
I often scroll up to see output of previously run commands. Losing scrollback history feels like a bad haircut.

## Safety Assurance

### Safety story

Tiny change to management command.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations