### PR TITLE
Add z-index to sticky submit button

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-webapp/form.less
@@ -40,6 +40,9 @@
 
   .sticky-submit {
     position: sticky;
+    /* Puts the anchored submit button in front of form elements that use bootstrap's .form-control,
+       which adds z-index of 2 (3 when focused) */
+    z-index: @zindex-formplayer-anchored-submit;
   }
 
   // Bootstrap introduces -10px left/right margin for row classes. This causes element to overflow parent.

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/form.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/form.scss
@@ -33,6 +33,9 @@ $group-indent: 15px;
 
   .sticky-submit {
     position: sticky;
+    /* Puts the anchored submit button in front of form elements that use bootstrap's .form-control,
+       which adds z-index of 2 (3 when focused) */
+    z-index: $zindex-formplayer-anchored-submit;
   }
 
   // Bootstrap introduces -10px left/right margin for row classes. This causes element to overflow parent.

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/includes/variables.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/includes/variables.less
@@ -116,6 +116,7 @@
 @zindex-formplayer-progress:          990;
 @zindex-cloudcare-debugger:           1005;
 @zindex-formplayer-scroll-to-bottom:    5;
+@zindex-formplayer-anchored-submit:     4;
 
 
 @input-border-radius-large:       5px;

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables_bootstrap3.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables_bootstrap3.scss
@@ -64,6 +64,7 @@ $zindex-persistent-tile-cloudcare:    993;
 $zindex-formplayer-progress:          990;
 $zindex-cloudcare-debugger:          1005;
 $zindex-formplayer-scroll-to-bottom:    5;
+$zindex-formplayer-anchored-submit:     4;
 $zindex-select2-results:             1056;  // higher than $zindex-modal so select2s can be used in modals
 
 $cursor-disabled: 'not-allowed';

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-webapp_form.formplayer-webapp_form.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-webapp_form.formplayer-webapp_form.style.diff.txt
@@ -49,7 +49,16 @@
      }
    }
  
-@@ -48,8 +41,8 @@
+@@ -42,7 +35,7 @@
+     position: sticky;
+     /* Puts the anchored submit button in front of form elements that use bootstrap's .form-control,
+        which adds z-index of 2 (3 when focused) */
+-    z-index: @zindex-formplayer-anchored-submit;
++    z-index: $zindex-formplayer-anchored-submit;
+   }
+ 
+   // Bootstrap introduces -10px left/right margin for row classes. This causes element to overflow parent.
+@@ -51,8 +44,8 @@
      margin-right: 0px;
    }
    .question-container {
@@ -60,7 +69,7 @@
    }
  
    .form-group {
-@@ -61,8 +54,8 @@
+@@ -64,8 +57,8 @@
    }
  
    .group-body {
@@ -71,7 +80,7 @@
    }
  
    .gr.panel {
-@@ -94,7 +87,7 @@
+@@ -97,7 +90,7 @@
    }
  
    .panel-body {
@@ -80,7 +89,7 @@
        padding-left: 0px;
        padding-right: 0px;
      }
-@@ -103,19 +96,19 @@
+@@ -106,19 +99,19 @@
    .stripe-repeats {
      > .row, .panel-body > .children > .row {
        &:nth-of-type(odd) {
@@ -103,7 +112,7 @@
      border-radius: 8px;
      margin: 2px;
      padding-top: 5px;
-@@ -157,7 +150,7 @@
+@@ -160,7 +153,7 @@
    }
  
    .form-group.required {
@@ -112,7 +121,7 @@
      margin-bottom: 0;
      label:before {
        display: none;
-@@ -165,8 +158,8 @@
+@@ -168,8 +161,8 @@
    }
  
    .form-group.required.on {
@@ -123,7 +132,7 @@
      border-bottom: none;
      padding-top: 10px;
      padding-bottom: 10px;
-@@ -180,13 +173,13 @@
+@@ -183,13 +176,13 @@
    .form-group-required-label {
      display: block;
      opacity: 0;
@@ -139,7 +148,7 @@
      color: white;
      width: auto;
      line-height: 14px;
-@@ -265,3 +258,8 @@
+@@ -268,3 +261,8 @@
    padding-top: 0px !important;
    padding-bottom: 7px;
  }

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,123 +1,229 @@
+@@ -1,124 +1,229 @@
 -@import "@{b3-import-variables}";
 -
 -// Nunito Sans is used on dimagi.com and embedded in hqwebapp/base.html
@@ -198,6 +198,7 @@
 -@zindex-formplayer-progress:          990;
 -@zindex-cloudcare-debugger:           1005;
 -@zindex-formplayer-scroll-to-bottom:    5;
+-@zindex-formplayer-anchored-submit:     4;
 -
 -
 -@input-border-radius-large:       5px;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables_bootstrap3.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables_bootstrap3.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,123 +1,69 @@
+@@ -1,124 +1,70 @@
 -@import "@{b3-import-variables}";
 +/*
 +These are Boostrap 3 variables that were carried over in the
@@ -161,6 +161,7 @@
 -@zindex-formplayer-progress:          990;
 -@zindex-cloudcare-debugger:           1005;
 -@zindex-formplayer-scroll-to-bottom:    5;
+-@zindex-formplayer-anchored-submit:     4;
 +$zindex-navbar:                      1000;
 +$zindex-report-loading:               100;
 +$zindex-app-preview:                  998;
@@ -169,6 +170,7 @@
 +$zindex-formplayer-progress:          990;
 +$zindex-cloudcare-debugger:          1005;
 +$zindex-formplayer-scroll-to-bottom:    5;
++$zindex-formplayer-anchored-submit:     4;
 +$zindex-select2-results:             1056;  // higher than $zindex-modal so select2s can be used in modals
  
 -


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Fixes [USH-4564](https://dimagi.atlassian.net/browse/USH-4564), and puts the anchored submit button in front of a form's datetime field.

Before:

![Screenshot 2024-05-23 at 10 07 50 AM](https://github.com/dimagi/commcare-hq/assets/6729291/6c054fdf-77cb-4371-af92-2231a3cb9ed0)

After:

![Screenshot 2024-05-23 at 11 51 54 AM](https://github.com/dimagi/commcare-hq/assets/6729291/f8b1b721-33f3-4fec-a0e0-a8d304d4b82f)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The datetime field uses the Bootstrap class `form-control`, which adds a z-index of 2 (3 if focused). So this PR adds a z-index=4 to the sticky submit button.

Hoping I went about updating the different files related to the Bootstrap migration correctly, please feel free to correct me around that.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

WEB_APPS_ANCHORED_SUBMIT

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tested locally
- Only updated the z-index of a single element. It's hard to see any risks of the sticky submit button being at a layer closer to the front.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

QA does weekly testing of web apps UI. This should go through that before merged/deployed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4564]: https://dimagi.atlassian.net/browse/USH-4564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ