### PR TITLE
[B5] web apps: possibly the last cherry picks

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -126,7 +126,7 @@ hqDefine("cloudcare/js/formplayer/app", [
 
     FormplayerFrontend.on('clearForm', function () {
         $('#webforms').html("");
-        $('.menu-scrollable-container').removeClass('hide');
+        $('.menu-scrollable-container').removeClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
         $('#webforms-nav').html("");
         $('#cloudcare-debugger').html("");
         $('.atwho-container').remove();
@@ -291,7 +291,7 @@ hqDefine("cloudcare/js/formplayer/app", [
         };
         var sess = WebFormSession.WebFormSession(data);
         sess.renderFormXml(data, $('#webforms'));
-        $('.menu-scrollable-container').addClass('hide');
+        $('.menu-scrollable-container').addClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
     });
 
     FormplayerFrontend.on("start", function (model, options) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
@@ -31,14 +31,14 @@ hqDefine("cloudcare/js/formplayer/main", [
             $trialBanner = $('#cta-trial-banner');
         var hideMenu = function () {
             $menuToggle.data('minimized', 'yes');
-            $navbar.hide();
-            $trialBanner.hide();
+            $navbar.addClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
+            $trialBanner.addClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
             $menuToggle.text(gettext('Show Full Menu'));
         };
         var showMenu = function () {
             $menuToggle.data('minimized', 'no');
-            $navbar.show();
-            $trialBanner.show();
+            $navbar.removeClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
+            $trialBanner.removeClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
             $navbar.css('margin-top', '');
             $menuToggle.text(gettext('Hide Full Menu'));
         };

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -85,14 +85,15 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             e.preventDefault();
             const $playBtn = $(e.originalEvent.srcElement).closest('.js-module-audio-play');
             const $pauseBtn = $playBtn.parent().find('.js-module-audio-pause');
-            $pauseBtn.removeClass('hide');
-            $playBtn.addClass('hide');
+            const displayClass = window.USE_BOOTSTRAP5 ? "d-none" : "hide";
+            $pauseBtn.removeClass(displayClass);
+            $playBtn.addClass(displayClass);
             const $audioElem = $playBtn.parent().find('.js-module-audio');
             if ($audioElem.data('isFirstPlay') !== 'yes') {
                 $audioElem.data('isFirstPlay', 'yes');
                 $audioElem.one('ended', function () {
-                    $playBtn.removeClass('hide');
-                    $pauseBtn.addClass('hide');
+                    $playBtn.removeClass(displayClass);
+                    $pauseBtn.addClass(displayClass);
                     $audioElem.data('isFirstPlay', 'no');
                 });
             }
@@ -101,8 +102,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
         audioPause: function (e) {
             e.preventDefault();
             const $pauseBtn = $(e.originalEvent.srcElement).closest('.js-module-audio-pause');
-            $pauseBtn.parent().find('.js-module-audio-play').removeClass('hide');
-            $pauseBtn.addClass('hide');
+            const displayClass = window.USE_BOOTSTRAP5 ? "d-none" : "hide";
+            $pauseBtn.parent().find('.js-module-audio-play').removeClass(displayClass);
+            $pauseBtn.addClass(displayClass);
             $pauseBtn.parent().find('.js-module-audio').get(0).pause();
         },
         rowKeyAction: function (e) {
@@ -793,13 +795,14 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             const mapDiv = $('#module-case-list-map');
             const moduleCaseList = $('#module-case-list');
             const hideButton = $('#hide-map-button');
-            if (!mapDiv.hasClass('hide')) {
-                mapDiv.addClass('hide');
+            const displayClass = window.USE_BOOTSTRAP5 ? "d-none" : "hide";
+            if (!mapDiv.hasClass(displayClass)) {
+                mapDiv.addClass(displayClass);
                 moduleCaseList.removeClass('col-md-7 col-md-pull-5').addClass('col-md');
                 hideButton.text(gettext('Show Map'));
                 $(e.target).attr('aria-expanded', 'false');
             } else {
-                mapDiv.removeClass('hide');
+                mapDiv.removeClass(displayClass);
                 moduleCaseList.addClass('col-md-7 col-md-pull-5').removeClass('col-md');
                 hideButton.text(gettext('Hide Map'));
                 $(e.target).attr('aria-expanded', 'true');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -514,7 +514,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", [
                 }
             });
             if (this.model.get('hidden') === 'true') {
-                this.$el.hide();
+                this.$el.addClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
             }
         },
 

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/bootstrap5/settings_view.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/bootstrap5/settings_view.html
@@ -4,7 +4,7 @@
 <script type="text/template" id="settings-template">
   <div class="module-menu-container module-menu-bar-offset">
     <div class="page-header menu-header d-none d-md-block">
-      <h1 class="page-title">Settings</h1>
+      <h1 class="page-title">{% trans "Settings" %}</h1>
     </div>
     <table class="table module-table">
       <tbody>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/bootstrap5/menu_header.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/bootstrap5/menu_header.html
@@ -1,7 +1,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<div class="page-header menu-header d-none d-md-block clearfix" id="case-list-menu-header">
+<div class="page-header menu-header clearfix" id="case-list-menu-header">
   <div class="float-end">
     <% if (showMap) { %>
       <button id="hide-map-button" class="btn btn-primary float-end" type="button"
@@ -17,7 +17,7 @@
     <% } %>
   </div>
   <% if (title.length > 0) { %>
-    <h1  aria-label="<%- title %>" tabindex="0" class="page-title"><%- title %></h1>
+    <h1 aria-label="<%- title %>" tabindex="0" class="page-title d-none d-md-block"><%- title %></h1>
   <% } %>
   <% if (sidebarEnabled && description.length > 0) { %>
     <div aria-label="<%- description %>" tabindex="0" class="query-description"><%= description %></div>

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
@@ -19,8 +19,8 @@ hqDefine("hqwebapp/js/tempus_dominus", [
     // https://github.com/Eonasdan/tempus-dominus/discussions/2698
     window.Popper = Popper;
 
-    let createDatePicker = function (el, extraOptions) {
-        return new tempusDominus.TempusDominus(el, _.extend({
+    let createDatePicker = function (el, options) {
+        return new tempusDominus.TempusDominus(el, _addDefaultOptions(options, {
             display: {
                 theme: 'light',
                 components: {
@@ -30,7 +30,7 @@ hqDefine("hqwebapp/js/tempus_dominus", [
             localization: _.extend(defaultTranslations, {
                 format: 'yyyy-MM-dd',
             }),
-        }, extraOptions || {}));
+        }));
     };
 
     // This replaces createBootstrap3DefaultDateRangePicker in hqwebapp/js/daterangepicker.config
@@ -70,8 +70,8 @@ hqDefine("hqwebapp/js/tempus_dominus", [
         });
     };
 
-    let createTimePicker = function (el, extraOptions) {
-        return new tempusDominus.TempusDominus(el, _.extend({
+    let createTimePicker = function (el, options) {
+        return new tempusDominus.TempusDominus(el, _addDefaultOptions(options, {
             display: {
                 theme: 'light',
                 components: {
@@ -81,7 +81,30 @@ hqDefine("hqwebapp/js/tempus_dominus", [
             localization: _.extend(defaultTranslations, {
                 format: 'yyyy-MM-dd',
             }),
-        }, extraOptions || {}));
+        }));
+    };
+
+    // Combine user-passed TD options with default options.
+    // A shallow extend is insufficient because TD options can be nested.
+    // A truly generic deep extension is complex, so cheat based on what
+    // we know about TD options: it's an object, but at most two levels,
+    // and values are either primitives or objects, no arrays.
+    let _addDefaultOptions = function (options, defaults) {
+        options = options || {};
+        Object.keys(defaults).forEach((key) => {
+            if (!Object.hasOwn(options, key)) {
+                options[key] = defaults[key];
+            } else {
+                if (options[key] && typeof(options[key]) === "object") {
+                    Object.keys(defaults[key]).forEach((innerKey) => {
+                        if (!Object.hasOwn(options[key], innerKey)) {
+                            options[key][innerKey] = defaults[key][innerKey];
+                        }
+                    });
+                }
+            }
+        })
+        return options;
     };
 
     let getDateRangeSeparator = function () {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
@@ -79,7 +79,8 @@ hqDefine("hqwebapp/js/tempus_dominus", [
                 },
             },
             localization: _.extend(defaultTranslations, {
-                format: 'yyyy-MM-dd',
+                hourCycle: 'h23',
+                format: 'H:mm',
             }),
         }));
     };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
@@ -104,7 +104,7 @@ hqDefine("hqwebapp/js/tempus_dominus", [
                     });
                 }
             }
-        })
+        });
         return options;
     };
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/case_list/menu_header.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/case_list/menu_header.html.diff.txt
@@ -1,12 +1,10 @@
 --- 
 +++ 
-@@ -1,17 +1,17 @@
- {% load hq_shared_tags %}
+@@ -2,24 +2,24 @@
  {% load i18n %}
  
--<div class="page-header menu-header clearfix" id="case-list-menu-header">
+ <div class="page-header menu-header clearfix" id="case-list-menu-header">
 -  <div class="pull-right">
-+<div class="page-header menu-header d-none d-md-block clearfix" id="case-list-menu-header">
 +  <div class="float-end">
      <% if (showMap) { %>
 -      <button id="hide-map-button" class="btn btn-primary pull-right" type="button"
@@ -23,7 +21,11 @@
          {% trans "Refine search" %}
        </button>
      <% } %>
-@@ -22,4 +22,4 @@
+   </div>
+   <% if (title.length > 0) { %>
+-    <h1  aria-label="<%- title %>" tabindex="0" class="page-title"><%- title %></h1>
++    <h1 aria-label="<%- title %>" tabindex="0" class="page-title d-none d-md-block"><%- title %></h1>
+   <% } %>
    <% if (sidebarEnabled && description.length > 0) { %>
      <div aria-label="<%- description %>" tabindex="0" class="query-description"><%= description %></div>
    <% } %>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/settings_view.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/settings_view.html.diff.txt
@@ -1,14 +1,16 @@
 --- 
 +++ 
-@@ -3,7 +3,7 @@
+@@ -3,8 +3,8 @@
  
  <script type="text/template" id="settings-template">
    <div class="module-menu-container module-menu-bar-offset">
 -    <div class="page-header menu-header">
+-      <h1 class="page-title">Settings</h1>
 +    <div class="page-header menu-header d-none d-md-block">
-       <h1 class="page-title">Settings</h1>
++      <h1 class="page-title">{% trans "Settings" %}</h1>
      </div>
      <table class="table module-table">
+       <tbody>
 @@ -18,8 +18,14 @@
    </div>
  </script>


### PR DESCRIPTION
## Technical Summary
These may be the last cherry picks before the "real" PR turning on B5 in web apps, although I thought that about the last such PR.

## Safety Assurance

### Safety story
Most changes are all either to B5 files that aren't live, or they're minor javascript changes gated behind `window.USE_BOOTSTRAP5`, which is always false in production. There are a couple of bugs fixed in tempus dominus, which is used on a couple of B5 pages (data registries & the user API keys page).

### Automated test coverage

Little if any

### QA Plan

Not right now

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
