### PR TITLE
Add Collapsible Widget in Geospatial Settings

### DIFF
--- a/corehq/apps/geospatial/forms.py
+++ b/corehq/apps/geospatial/forms.py
@@ -143,7 +143,7 @@ class GeospatialConfigForm(forms.ModelForm):
                 hqcrispy.FieldsetAccordionGroup(
                     _('Advanced Settings'),
                     crispy.Fieldset(
-                        _("Configure Geospatial Settings"),
+                        _("Location Data Properties"),
                         crispy.Field(
                             'user_location_property_name',
                             data_bind="value: customUserFieldName"

--- a/corehq/apps/geospatial/forms.py
+++ b/corehq/apps/geospatial/forms.py
@@ -106,41 +106,6 @@ class GeospatialConfigForm(forms.ModelForm):
         self.helper.add_layout(
             crispy.Layout(
                 crispy.Fieldset(
-                    _("Configure Geospatial Settings"),
-                    crispy.Field(
-                        'user_location_property_name',
-                        data_bind="value: customUserFieldName"
-                    ),
-                    crispy.Field(
-                        'case_location_property_name',
-                        data_bind="options: geoCasePropOptions, "
-                                  "value: geoCasePropertyName, "
-                                  "event: {change: onGeoCasePropChange}"
-                    ),
-                    crispy.Div(
-                        crispy.HTML('%s' % _(
-                            'The currently used "{{ config.case_location_property_name }}" case property '
-                            'has been deprecated in the Data Dictionary. Please consider switching this '
-                            'to another property.')
-                        ),
-                        css_class='alert alert-warning',
-                        data_bind="visible: isCasePropDeprecated"
-                    ),
-                    crispy.Div(
-                        crispy.HTML('%s' % _(
-                            'The currently used "{{ config.case_location_property_name }}" case '
-                            'property may be associated with cases. Selecting a new case '
-                            'property will have the following effects:'
-                            '<ul><li>All cases using the old case property will no longer appear on maps.</li>'
-                            '<li>If the old case property is being used in an application, a new version would '
-                            'need to be released with the new case property for all users that capture '
-                            'location data.</li></ul>')
-                        ),
-                        css_class='alert alert-warning',
-                        data_bind="visible: hasGeoCasePropChanged"
-                    ),
-                ),
-                crispy.Fieldset(
                     _('Case Grouping Parameters'),
                     crispy.Field('selected_grouping_method', data_bind="value: selectedGroupMethod"),
                     crispy.Div(
@@ -173,6 +138,45 @@ class GeospatialConfigForm(forms.ModelForm):
                         ),
                         css_class=hqcrispy.CSS_ACTION_CLASS,
                         data_bind="visible: captureApiToken"
+                    ),
+                ),
+                hqcrispy.FieldsetAccordionGroup(
+                    _('Advanced Settings'),
+                    crispy.Fieldset(
+                        _("Configure Geospatial Settings"),
+                        crispy.Field(
+                            'user_location_property_name',
+                            data_bind="value: customUserFieldName"
+                        ),
+                        crispy.Field(
+                            'case_location_property_name',
+                            data_bind="options: geoCasePropOptions, "
+                                      "value: geoCasePropertyName, "
+                                      "event: {change: onGeoCasePropChange}"
+                        ),
+                        crispy.Div(
+                            crispy.HTML('%s' % _(
+                                'The currently used "{{ config.case_location_property_name }}" case property '
+                                'has been deprecated in the Data Dictionary. Please consider switching this '
+                                'to another property.')
+                            ),
+                            css_class='alert alert-warning',
+                            data_bind="visible: isCasePropDeprecated"
+                        ),
+                        crispy.Div(
+                            crispy.HTML('%s' % _(
+                                'The currently used "{{ config.case_location_property_name }}" case '
+                                'property may be associated with cases. Selecting a new case '
+                                'property will have the following effects:'
+                                '<ul><li>All cases using the old case property will no longer '
+                                'appear on maps.</li><li>If the old case property is being used '
+                                'in an application, a new version would need to be released with '
+                                'the new case property for all users that capture location data.'
+                                '</li></ul>')
+                            ),
+                            css_class='alert alert-warning',
+                            data_bind="visible: hasGeoCasePropChanged"
+                        ),
                     ),
                 ),
                 hqcrispy.FormActions(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The section to configure geospatial settings has been moved into a separate collapsible widget at the bottom of the page:
![collapsible-widget](https://github.com/dimagi/commcare-hq/assets/122617251/9b0fd6d9-d507-46d2-b724-369ee45fa8a3)

These settings have default values, and so just add UI clutter to the page if not being used at all. Putting it behind a collapsed widget puts them out the way for users that don't need them but still keeps them available for users that do.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3488).

Quite a straightforward PR. The crispy fieldset for the "Configure Geospatial Settings" inputs has simply been moved into a `FieldsetAccordionGroup`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Small UI change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests exist for the form.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
