### PR TITLE
[Draft] Further Optimizations to improve load times for clean case panel

### DIFF
--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -454,7 +454,8 @@ def case_property_names(request, domain, case_id):
     # We need to look at the export schema in order to remove any case properties that
     # have been deleted from the app. When the data dictionary is fully public, we can use that
     # so that users may deprecate those properties manually
-    export_schema = CaseExportDataSchema.generate_schema_from_builds(domain, None, case.type)
+    export_schema = CaseExportDataSchema.generate_schema_from_builds(domain, None, case.type,
+                                                                     is_identifier_case_type=True)
     property_schema = export_schema.group_schemas[0]
     last_app_ids = get_latest_app_ids_and_versions(domain)
     all_property_names = {


### PR DESCRIPTION
## Technical Summary
This is work toward improving the loading time of the "Clean Case Data" panel as described in this related ticket.
https://dimagi.atlassian.net/browse/SAAS-15406

This builds on the optimizations covered [in this PR](https://github.com/dimagi/commcare-hq/pull/34718), adding an additional optimization to parallelize the expensive call of `_process_app_build` within `_process_apps_for_export`.

Note: the first commit is already part of the PR mentioned above.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
