### PR TITLE
Add Assigned Location Column to Application Status Report

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/application_status.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/application_status.js.diff.txt
@@ -1,0 +1,9 @@
+--- 
++++ 
+@@ -1,5 +1,5 @@
+ 'use strict';
+-hqDefine("reports/js/bootstrap3/application_status", [
++hqDefine("reports/js/bootstrap5/application_status", [
+     "jquery",
+ ], function (
+     $

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,44 +1,44 @@
+@@ -1,45 +1,45 @@
 -{% extends "hqwebapp/bootstrap3/two_column.html" %}
 +{% extends "hqwebapp/bootstrap5/two_column.html" %}
  {% load compress %}
@@ -48,8 +48,10 @@
      <script src="{% static 'reports/js/inspect_data.js' %}"></script>
 -    <script src="{% static 'reports/js/bootstrap3/project_health_dashboard.js' %}"></script>
 -    <script src="{% static 'reports/js/bootstrap3/aggregate_user_status.js' %}"></script>
+-    <script src="{% static 'reports/js/bootstrap3/application_status.js' %}"></script>
 +    <script src="{% static 'reports/js/bootstrap5/project_health_dashboard.js' %}"></script>
 +    <script src="{% static 'reports/js/bootstrap5/aggregate_user_status.js' %}"></script>
++    <script src="{% static 'reports/js/bootstrap5/application_status.js' %}"></script>
      <script src="{% static 'reports/js/user_history.js' %}"></script>
      <script src="{% static 'reports/js/case_activity.js' %}"></script>
 -    <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
@@ -57,7 +59,7 @@
    {% endcompress %}
  {% endblock %}
  
-@@ -58,8 +58,8 @@
+@@ -59,8 +59,8 @@
  {% block title %}{{ report.title|default:"Project Reports" }}{% endblock %}
  
  {% block page_breadcrumbs %}
@@ -68,7 +70,7 @@
      <li>
        <a href="{{ report.default_url }}"><strong>{% trans report.section_name|default:"Reports" %}</strong></a>
      </li>
-@@ -98,17 +98,17 @@
+@@ -99,17 +99,17 @@
    {% initial_page_data 'slug' report.slug %}
  
    {% block filter_panel %}
@@ -90,7 +92,7 @@
                      aria-label="Close"
                      data-bind="click: resetModal"><span aria-hidden="true">&times;</span></button>
              <h4 class="modal-title">
-@@ -120,14 +120,14 @@
+@@ -121,14 +121,14 @@
                {{ datespan.enddate|date:"Y-m-d" }}
              </h4>
            </div>
@@ -107,7 +109,7 @@
        <h4>{% trans 'Notice' %}</h4>
        <p>{{ report.special_notice }}</p>
      </div>
-@@ -137,7 +137,7 @@
+@@ -138,7 +138,7 @@
        {% block reportcontent %}
        {% endblock %}
      {% else %}

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -501,7 +501,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         primary_location_id = user.get('location_id')
         formatted_loc_names = []
         for loc in locs:
-            if loc.location_id == primary_location_id and len(assigned_location_ids) > 1:
+            if loc.location_id == primary_location_id:
                 formatted_loc_names.append(
                     f'<strong>{loc.name}</strong>'
                 )

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -538,7 +538,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
             all_str = ', '.join(formatted_loc_names)
             view_controls_html_nodes = [
                 f'<span class="loc-view-control">{_("...See more")}</span>',
-                f'<span class="loc-view-control" style="display:none">{_("...See less")}</span>',
+                f'<span class="loc-view-control" style="display:none">{_("...Collapse")}</span>',
             ]
             html_nodes += [
                 f'<span class="all-locations-list" style="display:none">{all_str}</span>',

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -312,7 +312,14 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
             )
         )
 
-    def user_locations_dict(self, user_docs):
+    def locations_names_dict(self, user_docs):
+        """
+        Returns a dict of all assigned location names for given `user_docs`.
+        The dict has the following structure:
+        {
+            'loc_id': 'loc_name'
+        }
+        """
         all_loc_ids = set()
         for user_doc in user_docs:
             user = CouchUser.wrap_correctly(user_doc)
@@ -331,7 +338,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
             grouped_ancestor_locs = self.get_bulk_ancestors(location_ids)
             self.required_loc_columns = self.get_location_columns(grouped_ancestor_locs)
 
-        user_loc_dict = self.user_locations_dict(users)
+        loc_names_dict = self.locations_names_dict(users)
         for user in users:
             last_build = last_seen = last_sub = last_sync = last_sync_date = app_name = commcare_version = None
             last_build_profile_name = device = device_app_meta = num_unsent_forms = None
@@ -389,7 +396,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
                 user_display_string(user.get('username', ''),
                                     user.get('first_name', ''),
                                     user.get('last_name', '')),
-                self.get_location_column(user, user_loc_dict),
+                self.get_location_column(user, loc_names_dict),
                 _fmt_date(last_seen, fmt_for_export), _fmt_date(last_sync_date, fmt_for_export),
                 app_name or "---", build_version, commcare_version or '---',
                 num_unsent_forms if num_unsent_forms is not None else "---",

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -527,8 +527,8 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         if len(formatted_loc_names) > 4:
             all_str = ', '.join(formatted_loc_names)
             view_controls_html_nodes = [
-                f'<span>{_("...See more")}</span>',
-                f'<span style="display:none">{_("...See less")}</span>',
+                f'<span class="loc-view-control">{_("...See more")}</span>',
+                f'<span class="loc-view-control" style="display:none">{_("...See less")}</span>',
             ]
             html_nodes += [
                 f'<span class="all-locations-list" style="display:none">{all_str}</span>',

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -514,8 +514,8 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         for loc_id in assigned_location_ids:
             loc_name = user_loc_dict.get(loc_id)
             if loc_id == primary_location_id:
-                formatted_loc_names.append(
-                    f'<strong>{loc_name}</strong>'
+                formatted_loc_names.insert(
+                    0, f'<strong>{loc_name}</strong>'
                 )
             else:
                 formatted_loc_names.append(loc_name)

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -482,9 +482,9 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
 
         for row in table[1:]:
             # Last submission
-            row[len(location_colums) + 1] = _fmt_timestamp(row[len(location_colums) + 1])
-            # Last sync
             row[len(location_colums) + 2] = _fmt_timestamp(row[len(location_colums) + 2])
+            # Last sync
+            row[len(location_colums) + 3] = _fmt_timestamp(row[len(location_colums) + 3])
         result[0][1] = table
         return result
 

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -395,7 +395,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
             rows.append(row_data)
         return rows
 
-    def _locations_names_dict(self, user_docs_es):
+    def _locations_names_dict(self, user_es_docs):
         """
         Returns a dict of all assigned location names for given `user_docs`.
         The dict has the following structure:
@@ -404,8 +404,8 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         }
         """
         all_loc_ids = set()
-        for user_doc in user_docs_es:
-            user = CouchUser.wrap_correctly(user_doc)
+        for user_es_doc in user_es_docs:
+            user = CouchUser.wrap_correctly(user_es_doc)
             for loc_id in user.get_location_ids(self.domain):
                 all_loc_ids.add(loc_id)
         return dict(SQLLocation.objects.filter(
@@ -507,8 +507,8 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         result[0][1] = table
         return result
 
-    def _get_location_column(self, user_doc_es, user_loc_dict):
-        user = CouchUser.wrap_correctly(user_doc_es)
+    def _get_location_column(self, user_es_doc, user_loc_dict):
+        user = CouchUser.wrap_correctly(user_es_doc)
         if not user.get_location_ids(self.domain):
             return '---'
         return self._get_formatted_assigned_location_names(user, user_loc_dict)

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -82,8 +82,8 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
                              prop_name='username.exact',
                              sql_col='user_dim__username'),
             DataTablesColumn(_("Assigned Location(s)"),
-                             help_text=_('The location(s) that the user is assigned to, '
-                                         'including the primary location which is highlighted in bold.'),
+                             help_text=_('Assigned locations for the user, with the primary '
+                                         'location highlighted in bold.'),
                              sortable=False),
             DataTablesColumn(_("Last Submission"),
                              prop_name='reporting_metadata.last_submissions.submission_date',

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -522,14 +522,18 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
 
         formatted_str = ', '.join(formatted_loc_names[:4])
         all_str = ', '.join(formatted_loc_names)
-        eplise_str = _('...See more') if len(formatted_loc_names) > 4 else ''
+        view_all_str = _('...See more') if len(formatted_loc_names) > 4 else ''
+        view_less_str = _('...See less') if len(formatted_loc_names) > 4 else ''
         out_str = ('''
             <div>
                 <span class="locations-list">{}</span>
-                <a href="#" class="toggle-all-locations">{}</a>
                 <span class="all-locations-list" style="display:none">{}</span>
+                <a href="#" class="toggle-all-locations">
+                   <span>{}</span>
+                   <span style="display:none">{}</span>
+                </a>
             </div>
-        ''').format(formatted_str, eplise_str, all_str)
+        ''').format(formatted_str, all_str, view_all_str, view_less_str)
         return format_html(out_str)
 
 

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -317,7 +317,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
             for loc_id in user.get('assigned_location_ids'):
                 all_loc_ids.add(loc_id)
         return dict(SQLLocation.objects.filter(
-            location_id__in=all_loc_ids
+            location_id__in=all_loc_ids, domain=self.domain
         ).values_list('location_id', 'name'))
 
     def process_rows(self, users, fmt_for_export=False):

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -81,6 +81,9 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
             DataTablesColumn(_("Username"),
                              prop_name='username.exact',
                              sql_col='user_dim__username'),
+            DataTablesColumn(_("Assigned Location(s)"),
+                             help_text=_('The location(s) that the user is assigned to'),
+                             sortable=False),
             DataTablesColumn(_("Last Submission"),
                              prop_name='reporting_metadata.last_submissions.submission_date',
                              alt_prop_name='reporting_metadata.last_submission_for_user.submission_date',
@@ -119,7 +122,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
                                  sortable=False)
             )
         headers = DataTablesHeader(*columns)
-        headers.custom_sort = [[1, 'desc']]
+        headers.custom_sort = [[2, 'desc']]
         return headers
 
     @cached_property

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -488,19 +488,17 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         result[0][1] = table
         return result
 
-    def get_location_column(self, user):
-        assigned_loc_ids = user.get('assigned_location_ids')
-        if not assigned_loc_ids:
+        if not user.get('assigned_location_ids'):
             return '---'
-        primary_loc_id = user.get('location_id')
-        return self._get_formatted_assigned_location_names(primary_loc_id, assigned_loc_ids)
+        return self._get_formatted_assigned_location_names(user)
 
-    def _get_formatted_assigned_location_names(self, primary_location_id, assigned_location_ids):
+    def _get_formatted_assigned_location_names(self, user):
         """
         Create an HTML formatted string of the given assigned location names.
         The primary location will be highlighted in bold.
         """
-        locs = SQLLocation.objects.filter(location_id__in=assigned_location_ids)
+        assigned_location_ids = user.get('assigned_location_ids')
+        primary_location_id = user.get('location_id')
         formatted_loc_names = []
         for loc in locs:
             if loc.location_id == primary_location_id and len(assigned_location_ids) > 1:

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -521,20 +521,20 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
                 formatted_loc_names.append(loc_name)
 
         formatted_str = ', '.join(formatted_loc_names[:4])
-        all_str = ', '.join(formatted_loc_names)
-        view_all_str = _('...See more') if len(formatted_loc_names) > 4 else ''
-        view_less_str = _('...See less') if len(formatted_loc_names) > 4 else ''
-        out_str = ('''
-            <div>
-                <span class="locations-list">{}</span>
-                <span class="all-locations-list" style="display:none">{}</span>
-                <a href="#" class="toggle-all-locations">
-                   <span>{}</span>
-                   <span style="display:none">{}</span>
-                </a>
-            </div>
-        ''').format(formatted_str, all_str, view_all_str, view_less_str)
-        return format_html(out_str)
+        html_nodes = [
+            f'<span class="locations-list">{formatted_str}</span>',
+        ]
+        if len(formatted_loc_names) > 4:
+            all_str = ', '.join(formatted_loc_names)
+            view_controls_html_nodes = [
+                f'<span>{_("...See more")}</span>',
+                f'<span style="display:none">{_("...See less")}</span>',
+            ]
+            html_nodes += [
+                f'<span class="all-locations-list" style="display:none">{all_str}</span>',
+                f'<a href="#" class="toggle-all-locations">{"".join(view_controls_html_nodes)}</a>',
+            ]
+        return format_html(f'<div>{"".join(html_nodes)}</div>')
 
 
 def _get_commcare_version(app_version_info):

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -311,6 +311,15 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
             )
         )
 
+    def user_locations_dict(self, users):
+        all_loc_ids = set()
+        for user in users:
+            for loc_id in user.get('assigned_location_ids'):
+                all_loc_ids.add(loc_id)
+        return dict(SQLLocation.objects.filter(
+            location_id__in=all_loc_ids
+        ).values_list('location_id', 'name'))
+
     def process_rows(self, users, fmt_for_export=False):
         rows = []
         users = list(users)
@@ -320,6 +329,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
             grouped_ancestor_locs = self.get_bulk_ancestors(location_ids)
             self.required_loc_columns = self.get_location_columns(grouped_ancestor_locs)
 
+        user_loc_dict = self.user_locations_dict(users)
         for user in users:
             last_build = last_seen = last_sub = last_sync = last_sync_date = app_name = commcare_version = None
             last_build_profile_name = device = device_app_meta = num_unsent_forms = None
@@ -377,7 +387,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
                 user_display_string(user.get('username', ''),
                                     user.get('first_name', ''),
                                     user.get('last_name', '')),
-                self.get_location_column(user),
+                self.get_location_column(user, user_loc_dict),
                 _fmt_date(last_seen, fmt_for_export), _fmt_date(last_sync_date, fmt_for_export),
                 app_name or "---", build_version, commcare_version or '---',
                 num_unsent_forms if num_unsent_forms is not None else "---",
@@ -488,11 +498,12 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         result[0][1] = table
         return result
 
+    def get_location_column(self, user, user_loc_dict):
         if not user.get('assigned_location_ids'):
             return '---'
-        return self._get_formatted_assigned_location_names(user)
+        return self._get_formatted_assigned_location_names(user, user_loc_dict)
 
-    def _get_formatted_assigned_location_names(self, user):
+    def _get_formatted_assigned_location_names(self, user, user_loc_dict):
         """
         Create an HTML formatted string of the given assigned location names.
         The primary location will be highlighted in bold.
@@ -500,13 +511,14 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         assigned_location_ids = user.get('assigned_location_ids')
         primary_location_id = user.get('location_id')
         formatted_loc_names = []
-        for loc in locs:
-            if loc.location_id == primary_location_id:
+        for loc_id in assigned_location_ids:
+            loc_name = user_loc_dict.get(loc_id)
+            if loc_id == primary_location_id:
                 formatted_loc_names.append(
-                    f'<strong>{loc.name}</strong>'
+                    f'<strong>{loc_name}</strong>'
                 )
             else:
-                formatted_loc_names.append(loc.name)
+                formatted_loc_names.append(loc_name)
 
         formatted_str = ', '.join(formatted_loc_names[:4])
         all_str = ', '.join(formatted_loc_names)

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -377,6 +377,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
                 user_display_string(user.get('username', ''),
                                     user.get('first_name', ''),
                                     user.get('last_name', '')),
+                self.get_location_column(user),
                 _fmt_date(last_seen, fmt_for_export), _fmt_date(last_sync_date, fmt_for_export),
                 app_name or "---", build_version, commcare_version or '---',
                 num_unsent_forms if num_unsent_forms is not None else "---",
@@ -486,6 +487,40 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
             row[len(location_colums) + 2] = _fmt_timestamp(row[len(location_colums) + 2])
         result[0][1] = table
         return result
+
+    def get_location_column(self, user):
+        assigned_loc_ids = user.get('assigned_location_ids')
+        if not assigned_loc_ids:
+            return '---'
+        primary_loc_id = user.get('location_id')
+        return self._get_formatted_assigned_location_names(primary_loc_id, assigned_loc_ids)
+
+    def _get_formatted_assigned_location_names(self, primary_location_id, assigned_location_ids):
+        """
+        Create an HTML formatted string of the given assigned location names.
+        The primary location will be highlighted in bold.
+        """
+        locs = SQLLocation.objects.filter(location_id__in=assigned_location_ids)
+        formatted_loc_names = []
+        for loc in locs:
+            if loc.location_id == primary_location_id and len(assigned_location_ids) > 1:
+                formatted_loc_names.append(
+                    f'<strong>{loc.name}</strong>'
+                )
+            else:
+                formatted_loc_names.append(loc.name)
+
+        formatted_str = ', '.join(formatted_loc_names[:4])
+        all_str = ', '.join(formatted_loc_names)
+        eplise_str = _('...See more') if len(formatted_loc_names) > 4 else ''
+        out_str = ('''
+            <div>
+                <span class="locations-list">{}</span>
+                <a href="#" class="toggle-all-locations">{}</a>
+                <span class="all-locations-list" style="display:none">{}</span>
+            </div>
+        ''').format(formatted_str, eplise_str, all_str)
+        return format_html(out_str)
 
 
 def _get_commcare_version(app_version_info):

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -82,7 +82,8 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
                              prop_name='username.exact',
                              sql_col='user_dim__username'),
             DataTablesColumn(_("Assigned Location(s)"),
-                             help_text=_('The location(s) that the user is assigned to'),
+                             help_text=_('The location(s) that the user is assigned to, '
+                                         'including the primary location which is highlighted in bold.'),
                              sortable=False),
             DataTablesColumn(_("Last Submission"),
                              prop_name='reporting_metadata.last_submissions.submission_date',

--- a/corehq/apps/reports/static/reports/js/bootstrap3/application_status.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/application_status.js
@@ -7,7 +7,7 @@ hqDefine("reports/js/bootstrap3/application_status", [
     $(function () {
         $('#report-content').on('click', '.toggle-all-locations', function (e) {
             $(this).prevAll('.locations-list').toggle();
-            $(this).children('span').toggle();
+            $(this).children('.loc-view-control').toggle();
             $(this).prevAll('.all-locations-list').toggle();
             e.preventDefault();
         });

--- a/corehq/apps/reports/static/reports/js/bootstrap3/application_status.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/application_status.js
@@ -7,8 +7,8 @@ hqDefine("reports/js/bootstrap3/application_status", [
     $(function () {
         $('#report-content').on('click', '.toggle-all-locations', function (e) {
             $(this).prevAll('.locations-list').toggle();
-            $(this).toggle();
-            $(this).nextAll('.all-locations-list').toggle();
+            $(this).children('span').toggle();
+            $(this).prevAll('.all-locations-list').toggle();
             e.preventDefault();
         });
     });

--- a/corehq/apps/reports/static/reports/js/bootstrap3/application_status.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/application_status.js
@@ -1,0 +1,15 @@
+'use strict';
+hqDefine("reports/js/bootstrap3/application_status", [
+    "jquery",
+], function (
+    $
+) {
+    $(function () {
+        $('#report-content').on('click', '.toggle-all-locations', function (e) {
+            $(this).prevAll('.locations-list').toggle();
+            $(this).toggle();
+            $(this).nextAll('.all-locations-list').toggle();
+            e.preventDefault();
+        });
+    });
+});

--- a/corehq/apps/reports/static/reports/js/bootstrap5/application_status.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/application_status.js
@@ -1,0 +1,15 @@
+'use strict';
+hqDefine("reports/js/bootstrap5/application_status", [
+    "jquery",
+], function (
+    $
+) {
+    $(function () {
+        $('#report-content').on('click', '.toggle-all-locations', function (e) {
+            $(this).prevAll('.locations-list').toggle();
+            $(this).toggle();
+            $(this).nextAll('.all-locations-list').toggle();
+            e.preventDefault();
+        });
+    });
+});

--- a/corehq/apps/reports/static/reports/js/bootstrap5/application_status.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/application_status.js
@@ -7,7 +7,7 @@ hqDefine("reports/js/bootstrap5/application_status", [
     $(function () {
         $('#report-content').on('click', '.toggle-all-locations', function (e) {
             $(this).prevAll('.locations-list').toggle();
-            $(this).children('span').toggle();
+            $(this).children('.loc-view-control').toggle();
             $(this).prevAll('.all-locations-list').toggle();
             e.preventDefault();
         });

--- a/corehq/apps/reports/static/reports/js/bootstrap5/application_status.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/application_status.js
@@ -7,8 +7,8 @@ hqDefine("reports/js/bootstrap5/application_status", [
     $(function () {
         $('#report-content').on('click', '.toggle-all-locations', function (e) {
             $(this).prevAll('.locations-list').toggle();
-            $(this).toggle();
-            $(this).nextAll('.all-locations-list').toggle();
+            $(this).children('span').toggle();
+            $(this).prevAll('.all-locations-list').toggle();
             e.preventDefault();
         });
     });

--- a/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
@@ -36,6 +36,7 @@
     <script src="{% static 'reports/js/inspect_data.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap3/project_health_dashboard.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap3/aggregate_user_status.js' %}"></script>
+    <script src="{% static 'reports/js/bootstrap3/application_status.js' %}"></script>
     <script src="{% static 'reports/js/user_history.js' %}"></script>
     <script src="{% static 'reports/js/case_activity.js' %}"></script>
     <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>

--- a/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
@@ -36,6 +36,7 @@
     <script src="{% static 'reports/js/inspect_data.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap5/project_health_dashboard.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap5/aggregate_user_status.js' %}"></script>
+    <script src="{% static 'reports/js/bootstrap5/application_status.js' %}"></script>
     <script src="{% static 'reports/js/user_history.js' %}"></script>
     <script src="{% static 'reports/js/case_activity.js' %}"></script>
     <script src="{% static 'hqwebapp/js/bootstrap5/widgets.js' %}"></script>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

The Application Status Report includes a new "Assigned Location(s)" column which will show (up to a max of 4) assigned locations for each user:
![Screenshot from 2024-06-12 11-03-57](https://github.com/dimagi/commcare-hq/assets/122617251/a679e8f6-88e3-4038-bd2c-6cdbb2502756)

If a user has more than 4 assigned locations, a "...See More" link becomes available in the column which allows the user to display all the assigned locations for a user:
![show-all](https://github.com/dimagi/commcare-hq/assets/122617251/df36469a-a126-41dc-9127-45d07c8b4865)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3681).

New functions have been added to the `ApplicationStatusReport` class for formatting assigned locations for a user in an HTML format. This has been done so that the primary location of the user can be shown in bold.

A new JS file has been added which is simply there to handle toggling the "...See More" button on the front-end. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Tested locally
- Have tested on staging
- QA done

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA ticket has been done. Available [here](https://dimagi.atlassian.net/browse/QA-6660).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
