### PR TITLE
Add zoom control to geospatial map

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -148,6 +148,10 @@ hqDefine('geospatial/js/models', [
                 },
             });
             self.mapInstance.addControl(self.drawControls);
+
+            // Add zoom and rotation controls to the map.
+            self.mapInstance.addControl(new mapboxgl.NavigationControl());
+
             if (self.usesClusters) {
                 createClusterLayers();
             }

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -150,7 +150,7 @@ hqDefine('geospatial/js/models', [
             self.mapInstance.addControl(self.drawControls);
 
             // Add zoom and rotation controls to the map.
-            self.mapInstance.addControl(new mapboxgl.NavigationControl());
+            self.mapInstance.addControl(new mapboxgl.NavigationControl());  // eslint-disable-line no-undef
 
             if (self.usesClusters) {
                 createClusterLayers();


### PR DESCRIPTION
## Product Description
Zoom controls have been added to the geospatial map. This includes zoom in, zoom out and pan functions. See below...

![image](https://github.com/dimagi/commcare-hq/assets/44245062/556b7d3f-cbd1-4c55-bd07-372bdfdf576d)


## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3621)

The zoom control is part of the mapbox functions that we can use.

## Feature Flag
Geospatial

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
No automated tests

### QA Plan
No QA necessary

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
