### PR TITLE
Update software plan visibilities

### DIFF
--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -171,8 +171,9 @@ def _ensure_software_plan(plan_key, product, product_rate, verbose, apps):
         plan_opts = {
             'name': plan_name,
             'edition': plan_key.edition,
-            'visibility': (SoftwarePlanVisibility.ANNUAL
-                           if plan_key.is_annual_plan else SoftwarePlanVisibility.PUBLIC),
+            'visibility': (SoftwarePlanVisibility.INTERNAL
+                if plan_key.edition == SoftwarePlanEdition.ENTERPRISE
+                else SoftwarePlanVisibility.PUBLIC),
         }
         if plan_key.is_annual_plan is not None:
             plan_opts['is_annual_plan'] = plan_key.is_annual_plan

--- a/corehq/apps/accounting/migrations/0095_update_softwareplan_visibilities.py
+++ b/corehq/apps/accounting/migrations/0095_update_softwareplan_visibilities.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+from django.db import migrations, models
+
+from corehq.apps.accounting.models import SoftwarePlanVisibility
+
+ANNUAL = "ANNUAL"
+
+
+def change_plan_visibilities(apps, schema_editor):
+    # one-time cleanup of existing software plans
+    SoftwarePlan = apps.get_model('accounting', 'SoftwarePlan')
+
+    enterprise_names = ["Dimagi Only CommCare Enterprise Edition"]
+    enterprise_plans = SoftwarePlan.objects.filter(name__in=enterprise_names)
+    enterprise_plans.update(visibility=SoftwarePlanVisibility.INTERNAL, last_modified=datetime.now())
+
+    annual_plans = SoftwarePlan.objects.filter(visibility=ANNUAL)
+    annual_plans.update(visibility=SoftwarePlanVisibility.PUBLIC, last_modified=datetime.now())
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounting", "0094_add_annual_softwareplans"),
+    ]
+
+    operations = [
+        migrations.RunPython(change_plan_visibilities),
+        migrations.AlterField(
+            model_name="softwareplan",
+            name="visibility",
+            field=models.CharField(
+                choices=[
+                    ("PUBLIC", "PUBLIC - Anyone can subscribe"),
+                    ("INTERNAL", "INTERNAL - Dimagi must create subscription"),
+                    ("TRIAL", "TRIAL- This is a Trial Plan"),
+                    ("ARCHIVED", "ARCHIVED - hidden from subscription change forms"),
+                ],
+                default="INTERNAL",
+                max_length=10,
+            ),
+        ),
+    ]

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -171,14 +171,12 @@ class SoftwarePlanVisibility(object):
     PUBLIC = "PUBLIC"
     INTERNAL = "INTERNAL"
     TRIAL = "TRIAL"
-    ANNUAL = "ANNUAL"
     ARCHIVED = "ARCHIVED"
     CHOICES = (
         (PUBLIC, "PUBLIC - Anyone can subscribe"),
         (INTERNAL, "INTERNAL - Dimagi must create subscription"),
         (TRIAL, "TRIAL- This is a Trial Plan"),
         (ARCHIVED, "ARCHIVED - hidden from subscription change forms"),
-        (ANNUAL, "ANNUAL - public plans that on annual pricing"),
     )
 
 

--- a/corehq/apps/accounting/tests/test_ensure_plans.py
+++ b/corehq/apps/accounting/tests/test_ensure_plans.py
@@ -104,7 +104,8 @@ class TestEnsurePlans(BaseAccountingTest):
             )
             self.assertEqual(sms_feature_rate.per_excess_fee, 0)
 
-            expected_visibility = (SoftwarePlanVisibility.ANNUAL
-                                   if is_annual_plan else SoftwarePlanVisibility.PUBLIC)
+            expected_visibility = (SoftwarePlanVisibility.INTERNAL
+                                   if edition == SoftwarePlanEdition.ENTERPRISE
+                                   else SoftwarePlanVisibility.PUBLIC)
             self.assertEqual(software_plan_version.plan.visibility, expected_visibility)
             self.assertEqual(software_plan_version.plan.is_annual_plan, is_annual_plan)

--- a/migrations.lock
+++ b/migrations.lock
@@ -114,6 +114,7 @@ accounting
  0092_revert_application_error_report_priv
  0093_defaultproductplan_is_annual_plan
  0094_add_annual_softwareplans
+ 0095_update_softwareplan_visibilities
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Product Description
- Change "Dimagi Only CommCare Enterprise Edition" to 'INTERNAL' visibility
- Change all 'ANNUAL' visibility software plans to 'PUBLIC'
- Remove 'ANNUAL' software plan visibility choice

## Technical Summary
Requests 1 and 3 from [SAAS-15555](https://dimagi.atlassian.net/browse/SAAS-15555)

## Safety Assurance

### Safety story
"Visibility" is used by accounting/ops to filter through plans visually, not for any functionality, so modifying it is fairly low risk. Tested various situations locally, for example running `.update` on an empty queryset to see that nothing happens, and that having existing DB objects using `ANNUAL` visibility doesn't throw any errors, if for some reason there are still any after running `change_plan_visibilities` but before the choice is removed. Tested locally and on staging.

### Automated test coverage
Updated test_ensure_plans

### QA Plan
Not planned for QA.


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions
This migration is not strictly reversible. Given that visibility is used only as a visual filter field and its choices are not enforced by the DB, the migration should be able to be faked backward without concern, if needed.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-15555]: https://dimagi.atlassian.net/browse/SAAS-15555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ