### PR TITLE
Migration: Remove user data from couch model

### DIFF
--- a/corehq/apps/users/migrations/0071_rm_user_data.py
+++ b/corehq/apps/users/migrations/0071_rm_user_data.py
@@ -1,0 +1,20 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def remove_user_data(apps, schema_editor):
+    call_command('rm_couch_user_data')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0070_alter_invitation_tableau_role"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_user_data, migrations.RunPython.noop),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -1244,6 +1244,7 @@ users
  0068_grant_web_apps_to_default_mobile_worker_role
  0069_alter_invitation_custom_user_data_and_more
  0070_alter_invitation_tableau_role
+ 0071_rm_user_data
 util
  0001_initial
  0002_complaintbouncemeta_permanentbouncemeta_transientbounceemail


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
https://dimagi.atlassian.net/browse/USH-951
This is cleanup from the migration to SQL that happened earlier in the year.  The couch field is no longer being updated and isn't in use anywhere, so this PR removes it.

Follow up from https://github.com/dimagi/commcare-hq/pull/34805
The management command has been run on all Dimagi environments and announced on the forum.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

Gonna rely on local and automated testing here mostly, as there's nothing that uses this in the UI.  I'm going to pilot the migration on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

The migration can be run whenever.  I'll manually run it on production environments before deploy, just to avoid making deploy take a while.

### Rollback instructions

This PR should not be reverted, as it contains a migration

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
