### PR TITLE
Linted hqModules.js

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -1,4 +1,11 @@
 /*
+    This file does a number of manipulations of global variables that are typically bad practice.
+    It does not use strict because it's included everywhere, and strictness is not fully tested.
+*/
+/* eslint no-implicit-globals: 0 */
+/* eslint no-redeclare: 0 */
+/* eslint strict: 0 */
+/*
  * hqModules provides a poor man's module system for js. It is not a module *loader*,
  * only a module *referencer*: "importing" a module doesn't automatically load it as
  * a script to the page; it must already have been loaded with an explict script tag.
@@ -76,26 +83,25 @@ function hqDefine(path, dependencies, moduleAccessor) {
             var args = [];
             for (var i = 0; i < dependencies.length; i++) {
                 var dependency = dependencies[i];
-                if (COMMCAREHQ_MODULES.hasOwnProperty(dependency)) {
+                if (Object.hasOwn(COMMCAREHQ_MODULES, dependency)) {
                     args[i] = hqImport(dependency);
-                } else if (thirdPartyGlobals.hasOwnProperty(dependency)) {
+                } else if (Object.hasOwn(thirdPartyGlobals, dependency)) {
                     args[i] = window[thirdPartyGlobals[dependency]];
                 }
             }
-            if (!COMMCAREHQ_MODULES.hasOwnProperty(path)) {
+            if (!Object.hasOwn(COMMCAREHQ_MODULES, path)) {
                 if (path.match(/\.js$/)) {
                     throw new Error("Error in '" + path + "': module names should not end in .js.");
                 }
                 COMMCAREHQ_MODULES[path] = factory.apply(undefined, args);
-            }
-            else {
+            } else {
                 throw new Error("The module '" + path + "' has already been defined elsewhere.");
             }
         }
     }(moduleAccessor));
 }
 if (typeof define === 'undefined') {
-    define = hqDefine;
+    define = hqDefine;      // eslint-disable-line no-global-assign
 }
 
 // For use only with modules that are never used in a requirejs context.
@@ -110,11 +116,11 @@ function hqImport(path) {
 // Support require calls within a module. Best practice is to require all dependencies
 // at module definition time, but this function can be used when doing so would
 // introduce a circular dependency.
-function hqRequire(paths, callback) {
+function hqRequire(paths, callback) {       // eslint-disable-line no-unused-vars
     if (typeof define === 'function' && define.amd && window.USE_REQUIREJS) {
         // HQ's requirejs build process (build_requirejs.py) replaces hqRequire calls with
         // require calls, so it's important that this do nothing but pass through to require
-        require(paths, callback);
+        require(paths, callback);   // eslint-disable-line no-undef
     } else {
         var args = [];
         for (var i = 0; i < paths.length; i++) {


### PR DESCRIPTION
## Technical Summary
This is largely disabling lint checks because this file is...special. But at least GitHub will stop complaining about it now.

## Safety Assurance

### Safety story
Most of these changes are comments. There are a couple of mechanical switches from `hasOwnProperty` to `Object.hasOwn`. Code review is sufficient for safety here.

### Automated test coverage

There's moderate coverage of this logic. All of our js tests implicitly test this file, although I doubt that amounts to full coverage.

### QA Plan

no


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
