### PR TITLE
Adapt delete_couch_dbs to delete single database

### DIFF
--- a/corehq/apps/cleanup/management/commands/delete_couch_dbs.py
+++ b/corehq/apps/cleanup/management/commands/delete_couch_dbs.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
+from couchdbkit.client import Database
 from requests import HTTPError
 
 from corehq.apps.cleanup.utils import abort, confirm_destructive_operation
@@ -7,7 +9,7 @@ from corehq.util.couchdb_management import couch_config
 
 
 class Command(BaseCommand):
-    help = "Delete all couch databases. Used to reset an environment."
+    help = "Delete couch databases. Used to reset an environment or delete a single database."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -16,18 +18,30 @@ class Command(BaseCommand):
             dest='commit',
             default=False,
         )
+        parser.add_argument(
+            '--dbname',
+            dest='dbname',
+            help='A single couch database to be deleted.',
+        )
 
-    def handle(self, *args, **options):
+    def handle(self, *, dbname=None, **options):
         confirm_destructive_operation()
 
         print("This operation will delete the following DBs")
 
+        if dbname is not None:
+            database = Database(f"{settings.COUCH_DATABASE}__{dbname}")
+            dbs = [(database.dbname, database)]
+        else:
+            dbs = couch_config.all_dbs_by_db_name.items()
+
         found_dbs_by_db_name = {}
-        for name, db in couch_config.all_dbs_by_db_name.items():
+        for name, db in dbs:
             try:
                 print(" ", name.ljust(40), db.info()['doc_count'], "docs")
             except HTTPError as err:
                 if 'Database does not exist' in str(err):
+                    print(" ", name.ljust(40), "NOT FOUND, IGNORED")
                     continue
                 raise
             found_dbs_by_db_name[name] = db
@@ -42,5 +56,5 @@ class Command(BaseCommand):
 
         if not options['commit']:
             print("You need to run it with --commit for the deletion to happen")
-
-        print("deletion done")
+        else:
+            print("deletion done")

--- a/corehq/apps/cleanup/management/commands/delete_couch_dbs.py
+++ b/corehq/apps/cleanup/management/commands/delete_couch_dbs.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 from couchdbkit.client import Database
 from requests import HTTPError
 
-from corehq.apps.cleanup.utils import abort, confirm_destructive_operation
+from corehq.apps.cleanup.utils import abort, color_style, confirm, confirm_destructive_operation
 from corehq.util.couchdb_management import couch_config
 
 
@@ -25,7 +25,12 @@ class Command(BaseCommand):
         )
 
     def handle(self, *, dbname=None, **options):
-        confirm_destructive_operation()
+        if dbname is None:
+            confirm_destructive_operation()
+        else:
+            style = color_style()
+            print(style.ERROR("\nHEY! This is wicked dangerous, pay attention.\n"))
+            confirm("Are you SURE you want to proceed?")
 
         print("This operation will delete the following DBs")
 


### PR DESCRIPTION
Add option to delete a single database.

## Safety Assurance

### Safety story

This is a dangerous command, but it gives plenty of warnings and options to abort before committing a dangerous act.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations