### PR TITLE
Improve rebuild_tables_by_domain command

### DIFF
--- a/corehq/apps/userreports/management/commands/rebuild_tables_by_domain.py
+++ b/corehq/apps/userreports/management/commands/rebuild_tables_by_domain.py
@@ -20,10 +20,11 @@ class Command(BaseCommand):
     def handle(self, domain, **options):
         tables = StaticDataSourceConfiguration.by_domain(domain)
         tables.extend(DataSourceConfiguration.by_domain(domain))
+        tables_by_id = {table.table_id: table for table in tables}
 
-        print("Rebuilding {} tables".format(len(tables)))
+        print("Rebuilding {} tables".format(len(tables_by_id)))
 
-        for table in tables:
+        for table in tables_by_id.values():
             tasks.rebuild_indicators(
                 table._id, initiated_by=options['initiated'], source='rebuild_tables_by_domain'
             )


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

I'm not sure if I actually intend to merge this PR, but mainly creating this to review prior to sharing this branch with a customer to run in their migration to on-prem.

### Multiple DataSourceConfigurations referencing one SQL UCR table

It is possible for multiple data source configurations to reference the same backing SQL table if the `table_id` properties match. There isn't anything about the configuration besides the table_id and domain that factor into [the name used](https://github.com/dimagi/commcare-hq/blob/8cc6e5089889d5b22b596ef2333b44906b0631a9/corehq/apps/userreports/util.py#L207-L230) when creating the SQL table.

### Support asynchronous option

Since `rebuild_indicators` is already a celery task, it seems easy and safe to provide an option in this command to asynchronously rebuild tables. This way, the concurrency that celery enables can be put to use.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This preserves existing behavior in that the _last_ DataSourceConfiguration referencing a SQL table will ultimately win, however this change just makes it so that we don't spend time rebuilding the table for other configurations that overlap and will ultimately be overwritten anyway.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
