### PR TITLE
Remove receiverwrapper from Couch preindex

### DIFF
--- a/corehq/couchapps/__init__.py
+++ b/corehq/couchapps/__init__.py
@@ -5,7 +5,6 @@ CouchAppsPreindexPlugin.register('couchapps', __file__, {
     'schemas_by_xmlns_or_case_type': settings.META_DB,
     'export_instances_by_domain': settings.META_DB,
     'export_instances_by_is_daily_saved': settings.META_DB,
-    'receiverwrapper': 'receiverwrapper',
     'users_extra': settings.USERS_GROUPS_DB,
     'deleted_users_by_username': settings.USERS_GROUPS_DB,
     'all_docs': (


### PR DESCRIPTION
Remove `recevierwrapper` from `CouchAppsPreindexPlugin`. This probably should have been done as part of https://github.com/dimagi/commcare-hq/pull/34371.

## Safety Assurance

### Safety story

The `receiverwrapper` Couch database is no longer used and all code that references it should be removed.

### Automated test coverage

No.

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations