### PR TITLE
Refactor Function Naming

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -101,7 +101,7 @@ class WorkerMonitoringReportTableBase(GenericTabularReport, ProjectReport, Proje
         """
         name = row_obj.raw_username if hasattr(row_obj, 'raw_username') else row_obj.name
         if self._has_form_view_permission():
-            row_link = self.get_raw_user_link(row_obj)
+            row_link = self.get_raw_row_link(row_obj)
             return self.table_cell(name, row_link)
         return self.table_cell(name)
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This is a small refactor PR that changes some naming of helper functions to make them more generic. This change is done because the helper function supports both `User` and `RowData` objects, and having the helper refer to users only can be confusing to read through.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Tested locally
- Small renaming change

The row links for all monitoring reports have been tested locally to ensure they still work as expected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
