### PR TITLE
Use USERCASE_TYPE const

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -204,6 +204,9 @@ _case_type_regex = re.compile(CASE_TYPE_REGEX)
 
 def is_valid_case_type(case_type, module):
     """
+    Returns ``True`` if ``case_type`` is valid for ``module``
+
+    >>> from corehq.apps.app_manager.const import USERCASE_TYPE
     >>> from corehq.apps.app_manager.models import Module, AdvancedModule
     >>> is_valid_case_type('foo', Module())
     True
@@ -215,9 +218,9 @@ def is_valid_case_type(case_type, module):
     False
     >>> is_valid_case_type(None, Module())
     False
-    >>> is_valid_case_type('commcare-user', Module())
+    >>> is_valid_case_type(USERCASE_TYPE, Module())
     False
-    >>> is_valid_case_type('commcare-user', AdvancedModule())
+    >>> is_valid_case_type(USERCASE_TYPE, AdvancedModule())
     True
     """
     from corehq.apps.app_manager.models import AdvancedModule

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -14,6 +14,7 @@ from couchforms.analytics import (
 )
 from dimagi.utils.parsing import json_format_datetime
 
+from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.dbaccessors import domain_has_apps
 from corehq.apps.data_analytics.esaccessors import get_mobile_users
 from corehq.apps.domain.models import Domain
@@ -386,7 +387,7 @@ def calced_props(domain_obj, id, all_stats):
         "cp_n_sms_out_60_d": int(CALC_FNS["sms_out_in_last"](dom, 60)),
         "cp_n_sms_out_90_d": int(CALC_FNS["sms_out_in_last"](dom, 90)),
         "cp_300th_form": CALC_FNS["300th_form_submission"](dom),
-        "cp_n_30_day_user_cases": cases_in_last(dom, 30, case_type="commcare-user"),
+        "cp_n_30_day_user_cases": cases_in_last(dom, 30, case_type=USERCASE_TYPE),
         "cp_n_trivet_backends": num_telerivet_backends(dom),
         "cp_use_domain_security": use_domain_security_settings(domain_obj),
         "cp_n_custom_roles": num_custom_roles(dom),

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from dimagi.utils.chunked import chunked
 from dimagi.utils.parsing import string_to_datetime
 
+from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.data_dictionary.util import get_data_dict_case_types, get_data_dict_deprecated_case_types
 from corehq.apps.es import (
     CaseES,
@@ -87,7 +88,7 @@ def _get_case_case_counts_by_owner(domain, datespan, case_types, is_total=False,
     if case_types:
         case_query = case_query.filter({"terms": {"type.exact": case_types}})
     else:
-        case_query = case_query.filter(filters.NOT(case_type_filter('commcare-user')))
+        case_query = case_query.filter(filters.NOT(case_type_filter(USERCASE_TYPE)))
 
     if not is_total:
         case_query = case_query.active_in_range(
@@ -130,7 +131,7 @@ def _get_case_counts_by_user(domain, datespan, case_types=None, is_opened=True, 
     if case_types:
         case_query = case_query.case_type(case_types)
     else:
-        case_query = case_query.filter(filters.NOT(case_type_filter('commcare-user')))
+        case_query = case_query.filter(filters.NOT(case_type_filter(USERCASE_TYPE)))
 
     if user_ids:
         case_query = case_query.filter(filters.term(user_field, user_ids))

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -17,6 +17,7 @@ from dimagi.utils.parsing import json_format_date, string_to_utc_datetime
 
 from corehq import toggles
 from corehq.apps.analytics.tasks import track_workflow
+from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.es import UserES
 from corehq.apps.es import cases as case_es
 from corehq.apps.es import filters
@@ -568,7 +569,7 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
         if self.case_type:
             query = query.filter(case_es.case_type(self.case_type))
         else:
-            query = query.filter(filters.NOT(case_es.case_type('commcare-user')))
+            query = query.filter(filters.NOT(case_es.case_type(USERCASE_TYPE)))
 
         query = (
             query
@@ -629,7 +630,7 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
         if self.case_type:
             query = query.case_type(self.case_type)
         else:
-            query = query.filter(filters.NOT(case_es.case_type('commcare-user')))
+            query = query.filter(filters.NOT(case_es.case_type(USERCASE_TYPE)))
 
         query = query.aggregation(top_level_aggregation)
 

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -8,6 +8,7 @@ import pytz
 
 from dimagi.utils.dates import DateSpan
 
+from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.commtrack.tests.util import bootstrap_domain
 from corehq.apps.custom_data_fields.models import (
     PROFILE_SLUG,
@@ -1200,7 +1201,7 @@ class TestCaseESAccessors(TestCase):
 
         self._send_case_to_es(opened_on=opened_on)
         self._send_case_to_es(opened_on=opened_on_not_active_range)
-        self._send_case_to_es(opened_on=opened_on, case_type='commcare-user')
+        self._send_case_to_es(opened_on=opened_on, case_type=USERCASE_TYPE)
 
         results = get_total_case_counts_by_owner(self.domain, datespan)
         self.assertEqual(results[self.owner_id], 2)
@@ -1270,7 +1271,7 @@ class TestCaseESAccessors(TestCase):
         opened_on = datetime(2013, 7, 15)
 
         self._send_case_to_es(opened_on=opened_on)
-        self._send_case_to_es(opened_on=opened_on, case_type='commcare-user')
+        self._send_case_to_es(opened_on=opened_on, case_type=USERCASE_TYPE)
 
         results = get_case_counts_opened_by_user(self.domain, datespan)
         self.assertEqual(results[self.user_id], 1)

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -5,6 +5,7 @@ from django.test import TestCase, override_settings
 
 from casexml.apps.case.tests.util import create_case
 
+from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.casegroups.models import CommCareCaseGroup
 from corehq.apps.custom_data_fields.models import (
     PROFILE_SLUG,
@@ -693,7 +694,7 @@ class SchedulingRecipientTest(TestCase):
                 'external_id': user.get_id,
                 'update': {'hq_user_id': user.get_id},
             }
-            return create_case(self.domain, 'commcare-user', **create_case_kwargs)
+            return create_case(self.domain, USERCASE_TYPE, **create_case_kwargs)
 
     def update_case_and_process_change(self, *args, **kwargs):
         with self.process_pillow_changes:


### PR DESCRIPTION
## Technical Summary

Nit: Replaces hard-coded usercase case type value "commcare-user" with existing `USERCASE_TYPE` constant.

## Feature Flag

N/A

## Safety Assurance

### Safety story

* This change does nothing other than replace a string with a const.
* `corehq.apps.app_manager.const` does not import anything, so this change should not introduce any circular imports.

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
