### PR TITLE
Improve report builder preview error handling

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -49,6 +49,7 @@ from corehq.apps.userreports.const import (
     REPORT_BUILDER_EVENTS_KEY,
 )
 from corehq.apps.userreports.exceptions import (
+    BadBuilderConfigError,
     BadSpecError,
     DataSourceConfigurationNotFoundError,
     TableNotFoundWarning,
@@ -593,9 +594,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
                 "aaData": cls.sanitize_page(export.get_data()),
             }
         except DataSourceConfigurationNotFoundError:
-            # A temporary data source has probably expired
-            # TODO: It would be more helpful just to quietly recreate the data source config from GET params
-            return None
+            raise BadBuilderConfigError(DATA_SOURCE_NOT_FOUND_ERROR_MESSAGE)
 
 
 # Base class for classes that provide custom rendering for UCRs

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -592,9 +592,6 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
                 "chart_configs": report_config.charts,
                 "aaData": cls.sanitize_page(export.get_data()),
             }
-        except UserReportsError:
-            # User posted an invalid report configuration
-            return None
         except DataSourceConfigurationNotFoundError:
             # A temporary data source has probably expired
             # TODO: It would be more helpful just to quietly recreate the data source config from GET params

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -15,8 +15,13 @@ from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.es.tests.utils import es_test, populate_case_search_index
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.userreports import tasks
+from corehq.apps.userreports.const import DATA_SOURCE_NOT_FOUND_ERROR_MESSAGE
 from corehq.apps.userreports.dbaccessors import delete_all_report_configs
-from corehq.apps.userreports.exceptions import UserReportsError
+from corehq.apps.userreports.exceptions import (
+    BadBuilderConfigError,
+    DataSourceConfigurationNotFoundError,
+    UserReportsError,
+)
 from corehq.apps.userreports.models import (
     DataSourceConfiguration,
     ReportConfiguration,
@@ -370,6 +375,15 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
 
         with self.assertRaises(UserReportsError):
             ConfigurableReportView.report_preview_data(report.domain, report)
+
+    @patch("corehq.apps.userreports.reports.view.ReportExport")
+    def test_report_preview_data_propagates_data_source_not_found_error(self, mock):
+        mock.side_effect = DataSourceConfigurationNotFoundError
+        report, view = self._build_report_and_view()
+
+        with self.assertRaises(BadBuilderConfigError) as err:
+            ConfigurableReportView.report_preview_data(report.domain, report)
+        self.assertEqual(str(err.exception), DATA_SOURCE_NOT_FOUND_ERROR_MESSAGE)
 
     def test_paginated_build_table(self):
         """

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -16,6 +16,7 @@ from corehq.apps.es.tests.utils import es_test, populate_case_search_index
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.userreports import tasks
 from corehq.apps.userreports.dbaccessors import delete_all_report_configs
+from corehq.apps.userreports.exceptions import UserReportsError
 from corehq.apps.userreports.models import (
     DataSourceConfiguration,
     ReportConfiguration,
@@ -361,6 +362,14 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
                 },
             ]
         )
+
+    @patch("corehq.apps.userreports.reports.view.ReportExport")
+    def test_report_preview_data_does_not_handle_user_reports_error(self, mock):
+        mock.side_effect = UserReportsError
+        report, view = self._build_report_and_view()
+
+        with self.assertRaises(UserReportsError):
+            ConfigurableReportView.report_preview_data(report.domain, report)
 
     def test_paginated_build_table(self):
         """

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -826,6 +826,10 @@ class ReportPreview(BaseDomainView):
             except BadBuilderConfigError as e:
                 return json_response({'status': 'error', 'message': str(e)}, status_code=400)
 
+            return json_response({
+                'status': 'error',
+                'message': 'Report preview returned no response',
+            }, status_code=400)
         else:
             return json_response({
                 'status': 'error',

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -108,6 +108,7 @@ from corehq.apps.userreports.exceptions import (
     ReportConfigurationNotFoundError,
     TableNotFoundWarning,
     UserQueryError,
+    UserReportsError,
     translate_programming_error,
 )
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
@@ -825,7 +826,10 @@ class ReportPreview(BaseDomainView):
                     return json_response(response_data)
             except BadBuilderConfigError as e:
                 return json_response({'status': 'error', 'message': str(e)}, status_code=400)
-
+            except UserReportsError as err:
+                notify_exception(request, str(err), details={'domain': self.domain})
+                # Empty message -> generic error in the template.
+                return json_response({'status': 'error', 'message': ''}, status_code=400)
             return json_response({
                 'status': 'error',
                 'message': 'Report preview returned no response',


### PR DESCRIPTION
Debugging the issue in the linked Jira ticket was unnecessarily difficult because preview errors were swallowed rather than propagating them to the end user and Sentry. This PR attempts to improve that situation.

https://dimagi.atlassian.net/browse/SAAS-15132

## Safety Assurance

### Safety story

Error handling was improved, but otherwise no functionality was changed.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations