### PR TITLE
Put switch to dedicated ES index behind a flag

### DIFF
--- a/corehq/apps/case_search/tests/test_case_search_es_queries.py
+++ b/corehq/apps/case_search/tests/test_case_search_es_queries.py
@@ -427,7 +427,7 @@ class CaseSearchTests(ElasticTestMixin, TestCase):
 
 
 def test_use_custom_index():
-    helper = QueryHelper(DOMAIN)
+    helper = QueryHelper(DOMAIN, allow_dedicated_index=True)
     helper.config = CaseSearchConfig(domain=DOMAIN, index_name="my_test_index")
     with patch('corehq.apps.es.es_query.doc_adapter_from_cname') as get_adapter:
         helper.get_base_queryset()

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1012,6 +1012,18 @@ CASE_SEARCH_INDEXED_METADATA = StaticToggle(
     """
 )
 
+PILOT_DEDICATED_CASE_SEARCH_INDEX = StaticToggle(
+    'PILOT_DEDICATED_CASE_SEARCH_INDEX',
+    "Pilot test the new dedicated case search index",
+    TAG_INTERNAL,
+    description="""
+    When enabled for a particular user, that user's case search requests will
+    go to a dedicated case search index, if configured for the domain. This
+    will let us test out the new index on a per-user basis before enabling it
+    for everyone.
+    """
+)
+
 USH_CASE_CLAIM_UPDATES = StaticToggle(
     'case_claim_autolaunch',
     "USH Specific toggle to support several different case search/claim workflows in web apps",


### PR DESCRIPTION
This is just for rollout, I expect us to remove this within the next week or two

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
