### PR TITLE
Remove self service annual renewals feature flag

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1633,11 +1633,7 @@ class Subscription(models.Model):
             reason=SubscriptionAdjustmentReason.RENEW,
         )
 
-        from corehq.toggles import SELF_SERVICE_ANNUAL_RENEWALS
-        from corehq.util.global_request import get_request
-        request = get_request()
-        if request is not None and SELF_SERVICE_ANNUAL_RENEWALS.enabled_for_request(request):
-            send_subscription_renewal_alert(self.subscriber.domain, renewed_subscription, self)
+        send_subscription_renewal_alert(self.subscriber.domain, renewed_subscription, self)
 
         return renewed_subscription
 

--- a/corehq/apps/accounting/static/accounting/js/renew_plan_selection.js
+++ b/corehq/apps/accounting/static/accounting/js/renew_plan_selection.js
@@ -7,8 +7,7 @@ hqDefine('accounting/js/renew_plan_selection', [
 ], function (
     $,
     ko,
-    initialPageData,
-    toggles
+    initialPageData
 ) {
     var PlanRenewalView = function (options) {
         var self = this;
@@ -21,8 +20,7 @@ hqDefine('accounting/js/renew_plan_selection', [
     };
 
     $(function () {
-        if (toggles.toggleEnabled('SELF_SERVICE_ANNUAL_RENEWALS')
-            && initialPageData.get('is_self_renewable_plan')) {
+        if (initialPageData.get('is_self_renewable_plan')) {
             var planRenewalView = new PlanRenewalView({
                 renewalChoices: initialPageData.get('renewal_choices'),
                 isAnnualPlan: initialPageData.get('is_annual_plan'),

--- a/corehq/apps/domain/templates/domain/renew_plan.html
+++ b/corehq/apps/domain/templates/domain/renew_plan.html
@@ -24,7 +24,7 @@
         action="{% url 'domain_subscription_renewal_confirmation' domain %}">
     {% csrf_token %}
 
-    {% if request|toggle_enabled:'SELF_SERVICE_ANNUAL_RENEWALS' and is_self_renewable_plan %}
+    {% if is_self_renewable_plan %}
       {% include 'accounting/partials/renew_plan_selection.html' %}
     {% else %}
       {% include 'accounting/partials/confirm_plan_summary.html' %}

--- a/corehq/apps/domain/tests/test_views.py
+++ b/corehq/apps/domain/tests/test_views.py
@@ -487,9 +487,7 @@ class TestSubscriptionRenewalViews(TestCase):
     def test_renewal_page_context(self):
         edition = SoftwarePlanEdition.PRO
         subscription = self._generate_subscription(edition)
-
-        with patch('corehq.toggles.SELF_SERVICE_ANNUAL_RENEWALS.enabled_for_request', return_value=True):
-            response = self.client.get(reverse('domain_subscription_renewal', args=[self.domain.name]))
+        response = self.client.get(reverse('domain_subscription_renewal', args=[self.domain.name]))
 
         self.assertEqual(response.status_code, 200)
 
@@ -515,9 +513,7 @@ class TestSubscriptionRenewalViews(TestCase):
     def test_non_self_renewable_edition(self):
         # a billing admin may still view the renewal page even if their plan is not self-renewable
         self._generate_subscription(SoftwarePlanEdition.ENTERPRISE)
-
-        with patch('corehq.toggles.SELF_SERVICE_ANNUAL_RENEWALS.enabled_for_request', return_value=True):
-            response = self.client.get(reverse('domain_subscription_renewal', args=[self.domain.name]))
+        response = self.client.get(reverse('domain_subscription_renewal', args=[self.domain.name]))
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['renewal_choices'], {})
@@ -527,12 +523,10 @@ class TestSubscriptionRenewalViews(TestCase):
         edition = SoftwarePlanEdition.PRO
         annual_plan = True
         subscription = self._generate_subscription(edition, annual_plan=annual_plan)
-
-        with patch('corehq.toggles.SELF_SERVICE_ANNUAL_RENEWALS.enabled_for_request', return_value=True):
-            response = self.client.post(
-                reverse('domain_subscription_renewal_confirmation', args=[self.domain.name]),
-                data={'is_annual_plan': annual_plan, 'plan_edition': edition, 'from_plan_page': True}
-            )
+        response = self.client.post(
+            reverse('domain_subscription_renewal_confirmation', args=[self.domain.name]),
+            data={'is_annual_plan': annual_plan, 'plan_edition': edition, 'from_plan_page': True}
+        )
 
         self.assertEqual(response.status_code, 200)
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2039,17 +2039,6 @@ ACCOUNTING_TESTING_TOOLS = StaticToggle(
     [NAMESPACE_USER]
 )
 
-SELF_SERVICE_ANNUAL_RENEWALS = StaticToggle(
-    'self_service_annual_renewals',
-    'Allow self service renewal for Pay Annually software plans',
-    TAG_SAAS_CONDITIONAL,
-    [NAMESPACE_USER],
-    description=(
-        "Allows billing admin users to choose between Pay Monthly or Pay Annually plans when renewing"
-        "This is a temporary flag to be removed upon completion of self service annual renewals feature."
-    )
-)
-
 ADD_ROW_INDEX_TO_MOBILE_UCRS = StaticToggle(
     'add_row_index_to_mobile_ucrs',
     'Add row index to mobile UCRs as the first column to retain original order of data',


### PR DESCRIPTION
## Product Description
Enables self service annual renewals through the "Renew Plan" workflow for all users by removing the feature flag. In practice should only affect users in Dimagi-managed environments, since self-hosters are unlikely to have a reason to go through the renewal process.

## Technical Summary
[SAAS-15499](https://dimagi.atlassian.net/browse/SAAS-15499)
Removes the self_service_annual_renewals feature flag and all checks for it, enabling changes from https://github.com/dimagi/commcare-hq/pull/34683 and https://github.com/dimagi/commcare-hq/pull/34650 for any subscription that has an end date. This flag was added for development and always intended to be temporary.

## Safety Assurance

### Safety story
The self service annual renewals feature has automated testing and has been tested by QA on staging and now production.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-15499]: https://dimagi.atlassian.net/browse/SAAS-15499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ