### PR TITLE
Removed bootstrap switch styles from app manager

### DIFF
--- a/corehq/apps/hqwebapp/static/app_manager/less/panel.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/panel.less
@@ -84,20 +84,6 @@
   &.build-latest-release {
     .box-shadow(0 0 10px fade(@cc-brand-mid, 40));
   }
-
-  .bootstrap-switch-handle-on.bootstrap-switch-primary {
-    background-color: @cc-brand-mid;
-  }
-  .bootstrap-switch-primary:focus {
-    border-color: @cc-brand-mid;
-  }
-  .bootstrap-switch.bootstrap-switch-mini .bootstrap-switch-handle-on,
-  .bootstrap-switch.bootstrap-switch-mini .bootstrap-switch-handle-off,
-  .bootstrap-switch.bootstrap-switch-mini .bootstrap-switch-label {
-    font-size: 10px;
-    text-transform: uppercase;
-    font-weight: 800;
-  }
 }
 
 .panel-release-title {


### PR DESCRIPTION
## Technical Summary
Dead code removal. This was added way back in https://github.com/dimagi/commcare-hq/commit/e423e2cc654df255584bf99380df49d283fb2af7, but this part of the no longer uses a switch. App manager doesn't even include `bootstrap-switch.css` anymore.

## Safety Assurance

### Safety story
Dead code removal. Dead styles, even less likely to cause a problem.

### Automated test coverage

no

### QA Plan

no


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
