### PR TITLE
[B5] migration tool: remove .panel-default

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
@@ -22,7 +22,7 @@
         "panel-modern-gray": "card-modern-gray",
         "panel-form-only": "card-form-only",
         "panel-heading": "card-header",
-        "panel-default": "card-default",
+        "panel-default": "",
         "panel-info": "text-bg-info",
         "panel-danger": "text-bg-danger",
         "panel": "card",


### PR DESCRIPTION
## Technical Summary
The B5 card classes largely match the B3 panel classes, but there's no `card-default`

## Safety Assurance

### Safety story
Config change in internal engineering tool.

### Automated test coverage

Tool has tests.

### QA Plan

no

### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
