### PR TITLE
[B5] reminders / keywords

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -88,6 +88,9 @@
   "notifications": {
     "in_progress": true
   },
+  "reminders": {
+    "is_complete": true
+  },
   "reports": {
     "in_progress": true
   },

--- a/corehq/apps/reminders/forms.py
+++ b/corehq/apps/reminders/forms.py
@@ -23,6 +23,7 @@ from dimagi.utils.django.fields import TrimmedCharField
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp import crispy as hqcrispy
+from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
 from corehq.apps.reminders.util import DotExpandedDict, get_form_list, split_combined_id
 from corehq.apps.sms.models import Keyword
 
@@ -128,9 +129,12 @@ class KeywordForm(Form):
     keyword = CharField(label=gettext_noop("Keyword"))
     description = TrimmedCharField(label=gettext_noop("Description"))
     override_open_sessions = BooleanField(
+        label="",
         required=False,
         initial=False,
-        label=gettext_noop("Override open SMS Surveys"),
+        widget=BootstrapCheckboxInput(
+            inline_label=gettext_lazy("Override open SMS Surveys"),
+        ),
     )
     allow_keyword_use_by = ChoiceField(
         required=False,
@@ -186,7 +190,10 @@ class KeywordForm(Form):
     )
     use_custom_delimiter = BooleanField(
         required=False,
-        label=gettext_noop("Use Custom Delimiter"),
+        label="",
+        widget=BootstrapCheckboxInput(
+            inline_label=gettext_lazy("Use Custom Delimiter"),
+        ),
     )
     delimiter = TrimmedCharField(
         required=False,
@@ -194,11 +201,17 @@ class KeywordForm(Form):
     )
     use_named_args_separator = BooleanField(
         required=False,
-        label=gettext_noop("Use Joining Character"),
+        label="",
+        widget=BootstrapCheckboxInput(
+            inline_label=gettext_lazy("Use Joining Character"),
+        ),
     )
     use_named_args = BooleanField(
         required=False,
-        label=gettext_noop("Use Named Answers"),
+        label="",
+        widget=BootstrapCheckboxInput(
+            inline_label=gettext_lazy("Use Named Answers"),
+        ),
     )
     named_args_separator = TrimmedCharField(
         required=False,
@@ -239,9 +252,8 @@ class KeywordForm(Form):
 
         from corehq.apps.reminders.views import KeywordsListView
         self.helper = FormHelper()
-        self.helper.form_class = "form form-horizontal"
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper.form_class = "form"
+        self.helper.label_class = "form-label"
 
         layout_fields = [
             crispy.Fieldset(
@@ -268,87 +280,58 @@ class KeywordForm(Form):
                         data_bind="value: structuredSmsAppAndFormUniqueId",
                         css_class="hqwebapp-select2",
                     ),
-                    hqcrispy.B3MultiField(
-                        _("Delimiters"),
-                        crispy.Div(
-                            crispy.Div(
-                                InlineField(
-                                    twbscrispy.PrependedText('use_custom_delimiter', '',
-                                                             data_bind="checked: useCustomDelimiter, "
-                                                                       "click: updateExampleStructuredSMS"),
-
-                                    block_css_class="span2",
-                                ),
-                                css_class='col-md-4 col-lg-4'
-                            ),
-                            crispy.Div(
-                                InlineField(
-                                    'delimiter',
-                                    data_bind="value: delimiter, "
-                                              "valueUpdate: 'afterkeydown', "
-                                              "event: {keyup: updateExampleStructuredSMS},"
-                                              "visible: useCustomDelimiter",
-                                    block_css_class="span4",
-                                ),
-                                css_class='col-md-4 col-lg-4'
-                            )
-
-                        ),
+                    twbscrispy.PrependedText('use_custom_delimiter', '',
+                                             data_bind="checked: useCustomDelimiter, "
+                                                       "click: updateExampleStructuredSMS"),
+                    InlineField(
+                        'delimiter',
+                        data_bind="value: delimiter, "
+                                  "valueUpdate: 'afterkeydown', "
+                                  "event: {keyup: updateExampleStructuredSMS},"
+                                  "visible: useCustomDelimiter",
+                        css_class="mb-3",
                     ),
-                    hqcrispy.B3MultiField(
-                        _("Named Answers"),
+                    twbscrispy.PrependedText('use_named_args', '',
+                                             data_bind="checked: useNamedArgs, "
+                                                       "click: updateExampleStructuredSMS"),
+                    hqcrispy.ErrorsOnlyField('named_args'),
+                    crispy.Div(
+                        data_bind="template: {"
+                                  " name: 'ko-template-named-args', "
+                                  " data: $data"
+                                  "}, "
+                                  "visible: useNamedArgs",
+                        css_class="mb-3",
+                    ),
+                    crispy.Div(
                         crispy.Div(
                             InlineField(
-                                twbscrispy.PrependedText('use_named_args', '',
-                                                         data_bind="checked: useNamedArgs, "
-                                                                   "click: updateExampleStructuredSMS"),
-
+                                twbscrispy.PrependedText(
+                                    'use_named_args_separator', '',
+                                    data_bind="checked: useNamedArgsSeparator, "
+                                              "click: updateExampleStructuredSMS"
+                                ),
                             ),
-                            css_class='col-md-4 col-lg-4'
                         ),
 
-                        hqcrispy.ErrorsOnlyField('named_args'),
                         crispy.Div(
-                            data_bind="template: {"
-                                      " name: 'ko-template-named-args', "
-                                      " data: $data"
-                                      "}, "
-                                      "visible: useNamedArgs",
-                        ),
-                    ),
-                    hqcrispy.B3MultiField(
-                        _("Joining Characters"),
-                        crispy.Div(
-                            crispy.Div(
-                                InlineField(
-                                    twbscrispy.PrependedText(
-                                        'use_named_args_separator', '',
-                                        data_bind="checked: useNamedArgsSeparator, "
-                                                  "click: updateExampleStructuredSMS"
-                                    ),
-                                ),
-                                css_class='col-md-4 col-lg-4'
+                            InlineField(
+                                'named_args_separator',
+                                data_bind="value: namedArgsSeparator, "
+                                          "valueUpdate: 'afterkeydown', "
+                                          "event: {keyup: updateExampleStructuredSMS},"
+                                          "visible: useJoiningCharacter",
                             ),
-
-                            crispy.Div(
-                                InlineField(
-                                    'named_args_separator',
-                                    data_bind="value: namedArgsSeparator, "
-                                              "valueUpdate: 'afterkeydown', "
-                                              "event: {keyup: updateExampleStructuredSMS},"
-                                              "visible: useJoiningCharacter",
-                                ),
-                                css_class='col-md-6 col-lg-4'
-                            )
-
                         ),
                         data_bind="visible: useNamedArgs",
+                        css_class="mb-3",
                     ),
                     hqcrispy.B3MultiField(
                         _("Example Structured Message"),
-                        crispy.HTML('<pre style="background: white;" '
+                        crispy.HTML('<span class="font-monospace badge rounded-pill bg-secondary" '
                                     'data-bind="text: exampleStructuredSms">'
                                     '</pre>'),
+                        css_class="mb-3",
                     ),
                     disabled=self.readonly,
                 ),
@@ -379,44 +362,41 @@ class KeywordForm(Form):
                     'other_recipient_content_type',
                     data_bind="value: otherRecipientContentType",
                 ),
-                hqcrispy.B3MultiField(
-                    "",
-                    crispy.Div(
-                        crispy.HTML(
-                            '<h4 style="margin-bottom: 20px;">%s</h4>'
-                            % _("Recipient Information"),
-                        ),
-                        crispy.Field(
-                            'other_recipient_type',
-                            data_bind="value: otherRecipientType",
-                        ),
-                        crispy.Div(
-                            crispy.Field(
-                                'other_recipient_id',
-                                data_bind="value: otherRecipientId",
-                            ),
-                            data_bind="visible: showRecipientGroup",
-                        ),
-                        crispy.Div(
-                            crispy.Field(
-                                'other_recipient_message',
-                                data_bind="value: otherRecipientMessage",
-                            ),
-                            data_bind="visible: otherRecipientContentType() == 'sms'",
-                        ),
-                        crispy.Div(
-                            crispy.Field(
-                                'other_recipient_app_and_form_unique_id',
-                                data_bind="value: otherRecipientAppAndFormUniqueId",
-                                css_class="hqwebapp-select2",
-                            ),
-                            data_bind="visible: otherRecipientContentType() == 'survey'",
-                        ),
-                        css_class="well",
-                        data_bind="visible: notifyOthers",
+                crispy.Div(
+                    crispy.HTML(
+                        '<h4>%s</h4>'
+                        % _("Recipient Information"),
                     ),
+                    crispy.Field(
+                        'other_recipient_type',
+                        data_bind="value: otherRecipientType",
+                    ),
+                    crispy.Div(
+                        crispy.Field(
+                            'other_recipient_id',
+                            data_bind="value: otherRecipientId",
+                        ),
+                        data_bind="visible: showRecipientGroup",
+                    ),
+                    crispy.Div(
+                        crispy.Field(
+                            'other_recipient_message',
+                            data_bind="value: otherRecipientMessage",
+                        ),
+                        data_bind="visible: otherRecipientContentType() == 'sms'",
+                    ),
+                    crispy.Div(
+                        crispy.Field(
+                            'other_recipient_app_and_form_unique_id',
+                            data_bind="value: otherRecipientAppAndFormUniqueId",
+                            css_class="hqwebapp-select2",
+                        ),
+                        data_bind="visible: otherRecipientContentType() == 'survey'",
+                    ),
+                    css_class="well",
+                    data_bind="visible: notifyOthers",
+                    disabled=self.readonly,
                 ),
-                disabled=self.readonly,
             ),
             crispy.Fieldset(
                 _("Advanced Options"),
@@ -427,16 +407,14 @@ class KeywordForm(Form):
                 'allow_keyword_use_by',
                 disabled=self.readonly,
             ),
-            hqcrispy.FormActions(
-                twbscrispy.StrictButton(
-                    _("Save"),
-                    css_class='btn-primary',
-                    type='submit',
-                    disabled=self.readonly,
-                ),
-                crispy.HTML('<a href="%s" class="btn btn-default">Cancel</a>'
-                            % reverse(KeywordsListView.urlname, args=[self.domain]))
+            twbscrispy.StrictButton(
+                _("Save"),
+                css_class='btn-primary',
+                type='submit',
+                disabled=self.readonly,
             ),
+            crispy.HTML('<a href="%s" class="btn btn-outline-primary">%s</a>'
+                        % (reverse(KeywordsListView.urlname, args=[self.domain]), _("Cancel")))
         ])
         self.helper.layout = crispy.Layout(*layout_fields)
 

--- a/corehq/apps/reminders/static/reminders/js/keywords_list.js
+++ b/corehq/apps/reminders/static/reminders/js/keywords_list.js
@@ -3,7 +3,7 @@ hqDefine('reminders/js/keywords_list', [
     "knockout",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/multiselect_utils",
-    "hqwebapp/js/bootstrap3/crud_paginated_list",
+    "hqwebapp/js/bootstrap5/crud_paginated_list",
 ], function ($, ko, initialPageData, multiselectUtils, CRUDPaginatedList) {
     $(function () {
         multiselectUtils.createFullMultiselectWidget('keyword-selector', {

--- a/corehq/apps/reminders/static/reminders/js/reminders.keywords.ko.js
+++ b/corehq/apps/reminders/static/reminders/js/reminders.keywords.ko.js
@@ -2,7 +2,7 @@ hqDefine("reminders/js/reminders.keywords.ko", [
     "jquery",
     "knockout",
     "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/bootstrap3/widgets",      // .hqwebapp-select2 for survey dropdown
+    "hqwebapp/js/bootstrap5/widgets",      // .hqwebapp-select2 for survey dropdown
 ], function (
     $,
     ko,

--- a/corehq/apps/reminders/templates/reminders/keyword.html
+++ b/corehq/apps/reminders/templates/reminders/keyword.html
@@ -1,18 +1,18 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main 'reminders/js/reminders.keywords.ko' %}
+{% requirejs_main_b5 'reminders/js/reminders.keywords.ko' %}
 
 {% block page_content %}
   {% initial_page_data 'current_values' form.current_values %}
   <div id="keywords-form">
-    {% crispy form %}
+    {% crispy form %}  {# todo B5: check crispy #}
   </div>
 
   <script type="text/html" id="ko-template-named-args">
-    <table class="table table-bordered table-striped col-md-6 col-lg-6">
+    <table class="table table-bordered table-striped col-lg-6 col-xl-6">
       <thead>
       <tr>
         <th>{% trans "Name" %}</th>
@@ -37,13 +37,13 @@
                               attr: {name : ('named_args.' + $index() + '.xpath')}
                               " /></td>
         <td><button type="button"
-                    class="btn btn-danger"
+                    class="btn btn-outline-danger"
                     data-bind="click: $parent.removeNamedArg">
           <i class="fa fa-remove"></i> {% trans "Remove" %}</button></td>
       </tr>
       </tbody>
     </table>
-    <button class="btn btn-primary pull-left"
+    <button class="btn btn-primary float-start"
             type="button"
             data-bind="click: addNamedArg">
       <i class="fa fa-plus"></i> {% trans 'Add Named Answer' %}

--- a/corehq/apps/reminders/templates/reminders/keyword.html
+++ b/corehq/apps/reminders/templates/reminders/keyword.html
@@ -8,7 +8,7 @@
 {% block page_content %}
   {% initial_page_data 'current_values' form.current_values %}
   <div id="keywords-form">
-    {% crispy form %}  {# todo B5: check crispy #}
+    {% crispy form %}
   </div>
 
   <script type="text/html" id="ko-template-named-args">
@@ -43,7 +43,7 @@
       </tr>
       </tbody>
     </table>
-    <button class="btn btn-primary float-start"
+    <button class="btn btn-outline-primary"
             type="button"
             data-bind="click: addNamedArg">
       <i class="fa fa-plus"></i> {% trans 'Add Named Answer' %}

--- a/corehq/apps/reminders/templates/reminders/keyword_list.html
+++ b/corehq/apps/reminders/templates/reminders/keyword_list.html
@@ -17,7 +17,7 @@
       <i class="fa fa-plus"></i>
       {% trans 'Add Keyword' %}
     </a>
-    <a href="{% url 'add_structured_keyword' domain %}" class="btn btn-primary">
+    <a href="{% url 'add_structured_keyword' domain %}" class="btn btn-primary mx-3">
       <i class="fa fa-plus"></i>
       {% trans 'Add Structured Keyword' %}
     </a>

--- a/corehq/apps/reminders/templates/reminders/keyword_list.html
+++ b/corehq/apps/reminders/templates/reminders/keyword_list.html
@@ -1,8 +1,8 @@
-{% extends 'hqwebapp/bootstrap3/base_paginated_crud.html' %}
+{% extends 'hqwebapp/bootstrap5/base_paginated_crud.html' %}
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "reminders/js/keywords_list" %}
+{% requirejs_main_b5 "reminders/js/keywords_list" %}
 
 {% block pagination_header %}
   <h2>{% trans 'Manage Keywords' %}</h2>
@@ -22,10 +22,10 @@
       {% trans 'Add Structured Keyword' %}
     </a>
 
-    <p class="pull-right ko-template" id="lock-container" data-bind="if: hasLinkedModels">
+    <p class="float-end ko-template" id="lock-container" data-bind="if: hasLinkedModels">
       <!-- ko if: allowEdit -->
         <!-- ko ifnot: unlockLinkedData -->
-          <button class="btn btn-primary" data-toggle="modal" data-target="#edit-warning-modal">
+          <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#edit-warning-modal">
             <i class="fa fa-link"></i>
             {% trans 'Unlock Linked Keywords For Me' %}
           </button>
@@ -57,7 +57,7 @@
 
 {% block pagination_templates %}
   <script type="text/html" id="keyword-row-template">
-    <td class="col-md-5">
+    <td class="col-lg-5">
       <span data-bind="ifnot: !upstream_id || $root.unlockLinkedData()">
         <a data-bind="attr: { href: viewUrl }, text: keyword"></a>
       </span>
@@ -65,18 +65,18 @@
         <a data-bind="attr: { href: editUrl }, text: keyword"></a>
       </span>
     </td>
-    <td class="col-md-5" data-bind="text: description"></td>
-    <td class="col-md-2">
+    <td class="col-lg-5" data-bind="text: description"></td>
+    <td class="col-lg-2">
 
-      <button type="button" class="btn btn-danger" data-toggle="modal"
+      <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal"
         data-bind="enable: !upstream_id || $root.unlockLinkedData(), attr: {'data-target': '#' + deleteModalId}">
          <i class="fa fa-remove"></i> {% trans 'Delete' %}</a>
       </button>
       <div class="modal fade" data-bind="attr: {id: deleteModalId}">
         <div class="modal-dialog">
           <div class="modal-content">
-            <div class="modal-header">
-              <a class="close" data-dismiss="modal">&times;</a>
+            <div class="modal-header">  {# todo B5: css:modal-header #}
+              <a class="btn-close" data-bs-dismiss="modal">&times;</a>  {# todo B5: css:close #}
               <h4>
                 {% blocktrans %}
                   Delete the keyword '<span data-bind="text: keyword"></span>'.
@@ -91,10 +91,10 @@
               </p>
             </div>
             <div class="modal-footer">
-              <a href="#" class="btn btn-danger delete-item-confirm">
+              <a href="#" class="btn btn-outline-danger delete-item-confirm">
                 <i class="fa fa-remove"></i> {% trans "Delete" %}
               </a>
-              <a href="#" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</a>
+              <a href="#" data-bs-dismiss="modal" class="btn btn-outline-primary">{% trans "Cancel" %}</a>
             </div>
           </div>
         </div>
@@ -107,11 +107,11 @@
     {% endif %}
   </script>
   <script type="text/html" id="keyword-deleted-template">
-    <td class="col-md-5">
+    <td class="col-lg-5">
       <a data-bind="text: keyword"></a>
     </td>
-    <td class="col-md-5" data-bind="text: description"></td>
-    <td class="col-md-2"><span class="label label-inverse">{% trans 'DELETED' %}</span></td>
+    <td class="col-lg-5" data-bind="text: description"></td>
+    <td class="col-lg-2"><span class="badge label-inverse">{% trans 'DELETED' %}</span></td>
   </script>
 {% endblock %}
 

--- a/corehq/apps/reminders/templates/reminders/keyword_list.html
+++ b/corehq/apps/reminders/templates/reminders/keyword_list.html
@@ -69,19 +69,19 @@
     <td class="col-lg-2">
 
       <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal"
-        data-bind="enable: !upstream_id || $root.unlockLinkedData(), attr: {'data-target': '#' + deleteModalId}">
+        data-bind="enable: !upstream_id || $root.unlockLinkedData(), attr: {'data-bs-target': '#' + deleteModalId}">
          <i class="fa fa-remove"></i> {% trans 'Delete' %}</a>
       </button>
       <div class="modal fade" data-bind="attr: {id: deleteModalId}">
         <div class="modal-dialog">
           <div class="modal-content">
-            <div class="modal-header">  {# todo B5: css:modal-header #}
-              <a class="btn-close" data-bs-dismiss="modal">&times;</a>  {# todo B5: css:close #}
+            <div class="modal-header">
               <h4>
                 {% blocktrans %}
                   Delete the keyword '<span data-bind="text: keyword"></span>'.
                 {% endblocktrans %}
               </h4>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans_html_attr "Close" %}"></button>
             </div>
             <div class="modal-body">
               <p>

--- a/corehq/apps/reminders/templates/reminders/partials/modal_edit.html
+++ b/corehq/apps/reminders/templates/reminders/partials/modal_edit.html
@@ -3,8 +3,8 @@
 <div class="modal fade" id="edit-warning-modal">
     <div class="modal-dialog">
         <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal">
+            <div class="modal-header">  {# todo B5: css:modal-header #}
+                <button type="button" class="btn-close" data-bs-dismiss="modal">  {# todo B5: css:close #}
                     <span aria-hidden="true">&times;</span>
                 </button>
                 <h3 class="modal-title">
@@ -19,7 +19,7 @@
                     and may also affect solutions on this project space.</p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-danger" data-dismiss="modal" data-bind="click: $root.toggleLinkedLock">{% trans "Unlock" %}</button>
+                <button type="button" class="btn btn-outline-danger" data-bs-dismiss="modal" data-bind="click: $root.toggleLinkedLock">{% trans "Unlock" %}</button>
             </div>
         </div>
     </div>

--- a/corehq/apps/reminders/templates/reminders/partials/modal_edit.html
+++ b/corehq/apps/reminders/templates/reminders/partials/modal_edit.html
@@ -1,22 +1,23 @@
+{% load hq_shared_tags %}
 {% load i18n %}
 
 <div class="modal fade" id="edit-warning-modal">
     <div class="modal-dialog">
         <div class="modal-content">
-            <div class="modal-header">  {# todo B5: css:modal-header #}
-                <button type="button" class="btn-close" data-bs-dismiss="modal">  {# todo B5: css:close #}
-                    <span aria-hidden="true">&times;</span>
-                </button>
-                <h3 class="modal-title">
+            <div class="modal-header">
+                <h4 class="modal-title">
                     <i class="fa fa-link"></i>
-                    Unlock Linked Keywords?
-                </h3>
+                    {% trans "Unlock Linked Keywords?" %}
+                </h4>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans_html_attr "Close" %}"></button>
             </div>
             <div class="modal-body">
+                {% blocktrans %}
                 <p>Linked Keywords are keywords that are controlled by a separate project space linked to this project.
                     Click here to learn more.</p>
                 <p>Changes made to Linked Keywords may be overwritten by the next updates from the linked project space,
                     and may also affect solutions on this project space.</p>
+                {% endblocktrans %}
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-outline-danger" data-bs-dismiss="modal" data-bind="click: $root.toggleLinkedLock">{% trans "Unlock" %}</button>

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -10,7 +10,7 @@ from memoized import memoized
 
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
-from corehq.apps.hqwebapp.decorators import use_multiselect
+from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_multiselect
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.reminders.forms import NO_RESPONSE, KeywordForm
 from corehq.apps.reminders.util import get_combined_id, split_combined_id
@@ -279,6 +279,7 @@ class KeywordsListView(BaseMessagingSectionView, CRUDPaginatedViewMixin):
     empty_notification = gettext_noop("You have no keywords. Please add one!")
     loading_message = gettext_noop("Loading keywords...")
 
+    @use_bootstrap5
     @use_multiselect
     @method_decorator(requires_privilege_with_fallback(privileges.INBOUND_SMS))
     def dispatch(self, *args, **kwargs):

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -24,6 +24,7 @@ class AddStructuredKeywordView(BaseMessagingSectionView):
     template_name = 'reminders/keyword.html'
     process_structured_message = True
 
+    @use_bootstrap5
     @method_decorator(requires_privilege_with_fallback(privileges.INBOUND_SMS))
     def dispatch(self, *args, **kwargs):
         return super(AddStructuredKeywordView, self).dispatch(*args, **kwargs)


### PR DESCRIPTION
## Product Description

| before | after |
| ------ | ----- |
| <img width="1168" alt="Screenshot 2024-05-28 at 4 14 45 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/c838173e-dd51-49cb-99ca-84a6b195bff1"> | <img width="1164" alt="Screenshot 2024-05-28 at 4 15 53 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/0becc51b-84e2-47f9-90fc-546e856bfe42"> |
| <img width="810" alt="Screenshot 2024-05-28 at 4 14 59 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/7e7e602b-2503-4733-bdc2-8c6190962d01"> | <img width="1168" alt="Screenshot 2024-05-28 at 4 16 10 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/8502a3c5-a66c-4953-a70c-552272b5375b"> |
| <img width="851" alt="Screenshot 2024-05-28 at 4 15 12 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/2dc05143-d211-42d4-b2a2-6652652290f5"> | <img width="1167" alt="Screenshot 2024-05-28 at 4 16 30 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/b3104a3f-b3b9-4d64-a4dd-4aa30c5dbd6d"> |
| <img width="866" alt="Screenshot 2024-05-28 at 4 15 18 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/eb38e11e-0653-45c1-9d18-a8bb54d616ac"> | <img width="1167" alt="Screenshot 2024-05-28 at 4 16 54 PM" src="https://github.com/dimagi/commcare-hq/assets/1486591/83bd966a-9ff5-413d-82fb-4b38e99c2a68"> |

## Safety Assurance

### Safety story
Risk should be limited to these pages. Sending through QA because the structured keyword form is intricate.

### Automated test coverage

Probably not much for the UI.

### QA Plan

https://dimagi.atlassian.net/browse/QA-6572

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
