### PR TITLE
Sync writes/deletes on sub case search indices.

### DIFF
--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -191,11 +191,11 @@ class ElasticCaseSearch(ElasticDocumentAdapter):
         """
         Selectively multiplexes writes to a sub index based on the domain of the doc.
         """
-        adapter = multiplex_to_adapter(self._get_domain_from_doc(doc))
-        if adapter:
-            # If we get a valid adapter then we multiplex writes
+        sub_index_adapter = multiplex_to_adapter(self._get_domain_from_doc(doc))
+        if sub_index_adapter:
+            # If we get a valid sub index adapter then we multiplex writes
             doc_obj = BulkActionItem.index(doc)
-            payload = [self._render_bulk_action(doc_obj), adapter._render_bulk_action(doc_obj)]
+            payload = [self._render_bulk_action(doc_obj), sub_index_adapter._render_bulk_action(doc_obj)]
             return self._bulk(payload, refresh=refresh, raise_errors=True)
         # If adapter is None then simply index the docs
         super().index(doc, refresh=refresh)

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -210,7 +210,7 @@ class ElasticCaseSearch(ElasticDocumentAdapter):
             adapter = multiplex_to_adapter(self._get_domain_from_doc(action.doc))
             if adapter:
                 payload.append(adapter._render_bulk_action(action))
-        self._bulk(payload, refresh=refresh, raise_errors=raise_errors)
+        return self._bulk(payload, refresh=refresh, raise_errors=raise_errors)
 
 
 case_search_adapter = create_document_adapter(

--- a/corehq/apps/es/tests/test_case_search_adapter.py
+++ b/corehq/apps/es/tests/test_case_search_adapter.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from corehq.apps.es.case_search import case_search_adapter
+from corehq.apps.es.case_search_bha import case_search_bha_adapter
 from corehq.apps.es.tests.utils import es_test
 from corehq.form_processor.tests.utils import create_case
 
@@ -43,3 +46,46 @@ class TestFromPythonInCaseSearch(TestCase):
         es_case = case_search_adapter.search({})['hits']['hits'][0]['_source']
         es_case.pop('@indexed_on')
         self.assertEqual(es_case, case)
+
+
+@es_test(requires=[case_search_adapter, case_search_bha_adapter], setup_class=True)
+class TestCaseSearchAdapterAlsoWritesToAnotherIndex(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'casesearch-dual-writetests'
+        cls.case = create_case(cls.domain, save=True)
+
+    def _get_normalized_cases_from_hits(self, cases):
+        normalised_cases = []
+        for hit in cases['hits']['hits']:
+            normalised_case = self._normalise_case(hit['_source'])
+            normalised_cases.append(normalised_case)
+        return normalised_cases
+
+    def _normalise_case(self, case):
+        case.pop('@indexed_on')
+        return case
+
+    def test_index_writes_to_both_adapters(self):
+        with patch('corehq.apps.es.case_search.multiplex_to_adapter', return_value=case_search_bha_adapter):
+            case_search_adapter.index(self.case, refresh=True)
+            self.addCleanup(case_search_bha_adapter.delete, self.case.case_id)
+            self.addCleanup(case_search_adapter.delete, self.case.case_id)
+
+        docs_in_bha = self._get_normalized_cases_from_hits(case_search_bha_adapter.search({}))
+        docs_in_case_search = self._get_normalized_cases_from_hits(case_search_adapter.search({}))
+
+        self.assertEqual(docs_in_bha, docs_in_case_search)
+
+    def test_index_not_writes_to_bha_adapter_if_not_required(self):
+        with patch('corehq.apps.es.case_search.multiplex_to_adapter', return_value=None):
+            case_search_adapter.index(self.case, refresh=True)
+            self.addCleanup(case_search_adapter.delete, self.case.case_id)
+
+        docs_in_bha = self._get_normalized_cases_from_hits(case_search_bha_adapter.search({}))
+        docs_in_case_search = self._get_normalized_cases_from_hits(case_search_adapter.search({}))
+
+        self.assertEqual(docs_in_bha, [])
+        self.assertEqual(len(docs_in_case_search), 1)

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -72,7 +72,7 @@ class ElasticProcessor(PillowProcessor):
             doc = change.get_document()
             domain = doc.get('domain') if doc else None
             if not domain:
-                meta = getattr(change, 'metadata')
+                meta = getattr(change, 'metadata', None)
                 domain = meta.domain if meta else None
             if doc and doc.get('doc_type'):
                 logger.info(

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -72,7 +72,8 @@ class ElasticProcessor(PillowProcessor):
             doc = change.get_document()
             domain = doc.get('domain') if doc else None
             if not domain:
-                domain = change.metadata.domain
+                meta = getattr(change, 'metadata')
+                domain = meta.domain if meta else None
             if doc and doc.get('doc_type'):
                 logger.info(
                     f'[process_change] Attempting to delete doc {change.id}')

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -4,6 +4,8 @@ import time
 
 from django.conf import settings
 
+from corehq.apps.es.case_search import multiplex_to_adapter
+from corehq.apps.es.const import HQ_CASE_SEARCH_INDEX_CANONICAL_NAME
 from pillowtop.exceptions import BulkDocException, PillowtopIndexingError
 from pillowtop.logger import pillow_logging
 from pillowtop.utils import (
@@ -68,12 +70,15 @@ class ElasticProcessor(PillowProcessor):
 
         if change.deleted and change.id:
             doc = change.get_document()
+            domain = doc.get('domain') if doc else None
+            if not domain:
+                domain = change.metadata.domain
             if doc and doc.get('doc_type'):
                 logger.info(
                     f'[process_change] Attempting to delete doc {change.id}')
                 current_meta = get_doc_meta_object_from_document(doc)
                 if current_meta.is_deletion:
-                    self._delete_doc_if_exists(change.id)
+                    self._delete_doc_if_exists(change.id, domain=domain)
                     logger.info(
                         f"[process_change] Deleted doc {change.id}")
                 else:
@@ -81,7 +86,7 @@ class ElasticProcessor(PillowProcessor):
                         f"[process_change] Not deleting doc {change.id} "
                         "because current_meta.is_deletion is false")
             else:
-                self._delete_doc_if_exists(change.id)
+                self._delete_doc_if_exists(change.id, domain=domain)
                 logger.info(
                     f"[process_change] Deleted doc {change.id}")
             return
@@ -97,7 +102,7 @@ class ElasticProcessor(PillowProcessor):
                 return
 
             if doc.get('doc_type') is not None and doc['doc_type'].endswith("-Deleted"):
-                self._delete_doc_if_exists(change.id)
+                self._delete_doc_if_exists(change.id, domain=doc.get('domain'))
                 return
 
         # send it across
@@ -109,7 +114,14 @@ class ElasticProcessor(PillowProcessor):
                 data=doc,
             )
 
-    def _delete_doc_if_exists(self, doc_id):
+    def _delete_doc_if_exists(self, doc_id, domain=None):
+        if self.adapter.canonical_name == HQ_CASE_SEARCH_INDEX_CANONICAL_NAME:
+            sub_index_adapter = multiplex_to_adapter(domain)
+            if sub_index_adapter:
+                send_to_elasticsearch(
+                    doc_id=doc_id, adapter=sub_index_adapter,
+                    name='ElasticProcessor', delete=True
+                )
         send_to_elasticsearch(
             doc_id=doc_id,
             adapter=self.adapter,

--- a/settings.py
+++ b/settings.py
@@ -1076,6 +1076,17 @@ CUSTOM_LANDING_TEMPLATE = {
 # used to override low-level index settings (number_of_replicas, number_of_shards, etc)
 ES_SETTINGS = None
 
+"""
+The CASE_SEARCH_SUB_INDICES should look like this:
+{
+    'co-carecoordination-perf': {
+        'index_cname': 'case_search_bha',
+        'multiplex_writes': True,
+    }
+}
+"""
+CASE_SEARCH_SUB_INDICES = {}
+
 PHI_API_KEY = None
 PHI_PASSWORD = None
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This PR builds up on https://github.com/dimagi/commcare-hq/pull/34663 and adds ability to sync writes and deletes to sub-case search indices. 
It uses a django-setting called `CASE_SEARCH_SUB_INDICES` which will look something like 
```
{
    'co-carecoordination-perf': {
        'index_cname': 'case_search_bha',
        'multiplex_writes': True,
    }
}
```

This setting will be used to decide which sub-index should the duplicate writes be routed to.

This PR in some ways combine commits from https://github.com/dimagi/commcare-hq/pull/34602 with certain modifications to make the changes less error prone.

Review by commit 🐡 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Most of the changes(except pillow delete) have been covered by tests and have been tested locally by running case-pillow, submitting forms and ensuring that data is present in both the indices. Then archiving the form to ensure that the case is deleted from both case-search indices.

Another thing to note here is that the changes are added in a way that if setting is not enabled on the domain then it should not have any effect. I am also putting this on staging to test out the changes with `co-carecoordination-test` on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests are added for most of the changes.
### QA Plan
Given the nature of the change it would be a good idea to get QA done but given time sensitivity of the work, I am not sure if we should do it.
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
