### PR TITLE
Ignore sub-indices in ptop_preindex

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         runs = []
-        all_es_index_adapters = list(get_all_expected_es_indices())
+        all_es_index_adapters = get_all_expected_es_indices(ignore_subindices=True)
 
         if options['reset']:
             indices_needing_reindex = all_es_index_adapters

--- a/corehq/ex-submodules/pillowtop/management/commands/update_es_settings.py
+++ b/corehq/ex-submodules/pillowtop/management/commands/update_es_settings.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         noinput = options.pop('noinput')
-        es_indices = list(get_all_expected_es_indices())
+        es_indices = get_all_expected_es_indices()
 
         to_update = []
 

--- a/corehq/pillows/utils.py
+++ b/corehq/pillows/utils.py
@@ -82,8 +82,11 @@ def get_user_type_deep_cache_for_unknown_users(user_id):
     return get_user_type(user_id)
 
 
-def get_all_expected_es_indices():
-    yield from CANONICAL_NAME_ADAPTER_MAP.values()
+def get_all_expected_es_indices(ignore_subindices=False):
+    all_es_adapters = CANONICAL_NAME_ADAPTER_MAP.values()
+    if ignore_subindices:
+        return [adapter for adapter in all_es_adapters if not adapter.parent_index_cname]
+    return all_es_adapters
 
 
 def format_form_meta_for_es(form_metadata):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
When we created adapter for sub-indices, it wasn't assigned to a pillow as it's multiplexing is handled at adapter level. So the change broke ptop_preindex command, the command complained that a valid reindexer is not assigned for the case-search-bha index which is not required.
This PR adds support to filter our subindices when required.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Tested locally
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Does not affect anything in HQ except the management command which is generally used in dev envs.
### Automated test coverage
NA
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
