### PR TITLE
Don't wipe out location in bulk upload when location column is not provided

### DIFF
--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -702,7 +702,7 @@ class WebUserRow(BaseUserRow):
             'username': self.row.get('username'),
             'role': self.row.get('role'),
             'status': self.row.get('status'),
-            'location_codes': format_location_codes(self.row.get('location_code', [])),
+            'location_codes': format_location_codes(self.row.get('location_code')),
             'remove': spec_value_to_boolean_or_none(self.row, 'remove'),
             "data": self.row.get('data', {}),
             "uncategorized_data": self.row.get('uncategorized_data', {}),

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -519,9 +519,7 @@ class CCUserRow(BaseUserRow):
             "name": self.row.get('name'),
             "uncategorized_data": self.row.get('uncategorized_data', {}),
             "user_id": self.row.get('user_id'),
-            "location_codes": format_location_codes(
-                self.row.get('location_code', []) if 'location_code' in self.row else None
-            ),
+            "location_codes": format_location_codes(self.row.get('location_code')),
             "role": self.row.get('role', None),
             "profile_name": self.row.get('user_profile', None),
             "web_user_username": self.row.get('web_user'),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Before changes: the assigned location for web user will be wiped out if no location column is provided in the uploaded excel file
After changes: if no location column is provided, we can expect no changes for locations.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15539

The default value for `location_code` will be an empty array if no location provided. It should return None.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

NA

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. Small change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
