### PR TITLE
Allow case_search_display and case_search_hint values to be translated in Transifex

### DIFF
--- a/corehq/apps/translations/app_translations/upload_module.py
+++ b/corehq/apps/translations/app_translations/upload_module.py
@@ -133,14 +133,18 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
                         field=row.get('case_property', ""))
                     self.msgs.append((messages.error, message))
 
+        def get_unexpected_case_property_msg(is_display, field):
+            return _('A {display_or_hint} row for menu {index} has an unexpected case search property "{field}". '
+                     'Case properties must appear in the same order as they do in the bulk '
+                     'app translation download. No translations updated for this row.').format(
+                display_or_hint='display' if is_display else 'hint',
+                index=self.module.id + 1,
+                field=field)
+
         if len(displays) == len(properties):
             for display_row, prop in itertools.chain(zip(displays, properties)):
                 if display_row.get('case_property') != prop.name:
-                    message = _('A display row for menu {index} has an unexpected case search property "{field}". '
-                                'Case properties must appear in the same order as they do in the bulk '
-                                'app translation download. No translations updated for this row.').format(
-                                    index=self.module.id + 1,
-                                    field=display_row.get('case_property', ""))
+                    message = get_unexpected_case_property_msg(True, display_row.get('case_property', ""))
                     self.msgs.append((messages.error, message))
                     continue
                 self._update_translation(display_row, prop.label)
@@ -160,11 +164,7 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
         if len(hints) == len(properties):
             for hint_row, prop in itertools.chain(zip(hints, properties)):
                 if hint_row.get('case_property') != prop.name:
-                    message = _('A hint row for menu {index} has an unexpected case search property "{field}". '
-                                'Case properties must appear in the same order as they do in the bulk '
-                                'app translation download. No translations updated for this row.').format(
-                                    index=self.module.id + 1,
-                                    field=hint_row.get('case_property', ""))
+                    message = get_unexpected_case_property_msg(False, hint_row.get('case_property', ""))
                     self.msgs.append((messages.error, message))
                     continue
                 self._update_translation(hint_row, prop.hint)

--- a/corehq/apps/translations/app_translations/upload_module.py
+++ b/corehq/apps/translations/app_translations/upload_module.py
@@ -107,27 +107,23 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
         if self.no_items_text:
             self._update_translation(self.no_items_text, self.module.case_details.short.no_items_text)
 
-        self._update_case_search_labels(rows)
+        self._update_case_search_labels()
 
         return self.msgs
 
-    def _update_case_search_labels(self, rows):
+    def _update_case_search_labels(self):
         properties = self.module.search_config.properties
         displays = [row for row in self.condensed_rows if row['list_or_detail'] == 'case_search_display']
         hints = [row for row in self.condensed_rows if row['list_or_detail'] == 'case_search_hint']
-        if len(displays) != len(properties):
-            message = _(
-                'Expected {expected_count} case_search_display '
-                'properties in  menu {index}, found {actual_label_count} for case_search_display. '
-                'No Case Search config properties for menu {index} were updated.'
-            ).format(
-                expected_count=len(properties),
-                actual_label_count=len(displays),
-                actual_hint_count=len(hints),
-                index=self.module.id + 1,
-            )
-            self.msgs.append((messages.error, message))
-        else:
+
+        def partially_update_translations(incomplete_rows):
+            property_dict = {prop.name: prop for prop in properties}
+            for row in incomplete_rows:
+                prop_name = row.get('case_property')
+                if prop_name in property_dict:
+                    self._update_translation(row, property_dict[prop_name].hint)
+
+        if len(displays) == len(properties):
             for display_row, prop in itertools.chain(zip(displays, properties)):
                 if display_row.get('case_property') != prop.name:
                     message = _('A display row for menu {index} has an unexpected case search property "{field}". '
@@ -138,26 +134,34 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
                     self.msgs.append((messages.error, message))
                     continue
                 self._update_translation(display_row, prop.label)
-            if len(hints) == len(properties):
-                for hint_row, prop in itertools.chain(zip(hints, properties)):
-                    if hint_row.get('case_property') != prop.name:
-                        message = _('A hint row for menu {index} has an unexpected case search property "{field}".'
-                                    ' Case properties must appear in the same order as they do in the bulk '
-                                    'app translation download. No translations updated for this row.').format(
-                                        index=self.module.id + 1,
-                                        field=hint_row.get('case_property', ""))
-                        self.msgs.append((messages.error, message))
-                        continue
-                    self._update_translation(hint_row, prop.hint)
-            elif hints and len(hints) != len(properties):
-                # Transifex translations don't include empty hint rows
-                prop_index = -1
-                for hint_row in hints:
-                    while prop_index < len(properties):
-                        prop_index += 1
-                        if hint_row.get('case_property') == properties[prop_index].name:
-                            self._update_translation(hint_row, properties[prop_index].hint)
-                            break
+        else:
+            message = _(
+                'Expected {expected_count} case_search_display '
+                'properties in  menu {index}, found {actual_label_count} for case_search_display. '
+                'Case Search config properties for menu {index} were only partially updated.'
+            ).format(
+                expected_count=len(properties),
+                actual_label_count=len(displays),
+                index=self.module.id + 1,
+            )
+            self.msgs.append((messages.warning, message))
+            partially_update_translations(displays)
+
+        if len(hints) == len(properties):
+            for hint_row, prop in itertools.chain(zip(hints, properties)):
+                if hint_row.get('case_property') != prop.name:
+                    message = _('A hint row for menu {index} has an unexpected case search property "{field}". '
+                                'Case properties must appear in the same order as they do in the bulk '
+                                'app translation download. No translations updated for this row.').format(
+                                    index=self.module.id + 1,
+                                    field=hint_row.get('case_property', ""))
+                    self.msgs.append((messages.error, message))
+                    continue
+                self._update_translation(hint_row, prop.hint)
+        else:
+            # Empty hint rows are not pushed to Transifex
+            # So it could commonly give back a translations file with these rows "missing"
+            partially_update_translations(hints)
 
     def _update_report_module_rows(self, rows):
         new_headers = [None for i in self.module.report_configs]

--- a/corehq/apps/translations/integrations/transifex/parser.py
+++ b/corehq/apps/translations/integrations/transifex/parser.py
@@ -12,7 +12,7 @@ CONTEXT_REGEXS = {
     # Module or Form: sheet name for module/form: unique id
     'module_and_forms_sheet': r'^(Module|Form):(\w+):(\w+)$',  # maintain legacy module usage instead of menu
     # case property: list/detail
-    'module_sheet': r'^(.+):(list|detail)$',
+    'module_sheet': r'^(.+):(list|detail|case_search_display|case_search_hint)$',
 }
 
 TRANSIFEX_MODULE_RESOURCE_NAME = re.compile(r'^module_(\w+)(_v\d+)?$')  # module_moduleUniqueID_v123

--- a/corehq/apps/translations/integrations/transifex/parser.py
+++ b/corehq/apps/translations/integrations/transifex/parser.py
@@ -11,7 +11,7 @@ from corehq.apps.translations.const import MODULES_AND_FORMS_SHEET_NAME
 CONTEXT_REGEXS = {
     # Module or Form: sheet name for module/form: unique id
     'module_and_forms_sheet': r'^(Module|Form):(\w+):(\w+)$',  # maintain legacy module usage instead of menu
-    # case property: list/detail
+    # case property: list/detail/case_search_display/case_search_hint
     'module_sheet': r'^(.+):(list|detail|case_search_display|case_search_hint)$',
 }
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

This PR fixes a bug that was preventing case property display text under the Case Search and Claim section from being pushed to Transifex and from being uploaded back into the app. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4630)

These values weren't being pushed simply their type (`case_search_display` and `case_search_hint`) wasn't matching the regex. There was also an old conditional where if a bulk translations upload had any of its case property text and their corresponding hints missing, it wouldn't update any of either field, even if there was partial data. I've made this more lenient for hints because empty hints won't be pushed to Transifex and so won't be included as a row in the pulled file that you upload back into the app. The bulk application translation uploader will not be blocked by partially complete hint data. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

Feature flags necessary to use Case Search and Claim (see [here](https://dimagi.atlassian.net/wiki/spaces/USH/pages/2146962056/Case+Search+Configuration#CaseSearchConfiguration-HowtoconfigureCaseSearch))

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging. 

Minimal impact to existing data. Transifex pushing and pulling are now more inclusive, as is the bulk translations uploader. If it sees that it's missing a certain hint field, it'll skip updating it. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
