### PR TITLE
Dont show "view child data to level" column if not advanced mode or FF is off

### DIFF
--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -7,6 +7,7 @@
 {% block page_content %}
   {% initial_page_data 'location_types' location_types %}
   {% initial_page_data 'commtrack_enabled' commtrack_enabled %}
+  {% initial_page_data 'location_case_sync_restriction_enabled' location_case_sync_restriction_enabled %}
   {% initial_page_data 'suggest_orphan_case_alerts_setting' suggest_orphan_case_alerts_setting %}
   {% initial_page_data 'project_settings_url' project_settings_url %}
   <div class="row">
@@ -157,15 +158,17 @@
                                           {% endblocktrans %}">
                                     </span>
               </th>
-              <th>
-                {% trans "View Child Data to Level" %}
-                <span class="hq-help-template"
-                      data-title="{% trans "View Child Data to Level" %}"
-                      data-content="{% blocktrans %}
-                          <p>Only include cases that show up in the user's restore file down to this level (inclusive).</p>
-                      {% endblocktrans %}">
-                </span>
-              </th>
+              {% if location_case_sync_restriction_enabled %}
+                <th data-bind="visible: advanced_mode">
+                  {% trans "View Child Data to Level" %}
+                  <span class="hq-help-template"
+                        data-title="{% trans "View Child Data to Level" %}"
+                        data-content="{% blocktrans %}
+                            <p>Only include cases that show up in the user's restore file down to this level (inclusive).</p>
+                        {% endblocktrans %}">
+                  </span>
+                </th>
+              {% endif %}
               <th></th>
             </tr>
             </thead>
@@ -243,16 +246,18 @@
               <td>
                 <input data-bind="checked: view_descendants" type="checkbox" />
               </td>
-              <td>
-                <select class="form-control"
-                        data-bind="options: $data.child_loc_types(),
-                                   optionsText: 'name',
-                                   optionsValue: 'pk',
-                                   value: expand_view_child_data_to,
-                                   optionsCaption: '\u2013{% trans 'none' %}\u2013',
-                                   enable: view_descendants">
-                </select>
-              </td>
+              {% if location_case_sync_restriction_enabled %}
+                <td data-bind="visible: $parent.advanced_mode">
+                  <select class="form-control"
+                          data-bind="options: $data.child_loc_types(),
+                                    optionsText: 'name',
+                                    optionsValue: 'pk',
+                                    value: expand_view_child_data_to,
+                                    optionsCaption: '\u2013{% trans 'none' %}\u2013',
+                                    enable: view_descendants">
+                  </select>
+                </td>
+              {% endif %}
               <td>
                 <button type="button" class="btn btn-danger" data-bind="click: $root.remove_loctype">
                   <i class="fa-regular fa-trash-can"></i> {% trans "Remove" %}

--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -7,7 +7,6 @@
 {% block page_content %}
   {% initial_page_data 'location_types' location_types %}
   {% initial_page_data 'commtrack_enabled' commtrack_enabled %}
-  {% initial_page_data 'location_case_sync_restriction_enabled' location_case_sync_restriction_enabled %}
   {% initial_page_data 'suggest_orphan_case_alerts_setting' suggest_orphan_case_alerts_setting %}
   {% initial_page_data 'project_settings_url' project_settings_url %}
   <div class="row">
@@ -158,7 +157,7 @@
                                           {% endblocktrans %}">
                                     </span>
               </th>
-              {% if location_case_sync_restriction_enabled %}
+              {% if request|toggle_enabled:"USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION" %}
                 <th data-bind="visible: advanced_mode">
                   {% trans "View Child Data to Level" %}
                   <span class="hq-help-template"
@@ -246,7 +245,7 @@
               <td>
                 <input data-bind="checked: view_descendants" type="checkbox" />
               </td>
-              {% if location_case_sync_restriction_enabled %}
+              {% if request|toggle_enabled:"USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION" %}
                 <td data-bind="visible: $parent.advanced_mode">
                   <select class="form-control"
                           data-bind="options: $data.child_loc_types(),

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -310,8 +310,6 @@ class LocationTypesView(BaseDomainView):
         return {
             'location_types': self._location_types,
             'commtrack_enabled': self.domain_object.commtrack_enabled,
-            'location_case_sync_restriction_enabled':
-                toggles.USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION.enabled(self.domain),
             'suggest_orphan_case_alerts_setting': self._suggest_orphan_case_alerts_setting,
             'project_settings_url': reverse('domain_settings_default', args=[self.domain])
         }

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -310,6 +310,8 @@ class LocationTypesView(BaseDomainView):
         return {
             'location_types': self._location_types,
             'commtrack_enabled': self.domain_object.commtrack_enabled,
+            'location_case_sync_restriction_enabled':
+                toggles.USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION.enabled(self.domain),
             'suggest_orphan_case_alerts_setting': self._suggest_orphan_case_alerts_setting,
             'project_settings_url': reverse('domain_settings_default', args=[self.domain])
         }


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

JIRA: [USH-4554](https://dimagi.atlassian.net/browse/USH-4554?atlOrigin=eyJpIjoiYTM3Njg0OGE3MGFiNGUzMDk4MzM3MjdiZDZmZWMzZjciLCJwIjoiaiJ9)

Only displays the "View child data to level" column on the "organization structure" page if the FF is on and the "advanced mode" checkbox is checked.

This is the column in question:

![Screenshot 2024-06-04 at 2 04 59 PM](https://github.com/dimagi/commcare-hq/assets/6729291/b42a940c-d6c9-4dee-814f-072b0b09d8d7)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Pretty straightforward change I think.

Original PR, for context: #34427

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Straightforward change
- Just UI/HTML
- Tested out different scenarios locally, checking/unchecking advanced mode, the FF on/off, seeing that the dropdown still disables properly when "view child data" is turned off

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Don't think this change warrants QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4554]: https://dimagi.atlassian.net/browse/USH-4554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ