### PR TITLE
Update colors for Bootstrap 5 pages

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_type.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_type.scss
@@ -85,3 +85,7 @@ code {
 a {
     cursor: pointer;
 }
+
+button {
+  font-weight: bold !important; // to meet WCAG AA guidelines
+}

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
@@ -116,10 +116,10 @@ $dimagi-mango: #FC5F36;
 
 
 // Base color overrides
-$blue: darken(#5D70D2, 20%);
-$green: darken(#3FA12A, 10%);
-$red: darken($dimagi-sunset, 20%);
-$teal: #01A2A9;
+$blue: #5B6FD2;
+$green: #358623;
+$red: #E13019;
+$teal: #018289;
 $yellow: $dimagi-marigold;
 $indigo: $dimagi-indigo;
 $purple: mix($dimagi-mango, $dimagi-indigo, 25%);

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
@@ -116,7 +116,7 @@ $dimagi-mango: #FC5F36;
 
 
 // Base color overrides
-$blue: #5B6FD2;
+$blue: #5D70D2;
 $green: #358623;
 $red: #E13019;
 $teal: #01A2A9;

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
@@ -119,7 +119,7 @@ $dimagi-mango: #FC5F36;
 $blue: #5B6FD2;
 $green: #358623;
 $red: #E13019;
-$teal: #018289;
+$teal: #01A2A9;
 $yellow: $dimagi-marigold;
 $indigo: $dimagi-indigo;
 $purple: mix($dimagi-mango, $dimagi-indigo, 25%);

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -226,7 +226,7 @@
 +$blue: #5B6FD2;
 +$green: #358623;
 +$red: #E13019;
-+$teal: #018289;
++$teal: #01A2A9;
 +$yellow: $dimagi-marigold;
 +$indigo: $dimagi-indigo;
 +$purple: mix($dimagi-mango, $dimagi-indigo, 25%);

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -223,10 +223,10 @@
 +
 +
 +// Base color overrides
-+$blue: darken(#5D70D2, 20%);
-+$green: darken(#3FA12A, 10%);
-+$red: darken($dimagi-sunset, 20%);
-+$teal: #01A2A9;
++$blue: #5B6FD2;
++$green: #358623;
++$red: #E13019;
++$teal: #018289;
 +$yellow: $dimagi-marigold;
 +$indigo: $dimagi-indigo;
 +$purple: mix($dimagi-mango, $dimagi-indigo, 25%);

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -223,7 +223,7 @@
 +
 +
 +// Base color overrides
-+$blue: #5B6FD2;
++$blue: #5D70D2;
 +$green: #358623;
 +$red: #E13019;
 +$teal: #01A2A9;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/typography._type.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/typography._type.style.diff.txt
@@ -28,7 +28,7 @@
  }
  
  .no-border {
-@@ -81,11 +82,6 @@
+@@ -81,11 +82,10 @@
    }
  }
  
@@ -39,5 +39,8 @@
 -
  a {
      cursor: pointer;
--}
+ }
++
++button {
++  font-weight: bold !important; // to meet WCAG AA guidelines
 +}

--- a/corehq/apps/styleguide/context.py
+++ b/corehq/apps/styleguide/context.py
@@ -72,22 +72,24 @@ def get_interaction_colors():
             title="Call to Action",
             description="Referred to as 'CommCare Blue'. "
                         "Use for buttons, checkmarks, radio buttons or actionable primary icons. "
-                        "Links are a slightly darkened shade of this color ($blue-600) to improve contrast.",
-            main_color=Color('primary', '5D70D2'),
+                        "Links are a slightly darkened shade of this color ($blue-600) to improve contrast. "
+                        "Note the official brand color is: #5D70D2, but this is adjusted slightly to meet "
+                        "web accessibility guidelines.",
+            main_color=Color('primary', '5B6FD2'),
             subtle_color=Color('primary-subtle', 'DFE2H6'),
         ),
         ColorGroup(
             title="Download / Upload",
             description="Used typically for buttons indicating a download or upload action. "
                         "Corresponds with 'info' classes",
-            main_color=Color('info', '01A2A9'),
+            main_color=Color('info', '018289'),
             subtle_color=Color('info-subtle', 'CCECEE'),
         ),
         ColorGroup(
             title="Success",
             description="Use when an action has been completed successfully, primarily for messaging. "
                         "Rarely used for interactive elements like buttons.",
-            main_color=Color('success', '3FA12A'),
+            main_color=Color('success', '358623'),
             subtle_color=Color('success-subtle', 'D9ECD4'),
         ),
         ColorGroup(
@@ -101,7 +103,7 @@ def get_interaction_colors():
             title="Error, Negative Attention",
             description="Use to highlight an error, something negative or a critical risk. "
                         "Use as text, highlights, banners or destructive buttons. ",
-            main_color=Color('danger', 'E73C27'),
+            main_color=Color('danger', 'E13019'),
             subtle_color=Color('danger-subtle', 'FAD8D4'),
         ),
     ]
@@ -134,15 +136,15 @@ def get_neutral_colors():
 def get_gradient_colors():
     return {
         'blue': [
-            Color('blue-100', 'DFE2F6'),
-            Color('blue-200', 'BEC6ED'),
-            Color('blue-300', '9EA9E4'),
-            Color('blue-400', '7D8DDB'),
-            ThemeColor('blue-500', '5D70D2', theme_equivalent='primary'),
-            Color('blue-600', '4A5AA8'),
-            Color('blue-700', '38437E'),
-            Color('blue-800', '252D54'),
-            Color('blue-900', '13162A'),
+            Color('blue-100', 'DEE2F6'),
+            Color('blue-200', 'BDC5ED'),
+            Color('blue-300', '9DA9E4'),
+            Color('blue-400', '7C8CDB'),
+            ThemeColor('blue-500', '5B6FD2', theme_equivalent='primary'),
+            Color('blue-600', '#4959A8'),
+            Color('blue-700', '37437E'),
+            Color('blue-800', '242C54'),
+            Color('blue-900', '12162A'),
         ],
         'gray': [
             ThemeColor('gray-100', 'f8f9fa', theme_equivalent='light'),

--- a/corehq/apps/styleguide/context.py
+++ b/corehq/apps/styleguide/context.py
@@ -82,7 +82,7 @@ def get_interaction_colors():
             title="Download / Upload",
             description="Used typically for buttons indicating a download or upload action. "
                         "Corresponds with 'info' classes",
-            main_color=Color('info', '018289'),
+            main_color=Color('info', '01A2A9'),
             subtle_color=Color('info-subtle', 'CCECEE'),
         ),
         ColorGroup(

--- a/corehq/apps/styleguide/context.py
+++ b/corehq/apps/styleguide/context.py
@@ -72,10 +72,8 @@ def get_interaction_colors():
             title="Call to Action",
             description="Referred to as 'CommCare Blue'. "
                         "Use for buttons, checkmarks, radio buttons or actionable primary icons. "
-                        "Links are a slightly darkened shade of this color ($blue-600) to improve contrast. "
-                        "Note the official brand color is: #5D70D2, but this is adjusted slightly to meet "
-                        "web accessibility guidelines.",
-            main_color=Color('primary', '5B6FD2'),
+                        "Links are a slightly darkened shade of this color ($blue-600) to improve contrast.",
+            main_color=Color('primary', '5D70D2'),
             subtle_color=Color('primary-subtle', 'DFE2H6'),
         ),
         ColorGroup(
@@ -136,15 +134,15 @@ def get_neutral_colors():
 def get_gradient_colors():
     return {
         'blue': [
-            Color('blue-100', 'DEE2F6'),
-            Color('blue-200', 'BDC5ED'),
-            Color('blue-300', '9DA9E4'),
-            Color('blue-400', '7C8CDB'),
-            ThemeColor('blue-500', '5B6FD2', theme_equivalent='primary'),
-            Color('blue-600', '#4959A8'),
-            Color('blue-700', '37437E'),
-            Color('blue-800', '242C54'),
-            Color('blue-900', '12162A'),
+            Color('blue-100', 'DFE2F6'),
+            Color('blue-200', 'BEC6ED'),
+            Color('blue-300', '9EA9E4'),
+            Color('blue-400', '7D8DDB'),
+            ThemeColor('blue-500', '5D70D2', theme_equivalent='primary'),
+            Color('blue-600', '4A5AA8'),
+            Color('blue-700', '38437E'),
+            Color('blue-800', '252D54'),
+            Color('blue-900', '13162A'),
         ],
         'gray': [
             ThemeColor('gray-100', 'f8f9fa', theme_equivalent='light'),


### PR DESCRIPTION
## Technical Summary
[This PR](https://github.com/dimagi/commcare-hq/pull/34732) updated the colors recently to match WCAG AA guidelines.

However, that PR did not take into consideration updating the styleguide or the restrictions on the CommCare brand.
We have come to a compromise:
- red text updated to `E13019` (less dark, [still accessible](https://webaim.org/resources/contrastchecker/?fcolor=E13019&bcolor=FFFFFF))
- green text updated to `3FA12A` (also less dark, [still accessible](https://webaim.org/resources/contrastchecker/?fcolor=358623&bcolor=FFFFFF))
- blue goes back to "cornflower blue" `5D70D2`
- teal goes back previous `01A2A9`

Both blue and teal meet WCAG AA guidelines for everything except the first category (regular text) (see [blue](https://webaim.org/resources/contrastchecker/?fcolor=5D70D2&bcolor=FFFFFF), [teal](https://webaim.org/resources/contrastchecker/?fcolor=01A2A9&bcolor=FFFFFF)). Since links are already darkened to `$blue-600`, which [does pass](https://webaim.org/resources/contrastchecker/?fcolor=4A5AA8&bcolor=FFFFFF), button text is the only thing not meeting guidelines. We have decided to require all button text to be bold.

## Safety Assurance

### Safety story
style change only

### Automated test coverage
diffs yes

### QA Plan
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
