### PR TITLE
Location Type 'has users' util function check

### DIFF
--- a/corehq/apps/locations/tests/test_util.py
+++ b/corehq/apps/locations/tests/test_util.py
@@ -1,0 +1,43 @@
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.commtrack.tests.util import TEST_LOCATION_TYPE, make_loc
+from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.apps.locations.util import does_location_type_have_users
+
+from django.test import TestCase
+from corehq.apps.users.dbaccessors import delete_all_users
+from corehq.apps.es.client import manager
+from corehq.apps.es.tests.utils import es_test
+from corehq.apps.es.users import user_adapter
+from corehq.util.es.testing import sync_users_to_es
+from corehq.apps.locations.models import LocationType
+
+
+@es_test(requires=[user_adapter])
+class UtilTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(UtilTest, cls).setUpClass()
+        cls.domain = create_domain('locations-test')
+        cls.loc = make_loc('loc', type='outlet', domain=cls.domain.name)
+        cls.loc_type = LocationType.objects.get(name=TEST_LOCATION_TYPE)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain.delete()
+        super(UtilTest, cls).tearDownClass()
+
+    def tearDown(self):
+        delete_all_users()
+
+    @sync_users_to_es()
+    def test_loc_type_has_users(self):
+        delete_all_users()
+        user1 = WebUser.create(self.domain.name, 'web-user@example.com', '123', None, None)
+        user2 = CommCareUser.create(self.domain.name, 'mobile-user', '123', None, None)
+        user1.set_location(self.domain.name, self.loc)
+        user2.set_location(self.loc)
+        manager.index_refresh(user_adapter.index_name)
+        self.assertTrue(does_location_type_have_users(self.loc_type))
+
+    def _loc_type_does_not_have_user(self):
+        self.assertFalse(does_location_type_have_users(self.loc_type))

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -20,6 +20,7 @@ from corehq.apps.consumption.shortcuts import (
     get_loaded_default_monthly_consumption,
 )
 from corehq.apps.domain.models import Domain
+from corehq.apps.es.users import UserES
 from corehq.apps.locations.const import (
     LOCATION_SHEET_HEADERS_BASE,
     LOCATION_SHEET_HEADERS_OPTIONAL,
@@ -30,7 +31,6 @@ from corehq.apps.products.models import Product
 from corehq.blobs import CODES, get_blob_db
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from corehq.util.files import safe_filename_header
-from corehq.apps.locations.dbaccessors import user_ids_at_locations
 
 
 def load_locs_json(domain, selected_loc_id=None, include_archived=False,
@@ -435,5 +435,4 @@ def get_location_type(domain, location, parent, loc_type_string, exception, is_n
 # Checks if a location type has any users assigned to it's related locations
 def does_location_type_have_users(loc_type):
     location_ids = list(SQLLocation.objects.filter(location_type=loc_type).values_list('location_id', flat=True))
-    users = user_ids_at_locations(location_ids)
-    return bool(users)
+    return bool(UserES().location(location_ids).count())

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -30,6 +30,7 @@ from corehq.apps.products.models import Product
 from corehq.blobs import CODES, get_blob_db
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from corehq.util.files import safe_filename_header
+from corehq.apps.locations.dbaccessors import user_ids_at_locations
 
 
 def load_locs_json(domain, selected_loc_id=None, include_archived=False,
@@ -429,3 +430,10 @@ def get_location_type(domain, location, parent, loc_type_string, exception, is_n
     return loc_type_obj
 
 # ---
+
+
+# Checks if a location type has any users assigned to it's related locations
+def does_location_type_have_users(loc_type):
+    location_ids = list(SQLLocation.objects.filter(location_type=loc_type).values_list('location_id', flat=True))
+    users = user_ids_at_locations(location_ids)
+    return bool(users)

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -393,7 +393,7 @@ class LocationTypesView(BaseDomainView):
             if not loc_type.get('has_users'):
                 if _is_fake_pk(pk):
                     return
-                if does_location_type_have_users(LocationType.objects.get(pk=pk)):
+                if does_location_type_have_users(LocationType.objects.get(pk=pk, domain=self.domain)):
                     raise LocationConsistencyError(f"Locations of the organization level '{loc_type['name']}' "
                                                 "have users assigned to them. You can't uncheck the "
                                                 "'Has Users' setting for this level!")

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -417,10 +417,8 @@ class LocationTypesView(BaseDomainView):
             payload_loc_type_name_by_pk[loc_type['pk']] = loc_type['name']
             if loc_type.get('code'):
                 payload_loc_type_code_by_pk[loc_type['pk']] = loc_type['code']
-            # All location types have users until UI allows otherwise.
-            # Remove below line when UI work is being done.
-            loc_type['has_users'] = True
-            _verify_has_users_config(loc_type, pk)
+            if toggles.LOCATION_HAS_USERS.enabled(self.domain):
+                _verify_has_users_config(loc_type, pk)
         names = list(payload_loc_type_name_by_pk.values())
         names_are_unique = len(names) == len(set(names))
         codes = list(payload_loc_type_code_by_pk.values())

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -3,7 +3,6 @@ import logging
 
 from django.contrib import messages
 from django.core.cache import cache
-from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404, HttpResponseRedirect
 from django.http.response import HttpResponseServerError
 from django.shortcuts import get_object_or_404, redirect, render
@@ -392,11 +391,9 @@ class LocationTypesView(BaseDomainView):
 
         def _verify_has_users_config(loc_type_payload, pk):
             if not loc_type.get('has_users'):
-                try:
-                    existing_loc_type_sql_obj = LocationType.objects.get(pk=pk)
-                except ObjectDoesNotExist:  # Location type not created yet
+                if _is_fake_pk(pk):
                     return
-                if does_location_type_have_users(existing_loc_type_sql_obj):
+                if does_location_type_have_users(LocationType.objects.get(pk=pk)):
                     raise LocationConsistencyError(f"Locations of the organization level '{loc_type['name']}' "
                                                 "have users assigned to them. You can't uncheck the "
                                                 "'Has Users' setting for this level!")

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2888,3 +2888,10 @@ SMART_LINKS_FOR_WEB_USERS = StaticToggle(
     tag=TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
 )
+
+LOCATION_HAS_USERS = StaticToggle(
+    slug='location_has_users',
+    label='USH Dev: Allows marking whether a location should have users assigned or not.',
+    tag=TAG_PRODUCT,
+    namespaces=[NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

[Jira](https://dimagi.atlassian.net/browse/USH-4654) ticket that's part of an epic to create a "has users" configuration option for organization levels to mark that a level has no users and should not be included in the location dropdown when assigning locations to a user.

This PR has no user-facing impact.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Adds a util method that checks whether a location type has any users in it (w test), and backend validation that a location type passed in does not have any users if the "has users" setting is being turned off.

## Safety Assurance

Adds feature flag, LOCATION_HAS_USERS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

All logic is behind a FF check. Checked locally to verify the org levels page could save without error when the FF is off.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added for the util function to make sure it works.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

QA will be done at the end of this feature's build.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
