### PR TITLE
Df/update permissions max cases

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1168,6 +1168,7 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
     )
 
     def __init__(self, domain, can_edit_eula, *args, **kwargs):
+        self.user = kwargs.pop('user', None)
         super(DomainInternalForm, self).__init__(*args, **kwargs)
         self.domain = domain
         self.can_edit_eula = can_edit_eula
@@ -1265,6 +1266,13 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
                 ),
             ),
         )
+
+        if not self.user.is_staff:
+            self.fields['auto_case_update_limit'].disabled = True
+            self.fields['auto_case_update_limit'].help_text = (
+                'Case update rule limits are only modifiable by Dimagi admins. '
+                'Please reach out to support@dimagi.com if you wish to update this setting.'
+            )
 
     @property
     def current_values(self):

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1167,8 +1167,8 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
         required=False,
     )
 
-    def __init__(self, domain, can_edit_eula, *args, **kwargs):
-        self.user = kwargs.pop('user', None)
+    def __init__(self, domain, can_edit_eula, *args, user, **kwargs):
+        self.user = user
         super(DomainInternalForm, self).__init__(*args, **kwargs)
         self.domain = domain
         self.can_edit_eula = can_edit_eula

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -97,7 +97,8 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
     def internal_settings_form(self):
         can_edit_eula = toggles.CAN_EDIT_EULA.enabled(self.request.couch_user.username)
         if self.request.method == 'POST':
-            return DomainInternalForm(self.request.domain, can_edit_eula, self.request.POST)
+            return DomainInternalForm(self.request.domain, can_edit_eula,
+                                      self.request.POST, user=self.request.user)
         initial = {
             'countries': self.domain_object.deployment.countries,
             'is_test': self.domain_object.is_test,
@@ -150,7 +151,7 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
         initial['active_ucr_expressions'] = AllowedUCRExpressionSettings.get_allowed_ucr_expressions(
             domain_name=self.domain_object.name
         )
-        return DomainInternalForm(self.request.domain, can_edit_eula, initial=initial)
+        return DomainInternalForm(self.request.domain, can_edit_eula, initial=initial, user=self.request.user)
 
     @property
     def page_context(self):

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -97,8 +97,8 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
     def internal_settings_form(self):
         can_edit_eula = toggles.CAN_EDIT_EULA.enabled(self.request.couch_user.username)
         if self.request.method == 'POST':
-            return DomainInternalForm(self.request.domain, can_edit_eula, self.request.user,
-                                      self.request.POST)
+            return DomainInternalForm(self.request.domain, can_edit_eula,
+                                      self.request.POST, user=self.request.user)
         initial = {
             'countries': self.domain_object.deployment.countries,
             'is_test': self.domain_object.is_test,

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -97,8 +97,8 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
     def internal_settings_form(self):
         can_edit_eula = toggles.CAN_EDIT_EULA.enabled(self.request.couch_user.username)
         if self.request.method == 'POST':
-            return DomainInternalForm(self.request.domain, can_edit_eula,
-                                      self.request.POST, user=self.request.user)
+            return DomainInternalForm(self.request.domain, can_edit_eula, self.request.user,
+                                      self.request.POST)
         initial = {
             'countries': self.domain_object.deployment.countries,
             'is_test': self.domain_object.is_test,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This disables the custom max update field in the project information settings for non-developers (django users with an is_staff value of False).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15607

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I observed the local effects of this change when user.is_staff was both True and False.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
