### PR TITLE
Lower MAX_MOBILE_UCR_SIZE to 100,000

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1147,7 +1147,7 @@ FCM_CREDS = None
 CONNECTID_USERINFO_URL = 'http://localhost:8080/o/userinfo'
 
 MAX_MOBILE_UCR_LIMIT = 300  # used in corehq.apps.cloudcare.util.should_restrict_web_apps_usage
-MAX_MOBILE_UCR_SIZE = 250000  # max number of rows allowed when syncing a mobile UCR
+MAX_MOBILE_UCR_SIZE = 100000  # max number of rows allowed when syncing a mobile UCR
 
 # used by periodic tasks that delete soft deleted data older than PERMANENT_DELETION_WINDOW days
 PERMANENT_DELETION_WINDOW = 30  # days


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A follow up to https://github.com/dimagi/commcare-hq/pull/34704/files to further drop the limit to 100k.
The project that motivated this restriction to be added originally, is currently blocked on using mobile UCRs via a feature flag. In order to allow them to use mobile UCRs at least where feasible, the limit is being dropped further to confirm performance impact.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`MOBILE_UCR` and `USER_CONFIGURABLE_REPORTS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Solutions is aware of the domains that will get effected by this (only 2 domains right now) and will be informing them about the change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
