### PR TITLE
[B5] motech: generic inbound (except for report page)

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/field_with_addons.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/field_with_addons.html
@@ -5,7 +5,7 @@
 {% else %}
     <div
         id="div_{{ field.auto_id }}"
-        class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} error has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}"
+        class="mb-3{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} error has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}"
     >
         {% if field.label and form_show_labels %}
             <div class="control-label {{ label_class }} {% if field.field.required %}requiredField{% endif %}">
@@ -17,9 +17,9 @@
 
         <div class="controls {{ field_class }}">
           {% if pre_addon or post_addon %}<div class="input-group">{% endif %}
-            {% if pre_addon %}<div class="input-group-addon">{{ pre_addon }}</div>{% endif %}
+            {% if pre_addon %}<span class="input-group-text">{{ pre_addon }}</span>{% endif %}
             {% crispy_field field 'class' 'form-control' %}
-            {% if post_addon %}<div class="input-group-addon">{{ post_addon }}</div>{% endif %}
+            {% if post_addon %}<span class="input-group-text">{{ post_addon }}</span>{% endif %}
           {% if pre_addon or post_addon %}</div>{% endif %}
           {% include 'bootstrap3to5/layout/help_text_and_errors.html' %}
         </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/crispy/field_with_addons.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/crispy/field_with_addons.html.diff.txt
@@ -1,0 +1,23 @@
+--- 
++++ 
+@@ -5,7 +5,7 @@
+ {% else %}
+     <div
+         id="div_{{ field.auto_id }}"
+-        class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} error has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}"
++        class="mb-3{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} error has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}"
+     >
+         {% if field.label and form_show_labels %}
+             <div class="control-label {{ label_class }} {% if field.field.required %}requiredField{% endif %}">
+@@ -17,9 +17,9 @@
+ 
+         <div class="controls {{ field_class }}">
+           {% if pre_addon or post_addon %}<div class="input-group">{% endif %}
+-            {% if pre_addon %}<div class="input-group-addon">{{ pre_addon }}</div>{% endif %}
++            {% if pre_addon %}<span class="input-group-text">{{ pre_addon }}</span>{% endif %}
+             {% crispy_field field 'class' 'form-control' %}
+-            {% if post_addon %}<div class="input-group-addon">{{ post_addon }}</div>{% endif %}
++            {% if post_addon %}<span class="input-group-text">{{ post_addon }}</span>{% endif %}
+           {% if pre_addon or post_addon %}</div>{% endif %}
+           {% include 'bootstrap3to5/layout/help_text_and_errors.html' %}
+         </div>

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -68,17 +68,7 @@
     "is_complete": true
   },
   "motech.generic_inbound": {
-    "in_progress": true,
-    "templates": [
-        "api_edit.html",
-        "api_list.html"
-    ],
-    "javascript": [
-        "js/api_edit.js",
-        "js/api_list.js",
-        "js/copy_data.js",
-        "js/manage_links.js"
-    ]
+    "is_complete": true
   },
   "user_importer": {
     "is_complete": true

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -74,8 +74,10 @@
         "api_list.html"
     ],
     "javascript": [
+        "js/api_edit.js",
         "js/api_list.js",
-        "js/copy_data.js"
+        "js/copy_data.js",
+        "js/manage_links.js"
     ]
   },
   "user_importer": {

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -67,6 +67,17 @@
   "registry": {
     "is_complete": true
   },
+  "motech.generic_inbound": {
+    "in_progress": true,
+    "templates": [
+        "api_edit.html",
+        "api_list.html"
+    ],
+    "javascript": [
+        "js/api_list.js",
+        "js/copy_data.js"
+    ]
+  },
   "user_importer": {
     "is_complete": true
   },

--- a/corehq/motech/generic_inbound/reports.py
+++ b/corehq/motech/generic_inbound/reports.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy
 
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.views import BaseProjectSettingsView
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.dispatcher import DomainReportDispatcher
 from corehq.apps.reports.filters.base import BaseMultipleOptionFilter
@@ -117,6 +118,7 @@ def _to_link(log):
     )
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 @method_decorator([GENERIC_INBOUND_API.required_decorator(), domain_admin_required], name='dispatch')
 class ApiLogDetailView(BaseProjectSettingsView):
     page_title = gettext_lazy("API Request Log")

--- a/corehq/motech/generic_inbound/static/generic_inbound/js/api_list.js
+++ b/corehq/motech/generic_inbound/static/generic_inbound/js/api_list.js
@@ -1,5 +1,5 @@
 hqDefine('generic_inbound/js/api_list', [
-    "hqwebapp/js/bootstrap3/crud_paginated_list_init",
+    "hqwebapp/js/bootstrap5/crud_paginated_list_init",
     "generic_inbound/js/copy_data",
     "generic_inbound/js/manage_links",
 ], function () {

--- a/corehq/motech/generic_inbound/static/generic_inbound/js/copy_data.js
+++ b/corehq/motech/generic_inbound/static/generic_inbound/js/copy_data.js
@@ -1,5 +1,5 @@
 hqDefine('generic_inbound/js/copy_data', [
-    'hqwebapp/js/bootstrap3/alert_user',
+    'hqwebapp/js/bootstrap5/alert_user',
 ], function (alertUserModule) {
     let alertUser = alertUserModule.alert_user;
 

--- a/corehq/motech/generic_inbound/templates/generic_inbound/api_edit.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/api_edit.html
@@ -12,108 +12,94 @@
 {% registerurl 'edit_ucr_expression' domain '---' %}
 {% registerurl 'ucr_expressions' domain %}
 <div id="edit-api">
-  <div class="row">
-    <div class="col-sm-12 col-md-10 col-lg-8 col-xl-8">
-      <div class="form-group">  {# todo B5: css:form-group #}
-        <label class="form-label col-sm-12 col-md-4 col-lg-4 col-xl-2">
-          {% trans "URL" %}
-        </label>
-        <div class="controls col-sm-12 col-md-8 col-lg-8 col-xl-6">
-          <pre id="api_url">{{ api_model.absolute_url }}</pre>
-          <a class="btn btn-outline-primary" onclick="copyData('api_url')">
-            <i class="fa fa-copy"></i> {% trans "Copy URL" %}
-          </a>
-        </div>
-      </div>
-    </div>
+  <div class="mb-3">
+    <pre id="api_url">{{ api_model.absolute_url }}</pre>
+    <a class="btn btn-outline-primary" onclick="copyData('api_url')">
+      <i class="fa fa-copy"></i> {% trans "Copy URL" %}
+    </a>
   </div>
   <div class="spacer"></div>
-  <div class="row">
-    <div class="col-sm-12 col-md-10 col-lg-8 col-xl-8">
-      <form class="form-horizontal" method="post" id="edit-api" data-bind="submit: validateForm">
-        {% crispy form %}  {# todo B5: check crispy #}
-        <div class="spacer"></div>
-        <fieldset data-bind="with: validations">
-          <legend>{% translate "Validation Expressions" %}</legend>
-        <table class="table table-striped table-hover">
-          <thead>
-            <tr>
-              <th class="col-md-2">{% translate "Name" %}</th>
-              <th class="col-md-4">{% translate "Expression" %}</th>
-              <th class="col-md-4">{% translate "Message" %}</th>
-              <th class="col-md-2">{% translate "Delete" %}</th>
-            </tr>
-          </thead>
-          <tbody data-bind="foreach: models">
-            <tr>
-              <td data-bind="css: {'has-error': nameError}">  {# todo B5: css:has-error #}
-                <input type="hidden" data-bind="value: id, attr: {name: `validations-${$index()}-id`}">
-                <input type="hidden" value="{{ api_model.id }}" data-bind="attr: {name: `validations-${$index()}-api`}">
-                <input type="text" maxlength="64" class="textinput textInput form-control" required data-bind="
-                  value: name, attr: {name: `validations-${$index()}-name`}">
-                <span class='help-block' data-bind="visible: nameError">
-                  {% translate "Name is required and must be less than 64 characters" %}
+  <div class="mb-3">
+    <form method="post" id="edit-api" data-bind="submit: validateForm">
+      {% crispy form %}
+      <fieldset class="my-3" data-bind="with: validations">
+        <legend>{% translate "Validation Expressions" %}</legend>
+      <table class="table table-striped table-hover">
+        <thead>
+          <tr>
+            <th class="col-md-2">{% translate "Name" %}</th>
+            <th class="col-md-4">{% translate "Expression" %}</th>
+            <th class="col-md-4">{% translate "Message" %}</th>
+            <th class="col-md-2">{% translate "Delete" %}</th>
+          </tr>
+        </thead>
+        <tbody data-bind="foreach: models">
+          <tr>
+            <td>
+              <input type="hidden" data-bind="value: id, attr: {name: `validations-${$index()}-id`}">
+              <input type="hidden" value="{{ api_model.id }}" data-bind="attr: {name: `validations-${$index()}-api`}">
+              <input type="text" maxlength="64" class="textinput textInput form-control" required data-bind="
+                value: name, attr: {name: `validations-${$index()}-name`}, css: {'is-invalid': nameError}">
+              <span data-bind="visible: nameError, css: {'invalid-feedback': nameError}">
+                {% translate "Name is required and must be less than 64 characters" %}
+              </span>
+            </td>
+            <td>
+              <div class="input-group" data-bind="css: {'is-invalid': expressionError}">
+                <select class="select form-control" required data-bind="
+                  value: expression_id,
+                  valueAllowUnset: true,
+                  options: $root.filters,
+                  optionsText: 'label',
+                  optionsValue: 'id',
+                  attr: {name: `validations-${$index()}-expression`},
+                  css: {'is-invalid': expressionError},
+                  ">
+                  </select>
+                  <a class="input-group-text" data-bind="attr: {href: editUrl}" target="_blank">
+                    <i class="fa-solid fa-up-right-from-square"></i>
+                  </a>
+              </div>
+                <span data-bind="visible: expressionError, css: {'invalid-feedback': expressionError}">
+                  {% translate "Expression is required" %}
                 </span>
-              </td>
-              <td data-bind="css: {'has-error': expressionError}">  {# todo B5: css:has-error #}
-                <div class="input-group">
-                  <select class="select form-control" required data-bind="
-                    value: expression_id,
-                    valueAllowUnset: true,
-                    options: $root.filters,
-                    optionsText: 'label',
-                    optionsValue: 'id',
-                    attr: {name: `validations-${$index()}-expression`},
-                    ">
-                    </select>
-                    <div class="input-group-addon">  {# todo B5: css:input-group-addon - also referenced in js #}
-                      <a data-bind="attr: {href: editUrl}" target="_blank"><i class="fa-solid fa-up-right-from-square"></i></a>
-                    </div>
-                </div>
-                  <span class='help-block' data-bind="visible: expressionError">
-                    {% translate "Expression is required" %}
-                  </span>
-              </td>
-              <td data-bind="css: {'has-error': messageError}">  {# todo B5: css:has-error #}
-                <textarea type="text" class="form-control vertical-resize" required data-bind="
-                  value: message, attr: {name: `validations-${$index()}-message`}"></textarea>
-                  <span class='help-block' data-bind="visible: messageError">
-                    {% translate "Message is required" %}
-                  </span>
-              </td>
-              <td>
-                <input type="checkbox" data-bind="  {# todo B5: css:checkbox #}
+            </td>
+            <td>
+              <textarea type="text" class="form-control vertical-resize" required data-bind="
+                value: message, attr: {name: `validations-${$index()}-message`}, css: {'is-invalid': messageError}"></textarea>
+                <span data-bind="visible: messageError, css: {'invalid-feedback': messageError}">
+                  {% translate "Message is required" %}
+                </span>
+            </td>
+            <td>
+              <div class="form-check" data-bind="visible: id">
+                <input type="checkbox" class="form-check-input" data-bind="
                   checked: toDelete,
                   attr: {name: `validations-${$index()}-DELETE`},
-                  visible: id
                 ">
-                <button type="btn" data-bind="
-                  click: $parent.remove,
-                  hidden: id
-                "><i class="fa-regular fa-trash-can"></i></button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <div>
-          <input type="hidden" name="validations-TOTAL_FORMS" data-bind="attr: {value: total}">
-          <input type="hidden" name="validations-INITIAL_FORMS" data-bind="attr: {value: initialCount}">
-          <input type="hidden" name="validations-MIN_NUM_FORMS" value="0">
-          <input type="hidden" name="validations-MAX_NUM_FORMS" value="1000">
-        </div>
-        <button type="button" class="btn btn-primary" data-bind="click: add">
-          <i class="fa fa-plus"></i>
-          {% trans "Add Validation" %}
-        </button>
-        </fieldset>
-        <div class="form-actions">
-          <div class="col-sm-12 col-md-8 col-lg-8 col-xl-6 offset-md-4 offset-lg-4 offset-xl-2 controls">
-            <button class="btn btn-primary" type="submit" id="submit">{% trans "Save" %}</button>
-            <a href="{% url 'configurable_api_list' domain %}" class="btn btn-outline-primary">{% trans "Cancel" %}</a>
-          </div>
-        </div>
-      </form>
-    </div>
+              </div>
+              <button type="button" class="btn btn-outline-danger" data-bind="
+                click: $parent.remove,
+                hidden: id
+              "><i class="fa-regular fa-trash-can"></i></button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div>
+        <input type="hidden" name="validations-TOTAL_FORMS" data-bind="attr: {value: total}">
+        <input type="hidden" name="validations-INITIAL_FORMS" data-bind="attr: {value: initialCount}">
+        <input type="hidden" name="validations-MIN_NUM_FORMS" value="0">
+        <input type="hidden" name="validations-MAX_NUM_FORMS" value="1000">
+      </div>
+      <button type="button" class="btn btn-outline-primary" data-bind="click: add">
+        <i class="fa fa-plus"></i>
+        {% trans "Add Validation" %}
+      </button>
+      </fieldset>
+      <button class="btn btn-primary" type="submit" id="submit">{% trans "Save" %}</button>
+      <a href="{% url 'configurable_api_list' domain %}" class="btn btn-outline-primary">{% trans "Cancel" %}</a>
+    </form>
   </div>
 </div>
 {% endblock %}

--- a/corehq/motech/generic_inbound/templates/generic_inbound/api_edit.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/api_edit.html
@@ -1,9 +1,9 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load i18n %}
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "generic_inbound/js/api_edit" %}
+{% requirejs_main_b5 "generic_inbound/js/api_edit" %}
 
 {% block page_title %}{{ page_title }}{% endblock %}
 {% block page_content %}
@@ -13,14 +13,14 @@
 {% registerurl 'ucr_expressions' domain %}
 <div id="edit-api">
   <div class="row">
-    <div class="col-xs-12 col-sm-10 col-md-8 col-lg-8">
-      <div class="form-group">
-        <label class="control-label col-xs-12 col-sm-4 col-md-4 col-lg-2">
+    <div class="col-sm-12 col-md-10 col-lg-8 col-xl-8">
+      <div class="form-group">  {# todo B5: css:form-group #}
+        <label class="form-label col-sm-12 col-md-4 col-lg-4 col-xl-2">
           {% trans "URL" %}
         </label>
-        <div class="controls col-xs-12 col-sm-8 col-md-8 col-lg-6">
+        <div class="controls col-sm-12 col-md-8 col-lg-8 col-xl-6">
           <pre id="api_url">{{ api_model.absolute_url }}</pre>
-          <a class="btn btn-default" onclick="copyData('api_url')">
+          <a class="btn btn-outline-primary" onclick="copyData('api_url')">
             <i class="fa fa-copy"></i> {% trans "Copy URL" %}
           </a>
         </div>
@@ -29,24 +29,24 @@
   </div>
   <div class="spacer"></div>
   <div class="row">
-    <div class="col-xs-12 col-sm-10 col-md-8 col-lg-8">
+    <div class="col-sm-12 col-md-10 col-lg-8 col-xl-8">
       <form class="form-horizontal" method="post" id="edit-api" data-bind="submit: validateForm">
-        {% crispy form %}
+        {% crispy form %}  {# todo B5: check crispy #}
         <div class="spacer"></div>
         <fieldset data-bind="with: validations">
           <legend>{% translate "Validation Expressions" %}</legend>
         <table class="table table-striped table-hover">
           <thead>
             <tr>
-              <th class="col-sm-2">{% translate "Name" %}</th>
-              <th class="col-sm-4">{% translate "Expression" %}</th>
-              <th class="col-sm-4">{% translate "Message" %}</th>
-              <th class="col-sm-2">{% translate "Delete" %}</th>
+              <th class="col-md-2">{% translate "Name" %}</th>
+              <th class="col-md-4">{% translate "Expression" %}</th>
+              <th class="col-md-4">{% translate "Message" %}</th>
+              <th class="col-md-2">{% translate "Delete" %}</th>
             </tr>
           </thead>
           <tbody data-bind="foreach: models">
             <tr>
-              <td data-bind="css: {'has-error': nameError}">
+              <td data-bind="css: {'has-error': nameError}">  {# todo B5: css:has-error #}
                 <input type="hidden" data-bind="value: id, attr: {name: `validations-${$index()}-id`}">
                 <input type="hidden" value="{{ api_model.id }}" data-bind="attr: {name: `validations-${$index()}-api`}">
                 <input type="text" maxlength="64" class="textinput textInput form-control" required data-bind="
@@ -55,7 +55,7 @@
                   {% translate "Name is required and must be less than 64 characters" %}
                 </span>
               </td>
-              <td data-bind="css: {'has-error': expressionError}">
+              <td data-bind="css: {'has-error': expressionError}">  {# todo B5: css:has-error #}
                 <div class="input-group">
                   <select class="select form-control" required data-bind="
                     value: expression_id,
@@ -66,7 +66,7 @@
                     attr: {name: `validations-${$index()}-expression`},
                     ">
                     </select>
-                    <div class="input-group-addon">
+                    <div class="input-group-addon">  {# todo B5: css:input-group-addon - also referenced in js #}
                       <a data-bind="attr: {href: editUrl}" target="_blank"><i class="fa-solid fa-up-right-from-square"></i></a>
                     </div>
                 </div>
@@ -74,7 +74,7 @@
                     {% translate "Expression is required" %}
                   </span>
               </td>
-              <td data-bind="css: {'has-error': messageError}">
+              <td data-bind="css: {'has-error': messageError}">  {# todo B5: css:has-error #}
                 <textarea type="text" class="form-control vertical-resize" required data-bind="
                   value: message, attr: {name: `validations-${$index()}-message`}"></textarea>
                   <span class='help-block' data-bind="visible: messageError">
@@ -82,7 +82,7 @@
                   </span>
               </td>
               <td>
-                <input type="checkbox" data-bind="
+                <input type="checkbox" data-bind="  {# todo B5: css:checkbox #}
                   checked: toDelete,
                   attr: {name: `validations-${$index()}-DELETE`},
                   visible: id
@@ -107,9 +107,9 @@
         </button>
         </fieldset>
         <div class="form-actions">
-          <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6 col-sm-offset-4 col-md-offset-4 col-lg-offset-2 controls">
+          <div class="col-sm-12 col-md-8 col-lg-8 col-xl-6 offset-md-4 offset-lg-4 offset-xl-2 controls">
             <button class="btn btn-primary" type="submit" id="submit">{% trans "Save" %}</button>
-            <a href="{% url 'configurable_api_list' domain %}" class="btn btn-default">{% trans "Cancel" %}</a>
+            <a href="{% url 'configurable_api_list' domain %}" class="btn btn-outline-primary">{% trans "Cancel" %}</a>
           </div>
         </div>
       </form>

--- a/corehq/motech/generic_inbound/templates/generic_inbound/api_list.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/api_list.html
@@ -1,8 +1,8 @@
-{% extends 'hqwebapp/bootstrap3/base_paginated_crud.html' %}
+{% extends 'hqwebapp/bootstrap5/base_paginated_crud.html' %}
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "generic_inbound/js/api_list" %}
+{% requirejs_main_b5 "generic_inbound/js/api_list" %}
 
 {% block page_title %}{{ current_page.title }}{% endblock %}
 
@@ -16,7 +16,7 @@
     <td data-bind="text: description"></td>
     <td><pre data-bind="text: api_url, attr: {id: 'api_url_' + id}"></pre></td>
     <td> <!-- actions -->
-        <a class="btn btn-default copy_url" data-bind="click: () => copyData('api_url_' + id)">
+        <a class="btn btn-outline-primary copy_url" data-bind="click: () => copyData('api_url_' + id)">
           <i class="fa fa-copy"></i> {% trans "Copy URL" %}
         </a>
         <a class="btn btn-primary" data-bind="attr: {href: edit_url}">

--- a/corehq/motech/generic_inbound/templates/generic_inbound/request_log_detail.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/request_log_detail.html
@@ -16,139 +16,123 @@
 
 <h1>{{ current_page.title }}</h1>
 
-<div class="card">
-  <div class="card-body">
-    <h3 class="card-title">{% trans "Metadata" %}</h3>
-    <table class="table table-bordered">
-      <tbody>
-        <tr>
-          <th>API</th>
-          <td>
-            <a href="{% url 'configurable_api_edit' domain log.api_id %}">{{ log.api.name }}</a>
-          </td>
-        </tr>
-        <tr>
-          <th>status</th>
-          <td>
-            <span class="badge text-bg-{{ status_css.strip }}">
-              {{ log.get_status_display }}
-            </span>
-          </td>
-        </tr>
-        <tr>
-          <th>timestamp</th>
-          <td>{% utc_to_timezone log.timestamp timezone %}</td>
-        </tr>
-        <tr>
-          <th>username</th>
-          <td>{{ log.username }}</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
+<h3>{% trans "Metadata" %}</h3>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <th class="col-3">API</th>
+      <td class="col-9">
+        <a href="{% url 'configurable_api_edit' domain log.api_id %}">{{ log.api.name }}</a>
+      </td>
+    </tr>
+    <tr>
+      <th>status</th>
+      <td>
+        <span class="badge text-bg-{{ status_css.strip }}">
+          {{ log.get_status_display }}
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <th>timestamp</th>
+      <td>{% utc_to_timezone log.timestamp timezone %}</td>
+    </tr>
+    <tr>
+      <th>username</th>
+      <td>{{ log.username }}</td>
+    </tr>
+  </tbody>
+</table>
 
 
-<div class="card">
-  <div class="card-body">
-    <h3 class="card-title">{% trans "Request Details" %}</h3>
-    <table class="table table-bordered">
-      <tbody>
-        <tr>
-          <th>request_method</th>
-          <td>{{ log.request_method }}</td>
-        </tr>
-        <tr>
-          <th>request_query</th>
-          <td>{{ log.request_query }}</td>
-        </tr>
-        <tr>
-          <th>request_body</th>
-          <td>{{ log.request_body }}</td>
-        </tr>
-        <tr>
-          <th>request_headers</th>
-          <td>
-            <dl class="row">
-            {% for key, value in log.request_headers.items|dictsort:0 %}
-              <dt class="col-3 fw-bold">{{ key }}</dt>
-              <dd class="col-9">{{ value }}</dd>
-            {% endfor %}
-            </dl>
-          </td>
-        </tr>
-        <tr>
-          <th>request_ip</th>
-          <td>{{ log.request_ip }}</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-
-<div class="card">
-  <div class="card-body">
-    <h3 class="card-title">{% trans "Response Details" %}</h3>
-    <table class="table table-bordered">
-      <tbody>
-        <tr>
-          <th>response_status</th>
-          <td>{{ log.response_status }}</td>
-        </tr>
-        <tr>
-          <th>attempts</th>
-          <td>{{ log.attempts }}</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-
-<div class="card">
-  <div class="card-body">
-    <h3 class="card-title">{% trans "Processing Attempts" %}</h3>
-    <table class="table table-bordered">
-      <thead>
-        <tr>
-          <th>timestamp</th>
-          <th>is_retry</th>
-          <th>response_status</th>
-          <th>raw_response</th>
-          <th>xform_id</th>
-          <th>case_ids</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for attempt in log.processingattempt_set.all %}
-        <tr>
-          <td>{% utc_to_timezone attempt.timestamp timezone %}</td>
-          <td>{{ attempt.is_retry }}</td>
-          <td>{{ attempt.response_status }}</td>
-          <td class="font-monospace">{{ attempt.raw_response }}</td>
-          <td>
-            {% if attempt.xform_id %}
-              <a href="{% url 'render_form_data' domain attempt.xform_id %}">{{ attempt.xform_id }}</a>
-            {% else %}
-              ---
-            {% endif %}
-          </td>
-          <td>
-            <ul class="list-unstyled">
-            {% for case_id in attempt.case_ids %}
-              <li>
-                <a href="{% url 'case_data' domain case_id %}">{{ case_id }}</a>
-              </li>
-            {% empty %}
-              ---
-            {% endfor %}
-            </ul>
-          </td>
-        </tr>
+<h3>{% trans "Request Details" %}</h3>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <th class="col-3">request_method</th>
+      <td class="col-9">{{ log.request_method }}</td>
+    </tr>
+    <tr>
+      <th>request_query</th>
+      <td>{{ log.request_query }}</td>
+    </tr>
+    <tr>
+      <th>request_body</th>
+      <td>{{ log.request_body }}</td>
+    </tr>
+    <tr>
+      <th>request_headers</th>
+      <td>
+        <dl class="row">
+        {% for key, value in log.request_headers.items|dictsort:0 %}
+          <dt class="col-3 fw-bold">{{ key }}</dt>
+          <dd class="col-9">{{ value }}</dd>
         {% endfor %}
-      </tbody>
-    </table>
-  </div>
-</div>
+        </dl>
+      </td>
+    </tr>
+    <tr>
+      <th>request_ip</th>
+      <td>{{ log.request_ip }}</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>{% trans "Response Details" %}</h3>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <th class="col-3">response_status</th>
+      <td class="col-9">{{ log.response_status }}</td>
+    </tr>
+    <tr>
+      <th>attempts</th>
+      <td>{{ log.attempts }}</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>{% trans "Processing Attempts" %}</h3>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>timestamp</th>
+      <th>is_retry</th>
+      <th>response_status</th>
+      <th>raw_response</th>
+      <th>xform_id</th>
+      <th>case_ids</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for attempt in log.processingattempt_set.all %}
+    <tr>
+      <td>{% utc_to_timezone attempt.timestamp timezone %}</td>
+      <td>{{ attempt.is_retry }}</td>
+      <td>{{ attempt.response_status }}</td>
+      <td class="font-monospace">{{ attempt.raw_response }}</td>
+      <td>
+        {% if attempt.xform_id %}
+          <a href="{% url 'render_form_data' domain attempt.xform_id %}">{{ attempt.xform_id }}</a>
+        {% else %}
+          ---
+        {% endif %}
+      </td>
+      <td>
+        <ul class="list-unstyled">
+        {% for case_id in attempt.case_ids %}
+          <li>
+            <a href="{% url 'case_data' domain case_id %}">{{ case_id }}</a>
+          </li>
+        {% empty %}
+          ---
+        {% endfor %}
+        </ul>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 
 {% if log.status != 'success' %}
   <form action="{% url 'retry_api_request' domain log.id %}" method="post" class="float-start">{% csrf_token %}

--- a/corehq/motech/generic_inbound/templates/generic_inbound/request_log_detail.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/request_log_detail.html
@@ -7,20 +7,18 @@
 
 {% captureas status_css %}
   {% case log.status 'success' %} success
-  {% case 'filtered' %} default
+  {% case 'filtered' %} secondary
   {% case 'reverted' %} warning
   {% case 'error' 'validation-failed' %} danger
-  {% else %} default
+  {% else %} secondary
   {% endcase %}
 {% endcaptureas %}
 
 <h1>{{ current_page.title }}</h1>
 
-<div class="card ">  {# todo B5: css:panel #}
-  <div class="card-header">
-    <h3 class="card-title">{% trans "Metadata" %}</h3>
-  </div>
+<div class="card">
   <div class="card-body">
+    <h3 class="card-title">{% trans "Metadata" %}</h3>
     <table class="table table-bordered">
       <tbody>
         <tr>
@@ -32,7 +30,7 @@
         <tr>
           <th>status</th>
           <td>
-            <span class="badge label-{{ status_css.strip }}">
+            <span class="badge text-bg-{{ status_css.strip }}">
               {{ log.get_status_display }}
             </span>
           </td>
@@ -51,11 +49,9 @@
 </div>
 
 
-<div class="card ">  {# todo B5: css:panel #}
-  <div class="card-header">
-    <h3 class="card-title">{% trans "Request Details" %}</h3>
-  </div>
+<div class="card">
   <div class="card-body">
+    <h3 class="card-title">{% trans "Request Details" %}</h3>
     <table class="table table-bordered">
       <tbody>
         <tr>
@@ -73,10 +69,10 @@
         <tr>
           <th>request_headers</th>
           <td>
-            <dl class="dl-horizontal">  {# todo B5: css:dl-horizontal #}
+            <dl class="row">
             {% for key, value in log.request_headers.items|dictsort:0 %}
-              <dt>{{ key }}</dt>
-              <dd>{{ value }}</dd>
+              <dt class="col-3 fw-bold">{{ key }}</dt>
+              <dd class="col-9">{{ value }}</dd>
             {% endfor %}
             </dl>
           </td>
@@ -90,11 +86,9 @@
   </div>
 </div>
 
-<div class="card ">  {# todo B5: css:panel #}
-  <div class="card-header">
-    <h3 class="card-title">{% trans "Response Details" %}</h3>
-  </div>
+<div class="card">
   <div class="card-body">
+    <h3 class="card-title">{% trans "Response Details" %}</h3>
     <table class="table table-bordered">
       <tbody>
         <tr>
@@ -110,11 +104,9 @@
   </div>
 </div>
 
-<div class="card ">  {# todo B5: css:panel #}
-  <div class="card-header">
-    <h3 class="card-title">{% trans "Processing Attempts" %}</h3>
-  </div>
+<div class="card">
   <div class="card-body">
+    <h3 class="card-title">{% trans "Processing Attempts" %}</h3>
     <table class="table table-bordered">
       <thead>
         <tr>
@@ -132,7 +124,7 @@
           <td>{% utc_to_timezone attempt.timestamp timezone %}</td>
           <td>{{ attempt.is_retry }}</td>
           <td>{{ attempt.response_status }}</td>
-          <td><code>{{ attempt.raw_response }}</code></td>
+          <td class="font-monospace">{{ attempt.raw_response }}</td>
           <td>
             {% if attempt.xform_id %}
               <a href="{% url 'render_form_data' domain attempt.xform_id %}">{{ attempt.xform_id }}</a>
@@ -158,26 +150,24 @@
   </div>
 </div>
 
-<div class="form-actions">
-  {% if log.status != 'success' %}
-    <form action="{% url 'retry_api_request' domain log.id %}" method="post" class="float-start">{% csrf_token %}
-      <button type="submit" class="btn btn-outline-primary disable-on-submit" >
-        <i class="fa fa-repeat"></i>
-        {% trans 'Retry' %}
-      </button>
-    </form>
-  {% elif log.status == 'success' %}
-    <form action="{% url 'revert_api_request' domain log.id %}" method="post" class="float-start">{% csrf_token %}
-      <button type="submit" class="btn btn-outline-danger disable-on-submit" >
-        <i class="fa fa-undo"></i>
-        {% trans 'Revert' %}
-      </button>
-      <span class="hq-help-template"
-            data-title="{% trans 'Reverting API Requests' %}"
-            data-content="{% blocktrans %}Reverts actions performed in this request and archives any associated forms.{% endblocktrans %}">
-      </span>
-    </form>
-  {% endif %}
-</div>
+{% if log.status != 'success' %}
+  <form action="{% url 'retry_api_request' domain log.id %}" method="post" class="float-start">{% csrf_token %}
+    <button type="submit" class="btn btn-outline-primary disable-on-submit" >
+      <i class="fa fa-repeat"></i>
+      {% trans 'Retry' %}
+    </button>
+  </form>
+{% elif log.status == 'success' %}
+  <form action="{% url 'revert_api_request' domain log.id %}" method="post" class="float-start">{% csrf_token %}
+    <button type="submit" class="btn btn-outline-danger disable-on-submit" >
+      <i class="fa fa-undo"></i>
+      {% trans 'Revert' %}
+    </button>
+    <span class="hq-help-template"
+          data-title="{% trans 'Reverting API Requests' %}"
+          data-content="{% blocktrans %}Reverts actions performed in this request and archives any associated forms.{% endblocktrans %}">
+    </span>
+  </form>
+{% endif %}
 
 {% endblock %}

--- a/corehq/motech/generic_inbound/templates/generic_inbound/request_log_detail.html
+++ b/corehq/motech/generic_inbound/templates/generic_inbound/request_log_detail.html
@@ -1,4 +1,4 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load timezone_tags %}
@@ -16,11 +16,11 @@
 
 <h1>{{ current_page.title }}</h1>
 
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <h3 class="panel-title">{% trans "Metadata" %}</h3>
+<div class="card ">  {# todo B5: css:panel #}
+  <div class="card-header">
+    <h3 class="card-title">{% trans "Metadata" %}</h3>
   </div>
-  <div class="panel-body">
+  <div class="card-body">
     <table class="table table-bordered">
       <tbody>
         <tr>
@@ -32,7 +32,7 @@
         <tr>
           <th>status</th>
           <td>
-            <span class="label label-{{ status_css.strip }}">
+            <span class="badge label-{{ status_css.strip }}">
               {{ log.get_status_display }}
             </span>
           </td>
@@ -51,11 +51,11 @@
 </div>
 
 
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <h3 class="panel-title">{% trans "Request Details" %}</h3>
+<div class="card ">  {# todo B5: css:panel #}
+  <div class="card-header">
+    <h3 class="card-title">{% trans "Request Details" %}</h3>
   </div>
-  <div class="panel-body">
+  <div class="card-body">
     <table class="table table-bordered">
       <tbody>
         <tr>
@@ -73,7 +73,7 @@
         <tr>
           <th>request_headers</th>
           <td>
-            <dl class="dl-horizontal">
+            <dl class="dl-horizontal">  {# todo B5: css:dl-horizontal #}
             {% for key, value in log.request_headers.items|dictsort:0 %}
               <dt>{{ key }}</dt>
               <dd>{{ value }}</dd>
@@ -90,11 +90,11 @@
   </div>
 </div>
 
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <h3 class="panel-title">{% trans "Response Details" %}</h3>
+<div class="card ">  {# todo B5: css:panel #}
+  <div class="card-header">
+    <h3 class="card-title">{% trans "Response Details" %}</h3>
   </div>
-  <div class="panel-body">
+  <div class="card-body">
     <table class="table table-bordered">
       <tbody>
         <tr>
@@ -110,11 +110,11 @@
   </div>
 </div>
 
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <h3 class="panel-title">{% trans "Processing Attempts" %}</h3>
+<div class="card ">  {# todo B5: css:panel #}
+  <div class="card-header">
+    <h3 class="card-title">{% trans "Processing Attempts" %}</h3>
   </div>
-  <div class="panel-body">
+  <div class="card-body">
     <table class="table table-bordered">
       <thead>
         <tr>
@@ -160,15 +160,15 @@
 
 <div class="form-actions">
   {% if log.status != 'success' %}
-    <form action="{% url 'retry_api_request' domain log.id %}" method="post" class="pull-left">{% csrf_token %}
-      <button type="submit" class="btn btn-default disable-on-submit" >
+    <form action="{% url 'retry_api_request' domain log.id %}" method="post" class="float-start">{% csrf_token %}
+      <button type="submit" class="btn btn-outline-primary disable-on-submit" >
         <i class="fa fa-repeat"></i>
         {% trans 'Retry' %}
       </button>
     </form>
   {% elif log.status == 'success' %}
-    <form action="{% url 'revert_api_request' domain log.id %}" method="post" class="pull-left">{% csrf_token %}
-      <button type="submit" class="btn btn-danger disable-on-submit" >
+    <form action="{% url 'revert_api_request' domain log.id %}" method="post" class="float-start">{% csrf_token %}
+      <button type="submit" class="btn btn-outline-danger disable-on-submit" >
         <i class="fa fa-undo"></i>
         {% trans 'Revert' %}
       </button>

--- a/corehq/motech/generic_inbound/views.py
+++ b/corehq/motech/generic_inbound/views.py
@@ -15,6 +15,7 @@ from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.api.decorators import allow_cors, api_throttle
 from corehq.apps.domain.decorators import api_auth
 from corehq.apps.domain.views import BaseProjectSettingsView
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.userreports.models import UCRExpression
 from corehq.apps.users.decorators import require_permission
@@ -107,6 +108,7 @@ class ConfigurableAPIListView(BaseProjectSettingsView, CRUDPaginatedViewMixin):
         }
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 @method_decorator(can_administer_generic_inbound, name='dispatch')
 class ConfigurableAPIEditView(BaseProjectSettingsView):
     page_title = gettext_lazy("Edit API Configuration")

--- a/corehq/motech/generic_inbound/views.py
+++ b/corehq/motech/generic_inbound/views.py
@@ -47,6 +47,7 @@ def can_administer_generic_inbound(view_fn):
     )
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 @method_decorator(can_administer_generic_inbound, name='dispatch')
 class ConfigurableAPIListView(BaseProjectSettingsView, CRUDPaginatedViewMixin):
     page_title = gettext_lazy("Inbound API Configurations")


### PR DESCRIPTION
## Product Description
This migrates the list page (basically already done, since it uses the generic CRUD view) and and API config edit page. It doesn't touch the Inbound API Request Logs page, which depends on reports.

### before: list
![Screenshot 2024-05-29 at 9 22 17 PM](https://github.com/dimagi/commcare-hq/assets/1486591/8ee80b92-d253-4b1f-8dba-ff1f7bdaa32f)

### before: edit
![Screenshot 2024-05-29 at 9 22 38 PM](https://github.com/dimagi/commcare-hq/assets/1486591/aa2d7f0e-54d3-4185-8805-b86f7b6e79ef)

### before: log detail
![Screenshot 2024-05-30 at 4 48 07 PM](https://github.com/dimagi/commcare-hq/assets/1486591/c1bbe1d6-9692-43d5-bf54-20100ba26f33)

### after: list
![Screenshot 2024-05-29 at 9 21 14 PM](https://github.com/dimagi/commcare-hq/assets/1486591/832a3861-a6c3-4236-ab5b-4f8742500f48)

### after: edit
![Screenshot 2024-05-29 at 9 21 52 PM](https://github.com/dimagi/commcare-hq/assets/1486591/78dbb929-5466-4447-accd-5f3f6bdae5ad)

### after: log detail
![Screenshot 2024-05-30 at 4 46 52 PM](https://github.com/dimagi/commcare-hq/assets/1486591/f0915d35-3166-4588-a546-02af89580bf6)

## Feature Flag
Generic inbound APIs

## Safety Assurance

### Safety story
These are pretty minor UI-level changes, and risk should be limited to this area. There's one change to the B5 version of a shared crispy file.

### Automated test coverage

Probably not at the UI level

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
