### PR TITLE
Migration - Add HQPermissions fields for restricting access to user profiles

### DIFF
--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -385,7 +385,7 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
 
         expected_object_counts = Counter({
             UserRole: 2,
-            RolePermission: 5,
+            RolePermission: 7,
             RoleAssignableBy: 1
         })
 

--- a/corehq/apps/users/migrations/0066_add_profile_permissions.py
+++ b/corehq/apps/users/migrations/0066_add_profile_permissions.py
@@ -20,11 +20,11 @@ def _assert_migrated(apps, schema_editor):
 
     def default_profile_permissions_on_for_existing_roles():
         # All existing roles should be allowed to edit profiles since that was the default behavior
-        edit_all_user_profiles = Permission.objects.get(value='edit_all_user_profiles')
+        edit_user_profile = Permission.objects.get(value='edit_user_profile')
         for chunk in with_progress_bar(chunked(UserRole.objects.values_list('id', flat=True).iterator(), 1000),
                                        length=UserRole.objects.count()):
             for role in UserRole.objects.filter(id__in=chunk):
-                role.rolepermission_set.get_or_create(permission_fk=edit_all_user_profiles, defaults={"allow_all": True})
+                role.rolepermission_set.get_or_create(permission_fk=edit_user_profile, defaults={"allow_all": True})
 
     try:
         default_profile_permissions_on_for_existing_roles()

--- a/corehq/apps/users/migrations/0066_add_profile_permissions.py
+++ b/corehq/apps/users/migrations/0066_add_profile_permissions.py
@@ -1,0 +1,47 @@
+import sys
+import traceback
+from corehq.apps.users.models_role import Permission
+from corehq.util.django_migrations import skip_on_fresh_install
+from corehq.util.log import with_progress_bar
+from dimagi.utils.chunked import chunked
+from django.db import migrations
+
+MIGRATION_SLUG = "default_profile_permissions_on_for_existing_roles"
+
+
+@skip_on_fresh_install
+def create_profile_permissions(apps, schema_editor):
+    Permission.create_all()
+
+
+def _assert_migrated(apps, schema_editor):
+    UserRole = apps.get_model('users', 'UserRole')
+    Permission = apps.get_model('users', 'Permission')
+
+    def default_profile_permissions_on_for_existing_roles():
+        # All existing roles should be allowed to edit profiles since that was the default behavior
+        edit_all_user_profiles = Permission.objects.get(value='edit_all_user_profiles')
+        for chunk in with_progress_bar(chunked(UserRole.objects.values_list('id', flat=True).iterator(), 1000),
+                                       length=UserRole.objects.count()):
+            for role in UserRole.objects.filter(id__in=chunk):
+                role.rolepermission_set.get_or_create(permission_fk=edit_all_user_profiles, defaults={"allow_all": True})
+
+    try:
+        default_profile_permissions_on_for_existing_roles()
+    except Exception:
+        traceback.print_exc()
+        print("")
+        print("Migration failed.")
+        sys.exit(1)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0065_transfer_to_tableau_config_permission'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_profile_permissions, migrations.RunPython.noop),
+        migrations.RunPython(_assert_migrated, migrations.RunPython.noop)
+    ]

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -163,7 +163,7 @@ PARAMETERIZED_PERMISSIONS = {
     'view_tableau': 'view_tableau_list',
     'access_web_apps': 'web_apps_list',
     'commcare_analytics_roles': 'commcare_analytics_roles_list',
-    'edit_profiles_list': 'edit_profiles_list',
+    'edit_user_profile': 'edit_user_profile_list',
 }
 
 
@@ -238,8 +238,8 @@ class HqPermissions(DocumentSchema):
     edit_user_tableau_config = BooleanProperty(default=False)
     view_user_tableau_config = BooleanProperty(default=False)
 
-    edit_all_user_profiles = BooleanProperty(default=True)
-    edit_profiles_list = StringListProperty(default=[])  # List of profile obj IDs
+    edit_user_profile = BooleanProperty(default=True)
+    edit_user_profile_list = StringListProperty(default=[])  # List of profile obj IDs
 
     @classmethod
     def from_permission_list(cls, permission_list):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -163,6 +163,7 @@ PARAMETERIZED_PERMISSIONS = {
     'view_tableau': 'view_tableau_list',
     'access_web_apps': 'web_apps_list',
     'commcare_analytics_roles': 'commcare_analytics_roles_list',
+    'edit_profiles_list': 'edit_profiles_list',
 }
 
 
@@ -236,6 +237,9 @@ class HqPermissions(DocumentSchema):
 
     edit_user_tableau_config = BooleanProperty(default=False)
     view_user_tableau_config = BooleanProperty(default=False)
+
+    edit_all_user_profiles = BooleanProperty(default=True)
+    edit_profiles_list = StringListProperty(default=[])  # List of profile obj IDs
 
     @classmethod
     def from_permission_list(cls, permission_list):

--- a/corehq/apps/users/tests/test_models_role.py
+++ b/corehq/apps/users/tests/test_models_role.py
@@ -319,7 +319,7 @@ class HqPermissionsTest(SimpleTestCase):
         self.permissions = {name: getattr(self.hq_permissions, name) for name in self.permission_names}
 
     def test_permissions_default(self):
-        default_true_permissions = ['access_all_locations', 'report_an_issue', 'edit_all_user_profiles']
+        default_true_permissions = ['access_all_locations', 'report_an_issue', 'edit_user_profile']
         for name, value in self.permissions.items():
             if name not in default_true_permissions:
                 self.assertFalse(value)

--- a/corehq/apps/users/tests/test_models_role.py
+++ b/corehq/apps/users/tests/test_models_role.py
@@ -319,7 +319,7 @@ class HqPermissionsTest(SimpleTestCase):
         self.permissions = {name: getattr(self.hq_permissions, name) for name in self.permission_names}
 
     def test_permissions_default(self):
-        default_true_permissions = ['access_all_locations', 'report_an_issue']
+        default_true_permissions = ['access_all_locations', 'report_an_issue', 'edit_all_user_profiles']
         for name, value in self.permissions.items():
             if name not in default_true_permissions:
                 self.assertFalse(value)

--- a/migrations.lock
+++ b/migrations.lock
@@ -1226,6 +1226,7 @@ users
  0063_rename_location_invitation_primary_location_and_more
  0064_add_edit_view_tableau_config_permissions
  0065_transfer_to_tableau_config_permission
+ 0066_add_profile_permissions
 util
  0001_initial
  0002_complaintbouncemeta_permanentbouncemeta_transientbounceemail


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

In Jira: [USH-4424](https://dimagi.atlassian.net/browse/USH-4424).

No user facing effects.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Following Jonathan's PR #34468 pretty closely, which _also_ adds new permissions and sets a default value for them.

In a production shell session I ran:

```
In [17]: import time
    ...: t0 = time.time()
    ...: x = 0
    ...: for role in UserRole.objects.all():
    ...:     role.rolepermission_set
    ...:     x += 1
    ...: print(time.time() - t0)
7.912802457809448
```

So I'm surmising that this migration will only take 8 seconds on prod, and should be pretty straightforward. Chunking/progress bar is probably unnecessary, but it's there.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tested locally so far. Gonna run on staging, too
- can't possibly effect any live users. Biggest risk is that deploy or third-party upgrade is somehow interrupted

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

QA will be done at the end of the build of this feature.


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [X] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Migration will need to be reversed, i.e. the fields removed

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4424]: https://dimagi.atlassian.net/browse/USH-4424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ