### PR TITLE
Create empty datasource table after undoing deletion in UCRs

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -902,6 +902,8 @@ def undelete_report(request, domain, report_id):
     ])
     if config and is_deleted(config):
         undo_delete(config)
+        indicator_adapter = get_indicator_adapter(config.config)
+        indicator_adapter.adapter.rebuild_table(initiated_by=request.user.username)
         messages.success(
             request,
             _('Successfully restored report "{name}"').format(name=config.title)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
https://dimagi.atlassian.net/browse/SAAS-14698
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
After we undelete a deleted UCR, we used to get an error saying table does not exist while fetching the data. However a workaround was going to the Edit reports page and saving the UCR from there used to fix the issue. 
After poking around a bit in UCR codebase with @biyeun we figured that if we create the empty table after we have undeleted the UCRs the issue can be fixed.
The code changes attempts the following only. It does not populate the data again and for that report is needed to be saved again.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A
## Safety Assurance
A very specific case in HQ and fixes an infinite loader which was caused due to error.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.
### Automated test coverage
NA
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
