### PR TITLE
Handle paginated response from Entra

### DIFF
--- a/corehq/apps/sso/tasks.py
+++ b/corehq/apps/sso/tasks.py
@@ -21,7 +21,7 @@ from corehq.apps.sso.utils.context_helpers import (
     get_sso_deactivation_skip_email_context,
 )
 from corehq.apps.sso.utils.entra import MSGraphIssue
-from corehq.apps.sso.utils.user_helpers import get_email_domain_from_username
+from corehq.apps.sso.utils.user_helpers import convert_emails_to_lowercase, get_email_domain_from_username
 from corehq.apps.users.models import WebUser
 from corehq.apps.users.models import HQApiKey
 from django.contrib.auth.models import User
@@ -132,7 +132,7 @@ def auto_deactivate_removed_sso_users():
         login_enforcement_type=LoginEnforcementType.GLOBAL,
     ).all():
         try:
-            usernames_in_idp = idp.get_all_usernames_of_the_idp()
+            usernames_in_idp = convert_emails_to_lowercase(idp.get_all_usernames_of_the_idp())
         except EntraVerificationFailed as e:
             notify_exception(None, f"Failed to get members of the IdP. {str(e)}")
             send_deactivation_skipped_email(idp=idp, failure_code=MSGraphIssue.VERIFICATION_ERROR,

--- a/corehq/apps/sso/utils/user_helpers.py
+++ b/corehq/apps/sso/utils/user_helpers.py
@@ -16,3 +16,9 @@ def get_email_domain_from_username(username):
         # not a real email address as the username contains invalid characters
         return
     return split_username[-1]
+
+
+def convert_emails_to_lowercase(emails):
+    # Convert each email in the list to lowercase
+    lowercase_emails = [email.lower() for email in emails]
+    return lowercase_emails


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15622

Microsoft split the response into multiple “pages” when handling large sets of data. The `@odata.nextLink` is a URL that contains all the necessary parameters to request the next set of data. So in this PR, I iterate through the pages using the `@odata.nextLink`, until the response no longer contains `@odata.nextLink`.

In addition, I realized userPrincipalNames in Entra can have uppercase letters, I expect this can happen to other idp too. But in commcare, we store email in lowercase, so I converted the results we get to lowercase before we make comparison.


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested with CRS's idp, and confirmed that the number of users we get matches their number.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA as this requested more than 100 users also group settings which require paid subscriptions.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
