### PR TITLE
Preserve max bucket size if limit < 250K

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -68,10 +68,11 @@ def _should_sync(restore_state):
 
 @memoized
 def _count_buckets():
+    max_size = max(settings.MAX_MOBILE_UCR_SIZE, 250000)
     count_buckets = []
     for x in range(10):
         bucket_value = 100 * 10 ** x
-        if bucket_value >= settings.MAX_MOBILE_UCR_SIZE:
+        if bucket_value >= max_size:
             count_buckets.append(settings.MAX_MOBILE_UCR_SIZE)
             break
         else:


### PR DESCRIPTION
Currently if we change `MAX_MOBILE_UCR_SIZE` as in https://github.com/dimagi/commcare-hq/pull/34816, the buckets will change as well to adapt to the new limit. This PR is preserving the maximum bucket size of 250K _unless_ the limit is set higher than 250K.

## Safety Assurance

### Safety story

Tiny change that only affects metrics.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations