### PR TITLE
HELPME: `view_generic()`

### DIFF
--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -42,39 +42,56 @@ from .test_form_versioning import INVALID_TEMPLATE
 User = get_user_model()
 
 
-@flag_enabled('CUSTOM_PROPERTIES')
-@patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
-@es_test(requires=[app_adapter], setup_class=True)
-class TestViews(TestCase):
-    app = None
-    build = None
+class ViewsBase(TestCase):
+    domain = 'test-views-base'
+    username = 'dolores.umbridge'
+    password = 'bumblesn0re'
 
     @classmethod
     def setUpClass(cls):
-        super(TestViews, cls).setUpClass()
-        cls.project = Domain.get_or_create_with_name('app-manager-testviews-domain', is_active=True)
-        cls.username = 'cornelius'
-        cls.password = 'fudge'
-        cls.user = WebUser.create(cls.project.name, cls.username, cls.password, None, None, is_active=True)
-        cls.user.is_superuser = True
-        cls.user.save()
+        super().setUpClass()
+
+        cls.domain_obj = Domain.get_or_create_with_name(
+            cls.domain,
+            is_active=True,
+        )
         cls.build = add_build(version='2.7.0', build_number=20655)
 
+        cls.user = WebUser.create(
+            cls.domain,
+            cls.username,
+            cls.password,
+            created_by=None,
+            created_via=None,
+            is_active=True,
+        )
+        cls.user.is_superuser = True
+        cls.user.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(cls.domain, deleted_by=None)
+        cls.build.delete()
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+
+@flag_enabled('CUSTOM_PROPERTIES')
+@patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+@es_test(requires=[app_adapter], setup_class=True)
+class TestViews(ViewsBase):
+    domain = 'app-manager-testviews-domain'
+    username = 'cornelius'
+    password = 'fudge'
+
     def setUp(self):
-        self.app = Application.new_app(self.project.name, "TestApp")
+        self.app = Application.new_app(self.domain, "TestApp")
         self.app.build_spec = BuildSpec.from_string('2.7.0/latest')
         self.client.login(username=self.username, password=self.password)
 
     def tearDown(self):
         if self.app._id:
             self.app.delete()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete(cls.project.name, deleted_by=None)
-        cls.build.delete()
-        cls.project.delete()
-        super(TestViews, cls).tearDownClass()
 
     def test_download_file_bad_xform_404(self, mock):
         '''
@@ -96,13 +113,13 @@ class TestViews(TestCase):
         self.app.save()
 
         mock.side_effect = XFormValidationError('')
-        response = self.client.get(reverse('app_download_file', kwargs=dict(domain=self.project.name,
+        response = self.client.get(reverse('app_download_file', kwargs=dict(domain=self.domain,
                                                                             app_id=self.app.get_id,
                                                                             path='modules-0/forms-0.xml')))
         self.assertEqual(response.status_code, 404)
 
     def test_edit_commcare_profile(self, mock):
-        app2 = Application.new_app(self.project.name, "TestApp2")
+        app2 = Application.new_app(self.domain, "TestApp2")
         app2.save()
         self.addCleanup(lambda: Application.get_db().delete_doc(app2.id))
         data = {
@@ -112,7 +129,7 @@ class TestViews(TestCase):
             }
         }
 
-        response = self.client.post(reverse('edit_commcare_profile', args=[self.project.name, app2._id]),
+        response = self.client.post(reverse('edit_commcare_profile', args=[self.domain, app2._id]),
                                     json.dumps(data),
                                     content_type='application/json')
 
@@ -128,7 +145,7 @@ class TestViews(TestCase):
             }
         }
 
-        response = self.client.post(reverse('edit_commcare_profile', args=[self.project.name, app2._id]),
+        response = self.client.post(reverse('edit_commcare_profile', args=[self.domain, app2._id]),
                                     json.dumps(data),
                                     content_type='application/json')
 
@@ -159,7 +176,7 @@ class TestViews(TestCase):
         self._send_to_es(self.app)
 
         kwargs = {
-            'domain': self.project.name,
+            'domain': self.domain,
             'app_id': self.app.id,
         }
         self._test_status_codes([
@@ -174,7 +191,7 @@ class TestViews(TestCase):
         self._send_to_es(build)
 
         content = self._json_content_from_get('current_app_version', {
-            'domain': self.project.name,
+            'domain': self.domain,
             'app_id': self.app.id,
         })
         self.assertEqual(content['currentVersion'], 1)
@@ -182,13 +199,13 @@ class TestViews(TestCase):
         self._send_to_es(self.app)
 
         content = self._json_content_from_get('current_app_version', {
-            'domain': self.project.name,
+            'domain': self.domain,
             'app_id': self.app.id,
         })
         self.assertEqual(content['currentVersion'], 2)
 
         content = self._json_content_from_get('paginate_releases', {
-            'domain': self.project.name,
+            'domain': self.domain,
             'app_id': self.app.id,
         }, {'limit': 5})
         self.assertEqual(len(content['apps']), 1)
@@ -219,7 +236,7 @@ class TestViews(TestCase):
         module = self.app.add_module(AdvancedModule.new_module("Module0", "en"))
         self.app.save()
         self._test_status_codes(['view_module'], {
-            'domain': self.project.name,
+            'domain': self.domain,
             'app_id': self.app.id,
             'module_unique_id': module.unique_id,
         })
@@ -228,7 +245,7 @@ class TestViews(TestCase):
         module = self.app.add_module(ReportModule.new_module("Module0", "en"))
         self.app.save()
         self._test_status_codes(['view_module'], {
-            'domain': self.project.name,
+            'domain': self.domain,
             'app_id': self.app.id,
             'module_unique_id': module.unique_id,
         })
@@ -237,14 +254,14 @@ class TestViews(TestCase):
         module = self.app.add_module(ShadowModule.new_module("Module0", "en"))
         self.app.save()
         self._test_status_codes(['view_module'], {
-            'domain': self.project.name,
+            'domain': self.domain,
             'app_id': self.app.id,
             'module_unique_id': module.unique_id,
         })
 
     def test_default_new_app(self, mock):
         response = self.client.get(reverse('default_new_app', kwargs={
-            'domain': self.project.name,
+            'domain': self.domain,
         }), follow=False)
 
         self.assertEqual(response.status_code, 302)
@@ -256,7 +273,7 @@ class TestViews(TestCase):
 
     def test_get_apps_modules(self, mock):
         with apps_modules_setup(self):
-            apps_modules = get_apps_modules(self.project.name)
+            apps_modules = get_apps_modules(self.domain)
 
             names = sorted([a['name'] for a in apps_modules])
             self.assertEqual(
@@ -275,7 +292,7 @@ class TestViews(TestCase):
     def test_get_apps_modules_doc_types(self, mock):
         with apps_modules_setup(self):
             apps_modules = get_apps_modules(
-                self.project.name, app_doc_types=('Application', 'LinkedApplication')
+                self.domain, app_doc_types=('Application', 'LinkedApplication')
             )
             names = sorted([a['name'] for a in apps_modules])
             self.assertEqual(names, ['LinkedApp', 'OtherApp', 'TestApp'])
@@ -439,24 +456,179 @@ def apps_modules_setup(test_case):
     test_case.app.add_module(Module.new_module("Module0", "en"))
     test_case.app.save()
 
-    test_case.other_app = Application.new_app(test_case.project.name, "OtherApp")
+    test_case.other_app = Application.new_app(test_case.domain, "OtherApp")
     test_case.other_app.add_module(Module.new_module("Module0", "en"))
     test_case.other_app.save()
 
-    test_case.deleted_app = Application.new_app(test_case.project.name, "DeletedApp")
+    test_case.deleted_app = Application.new_app(test_case.domain, "DeletedApp")
     test_case.deleted_app.add_module(Module.new_module("Module0", "en"))
     test_case.deleted_app.save()
     test_case.deleted_app.delete_app()
     test_case.deleted_app.save()  # delete_app() changes doc_type. This save() saves that.
 
-    test_case.linked_app = create_linked_app(test_case.project.name, test_case.app.id,
-                                             test_case.project.name, 'LinkedApp')
+    test_case.linked_app = create_linked_app(test_case.domain, test_case.app.id,
+                                             test_case.domain, 'LinkedApp')
     try:
         yield
     finally:
         Application.get_db().delete_doc(test_case.linked_app.id)
         Application.get_db().delete_doc(test_case.deleted_app.id)
         Application.get_db().delete_doc(test_case.other_app.id)
+
+
+@patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+@es_test(requires=[app_adapter], setup_class=True)
+class TestViewGeneric(ViewsBase):
+    domain = 'test-view-generic'
+
+    def setUp(self):
+        self.client.login(username=self.username, password=self.password)
+
+        self.app = Application.new_app(self.domain, "TestApp")
+        self.app.build_spec = BuildSpec.from_string('2.7.0/latest')
+        self.module = self.app.add_module(Module.new_module("Module0", "en"))
+        self.form = self.app.new_form(
+            self.module.id, "Form0", "en",
+            attachment=get_simple_form(xmlns='xmlns-0.0'))
+        self.app.save()
+        app_adapter.index(self.app, refresh=True)  # Send to ES
+
+    def tearDown(self):
+        self.app.delete()
+
+    def test_view_app(self, mock1):
+        url = reverse('view_app', kwargs={
+            'domain': self.domain,
+            'app_id': self.app.id,
+        })
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context.keys(), self.expected_keys_app)
+
+    def test_view_module(self, mock1):
+        url = reverse('view_module', kwargs={
+            'domain': self.domain,
+            'app_id': self.app.id,
+            'module_unique_id': self.module.unique_id,
+        })
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context.keys(), self.expected_keys_module)
+
+    def test_view_module_legacy(self, mock1):
+        url = reverse('view_module_legacy', kwargs={
+            'domain': self.domain,
+            'app_id': self.app.id,
+            'module_id': self.module.id,
+        })
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context.keys(), self.expected_keys_module)
+
+    def test_view_form(self, mock1):
+        url = reverse('view_form', kwargs={
+            'domain': self.domain,
+            'app_id': self.app.id,
+            'form_unique_id': self.form.unique_id,
+        })
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context.keys(), self.expected_keys_form)
+
+    def test_view_form_legacy(self, mock1):
+        url = reverse('view_form_legacy', kwargs={
+            'domain': self.domain,
+            'app_id': self.app.id,
+            'module_id': self.module.id,
+            'form_id': self.form.id,
+        })
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context.keys(), self.expected_keys_form)
+
+    expected_keys_app = {
+        'None', 'perms', 'practice_users', 'EULA_COMPLIANCE', 'bulk_ui_translation_form',
+        'latest_released_version', 'show_live_preview', 'can_view_app_diff', 'bulk_app_translation_form',
+        'sms_contacts', 'DEFAULT_MESSAGE_LEVELS', 'jquery_ui', 'PRIVACY_EMAIL', 'user', 'privileges',
+        'MAPBOX_ACCESS_TOKEN', 'release_manager', 'WS4REDIS_HEARTBEAT', 'can_send_sms', 'tabs', 'base_template',
+        'STATIC_URL', 'tab', 'smart_lang_display_enabled', 'latest_commcare_version', 'MEDIA_URL', 'element_id',
+        'app', 'ko', 'BASE_MAIN', 'prompt_settings_url', 'is_remote_app', 'show_biometric', 'linked_name',
+        'WEBSOCKET_URI', 'selected_form', 'module', 'MINIMUM_PASSWORD_LENGTH', 'MINIMUM_ZXCVBN_SCORE',
+        'SUPPORT_EMAIL', 'app_view_options', 'show_advanced', 'role_version', 'custom_assertions',
+        'is_app_settings_page', 'domain_names', 'latest_version_for_build_profiles', 'ANALYTICS_CONFIG',
+        'csrf_token', 'LANGUAGE_CODE', 'app_name', 'requirejs_main', 'sub', 'is_saas_environment',
+        'selected_module', 'add_ons_layout', 'is_dimagi_environment', 'TIME_ZONE', 'env', 'add_ons',
+        'show_shadow_forms', 'can_edit_apps', 'ANALYTICS_IDS', 'active_tab', 'current_url_name',
+        'show_release_mode', 'application_profile_url', 'linkable_domains', 'domain_links',
+        'show_all_projects_link', 'releases_active', 'settings_active', 'menu', 'allow_report_an_issue', 'app_id',
+        'INVOICING_CONTACT_EMAIL', 'False', 'show_mobile_ux_warning', 'IS_DOMAIN_BILLING_ADMIN', 'translations',
+        'hq', 'SALES_EMAIL', 'linked_version', 'confirm', 'show_report_modules', 'lang', 'can_view_cloudcare',
+        'title_block', 'CUSTOM_LOGO_URL', 'items', 'request', 'messages', 'build_profile_access', 'form', 'error',
+        'alerts', 'prompt_settings_form', 'submenu', 'domain', 'enable_update_prompts', 'show_shadow_modules',
+        'sentry', 'bulk_ui_translation_upload', 'toggles_dict', 'True', 'full_name', 'latest_build_id',
+        'previews_dict', 'copy_app_form', 'show_status_page', 'is_linked_app', 'show_shadow_module_v1',
+        'use_bootstrap5', 'limit_to_linked_domains', 'add_ons_privileges', 'LANGUAGE_BIDI', 'page_title_block',
+        'LANGUAGES', 'underscore', 'analytics', 'block', 'app_subset', 'restrict_domain_creation',
+        'login_template', 'enterprise_mode', 'mobile_ux_cookie_name', 'commcare_hq_names', 'langs',
+        'title_context_block', 'timezone', 'helpers', 'has_mobile_workers', 'multimedia_state',
+        'bulk_app_translation_upload', 'show_training_modules', 'forloop', 'secure_cookies',
+    }
+
+    expected_keys_module = {
+        'show_advanced', 'session_endpoints_enabled', 'show_advanced_settings', 'toggles_dict',
+        'show_release_mode', 'linked_name', 'linked_version', 'latest_commcare_version',
+        'nav_menu_media_specifics', 'user', 'TIME_ZONE', 'domain', 'module_brief', 'timezone', 'active_tab',
+        'data_registry_enabled', 'confirm', 'messages', 'releases_active', 'show_status_page',
+        'show_search_workflow', 'data_registries', 'label', 'underscore', 'forloop', 'show_shadow_modules',
+        'requirejs_main', 'SUPPORT_EMAIL', 'valid_parents_for_child_module', 'parent_case_modules',
+        'current_url_name', 'LANGUAGE_BIDI', 'DEFAULT_MESSAGE_LEVELS', 'show_report_modules', 'BASE_MAIN',
+        'app_id', 'request', 'MINIMUM_PASSWORD_LENGTH', 'type', 'is_saas_environment', 'show_all_projects_link',
+        'enterprise_mode', 'csrf_token', 'WS4REDIS_HEARTBEAT', 'is_dimagi_environment', 'domain_names',
+        'IS_DOMAIN_BILLING_ADMIN', 'tabs', 'perms', 'show_training_modules', 'AUDIO_LABEL',
+        'show_shadow_module_v1', 'practice_users', 'add_ons', 'module_icon', 'SALES_EMAIL', 'app', 'domain_links',
+        'app_subset', 'show_biometric', 'case_list_form_options', 'MINIMUM_ZXCVBN_SCORE', 'ICON_LABEL', 'app_name',
+        'linkable_domains', 'alerts', 'show_shadow_forms', 'data_registry_workflow_choices', 'use_bootstrap5',
+        'title_block', 'login_template', 'base_template', 'MEDIA_URL', 'lang', 'show_live_preview', 'jquery_ui',
+        'latest_version_for_build_profiles', 'edit_name_url', 'case_types', 'js_options', 'ko', 'privileges',
+        'settings_active', 'commcare_hq_names', 'add_ons_layout', 'limit_to_linked_domains', 'module', 'True',
+        'multimedia', 'MAPBOX_ACCESS_TOKEN', 'helpers', 'all_case_modules', 'LANGUAGES', 'mobile_ux_cookie_name',
+        'allow_report_an_issue', 'ANALYTICS_CONFIG', 'custom_icon', 'page_title_block', 'INVOICING_CONTACT_EMAIL',
+        'form', 'error', 'previews_dict', 'copy_app_form', 'LANGUAGE_CODE', 'menu', 'add_ons_privileges',
+        'shadow_parent', 'restrict_domain_creation', 'show_mobile_ux_warning', 'WEBSOCKET_URI', 'PRIVACY_EMAIL',
+        'custom_assertions', 'analytics', 'form_endpoint_options', 'title_context_block', 'secure_cookies',
+        'langs', 'details', 'None', 'CUSTOM_LOGO_URL', 'hq', 'selected_form', 'slug', 'env', 'False',
+        'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'EULA_COMPLIANCE', 'sentry',
+        'case_list_form_not_allowed_reasons', 'child_module_enabled', 'block',
+    }
+
+    expected_keys_form = {
+        'show_advanced', 'is_module_filter_enabled', 'session_endpoints_enabled', 'toggles_dict',
+        'show_release_mode', 'linked_name', 'linked_version', 'latest_commcare_version',
+        'nav_menu_media_specifics', 'user', 'TIME_ZONE', 'domain', 'case_config_options', 'timezone',
+        'root_requires_same_case', 'active_tab', 'confirm', 'messages', 'releases_active', 'show_status_page',
+        'form_filter_patterns', 'form_workflows', 'label', 'underscore', 'forloop', 'requirejs_main',
+        'SUPPORT_EMAIL', 'current_url_name', 'LANGUAGE_BIDI', 'DEFAULT_MESSAGE_LEVELS', 'show_report_modules',
+        'BASE_MAIN', 'xform_languages', 'app_id', 'request', 'allow_usercase', 'MINIMUM_PASSWORD_LENGTH', 'type',
+        'is_saas_environment', 'show_all_projects_link', 'enterprise_mode', 'module_is_multi_select', 'csrf_token',
+        'WS4REDIS_HEARTBEAT', 'nav_form', 'xform_validation_errored', 'allow_form_filtering',
+        'is_dimagi_environment', 'domain_names', 'IS_DOMAIN_BILLING_ADMIN', 'tabs', 'perms',
+        'show_training_modules', 'AUDIO_LABEL', 'show_shadow_module_v1', 'practice_users', 'add_ons',
+        'module_icon', 'custom_instances', 'SALES_EMAIL', 'app', 'domain_links', 'form_errors', 'app_subset',
+        'show_biometric', 'MINIMUM_ZXCVBN_SCORE', 'ICON_LABEL', 'app_name', 'linkable_domains', 'alerts',
+        'show_shadow_forms', 'use_bootstrap5', 'form_icon', 'title_block', 'login_template', 'base_template',
+        'MEDIA_URL', 'lang', 'show_live_preview', 'jquery_ui', 'latest_version_for_build_profiles',
+        'edit_name_url', 'ko', 'privileges', 'settings_active', 'commcare_hq_names', 'add_ons_layout',
+        'limit_to_linked_domains', 'module', 'is_case_list_form', 'True', 'multimedia', 'MAPBOX_ACCESS_TOKEN',
+        'xform_validation_missing', 'helpers', 'LANGUAGES', 'mobile_ux_cookie_name', 'allow_report_an_issue',
+        'ANALYTICS_CONFIG', 'is_training_module', 'custom_icon', 'page_title_block', 'INVOICING_CONTACT_EMAIL',
+        'form', 'error', 'previews_dict', 'copy_app_form', 'LANGUAGE_CODE', 'menu', 'add_ons_privileges',
+        'restrict_domain_creation', 'show_mobile_ux_warning', 'WEBSOCKET_URI', 'PRIVACY_EMAIL',
+        'is_allowed_to_be_release_notes_form', 'custom_assertions', 'analytics', 'title_context_block',
+        'secure_cookies', 'langs', 'None', 'CUSTOM_LOGO_URL', 'hq', 'allow_form_copy', 'selected_form', 'slug',
+        'env', 'False', 'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'is_usercase_in_use',
+        'module_loads_registry_case', 'EULA_COMPLIANCE', 'sentry', 'show_shadow_modules', 'show_custom_ref',
+        'block',
+    }
 
 
 class TestDownloadCaseSummaryViewByAPIKey(TestCase):

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -1,4 +1,5 @@
 import base64
+import doctest
 import json
 import re
 from contextlib import contextmanager
@@ -753,3 +754,10 @@ class TestDownloadCaseSummaryViewByAPIKey(TestCase):
                 self.url, HTTP_AUTHORIZATION=f"Basic {invalid_credentials}"
             )
             self.assertEqual(response.status_code, 401)
+
+
+def test_doctests():
+    import corehq.apps.app_manager.views.view_generic as module
+
+    results = doctest.testmod(module)
+    assert results.failed == 0

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -649,7 +649,14 @@ def get_apps_modules(domain, current_app_id=None, current_module_id=None, app_do
     ]
 
 
-def get_form_view_context_and_template(request, domain, form, langs, current_lang, messages=messages):
+def get_form_view_context(
+        request,
+        domain,
+        form,
+        langs,
+        current_lang,
+        messages=messages,
+):
     # HELPME
     #
     # This method has been flagged for refactoring due to its complexity and
@@ -889,7 +896,7 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
         })
 
     context.update({'case_config_options': case_config_options})
-    return "app_manager/form_view.html", context
+    return context
 
 
 def _get_form_link_context(app, module, form, langs):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -147,6 +147,9 @@ def get_module_template(user, module):
 
 
 def get_module_view_context(request, app, module, lang=None):
+    # make sure all modules have unique ids
+    app.ensure_module_unique_ids(should_save=True)
+
     context = {
         'edit_name_url': reverse('edit_module_attr', args=[app.domain, app.id, module.unique_id, 'name']),
         'show_search_workflow': (

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -157,7 +157,6 @@ def view_generic(
     error = request.GET.get('error', '')
     context.update({
         'error': error,
-        'app': app,
     })
 
     # Pass form for Copy Application to template

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -24,7 +24,7 @@ from corehq.apps.app_manager.views.apps import (
     get_apps_base_context,
 )
 from corehq.apps.app_manager.views.forms import (
-    get_form_view_context_and_template,
+    get_form_view_context,
 )
 from corehq.apps.app_manager.views.modules import (
     get_module_template,
@@ -161,7 +161,8 @@ def view_generic(
         })
 
     if form:
-        template, form_context = get_form_view_context_and_template(
+        template = "app_manager/form_view.html"
+        form_context = get_form_view_context(
             request, domain, form, context['langs'], current_lang=lang
         )
         context.update(form_context)

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -177,37 +177,7 @@ def view_generic(
         not is_remote_app(app)
         and has_privilege(request, privileges.COMMCARE_LOGO_UPLOADER)
     ):
-        from corehq.apps.hqmedia.controller import (
-            MultimediaLogoUploadController,
-        )
-        from corehq.apps.hqmedia.views import ProcessLogoFileUploadView
-
-        uploader_slugs = list(ANDROID_LOGO_PROPERTY_MAPPING.keys())
-        uploaders = [
-            MultimediaLogoUploadController(
-                slug,
-                reverse(
-                    ProcessLogoFileUploadView.urlname,
-                    args=[domain, app_id, slug],
-                )
-            )
-            for slug in uploader_slugs
-        ]
-        context.update({
-            "uploaders": uploaders,
-            "uploaders_js": [u.js_options for u in uploaders],
-            "refs": {
-                slug: ApplicationMediaReference(
-                    app.logo_refs.get(slug, {}).get("path", slug),
-                    media_class=CommCareImage,
-                ).as_dict()
-                for slug in uploader_slugs
-            },
-            "media_info": {
-                slug: app.logo_refs.get(slug)
-                for slug in uploader_slugs if app.logo_refs.get(slug)
-            },
-        })
+        context.update(_get_logo_uploader_context(domain, app_id, app))
 
     context.update({
         'show_live_preview': should_show_preview_app(
@@ -495,6 +465,40 @@ def _get_domain_context(domain, request_domain, couch_user):
         'domain_names': sorted(domain_names),
         'linkable_domains': sorted(linkable_domains),
         'limit_to_linked_domains': limit_to_linked_domains,
+    }
+
+
+def _get_logo_uploader_context(domain, app_id, app):
+    from corehq.apps.hqmedia.controller import (
+        MultimediaLogoUploadController,
+    )
+    from corehq.apps.hqmedia.views import ProcessLogoFileUploadView
+
+    uploader_slugs = list(ANDROID_LOGO_PROPERTY_MAPPING.keys())
+    uploaders = [
+        MultimediaLogoUploadController(
+            slug,
+            reverse(
+                ProcessLogoFileUploadView.urlname,
+                args=[domain, app_id, slug],
+            )
+        )
+        for slug in uploader_slugs
+    ]
+    return {
+        "uploaders": uploaders,
+        "uploaders_js": [u.js_options for u in uploaders],
+        "refs": {
+            slug: ApplicationMediaReference(
+                app.logo_refs.get(slug, {}).get("path", slug),
+                media_class=CommCareImage,
+            ).as_dict()
+            for slug in uploader_slugs
+        },
+        "media_info": {
+            slug: app.logo_refs.get(slug)
+            for slug in uploader_slugs if app.logo_refs.get(slug)
+        },
     }
 
 

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -175,19 +175,16 @@ def view_generic(
             and not isinstance(module, ReportModule)
             and module.uses_media()
         ):
-            def _make_name(suffix):
-                return "{default_name}_{suffix}_{lang}".format(
-                    default_name=default_file_name,
-                    suffix=suffix,
-                    lang=lang,
-                )
-
             specific_media.append({
                 'menu_refs': app.get_case_list_form_media(
                     module,
                     to_language=lang,
                 ),
-                'default_file_name': _make_name('case_list_form'),
+                'default_file_name': _make_file_name(
+                    default_file_name,
+                    'case_list_form',
+                    lang,
+                ),
                 'qualifier': 'case_list_form_',
             })
             specific_media.append({
@@ -195,7 +192,11 @@ def view_generic(
                     module,
                     to_language=lang,
                 ),
-                'default_file_name': _make_name('case_list_menu_item'),
+                'default_file_name': _make_file_name(
+                    default_file_name,
+                    'case_list_menu_item',
+                    lang,
+                ),
                 'qualifier': 'case_list-menu_item_',
             })
             if (
@@ -211,8 +212,10 @@ def view_generic(
                             module.search_config.search_label,
                             to_language=lang,
                         ),
-                        'default_file_name': _make_name(
-                            'case_search_label_item'
+                        'default_file_name': _make_file_name(
+                            default_file_name,
+                            'case_search_label_item',
+                            lang,
                         ),
                         'qualifier': 'case_search-search_label_media_'
                     },
@@ -222,8 +225,10 @@ def view_generic(
                             module.search_config.search_again_label,
                             to_language=lang,
                         ),
-                        'default_file_name': _make_name(
-                            'case_search_again_label_item'
+                        'default_file_name': _make_file_name(
+                            default_file_name,
+                            'case_search_again_label_item',
+                            lang,
                         ),
                         'qualifier': 'case_search-search_again_label_media_'
                     }
@@ -452,3 +457,14 @@ def _handle_bad_states(
             'form_id': form.id,
             'form_unique_id': form_unique_id,
         })
+
+
+def _make_file_name(default_name, suffix, lang):
+    """
+    Appends ``suffix`` and ``lang`` to ``default_name``
+
+    >>> _make_file_name('sir_lancelot', 'obe', 'fr')
+    'sir_lancelot_obe_fr'
+
+    """
+    return f'{default_name}_{suffix}_{lang}'


### PR DESCRIPTION
## Technical Summary

This change addresses the level of code complexity in the `view_generic()` function in corehq/apps/app_manager/views/view_generic.py. It reduces radon's cyclomatic complexity score from an F to a C. It does this by breaking down the function into smaller chunks.

It also adds a test suite to ensure that we are passing the same data to the view's context.

It was done as part of the Team Day hackathon session. 

## Safety Assurance

### Safety story

* No functionality was changed in this refactor.
* Tested locally

### Automated test coverage

Automated test added

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
