### PR TITLE
Updated base colors for B5

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
@@ -117,7 +117,7 @@ $dimagi-mango: #FC5F36;
 
 // Base color overrides
 $blue: darken(#5D70D2, 20%);
-$green: lighten(#3FA12A, 20%);
+$green: darken(#3FA12A, 10%);
 $red: darken($dimagi-sunset, 20%);
 $teal: #01A2A9;
 $yellow: $dimagi-marigold;

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
@@ -118,7 +118,7 @@ $dimagi-mango: #FC5F36;
 // Base color overrides
 $blue: #5D70D2;
 $green: #3FA12A;
-$red: $dimagi-sunset;
+$red: darken($dimagi-sunset, 20%);
 $teal: #01A2A9;
 $yellow: $dimagi-marigold;
 $indigo: $dimagi-indigo;

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
@@ -116,8 +116,8 @@ $dimagi-mango: #FC5F36;
 
 
 // Base color overrides
-$blue: #5D70D2;
-$green: #3FA12A;
+$blue: darken(#5D70D2, 20%);
+$green: lighten(#3FA12A, 20%);
 $red: darken($dimagi-sunset, 20%);
 $teal: #01A2A9;
 $yellow: $dimagi-marigold;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -224,7 +224,7 @@
 +
 +// Base color overrides
 +$blue: darken(#5D70D2, 20%);
-+$green: lighten(#3FA12A, 20%);
++$green: darken(#3FA12A, 10%);
 +$red: darken($dimagi-sunset, 20%);
 +$teal: #01A2A9;
 +$yellow: $dimagi-marigold;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -225,7 +225,7 @@
 +// Base color overrides
 +$blue: #5D70D2;
 +$green: #3FA12A;
-+$red: $dimagi-sunset;
++$red: darken($dimagi-sunset, 20%);
 +$teal: #01A2A9;
 +$yellow: $dimagi-marigold;
 +$indigo: $dimagi-indigo;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -223,8 +223,8 @@
 +
 +
 +// Base color overrides
-+$blue: #5D70D2;
-+$green: #3FA12A;
++$blue: darken(#5D70D2, 20%);
++$green: lighten(#3FA12A, 20%);
 +$red: darken($dimagi-sunset, 20%);
 +$teal: #01A2A9;
 +$yellow: $dimagi-marigold;


### PR DESCRIPTION
## Product Description
These don't have enough contrast when used as text on a white background (or as buttons with white text).

* `$red`
   * Old value: https://webaim.org/resources/contrastchecker/?fcolor=E44434&bcolor=FFFFFF
   * New value: https://webaim.org/resources/contrastchecker/?fcolor=9D2115&bcolor=FFFFFF
* `$blue`
   * Old value: https://webaim.org/resources/contrastchecker/?fcolor=5D70D2&bcolor=FFFFFF
   * New value: https://webaim.org/resources/contrastchecker/?fcolor=2c3e9d&bcolor=FFFFFF
* `$green`
   * Old value: https://webaim.org/resources/contrastchecker/?fcolor=3FA12A&bcolor=FFFFFF
   * New value: https://webaim.org/resources/contrastchecker/?fcolor=2F791F&bcolor=FFFFFF

Also see [B5 web apps documentation](https://docs.google.com/document/d/1aw_F8A5u73CXaqNT0NEq0p3idh9PoVmqdErKRa8mN1g/edit#heading=h.4g9763jpi730)

## Safety Assurance

### Safety story
Changes a single sass variable.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
