### PR TITLE
Check loaded login-as cookie when when getting web apps for a user

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -134,7 +134,7 @@ class FormplayerMain(View):
                 domain,
                 request.couch_user,
                 search_string='',
-                limit=500,
+                limit=1,
                 offset=0
             ).run()
 

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -143,7 +143,7 @@ class FormplayerMain(View):
                     domain,
                     request.couch_user,
                     search_string='',
-                    limit=50,
+                    limit=500,
                     offset=0
                 ).run().hits
                 if user._id in [user['_id'] for user in allowed_login_as_users]:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

In https://dimagi.atlassian.net/browse/SUPPORT-19944, users were seeing all apps upon opening Web Apps instead of the limited list defined by their role's permissions. This was because Web Apps was being loaded as their "login as" user (which had the default mobile worker role, which has access to all web apps) instead of their normal web user, even though they had turned the "limit login as" permission off for the web user's role. This PR fixes that.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Web apps loaded as a "login as" user because of a cookie named `restoreAs`. This PR rewrites the code to check if the user can still "login as" that user before utilizing the cookie, and deleting the cookie if not.

This fix also adds a sort of informal limit of being able to "log in as" 50 different users. If this limit were to be passed the cookie would be deleted--not sure the effect that would have.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

Related but not entirely limited to the RESTRICT_LOGIN_AS feature flag.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tested locally and on staging: used web apps with login as, without login as, and tested the acute issue (turning off the "limited login as" permission and then immediately using web apps) and everything looks good.
- This is a relatively small change, which is why this doesn't seem worth asking for QA.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

No related automated tests exist that I'm aware of.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None. Did some quick tests locally and on staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
