### PR TITLE
Return generators in ReportFixturesProviderV2

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -95,8 +95,6 @@ class ReportFixturesProvider(FixtureProvider):
         if not report_configs:
             return []
 
-        fixtures = []
-
         needed_versions = {
             app.mobile_ucr_restore_version
             for app in apps
@@ -110,13 +108,11 @@ class ReportFixturesProvider(FixtureProvider):
 
         for provider in providers:
             try:
-                fixtures.extend(provider(restore_state, restore_user, needed_versions, report_configs))
+                yield from provider(restore_state, restore_user, needed_versions, report_configs)
                 self.report_ucr_row_count(provider.row_count, provider.version, restore_user.domain)
             except MobileUCRTooLargeException as err:
                 self.report_ucr_row_count(err.row_count, provider.version, restore_user.domain)
                 raise
-
-        return fixtures
 
     def report_ucr_row_count(self, row_count, provider_version, domain):
         metrics_histogram(
@@ -239,9 +235,8 @@ class ReportFixturesProviderV1(BaseReportFixtureProvider):
         """
         Generates a report fixture for mobile that can be used by a report module
         """
-        fixtures = []
         if needed_versions.intersection({MOBILE_UCR_VERSION_1, MOBILE_UCR_MIGRATING_TO_2}):
-            fixtures.append(_get_report_index_fixture(restore_user))
+            yield _get_report_index_fixture(restore_user)
             try:
                 self.report_data_cache.load_reports()
             except Exception:
@@ -249,16 +244,14 @@ class ReportFixturesProviderV1(BaseReportFixtureProvider):
                     "domain": restore_user.domain,
                     "report_config_ids": [config.report_id for config in report_configs]
                 })
-                return []
+                return
 
-            fixtures.extend(self._v1_fixture(restore_user, report_configs, restore_state.params.fail_hard))
+            yield self._v1_fixture(restore_user, report_configs, restore_state.params.fail_hard)
         else:
-            fixtures.extend(self._empty_v1_fixture(restore_user))
-
-        return fixtures
+            yield self._empty_v1_fixture(restore_user)
 
     def _empty_v1_fixture(self, restore_user):
-        return [E.fixture(id=self.id, user_id=restore_user.user_id)]
+        return E.fixture(id=self.id, user_id=restore_user.user_id)
 
     def _v1_fixture(self, restore_user, report_configs, fail_hard=False):
         user_id = restore_user.user_id
@@ -283,7 +276,7 @@ class ReportFixturesProviderV1(BaseReportFixtureProvider):
                 if settings.UNIT_TESTING or settings.DEBUG or fail_hard:
                     raise
         root.append(reports_elem)
-        return [root]
+        return root
 
     def report_config_to_fixture(self, report_config, restore_user):
         row_index_enabled = toggles.ADD_ROW_INDEX_TO_MOBILE_UCRS.enabled(restore_user.domain)
@@ -325,13 +318,11 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
         """
         Generates a report fixture for mobile that can be used by a report module
         """
-        fixtures = []
-
         if needed_versions.intersection({MOBILE_UCR_MIGRATING_TO_2, MOBILE_UCR_VERSION_2}):
             synced_fixtures, purged_fixture_ids = self._relevant_report_configs(restore_state, report_configs)
 
             oldest_sync_time = self._get_oldest_sync_time(restore_state, synced_fixtures, purged_fixture_ids)
-            fixtures.append(_get_report_index_fixture(restore_user, oldest_sync_time))
+            yield _get_report_index_fixture(restore_user, oldest_sync_time)
 
             try:
                 self.report_data_cache.load_reports(synced_fixtures)
@@ -342,11 +333,9 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
                 })
                 return []
 
-            fixtures.extend(self._v2_fixtures(restore_user, synced_fixtures, restore_state.params.fail_hard))
+            yield from self._v2_fixtures(restore_user, synced_fixtures, restore_state.params.fail_hard)
             for report_uuid in purged_fixture_ids:
-                fixtures.extend(self._empty_v2_fixtures(report_uuid))
-
-        return fixtures
+                yield from self._empty_v2_fixtures(report_uuid)
 
     @staticmethod
     def _get_oldest_sync_time(restore_state, synced_fixtures, purged_fixture_ids):
@@ -416,16 +405,13 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
         return configs_to_sync, extra_configs_on_phone
 
     def _empty_v2_fixtures(self, report_uuid):
-        return [
-            E.fixture(id=self._report_fixture_id(report_uuid)),
-            E.fixture(id=self._report_filter_id(report_uuid))
-        ]
+        yield E.fixture(id=self._report_fixture_id(report_uuid))
+        yield E.fixture(id=self._report_filter_id(report_uuid))
 
     def _v2_fixtures(self, restore_user, report_configs, fail_hard=False):
-        fixtures = []
         for report_config in report_configs:
             try:
-                fixtures.extend(self.report_config_to_fixture(report_config, restore_user))
+                yield from self.report_config_to_fixture(report_config, restore_user)
             except ReportConfigurationNotFoundError as err:
                 logging.exception('Error generating report fixture: {}'.format(err))
                 if fail_hard:
@@ -441,7 +427,6 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
                 logging.exception('Error generating report fixture: {}'.format(err))
                 if settings.UNIT_TESTING or settings.DEBUG or fail_hard:
                     raise
-        return fixtures
 
     def report_config_to_fixture(self, report_config, restore_user):
         def _row_to_row_elem(deferred_fields, filter_options_by_field, row, index, is_total_row=False):
@@ -458,21 +443,23 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
         rows, filters_elem = generate_rows_and_filters(
             self.report_data_cache, report_config, restore_user, _row_to_row_elem
         )
+
+        report_filter_elem = E.fixture(id=ReportFixturesProviderV2._report_filter_id(report_config.uuid))
+        report_filter_elem.append(filters_elem)
+        yield report_filter_elem
+
         # the v2 provider writes each report to its own fixture so we only care about the max row_count
         self.row_count = max(len(rows), self.row_count)
         rows_elem = E.rows(last_sync=_format_last_sync_time(restore_user))
         for row in rows:
             rows_elem.append(row)
 
-        report_filter_elem = E.fixture(id=ReportFixturesProviderV2._report_filter_id(report_config.uuid))
-        report_filter_elem.append(filters_elem)
-
         report_elem = E.fixture(
             id=ReportFixturesProviderV2._report_fixture_id(report_config.uuid), user_id=restore_user.user_id,
             report_id=report_config.report_id, indexed='true'
         )
         report_elem.append(rows_elem)
-        return [report_filter_elem, report_elem]
+        yield report_elem
 
     @staticmethod
     def _report_fixture_id(report_uuid):

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -557,10 +557,10 @@ def get_report_element(
             f"{settings.MAX_MOBILE_UCR_SIZE}",
             row_count=len(rows),
         )
-    if len(rows) + current_row_count > settings.MAX_MOBILE_UCR_SIZE * 2:
+    if len(rows) + current_row_count > settings.MAX_MOBILE_UCR_SIZE:
         raise MobileUCRTooLargeException(
-            "You are attempting to restore too many mobile reports. Your Mobile UCR Restore Version is set to 1.0."
-            " Try upgrading to 2.0.",
+            "You are attempting to restore too many mobile report rows. Your "
+            "Mobile UCR Restore Version is set to 1.0. Try upgrading to 2.0.",
             row_count=len(rows) + current_row_count,
         )
     for row_index, row in enumerate(rows):

--- a/corehq/apps/ota/tests/test_app_aware_restore.py
+++ b/corehq/apps/ota/tests/test_app_aware_restore.py
@@ -96,8 +96,7 @@ class AppAwareSyncTests(TestCase):
             get_data_mock.return_value = self.rows
             with mock_datasource_config():
                 fixtures = call_fixture_generator(report_fixture_generator, self.user)
-
-        reports = self._get_fixture(fixtures, ReportFixturesProviderV1.id).findall('.//report')
+                reports = self._get_fixture(fixtures, ReportFixturesProviderV1.id).findall('.//report')
         self.assertEqual(len(reports), 2)
         report_ids = {r.attrib.get('id') for r in reports}
         self.assertEqual(report_ids, {'123456', 'abcdef'})
@@ -111,7 +110,7 @@ class AppAwareSyncTests(TestCase):
             get_data_mock.return_value = self.rows
             with mock_datasource_config():
                 fixtures = call_fixture_generator(report_fixture_generator, self.user, app=self.app1)
-        reports = self._get_fixture(fixtures, ReportFixturesProviderV1.id).findall('.//report')
+                reports = self._get_fixture(fixtures, ReportFixturesProviderV1.id).findall('.//report')
 
         self.assertEqual(len(reports), 1)
         self.assertEqual(reports[0].attrib.get('id'), '123456')
@@ -158,7 +157,7 @@ class AppAwareSyncTests(TestCase):
         with patch.object(ConfigurableReportDataSource, 'get_data') as get_data_mock:
             get_data_mock.return_value = self.rows
             fixtures = call_fixture_generator(report_fixture_generator, self.user, app=self.app3)
-        self.assertEqual(len(fixtures), 0)
+        self.assertEqual(len(list(fixtures)), 0)
 
     def test_user_restore(self):
         from casexml.apps.phone.utils import MockDevice


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR includes a couple of changes:
- the main one is to yield reports from ReportFixturesProviderV2 to avoid storing all xml serialized reports for a restore in memory together. I thought this was already the case, but clearly missed that this provider still currently collects all reports into a fixtures list. The top level provider that collects restore elements from each specific provider already supports interfacing with generators (see [here](https://github.com/dimagi/commcare-hq/blob/394f983baed9b78f613c3317ee3b52eb54f83ffe/corehq/ex-submodules/casexml/apps/phone/data_providers/standard.py#L59-L63)), so this change is only needed in the ReportFixturesProviderV2 for it to take effect. We also made changes to ReportFixturesProviderV1 to return generators instead, though do not anticipate those changes to have a meaningful impact.
- removed the separate, higher limit for V1 reports which multiplied the MAX_MOBILE_UCR_SIZE constant by 2. This value really represents that max number of rows we want to hold in memory at once, and should be the same for either version.

## Feature Flag
MOBILE_UCR

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and on staging. There were tests that exercised this code as well that failed after the initial change and the tests were updated to handle a generator being returned instead of a list. However in production code, the only path to this code is through the report providers, so testing that restores still behave as expected is sufficient. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Could do post deploy QA in the interest of time, but the testing I've done feels sufficient.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
