### PR TITLE
Fix error on question required changed

### DIFF
--- a/corehq/apps/app_manager/app_schemas/form_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/form_metadata.py
@@ -419,7 +419,7 @@ class _AppDiffGenerator(object):
     def _mark_item_removed(self, item, key):
         self._set_contains_changes(item)
         try:
-            old_value = item[key]
+            old_value = stringify(item[key])
         except KeyError:
             old_value = None
         if isinstance(old_value, dict):
@@ -431,7 +431,7 @@ class _AppDiffGenerator(object):
     def _mark_item_added(self, item, key):
         self._set_contains_changes(item)
         try:
-            new_value = item[key]
+            new_value = stringify(item[key])
         except KeyError:
             new_value = None
         if isinstance(new_value, dict):
@@ -447,7 +447,11 @@ class _AppDiffGenerator(object):
             change_class = _TranslationChange
         else:
             change_class = _Change
-        change = change_class(type=CHANGED, old_value=first_item[key], new_value=second_item[key])
+        change = change_class(
+            type=CHANGED,
+            old_value=stringify(first_item[key]),
+            new_value=stringify(second_item[key]),
+        )
         first_item.changes[key] = change
         second_item.changes[key] = change
 
@@ -466,6 +470,10 @@ class _AppDiffGenerator(object):
                         form.changes.contains_changes = True
         except AttributeError:
             pass
+
+
+def stringify(value):
+    return value if value is None or isinstance(value, dict) else str(value)
 
 
 def get_app_diff(app1, app2):

--- a/corehq/apps/app_manager/app_schemas/tests/test_app_diffs.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_app_diffs.py
@@ -145,6 +145,18 @@ class TestAppDiffs(_BaseTestAppDiffs, SimpleTestCase):
         self.assertEqual(first[0]['forms'][0]['questions'][0]['changes']['label']['type'], CHANGED)
         self.assertEqual(second[0]['forms'][0]['questions'][0]['changes']['label']['type'], CHANGED)
 
+    def test_change_question_to_be_required(self):
+        self._add_question(self.app1.modules[0].forms[0], {'name': 'foo'})
+        self._add_question(self.app2.modules[0].forms[0], {'name': 'foo', 'required': 'true()'})
+        first, second = get_app_diff(self.app1, self.app2)
+        self.assertEqual(first[0]['forms'][0]['questions'][0]['changes']['required']['type'], CHANGED)
+
+    def test_change_question_to_be_not_required(self):
+        self._add_question(self.app1.modules[0].forms[0], {'name': 'foo', 'required': 'true()'})
+        self._add_question(self.app2.modules[0].forms[0], {'name': 'foo'})
+        first, second = get_app_diff(self.app1, self.app2)
+        self.assertEqual(second[0]['forms'][0]['questions'][0]['changes']['required']['type'], CHANGED)
+
     def test_add_question_translation(self):
         self.app1.langs = ['en', 'it']
         self.app2.langs = ['en', 'it']

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -60,7 +60,7 @@ GROUP_TYPES = ('group', 'repeatGroup')  # TODO: Support 'questionList'
 
 
 # Supported question parameters
-QUESTION_PARAMS = ('calculate', 'constraint', 'jr:constraintMsg')
+QUESTION_PARAMS = ('calculate', 'constraint', 'required', 'jr:constraintMsg')
 
 
 class XFormBuilder(object):


### PR DESCRIPTION
Convert non-string (boolean) value to string to prevent  jsonobject `StringProperty` from throwing an error

After fixing the bug, changing the question required value results in diffs that look like:

![Screenshot from 2024-06-04 09-43-02](https://github.com/dimagi/commcare-hq/assets/464726/e6082d1e-212d-4616-9df6-f1204873ae0f)

![Screenshot from 2024-06-04 09-43-27](https://github.com/dimagi/commcare-hq/assets/464726/764816c8-b4a7-4727-9877-7e6039b28c3b)

There is an open question around whether these changes should appear as _changed_ or _added_/_removed_ in the UI. It is possible that there are other bugs or at least questionable behaviors of the app diff code that have not been addressed in this PR.

https://dimagi.atlassian.net/browse/SAAS-13743

Written while pairing with @jingcheng16 and @gherceg.

## Safety Assurance

### Safety story

Minimal changes were made to handle non-string values in the diff logic.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations