### PR TITLE
Adds Export area and Save area functionality to Case Grouping page.

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -544,9 +544,11 @@ hqDefine("geospatial/js/case_grouping_map",[
             });
             mapModel.mapInstance.on('draw.delete', function (e) {
                 polygonFilterInstance.removePolygonsFromFilterList(e.features);
+                polygonFilterInstance.btnSaveDisabled(!mapModel.mapHasPolygons());
             });
             mapModel.mapInstance.on('draw.create', function (e) {
                 polygonFilterInstance.addPolygonsToFilterList(e.features);
+                polygonFilterInstance.btnSaveDisabled(!mapModel.mapHasPolygons());
             });
         }
 

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -283,12 +283,6 @@ hqDefine("geospatial/js/geospatial_map", [
             }
         });
 
-        var $exportDrawnArea = $("#btnExportDrawnArea");
-        $exportDrawnArea.click(function () {
-            if (mapModel && mapModel.mapInstance) {
-                polygonFilterModel.exportGeoJson("btnExportDrawnArea");
-            }
-        });
 
         var $runDisbursement = $("#btnRunDisbursement");
         $runDisbursement.click(function () {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -26,7 +26,6 @@ hqDefine("geospatial/js/geospatial_map", [
 
     const MAP_CONTAINER_ID = 'geospatial-map';
 
-    var saveGeoJSONUrl = initialPageData.reverse('geo_polygons');
     var runDisbursementUrl = initialPageData.reverse('case_disbursement');
     var disbursementRunner;
 
@@ -39,37 +38,6 @@ hqDefine("geospatial/js/geospatial_map", [
         $("#mapControls").toggle(state);
         $("#user-filters-panel").toggle(state);
     }
-
-    var saveGeoJson = function () {
-        const data = mapModel.drawControls.getAll();
-        if (data.features.length) {
-            let name = window.prompt(gettext("Name of the Area"));
-            data['name'] = name;
-
-            $.ajax({
-                type: 'post',
-                url: saveGeoJSONUrl,
-                dataType: 'json',
-                data: JSON.stringify({'geo_json': data}),
-                contentType: "application/json; charset=utf-8",
-                success: function (ret) {
-                    delete data.name;
-                    // delete drawn area
-                    mapModel.drawControls.deleteAll();
-                    console.log('newPoly', name);
-                    polygonFilterModel.savedPolygons.push(
-                        new models.SavedPolygon({
-                            name: name,
-                            id: ret.id,
-                            geo_json: data,
-                        })
-                    );
-                    // redraw using mapControlsModelInstance
-                    polygonFilterModel.selectedSavedPolygonId(ret.id);
-                },
-            });
-        }
-    };
 
     var disbursementRunnerModel = function () {
         var self = {};
@@ -275,14 +243,6 @@ hqDefine("geospatial/js/geospatial_map", [
             ko.cleanNode($mapControlDiv[0]);
             $mapControlDiv.koApplyBindings(polygonFilterModel);
         }
-
-        const $saveDrawnArea = $("#btnSaveDrawnArea");
-        $saveDrawnArea.click(function () {
-            if (mapModel && mapModel.mapInstance) {
-                saveGeoJson();
-            }
-        });
-
 
         var $runDisbursement = $("#btnRunDisbursement");
         $runDisbursement.click(function () {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -755,16 +755,12 @@ hqDefine('geospatial/js/models', [
             self.loadSelectedPolygonFromQueryParam();
         };
 
-        self.exportGeoJson = function (exportButtonId) {
-            const exportButton = $(`#${exportButtonId}`);
-            const selectedId = parseInt(self.selectedSavedPolygonId());
-            const selectedPolygon = self.savedPolygons().find(
-                function (o) { return o.id === selectedId; }
-            );
-            if (selectedPolygon) {
-                const convertedData = 'text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(selectedPolygon.geoJson));
-                exportButton.attr('href', 'data:' + convertedData);
-                exportButton.attr('download','data.geojson');
+        self.exportGeoJson = function (data, event) {
+            if (self.activeSavedPolygon()) {
+                const convertedData = 'text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(self.activeSavedPolygon().geoJson));
+                $(event.target).attr('href', 'data:' + convertedData);
+                $(event.target).attr('download','data.geojson');
+                return true;
             }
         };
     };

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -781,6 +781,7 @@ hqDefine('geospatial/js/models', [
                         delete data.name;
                         // delete drawn area
                         self.mapObj.drawControls.deleteAll();
+                        self.removePolygonsFromFilterList(data.features);
                         self.savedPolygons.push(
                             new SavedPolygon({
                                 name: name,

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -668,7 +668,7 @@ hqDefine('geospatial/js/models', [
             if (self.activeSavedPolygon()) {
                 const convertedData = 'text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(self.activeSavedPolygon().geoJson));
                 $(event.target).attr('href', 'data:' + convertedData);
-                $(event.target).attr('download','data.geojson');
+                $(event.target).attr('download',self.activeSavedPolygon().text + '.geojson');
                 return true;
             }
             return false;

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -21,6 +21,7 @@ hqDefine('geospatial/js/models', [
     const DEFAULT_CENTER_COORD = [-20.0, -0.0];
     const DISBURSEMENT_LAYER_PREFIX = 'route-';
     const saveGeoPolygonUrl = initialPageData.reverse('geo_polygons');
+    const unexpectedErrorMessage = "Oops! Something went wrong! Please report an issue if the problem persists.";
 
     var MissingGPSModel = function () {
         this.casesWithoutGPS = ko.observable([]);
@@ -689,10 +690,7 @@ hqDefine('geospatial/js/models', [
                     }, 2000);
                 },
                 error: function () {
-                    alertUser.alert_user(
-                        gettext("Oops! Something went wrong! Please report an issue if the problem persists."),
-                        'danger'
-                    );
+                    alertUser.alert_user(gettext(unexpectedErrorMessage), 'danger');
                 },
             });
         };
@@ -792,6 +790,9 @@ hqDefine('geospatial/js/models', [
                         );
                         // redraw using mapControlsModelInstance
                         self.selectedSavedPolygonId(ret.id);
+                    },
+                    error: function () {
+                        alertUser.alert_user(gettext(unexpectedErrorMessage), 'danger');
                     },
                 });
             }

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -767,7 +767,11 @@ hqDefine('geospatial/js/models', [
             let data = self.mapObj.drawControls.getAll();
             if (data.features.length) {
                 let name = window.prompt(gettext("Name of the Area"));
-                if (!name) {
+                if (name === null) {
+                    return;
+                }
+                if (name === '') {
+                    alertUser.alert_user(gettext("Please enter the name for the area!"), 'warning', false, true);
                     return;
                 }
                 data['name'] = name;

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -671,6 +671,7 @@ hqDefine('geospatial/js/models', [
                 $(event.target).attr('download','data.geojson');
                 return true;
             }
+            return false;
         };
 
         self.deleteSelectedPolygonFilter = function () {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -766,11 +766,13 @@ hqDefine('geospatial/js/models', [
         };
 
         self.saveGeoPolygon = function () {
-            const data = self.mapObj.drawControls.getAll();
+            let data = self.mapObj.drawControls.getAll();
             if (data.features.length) {
                 let name = window.prompt(gettext("Name of the Area"));
+                if (!name) {
+                    return;
+                }
                 data['name'] = name;
-
                 $.ajax({
                     type: 'post',
                     url: saveGeoPolygonUrl,

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -20,7 +20,7 @@ hqDefine('geospatial/js/models', [
     const MAX_URL_LENGTH = 4500;
     const DEFAULT_CENTER_COORD = [-20.0, -0.0];
     const DISBURSEMENT_LAYER_PREFIX = 'route-';
-    const saveGeoJSONUrl = initialPageData.reverse('geo_polygons');
+    const saveGeoPolygonUrl = initialPageData.reverse('geo_polygons');
 
     var MissingGPSModel = function () {
         this.casesWithoutGPS = ko.observable([]);
@@ -765,7 +765,7 @@ hqDefine('geospatial/js/models', [
             self.loadSelectedPolygonFromQueryParam();
         };
 
-        self.saveGeoJson = function () {
+        self.saveGeoPolygon = function () {
             const data = self.mapObj.drawControls.getAll();
             if (data.features.length) {
                 let name = window.prompt(gettext("Name of the Area"));
@@ -773,7 +773,7 @@ hqDefine('geospatial/js/models', [
 
                 $.ajax({
                     type: 'post',
-                    url: saveGeoJSONUrl,
+                    url: saveGeoPolygonUrl,
                     dataType: 'json',
                     data: JSON.stringify({'geo_json': data}),
                     contentType: "application/json; charset=utf-8",

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -662,6 +662,15 @@ hqDefine('geospatial/js/models', [
             updateSelectedSavedPolygonParam();
         };
 
+        self.exportSelectedPolygonGeoJson = function (data, event) {
+            if (self.activeSavedPolygon()) {
+                const convertedData = 'text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(self.activeSavedPolygon().geoJson));
+                $(event.target).attr('href', 'data:' + convertedData);
+                $(event.target).attr('download','data.geojson');
+                return true;
+            }
+        };
+
         self.deleteSelectedPolygonFilter = function () {
             const deleteGeoJSONUrl = initialPageData.reverse('geo_polygon', self.selectedSavedPolygonId());
             $.ajax({
@@ -755,14 +764,6 @@ hqDefine('geospatial/js/models', [
             self.loadSelectedPolygonFromQueryParam();
         };
 
-        self.exportGeoJson = function (data, event) {
-            if (self.activeSavedPolygon()) {
-                const convertedData = 'text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(self.activeSavedPolygon().geoJson));
-                $(event.target).attr('href', 'data:' + convertedData);
-                $(event.target).attr('download','data.geojson');
-                return true;
-            }
-        };
     };
 
     return {

--- a/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
+++ b/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
@@ -1,28 +1,25 @@
 {% load i18n %}
 
-<div class="col-sm-5">
+<div class="col-sm-8">
     <div class="row form-horizontal">
-        <label for="saved-polygons" class="control-label col-sm-3">
-        {% trans "Filter by Saved Area" %}
+        <label for="saved-polygons" class="control-label col-sm-2">
+          {% trans "Filter by Saved Area" %}
         </label>
-        <div class="col-sm-5">
+        <div class="col-sm-5" style="display:flex">
             <select id="saved-polygons"
                     class="form-control"
                     data-bind="select2: savedPolygons,value: selectedSavedPolygonId,">
             </select>
-        </div>
-        <div class="col-sm-1">
             <button class="btn btn-default" data-bind="click: clearSelectedPolygonFilter, visible: selectedSavedPolygonId">
-                {% trans 'Clear' %}
+              <i class="fa fa-remove"></i>
             </button>
         </div>
-        <div class="col-sm-2">
+        <div class="col-sm-5">
             <a class="btn btn-default" data-bind="click: exportSelectedPolygonGeoJson, visible: selectedSavedPolygonId">
                 {% trans 'Export Area' %}
             </a>
-        </div>
-        <div class="col-sm-2" style="margin-left:5px">
-            <button class="btn btn-danger" data-toggle="modal" data-target="#delete-saved-area-modal" data-bind="visible: selectedSavedPolygonId">
+            <button class="btn btn-danger" data-toggle="modal" data-target="#delete-saved-area-modal"
+                    data-bind="visible: selectedSavedPolygonId">
                 <i class="fa fa-trash"></i>
                 {% trans 'Delete Area' %}
             </button>

--- a/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
+++ b/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
@@ -30,7 +30,7 @@
     </div>
 </div>
  <button id="btnSaveDrawnArea" class="btn btn-default" style="float:right; margin-right:1em"
-         data-bind="attr: { disabled: btnSaveDisabled }, click: saveGeoJson">
+         data-bind="attr: { disabled: btnSaveDisabled }, click: saveGeoPolygon">
     {% trans 'Save Area' %}
 </button>
 {% include 'geospatial/partials/delete_saved_area_modal.html' %}

--- a/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
+++ b/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
@@ -29,4 +29,8 @@
         </div>
     </div>
 </div>
+ <button id="btnSaveDrawnArea" class="btn btn-default" style="float:right; margin-right:1em"
+         data-bind="attr: { disabled: btnSaveDisabled }, click: saveGeoJson">
+    {% trans 'Save Area' %}
+</button>
 {% include 'geospatial/partials/delete_saved_area_modal.html' %}

--- a/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
+++ b/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
@@ -16,6 +16,11 @@
                 {% trans 'Clear' %}
             </button>
         </div>
+        <div class="col-sm-2">
+            <a class="btn btn-default" data-bind="click: exportGeoJson, visible: selectedSavedPolygonId">
+                {% trans 'Export Area' %}
+            </a>
+        </div>
         <div class="col-sm-2" style="margin-left:5px">
             <button class="btn btn-danger" data-toggle="modal" data-target="#delete-saved-area-modal" data-bind="visible: selectedSavedPolygonId">
                 <i class="fa fa-trash"></i>

--- a/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
+++ b/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
@@ -17,7 +17,7 @@
             </button>
         </div>
         <div class="col-sm-2">
-            <a class="btn btn-default" data-bind="click: exportGeoJson, visible: selectedSavedPolygonId">
+            <a class="btn btn-default" data-bind="click: exportSelectedPolygonGeoJson, visible: selectedSavedPolygonId">
                 {% trans 'Export Area' %}
             </a>
         </div>

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -69,9 +69,6 @@
 </div>
 <div class="row panel" id="mapControls">
     {% include 'geospatial/partials/saved_polygon_filter.html' %}
-    <a id="btnSaveDrawnArea" class="col-sm-2 btn btn-default" style="float:right; margin-right:1em" data-bind="attr: { disabled: btnSaveDisabled }">
-        {% trans 'Save Area' %}
-    </a>
     <a id="btnRunDisbursement" class="col-sm-2 btn btn-primary" style="float:right; margin-right:1em" data-bind="attr: { disabled: btnRunDisbursementDisabled }">
         {% trans 'Run Disbursement' %}
     </a>

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -69,9 +69,6 @@
 </div>
 <div class="row panel" id="mapControls">
     {% include 'geospatial/partials/saved_polygon_filter.html' %}
-    <a id="btnExportDrawnArea" class="col-sm-2 btn btn-default" style="float:right; margin-right:1em" data-bind="attr: { disabled: btnExportDisabled }">
-        {% trans 'Export Area' %}
-    </a>
     <a id="btnSaveDrawnArea" class="col-sm-2 btn btn-default" style="float:right; margin-right:1em" data-bind="attr: { disabled: btnSaveDisabled }">
         {% trans 'Save Area' %}
     </a>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

We have two additional functionalities on Case Grouping page related to polygons on map. 
- Save area: lets user save drawn polygon on the map to the database for future use
- Export saved area: lets user export any saved area, This button is only visible when a saved area is selected from the saved area filter.

Additionally, minor UI enhancements were made for the related buttons

The UI on the case grouping page after adding these functionalities:
![image](https://github.com/dimagi/commcare-hq/assets/125016806/35d6bcb0-59b3-4dbc-bd9b-5c552513524b)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket : https://dimagi.atlassian.net/browse/SC-3700

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Geospatial Feature flag

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change affects only functionalities around saved polygons under Geospatial FF.
Local testing performed.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi.atlassian.net/browse/QA-6677

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
