### PR TITLE
Add link to case export in Data Dictionary

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -530,6 +530,16 @@ hqDefine("data_dictionary/js/data_dictionary", [
             return true;
         };
 
+        self.quickCaseExportPath = ko.computed(function () {
+            if (self.getActiveCaseType()) {
+                return (
+                    initialPageData.reverse('new_custom_export_case') +
+                    "?export_tag=" +
+                    self.getActiveCaseType().name
+                );
+            }
+        });
+
         self.clearForm = function () {
             $("#create-case-type-form").trigger("reset");
             self.name("");

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -129,6 +129,7 @@
   {% registerurl 'deprecate_or_restore_case_type' domain '---' %}
   {% registerurl 'delete_case_type' domain '---' %}
   {% registerurl 'data_dictionary' domain %}
+  {% registerurl 'new_custom_export_case' domain %}
   {% initial_page_data 'typeChoices' question_types %}
   {% initial_page_data 'fhirResourceTypes' fhir_resource_types %}
   {% initial_page_data 'read_only_mode' request.is_view_only %}
@@ -191,6 +192,13 @@
         <a class="btn btn-danger" href="#" data-bind="openModal: 'delete-case-type-modal', visible: $root.canDeleteActiveCaseType()">
           <i class="fa fa-trash"></i>
           {% trans "Delete Case Type" %}
+        </a>
+      {% endif %}
+      {% if request.couch_user.can_edit_data %}
+        <a class="btn btn-default" id="export-case-type-data-dict"
+           data-bind="attr: { href: quickCaseExportPath }, visible: activeCaseType()">
+          <i class="icon icon-share fa-solid fa-share-square"></i>
+          {% trans "Export Case Data" %}
         </a>
       {% endif %}
       <div data-bind="visible: $root.activeCaseType()">


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Added a link (button) on data dictionary when viewing a case type to export case data. The link visible to users that have the permission to edit data which is the permission needed for creating case exports.

Amongst the many buttons on the page, I could not think of a better place for it without moving many other buttons. I am aligned that the page could use some redesigning though not taking that as a part of this PR.
Here is how it looks:

![image](https://github.com/dimagi/commcare-hq/assets/3864163/41e4c05a-f84e-472b-8748-a79de6abe875)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3454


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally that it works and does not break anything.
Link visible only when user has necessary permissions, additionally the view itself has necessary permission checks.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned. Will go through UAT though

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
