### PR TITLE
Fix get_timezone call on exports download page

### DIFF
--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -59,7 +59,6 @@ from corehq.apps.export.models.new import EmailExportWhenDoneRequest, datasource
 from corehq.apps.export.utils import get_export
 from corehq.apps.export.views.utils import (
     ExportsPermissionsManager,
-    get_timezone,
     case_type_or_app_limit_exceeded
 )
 from corehq.apps.hqwebapp.decorators import use_daterangepicker
@@ -74,6 +73,7 @@ from corehq.apps.reports.util import datespan_from_beginning
 from corehq.apps.settings.views import BaseProjectDataView
 from corehq.apps.users.models import CouchUser
 from corehq.toggles import PAGINATED_EXPORTS
+from corehq.util.timezones.utils import get_timezone
 from corehq.util.view_utils import is_ajax
 from corehq.toggles import EXPORT_DATA_SOURCE_DATA
 from corehq.apps.userreports.models import DataSourceConfiguration
@@ -115,7 +115,7 @@ class DownloadExportViewHelper(object):
 
     def get_filter_form(self, filter_form_data):
         domain_object = Domain.get_by_name(self.domain)
-        timezone = get_timezone(self.domain, self.request.couch_user)
+        timezone = get_timezone(self.request, self.domain)
         filter_form = self.filter_form_class(domain_object, timezone, filter_form_data)
 
         if not filter_form.is_valid():
@@ -179,7 +179,7 @@ class BaseDownloadExportView(BaseProjectDataView):
     @property
     @memoized
     def timezone(self):
-        return get_timezone(self.domain, self.request.couch_user)
+        return get_timezone(self.request, self.domain)
 
     @property
     @memoized


### PR DESCRIPTION
## Product Description
Fix 500 error on exports page

## Technical Summary
https://dimagi.sentry.io/issues/5479646311/?environment=staging&project=136860&query=is%3Aunresolved+issue.priority%3A[high%2C+medium]&referrer=issue-stream&statsPeriod=1h&stream_index=0
Introduced in https://github.com/dimagi/commcare-hq/pull/34734
In https://github.com/dimagi/commcare-hq/pull/34734/commits/9f1a31c4677de2ccd4f2f25fda08d7e7e083bb7c, I removed a helper function that was a near duplicate (with a different function signature) of a core util, but I neglected to see if that helper function was referenced in other files.  It was, and since it had the same name as the core utility, the other file, the import didn't break.  Only when it was called and encountered the different function signature did it actually error.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Testing on staging now, but it's pretty straightforward

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
