### PR TITLE
fix language menu for languages not showing in native script

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -22,6 +22,13 @@ from corehq.apps.app_manager.util import (
 from corehq.util.translation import localize
 
 
+# If the language name is not showing up properly in the language menu, you can
+# define those languages here, mapped to their two-letter language codes.
+CUSTOM_LANGUAGE_NAMES = {
+    'km': "ខ្មែរ",
+}
+
+
 def non_empty_only(dct):
     return {key: value for key, value in dct.items() if value}
 
@@ -60,8 +67,16 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
             name = langcodes.get_name(lc) or lc
             if not name:
                 continue
-            with localize(convert_to_two_letter_code(lc)):
-                name = gettext(name)
+            letter_code = convert_to_two_letter_code(lc)
+
+            if letter_code in CUSTOM_LANGUAGE_NAMES.keys():
+                # These are languages not installed on our machines, so localize does not understand them.
+                # Though we don't want to install these langauges, we still want to support projects
+                # who want to see the name written properly.
+                name = CUSTOM_LANGUAGE_NAMES[letter_code]
+            else:
+                with localize(letter_code):
+                    name = gettext(name)
             yield lc, name
 
     yield id_strings.current_language(), lang


### PR DESCRIPTION
## Technical Summary
Certain languages are not understood by the system (unless explicitly installed), so a call to `localize` text in that language does not return strings formatted in that language's character set. As a result, the value for that 
language in `app_strings` remains written in English. This isn't ideal for users who are trying to find their language and are not familiar with their language's name written in English. For instance, `Central Khmer` is written as `ខ្មែរ`

This allows us to specify custom language names for a given two-letter language code so that 

For additional context see: https://dimagi.atlassian.net/browse/SAAS-14944

## Safety Assurance

### Safety story
Safe change. Only affects text in `app_strings` for apps using `Central Khmer`, and this was tested well locally.

### Automated test coverage
No

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
