### PR TITLE
Adds button to clear the area filter on Case Management Page

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -681,7 +681,6 @@ hqDefine('geospatial/js/models', [
             }
             self.clearActivePolygon();
 
-            removeActivePolygonLayer();
             createActivePolygonLayer(polygonObj);
 
             self.activeSavedPolygon = polygonObj;

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -635,6 +635,11 @@ hqDefine('geospatial/js/models', [
             }
         };
 
+        self.clearSelectedPolygonFilter = function clearSelectedPolygonFilter() {
+            self.selectedSavedPolygonId('');
+            self.clearActivePolygon();
+        };
+
         self.selectedSavedPolygonId.subscribe(function (selectedPolygonID) {
             self.oldSelectedSavedPolygonId(selectedPolygonID);
         }, null, "beforeChange");

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -638,6 +638,7 @@ hqDefine('geospatial/js/models', [
         self.clearSelectedPolygonFilter = function clearSelectedPolygonFilter() {
             self.selectedSavedPolygonId('');
             self.clearActivePolygon();
+            updateSelectedSavedPolygonParam();
         };
 
         self.selectedSavedPolygonId.subscribe(function (selectedPolygonID) {

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -32,19 +32,7 @@
 
 <div class="panel" id="polygon-filters">
   <div class="row">
-    <label for="saved-polygons" class="control-label col-sm-2 col-md-2 col-lg-2">
-    {% trans "Filter by Saved Area" %}</label>
-    <div class="controls col-sm-2 col-md-2 col-lg-2">
-        <select id="saved-polygons"
-                class="form-control"
-                data-bind="select2: savedPolygons,
-                        value: selectedSavedPolygonId,
-                        ">
-        </select>
-    </div>
-    <button class="btn btn-default" data-bind="click: clearActivePolygon, enable: selectedSavedPolygonId">
-      {% trans 'Clear' %}
-    </button>
+    {% include 'geospatial/partials/saved_polygon_filter.html' %}
   </div>
   <div class="alert alert-info" data-bind="visible: shouldRefreshPage">
     {% blocktrans %}

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -34,7 +34,7 @@
   <div class="row">
     {% include 'geospatial/partials/saved_polygon_filter.html' %}
   </div>
-  <div class="alert alert-info" data-bind="visible: shouldRefreshPage">
+  <div class="alert alert-info" style="margin-top:10px;" data-bind="visible: shouldRefreshPage">
     {% blocktrans %}
       Please
       <a href="">refresh the page</a>

--- a/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
+++ b/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+
+<div class="col-sm-5">
+    <div class="row form-horizontal">
+        <label for="saved-polygons" class="control-label col-sm-4">
+        {% trans "Filter by Saved Area" %}
+        </label>
+        <div class="col-sm-6">
+            <select id="saved-polygons"
+                    class="form-control"
+                    data-bind="select2: savedPolygons,value: selectedSavedPolygonId,">
+            </select>
+        </div>
+        <button class="col-sm-2 btn btn-default" data-bind="click: clearSelectedPolygonFilter, visible: selectedSavedPolygonId">
+            {% trans 'Clear' %}
+        </button>
+    </div>
+</div>

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -78,6 +78,9 @@
                         ">
         </select>
     </div>
+    <button class="btn btn-default" data-bind="click: clearSelectedPolygonFilter, visible: selectedSavedPolygonId">
+      {% trans 'Clear' %}
+    </button>
     <a id="btnExportDrawnArea" class="col-sm-2 btn btn-default" style="float:right; margin-right:1em" data-bind="attr: { disabled: btnExportDisabled }">
         {% trans 'Export Area' %}
     </a>

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -68,22 +68,7 @@
     </div>
 </div>
 <div class="row panel" id="mapControls">
-    <div class="col-sm-4">
-        <div class="row form-horizontal">
-            <label for="saved-polygons" class="control-label col-sm-4">
-            {% trans "Filter by Saved Area" %}
-            </label>
-            <div class="col-sm-6">
-                <select id="saved-polygons"
-                        class="form-control"
-                        data-bind="select2: savedPolygons,value: selectedSavedPolygonId,">
-                </select>
-            </div>
-            <button class="col-sm-2 btn btn-default" data-bind="click: clearSelectedPolygonFilter, visible: selectedSavedPolygonId">
-                {% trans 'Clear' %}
-            </button>
-        </div>
-    </div>
+    {% include 'geospatial/partials/saved_polygon_filter.html' %}
     <a id="btnExportDrawnArea" class="col-sm-2 btn btn-default" style="float:right; margin-right:1em" data-bind="attr: { disabled: btnExportDisabled }">
         {% trans 'Export Area' %}
     </a>

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -68,19 +68,22 @@
     </div>
 </div>
 <div class="row panel" id="mapControls">
-    <label for="saved-polygons" class="control-label col-sm-2 col-md-2 col-lg-2">
-    {% trans "Filter by Saved Area" %}</label>
-    <div class="controls col-sm-2 col-md-2 col-lg-2">
-        <select id="saved-polygons"
-                class="form-control"
-                data-bind="select2: savedPolygons,
-                        value: selectedSavedPolygonId,
-                        ">
-        </select>
+    <div class="col-sm-4">
+        <div class="row form-horizontal">
+            <label for="saved-polygons" class="control-label col-sm-4">
+            {% trans "Filter by Saved Area" %}
+            </label>
+            <div class="col-sm-6">
+                <select id="saved-polygons"
+                        class="form-control"
+                        data-bind="select2: savedPolygons,value: selectedSavedPolygonId,">
+                </select>
+            </div>
+            <button class="col-sm-2 btn btn-default" data-bind="click: clearSelectedPolygonFilter, visible: selectedSavedPolygonId">
+                {% trans 'Clear' %}
+            </button>
+        </div>
     </div>
-    <button class="btn btn-default" data-bind="click: clearSelectedPolygonFilter, visible: selectedSavedPolygonId">
-      {% trans 'Clear' %}
-    </button>
     <a id="btnExportDrawnArea" class="col-sm-2 btn btn-default" style="float:right; margin-right:1em" data-bind="attr: { disabled: btnExportDisabled }">
         {% trans 'Export Area' %}
     </a>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This change adds `clear` button for the area filter on the Case Management Page. The button is only visible when a value is selected in the filter to avoid clutter. After the click, the filter is reset and selected filter id is also removed from the url query params.
(No action is done to the cases selected on the map - this decision can be better taken when we implement the upcoming functionalities related to selection of cases)

![image](https://github.com/dimagi/commcare-hq/assets/125016806/94029321-6d9d-4af9-b40e-7d391db5ee1b)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket - https://dimagi.atlassian.net/browse/SC-3258

Note this PR also makes below changes
- Reuse the filter template along with clear button for both Case Management and Grouping
- Minor CSS improvements.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Geospatial

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Changes made only to the UI. Local testing done.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Only UI changes.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
