### PR TITLE
Only Save Changed Case Properties in Data Dictionary

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -59,6 +59,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                     subscribePropObservable(propObj, propObj.deleted, changeSaveButton);
                     subscribePropObservable(propObj, propObj.removeFHIRResourcePropertyPath, changeSaveButton);
                     propObj.allowedValues.on('change', changeSaveButton);
+                    propObj.allowedValues.on('change', propObj.allowedValuesChanged);
                     groupObj.properties.push(propObj);
                 }
                 groupObj.properties.subscribe(changeSaveButton);
@@ -127,6 +128,11 @@ hqDefine("data_dictionary/js/data_dictionary", [
             }
         };
 
+        self.allowedValuesChanged = function () {
+            // Default to true on any change callback as this is how it is
+            // done for the save button
+            self.hasChanges = true;
+        };
 
         self.removeFHIRResourcePropertyPath = ko.observable(removeFHIRResourcePropertyPath || false);
         let subTitle;

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -50,7 +50,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
                     var propObj = propertyListItem(prop.name, prop.label, false, group.name, self.name, prop.data_type,
                         prop.description, prop.allowed_values, prop.fhir_resource_prop_path, prop.deprecated,
-                        prop.removeFHIRResourcePropertyPath, isGeoCaseProp, prop.is_safe_to_delete, prop.id, prop.index);
+                        prop.removeFHIRResourcePropertyPath, isGeoCaseProp, prop.is_safe_to_delete, prop.id, prop.index, groupObj.name());
                     subscribePropObservable(propObj, propObj.description, changeSaveButton);
                     subscribePropObservable(propObj, propObj.label, changeSaveButton);
                     subscribePropObservable(propObj, propObj.fhirResourcePropPath, changeSaveButton);
@@ -103,7 +103,8 @@ hqDefine("data_dictionary/js/data_dictionary", [
     };
 
     var propertyListItem = function (name, label, isGroup, groupName, caseType, dataType, description, allowedValues,
-        fhirResourcePropPath, deprecated, removeFHIRResourcePropertyPath, isGeoCaseProp, isSafeToDelete, id, index) {
+        fhirResourcePropPath, deprecated, removeFHIRResourcePropertyPath, isGeoCaseProp, isSafeToDelete, id, index,
+        loadedGroup) {
         var self = {};
         self.id = id;
         self.name = name;
@@ -122,6 +123,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.deleted = ko.observable(false);
         self.hasChanges = false;
         self.index = index;
+        self.loadedGroup = loadedGroup;  // The group this case property is part of when page was loaded. Used to identify group changes
 
         self.valChanged = function (newVal, oldVal) {
             if (newVal !== oldVal) {
@@ -269,7 +271,8 @@ hqDefine("data_dictionary/js/data_dictionary", [
                             'allowed_values': pureAllowedValues,
                         };
                         if (!element.hasChanges
-                            && data.index === element.index) {
+                            && data.index === element.index
+                            && element.loadedGroup === group.name()) {
                             return;
                         }
                         properties.push(data);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -50,7 +50,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
                     var propObj = propertyListItem(prop.name, prop.label, false, group.name, self.name, prop.data_type,
                         prop.description, prop.allowed_values, prop.fhir_resource_prop_path, prop.deprecated,
-                        prop.removeFHIRResourcePropertyPath, isGeoCaseProp, prop.is_safe_to_delete, prop.id);
+                        prop.removeFHIRResourcePropertyPath, isGeoCaseProp, prop.is_safe_to_delete, prop.id, prop.index);
                     subscribePropObservable(propObj, propObj.description, changeSaveButton);
                     subscribePropObservable(propObj, propObj.label, changeSaveButton);
                     subscribePropObservable(propObj, propObj.fhirResourcePropPath, changeSaveButton);
@@ -103,7 +103,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
     };
 
     var propertyListItem = function (name, label, isGroup, groupName, caseType, dataType, description, allowedValues,
-        fhirResourcePropPath, deprecated, removeFHIRResourcePropertyPath, isGeoCaseProp, isSafeToDelete, id) {
+        fhirResourcePropPath, deprecated, removeFHIRResourcePropertyPath, isGeoCaseProp, isSafeToDelete, id, index) {
         var self = {};
         self.id = id;
         self.name = name;
@@ -121,6 +121,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.isSafeToDelete = ko.observable(isSafeToDelete);
         self.deleted = ko.observable(false);
         self.hasChanges = false;
+        self.index = index;
 
         self.valChanged = function (newVal, oldVal) {
             if (newVal !== oldVal) {
@@ -246,9 +247,6 @@ hqDefine("data_dictionary/js/data_dictionary", [
                         if (element.deleted() && !element.id) {
                             return;
                         }
-                        if (!element.hasChanges) {
-                            return;
-                        }
 
                         const allowedValues = element.allowedValues.val();
                         let pureAllowedValues = {};
@@ -270,6 +268,10 @@ hqDefine("data_dictionary/js/data_dictionary", [
                             'removeFHIRResourcePropertyPath': element.removeFHIRResourcePropertyPath(),
                             'allowed_values': pureAllowedValues,
                         };
+                        if (!element.hasChanges
+                            && data.index === element.index) {
+                            return;
+                        }
                         properties.push(data);
                     });
                 });

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -473,6 +473,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                 prop.deprecated.subscribe(changeSaveButton);
                 prop.removeFHIRResourcePropertyPath.subscribe(changeSaveButton);
                 prop.allowedValues.on('change', changeSaveButton);
+                prop.hasChanges = true;
                 self.newPropertyName(undefined);
                 lastGroup.properties.push(prop);
             }

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -246,6 +246,9 @@ hqDefine("data_dictionary/js/data_dictionary", [
                         if (element.deleted() && !element.id) {
                             return;
                         }
+                        if (!element.hasChanges) {
+                            return;
+                        }
 
                         const allowedValues = element.allowedValues.val();
                         let pureAllowedValues = {};

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -51,13 +51,13 @@ hqDefine("data_dictionary/js/data_dictionary", [
                     var propObj = propertyListItem(prop.name, prop.label, false, group.name, self.name, prop.data_type,
                         prop.description, prop.allowed_values, prop.fhir_resource_prop_path, prop.deprecated,
                         prop.removeFHIRResourcePropertyPath, isGeoCaseProp, prop.is_safe_to_delete, prop.id);
-                    propObj.description.subscribe(changeSaveButton);
-                    propObj.label.subscribe(changeSaveButton);
-                    propObj.fhirResourcePropPath.subscribe(changeSaveButton);
-                    propObj.dataType.subscribe(changeSaveButton);
-                    propObj.deprecated.subscribe(changeSaveButton);
-                    propObj.deleted.subscribe(changeSaveButton);
-                    propObj.removeFHIRResourcePropertyPath.subscribe(changeSaveButton);
+                    subscribePropObservable(propObj, propObj.description, changeSaveButton);
+                    subscribePropObservable(propObj, propObj.label, changeSaveButton);
+                    subscribePropObservable(propObj, propObj.fhirResourcePropPath, changeSaveButton);
+                    subscribePropObservable(propObj, propObj.dataType, changeSaveButton);
+                    subscribePropObservable(propObj, propObj.deprecated, changeSaveButton);
+                    subscribePropObservable(propObj, propObj.deleted, changeSaveButton);
+                    subscribePropObservable(propObj, propObj.removeFHIRResourcePropertyPath, changeSaveButton);
                     propObj.allowedValues.on('change', changeSaveButton);
                     groupObj.properties.push(propObj);
                 }
@@ -65,6 +65,12 @@ hqDefine("data_dictionary/js/data_dictionary", [
                 self.groups.push(groupObj);
             }
         };
+
+        function subscribePropObservable(propObj, prop, changeSaveButton) {
+            prop.subscribe(changeSaveButton);
+            const valChangedFunc = (newVal) => propObj.valChanged(newVal, prop._oldValue);
+            prop.subscribe(valChangedFunc);
+        }
 
         return self;
     };
@@ -113,6 +119,15 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.isGeoCaseProp = ko.observable(isGeoCaseProp);
         self.isSafeToDelete = ko.observable(isSafeToDelete);
         self.deleted = ko.observable(false);
+        self.hasChanges = false;
+
+        self.valChanged = function (newVal, oldVal) {
+            if (newVal !== oldVal) {
+                self.hasChanges = true;
+            }
+        };
+
+
         self.removeFHIRResourcePropertyPath = ko.observable(removeFHIRResourcePropertyPath || false);
         let subTitle;
         if (toggles.toggleEnabled("CASE_IMPORT_DATA_DICTIONARY_VALIDATION")) {

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -69,8 +69,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
         function subscribePropObservable(propObj, prop, changeSaveButton) {
             prop.subscribe(changeSaveButton);
-            const valChangedFunc = (newVal) => propObj.valChanged(newVal, prop._oldValue);
-            prop.subscribe(valChangedFunc);
+            propObj.trackObservableChange(prop);
         }
 
         return self;
@@ -125,10 +124,19 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.index = index;
         self.loadedGroup = loadedGroup;  // The group this case property is part of when page was loaded. Used to identify group changes
 
-        self.valChanged = function (newVal, oldVal) {
-            if (newVal !== oldVal) {
-                self.hasChanges = true;
-            }
+        self.trackObservableChange = function (observable) {
+            // Keep track of old val for observable, and subscribe to new changes.
+            // We can then identify when the val has changed.
+            let oldVal = observable();
+            observable.subscribe(function (newVal) {
+                if (!newVal && !oldVal) {
+                    return;
+                }
+                if (newVal !== oldVal) {
+                    self.hasChanges = true;
+                }
+                oldVal = newVal;
+            });
         };
 
         self.allowedValuesChanged = function () {

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -249,6 +249,13 @@ hqDefine("data_dictionary/js/data_dictionary", [
                         if (element.deleted() && !element.id) {
                             return;
                         }
+                        const propIndex = group.toBeDeprecated() ? 0 : index;
+                        const propGroup = group.toBeDeprecated() ? "" : group.name();
+                        if (!element.hasChanges
+                            && propIndex === element.index
+                            && element.loadedGroup === propGroup) {
+                            return;
+                        }
 
                         const allowedValues = element.allowedValues.val();
                         let pureAllowedValues = {};
@@ -259,9 +266,9 @@ hqDefine("data_dictionary/js/data_dictionary", [
                             'caseType': element.caseType,
                             'name': element.name,
                             'label': element.label() || element.name,
-                            'index': group.toBeDeprecated() ? 0 : index,
+                            'index': propIndex,
                             'data_type': element.dataType(),
-                            'group': group.toBeDeprecated() ? "" : group.name(),
+                            'group': propGroup,
                             'description': element.description(),
                             'fhir_resource_prop_path': (
                                 element.fhirResourcePropPath() ? element.fhirResourcePropPath().trim() : element.fhirResourcePropPath()),
@@ -270,11 +277,6 @@ hqDefine("data_dictionary/js/data_dictionary", [
                             'removeFHIRResourcePropertyPath': element.removeFHIRResourcePropertyPath(),
                             'allowed_values': pureAllowedValues,
                         };
-                        if (!element.hasChanges
-                            && data.index === element.index
-                            && element.loadedGroup === group.name()) {
-                            return;
-                        }
                         properties.push(data);
                     });
                 });

--- a/corehq/apps/data_dictionary/tests/test_view.py
+++ b/corehq/apps/data_dictionary/tests/test_view.py
@@ -390,6 +390,7 @@ class DataDictionaryJsonTest(TestCase):
                                     "is_safe_to_delete": True,
                                     "allowed_values": {},
                                     "data_type": "number",
+                                    "index": 0,
                                 },
                             ],
                         },

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -104,6 +104,7 @@ def data_dictionary_json(request, domain, case_type_name=None):
                     'name': prop.name,
                     'deprecated': prop.deprecated,
                     'is_safe_to_delete': prop.name not in used_props and prop.name != geo_case_prop,
+                    'index': prop.index,
                 }
                 | (
                     {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No user-facing changes.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3710).

Minor modification has been done to the Data Dictionary JS code so that only case properties that have been changed are sent to the back-end for saving. Currently, the entire list of case properties for a case type is sent to the back-end for saving regardless of whether any changes were actually done for a case property. Reducing this count to only include changed case properties will reduce the data load sent to the back-end, as well as spare the back-end from needlessly saving case properties that have not changed.

The above changes are achieved through an extra `hasChanges` field on the `propertyListItem` JS model. All relevant case property observables are subscribed to a change callback function for correctly updating the `hasChanges` field.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Staging testing done
- QA done

This change only affects domains on the Advanced Plan and higher which have access to the Data Dictionary feature.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests as changes are only in JS.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA has been completed. Jira ticket can be found [here](https://dimagi.atlassian.net/browse/QA-6700).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
