### PR TITLE
Fix Pagination for Locked Case Groups

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -572,6 +572,11 @@ hqDefine("geospatial/js/case_grouping_map",[
                 return;
             }
 
+            // Groups need to be unlocked to load new case data
+            if (groupLockModelInstance.groupsLocked()) {
+                groupLockModelInstance.toggleGroupLock();
+            }
+
             // Hide the datatable rows but not the pagination bar
             $('.dataTables_scroll').hide();
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Before:
![lock-case-grouping-before](https://github.com/dimagi/commcare-hq/assets/122617251/d1ac6f55-f5f5-43a1-b4d5-3f37841cd9be)

After:
![lock-case-grouping-fixed](https://github.com/dimagi/commcare-hq/assets/122617251/bb288fd7-b3cf-4924-b9b8-0e518f22b7d7)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3270).

Navigating to a different page with case group locking enabled caused the previous page data to still show on the map. Only after clicking the unlock button would the new page's data be shown instead.

This PR fixes this behaviour by automatically unlocking the case groupings when a new page is being loaded. This causes the new data to show as expected.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
