### PR TITLE
removed the wait on case upload record

### DIFF
--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -25,11 +25,6 @@ from .util import (
 @task(queue='case_import_queue')
 def bulk_import_async(config_list_json, domain, excel_id):
     case_upload = CaseUpload.get(excel_id)
-    # case_upload.trigger_upload fires off this task right before saving the CaseUploadRecord
-    # because CaseUploadRecord needs to be saved with the task id firing off the task creates.
-    # Occasionally, this task could start before the CaseUploadRecord was saved,
-    # which causes unpredictable/undesirable error behavior
-    case_upload.wait_for_case_upload_record()
     result_stored = False
     deprecated_case_types = get_data_dict_deprecated_case_types(domain)
     try:

--- a/corehq/apps/case_importer/tracking/exceptions.py
+++ b/corehq/apps/case_importer/tracking/exceptions.py
@@ -1,2 +1,0 @@
-class TimedOutWaitingForCaseUploadRecord(Exception):
-    pass


### PR DESCRIPTION
## Technical Summary
The case uploader needs to create a case upload record that contains the task ID. Currently, that is done by first creating the task so that we have a task id, then generated the case upload record, and then finally causing the spawned task to sleep until it sees that case upload record, in order to avoid a race condition. In environments that use `CELERY_TASK_ALWAYS_EAGER`, this process will time out, as the task will attempt to execute fully before the case upload record is created. 

Instead, it appears that celery supports syntax to assign task IDs directly (see [here](https://github.com/celery/celery/blob/main/docs/faq.rst#can-i-specify-a-custom-task_id)). This avoids the same race condition, allows us to remove code, and lets this run with `CELERY_TASK_ALWAYS_EAGER` enabled.

## Safety Assurance

### Safety story
Verified this locally. I also verified that the task ID specified is indeed that task ID that is used within the task.

### Automated test coverage
I'm not quite clear if automated tests are appropriate here. The main test I think is essentially a library test -- we want to verify that we can assign custom task IDs, and that's really celery's code, not ours.

### QA Plan

No QA


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
