### PR TITLE
Set max limit on mobile report size during restores

### DIFF
--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -195,9 +195,9 @@ class AppMisconfigurationError(AppManagerException):
     """Errors in app configuration that are the user's responsibility"""
 
 
-class FailHardException(Exception):
+class CannotRestoreException(Exception):
     """Errors that inherit from this exception will always fail hard in restores"""
 
 
-class MobileUCRTooLargeException(FailHardException):
+class MobileUCRTooLargeException(CannotRestoreException):
     pass

--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -194,3 +194,7 @@ class DangerousXmlException(Exception):
 
 class AppMisconfigurationError(AppManagerException):
     """Errors in app configuration that are the user's responsibility"""
+
+
+class MobileUCRTooLargeException(Exception):
+    pass

--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -200,4 +200,7 @@ class CannotRestoreException(Exception):
 
 
 class MobileUCRTooLargeException(CannotRestoreException):
-    pass
+
+    def __init__(self, message, row_count):
+        super().__init__(message)
+        self.row_count = row_count

--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -195,5 +195,9 @@ class AppMisconfigurationError(AppManagerException):
     """Errors in app configuration that are the user's responsibility"""
 
 
-class MobileUCRTooLargeException(Exception):
+class FailHardException(Exception):
+    """Errors that inherit from this exception will always fail hard in restores"""
+
+
+class MobileUCRTooLargeException(FailHardException):
     pass

--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -1,5 +1,3 @@
-import couchdbkit
-
 from corehq.apps.app_manager.const import APP_V2
 
 
@@ -79,7 +77,8 @@ class XFormValidationError(XFormException):
             return msg
         # Don't display the first two lines which say "Parsing form..." and 'Title: "{form_name}"'
         #
-        # ... and if possible split the third line that looks like e.g. "org.javarosa.xform.parse.XFormParseException: Select question has no choices"
+        # ... and if possible split the third line that looks like
+        # e.g. "org.javarosa.xform.parse.XFormParseException: Select question has no choices"
         # and just return the undecorated string
         #
         # ... unless the first line says

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -548,9 +548,9 @@ def get_report_element(
     row_elements = []
     row_index = 0
     rows = report_data_cache.get_data(report_config.uuid, data_source)
+    if len(rows) > settings.MAX_MOBIE_UCR_SIZE:
+        raise MobileUCRTooLargeException
     for row_index, row in enumerate(rows):
-        if row_index + 1 >= settings.MAX_MOBILE_UCR_SIZE:
-            raise MobileUCRTooLargeException
         row_elements.append(row_to_element(deferred_fields, filter_options_by_field, row, row_index))
         total_row_calculator.update_totals(row)
 

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -111,10 +111,10 @@ class ReportFixturesProvider(FixtureProvider):
         for provider in providers:
             try:
                 fixtures.extend(provider(restore_state, restore_user, needed_versions, report_configs))
-                row_count = provider.row_count
+                self.report_ucr_row_count(provider.row_count, provider.version, restore_user.domain)
             except MobileUCRTooLargeException as err:
-                row_count = err.row_count
-            self.report_ucr_row_count(row_count, provider.version, restore_user.domain)
+                self.report_ucr_row_count(err.row_count, provider.version, restore_user.domain)
+                raise
 
         return fixtures
 

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -548,7 +548,7 @@ def get_report_element(
     row_elements = []
     row_index = 0
     rows = report_data_cache.get_data(report_config.uuid, data_source)
-    if len(rows) > settings.MAX_MOBIE_UCR_SIZE:
+    if len(rows) > settings.MAX_MOBILE_UCR_SIZE:
         raise MobileUCRTooLargeException
     for row_index, row in enumerate(rows):
         row_elements.append(row_to_element(deferred_fields, filter_options_by_field, row, row_index))

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -21,7 +21,7 @@ from corehq.apps.app_manager.const import (
     MOBILE_UCR_VERSION_2,
 )
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
-from corehq.apps.app_manager.exceptions import MobileUCRTooLargeException
+from corehq.apps.app_manager.exceptions import FailHardException, MobileUCRTooLargeException
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     is_valid_mobile_select_filter_type,
 )
@@ -271,6 +271,9 @@ class ReportFixturesProviderV1(BaseReportFixtureProvider):
             except UserReportsError:
                 if settings.UNIT_TESTING or settings.DEBUG or fail_hard:
                     raise
+            except FailHardException:
+                # raise regardless of fail_hard
+                raise
             except Exception as err:
                 logging.exception('Error generating report fixture: {}'.format(err))
                 if settings.UNIT_TESTING or settings.DEBUG or fail_hard:
@@ -427,6 +430,9 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
             except UserReportsError:
                 if settings.UNIT_TESTING or settings.DEBUG or fail_hard:
                     raise
+            except FailHardException:
+                # raise regardless of fail_hard
+                raise
             except Exception as err:
                 logging.exception('Error generating report fixture: {}'.format(err))
                 if settings.UNIT_TESTING or settings.DEBUG or fail_hard:

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -21,6 +21,7 @@ from corehq.apps.app_manager.const import (
     MOBILE_UCR_VERSION_2,
 )
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
+from corehq.apps.app_manager.exceptions import MobileUCRTooLargeException
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     is_valid_mobile_select_filter_type,
 )
@@ -542,6 +543,8 @@ def get_report_element(
     row_index = 0
     rows = report_data_cache.get_data(report_config.uuid, data_source)
     for row_index, row in enumerate(rows):
+        if row_index + 1 >= settings.MAX_MOBILE_UCR_SIZE:
+            raise MobileUCRTooLargeException
         row_elements.append(row_to_element(deferred_fields, filter_options_by_field, row, row_index))
         total_row_calculator.update_totals(row)
 

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -549,7 +549,10 @@ def get_report_element(
     row_index = 0
     rows = report_data_cache.get_data(report_config.uuid, data_source)
     if len(rows) > settings.MAX_MOBILE_UCR_SIZE:
-        raise MobileUCRTooLargeException
+        raise MobileUCRTooLargeException(
+            f"Report {report_config.report_id} row count {len(rows)} exceeds max allowed row count "
+            f"{settings.MAX_MOBILE_UCR_SIZE}"
+        )
     for row_index, row in enumerate(rows):
         row_elements.append(row_to_element(deferred_fields, filter_options_by_field, row, row_index))
         total_row_calculator.update_totals(row)

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -565,7 +565,7 @@ def get_report_element(
             f"Report {report_config.report_id} row count {len(rows)} exceeds max allowed row count "
             f"{settings.MAX_MOBILE_UCR_SIZE}"
         )
-    if current_row_count and len(rows) + current_row_count > settings.MAX_MOBILE_UCR_SIZE * 2:
+    if current_row_count is not None and len(rows) + current_row_count > settings.MAX_MOBILE_UCR_SIZE * 2:
         raise MobileUCRTooLargeException(
             "You are attempting to restore too many mobile reports. Your Mobile UCR Restore Version is set to 1.0."
             " Try upgrading to 2.0."

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -490,7 +490,7 @@ def _format_last_sync_time(restore_user, sync_time=None):
 
 
 def generate_rows_and_filters(
-    report_data_cache, report_config, restore_user, row_to_element, current_row_count=None
+    report_data_cache, report_config, restore_user, row_to_element, current_row_count=0
 ):
     """Generate restore row and filter elements
     :param row_to_element: function (
@@ -544,7 +544,7 @@ def get_report_element(
     deferred_fields,
     filter_options_by_field,
     row_to_element,
-    current_row_count=None,
+    current_row_count=0,
 ):
     """
     :param row_to_element: function (
@@ -565,7 +565,7 @@ def get_report_element(
             f"Report {report_config.report_id} row count {len(rows)} exceeds max allowed row count "
             f"{settings.MAX_MOBILE_UCR_SIZE}"
         )
-    if current_row_count is not None and len(rows) + current_row_count > settings.MAX_MOBILE_UCR_SIZE * 2:
+    if len(rows) + current_row_count > settings.MAX_MOBILE_UCR_SIZE * 2:
         raise MobileUCRTooLargeException(
             "You are attempting to restore too many mobile reports. Your Mobile UCR Restore Version is set to 1.0."
             " Try upgrading to 2.0."

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -21,7 +21,7 @@ from corehq.apps.app_manager.const import (
     MOBILE_UCR_VERSION_2,
 )
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
-from corehq.apps.app_manager.exceptions import FailHardException, MobileUCRTooLargeException
+from corehq.apps.app_manager.exceptions import CannotRestoreException, MobileUCRTooLargeException
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     is_valid_mobile_select_filter_type,
 )
@@ -271,7 +271,7 @@ class ReportFixturesProviderV1(BaseReportFixtureProvider):
             except UserReportsError:
                 if settings.UNIT_TESTING or settings.DEBUG or fail_hard:
                     raise
-            except FailHardException:
+            except CannotRestoreException:
                 # raise regardless of fail_hard
                 raise
             except Exception as err:
@@ -430,7 +430,7 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
             except UserReportsError:
                 if settings.UNIT_TESTING or settings.DEBUG or fail_hard:
                     raise
-            except FailHardException:
+            except CannotRestoreException:
                 # raise regardless of fail_hard
                 raise
             except Exception as err:

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -298,7 +298,7 @@ class ReportFixturesProviderV1(BaseReportFixtureProvider):
             return row_elem
 
         row_elements, filters_elem = generate_rows_and_filters(
-            self.report_data_cache, report_config, restore_user, _row_to_row_elem
+            self.report_data_cache, report_config, restore_user, _row_to_row_elem, self.row_count
         )
         # the v1 provider writes all reports to one fixture, so the "effective" row_count is the sum of every
         # report's row_count
@@ -489,11 +489,14 @@ def _format_last_sync_time(restore_user, sync_time=None):
     return ServerTime(sync_time).user_time(timezone).done().isoformat()
 
 
-def generate_rows_and_filters(report_data_cache, report_config, restore_user, row_to_element):
+def generate_rows_and_filters(
+    report_data_cache, report_config, restore_user, row_to_element, current_row_count=None
+):
     """Generate restore row and filter elements
     :param row_to_element: function (
                 deferred_fields, filter_options_by_field, row, index, is_total_row
             ) -> row_element
+    :param current_row_count: optional int used by v1 reports provider to accumulate row count across all reports
     """
     report, data_source = report_data_cache.get_report_and_datasource(report_config.report_id)
 
@@ -527,6 +530,7 @@ def generate_rows_and_filters(report_data_cache, report_config, restore_user, ro
         {f.field for f in defer_filters},
         filter_options_by_field,
         row_to_element,
+        current_row_count,
     )
     filters_elem = _get_filters_elem(defer_filters, filter_options_by_field, restore_user._couch_user)
 
@@ -534,11 +538,19 @@ def generate_rows_and_filters(report_data_cache, report_config, restore_user, ro
 
 
 def get_report_element(
-        report_data_cache, report_config, data_source, deferred_fields, filter_options_by_field, row_to_element):
+    report_data_cache,
+    report_config,
+    data_source,
+    deferred_fields,
+    filter_options_by_field,
+    row_to_element,
+    current_row_count=None,
+):
     """
     :param row_to_element: function (
                 deferred_fields, filter_options_by_field, row, index, is_total_row
             ) -> row_element
+    :param current_row_count: optional int used by v1 reports provider to accumulate row count across all reports
     """
     if data_source.has_total_row:
         total_row_calculator = IterativeTotalRowCalculator(data_source)
@@ -552,6 +564,11 @@ def get_report_element(
         raise MobileUCRTooLargeException(
             f"Report {report_config.report_id} row count {len(rows)} exceeds max allowed row count "
             f"{settings.MAX_MOBILE_UCR_SIZE}"
+        )
+    if current_row_count and len(rows) + current_row_count > settings.MAX_MOBILE_UCR_SIZE * 2:
+        raise MobileUCRTooLargeException(
+            "You are attempting to restore too many mobile reports. Your Mobile UCR Restore Version is set to 1.0."
+            " Try upgrading to 2.0."
         )
     for row_index, row in enumerate(rows):
         row_elements.append(row_to_element(deferred_fields, filter_options_by_field, row, row_index))

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -26,6 +26,7 @@ from couchforms.openrosa_response import (
     get_simple_response_xml,
 )
 
+from corehq.apps.app_manager.exceptions import CannotRestoreException
 from corehq.apps.domain.models import Domain
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.exceptions import NotFound
@@ -595,6 +596,10 @@ class RestoreConfig(object):
             )
             response = HttpResponse(response, content_type="text/xml; charset=utf-8",
                                     status=412)  # precondition failed
+        except CannotRestoreException as e:
+            response = get_simple_response_xml(str(e), ResponseNature.OTA_RESTORE_ERROR)
+            response = HttpResponse(response, content_type="text/xml; charset=utf-8", status=400)
+
         if not is_async:
             self._record_timing(response.status_code)
         return response


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
![image](https://github.com/dimagi/commcare-hq/assets/15785053/d2906873-d280-4d1c-a0a2-2190864d90a0)
![Screenshot from 2024-06-19 23-06-07](https://github.com/dimagi/commcare-hq/assets/15785053/2cd91d71-04f1-4a30-8636-1279fb70793b)
![image](https://github.com/dimagi/commcare-hq/assets/15785053/7c135469-9463-4328-8703-a29627cfd1b9)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15544

We currently have no upper bound on the size of mobile UCRs included in a restore. This has caused memory issues on machines attempting to serve restore requests, since we have to load the entire report into memory before writing it to a file.

This change implements a max size of 250,000 rows, which is based on existing mobile UCR sizes (see the ticket for details). We've seen confirmed performance issues with mobile reports with 1 million rows, and the next largest mobile report on prod is ~210,000 rows. After that, there is a steep drop off where every report is below 100,000 rows. I arbitrarily picked 250,000 rows as a max limit based on this information, but we are also in the process of rolling out better metrics around mobile ucr sizes in restores, and can tune this number based on that.

This PR changes the report provider code to raise an exception if attempting to build a mobile report with too many rows (over 250k), _or_ if attempting to build mobile reports on V1 that sum up to be greater than 500k (250k * 2). This is again arbitrary, but designed to provide a buffer for V1 users. Once this error is more prevalent to the user and not just in the restore xml, it should also incentivize upgrading to V2.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
MOBILE_UCR

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will request

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
