### PR TITLE
Don't include non-numbers in average

### DIFF
--- a/custom/gcc_sangath/rules/custom_actions.py
+++ b/custom/gcc_sangath/rules/custom_actions.py
@@ -123,12 +123,14 @@ def _is_num(value):
     True
     >>> _is_num('')
     False
+    >>> _is_num(None)
+    False
 
     """
     try:
         float(value)
         return True
-    except ValueError:
+    except (TypeError, ValueError):
         return False
 
 

--- a/custom/gcc_sangath/rules/custom_actions.py
+++ b/custom/gcc_sangath/rules/custom_actions.py
@@ -31,7 +31,7 @@ def sanitize_session_peer_rating(session_case, rule):
             session_case.case_id,
             case_properties=case_updates,
             xmlns=AUTO_UPDATE_XMLNS,
-            device_id=__name__ + ".sanitize_session_peer_rating",
+            device_id=__name__ + '.sanitize_session_peer_rating',
             form_name=rule.name,
         )
         num_updates = 1
@@ -43,26 +43,46 @@ def sanitize_session_peer_rating(session_case, rule):
 
 
 def _get_peer_rating_cases(session_case):
-    case_ids = CommCareCaseIndex.objects.get_extension_case_ids(session_case.domain, [session_case.case_id])
-    extension_cases = CommCareCase.objects.get_cases(case_ids, session_case.domain)
-    peer_rating_cases = [case for case in extension_cases if case.type == PEER_RATING_CASE_TYPE]
+    case_ids = CommCareCaseIndex.objects.get_extension_case_ids(
+        session_case.domain,
+        [session_case.case_id],
+    )
+    extension_cases = CommCareCase.objects.get_cases(
+        case_ids,
+        session_case.domain,
+    )
+    peer_rating_cases = [
+        case for case in extension_cases
+        if case.type == PEER_RATING_CASE_TYPE
+    ]
     return peer_rating_cases
 
 
 def _get_case_updates(peer_rating_cases):
     number_of_peer_ratings = len(peer_rating_cases)
-    sum_of_session_rating = _get_sum(SESSION_RATING_CASE_PROP, peer_rating_cases)
+    sum_of_session_rating = _get_sum(
+        SESSION_RATING_CASE_PROP,
+        peer_rating_cases,
+    )
 
-    agg_of_mean_treatment_specific_score = _get_aggregate(MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP,
-                                                          peer_rating_cases)
-    agg_of_mean_general_skills_score = _get_aggregate(MEAN_GENERAL_SKILLS_SCORE_CASE_PROP, peer_rating_cases)
+    agg_of_mean_treatment_specific_score = _get_aggregate(
+        MEAN_TREATMENT_SPECIFIC_SCORE_CASE_PROP,
+        peer_rating_cases,
+    )
+    agg_of_mean_general_skills_score = _get_aggregate(
+        MEAN_GENERAL_SKILLS_SCORE_CASE_PROP,
+        peer_rating_cases,
+    )
 
     latest_peer_review = _get_latest_peer_review_date(peer_rating_cases)
 
     case_updates = dict({
         'feedback_num': number_of_peer_ratings,
         'total_session_rating': sum_of_session_rating,
-        'agg_rating': round(sum_of_session_rating / number_of_peer_ratings, 1),
+        'agg_rating': round(
+            sum_of_session_rating / number_of_peer_ratings,
+            1,
+        ),
         'agg_mean_treatment_specific_score': agg_of_mean_treatment_specific_score,
         'agg_mean_general_skills_score': agg_of_mean_general_skills_score,
         'date_of_peer_review': latest_peer_review,
@@ -77,21 +97,27 @@ def _get_sum(case_property, peer_rating_cases):
         float(peer_rating_case.get_case_property(case_property) or 0)
         for peer_rating_case in peer_rating_cases
     ])
-    return float("{:.1f}".format(total))
+    return float('{:.1f}'.format(total))
 
 
 def _get_aggregate(case_property, peer_rating_cases):
     total = _get_sum(case_property, peer_rating_cases)
     count = len(peer_rating_cases)
-    return float("{:.1f}".format(total / count))
+    return float('{:.1f}'.format(total / count))
 
 
 def _get_latest_peer_review_date(peer_rating_cases):
     latest_peer_review = None
     for peer_rating_case in peer_rating_cases:
-        date_of_peer_review = peer_rating_case.get_case_property(DATE_OF_PEER_REVIEW_CASE_PROP)
+        date_of_peer_review = peer_rating_case.get_case_property(
+            DATE_OF_PEER_REVIEW_CASE_PROP
+        )
         if not latest_peer_review and date_of_peer_review:
             latest_peer_review = date_of_peer_review
-        elif latest_peer_review and date_of_peer_review and date_of_peer_review > latest_peer_review:
+        elif (
+            latest_peer_review
+            and date_of_peer_review
+            and date_of_peer_review > latest_peer_review
+        ):
             latest_peer_review = date_of_peer_review
     return latest_peer_review

--- a/custom/gcc_sangath/rules/custom_actions.py
+++ b/custom/gcc_sangath/rules/custom_actions.py
@@ -60,10 +60,10 @@ def _get_peer_rating_cases(session_case):
 
 def _get_case_updates(peer_rating_cases):
     number_of_peer_ratings = len(peer_rating_cases)
-    sum_of_session_rating = _get_sum(
+    sum_of_session_rating = float('{:.1f}'.format(_get_sum(
         SESSION_RATING_CASE_PROP,
         peer_rating_cases,
-    )
+    )))
 
     agg_rating = _get_aggregate(SESSION_RATING_CASE_PROP, peer_rating_cases)
     agg_of_mean_treatment_specific_score = _get_aggregate(
@@ -91,12 +91,11 @@ def _get_case_updates(peer_rating_cases):
 
 
 def _get_sum(case_property, peer_rating_cases):
-    total = sum(
+    return sum(
         float(peer_rating_case.get_case_property(case_property))
         for peer_rating_case in peer_rating_cases
         if _is_num(peer_rating_case.get_case_property(case_property))
     )
-    return float("{:.1f}".format(total))
 
 
 def _get_aggregate(case_property, peer_rating_cases):

--- a/custom/gcc_sangath/rules/custom_actions.py
+++ b/custom/gcc_sangath/rules/custom_actions.py
@@ -77,7 +77,7 @@ def _get_case_updates(peer_rating_cases):
 
     latest_peer_review = _get_latest_peer_review_date(peer_rating_cases)
 
-    case_updates = dict({
+    case_updates = {
         'feedback_num': number_of_peer_ratings,
         'total_session_rating': sum_of_session_rating,
         'agg_rating': agg_rating,
@@ -85,8 +85,8 @@ def _get_case_updates(peer_rating_cases):
         'agg_mean_general_skills_score': agg_of_mean_general_skills_score,
         'date_of_peer_review': latest_peer_review,
         'share_score_check': 'yes',
-    })
-    case_updates[NEEDS_AGGREGATION_CASE_PROP] = NEEDS_AGGREGATION_NO_VALUE
+        NEEDS_AGGREGATION_CASE_PROP: NEEDS_AGGREGATION_NO_VALUE,
+    }
     return case_updates
 
 

--- a/custom/gcc_sangath/tests/test_custom_actions.py
+++ b/custom/gcc_sangath/tests/test_custom_actions.py
@@ -1,3 +1,4 @@
+import doctest
 from datetime import date
 from unittest.mock import patch
 
@@ -156,3 +157,10 @@ class SanitizeSessionPeerRatingTest(BaseCaseRuleTest):
 
         cases = CaseFactory(self.domain).create_or_update_cases(extension_cases)
         self.session_case = cases[-1]
+
+
+def test_doctests():
+    import custom.gcc_sangath.rules.custom_actions as module
+
+    results = doctest.testmod(module)
+    assert results.failed == 0

--- a/custom/gcc_sangath/tests/test_custom_actions.py
+++ b/custom/gcc_sangath/tests/test_custom_actions.py
@@ -2,6 +2,8 @@ import doctest
 from datetime import date
 from unittest.mock import patch
 
+from nose.tools import assert_equal
+
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
@@ -21,6 +23,9 @@ from custom.gcc_sangath.const import (
     SESSION_RATING_CASE_PROP,
 )
 from custom.gcc_sangath.rules.custom_actions import (
+    _get_aggregate,
+    _get_count,
+    _get_sum,
     sanitize_session_peer_rating,
 )
 
@@ -164,3 +169,36 @@ def test_doctests():
 
     results = doctest.testmod(module)
     assert results.failed == 0
+
+
+class MockCase(dict):
+    def get_case_property(self, prop):
+        return self[prop]
+
+
+peer_rating_cases = [
+    MockCase({SESSION_RATING_CASE_PROP: 1.1}),
+    MockCase({SESSION_RATING_CASE_PROP: '2.2'}),
+    MockCase({SESSION_RATING_CASE_PROP: 10 / 3}),
+    MockCase({SESSION_RATING_CASE_PROP: ' '}),
+]
+
+
+def test_get_sum():
+    total = _get_sum(SESSION_RATING_CASE_PROP, peer_rating_cases)
+    assert_equal(total, 6.633333333333334)
+
+
+def test_get_count():
+    count = _get_count(SESSION_RATING_CASE_PROP, peer_rating_cases)
+    assert_equal(count, 3)
+
+
+def test_get_aggregate():
+    aggregate = _get_aggregate(SESSION_RATING_CASE_PROP, peer_rating_cases)
+    assert_equal(aggregate, 2.2)
+
+
+def test_division_by_zero():
+    aggregate = _get_aggregate(SESSION_RATING_CASE_PROP, [])
+    assert_equal(aggregate, 0.0)


### PR DESCRIPTION
## Technical Summary

Context:
* [Jira](https://dimagi.atlassian.net/browse/SC-3673)
* [Problem description](https://docs.google.com/document/d/1oDy7uRtuBd1qCl9eF3hHJo0UcZ89H3FIYE90N3pCIsc/edit)

Currently the custom `GCC_SANGATH_SANITIZE_SESSIONS_PEER_RATING` auto-update rule includes non-numbers (`None`, `" "` and `""`) in calculations of aggregates. This change corrects that by skipping non-numbers.

Easier to :blowfish: review :fish: by :tropical_fish: commit.

## Feature Flag

N/A

## Safety Assurance

### Safety story

* Applies only to projects using the custom `GCC_SANGATH_SANITIZE_SESSIONS_PEER_RATING` auto-update rule.

### Automated test coverage

Includes tests

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
