### PR TITLE
Add formLoadTime column to report

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1236,7 +1236,9 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
 
     @property
     def headers(self):
-        return DataTablesHeader(DataTablesColumn(_("User")),
+        return DataTablesHeader(
+            DataTablesColumn(_("User")),
+            DataTablesColumn(_("Load Time (milliseconds)"), sort_type=DTSortType.DATE),
             DataTablesColumn(_("Completion Time"), sort_type=DTSortType.DATE),
             DataTablesColumn(_("Submission Time"), sort_type=DTSortType.DATE),
             DataTablesColumn(_("Form Name")),
@@ -1281,6 +1283,7 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
                 xmlnss=xmlnss,
             )
             for row in paged_result.hits:
+                load_time_ms = row['form']['meta'].get('formLoadTime', '')
                 completion_time = (PhoneTime(
                     string_to_utc_datetime(row['form']['meta']['timeEnd']),
                     self.timezone,
@@ -1293,6 +1296,7 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
                         row['form']['meta']['username'],
                         user_map.get(row['form']['meta']['userID'])
                     ),
+                    load_time_ms,
                     self._format_date(completion_time),
                     self._format_date(submission_time),
                     form_map[row['xmlns']],


### PR DESCRIPTION
This PR relates to [this one](https://github.com/dimagi/commcare-hq/pull/34819). 

## Product Description
This PR adds the form load time to the Form Completion vs. Submission report.

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3578)

## Feature Flag
No specific FF

## Safety Assurance

### Safety story
Tested locally. To be tested on staging.

### Automated test coverage
No automated tests

### QA Plan
QA ticket to be linked

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
