### PR TITLE
Change layout of new workflow form

### DIFF
--- a/corehq/apps/app_execution/forms.py
+++ b/corehq/apps/app_execution/forms.py
@@ -55,11 +55,17 @@ class AppWorkflowConfigForm(forms.ModelForm):
         self.helper.layout = crispy.Layout(
             crispy.Div(
                 crispy.Div(
-                    crispy.HTML("<p>&nbsp;</p>"),
                     *fields,
                     css_class="col",
                 ),
                 crispy.Div(
+                    "har_file",
+                    twbscrispy.StrictButton(
+                        "Populate workflow from HAR file",
+                        type='submit', css_class='btn-secondary', name="import_har", value="1",
+                        formnovalidate=True,
+                    ),
+                    crispy.HTML("<p>&nbsp;</p>"),
                     crispy.HTML("<p>Workflow:</p>"),
                     InlineField("workflow"),
                     css_class="col"
@@ -68,13 +74,6 @@ class AppWorkflowConfigForm(forms.ModelForm):
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton("Save", type='submit', css_class='btn-primary')
-            ),
-            "har_file",
-            hqcrispy.FormActions(
-                twbscrispy.StrictButton(
-                    "Import HAR", type='submit', css_class='btn-secondary', name="import_har", value="1",
-                    formnovalidate=True,
-                )
             ),
         )
 

--- a/corehq/apps/app_execution/forms.py
+++ b/corehq/apps/app_execution/forms.py
@@ -59,6 +59,8 @@ class AppWorkflowConfigForm(forms.ModelForm):
                     css_class="col",
                 ),
                 crispy.Div(
+                    crispy.HTML("<p>HAR file recording should start with the "
+                                "selection of the app (navigate_menu_start).</p>"),
                     "har_file",
                     twbscrispy.StrictButton(
                         "Populate workflow from HAR file",


### PR DESCRIPTION
## Product Description

* move the import button to the left
* rename it to "populate workflow" to make clear what it does.

![image](https://github.com/dimagi/commcare-hq/assets/1946138/9c7dbdc6-de79-46d5-8a9a-5f9644e38444)

## Technical Summary

Using the form the first time it was a bit confusing what the import that. I think the layout change makes it clearer

## Feature Flag

APP_TESTING

## Safety Assurance

### Safety story

Changes only impact the app testing feature. Tested locally

### Automated test coverage

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
