### PR TITLE
Fix form submission report

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -96,10 +96,12 @@ class WorkerMonitoringReportTableBase(GenericTabularReport, ProjectReport, Proje
     exportable = True
 
     def get_user_link(self, user):
+        name = user.raw_username if hasattr(user, 'raw_username') else user.name
+
         if self._has_form_view_permission():
             user_link = self.get_raw_user_link(user)
-            name = user.raw_username if hasattr(user, 'raw_username') else user.name
             return self.table_cell(name, user_link)
+
         return self.table_cell(name)
 
     def _has_form_view_permission(self):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Fixes a bug introduced in https://github.com/dimagi/commcare-hq/pull/34464/files#diff-d2b81aadf1221913aff389d7fa5c948360eb836616a2c65b44bf2fb30fd307eaR101 that breaks the form submission report for users that don't have access to the submit history report.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3689

[Sentry link for error](https://dimagi.sentry.io/issues/5330203551/?environment=production&query=is%3Aunresolved+domain%3Agivedirectly-kenya&referrer=issue-stream&statsPeriod=24h&stream_index=1)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
A straight forward fix. Tested locally that report loads well after the change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
