### PR TITLE
Limit batch size for entra api

### DIFF
--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy
 from corehq.apps.accounting.models import BillingAccount, Subscription
 from corehq.apps.sso import certificates
 from corehq.apps.sso.exceptions import ServiceProviderCertificateError
-from corehq.apps.sso.utils.entra import get_all_members_of_the_idp_from_entra
+from corehq.apps.sso.utils.entra import get_all_usernames_of_the_idp_from_entra
 from corehq.apps.sso.utils.user_helpers import get_email_domain_from_username
 from corehq.util.quickcache import quickcache
 
@@ -439,9 +439,9 @@ class IdentityProvider(models.Model):
             return idp
         return None
 
-    def get_all_members_of_the_idp(self):
+    def get_all_usernames_of_the_idp(self):
         if self.idp_type == IdentityProviderType.ENTRA_ID:
-            return get_all_members_of_the_idp_from_entra(self)
+            return get_all_usernames_of_the_idp_from_entra(self)
         else:
             raise NotImplementedError("Not implemented")
 

--- a/corehq/apps/sso/tasks.py
+++ b/corehq/apps/sso/tasks.py
@@ -130,7 +130,7 @@ def auto_deactivate_removed_sso_users():
         idp_type=IdentityProviderType.ENTRA_ID
     ).all():
         try:
-            idp_users = idp.get_all_members_of_the_idp()
+            usernames_in_idp = idp.get_all_usernames_of_the_idp()
         except EntraVerificationFailed as e:
             notify_exception(None, f"Failed to get members of the IdP. {str(e)}")
             send_deactivation_skipped_email(idp=idp, failure_code=MSGraphIssue.VERIFICATION_ERROR,
@@ -152,7 +152,7 @@ def auto_deactivate_removed_sso_users():
             continue
 
         # if the Graph Users API returns an empty list of users we will skip auto deactivation
-        if len(idp_users) == 0:
+        if len(usernames_in_idp) == 0:
             send_deactivation_skipped_email(idp=idp, failure_code=MSGraphIssue.EMPTY_ERROR)
             continue
 
@@ -167,7 +167,7 @@ def auto_deactivate_removed_sso_users():
         authenticated_email_domains = authenticated_domains.values_list('email_domain', flat=True)
 
         for username in usernames_in_account:
-            if username not in idp_users and username not in exempt_usernames:
+            if username not in usernames_in_idp and username not in exempt_usernames:
                 email_domain = get_email_domain_from_username(username)
                 if email_domain in authenticated_email_domains:
                     usernames_to_deactivate.append(username)

--- a/corehq/apps/sso/tests/test_tasks.py
+++ b/corehq/apps/sso/tests/test_tasks.py
@@ -333,8 +333,8 @@ class TestAutoDeactivationTask(TestCase):
             email_domain='vaultwax.com',
             identity_provider=cls.idp,
         )
-        idp_patcher = patch('corehq.apps.sso.models.IdentityProvider.get_all_members_of_the_idp')
-        cls.mock_get_all_members_of_the_idp = idp_patcher.start()
+        idp_patcher = patch('corehq.apps.sso.models.IdentityProvider.get_all_usernames_of_the_idp')
+        cls.mock_get_all_usernames_of_the_idp = idp_patcher.start()
         cls.addClassCleanup(idp_patcher.stop)
 
     def setUp(self):
@@ -345,7 +345,7 @@ class TestAutoDeactivationTask(TestCase):
 
     def test_user_is_deactivated_if_not_member_of_idp(self):
         self.assertTrue(self.web_user_c.is_active)
-        self.mock_get_all_members_of_the_idp.return_value = [self.web_user_a.username, self.web_user_b.username]
+        self.mock_get_all_usernames_of_the_idp.return_value = [self.web_user_a.username, self.web_user_b.username]
 
         auto_deactivate_removed_sso_users()
 
@@ -359,7 +359,7 @@ class TestAutoDeactivationTask(TestCase):
             username=sso_exempt.username,
             email_domain=self.email_domain,
         )
-        self.mock_get_all_members_of_the_idp.return_value = [self.web_user_a.username, self.web_user_b.username]
+        self.mock_get_all_usernames_of_the_idp.return_value = [self.web_user_a.username, self.web_user_b.username]
 
         auto_deactivate_removed_sso_users()
 
@@ -369,7 +369,7 @@ class TestAutoDeactivationTask(TestCase):
 
     @patch('corehq.apps.sso.tasks.send_html_email_async.delay')
     def test_deactivation_skipped_if_entra_return_empty_sso_user(self, mock_send):
-        self.mock_get_all_members_of_the_idp.return_value = []
+        self.mock_get_all_usernames_of_the_idp.return_value = []
 
         auto_deactivate_removed_sso_users()
 
@@ -384,7 +384,7 @@ class TestAutoDeactivationTask(TestCase):
 
     def test_deactivation_skip_members_of_the_domains_but_not_have_an_email_domain_controlled_by_the_idp(self):
         dimagi_user = self._create_web_user('superuser@dimagi.com')
-        self.mock_get_all_members_of_the_idp.return_value = [self.web_user_a.username, self.web_user_b.username]
+        self.mock_get_all_usernames_of_the_idp.return_value = [self.web_user_a.username, self.web_user_b.username]
 
         auto_deactivate_removed_sso_users()
 

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -72,7 +72,12 @@ def get_user_principal_names(user_ids, token):
         headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'},
         data=json.dumps(batch_payload)
     )
-    batch_response.raise_for_status()
+    try:
+        batch_response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        # Append the response body to the HTTPError message
+        error_message = f"{e.response.status_code} {e.response.reason} - {batch_response.text}"
+        raise requests.exceptions.HTTPError(error_message, response=e.response)
     batch_result = batch_response.json()
 
     for resp in batch_result['responses']:

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -18,6 +18,7 @@ class MSOdataType:
 
 
 ENDPOINT_BASE_URL = "https://graph.microsoft.com/v1.0"
+MS_BATCH_LIMIT = 20
 
 
 def get_all_members_of_the_idp_from_entra(idp):
@@ -56,39 +57,48 @@ def configure_idp(idp):
 
 
 def get_user_principal_names(user_ids, token):
-    # Prepare batch request
-    batch_payload = {
-        "requests": [
-            {
-                "id": str(i),
-                "method": "GET",
-                "url": f"/users/{principal_id}?$select=userPrincipalName"
-            } for i, principal_id in enumerate(user_ids)
-        ]
-    }
-    # Send batch request
-    batch_response = requests.post(
-        f'{ENDPOINT_BASE_URL}/$batch',
-        headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'},
-        data=json.dumps(batch_payload)
-    )
-    try:
-        batch_response.raise_for_status()
-    except requests.exceptions.HTTPError as e:
-        # Append the response body to the HTTPError message
-        error_message = f"{e.response.status_code} {e.response.reason} - {batch_response.text}"
-        raise requests.exceptions.HTTPError(error_message, response=e.response)
-    batch_result = batch_response.json()
+    # Convert set to list to make it subscriptable
+    user_ids = list(user_ids)
+    #JSON batch requests are currently limited to 20 individual requests.
+    user_id_chunks = [user_ids[i:i + MS_BATCH_LIMIT] for i in range(0, len(user_ids), MS_BATCH_LIMIT)]
 
-    for resp in batch_result['responses']:
-        if 'body' in resp and 'error' in resp['body']:
-            raise EntraVerificationFailed(resp['body']['error']['code'], resp['body']['message'])
+    user_principal_names = []
 
-    # Extract userPrincipalName from batch response
-    user_principal_names = [
-        resp['body']['userPrincipalName'] for resp in batch_result['responses']
-        if 'body' in resp and 'userPrincipalName' in resp['body']
-    ]
+    for chunk in user_id_chunks:
+        batch_payload = {
+            "requests": [
+                {
+                    "id": str(i),
+                    "method": "GET",
+                    "url": f"/users/{principal_id}?$select=userPrincipalName"
+                } for i, principal_id in enumerate(chunk)
+            ]
+        }
+
+        # Send batch request
+        batch_response = requests.post(
+            f'{ENDPOINT_BASE_URL}/$batch',
+            headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'},
+            data=json.dumps(batch_payload)
+        )
+
+        try:
+            batch_response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            # Append the response body to the HTTPError message
+            error_message = f"{e.response.status_code} {e.response.reason} - {batch_response.text}"
+            raise requests.exceptions.HTTPError(error_message, response=e.response)
+
+        batch_result = batch_response.json()
+        for resp in batch_result['responses']:
+            if 'body' in resp and 'error' in resp['body']:
+                raise EntraVerificationFailed(resp['body']['error']['code'], resp['body']['message'])
+
+        # Extract userPrincipalName from batch response
+        for resp in batch_result['responses']:
+            if 'body' in resp and 'userPrincipalName' in resp['body']:
+                user_principal_names.append(resp['body']['userPrincipalName'])
+
     return user_principal_names
 
 

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -21,7 +21,7 @@ ENDPOINT_BASE_URL = "https://graph.microsoft.com/v1.0"
 MS_BATCH_LIMIT = 20
 
 
-def get_all_members_of_the_idp_from_entra(idp):
+def get_all_usernames_of_the_idp_from_entra(idp):
     import msal
     config = configure_idp(idp)
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15588

Microsoft Graph API batch requests are limited to 20 individual requests per batch: https://learn.microsoft.com/en-us/graph/json-batching#batch-size-limitations

So I split the list of user_ids to many chunks of size 20.

Also, the error message is not very helpful, here is the [Sentry Error](https://dimagi.sentry.io/issues/5460734593/?environment=production&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+Microsoft&referrer=issue-stream&statsPeriod=90d&stream_index=0). So I append the raw error message from the request to the error message.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Pretty safe. Because it didn't change much logic, it adds iteration to the batch request, and improve the error message.
Tested on production with CRS's Azure configuration



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
