### PR TITLE
Support backfilling subindices in elasticsearch

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -402,7 +402,7 @@ class ElasticManageAdapter(BaseAdapter):
 
     def reindex(
             self, source, dest, wait_for_completion=False,
-            refresh=False, batch_size=1000, requests_per_second=None, copy_doc_ids=True, query={},
+            refresh=False, batch_size=1000, requests_per_second=None, copy_doc_ids=True, query=None,
     ):
         """
         Starts the reindex process in elastic search cluster

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -458,7 +458,7 @@ class ElasticManageAdapter(BaseAdapter):
             reindex_kwargs["requests_per_second"] = requests_per_second
 
         if query:
-            reindex_kwargs["query"] = {"term": query}
+            reindex_body["source"]["query"] = {"term": query}
 
         reindex_info = self._es.reindex(reindex_body, **reindex_kwargs)
         if not wait_for_completion:

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -402,7 +402,7 @@ class ElasticManageAdapter(BaseAdapter):
 
     def reindex(
             self, source, dest, wait_for_completion=False,
-            refresh=False, batch_size=1000, requests_per_second=None, copy_doc_ids=True
+            refresh=False, batch_size=1000, requests_per_second=None, copy_doc_ids=True, query={},
     ):
         """
         Starts the reindex process in elastic search cluster
@@ -417,6 +417,8 @@ class ElasticManageAdapter(BaseAdapter):
                            batches may process more quickly but risk errors if the documents are too
                            large. 1000 is the recommended maximum and elasticsearch default,
                            and can be reduced if you encounter scroll timeouts.
+        :param query: ``dict`` optional parameter to include a term query to filter which documents are included in
+                      the reindex
         :returns: None if wait_for_completion is True else would return task_id of reindex task
         """
 
@@ -454,6 +456,9 @@ class ElasticManageAdapter(BaseAdapter):
 
         if requests_per_second:
             reindex_kwargs["requests_per_second"] = requests_per_second
+
+        if query:
+            reindex_kwargs["query"] = {"term": query}
 
         reindex_info = self._es.reindex(reindex_body, **reindex_kwargs)
         if not wait_for_completion:

--- a/corehq/apps/es/exceptions.py
+++ b/corehq/apps/es/exceptions.py
@@ -27,3 +27,7 @@ class IndexMultiplexedException(Exception):
 
 class IndexAlreadySwappedException(Exception):
     pass
+
+
+class IndexNotPartialException(Exception):
+    pass

--- a/corehq/apps/es/exceptions.py
+++ b/corehq/apps/es/exceptions.py
@@ -29,5 +29,5 @@ class IndexAlreadySwappedException(Exception):
     pass
 
 
-class IndexNotPartialException(Exception):
+class IndexNotSubindexException(Exception):
     pass

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -82,10 +82,10 @@ class ESSyncUtil:
             + f"\"grep '{task_number}.*ReindexResponse' /opt/data/elasticsearch*/logs/*.log\""
             + "\n\n")
 
-    def reindex_partial_index(self, cname, domain):
-        destination_adapter = doc_adapter_from_cname(cname)
+    def reindex_partial_index(self, partial_index_cname, domain):
+        destination_adapter = doc_adapter_from_cname(partial_index_cname)
         if not destination_adapter.parent_index_cname:
-            raise IndexNotPartialException(f"Adapter for {cname} is not a partial index")
+            raise IndexNotPartialException(f"Adapter for {partial_index_cname} is not a partial index")
 
         source_adapter = doc_adapter_from_cname(destination_adapter.parent_index_cname)
         source_index = source_adapter.index_name

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -610,5 +610,7 @@ class Command(BaseCommand):
             cmd_func(options['index_cname'])
         elif sub_cmd == 'set_replicas':
             cmd_func(options["index_cname"])
+        elif sub_cmd == 'partial_reindex':
+            cmd_func(options["index_cname"], options["domain"])
         elif sub_cmd in ['remove_residual_indices', 'display_shard_info']:
             cmd_func()

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -95,7 +95,7 @@ class ESSyncUtil:
         self._prepare_index_for_reindex(destination_index)
 
         logger.info("Starting partial reindex process")
-        task_id = es_manager.reindex(source_index, destination_index, query={"term": domain})
+        task_id = es_manager.reindex(source_index, destination_index, query={"domain": domain})
 
         logger.info(f"Copying docs from index {source_index} to index {destination_index} for {domain}")
         task_number = task_id.split(':')[1]

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -187,8 +187,8 @@ class ESSyncUtil:
         source_count = source_adapter.count(query)
         destination_count = destination_adapter.count(query)
 
-        print(f"\nDoc Count In Source Index '{source_adapter.parent_index_name}' in domain '{domain}' - {source_count}")  # noqa: E501
-        print(f"\nDoc Count In Partial Index '{destination_adapter.index_name}' in domain '{domain}' - {destination_count}\n")  # noqa: E501
+        print(f"\nDoc Count In Source Index '{source_adapter.parent_index_cname}' in domain '{domain}' - {source_count}")  # noqa: E501
+        print(f"\nDoc Count In Partial Index '{destination_adapter.canonical_name}' in domain '{domain}' - {destination_count}\n")  # noqa: E501
 
     def perform_cleanup(self, adapter):
         logger.info("Performing required cleanup!")

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -85,7 +85,7 @@ class ESSyncUtil:
 
     def reindex_partial_index(self, cname, domain):
         adapter = doc_adapter_from_cname(cname)
-        if not adapter.parent_index_name:
+        if not adapter.parent_index_cname:
             raise IndexNotPartialException(f"Adapter for {cname} is not a partial index")
 
         source_index = adapter.parent_index_name

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -565,6 +565,19 @@ class Command(BaseCommand):
         display_shard_info_cmd = subparsers.add_parser("display_shard_info")
         display_shard_info_cmd.set_defaults(func=self.es_helper.display_shard_info)
 
+        # Partial Reindex
+        partial_reindex_cmd = subparsers.add_parser("partial_reindex")
+        partial_reindex_cmd.set_defaults(func=self.es_helper.reindex_partial_index)
+        partial_reindex_cmd.add_argument(
+            'index_cname',
+            choices=INDEXES,
+            help="""Cannonical Name of the index""",
+        )
+        partial_reindex_cmd.add_argument(
+            'domain',
+            help="""Only includes documents from this domain""",
+        )
+
     def handle(self, **options):
         sub_cmd = options['sub_command']
         cmd_func = options.get('func')

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -187,8 +187,8 @@ class ESSyncUtil:
         source_count = source_adapter.count(query)
         destination_count = destination_adapter.count(query)
 
-        print(f"\nDoc Count In Source Index '{source_adapter.parent_index_cname}' in domain '{domain}' - {source_count}")  # noqa: E501
-        print(f"\nDoc Count In Partial Index '{destination_adapter.canonical_name}' in domain '{domain}' - {destination_count}\n")  # noqa: E501
+        print(f"\nDoc Count In Source Index '{source_adapter.index_name}' in domain '{domain}' - {source_count}")  # noqa: E501
+        print(f"\nDoc Count In Partial Index '{destination_adapter.index_name}' in domain '{domain}' - {destination_count}\n")  # noqa: E501
 
     def perform_cleanup(self, adapter):
         logger.info("Performing required cleanup!")

--- a/corehq/apps/es/tests/test_client.py
+++ b/corehq/apps/es/tests/test_client.py
@@ -503,6 +503,26 @@ class TestElasticManageAdapter(AdapterWithIndexTestCase):
 
                 self.assertEqual(self._get_all_doc_ids_in_index(SECONDARY_INDEX), all_ids)
 
+    def test_partial_reindex_with_all_params(self):
+        PARTIAL_INDEX = 'partial_index'
+        partial_adapter = create_document_adapter(test_adapter.__class__, PARTIAL_INDEX, test_adapter.type)
+
+        with temporary_index(test_adapter.index_name, test_adapter.type, test_adapter.mapping):
+
+            self._index_test_docs_for_reindex()
+
+            with temporary_index(PARTIAL_INDEX, partial_adapter.type, partial_adapter.mapping):
+
+                manager.reindex(
+                    test_adapter.index_name, PARTIAL_INDEX,
+                    wait_for_completion=True,
+                    refresh=True,
+                    requests_per_second=2,
+                    query={"value": "val_7"},
+                )
+
+                self.assertCountEqual(list(self._get_all_doc_ids_in_index(PARTIAL_INDEX)), ['7'])
+
     def test_reindex_with_copy_doc_ids(self):
         SECONDARY_INDEX = 'secondary_index'
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This adds support for writing docs from a specific domain into a "subindex", meaning an index dedicated to only containing docs for specific domain(s).

I think it is the case that another PR will add specific settings in settings.py which we could use to assert that the requested domain for the partial reindex is included in that settings file. For now, I haven't included that here. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
