### PR TITLE
Fix data source rebuild restriction for forms

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1360,7 +1360,7 @@ def _number_of_records_to_be_iterated_for_rebuild(config):
             count_of_records = CaseSearchES().domain(config.domain).count()
     elif config.referenced_doc_type == 'XFormInstance':
         if case_types_or_xmlns:
-            count_of_records = FormES().domain(config.domain).xmlns(case_types_or_xmlns)
+            count_of_records = FormES().domain(config.domain).xmlns(case_types_or_xmlns).count()
         else:
             count_of_records = FormES().domain(config.domain).count()
 

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1360,9 +1360,9 @@ def _number_of_records_to_be_iterated_for_rebuild(config):
             count_of_records = CaseSearchES().domain(config.domain).count()
     elif config.referenced_doc_type == 'XFormInstance':
         if case_types_or_xmlns:
-            count_of_records = FormES().domain().xmlns(case_types_or_xmlns)
+            count_of_records = FormES().domain(config.domain).xmlns(case_types_or_xmlns)
         else:
-            count_of_records = FormES().domain().count()
+            count_of_records = FormES().domain(config.domain).count()
 
     return count_of_records
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Fix bug introduced in https://github.com/dimagi/commcare-hq/pull/34397 to restrict data source rebuilds for big data sources.
Sentry Error: https://dimagi.sentry.io/issues/5482330679/events/6784d61bb1614453bfff3bba576e23c1/events/?project=136860

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`RESTRICT_DATA_SOURCE_REBUILD` & `USER_CONFIGURABLE_REPORTS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally that form rebuild works locally now for domain with feature flag enabled.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA should not be needed on this.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
