### PR TITLE
USH-4599: Add FF for force login check for links

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -544,7 +544,8 @@ def session_endpoint(request, domain, app_id, endpoint_id=None):
             return _fail(_("No corresponding application found in this project."))
 
     restore_as_user, set_cookie = FormplayerMain.get_restore_as_user(request, domain)
-    force_login_as = not restore_as_user.is_commcare_user()
+    force_login_as = (not toggles.SMART_LINKS_FOR_WEB_USERS.enabled(domain)
+                      and not restore_as_user.is_commcare_user())
     if force_login_as and not can_use_restore_as(request):
         return _fail(_("This user cannot access this link."))
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2874,3 +2874,10 @@ APP_TESTING = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
     description=''
 )
+
+SMART_LINKS_FOR_WEB_USERS = StaticToggle(
+    slug='smart_links_for_web_users',
+    label='USH: Allow web users to use smart links without logging in as before',
+    tag=TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
## Product Description

* If web users without linked mobile users are making the request a login as is not needed anymore.
* Allow disabling the check with a FF.
* This will not be needed anymore once web users do not need to rely on linked mobile user anymore. At which point we should clean up the code and remove the check and related code.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-4599

## Feature Flag

SMART_LINKS_FOR_WEB_USERS

## Safety Assurance

Will only affect domains that have the FF set. Tested on staging.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
