### PR TITLE
Skip mobile reports beyond limit instead of failing restores

### DIFF
--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -193,14 +193,3 @@ class DangerousXmlException(Exception):
 
 class AppMisconfigurationError(AppManagerException):
     """Errors in app configuration that are the user's responsibility"""
-
-
-class CannotRestoreException(Exception):
-    """Errors that inherit from this exception will always fail hard in restores"""
-
-
-class MobileUCRTooLargeException(CannotRestoreException):
-
-    def __init__(self, message, row_count):
-        super().__init__(message)
-        self.row_count = row_count

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -21,7 +21,6 @@ from corehq.apps.app_manager.const import (
     MOBILE_UCR_VERSION_2,
 )
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
-from corehq.apps.app_manager.exceptions import CannotRestoreException, MobileUCRTooLargeException
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
     is_valid_mobile_select_filter_type,
 )
@@ -110,12 +109,8 @@ class ReportFixturesProvider(FixtureProvider):
         ]
 
         for provider in providers:
-            try:
-                fixtures.extend(provider(restore_state, restore_user, needed_versions, report_configs))
-                self.report_ucr_row_count(provider.row_count, provider.version, restore_user.domain)
-            except MobileUCRTooLargeException as err:
-                self.report_ucr_row_count(err.row_count, provider.version, restore_user.domain)
-                raise
+            fixtures.extend(provider(restore_state, restore_user, needed_versions, report_configs))
+            self.report_ucr_row_count(provider.row_count, provider.version, restore_user.domain)
 
         return fixtures
 

--- a/corehq/apps/userreports/exceptions.py
+++ b/corehq/apps/userreports/exceptions.py
@@ -73,6 +73,10 @@ class ReportConfigurationNotFoundError(UserReportsError):
     pass
 
 
+class MobileUCRTooLargeError(UserReportsError):
+    pass
+
+
 class InvalidQueryColumn(UserReportsError):
     pass
 

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -26,7 +26,6 @@ from couchforms.openrosa_response import (
     get_simple_response_xml,
 )
 
-from corehq.apps.app_manager.exceptions import CannotRestoreException
 from corehq.apps.domain.models import Domain
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.exceptions import NotFound
@@ -596,9 +595,6 @@ class RestoreConfig(object):
             )
             response = HttpResponse(response, content_type="text/xml; charset=utf-8",
                                     status=412)  # precondition failed
-        except CannotRestoreException as e:
-            response = get_simple_response_xml(str(e), ResponseNature.OTA_RESTORE_ERROR)
-            response = HttpResponse(response, content_type="text/xml; charset=utf-8", status=400)
 
         if not is_async:
             self._record_timing(response.status_code)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A follow up to https://github.com/dimagi/commcare-hq/pull/34704 to skip reporting data in restore if it crosses a certain threshold of records instead of failing restore entirely.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
