### PR TITLE
Relabel PREVENT_MOBILE_UCR_SYNC as a permanent internal tool

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1714,7 +1714,7 @@ MOBILE_RECOVERY_MEASURES = StaticToggle(
 
 PREVENT_MOBILE_UCR_SYNC = StaticToggle(
     'prevent_mobile_ucr_sync',
-    'Used for emergencies when UCR sync is causing operational problems',
+    'Prevent Mobile UCR sync (when a UCR sync is causing operational problems)',
     TAG_INTERNAL,
     [NAMESPACE_DOMAIN],
     description='Prevents mobile UCRs from being generated or included in the sync payload',

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1714,8 +1714,8 @@ MOBILE_RECOVERY_MEASURES = StaticToggle(
 
 PREVENT_MOBILE_UCR_SYNC = StaticToggle(
     'prevent_mobile_ucr_sync',
-    'ICDS: Used for ICDS emergencies when UCR sync is killing the DB',
-    TAG_CUSTOM,
+    'Used for emergencies when UCR sync is causing operational problems',
+    TAG_INTERNAL,
     [NAMESPACE_DOMAIN],
     description='Prevents mobile UCRs from being generated or included in the sync payload',
 )


### PR DESCRIPTION
Useful for firefighting, irrespective of historical connection to ICDS. My tiny, very not urgent offering.

## Product Description
None

## Technical Summary
No change in behavior, only change in the label applied and the description used for this feature flag.

Slight chance that taking away the ICDS and labeling it an internal tool will make it more discoverable in the future. (People might feel weird using a feature flag labeled ICDS, in addition to that just no longer being relevant.)

## Feature Flag
PREVENT_MOBILE_UCR_SYNC

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
