### PR TITLE
[B5] Use default appearance for form controls

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_forms.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_forms.scss
@@ -43,3 +43,7 @@ legend {
 .ms-header .btn {
   margin-top: -3px;
 }
+
+.form-control {
+  appearance: auto;   // Override B5's `appearance: none`
+}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/forms._forms.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/forms._forms.style.diff.txt
@@ -360,7 +360,7 @@
  }
  
  .form-hide-actions .form-actions {
-@@ -361,15 +12,34 @@
+@@ -361,15 +12,38 @@
    .validationMessage {
      display: block;
      padding-top: 8px;
@@ -401,4 +401,8 @@
 +
 +.ms-header .btn {
 +  margin-top: -3px;
++}
++
++.form-control {
++  appearance: auto;   // Override B5's `appearance: none`
 +}


### PR DESCRIPTION
## Product Description
This came up during web apps QA, but I'm creating a separate PR because it's a broader change.

B5 sets `appearance: none` on form inputs, which results in dropdowns no longer looking like dropdowns (see the language setting):
![Screenshot 2024-06-12 at 11 54 13 AM](https://github.com/dimagi/commcare-hq/assets/1486591/49617a0c-65a9-49e5-8b38-a81be5c3083d)

This PR restores the default appearance. Inputs will still look bootstrap-y, but they'll also have basic affordance:
![Screenshot 2024-06-12 at 11 53 02 AM](https://github.com/dimagi/commcare-hq/assets/1486591/8294f929-6987-4667-ad54-b069b216ad93)


Also see https://developer.mozilla.org/en-US/docs/Web/CSS/appearance

## Safety Assurance

### Safety story
No technical risk. Will have a subtle UI impact on B5 pages.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
