### PR TITLE
Keep replicas when backfilling an index

### DIFF
--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -91,9 +91,6 @@ class ESSyncUtil:
         source_index = source_adapter.index_name
         destination_index = destination_adapter.index_name
 
-        logger.info(f"Preparing subindex {destination_index} for backfill")
-        self._prepare_index_for_reindex(destination_index)
-
         logger.info("Starting process to backfill subindex")
         task_id = es_manager.reindex(source_index, destination_index, query={"domain": domain})
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Previously, we called code before backfilling an index that did the following:
- set replica count to 0 (which is why cluster routing needed to be enabled)
- update the index refresh interval to a much larger value

However backfilling is different from a regular reindex because it is likely that the index we are writing to is actively being read from. Therefore, we don't want to remove replica counts, and we don't want to update the refresh interval.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The biggest risk here is not updating the refresh interval as this could have performance implications when backfilling data, since a refresh every 5 seconds might be too frequent.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
