### PR TITLE
Removed erroneous description for the Duplicate Cases report

### DIFF
--- a/corehq/apps/reports/standard/cases/duplicate_cases.py
+++ b/corehq/apps/reports/standard/cases/duplicate_cases.py
@@ -19,6 +19,7 @@ from corehq.apps.data_interfaces.models import CaseDuplicateNew
 class DuplicateCasesExplorer(CaseListExplorer):
     name = _("Duplicate Cases")
     slug = 'duplicate_cases'
+    description = None
 
     fields = [
         DuplicateCaseRuleFilter,

--- a/corehq/apps/reports/standard/cases/duplicate_cases.py
+++ b/corehq/apps/reports/standard/cases/duplicate_cases.py
@@ -19,7 +19,7 @@ from corehq.apps.data_interfaces.models import CaseDuplicateNew
 class DuplicateCasesExplorer(CaseListExplorer):
     name = _("Duplicate Cases")
     slug = 'duplicate_cases'
-    description = None
+    description = _("Identify and manage duplicate cases")
 
     fields = [
         DuplicateCaseRuleFilter,


### PR DESCRIPTION
## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15569
It was discovered that the Duplicate Cases Report was displaying the same description as the Case List Explorer. This fix removes the description, as other reports in this same header had no description, and I felt that changing the description to something like "Duplicate Case information" wouldn't add any useful information.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
This is only displayed text. It doesn't affect any logic.

### Automated test coverage

No tests

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
