### PR TITLE
Web apps permissions checking: updated get to or

### DIFF
--- a/corehq/apps/cloudcare/tests/test_utils.py
+++ b/corehq/apps/cloudcare/tests/test_utils.py
@@ -126,7 +126,7 @@ class TestCanUserAccessWebApp(TestCase):
     def test_commcare_user_has_access_if_assigned_role_that_can_access_all_web_apps(self):
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(access_web_apps=True))
 
-        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
+        has_access = can_user_access_web_app(self.commcare_user, self.build_doc)
 
         self.assertTrue(has_access)
 
@@ -134,78 +134,78 @@ class TestCanUserAccessWebApp(TestCase):
         # mobile users have not historically required this new permission, so we need to assume they have access
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(access_web_apps=False))
 
-        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
+        has_access = can_user_access_web_app(self.commcare_user, self.build_doc)
 
         self.assertTrue(has_access)
 
     def test_commcare_user_has_access_if_assigned_role_that_can_access_specific_app(self):
         self.set_role_on_user_with_permissions(
-            self.commcare_user, HqPermissions(web_apps_list=[self.app_doc["copy_of"]])
+            self.commcare_user, HqPermissions(web_apps_list=[self.build_doc["copy_of"]])
         )
 
-        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
+        has_access = can_user_access_web_app(self.commcare_user, self.build_doc)
 
         self.assertTrue(has_access)
 
     def test_commcare_user_does_not_have_access_if_assigned_role_that_can_access_different_app(self):
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(web_apps_list=["random-app"]))
 
-        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
+        has_access = can_user_access_web_app(self.commcare_user, self.build_doc)
 
         self.assertFalse(has_access)
 
     def test_web_user_has_access_if_assigned_role_that_can_access_all_web_apps(self):
         self.set_role_on_user_with_permissions(self.web_user, HqPermissions(access_web_apps=True))
 
-        has_access = can_user_access_web_app(self.web_user, self.app_doc)
+        has_access = can_user_access_web_app(self.web_user, self.build_doc)
 
         self.assertTrue(has_access)
 
     def test_web_user_does_not_have_access_if_assigned_role_that_cannot_access_web_apps(self):
         self.set_role_on_user_with_permissions(self.web_user, HqPermissions(access_web_apps=False))
 
-        has_access = can_user_access_web_app(self.web_user, self.app_doc)
+        has_access = can_user_access_web_app(self.web_user, self.build_doc)
 
         self.assertFalse(has_access)
 
     def test_web_user_has_access_if_assigned_role_that_can_access_specific_app(self):
         self.set_role_on_user_with_permissions(
-            self.web_user, HqPermissions(web_apps_list=[self.app_doc["copy_of"]])
+            self.web_user, HqPermissions(web_apps_list=[self.build_doc["copy_of"]])
         )
 
-        has_access = can_user_access_web_app(self.web_user, self.app_doc)
+        has_access = can_user_access_web_app(self.web_user, self.build_doc)
 
         self.assertTrue(has_access)
 
     def test_web_user_has_access_to_canonical_if_assigned_role_that_can_access_specific_app(self):
         self.set_role_on_user_with_permissions(
-            self.web_user, HqPermissions(web_apps_list=[self.app_doc["copy_of"]])
+            self.web_user, HqPermissions(web_apps_list=[self.build_doc["copy_of"]])
         )
 
-        has_access = can_user_access_web_app(self.web_user, self.canonical_doc)
+        has_access = can_user_access_web_app(self.web_user, self.app_doc)
 
         self.assertTrue(has_access)
 
     def test_web_user_does_not_have_access_if_assigned_role_that_can_access_different_app(self):
         self.set_role_on_user_with_permissions(self.web_user, HqPermissions(web_apps_list=["random-app"]))
 
-        has_access = can_user_access_web_app(self.web_user, self.app_doc)
+        has_access = can_user_access_web_app(self.web_user, self.build_doc)
 
         self.assertFalse(has_access)
 
     def test_web_user_does_not_have_access_to_canonical_if_assigned_role_that_can_access_different_app(self):
         self.set_role_on_user_with_permissions(self.web_user, HqPermissions(web_apps_list=["random-app"]))
 
-        has_access = can_user_access_web_app(self.web_user, self.canonical_doc)
+        has_access = can_user_access_web_app(self.web_user, self.app_doc)
 
         self.assertFalse(has_access)
 
     @flag_enabled("WEB_APPS_PERMISSIONS_VIA_GROUPS")
     def test_commcare_user_has_access_if_assigned_role_that_cannot_access_web_apps_and_in_group_with_access_to_specific_app(self):  # noqa: E501
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(access_web_apps=False))
-        self.add_user_to_group_for_app_id(self.commcare_user, self.app_doc['_id'])
+        self.add_user_to_group_for_app_id(self.commcare_user, self.build_doc['_id'])
 
-        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
+        has_access = can_user_access_web_app(self.commcare_user, self.build_doc)
 
         self.assertTrue(has_access)
 
@@ -213,9 +213,9 @@ class TestCanUserAccessWebApp(TestCase):
     def test_commcare_user_does_not_have_access_if_assigned_role_that_can_access_different_app_and_in_group_with_access_to_specific_app(self):  # noqa: E501
         # this tests the precendence of permissions over groups
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(web_apps_list=["random-app"]))
-        self.add_user_to_group_for_app_id(self.commcare_user, self.app_doc['_id'])
+        self.add_user_to_group_for_app_id(self.commcare_user, self.build_doc['_id'])
 
-        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
+        has_access = can_user_access_web_app(self.commcare_user, self.build_doc)
 
         self.assertFalse(has_access)
 
@@ -224,29 +224,29 @@ class TestCanUserAccessWebApp(TestCase):
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(web_apps_list=["random-app"]))
         self.add_user_to_group_for_app_id(self.commcare_user, 'random-app')
 
-        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
+        has_access = can_user_access_web_app(self.commcare_user, self.build_doc)
 
         self.assertFalse(has_access)
 
     @flag_enabled("WEB_APPS_PERMISSIONS_VIA_GROUPS")
     def test_commcare_user_has_access_if_assigned_role_that_can_access_specific_app_and_in_group_with_access_to_specific_app(self):  # noqa: E501
         self.set_role_on_user_with_permissions(
-            self.commcare_user, HqPermissions(web_apps_list=[self.app_doc["copy_of"]])
+            self.commcare_user, HqPermissions(web_apps_list=[self.build_doc["copy_of"]])
         )
-        self.add_user_to_group_for_app_id(self.commcare_user, self.app_doc['_id'])
+        self.add_user_to_group_for_app_id(self.commcare_user, self.build_doc['_id'])
 
-        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
+        has_access = can_user_access_web_app(self.commcare_user, self.build_doc)
 
         self.assertTrue(has_access)
 
     @flag_enabled("WEB_APPS_PERMISSIONS_VIA_GROUPS")
     def test_commcare_user_has_access_if_assigned_role_that_can_access_specific_app_and_in_group_with_access_to_different_app(self):  # noqa: E501
         self.set_role_on_user_with_permissions(
-            self.commcare_user, HqPermissions(web_apps_list=[self.app_doc["copy_of"]])
+            self.commcare_user, HqPermissions(web_apps_list=[self.build_doc["copy_of"]])
         )
         self.add_user_to_group_for_app_id(self.commcare_user, "random-app")
 
-        has_access = can_user_access_web_app(self.commcare_user, self.app_doc)
+        has_access = can_user_access_web_app(self.commcare_user, self.build_doc)
 
         self.assertTrue(has_access)
 
@@ -255,7 +255,7 @@ class TestCanUserAccessWebApp(TestCase):
         # web users always have permission via groups
         self.set_role_on_user_with_permissions(self.commcare_user, HqPermissions(web_apps_list=["random-app"]))
 
-        has_access = can_user_access_web_app(self.web_user, self.app_doc)
+        has_access = can_user_access_web_app(self.web_user, self.build_doc)
 
         self.assertFalse(has_access)
 
@@ -268,10 +268,10 @@ class TestCanUserAccessWebApp(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.canonical_doc = {'doc_type': 'Application', '_id': 'def456', 'copy_of': None, 'domain': self.domain}
-        self.app_doc = {
-            **self.canonical_doc,
-            'copy_of': self.canonical_doc['_id'],
+        self.app_doc = {'doc_type': 'Application', '_id': 'def456', 'copy_of': None, 'domain': self.domain}
+        self.build_doc = {
+            **self.app_doc,
+            'copy_of': self.app_doc['_id'],
             '_id': 'abc123',
         }
         self.commcare_user = CommCareUser.create(self.domain, 'bob@test.commcarehq.org', 'password', None, None)

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -26,7 +26,7 @@ def can_user_access_web_app(user, app):
     # Backwards-compatibility - mobile users haven't historically required this permission
     has_access_via_permission = user.is_commcare_user()
     if user.is_web_user() or user.can_access_any_web_apps(domain):
-        app_id = app.get("copy_of", app.get("_id"))
+        app_id = app.get("copy_of") or app.get("_id")
         has_access_via_permission = user.can_access_web_app(domain, app_id)
 
     has_access_via_group = True  # permission takes precedence over groups, so default to True


### PR DESCRIPTION
## Technical Summary
I suspect this is causing https://dimagi.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/issue/SUPPORT-19944 

This expression is definitely *a* bug. Its intent is to replicate [ApplicationBase.origin_id](https://github.com/dimagi/commcare-hq/blob/a422bc91f77e5fd7736585d407cc8064c30f7e76/corehq/apps/app_manager/models.py#L4197-L4200): see comment thread [here](https://github.com/dimagi/commcare-hq/pull/34421#discussion_r1566269160).

But using `get` as in the old code means that if `copy_of` is present in the app document but null, `app_id` will evaluate to None (instead of the `_id` value). Then on the next line, `can_access_web_app` is a dynamic function implemented via `__getattr__` [here](https://github.com/dimagi/commcare-hq/blob/a422bc91f77e5fd7736585d407cc8064c30f7e76/corehq/apps/users/models.py#L1669-L1674), which goes through [has_permission](https://github.com/dimagi/commcare-hq/blob/a422bc91f77e5fd7736585d407cc8064c30f7e76/corehq/apps/users/models.py#L1682) and then [Permission.has](https://github.com/dimagi/commcare-hq/blob/a422bc91f77e5fd7736585d407cc8064c30f7e76/corehq/apps/users/models.py#L363-L367), which behaves differently based on whether or not it receives `data` (that `app_id`). If `data` is None, it doesn't invoke `getattr`, so it ends up returning a function all the way back to the original call, so `has_access_via_permission` becomes that function and gets interpreted as True.

The only way I've found to reproduce this is by editing the web apps url to access the `FormplayerMainPreview` view instead of the usual `FormplayerMain`. This view is an [old single-app preview mode](https://github.com/dimagi/commcare-hq/pull/13836) that I didn't think was still in use. It uses `get_current_app_doc` to fetch apps rather than `get_latest_build_for_web_apps`, which triggers the bug. Grepping quickly, I haven't found anywhere in HQ that constructs a link to that view, everything I see uses the `FormplayerMain` URL. I don't know if or how the reporting user was accessing this view - by manually typing in the preview URL? - or if there's another problem scenario.

Also noting I was surprised to see the reporting domain uses the use_latest_build_cloudcare flag, which I think of as a debugging tool and not meant for production projects. But even with that flag on, the apps web apps filters through are still builds and therefore should have `copy_of` set to a value.

## Safety Assurance

### Safety story
I have not tested this, it's just a hunch on a late-breaking bug.

### Automated test coverage

Adding test coverage would be a fantastic idea. If this does address the issue, I'm happy to do that in a followup.

### QA Plan

Unknown at this time

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
