### PR TITLE
Fix Geospatial Marker Popup Checkbox

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -440,8 +440,11 @@ hqDefine("geospatial/js/geospatial_map", [
         // This indicates clicking Apply button or initial page load
         if (isAfterReportLoad) {
             initMap();
-            initPolygonFilters();
-            initUserFilters();
+            mapModel.mapInstance.on('load', () => {
+                initPolygonFilters();
+                initUserFilters();
+            });
+
             // Hide controls until data is displayed
             showMapControls(false);
 

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -64,7 +64,17 @@ hqDefine('geospatial/js/models', [
             return gettext("Case");
         };
 
+        self.updateCheckbox = function () {
+            const checkbox = $(`#${self.selectCssId}`);
+            if (!checkbox) {
+                return;
+            }
+            checkbox.prop('checked', self.isSelected());
+        };
+
         self.isSelected.subscribe(function () {
+            // Popup might be open when value changes, so make sure checkbox shows correct value
+            self.updateCheckbox();
             var color = self.isSelected() ? self.markerColors.selected : self.markerColors.default;
             changeMarkerColor(self, color);
         });

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -65,6 +65,8 @@ hqDefine('geospatial/js/models', [
         };
 
         self.updateCheckbox = function () {
+            // Need to update the checkbox through JQuery as we can't rely on dynamically changing its value
+            // with an observable. Doing so breaks all KO bindings in the element
             const checkbox = $(`#${self.selectCssId}`);
             if (!checkbox) {
                 return;

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -357,15 +357,22 @@ hqDefine('geospatial/js/models', [
             marker.addTo(self.mapInstance);
 
             const popupDiv = document.createElement("div");
+
+            const mapItemInstance = new MapItem(itemId, itemData, marker, colors);
+            let openFunc;
+            if (self.usesClusters) {
+                openFunc = () => highlightMarkerGroup(itemId);
+            } else {
+                openFunc = () => mapItemInstance.updateCheckbox();
+            }
             const popup = utils.createMapPopup(
                 coordinates,
                 popupDiv,
-                () => highlightMarkerGroup(itemId),
+                openFunc,
                 resetMarkersOpacity
             );
 
             marker.setPopup(popup);
-            const mapItemInstance = new MapItem(itemId, itemData, marker, colors);
             $(popupDiv).koApplyBindings(mapItemInstance);
 
             return mapItemInstance;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Popup checkboxes will now reflect their correct selected value after changing the area to filter by.

Before:
![checkboxes-before](https://github.com/dimagi/commcare-hq/assets/122617251/07a6af96-3f45-4aab-b5dd-11a7003cc713)

After:
![checkboxes-fixed](https://github.com/dimagi/commcare-hq/assets/122617251/c17c63b5-6225-4681-b51e-d7c06099f555)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3267).

This PR fixes a bug where, after changing the area to filter by, the marker popups would no longer show the correct checked value for a `MapItem` object. This bug only occurs if the popup for a marker was opened at least once.

Additional checks have been put in place to use JQuery to correctly set the state of the checkbox upon a change to the `isSelected` field or when the popup is opened.

Furthermore, this PR also fixes a bug where a JS exception is thrown when the user refreshes the page with a filter area selected on the Case Management page.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

Testing by changing area to filter by was done to ensure that checkboxes retain their correct value. Keeping a popup open while changing areas was also done to make sure the checkbox correctly updates.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
