### PR TITLE
Add CCA dataset_editor role on HQ

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -789,6 +789,10 @@ def _commcare_analytics_roles_options():
         {
             'slug': 'sql_lab',
             'name': 'SQL Lab'
+        },
+        {
+            'slug': 'dataset_editor',
+            'name': 'Dataset Editor'
         }
     ]
 


### PR DESCRIPTION
## Product Description
Added a new CommCare Analytics role option to the CommCare Analytics section when creating/editing a role's permissions on HQ. See below.

![image](https://github.com/dimagi/commcare-hq/assets/44245062/a5081813-5f44-4eab-ab1f-d113e708d206)


## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3655)

This is a simple change. Note that this PR is part of a larger feature that is still a work in progress, so adding the role does not have any real effect on CCA yet until we link that part up.

The `dataset_editor` role is a custom role that currently exist on CCA.

## Feature Flag
CommCare Analytics FF

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
No tests requried

### QA Plan
No QA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
