### PR TITLE
[B5] motech (connection settings pages)

### DIFF
--- a/corehq/motech/forms.py
+++ b/corehq/motech/forms.py
@@ -10,6 +10,7 @@ from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 
 from corehq.apps.hqwebapp import crispy as hqcrispy
+from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
 from corehq.motech.const import (
     AUTH_PRESETS,
     AUTH_TYPES,
@@ -59,9 +60,12 @@ class ConnectionSettingsForm(forms.ModelForm):
         required=False,
     )
     skip_cert_verify = forms.BooleanField(
-        label=_('Skip certificate verification'),
+        label="",
         help_text=_('Do not use in a production environment'),
         required=False,
+        widget=BootstrapCheckboxInput(
+            inline_label=_('Skip certificate verification'),
+        ),
     )
     notify_addresses_str = forms.CharField(
         label=_('Addresses to send notifications'),
@@ -150,20 +154,18 @@ class ConnectionSettingsForm(forms.ModelForm):
             twbscrispy.PrependedText('skip_cert_verify', ''),
             self.test_connection_button,
 
-            hqcrispy.FormActions(
-                twbscrispy.StrictButton(
-                    _("Save"),
-                    type="submit",
-                    css_class="btn btn-primary",
+            twbscrispy.StrictButton(
+                _("Save"),
+                type="submit",
+                css_class="btn btn-primary",
+            ),
+            hqcrispy.LinkButton(
+                _("Cancel"),
+                reverse(
+                    ConnectionSettingsListView.urlname,
+                    kwargs={'domain': self.domain},
                 ),
-                hqcrispy.LinkButton(
-                    _("Cancel"),
-                    reverse(
-                        ConnectionSettingsListView.urlname,
-                        kwargs={'domain': self.domain},
-                    ),
-                    css_class="btn btn-default",
-                ),
+                css_class="btn btn-outline-primary",
             ),
         )
 
@@ -177,11 +179,14 @@ class ConnectionSettingsForm(forms.ModelForm):
                     _('Test Connection'),
                     type='button',
                     css_id='test-connection-button',
-                    css_class='btn btn-default disabled',
+                    css_class='btn btn-outline-primary disabled mb-3',
                 ),
-                css_class=hqcrispy.CSS_ACTION_CLASS,
             ),
-            css_class='form-group'
+            crispy.Div(
+                "",
+                css_id='test-connection-result',
+                css_class='text-success d-none mb-3',
+            ),
         )
 
     def clean_notify_addresses_str(self):

--- a/corehq/motech/static/motech/js/connection_settings.js
+++ b/corehq/motech/static/motech/js/connection_settings.js
@@ -1,7 +1,7 @@
 "use strict";
 hqDefine("motech/js/connection_settings", [
-    "hqwebapp/js/bootstrap3/crud_paginated_list_init",
-    "hqwebapp/js/bootstrap3/widgets",
+    "hqwebapp/js/bootstrap5/crud_paginated_list_init",
+    "hqwebapp/js/bootstrap5/widgets",
 ], function () {
     // No page-specific logic, just need to collect the dependencies above
 });

--- a/corehq/motech/static/motech/js/connection_settings_detail.js
+++ b/corehq/motech/static/motech/js/connection_settings_detail.js
@@ -22,11 +22,11 @@ hqDefine("motech/js/connection_settings_detail", [
                 ];
             if (authPreset === 'CUSTOM') {
                 _.each(customAuthPresetFields, function (field) {
-                    $('#div_id_' + field).show();
+                    $('#div_id_' + field).removeClass("d-none");
                 });
             } else {
                 _.each(customAuthPresetFields, function (field) {
-                    $('#div_id_' + field).hide();
+                    $('#div_id_' + field).addClass("d-none");
                 });
             }
 
@@ -74,13 +74,13 @@ hqDefine("motech/js/connection_settings_detail", [
             _.each(_.pairs(allFields), function ([field, label]) {
                 let div = $('#div_id_' + field);
                 if (field in visible) {
-                    div.show();
+                    div.removeClass("d-none");
                     let label = visible[field] || allFields[field];
                     if (label) {
                         div.find('label').text(label);
                     }
                 } else {
-                    div.hide();
+                    div.addClass("d-none");
                 }
             });
         });
@@ -93,7 +93,7 @@ hqDefine("motech/js/connection_settings_detail", [
          */
         var handleSuccess = function (resp) {
             var message;
-            $testResult.removeClass("hide text-danger text-success");
+            $testResult.removeClass("d-none text-danger text-success");
             $testConnectionButton.enableButton();
 
             if (resp.status) {
@@ -114,7 +114,7 @@ hqDefine("motech/js/connection_settings_detail", [
         var handleFailure = function (resp) {
             $testConnectionButton.enableButton();
             $testResult
-                .removeClass("hide text-success")
+                .removeClass("d-none text-success")
                 .addClass("text-danger");
             $testResult.text(gettext(
                 'CommCare HQ was unable to make the request: '

--- a/corehq/motech/templates/motech/connection_settings.html
+++ b/corehq/motech/templates/motech/connection_settings.html
@@ -24,7 +24,7 @@
       <!-- ko ifnot: usedBy -->
       <button type="button"
               class="btn btn-outline-danger"
-              data-bind="attr: {'data-target': '#delete-connection-settings-' + id}"
+              data-bind="attr: {'data-bs-target': '#delete-connection-settings-' + id}"
               data-bs-toggle="modal">
         <i class="fa fa-remove"></i> {% trans "Delete" %}
       </button>
@@ -33,11 +33,11 @@
            data-bind="attr: {'id': 'delete-connection-settings-' + id}">
         <div class="modal-dialog">
           <div class="modal-content">
-            <div class="modal-header">  {# todo B5: css:modal-header #}
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-hidden="true">&times;</button>  {# todo B5: css:close #}
-              <h3>
+            <div class="modal-header">
+              <h4 class="modal-title">
                 {% trans "Delete Connection Settings" %} <strong data-bind="text: name"></strong>?
-              </h3>
+              </h4>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans_html_attr "Close" %}"></button>
             </div>
             <div class="modal-footer">
               <button type="button"

--- a/corehq/motech/templates/motech/connection_settings.html
+++ b/corehq/motech/templates/motech/connection_settings.html
@@ -45,9 +45,7 @@
                       data-bs-dismiss="modal">
                 {% trans "Cancel" %}
               </button>
-              <button type="button"
-                      class="btn btn-outline-danger delete-item-confirm"
-                      data-loading-text="{% trans 'Deleting Connection Settings' %}">  {# todo B5: stateful button #}
+              <button type="button" class="btn btn-outline-danger delete-item-confirm">
                 <i class="fa fa-remove"></i> {% trans "Delete" %}
               </button>
             </div>

--- a/corehq/motech/templates/motech/connection_settings.html
+++ b/corehq/motech/templates/motech/connection_settings.html
@@ -66,13 +66,9 @@
 {% endblock %}
 
 {% block pagination_footer %}
-  <div class="row" style="margin-top: 50px;">  {# todo B5: inline style #}
-    <div class="col-md-12">
-      <a href="{% url 'connection_settings_detail_view' domain %}">
-        <button type="button" class="btn btn-primary">
-          {% trans "Add Connection Settings" %}
-        </button>
-      </a>
-    </div>
-  </div>
+  <a href="{% url 'connection_settings_detail_view' domain %}">
+    <button type="button" class="btn btn-primary">
+      {% trans "Add Connection Settings" %}
+    </button>
+  </a>
 {% endblock %}

--- a/corehq/motech/templates/motech/connection_settings.html
+++ b/corehq/motech/templates/motech/connection_settings.html
@@ -1,8 +1,8 @@
-{% extends 'hqwebapp/bootstrap3/base_paginated_crud.html' %}
+{% extends 'hqwebapp/bootstrap5/base_paginated_crud.html' %}
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "motech/js/connection_settings" %}
+{% requirejs_main_b5 "motech/js/connection_settings" %}
 
 {% block pagination_header %}
   <h2>{% trans "Connection Settings" %}</h2>
@@ -23,9 +23,9 @@
       <!-- /ko -->
       <!-- ko ifnot: usedBy -->
       <button type="button"
-              class="btn btn-danger"
+              class="btn btn-outline-danger"
               data-bind="attr: {'data-target': '#delete-connection-settings-' + id}"
-              data-toggle="modal">
+              data-bs-toggle="modal">
         <i class="fa fa-remove"></i> {% trans "Delete" %}
       </button>
       <!-- /ko -->
@@ -33,21 +33,21 @@
            data-bind="attr: {'id': 'delete-connection-settings-' + id}">
         <div class="modal-dialog">
           <div class="modal-content">
-            <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+            <div class="modal-header">  {# todo B5: css:modal-header #}
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-hidden="true">&times;</button>  {# todo B5: css:close #}
               <h3>
                 {% trans "Delete Connection Settings" %} <strong data-bind="text: name"></strong>?
               </h3>
             </div>
             <div class="modal-footer">
               <button type="button"
-                      class="btn btn-default"
-                      data-dismiss="modal">
+                      class="btn btn-outline-primary"
+                      data-bs-dismiss="modal">
                 {% trans "Cancel" %}
               </button>
               <button type="button"
-                      class="btn btn-danger delete-item-confirm"
-                      data-loading-text="{% trans 'Deleting Connection Settings' %}">
+                      class="btn btn-outline-danger delete-item-confirm"
+                      data-loading-text="{% trans 'Deleting Connection Settings' %}">  {# todo B5: stateful button #}
                 <i class="fa fa-remove"></i> {% trans "Delete" %}
               </button>
             </div>
@@ -66,8 +66,8 @@
 {% endblock %}
 
 {% block pagination_footer %}
-  <div class="row" style="margin-top: 50px;">
-    <div class="col-sm-12">
+  <div class="row" style="margin-top: 50px;">  {# todo B5: inline style #}
+    <div class="col-md-12">
       <a href="{% url 'connection_settings_detail_view' domain %}">
         <button type="button" class="btn btn-primary">
           {% trans "Add Connection Settings" %}

--- a/corehq/motech/templates/motech/connection_settings_detail.html
+++ b/corehq/motech/templates/motech/connection_settings_detail.html
@@ -11,13 +11,6 @@
   <h2>{% trans "Add Connection Settings" %}</h2>
   <div class="spacer"></div>
 
-  {% crispy form %}  {# todo B5: check crispy #}
-
-  {# crispy.CSS_ACTION_CLASS to match the "Test Connection" button #}
-  <div class="col-sm-12 col-md-8 col-lg-8 col-xl-6
-              offset-md-4 offset-lg-4 offset-xl-2">
-    <div id="test-connection-result"
-         class="text-success d-none"></div>
-  </div>
+  {% crispy form %}
 
 {% endblock %}

--- a/corehq/motech/templates/motech/connection_settings_detail.html
+++ b/corehq/motech/templates/motech/connection_settings_detail.html
@@ -1,9 +1,9 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main "motech/js/connection_settings_detail" %}
+{% requirejs_main_b5 "motech/js/connection_settings_detail" %}
 
 {% block page_content %}
   {% registerurl "test_connection_settings" domain %}
@@ -11,13 +11,13 @@
   <h2>{% trans "Add Connection Settings" %}</h2>
   <div class="spacer"></div>
 
-  {% crispy form %}
+  {% crispy form %}  {# todo B5: check crispy #}
 
   {# crispy.CSS_ACTION_CLASS to match the "Test Connection" button #}
-  <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6
-              col-sm-offset-4 col-md-offset-4 col-lg-offset-2">
+  <div class="col-sm-12 col-md-8 col-lg-8 col-xl-6
+              offset-md-4 offset-lg-4 offset-xl-2">
     <div id="test-connection-result"
-         class="text-success hide"></div>
+         class="text-success d-none"></div>
   </div>
 
 {% endblock %}

--- a/corehq/motech/templates/motech/log_detail.html
+++ b/corehq/motech/templates/motech/log_detail.html
@@ -1,4 +1,4 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load hq_shared_tags %}
 {% load i18n %}
 
@@ -71,7 +71,7 @@
         </table>
       </div>
       <p>
-        <a class="btn btn-default" href="javascript:history.back()">Back</a>
+        <a class="btn btn-outline-primary" href="javascript:history.back()">Back</a>
       </p>
 
     </fieldset>

--- a/corehq/motech/templates/motech/logs.html
+++ b/corehq/motech/templates/motech/logs.html
@@ -1,13 +1,13 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load hq_shared_tags %}
 {% load i18n %}
 
 {% block page_content %}
   <fieldset>
     <legend>{% trans "Remote API Logs" %}</legend>
-    <div class="form-group">
+    <div class="form-group">  {# todo B5: css:form-group #}
       <form method="GET">
-        <span class="col-sm-2">
+        <span class="col-md-2">
           <label for="filter_from_date">From date*</label>
           <input id="filter_from_date"
                  class="form-control"
@@ -17,7 +17,7 @@
                  placeholder="yyyy-mm-dd" />
         </span>
 
-        <span class="col-sm-2">
+        <span class="col-md-2">
           <label for="filter_to_date">To date</label>
           <input id="filter_to_date"
                  class="form-control"
@@ -27,7 +27,7 @@
                  placeholder="yyyy-mm-dd" />
         </span>
 
-        <span class="col-sm-2">
+        <span class="col-md-2">
           <label for="filter_payload">Payload</label>
           <input id="filter_payload"
                  class="form-control"
@@ -36,7 +36,7 @@
                  value="{{ filter_payload }}" />
         </span>
 
-        <span class="col-sm-3">
+        <span class="col-md-3">
           <label for="filter_url">URL starts with</label>
           <input id="filter_url"
                  class="form-control"
@@ -46,7 +46,7 @@
                  placeholder="http..." />
         </span>
 
-        <span class="col-sm-1">
+        <span class="col-md-1">
           <label for="filter_status">Status</label>
           <input id="filter_status"
                  class="form-control"
@@ -56,7 +56,7 @@
                  placeholder="2xx" />
         </span>
 
-        <span class="col-sm-1">
+        <span class="col-md-1">
           <label for="submit_button">&nbsp;</label>
           <input id="submit_button"
                  class="form-control btn btn-primary"
@@ -65,10 +65,10 @@
                  value="Filter"/>
         </span>
 
-        <span class="col-sm-1">
+        <span class="col-md-1">
           <label for="export_button">&nbsp;</label>
           <input id="export_button"
-                 class="form-control btn btn-default"
+                 class="form-control btn btn-outline-primary"
                  type="submit"
                  name="export_button"
                  formaction="{% url 'motech_log_export_view' domain %}"
@@ -92,16 +92,16 @@
       <tbody>
       {% for log in logs %}
         <tr>
-          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">
+          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">  {# todo B5: inline style #}
             {{ log.timestamp }}
           </a></td>
-          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">
+          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">  {# todo B5: inline style #}
             {% if log.payload_id %}{{ log.payload_id }}{% else %}&nbsp;{% endif %}
           </a></td>
-          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">
+          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">  {# todo B5: inline style #}
             {{ log.request_method }} {{ log.request_url }}
           </a></td>
-          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">
+          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">  {# todo B5: inline style #}
             {{ log.response_status }}
           </a></td>
         </tr>
@@ -110,7 +110,7 @@
     </table>
 
     {% if is_paginated %}
-    <div class="col-sm-10">
+    <div class="col-md-10">
       <span>
           {% if page_obj.has_previous %}
             [<a href="?{% url_replace 'page' page_obj.previous_page_number %}">Previous</a>]

--- a/corehq/motech/templates/motech/logs.html
+++ b/corehq/motech/templates/motech/logs.html
@@ -5,8 +5,8 @@
 {% block page_content %}
   <fieldset>
     <legend>{% trans "Remote API Logs" %}</legend>
-    <div class="form-group">  {# todo B5: css:form-group #}
-      <form method="GET">
+    <form method="GET">
+      <div class="row">
         <span class="col-md-2">
           <label for="filter_from_date">From date*</label>
           <input id="filter_from_date"
@@ -74,8 +74,8 @@
                  formaction="{% url 'motech_log_export_view' domain %}"
                  value="Export"/>
         </span>
-      </form>
-    </div>
+      </div>
+    </form>
   </fieldset>
   <div class="spacer"></div>
 
@@ -92,16 +92,16 @@
       <tbody>
       {% for log in logs %}
         <tr>
-          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">  {# todo B5: inline style #}
+          <td><a href="{% url 'motech_log_detail_view' domain log.id %}">
             {{ log.timestamp }}
           </a></td>
-          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">  {# todo B5: inline style #}
+          <td><a href="{% url 'motech_log_detail_view' domain log.id %}">
             {% if log.payload_id %}{{ log.payload_id }}{% else %}&nbsp;{% endif %}
           </a></td>
-          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">  {# todo B5: inline style #}
+          <td><a href="{% url 'motech_log_detail_view' domain log.id %}">
             {{ log.request_method }} {{ log.request_url }}
           </a></td>
-          <td><a href="{% url 'motech_log_detail_view' domain log.id %}" style="display: block;">  {# todo B5: inline style #}
+          <td><a href="{% url 'motech_log_detail_view' domain log.id %}">
             {{ log.response_status }}
           </a></td>
         </tr>

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -37,6 +37,7 @@ class Http409(Http400):
     message = "Resource is in use."
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 @method_decorator(require_permission(HqPermissions.edit_motech), name='dispatch')
 class MotechLogListView(BaseProjectSettingsView, ListView):
     urlname = 'motech_log_list_view'

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -187,6 +187,7 @@ class ConnectionSettingsListView(BaseProjectSettingsView, CRUDPaginatedViewMixin
     page_title = _('Connection Settings')
     template_name = 'motech/connection_settings.html'
 
+    @use_bootstrap5
     @method_decorator(require_permission(HqPermissions.edit_motech))
     def dispatch(self, request, *args, **kwargs):
         if has_privilege(request, privileges.DATA_FORWARDING):

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -18,6 +18,7 @@ from requests import RequestException
 from corehq import privileges
 from corehq.apps.domain.decorators import login_or_api_key
 from corehq.apps.domain.views.settings import BaseProjectSettingsView
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.doc_info import get_doc_info
 from corehq.apps.hqwebapp.doc_lookup import lookup_doc_id
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
@@ -71,6 +72,7 @@ class MotechLogListView(BaseProjectSettingsView, ListView):
         return self.get_queryset()
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 @method_decorator(require_permission(HqPermissions.edit_motech), name='dispatch')
 class MotechLogDetailView(BaseProjectSettingsView, DetailView):
     urlname = 'motech_log_detail_view'

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -264,6 +264,7 @@ class ConnectionSettingsDetailView(BaseProjectSettingsView, ModelFormMixin, Proc
     model = ConnectionSettings
     form_class = ConnectionSettingsForm
 
+    @use_bootstrap5
     @method_decorator(require_permission(HqPermissions.edit_motech))
     def dispatch(self, request, *args, **kwargs):
         if has_privilege(request, privileges.DATA_FORWARDING):


### PR DESCRIPTION
## Product Description
This is a pretty small one.
| before | after |
| ------ | ----- |
| ![Screenshot 2024-05-29 at 4 07 08 PM](https://github.com/dimagi/commcare-hq/assets/1486591/5defa382-6f7b-44fb-a598-8ac4f5193467) | ![Screenshot 2024-05-29 at 4 06 10 PM](https://github.com/dimagi/commcare-hq/assets/1486591/729795ca-be0a-44c1-b0aa-2ec1cbcae27e) |
| ![Screenshot 2024-05-29 at 4 07 02 PM](https://github.com/dimagi/commcare-hq/assets/1486591/19374bcc-3ce0-4082-96df-55a6fc4da2ff) | ![Screenshot 2024-05-29 at 4 06 21 PM](https://github.com/dimagi/commcare-hq/assets/1486591/1fe7452f-7a54-46f7-be70-095247c6a746) |
| ![Screenshot 2024-05-29 at 4 07 15 PM](https://github.com/dimagi/commcare-hq/assets/1486591/d922957c-484d-40ac-ac81-8d1581d64e59) | ![Screenshot 2024-05-29 at 4 06 33 PM](https://github.com/dimagi/commcare-hq/assets/1486591/b8d92f24-af1c-4382-8e5f-1eb6a38beec0) |

Not marking this complete in the bootstrap diff config because this app isn't recognized by the tool, it's a weird directory structure.

## Safety Assurance

### Safety story
These are fairly minor, localized changes. Risk is limited to these pages. I've done local testing of the page-specific javascript (testing the connection, showing/hiding inputs based on auth type, filtering logs).

### Automated test coverage

Not at the UI level

### QA Plan

Not requesting QA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
