### PR TITLE
Rebuilt bootstrap5 diffs

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -2,18 +2,25 @@
+@@ -2,19 +2,27 @@
  requirejs.config({
      baseUrl: '/static/',
      paths: {
@@ -26,9 +26,11 @@
          "sentry_captureconsole": "sentry/js/sentry.captureconsole.7.28.0.min",
 +        "tempusDominus": "@eonasdan/tempus-dominus/dist/js/tempus-dominus.min",
          "underscore": "underscore/underscore",
++        "nvd3/nv.d3.latest.min": "nvd3-1.8.6/build/nv.d3.min",
      },
      shim: {
-@@ -24,7 +31,6 @@
+         "accounting/js/lib/stripe": { exports: 'Stripe' },
+@@ -24,7 +32,6 @@
          "ace-builds/src-min-noconflict/ext-searchbox": { deps: ["ace-builds/src-min-noconflict/ace"] },
          "At.js/dist/js/jquery.atwho": { deps: ['jquery', 'Caret.js/dist/jquery.caret'] },
          "backbone": { exports: "backbone" },
@@ -36,7 +38,7 @@
          "calendars/dist/js/jquery.calendars.picker": {
              deps: [
                  "calendars/dist/js/jquery.plugin",
-@@ -60,10 +66,14 @@
+@@ -60,10 +67,14 @@
              ],
          },
          "datatables.bootstrap": { deps: ['datatables'] },
@@ -52,7 +54,18 @@
          "hqwebapp/js/lib/modernizr": {
              exports: 'Modernizr',
          },
-@@ -98,7 +108,7 @@
+@@ -84,6 +95,10 @@
+             deps: ['d3/d3.min'],
+             exports: 'nv',
+         },
++        "nvd3/nv.d3.latest.min": {
++            deps: ['d3/d3.min'],
++            exports: 'nv',
++        },
+         "sentry_browser": { exports: "Sentry" },
+     },
+     wrapShim: true,
+@@ -98,7 +113,7 @@
          },
      },
  


### PR DESCRIPTION
## Technical Summary
It looks like tests never ran on https://github.com/dimagi/commcare-hq/pull/34645 - maybe because it started off branched off of a non-master branch?

I just ran the diff builder rather than add the newer version of nvd3 to the B3 config, so that library isn't currently available for B3 pages, but I think that's fine.

## Safety Assurance

### Safety story
Non user-facing, fixes the build.

### Automated test coverage

It's a test.

### QA Plan

no


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
