### PR TITLE
Deprecated Function for Opening Case in Advanced Modules

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
@@ -669,6 +669,17 @@ hqDefine('app_manager/js/forms/advanced/actions', function () {
             });
             self.saveOnlyEditedFormFieldsEnabled = toggles.toggleEnabled("SAVE_ONLY_EDITED_FORM_FIELDS");
 
+            self.hasDeprecatedProperties = ko.computed(function () {
+                if (privileges.hasPrivilege('data_dictionary')) {
+                    for (const p of self.case_properties()) {
+                        if (p.isDeprecated()) {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            });
+
             return self;
         },
         unwrap: function (self) {


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to support ticket [here](https://dimagi.atlassian.net/browse/SUPPORT-19653)

This PR addresses adding the necessary deprecated property check function to the model for opening a new case in an Advanced Module. The models for loading/updating/closing cases have been dealt with in [this PR](https://github.com/dimagi/commcare-hq/pull/34636), however the scenario for opening cases was not addressed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ADVANCED_MODULES`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing of all case management functions (incl. opening/updating/closing case, and creating a new case)

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
