### PR TITLE
Update _software_plan_name helper

### DIFF
--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -184,14 +184,13 @@ def _ensure_software_plan(plan_key, product, product_rate, verbose, apps):
 
 
 def _software_plan_name(plan_key, product, product_rate):
-    plan_name = (
-        (f"{product_rate.name} Trial" if plan_key.is_trial else f"{product_rate.name} Edition")
-        if product is None else product.name)
-    if plan_key.is_annual_plan:
-        plan_name = f"{plan_name} - Pay Annually"
-    if plan_key.is_report_builder_enabled:
-        plan_name = f"{plan_name} - Report Builder (5 Reports)"
-    return plan_name
+    name_parts = (
+        product_rate.name if product is None else product.name,
+        (" Trial" if plan_key.is_trial else " Edition") if product is None else "",
+        " - Pay Annually" if plan_key.is_annual_plan else " - Pay Monthly",
+        " - Report Builder (5 Reports)" if plan_key.is_report_builder_enabled else "",
+    )
+    return "".join(name_parts)
 
 
 def _ensure_software_plan_version(role, software_plan, product_rate, feature_rates, apps):

--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -188,7 +188,7 @@ def _software_plan_name(plan_key, product, product_rate):
         product_rate.name if product is None else product.name,
         (" Trial" if plan_key.is_trial else " Edition") if product is None else "",
     ]
-    if plan_key.edition != SoftwarePlanEdition.ENTERPRISE:
+    if plan_key.edition in SoftwarePlanEdition.SELF_RENEWABLE_EDITIONS:
         name_parts.extend([
             " - Pay Annually" if plan_key.is_annual_plan else " - Pay Monthly",
             " - Report Builder (5 Reports)" if plan_key.is_report_builder_enabled else "",

--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -184,12 +184,15 @@ def _ensure_software_plan(plan_key, product, product_rate, verbose, apps):
 
 
 def _software_plan_name(plan_key, product, product_rate):
-    name_parts = (
+    name_parts = [
         product_rate.name if product is None else product.name,
         (" Trial" if plan_key.is_trial else " Edition") if product is None else "",
-        " - Pay Annually" if plan_key.is_annual_plan else " - Pay Monthly",
-        " - Report Builder (5 Reports)" if plan_key.is_report_builder_enabled else "",
-    )
+    ]
+    if plan_key.edition != SoftwarePlanEdition.ENTERPRISE:
+        name_parts.extend([
+            " - Pay Annually" if plan_key.is_annual_plan else " - Pay Monthly",
+            " - Report Builder (5 Reports)" if plan_key.is_report_builder_enabled else "",
+        ])
     return "".join(name_parts)
 
 

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -204,7 +204,8 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
         self.assertEqual(product_line_item_count, 1)
         product_line_item = invoice.lineitem_set.get_products().first()
         product_description = product_line_item.base_description
-        self.assertEqual(product_description, 'One month of CommCare Advanced Edition Software Plan.')
+        self.assertEqual(product_description,
+                         'One month of CommCare Advanced Edition - Pay Monthly Software Plan.')
         product_cost = product_line_item.base_cost
         self.assertEqual(product_cost, self.product_rate.monthly_fee)
 


### PR DESCRIPTION
## Product Description
No visible changes.

## Technical Summary
Part of [SAAS-15547](https://dimagi.atlassian.net/browse/SAAS-15547)
Small change to use the new naming convention with " - Pay Monthly" or " - Pay Annually" for built-in software plans going forward.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
This only affects the naming of software plans when added through `ensure_plans` (in migrations), and is equivalent to the existing code with the addition of a " - Pay Monthly" for software plans that are paid monthly.

### Automated test coverage
Naming is not _explicitly_ covered, but the function is used incidentally in `test_ensure_plans` and plan name checked in `test_customer_invoicing`

### QA Plan
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-15547]: https://dimagi.atlassian.net/browse/SAAS-15547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ