### PR TITLE
Ensure only one datasource repeater created for any one CCA instance

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1642,12 +1642,19 @@ def subscribe_to_data_source_changes(request, domain, config_id):
         ds=config_id,
         server=client_hostname,
     )
-    DataSourceRepeater.objects.create(
-        name=repeater_name,
+
+    datasource_query = DataSourceRepeater.objects.filter(
         domain=domain,
-        data_source_id=config_id,
         connection_settings_id=conn_settings.id,
+        options={"data_source_id": config_id},
     )
+    if not datasource_query.exists():
+        DataSourceRepeater.objects.create(
+            name=repeater_name,
+            domain=domain,
+            data_source_id=config_id,
+            connection_settings_id=conn_settings.id,
+        )
     return HttpResponse(status=201)
 
 


### PR DESCRIPTION
## Product Description
No visible effects

## Technical Summary
During testing of the datasource background refresh workflow I discovered that it's possible to create multiple datasource repeaters for the same datasource on the same CCA host. This PR simply ensures that one repeater exists for any one datasource on the same CCA host.

## Feature Flag
commcare analytics FF

## Safety Assurance

### Safety story
Automated tests

### Automated test coverage
Added a test

### QA Plan
No QA planned

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
