### PR TITLE
Admin report for domains which should have data source restriction FF enabled

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -372,6 +372,10 @@ class UCRRebuildRestrictionTable:
         return rows
 
     @property
+    def total_records(self):
+        return len(self.ucr_domains)
+
+    @property
     def ucr_domains(self):
         return USER_CONFIGURABLE_REPORTS.get_enabled_domains()
 
@@ -458,6 +462,7 @@ class UCRDataLoadReport(AdminReport):
     emailable = False
     exportable = False
     default_rows = 10
+    ajax_pagination = True
 
     def __init__(self, request, *args, **kwargs):
         self.table_data = UCRRebuildRestrictionTable(
@@ -471,4 +476,16 @@ class UCRDataLoadReport(AdminReport):
 
     @property
     def rows(self):
-        return self.table_data.rows
+        start = self.pagination.start
+        end = self.pagination.start + self.pagination.count
+        return self.table_data.rows[start:end]
+
+    @property
+    def total_records(self):
+        return self.table_data.total_records
+
+    @property
+    def shared_pagination_GET_params(self):
+        return [
+            {'name': 'ucr_rebuild_restriction', 'value': self.request.GET.get('ucr_rebuild_restriction')}
+        ]

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -342,11 +342,9 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
 class UCRRebuildRestrictionTable:
     UCR_RESTRICTION_THRESHOLD = 1_000_000
 
-    selected_domain: str
     restriction_ff_status: str
 
     def __init__(self, *args, **kwargs):
-        self.selected_domain = kwargs.get('selected_domain')
         self.restriction_ff_status = kwargs.get('restriction_ff_status')
 
     @property
@@ -362,7 +360,7 @@ class UCRRebuildRestrictionTable:
     def rows(self):
         rows = []
 
-        for domain in self.ucr_domains():
+        for domain in self.ucr_domains:
             case_count = CaseES().domain(domain).count()
             form_count = FormES().domain(domain).count()
 
@@ -373,14 +371,9 @@ class UCRRebuildRestrictionTable:
 
         return rows
 
+    @property
     def ucr_domains(self):
-        ucr_domains = USER_CONFIGURABLE_REPORTS.get_enabled_domains()
-        if self.selected_domain:
-            if self.selected_domain in ucr_domains:
-                return [self.selected_domain]
-            return []
-
-        return ucr_domains
+        return USER_CONFIGURABLE_REPORTS.get_enabled_domains()
 
     def should_show_domain(self, domain, total_cases, total_forms):
         if self._show_all_domains:
@@ -460,7 +453,6 @@ class UCRDataLoadReport(AdminReport):
     name = gettext_lazy("UCR Domains Data Report")
 
     fields = [
-        'corehq.apps.reports.filters.simple.SimpleDomain',
         'corehq.apps.reports.filters.select.UCRRebuildStatusFilter',
     ]
     emailable = False
@@ -469,7 +461,6 @@ class UCRDataLoadReport(AdminReport):
 
     def __init__(self, request, *args, **kwargs):
         self.table_data = UCRRebuildRestrictionTable(
-            selected_domain=request.GET.get('domain_name'),
             restriction_ff_status=request.GET.get('ucr_rebuild_restriction')
         )
         super().__init__(request, *args, **kwargs)

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -380,10 +380,6 @@ class UCRRebuildRestrictionTable:
         return rows
 
     @property
-    def total_records(self):
-        return len(self.ucr_domains)
-
-    @property
     def ucr_domains(self):
         return USER_CONFIGURABLE_REPORTS.get_enabled_domains()
 
@@ -482,7 +478,6 @@ class UCRDataLoadReport(AdminReport):
     emailable = False
     exportable = False
     default_rows = 10
-    ajax_pagination = True
 
     def __init__(self, request, *args, **kwargs):
         self.table_data = UCRRebuildRestrictionTable(
@@ -496,16 +491,4 @@ class UCRDataLoadReport(AdminReport):
 
     @property
     def rows(self):
-        start = self.pagination.start
-        end = self.pagination.start + self.pagination.count
-        return self.table_data.rows[start:end]
-
-    @property
-    def total_records(self):
-        return self.table_data.total_records
-
-    @property
-    def shared_pagination_GET_params(self):
-        return [
-            {'name': 'ucr_rebuild_restriction', 'value': self.request.GET.get('ucr_rebuild_restriction')}
-        ]
+        return self.table_data.rows

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -420,7 +420,7 @@ class UCRRebuildRestrictionTable:
             domain,
             case_count,
             form_count,
-            self._restrict_rebuild_column_data(domain, case_count, form_count),
+            self._ucr_rebuild_restriction_status_column_data(domain, case_count, form_count),
         ]
 
     def _should_restrict_rebuild(self, case_count, form_count):
@@ -451,7 +451,7 @@ class UCRRebuildRestrictionTable:
     def _show_all_domains(self):
         return not self.restriction_ff_status
 
-    def _restrict_rebuild_column_data(self, domain, case_count, form_count):
+    def _ucr_rebuild_restriction_status_column_data(self, domain, case_count, form_count):
         from django.utils.safestring import mark_safe
         from corehq.apps.toggle_ui.views import ToggleEditView
 

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -380,6 +380,7 @@ class UCRRebuildRestrictionTable:
         return rows
 
     @property
+    @memoized
     def ucr_domains(self):
         return USER_CONFIGURABLE_REPORTS.get_enabled_domains()
 

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -478,7 +478,9 @@ class UCRDataLoadReport(AdminReport):
     ]
     emailable = False
     exportable = False
-    default_rows = 10
+    disable_pagination = True
+    ajax_pagination = False
+    use_datatables = False
 
     def __init__(self, request, *args, **kwargs):
         self.table_data = UCRRebuildRestrictionTable(

--- a/corehq/apps/hqadmin/tests/test_reports.py
+++ b/corehq/apps/hqadmin/tests/test_reports.py
@@ -15,7 +15,7 @@ class TestUCRRebuildRestrictionTable(TestCase):
         table_data = UCRRebuildRestrictionTable()
 
         self.assertEqual(
-            table_data.ucr_domains(),
+            table_data.ucr_domains,
             ucr_enabled_domains
         )
 

--- a/corehq/apps/hqadmin/tests/test_reports.py
+++ b/corehq/apps/hqadmin/tests/test_reports.py
@@ -1,0 +1,90 @@
+from django.test import TestCase
+from unittest.mock import patch
+
+from corehq.apps.hqadmin.reports import UCRRebuildRestrictionTable
+from corehq.motech.repeaters.const import UCRRestrictionFFStatus
+
+
+class TestUCRRebuildRestrictionTable(TestCase):
+
+    @patch('corehq.apps.hqadmin.reports.USER_CONFIGURABLE_REPORTS.get_enabled_domains')
+    def test_all_ucr_domains(self, get_enabled_domains_mock):
+        ucr_enabled_domains = ['domain1', 'domain2']
+        get_enabled_domains_mock.return_value = ucr_enabled_domains
+
+        table_data = UCRRebuildRestrictionTable()
+
+        self.assertEqual(
+            table_data.ucr_domains(),
+            ucr_enabled_domains
+        )
+
+    @patch('corehq.apps.hqadmin.reports.USER_CONFIGURABLE_REPORTS.get_enabled_domains')
+    def test_filtered_ucr_domain(self, get_enabled_domains_mock):
+        ucr_enabled_domains = ['domain1', 'domain2']
+        get_enabled_domains_mock.return_value = ucr_enabled_domains
+
+        table_data = UCRRebuildRestrictionTable(selected_domain='domain1')
+
+        self.assertEqual(
+            table_data.ucr_domains(),
+            ['domain1'],
+        )
+
+    def test_should_show_domain_default_show_all(self):
+        table_data = UCRRebuildRestrictionTable()
+        self.assertTrue(table_data.should_show_domain)
+
+    @patch.object(UCRRebuildRestrictionTable, '_rebuild_restricted_ff_enabled')
+    def test_should_show_domain_show_ff_enabled_domains(self, restriction_ff_enabled_mock):
+        """ Test domains which does have the FF enabled """
+        restriction_ff_enabled_mock.return_value = True
+
+        table_data = UCRRebuildRestrictionTable(
+            restriction_ff_status=UCRRestrictionFFStatus.Enabled.name,
+        )
+        self.assertTrue(table_data.should_show_domain(
+            domain='domain', total_cases=100_000_000, total_forms=0)
+        )
+
+    @patch.object(UCRRebuildRestrictionTable, '_rebuild_restricted_ff_enabled')
+    def test_should_show_domain_show_ff_disabled_domains(self, restriction_ff_enabled_mock):
+        """ Test domains which does not have the FF enabled """
+        restriction_ff_enabled_mock.return_value = False
+
+        table_data = UCRRebuildRestrictionTable(
+            restriction_ff_status=UCRRestrictionFFStatus.NotEnabled.name,
+        )
+        self.assertTrue(table_data.should_show_domain(
+            domain='domain', total_cases=10, total_forms=0)
+        )
+
+    @patch.object(UCRRebuildRestrictionTable, '_rebuild_restricted_ff_enabled')
+    def test_should_show_domain_show_should_enable_ff_domains(self, restriction_ff_enabled_mock):
+        """ Test domains which does not have the FF enabled but should have it enabled """
+        restriction_ff_enabled_mock.return_value = False
+
+        table_data = UCRRebuildRestrictionTable(
+            restriction_ff_status=UCRRestrictionFFStatus.ShouldEnable.name,
+        )
+        self.assertTrue(table_data.should_show_domain(
+            domain='domain', total_cases=100_000_000, total_forms=0)
+        )
+        self.assertFalse(table_data.should_show_domain(
+            domain='domain', total_cases=10, total_forms=0)
+        )
+
+    @patch.object(UCRRebuildRestrictionTable, '_rebuild_restricted_ff_enabled')
+    def test_should_show_domain_show_should_disable_ff_domains(self, restriction_ff_enabled_mock):
+        """ Test domains which does have the FF enabled but should not have it enabled """
+        restriction_ff_enabled_mock.return_value = True
+
+        table_data = UCRRebuildRestrictionTable(
+            restriction_ff_status=UCRRestrictionFFStatus.CanDisable.name,
+        )
+        self.assertTrue(table_data.should_show_domain(
+            domain='domain', total_cases=10, total_forms=0)
+        )
+        self.assertFalse(table_data.should_show_domain(
+            domain='domain', total_cases=100_000_000, total_forms=0)
+        )

--- a/corehq/apps/hqadmin/tests/test_reports.py
+++ b/corehq/apps/hqadmin/tests/test_reports.py
@@ -19,18 +19,6 @@ class TestUCRRebuildRestrictionTable(TestCase):
             ucr_enabled_domains
         )
 
-    @patch('corehq.apps.hqadmin.reports.USER_CONFIGURABLE_REPORTS.get_enabled_domains')
-    def test_filtered_ucr_domain(self, get_enabled_domains_mock):
-        ucr_enabled_domains = ['domain1', 'domain2']
-        get_enabled_domains_mock.return_value = ucr_enabled_domains
-
-        table_data = UCRRebuildRestrictionTable(selected_domain='domain1')
-
-        self.assertEqual(
-            table_data.ucr_domains(),
-            ['domain1'],
-        )
-
     def test_should_show_domain_default_show_all(self):
         table_data = UCRRebuildRestrictionTable()
         self.assertTrue(table_data.should_show_domain)

--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -259,7 +259,7 @@ def clear_expired_oauth_tokens():
     call_command('cleartokens')
 
 
-@periodic_task(run_every=crontab(day_of_week=1))
+@periodic_task(run_every=crontab(minute=0, hour=1, day_of_week='mon'))
 def send_domain_ucr_data_info_to_admins():
     from corehq.apps.reports.dispatcher import AdminReportDispatcher
     from corehq.apps.reports.filters.select import UCRRebuildStatusFilter

--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -6,6 +6,8 @@ from django.core.mail.message import EmailMessage
 from django.core.management import call_command
 from django.utils.translation import gettext as _
 from dimagi.utils.django.email import get_email_configuration
+from django.urls import reverse
+from dimagi.utils.web import get_url_base
 
 from celery.exceptions import MaxRetriesExceededError
 from celery.schedules import crontab
@@ -22,6 +24,8 @@ from corehq.util.email_event_utils import get_bounced_system_emails
 from corehq.util.log import send_HTML_email
 from corehq.util.metrics import metrics_track_errors
 from corehq.util.models import TransientBounceEmail
+
+from corehq.motech.repeaters.const import UCRRestrictionFFStatus
 
 
 def mark_subevent_gateway_error(messaging_event_id, error, retrying=False):
@@ -253,3 +257,31 @@ def clean_expired_transient_emails():
 def clear_expired_oauth_tokens():
     # https://django-oauth-toolkit.readthedocs.io/en/latest/management_commands.html#cleartokens
     call_command('cleartokens')
+
+
+@periodic_task(run_every=crontab(day_of_week=1))
+def send_domain_ucr_data_info_to_admins():
+    from corehq.apps.reports.dispatcher import AdminReportDispatcher
+    from corehq.apps.reports.filters.select import UCRRebuildStatusFilter
+    from corehq.apps.hqadmin.reports import UCRRebuildRestrictionTable, UCRDataLoadReport
+
+    table = UCRRebuildRestrictionTable(
+        restriction_ff_status=UCRRestrictionFFStatus.ShouldEnable.name,
+    )
+    subject = "Weekly report: projects for ucr restriction FF"
+    recipient = "solutions-tech-app-engineers@dimagi.com"
+
+    endpoint = reverse(AdminReportDispatcher.name(), args=(UCRDataLoadReport.slug,))
+
+    filter_name = UCRRebuildStatusFilter.slug
+    filter_value = UCRRestrictionFFStatus.ShouldEnable.name
+    report_url = f"{get_url_base()}{endpoint}?{filter_name}={filter_value}"
+
+    message = f"""
+        We have identified {len(table.rows)} projects that require the RESTRICT_DATA_SOURCE_REBUILD
+        feature flag to be enabled. Please see the detailed report: {report_url}
+    """
+
+    send_mail_async.delay(
+        subject, message, [recipient]
+    )

--- a/corehq/apps/reports/filters/checkbox.py
+++ b/corehq/apps/reports/filters/checkbox.py
@@ -1,0 +1,5 @@
+from corehq.apps.reports.filters.base import CheckboxFilter
+
+
+class RestrictedDomainsCheckbox(CheckboxFilter):
+    label = "Show only restricted domains"

--- a/corehq/apps/reports/filters/select.py
+++ b/corehq/apps/reports/filters/select.py
@@ -15,7 +15,7 @@ from corehq.apps.reports.filters.base import (
     BaseMultipleOptionFilter,
     BaseSingleOptionFilter,
 )
-from corehq.motech.repeaters.const import State
+from corehq.motech.repeaters.const import State, UCRRestrictionFFStatus
 from corehq.motech.repeaters.models import Repeater
 
 
@@ -144,4 +144,19 @@ class RepeatRecordStateFilter(BaseSingleOptionFilter):
             State.Pending,
             State.Cancelled,
             State.Fail,
+        ]]
+
+
+class UCRRebuildStatusFilter(BaseSingleOptionFilter):
+    slug = "ucr_rebuild_restriction"
+    label = gettext_lazy("Rebuild restriction feature flag status")
+    default_text = gettext_lazy("Show All")
+
+    @property
+    def options(self):
+        return [(s.name, s.label) for s in [
+            UCRRestrictionFFStatus.Enabled,
+            UCRRestrictionFFStatus.NotEnabled,
+            UCRRestrictionFFStatus.ShouldEnable,
+            UCRRestrictionFFStatus.CanDisable,
         ]]

--- a/corehq/apps/reports/tests/test_dispatcher.py
+++ b/corehq/apps/reports/tests/test_dispatcher.py
@@ -52,7 +52,8 @@ class AdminReportDispatcherTests(SimpleTestCase):
             'user_audit_report',
             'device_log_soft_asserts',
             'deploy_history_report',
-            'phone_number_report'
+            'phone_number_report',
+            'ucr_data_load',
         })
 
 

--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -32,3 +32,10 @@ RECORD_SUCCESS_STATE = State.Success
 RECORD_FAILURE_STATE = State.Fail
 RECORD_CANCELLED_STATE = State.Cancelled
 RECORD_EMPTY_STATE = State.Empty
+
+
+class UCRRestrictionFFStatus(IntegerChoices):
+    Enabled = 1, _('Is enabled')
+    NotEnabled = 2, _('Is not enabled')
+    ShouldEnable = 3, _('Should be enabled')
+    CanDisable = 4, _('Can be disabled')

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -38,6 +38,7 @@ from corehq.apps.hqadmin.reports import (
     DeviceLogSoftAssertReport,
     UserAuditReport,
     UserListReport,
+    UCRDataLoadReport,
 )
 from corehq.apps.linked_domain.views import DomainLinkHistoryReport
 from corehq.apps.reports import commtrack
@@ -330,6 +331,7 @@ ADMIN_REPORTS = (
         AdminPhoneNumberReport,
         UserAuditReport,
         DeployHistoryReport,
+        UCRDataLoadReport,
     )),
 )
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -52,6 +52,7 @@ from corehq.apps.hqadmin.reports import (
     DeviceLogSoftAssertReport,
     UserAuditReport,
     UserListReport,
+    UCRDataLoadReport,
 )
 from corehq.apps.hqadmin.views.system import GlobalThresholds
 from corehq.apps.hqwebapp.models import GaTracker
@@ -2601,7 +2602,7 @@ class AdminTab(UITab):
                     url=reverse('admin_report_dispatcher', args=(report.slug,)),
                     params="?{}".format(urlencode(report.default_params)) if report.default_params else ""
                 )
-            } for report in [DeviceLogSoftAssertReport, UserAuditReport]
+            } for report in [DeviceLogSoftAssertReport, UserAuditReport, UCRDataLoadReport]
         ]))
         return sections
 


### PR DESCRIPTION
## Product Description
A new admin report is added to allow us to identify domains which have large amounts of data (forms or cases) which might cause data source rebuilds to be very slow. We use a heuristic (number of cases/form > 1,000,000) to determine whether or not those domains should have the `RESTRICT_DATA_SOURCE_REBUILD` feature flag enabled. 

The report looks like this:

![image](https://github.com/dimagi/commcare-hq/assets/44245062/670d6520-cd8d-4c42-8af6-dc42483bba85)

The column, `UCR rebuild restriction status` (feel free to suggest other names), shows the user whether the domain
1. is currently being restricted from rebuilding data sources (i.e. have the FF enabled)
2. is currently **not** being restricted from rebuilding UCRs (i.e. does not the FF enabled)
3. should be restricted from rebuilding data sources (i.e. should have the FF enabled)
4. should not be restricted (i.e. should have the FF disabled; although I don't think well necessarily have a case like this)

When the FF should be enabled or disabled, the column will have a link (see image above) to the FF page.

In addition, a weekly email is sent to a particular admin email (soltech AEs) using this report's data to identify domains which we should look at. The email links to this report.

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3662)

I decided to add a separate class, `UCRRebuildRestrictionTable`, handling the table feeding the `UCRDataLoadReport` report. This was decided so that we can easily have access to the report data when sending the email (e.g. specifying in the email the number of identified domains based on a certain filter) without having to create a mock request object as is needed when initializing a report class.  

## Feature Flag
No particular feature flag

## Safety Assurance

### Safety story
Tested locally. Added some tests

### Automated test coverage
Added automated tests

### QA Plan
No QA from QA team, but will have AE's test it.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
