### PR TITLE
Added simple logging to user role script

### DIFF
--- a/corehq/apps/users/management/commands/grant_web_apps_to_default_mobile_worker_role.py
+++ b/corehq/apps/users/management/commands/grant_web_apps_to_default_mobile_worker_role.py
@@ -1,7 +1,12 @@
+import logging
+
 from django.core.management.base import BaseCommand
 
 from corehq.apps.users.analytics import get_role_user_count
 from corehq.apps.users.models_role import Permission, UserRole
+
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -10,7 +15,11 @@ class Command(BaseCommand):
     def handle(self, **options):
         permission, created = Permission.objects.get_or_create(value='access_web_apps')
         roles_to_update = UserRole.objects.filter(is_commcare_user_default=True)
-        for role in roles_to_update:
+        total = roles_to_update.count()
+        logger.info(f"Found {total} roles to update")
+        for index, role in enumerate(roles_to_update):
+            if index % 100 == 0:
+                logger.info(f"Examining role {index} of {total}")
             permissions = role.permissions
             if not permissions.access_web_apps and not permissions.web_apps_list:
                 count = get_role_user_count(role.domain, role.couch_id, web_users_only=True)


### PR DESCRIPTION
## Technical Summary
Minor followup for https://github.com/dimagi/commcare-hq/pull/34544

There are ~1700 roles on staging, and the script ran in seconds. There are ~2000 on india, but ~80,000 on prod, so I'd like a bit of logging.

Planning to run this on india and prod after tomorrow's deploy, then merge https://github.com/dimagi/commcare-hq/pull/34545 after that.

## Safety Assurance

### Safety story
Minor logging change to engineering tool.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
