### PR TITLE
Show algorithm parameters when running disbursement

### DIFF
--- a/corehq/apps/geospatial/models.py
+++ b/corehq/apps/geospatial/models.py
@@ -114,8 +114,8 @@ class GeoConfig(models.Model):
         get_geo_user_property.clear(self.domain)
 
     @property
-    def max_travel_time_seconds(self):
-        return self.max_case_travel_time * 60
+    def supports_travel_mode(self):
+        return self.selected_disbursement_algorithm == self.ROAD_NETWORK_ALGORITHM
 
     @property
     def disbursement_solver(self):

--- a/corehq/apps/geospatial/routing_solvers/pulp.py
+++ b/corehq/apps/geospatial/routing_solvers/pulp.py
@@ -81,10 +81,6 @@ class RadialDistanceSolver(DisbursementAlgorithmSolverInterface):
         user_count = len(distance_costs)
         case_count = len(distance_costs[0])
 
-        # remove me
-        assert parameters.user_count == user_count
-        assert parameters.case_count == case_count
-
         # Define decision variables
         decision_variables = self.get_decision_variables(x_dim=user_count, y_dim=case_count)
 

--- a/corehq/apps/geospatial/routing_solvers/pulp.py
+++ b/corehq/apps/geospatial/routing_solvers/pulp.py
@@ -27,8 +27,9 @@ class Parameters:
         self.min_cases_per_user = config.min_cases_per_user or 0
         self.max_case_distance = config.max_case_distance
 
-        max_travel_time_secs = config.max_case_travel_time * 60 if config.max_case_travel_time else None
-        self.max_case_travel_time_seconds = max_travel_time_secs if config.supports_travel_mode else None
+        if config.supports_travel_mode:
+            max_travel_time_secs = config.max_case_travel_time * 60 if config.max_case_travel_time else None
+            self.max_case_travel_time_seconds = max_travel_time_secs
 
 
 class RadialDistanceSolver(DisbursementAlgorithmSolverInterface):

--- a/corehq/apps/geospatial/routing_solvers/pulp.py
+++ b/corehq/apps/geospatial/routing_solvers/pulp.py
@@ -3,8 +3,34 @@ import requests
 import pulp
 import copy
 
+from dataclasses import dataclass
 from .mapbox_utils import validate_routing_request
 from corehq.apps.geospatial.routing_solvers.base import DisbursementAlgorithmSolverInterface
+
+
+@dataclass
+class Parameters:
+    min_cases_per_user: int
+    max_cases_per_user: int
+    max_case_distance: int
+    max_case_travel_time: int
+    user_count: int
+    case_count: int
+
+    def __init__(self, config, user_count, case_count):
+        self.user_count = user_count
+        self.case_count = case_count
+
+        default_max_cases = int(case_count / user_count) + 1 if user_count else 0
+        self.max_cases_per_user = config.max_cases_per_user or default_max_cases
+
+        self.min_cases_per_user = config.min_cases_per_user or 0
+        self.max_case_distance = config.max_case_distance
+        self.max_case_travel_time = config.max_case_travel_time if config.supports_travel_mode else None
+
+    @property
+    def max_travel_time_seconds(self):
+        return self.max_case_travel_time * 60
 
 
 class RadialDistanceSolver(DisbursementAlgorithmSolverInterface):
@@ -33,14 +59,31 @@ class RadialDistanceSolver(DisbursementAlgorithmSolverInterface):
 
         return distance_matrix, None
 
+    def get_parameters(self, config):
+        return Parameters(
+            config=config,
+            user_count=len(self.user_locations),
+            case_count=len(self.case_locations),
+        )
+
     def solve(self, config, print_solution=False):
+        parameters = self.get_parameters(config)
+
         distance_costs, duration_costs = self.calculate_distance_matrix(config)
 
         if not distance_costs:
-            return self.solution_results(assigned=[], unassigned=self.case_locations)
+            return self.solution_results(
+                assigned=[],
+                unassigned=self.case_locations,
+                parameters=parameters
+            )
 
         user_count = len(distance_costs)
         case_count = len(distance_costs[0])
+
+        # remove me
+        assert parameters.user_count == user_count
+        assert parameters.case_count == case_count
 
         # Define decision variables
         decision_variables = self.get_decision_variables(x_dim=user_count, y_dim=case_count)
@@ -52,16 +95,12 @@ class RadialDistanceSolver(DisbursementAlgorithmSolverInterface):
         problem = self.add_user_case_assignment_constraint(
             lp_problem=problem,
             decision_variables=decision_variables,
-            user_count=user_count,
-            case_count=case_count,
-            min_cases=config.min_cases_per_user,
-            max_cases=config.max_cases_per_user,
+            parameters=parameters,
         )
         problem = self.add_case_owner_constraint(
             lp_problem=problem,
             decision_variables=decision_variables,
-            user_count=user_count,
-            case_count=case_count,
+            parameters=parameters,
         )
 
         # Define the objective function
@@ -85,7 +124,7 @@ class RadialDistanceSolver(DisbursementAlgorithmSolverInterface):
                 for j in range(case_count):
                     if pulp.value(decision_variables[i, j]) > 0.5:
                         case_is_valid = self.is_valid_user_case(
-                            config,
+                            parameters=parameters,
                             distance_to_case=distance_costs[i][j],
                             travel_secs_to_case=None if duration_costs is None else duration_costs[i][j],
                         )
@@ -94,11 +133,15 @@ class RadialDistanceSolver(DisbursementAlgorithmSolverInterface):
                             unassigned_cases.remove(self.case_locations[j])
             assigned_cases = solution
 
-        return self.solution_results(assigned=assigned_cases, unassigned=unassigned_cases)
+        return self.solution_results(
+            assigned=assigned_cases,
+            unassigned=unassigned_cases,
+            parameters=parameters,
+        )
 
     @staticmethod
-    def solution_results(assigned, unassigned):
-        return {"assigned": assigned, "unassigned": unassigned}
+    def solution_results(assigned, unassigned, parameters):
+        return {"assigned": assigned, "unassigned": unassigned, "parameters": parameters.__dict__}
 
     @staticmethod
     def get_decision_variables(x_dim, y_dim):
@@ -109,35 +152,34 @@ class RadialDistanceSolver(DisbursementAlgorithmSolverInterface):
         return matrix
 
     @staticmethod
-    def add_user_case_assignment_constraint(
-        lp_problem, decision_variables, user_count, case_count, min_cases=None, max_cases=None
-    ):
+    def add_user_case_assignment_constraint(lp_problem, decision_variables, parameters):
         # This constrain enforces the min/max amount of cases that could be assigned to each user,
         # with the default being the cases split equally between users.
-        max_constraint = max_cases or int(case_count / user_count) + 1
-        min_constraint = min_cases or 0
-
-        for i in range(user_count):
-            lp_problem += pulp.lpSum([decision_variables[i, j] for j in range(case_count)]) <= max_constraint
-            lp_problem += pulp.lpSum([decision_variables[i, j] for j in range(case_count)]) >= min_constraint
+        for i in range(parameters.user_count):
+            lp_problem += pulp.lpSum(
+                [decision_variables[i, j] for j in range(parameters.case_count)]
+            ) <= parameters.max_cases_per_user
+            lp_problem += pulp.lpSum(
+                [decision_variables[i, j] for j in range(parameters.case_count)]
+            ) >= parameters.min_cases_per_user
 
         return lp_problem
 
     @staticmethod
-    def add_case_owner_constraint(lp_problem, decision_variables, user_count, case_count):
+    def add_case_owner_constraint(lp_problem, decision_variables, parameters):
         # This constraint ensures that every case can only ever have one user assigned to it
-        for j in range(case_count):
-            lp_problem += pulp.lpSum([decision_variables[i, j] for i in range(user_count)]) == 1
+        for j in range(parameters.case_count):
+            lp_problem += pulp.lpSum([decision_variables[i, j] for i in range(parameters.user_count)]) == 1
         return lp_problem
 
     @staticmethod
-    def is_valid_user_case(config, distance_to_case=None, travel_secs_to_case=None):
-        should_check_distance = distance_to_case and config.max_case_distance
-        if should_check_distance and distance_to_case > config.max_case_distance:
+    def is_valid_user_case(parameters, distance_to_case=None, travel_secs_to_case=None):
+        should_check_distance = distance_to_case and parameters.max_case_distance
+        if should_check_distance and distance_to_case > parameters.max_case_distance:
             return False
 
-        should_check_duration = travel_secs_to_case and config.max_case_travel_time
-        if should_check_duration and travel_secs_to_case > config.max_travel_time_seconds:
+        should_check_duration = travel_secs_to_case and parameters.max_case_travel_time
+        if should_check_duration and travel_secs_to_case > parameters.max_travel_time_seconds:
             return False
 
         return True

--- a/corehq/apps/geospatial/routing_solvers/pulp.py
+++ b/corehq/apps/geospatial/routing_solvers/pulp.py
@@ -13,7 +13,7 @@ class Parameters:
     min_cases_per_user: int
     max_cases_per_user: int
     max_case_distance: int
-    max_case_travel_time: int
+    max_case_travel_time_seconds: int
     user_count: int
     case_count: int
 
@@ -26,11 +26,9 @@ class Parameters:
 
         self.min_cases_per_user = config.min_cases_per_user or 0
         self.max_case_distance = config.max_case_distance
-        self.max_case_travel_time = config.max_case_travel_time if config.supports_travel_mode else None
 
-    @property
-    def max_travel_time_seconds(self):
-        return self.max_case_travel_time * 60
+        max_travel_time_secs = config.max_case_travel_time * 60 if config.max_case_travel_time else None
+        self.max_case_travel_time_seconds = max_travel_time_secs if config.supports_travel_mode else None
 
 
 class RadialDistanceSolver(DisbursementAlgorithmSolverInterface):
@@ -174,8 +172,8 @@ class RadialDistanceSolver(DisbursementAlgorithmSolverInterface):
         if should_check_distance and distance_to_case > parameters.max_case_distance:
             return False
 
-        should_check_duration = travel_secs_to_case and parameters.max_case_travel_time
-        if should_check_duration and travel_secs_to_case > parameters.max_travel_time_seconds:
+        should_check_duration = travel_secs_to_case and parameters.max_case_travel_time_seconds
+        if should_check_duration and travel_secs_to_case > parameters.max_case_travel_time_seconds:
             return False
 
         return True

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -136,7 +136,7 @@ hqDefine("geospatial/js/geospatial_map", [
             self.setDisbursementParameters = function (parameters) {
                 var parametersList = [
                     {name: gettext("Max cases per user"), value: parameters.max_cases_per_user},
-                    {name: gettext("Min cases per user"), value: parameters.min_cases_per_user}
+                    {name: gettext("Min cases per user"), value: parameters.min_cases_per_user},
                 ];
 
                 if (parameters.max_case_distance) {
@@ -153,7 +153,7 @@ hqDefine("geospatial/js/geospatial_map", [
 
                 self.parameters(parametersList);
                 self.showParams(true);
-            }
+            };
 
             let userData = users.map(function (c) {
                 return {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -74,6 +74,8 @@ hqDefine("geospatial/js/geospatial_map", [
         var self = {};
 
         self.isBusy = ko.observable(false);
+        self.showParams = ko.observable(false);
+        self.parameters = ko.observableArray([]);
 
         self.disbursementErrorMessage = ko.observable('');
         self.showUnassignedCasesError = ko.observable(false);
@@ -131,6 +133,28 @@ hqDefine("geospatial/js/geospatial_map", [
                 });
             });
 
+            self.setDisbursementParameters = function (parameters) {
+                var parametersList = [
+                    {name: gettext("Max cases per user"), value: parameters.max_cases_per_user},
+                    {name: gettext("Min cases per user"), value: parameters.min_cases_per_user}
+                ];
+
+                if (parameters.max_case_distance) {
+                    const maxCaseDistanceParamValue = `${parameters.max_case_distance} km`;
+                    parametersList.push({name: gettext("Max distance to case"), value: maxCaseDistanceParamValue});
+                }
+
+                if (parameters.max_case_travel_time) {
+                    const travelParamValue = `${parameters.max_case_travel_time} ${gettext("minutes")}`;
+                    parametersList.push(
+                        {name: gettext("Max travel time"), value: travelParamValue}
+                    );
+                }
+
+                self.parameters(parametersList);
+                self.showParams(true);
+            }
+
             let userData = users.map(function (c) {
                 return {
                     id: c.itemId,
@@ -146,6 +170,8 @@ hqDefine("geospatial/js/geospatial_map", [
                 data: JSON.stringify({'users': userData, "cases": caseData}),
                 contentType: "application/json; charset=utf-8",
                 success: function (ret) {
+                    self.setDisbursementParameters(ret["parameters"]);
+
                     if (ret['unassigned'].length) {
                         self.showUnassignedCasesError(true);
                     }
@@ -418,8 +444,10 @@ hqDefine("geospatial/js/geospatial_map", [
             showMapControls(false);
 
             disbursementRunner = new disbursementRunnerModel();
+
             $("#disbursement-spinner").koApplyBindings(disbursementRunner);
             $("#disbursement-error").koApplyBindings(disbursementRunner);
+            $("#disbursement-params").koApplyBindings(disbursementRunner);
 
             return;
         }

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -144,8 +144,8 @@ hqDefine("geospatial/js/geospatial_map", [
                     parametersList.push({name: gettext("Max distance to case"), value: maxCaseDistanceParamValue});
                 }
 
-                if (parameters.max_case_travel_time) {
-                    const travelParamValue = `${parameters.max_case_travel_time} ${gettext("minutes")}`;
+                if (parameters.max_case_travel_time_seconds) {
+                    const travelParamValue = `${parameters.max_case_travel_time_seconds/60} ${gettext("minutes")}`;
                     parametersList.push(
                         {name: gettext("Max travel time"), value: travelParamValue}
                     );

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -115,6 +115,15 @@
         Previous disbursement was cleared.
     {% endblocktrans %}
 </div>
+<div id="disbursement-params" class="alert alert-info" data-bind="visible: showParams()">
+  <h4>{% trans 'Disbursement parameters' %}</h4>
+  <!-- ko foreach: parameters -->
+  <span style="padding-right: 1em">
+    <span data-bind="text: name"></span>:
+    <b><span data-bind="text: value"></span></b>
+  </span>
+  <!-- /ko -->
+</div>
 <div id="geospatial-map" style="height: 500px">
     <div id="layer-toggle-menu" class="btn-group-vertical hidden">
         <h4 class="text-center">

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -64,9 +64,11 @@ class CaseDisbursementAlgorithm(BaseDomainView):
         solver_class = config.disbursement_solver
         result = solver_class(request_json).solve(config=config)
 
-        return json_response(
-            {'assignments': result['assigned'], 'unassigned': result['unassigned']}
-        )
+        return json_response({
+            'assignments': result['assigned'],
+            'unassigned': result['unassigned'],
+            'parameters': result['parameters'],
+        })
 
 
 class GeoPolygonView(BaseDomainView):


### PR DESCRIPTION
## Product Description
This PR shows the geospatial algorithm parameters when running the disbursement. See image below.

![image](https://github.com/dimagi/commcare-hq/assets/44245062/e8e78326-93c2-4357-adbd-0c744836a0a7)

The alert banner is shown once the user clicks the "Run disbursement" button.

## Technical Summary
The disbursement parameters is now passed to the FE together with the results of the disbursement algorithm so that the user is informed on what the parameters where during processing.

I decided to have a dataclass, `Parameters`, contain and handle the parameters for the disbursement algorithm, since it nicer and easier to just have it all contained in one place. 

## Feature Flag
Geospatial

## Safety Assurance

### Safety story
Local testing

### Automated test coverage
No automated testing necessary, but existing tests have been updated.

### QA Plan
No QA planned

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
