### PR TITLE
Reorder case properties for bulk case export

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -2358,7 +2358,8 @@ class CaseExportDataSchema(ExportDataSchema):
         return get_latest_case_export_schema(domain, case_type)
 
     @classmethod
-    def _process_app_build(cls, current_schema, app, case_type, for_new_export_instance=False):
+    def _process_app_build(cls, current_schema, app, case_type, for_new_export_instance=False,
+                           for_bulk_export=False):
         builder = ParentCasePropertyBuilder(
             app.domain,
             [app],
@@ -2366,7 +2367,8 @@ class CaseExportDataSchema(ExportDataSchema):
         )
         case_property_mapping = builder.get_case_property_map([case_type])
 
-        if for_new_export_instance and domain_has_privilege(app.domain, privileges.DATA_DICTIONARY):
+        if ((for_bulk_export or for_new_export_instance)
+                and domain_has_privilege(app.domain, privileges.DATA_DICTIONARY)):
             case_property_mapping[case_type] = cls._reorder_case_properties_from_data_dictionary(
                 app.domain, case_type, case_property_mapping[case_type]
             )
@@ -2546,6 +2548,7 @@ class CaseExportDataSchema(ExportDataSchema):
                         case_type_schema,
                         app,
                         case_type,
+                        for_bulk_export=True,
                     )
                 except Exception as e:
                     logging.exception('Failed to process app {}. {}'.format(app._id, e))

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -1357,7 +1357,7 @@ class TestOrderingOfSchemas(SimpleTestCase):
         )
 
 
-class TestOrderingOfCaseSchemaItemsFromDataDictionary(TestCase, TestXmlMixin):
+class BaseTestOrderingOfCaseSchemaItems(TestCase, TestXmlMixin):
     file_path = ['data']
     root = os.path.dirname(__file__)
     case_type = 'person'
@@ -1365,7 +1365,7 @@ class TestOrderingOfCaseSchemaItemsFromDataDictionary(TestCase, TestXmlMixin):
 
     @classmethod
     def setUpClass(cls):
-        super(TestOrderingOfCaseSchemaItemsFromDataDictionary, cls).setUpClass()
+        super(BaseTestOrderingOfCaseSchemaItems, cls).setUpClass()
 
         factory = AppFactory(domain=cls.domain)
         module1, form1 = factory.new_basic_module('update_case', cls.case_type)
@@ -1405,12 +1405,17 @@ class TestOrderingOfCaseSchemaItemsFromDataDictionary(TestCase, TestXmlMixin):
     @classmethod
     def tearDownClass(cls):
         cls.current_app.delete()
-        super(TestOrderingOfCaseSchemaItemsFromDataDictionary, cls).tearDownClass()
+        super(BaseTestOrderingOfCaseSchemaItems, cls).tearDownClass()
 
     def _get_schema_item_order(self, for_new_export_instance=True):
         schema = self._generate_schema(for_new_export_instance=for_new_export_instance)
         return [item.label for item in schema.group_schemas[0].items]
 
+    def _generate_schema(self):
+        raise NotImplementedError
+
+
+class TestOrderingOfCaseSchemaItemsFromDataDictionary(BaseTestOrderingOfCaseSchemaItems):
     def _generate_schema(self, for_new_export_instance=True):
         return CaseExportDataSchema.generate_schema_from_builds(
             self.domain,
@@ -1457,3 +1462,27 @@ class TestOrderingOfCaseSchemaItemsFromDataDictionary(TestCase, TestXmlMixin):
             self._get_schema_item_order(),
             ['weight', 'height', 'address', 'age']
         )
+
+
+class TestOrderingOfBulkCaseExportSchemaItemsFromDataDictionary(BaseTestOrderingOfCaseSchemaItems):
+    def _generate_schema(self, **kwargs):
+        return CaseExportDataSchema.generate_schema_from_builds(
+            self.domain,
+            None,
+            ALL_CASE_TYPE_EXPORT,
+        )
+
+    def test_default_ordering(self, *args):
+        with patch('corehq.apps.export.models.new.get_case_types_for_domain', return_value=(self.case_type,)):
+            self.assertListEqual(
+                self._get_schema_item_order(),
+                ['address', 'age', 'height', 'weight']
+            )
+
+    @patch('corehq.apps.export.models.new.domain_has_privilege', return_value=True)
+    def test_ordering_for_bulk_export_with_feature_flag(self, *args):
+        with patch('corehq.apps.export.models.new.get_case_types_for_domain', return_value=(self.case_type,)):
+            self.assertListEqual(
+                self._get_schema_item_order(),
+                ['weight', 'height', 'address', 'age']
+            )


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Just a follow up to https://github.com/dimagi/commcare-hq/pull/34502 to implement order for bulk case exports.

For bulk case exports, when a new bulk export is created or when a bulk export is edited & saved, ordering of columns is set based on data dictionary.
This is different from how it was implemented earlier for exports for a single case type where the ordering was set only while creating the export and not during edit.
This is because, in case exports for a single case type, users can see columns & reorder them on the UI whereas in bulk case export users don't see the columns on the UI.
So, it is safe to reorder columns based on data dictionary for bulk case exports for new and the ones being edited whereas for case exports for single case type, implementing ordering was only done for new exports and not on edit to avoid removing any re-ordering done by users.

This change is limited to projects with access to data dictionary only.

No screenshots attached for reference, simply the excel sheet is populated as ordered columns based on data dictionary set at the time of creation/edit.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3675

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally that things work okay for bulk case exports.
Code changes are quite limited and should not impact anything about exports otherwise.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests for new code added.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Will go through QA considering this is a user facing change.
QA request submitted. https://dimagi.atlassian.net/browse/QA-6656

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
