### PR TITLE
Case Grouping Report : Downgrade max cases in geohash bucket from 10k to 1k

### DIFF
--- a/corehq/apps/geospatial/const.py
+++ b/corehq/apps/geospatial/const.py
@@ -4,7 +4,7 @@ GPS_POINT_CASE_PROPERTY = 'gps_point'
 ALGO_AES = 'aes'
 
 # Max number of cases per geohash
-MAX_GEOHASH_DOC_COUNT = 10_00
+MAX_GEOHASH_DOC_COUNT = 1_000
 
 # Modified version of https://geojson.org/schema/FeatureCollection.json
 #   Modification 1 - Added top-level name attribute

--- a/corehq/apps/geospatial/const.py
+++ b/corehq/apps/geospatial/const.py
@@ -4,7 +4,7 @@ GPS_POINT_CASE_PROPERTY = 'gps_point'
 ALGO_AES = 'aes'
 
 # Max number of cases per geohash
-MAX_GEOHASH_DOC_COUNT = 10_000
+MAX_GEOHASH_DOC_COUNT = 10_00
 
 # Modified version of https://geojson.org/schema/FeatureCollection.json
 #   Modification 1 - Added top-level name attribute

--- a/corehq/apps/geospatial/tests/test_es.py
+++ b/corehq/apps/geospatial/tests/test_es.py
@@ -25,6 +25,7 @@ def fake_get_max_doc_count(query, case_property, precision):
     return 2 * x + 9_983
 
 
+@patch('corehq.apps.geospatial.es.MAX_GEOHASH_DOC_COUNT', 10000)
 def test_find_precision():
     with patch(
         'corehq.apps.geospatial.es.get_max_doc_count',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The case grouping reports at present supports 10k as max cases in a geohash bucket. This causes performance issues in browser i(extreme lag and page crash) while interacting with mapbox markers for a bucket with such no. of cases.
The change made downgrades this value to 1k where the performance is way better and working with markers is quite smooth.
The value 1k was selected as a conservative estimate considering mapbox does not recommends to use markers for data points with thousands in numbers.

Note for future:  if say need arise to have a larger bucket , we should consider to use [layers](https://docs.mapbox.com/mapbox-gl-js/example/geojson-markers/) for data points instead of markers.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-3655)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Geospatial (Allows access to GIS functionality)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Extremely safe - only changes a constant value that determine max. no of cases in a bucket.
Local testing done

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Updated.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
