### PR TITLE
Add Tableau Config to Web User Invitation

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -524,7 +524,7 @@ class AdminInvitesUserForm(BaseLocationForm):
 
         self.helper.label_class = 'col-sm-3 col-md-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
-        self.helper.layout = crispy.Layout(
+        fields = [
             crispy.Fieldset(
                 gettext("Information for new Web User"),
                 crispy.Field(
@@ -534,11 +534,26 @@ class AdminInvitesUserForm(BaseLocationForm):
                 ),
                 'role',
                 'profile' if ('profile' in self.fields and len(self.fields['profile'].choices) > 0) else None,
-                'assigned_locations' if should_show_location else None,
-                'primary_location' if should_show_location else None,
-                'tableau_role' if 'tableau_role' in self.fields else None,
-                'tableau_group_indices' if 'tableau_group_indices' in self.fields else None
-            ),
+            )
+        ]
+        if should_show_location:
+            fields.append(
+                crispy.Fieldset(
+                    gettext("Location Settings"),
+                    'assigned_locations' if should_show_location else None,
+                    'primary_location' if should_show_location else None,
+                )
+            )
+        if self.can_edit_tableau_config:
+            fields.append(
+                crispy.Fieldset(
+                    gettext("Tableau Configuration"),
+                    'tableau_role' if 'tableau_role' in self.fields else None,
+                    'tableau_group_indices' if 'tableau_group_indices' in self.fields else None
+                ),
+            )
+        self.helper.layout = crispy.Layout(
+            *fields,
             crispy.HTML(
                 render_to_string(
                     'users/partials/confirm_trust_identity_provider_message.html',

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -590,7 +590,7 @@ class AdminInvitesUserForm(BaseLocationForm):
         cleaned_data = super(AdminInvitesUserForm, self).clean()
 
         if (('tableau_role' in cleaned_data or 'tableau_group_indices' in cleaned_data)
-        and self.can_edit_tableau_config):
+        and not self.can_edit_tableau_config):
             raise forms.ValidationError(_("You do not have permission to edit Tableau Configuraion."))
 
         if 'tableau_group_indices' in cleaned_data:

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -24,7 +24,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.utils.translation import mark_safe_lazy
 from corehq.apps.programs.models import Program
-from corehq.apps.users.forms import BaseLocationForm
+from corehq.apps.users.forms import BaseLocationForm, BaseTableauUserForm
 from corehq.apps.users.models import CouchUser
 
 
@@ -512,6 +512,9 @@ class AdminInvitesUserForm(BaseLocationForm):
                 choices = [('', '')] + list((prog.get_id, prog.name) for prog in programs)
                 self.fields['program'].choices = choices
         self.excluded_emails = excluded_emails or []
+
+        self._initialize_tableau_fields(data, domain)
+
         self.helper = FormHelper()
         self.helper.form_method = 'POST'
         self.helper.form_class = 'form-horizontal form-ko-validation'
@@ -530,6 +533,8 @@ class AdminInvitesUserForm(BaseLocationForm):
                 'profile' if ('profile' in self.fields and len(self.fields['profile'].choices) > 0) else None,
                 'assigned_locations' if should_show_location else None,
                 'primary_location' if should_show_location else None,
+                'tableau_role',
+                'tableau_group_ids'
             ),
             crispy.HTML(
                 render_to_string(
@@ -569,3 +574,10 @@ class AdminInvitesUserForm(BaseLocationForm):
             if isinstance(cleaned_data[field], str):
                 cleaned_data[field] = cleaned_data[field].strip()
         return cleaned_data
+
+    def _initialize_tableau_fields(self, data, domain):
+        tableau_form = BaseTableauUserForm(data, domain=domain)
+        self.fields['tableau_group_ids'] = tableau_form.fields["groups"]
+        self.fields['tableau_group_ids'].label = _('Tableau Groups')
+        self.fields['tableau_role'] = tableau_form.fields['role']
+        self.fields['tableau_role'].label = _('Tableau Role')

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -540,16 +540,16 @@ class AdminInvitesUserForm(BaseLocationForm):
             fields.append(
                 crispy.Fieldset(
                     gettext("Location Settings"),
-                    'assigned_locations' if should_show_location else None,
-                    'primary_location' if should_show_location else None,
+                    'assigned_locations',
+                    'primary_location',
                 )
             )
         if self.can_edit_tableau_config:
             fields.append(
                 crispy.Fieldset(
                     gettext("Tableau Configuration"),
-                    'tableau_role' if 'tableau_role' in self.fields else None,
-                    'tableau_group_indices' if 'tableau_group_indices' in self.fields else None
+                    'tableau_role',
+                    'tableau_group_indices' if len(self.fields['tableau_group_indices'].choices) > 0 else None
                 ),
             )
         self.helper.layout = crispy.Layout(

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -50,6 +50,7 @@ from corehq.apps.reports.util import (
     get_allowed_tableau_groups_for_domain,
     get_tableau_groups_for_user,
     update_tableau_user,
+    DEFAULT_TABLEAU_ROLE,
 )
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils.request_helpers import is_request_using_sso
@@ -1767,6 +1768,7 @@ class BaseTableauUserForm(forms.Form):
         label=gettext_noop("Role"),
         choices=TableauUser.Roles.choices,
         required=True,
+        initial=DEFAULT_TABLEAU_ROLE,
     )
     groups = forms.MultipleChoiceField(
         label=gettext_noop("Groups"),

--- a/corehq/apps/users/management/commands/accept_invite.py
+++ b/corehq/apps/users/management/commands/accept_invite.py
@@ -29,7 +29,9 @@ class Command(BaseCommand):
                             assigned_location_ids=list(
                                 invitation.assigned_locations.all().values_list('location_id', flat=True)),
                             program_id=invitation.program,
-                            profile=invitation.profile)
+                            profile=invitation.profile,
+                            tableau_role=invitation.tableau_role,
+                            tableau_group_ids=invitation.tableau_group_ids)
         invitation.is_accepted = True
         invitation.save()
         print("Operation completed")

--- a/corehq/apps/users/templates/users/edit_web_user.html
+++ b/corehq/apps/users/templates/users/edit_web_user.html
@@ -108,7 +108,6 @@
       {% csrf_token %}
       <input type="hidden" name="form_type" value="tableau" />
       <fieldset>
-        <legend>{% trans 'Tableau Configuration' %}</legend>
         {% crispy tableau_form %}
       </fieldset>
       {% if not request.is_view_only and edit_user_tableau_config%}

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1107,6 +1107,8 @@ class InviteWebUserView(BaseManageWebUserView):
         initial = {
             'email': domain_request.email if domain_request else None,
         }
+        can_edit_tableau_config = (self.request.couch_user.has_permission(self.domain, 'edit_user_tableau_config')
+                                and toggles.TABLEAU_USER_SYNCING.enabled(self.domain))
         if self.request.method == 'POST':
             current_users = [user.username for user in WebUser.by_domain(self.domain)]
             pending_invites = [di.email for di in Invitation.by_domain(self.domain)]
@@ -1117,6 +1119,7 @@ class InviteWebUserView(BaseManageWebUserView):
                 domain=self.domain,
                 is_add_user=is_add_user,
                 should_show_location=self.request.project.uses_locations,
+                can_edit_tableau_config=can_edit_tableau_config,
                 request=self.request
             )
         return AdminInvitesUserForm(
@@ -1125,6 +1128,7 @@ class InviteWebUserView(BaseManageWebUserView):
             domain=self.domain,
             is_add_user=is_add_user,
             should_show_location=self.request.project.uses_locations,
+            can_edit_tableau_config=can_edit_tableau_config,
             request=self.request
         )
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1153,6 +1153,10 @@ class InviteWebUserView(BaseManageWebUserView):
             create_invitation = True
             data = self.invite_web_user_form.cleaned_data
             domain_request = DomainRequest.by_email(self.domain, data["email"])
+            profile_id = data.get("profile", None)
+            profile = CustomDataFieldsProfile.objects.get(
+                id=profile_id,
+                definition__domain=self.domain) if profile_id else None
             if domain_request is not None:
                 domain_request.is_approved = True
                 domain_request.save()
@@ -1164,6 +1168,7 @@ class InviteWebUserView(BaseManageWebUserView):
                                          primary_location_id=data.get("primary_location", None),
                                          program_id=data.get("program", None),
                                          assigned_location_ids=data.get("assigned_locations", None),
+                                         profile=profile
                                          )
                 messages.success(request, "%s added." % data["email"])
             else:
@@ -1184,10 +1189,7 @@ class InviteWebUserView(BaseManageWebUserView):
                 if primary_location_id:
                     assert primary_location_id in assigned_location_ids
                 self._assert_user_has_permission_to_access_locations(assigned_location_ids)
-                profile_id = data.get("profile", None)
-                data["profile"] = CustomDataFieldsProfile.objects.get(
-                    id=profile_id,
-                    definition__domain=self.domain) if profile_id else None
+                data["profile"] = profile
                 invite = Invitation(**data)
                 invite.save()
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1168,7 +1168,9 @@ class InviteWebUserView(BaseManageWebUserView):
                                          primary_location_id=data.get("primary_location", None),
                                          program_id=data.get("program", None),
                                          assigned_location_ids=data.get("assigned_locations", None),
-                                         profile=profile
+                                         profile=profile,
+                                         tableau_role=data.get("tableau_role", None),
+                                         tableau_group_ids=data.get("tableau_group_ids", None)
                                          )
                 messages.success(request, "%s added." % data["email"])
             else:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Adds header labels for sections and adds "Tableau Configuration" Section

![Screen Shot 2024-05-23 at 12 54 33 PM](https://github.com/dimagi/commcare-hq/assets/88759246/eba98f16-a4a8-4ec9-a05e-08e6edfb60b0)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira Ticket
](https://dimagi.atlassian.net/browse/USH-4452)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[Tableau User Syncing](https://www.commcarehq.org/hq/flags/edit/tableau_user_syncing/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Locally Tested, changes limited to Web User invite workflows. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests exists that `add_web_user` correctly creates Web User with Tableau configs defined in the Invitation.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[QA-6560](https://dimagi.atlassian.net/browse/QA-6560)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
-  [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[QA-6560]: https://dimagi.atlassian.net/browse/QA-6560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ