### PR TITLE
[B5] Darkened borders

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
@@ -130,6 +130,7 @@ $orange: $dimagi-mango;
 // Grays from default stylesheet — needed for reference
 $gray-100: #f8f9fa;
 $gray-200: #e9ecef;
+$gray-400: #ced4da;
 $gray-600: #6c757d;
 $gray-800: #343a40;
 
@@ -164,7 +165,7 @@ $theme-colors: (
 $body-color: $dark;
 $link-color: $blue-600;
 $link-hover-color:$blue-900;
-$border-color: $gray-200;
+$border-color: $gray-400;
 
 // New gradient for salmon
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,124 +1,229 @@
+@@ -1,124 +1,230 @@
 -@import "@{b3-import-variables}";
 -
 -// Nunito Sans is used on dimagi.com and embedded in hqwebapp/base.html
@@ -237,6 +237,7 @@
 +// Grays from default stylesheet — needed for reference
 +$gray-100: #f8f9fa;
 +$gray-200: #e9ecef;
++$gray-400: #ced4da;
 +$gray-600: #6c757d;
 +$gray-800: #343a40;
 +
@@ -271,7 +272,7 @@
 +$body-color: $dark;
 +$link-color: $blue-600;
 +$link-hover-color:$blue-900;
-+$border-color: $gray-200;
++$border-color: $gray-400;
 +
 +// New gradient for salmon
 +


### PR DESCRIPTION
## Product Description
This has been bugging me for a while, and QA just reported it as a bug, so I'm not alone.

B5 borders are subtle to the point of being difficult to see, particularly for radio buttons and checkboxes.
![Screenshot 2024-06-12 at 12 37 48 PM](https://github.com/dimagi/commcare-hq/assets/1486591/b5103eb9-0fbd-4ca6-a2ef-e644cb4da22c)

This PR darkens them slightly:
![Screenshot 2024-06-12 at 12 37 28 PM](https://github.com/dimagi/commcare-hq/assets/1486591/ab6387f0-8565-40ac-8150-182afaffe5ce)


## Safety Assurance

### Safety story
No technical risk. Will have a subtle visual effect on B5 pages.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
