### PR TITLE
[docs] Update B5 migration guide

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -113,7 +113,8 @@ class Command(BaseCommand):
             if not confirm:
                 return
 
-        if not is_app_in_progress(app_name) and not is_app_migration_complete:
+        self.no_split = options.get('no_split')
+        if not is_app_in_progress(app_name) and not is_app_migration_complete and not self.no_split:
             self.stdout.write(self.style.WARNING(
                 f"\n\n'{app_name}' is not marked as 'in progress'.\n"
             ))
@@ -129,7 +130,6 @@ class Command(BaseCommand):
                     show_apply_commit=not has_changes
                 )
 
-        self.no_split = options.get('no_split')
         self.skip_all = options.get('skip_all')
         if self.skip_all and self.no_split:
             self.stderr.write(

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -221,10 +221,10 @@ def test_flag_inline_styles():
 def test_flag_crispy_forms_in_template():
     line = """    {% crispy form %}\n"""
     flags = flag_crispy_forms_in_template(line)
-    eq(flags, [["check crispy",
-                "This template uses crispy forms. "
-                "Please ensure the form looks good after migration, and refer to "
-                "the updated Style Guide for current best practices, especially with checkbox fields."]])
+    eq(flags[0][0], "check crispy")
+    eq(flags[0][1].startswith("This template uses crispy forms. "
+                              "Please ensure the form looks good after migration, and refer to "
+                              "the updated Style Guide for current best practices."), True)
 
 
 def test_flag_changed_javascript_plugins_bootstrap5():

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -222,9 +222,7 @@ def test_flag_crispy_forms_in_template():
     line = """    {% crispy form %}\n"""
     flags = flag_crispy_forms_in_template(line)
     eq(flags[0][0], "check crispy")
-    eq(flags[0][1].startswith("This template uses crispy forms. "
-                              "Please ensure the form looks good after migration, and refer to "
-                              "the updated Style Guide for current best practices."), True)
+    eq(flags[0][1].startswith("This template uses crispy forms."), True)
 
 
 def test_flag_changed_javascript_plugins_bootstrap5():

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -252,9 +252,7 @@ def flag_crispy_forms_in_template(line):
     if re.search(regex, line):
         flags.append([
             "check crispy",
-            "This template uses crispy forms. "
-            "Please ensure the form looks good after migration, and refer to "
-            "the updated Style Guide for current best practices, especially with checkbox fields."
+            _get_change_guide("crispy")
         ])
     return flags
 

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes_guide/crispy.md
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes_guide/crispy.md
@@ -1,0 +1,19 @@
+This template uses crispy forms.
+
+Please ensure the form looks good after migration, and refer to the
+<a href="https://www.commcarehq.org/styleguide/b5/organisms/forms/#crispy-forms" target="_blank">crispy forms
+section</a> of the style guide.
+
+A few useful things to know about crispy forms in Bootstrap 5:
+
+* Checkboxes, typically based on a `BooleanField`, need to be updated to use the `BootstrapCheckboxInput` as their
+`widget`, as shown in <a href="https://www.commcarehq.org/styleguide/b5/organisms/forms/#crispy-forms-simple"
+target="_blank">this style guide example</a>.
+* As described in <a href="https://www.commcarehq.org/styleguide/b5/organisms/forms/#crispy-forms-simple"
+target="_blank">this section of the style guide</a>, best practice is to use one of HQ's standard helper classes
+for layout. Doing so means you can delete <code>form_class</code>, <code>label_class</code>,
+<code>field_class</code>, and <code>offset_class</code> from the form itself. This allows us to change the layout
+of crispy forms across HQ without needing to update each individual form.
+* If you do need to troubleshoot Bootstrap issues with crispy forms, be aware that Dimagi maintains a <a
+href="https://github.com/dimagi/crispy-bootstrap3to5" target="_blank">crispy-bootstrap3to5 </a> repo with
+transitional templates. You may also need to troubleshoot in the crispy templates.

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
@@ -130,18 +130,25 @@
     Step 1: Announce Migration
   </h2>
   <p>
-    Before you begin the migration of an app, please announce your intention to do so in <code>#gtd-dev</code>. It is
-    important to communicate timelines for how long you expect the "split files" stage to last. Additionally, please
-    ask that people refrain from any front-end development in that app until changes from the split files step have
-    been merged.
-  </p>
-  <div class="alert alert-primary">
-    <strong>Important:</strong>
-    After announcing your intent to migrate the app, please update the app's migration status
     <strong><a href="https://docs.google.com/spreadsheets/d/1tkSXR643Da-fp6a-uYPa5dYs5if4W2LqtvUJs3IfUKs/edit#gid=0"
-       target="_blank">in this table</a></strong>. This is also a good place to see what apps have not been migrated yet, if
-    you are in need of ideas.
-  </div>
+       target="_blank">This spreadsheet</a></strong> is a high-level tracker of which apps have been migrated.
+    It contains notes on the approximate size of different apps (in terms of how many views they contain) and on
+    inter-app dependencies.
+  </p>
+  <p>
+    The migration tool supports two general workflows for migrating an app: one based on splitting all files into
+    Bootstrap 3 and Bootstrap 5 versions, and one based on migrating files "in place." The splitting files approach
+    is <strong>necessary</strong> for apps that are dependencies for other apps, which will need to support both
+    Bootstrap 3 and Bootstrap 5 for a while. It is <strong>optional</strong> for small, independent apps.
+  </p>
+  <p>
+    Before you begin the migration of an app, please announce your intention to do so in <code>#gtd-dev</code>.
+    It is helpful to be aware of other front-end development in the app. If the app has ongoing front-end
+    development, consider delaying either that development or the migration, to reduce code conflicts.
+    After announcing your intent to migrate the app, please update
+    <a href="https://docs.google.com/spreadsheets/d/1tkSXR643Da-fp6a-uYPa5dYs5if4W2LqtvUJs3IfUKs/edit#gid=0"
+    target="_blank">the app's migration status</a>.
+  </p>
 
   <h2 id="split-files" class="pt-4">
     Step 2: Auto-Migrate &amp; Split Files

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
@@ -13,7 +13,7 @@
   <nav id="TableOfContents">
     <ul>
       <li><a href="#overview">Overview</a></li>
-      <li><a href="#prepare-local-environment">Prepare Local Environment</a></li>
+      <li><a href="#prepare-local-environment">Step 0: Prepare Local Environment</a></li>
       <li><a href="#announce-migration">Step 1: Announce Migration</a></li>
       <li><a href="#no-split">Step 2 (small apps): The "No Split" Process</li>
       <li><a href="#split-files">Step 2 (large apps): Auto-Migrate &amp; Split Files</a>
@@ -114,7 +114,7 @@
   </p>
 
   <h2 id="prepare-local-environment" class="pt-4">
-    Prepare Local Environment
+    Step 0: Prepare Local Environment
   </h2>
   <p>
     If you haven't done so, you will need to install Dart Sass to compile

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
@@ -15,14 +15,14 @@
       <li><a href="#overview">Overview</a></li>
       <li><a href="#prepare-local-environment">Prepare Local Environment</a></li>
       <li><a href="#announce-migration">Step 1: Announce Migration</a></li>
-      <li><a href="#split-files">Step 2: Auto-Migrate &amp; Split Files</a>
+      <li><a href="#no-split">Step 2 (small apps): The "No Split" Process</li>
+      <li><a href="#split-files">Step 2 (large apps): Auto-Migrate &amp; Split Files</a>
         <ul>
           <li><a href="#pre-work">Pre-Work: Lint</a></li>
           <li><a href="#large-apps">Migrating Large Apps</a></li>
           <li><a href="#update-diffs">Configure &amp; Update Diffs</a></li>
           <li><a href="#verify-references">Verify References</a></li>
           <li><a href="#re-migrate">Re-Migrate Files</a></li>
-          <li><a href="#small-apps">Migrating Smaller Apps</a></li>
         </ul>
       </li>
       <li><a href="#update-stylesheets">Step 2B: Migrate Stylesheets</a></li>
@@ -150,8 +150,60 @@
     target="_blank">the app's migration status</a>.
   </p>
 
+  <h2 id="no-split" class="pt-3">
+    Step 2 (small apps): The "No Split" Process
+  </h2>
+  <p>
+    For small apps that are not depended on by other apps, the migration tool supports a streamlined process that
+    does not require splitting files into a Bootstrap 3 and Bootstrap 5 version. This is a good option for apps
+    with a small number of views, as it involves fewer pull requests and avoids the overhead of splitting files.
+    This approach does the entire migration in a single pull request, which
+    makes it unlikely to be a good choice for apps with 10+ views.
+  </p>
+  <p>
+    To begin a "no split" migration, first
+    <a href="http://localhost:8000/styleguide/b5/migration/#pre-work" target="_blank">lint</a> the app's JavaScript
+    and make a pull request for any linting changes. Then, to begin the actual migration, run:
+  </p>
+  <div class="card text-bg-light mb-3">
+    <div class="card-body">
+      <pre class="m-0">./manage.py migrate_app_to_bootstrap5 &lt;app_name&gt; --no-split</pre>
+    </div>
+  </div>
+  <p>
+    This will iterate through all the templates and javascript files in <code>&lt;app_name&gt;</code>,
+    applying all automated fixes and adding TODO comments for fixes that aren't automated. After
+    staging the changes to each file, you will have the option to auto-commit those changes.
+  </p>
+  <p>
+    For each migrated template, the command will wait for you to apply the <code>@use_bootstrap5</code> decorator
+    to the relevant views (see <a href="#migrating-views">Migrating Views</a>) before moving on to the next template.
+  </p>
+  <p>
+    Once all the files are migrated in-place, go through the TODO comments, which reference helper documents in the
+    <a href="https://github.com/dimagi/commcare-hq/tree/master/corehq/apps/hqwebapp/utils/bootstrap/changes_guide"
+    target="_blank">changes_guide</a> directory.
+  </p>
+  <p>
+    After all TODOs are addressed, test your work: load the page and
+    test out any interactivity. Most migrations should also go through QA. Migrations can skip QA if they make
+    relatively superficial changes and are in low-risk areas.
+  </p>
+  <p>
+    Also mark the migration as "complete" as part of your pull request. This updates a status file where we
+    programmatically track the status of the overall platform migration. To do so:
+  </p>
+  <div class="card text-bg-light mb-3">
+    <div class="card-body">
+      <pre class="m-0">./manage.py complete_bootstrap5_migration &lt;app_name&gt;</pre>
+    </div>
+  </div>
+  <p>
+    You're done! Ignore the rest of this document.
+  </p>
+
   <h2 id="split-files" class="pt-4">
-    Step 2: Auto-Migrate &amp; Split Files
+    Step 2 (large apps): Auto-Migrate &amp; Split Files
   </h2>
   <p>
     The next step is to split affected template and javascript files into <code>bootstrap3</code> and
@@ -334,36 +386,6 @@
     This command will then re-apply the migration changes to the <code>bootstrap3</code> file and then save those
     changes to the <code>bootstrap5</code> version. You can then commit those changes and then run
     <code>build_bootstrap5_diffs</code> to rebuild the diffs.
-  </p>
-
-  <h3 id="small-apps" class="pt-3">
-    Step 2.1B: Migrating Smaller Apps
-  </h3>
-  <p>
-    Some apps only have a handful of templates and javascript files, and it's possible to run the auto-migration
-    on the templates in-place and migrate the views to Bootstrap 5 all within the same Pull Request. In this case,
-    you can make use of the <code>--no-split</code> option for <code>migrate_app_to_bootstrap5</code>.
-  </p>
-  <div class="card text-bg-light mb-3">
-    <div class="card-body">
-      <pre class="m-0">./manage.py migrate_app_to_bootstrap5 &lt;app_name&gt; --no-split</pre>
-    </div>
-  </div>
-  <p>
-    This option will iterate through all the templates and javascript files in <code>&lt;app_name&gt;</code>. After
-    staging the changes to each file, you will have the option to auto-commit those changes.
-  </p>
-  <p>
-    For each migrated template, the command will wait for you to apply the <code>@use_bootstrap5</code> decorator
-    to the relevant views (see <a href="#migrating-views">Migrating Views</a>) before moving on to the next template.
-  </p>
-  <p>
-    Once all the files are migrated in-place, you can then make additional manual changes to each template and view.
-    When the views are fully migrated, you can then create your pull request.
-  </p>
-  <p>
-    This option is useful for smaller apps, because it avoids the split-files and reference renames. Please only
-    choose this option if you are confident you can migrate all the views and javascript files within 1 to 2 weeks.
   </p>
 
   <h2 id="update-stylesheets" class="pt-4">

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
@@ -206,7 +206,7 @@
     Step 2 (large apps): Auto-Migrate &amp; Split Files
   </h2>
   <p>
-    The next step is to split affected template and javascript files into <code>bootstrap3</code> and
+    For large migrations, the first step is to split affected template and javascript files into <code>bootstrap3</code> and
     <code>bootstrap5</code> versions. This is an automated process that uses a management command to find and
     replace the straightforward changes, while flagging more complex changes to be addressed later.
   </p>
@@ -268,7 +268,8 @@
   <p>
     The option <code>--skip-all</code> is optional, but recommended unless you have a particularly tricky app
     as it speeds up the migration process by auto-committing the split files changes for each template and
-    javascript file in the app.
+    javascript file in the app. If you use <code>--skip-all</code>, you are still responsible for changes made by
+    the tool, so it's a good idea to review the auto-generated commits in GitHub or your favorite diff tool.
   </p>
   <p>
     If <code>--skip-all</code> is not used, the management command will iterate through all template and javascript
@@ -276,15 +277,19 @@
     the diff for each file at the end.
   </p>
   <p>
-    Regardless of what route you take, a changelog for each file will be saved to a markdown file in
+    Regardless of what route you take, code will also be updated with TODO comments noting areas that need
+    attention and could not automatically be updated.  These comments reference helper documents in the
+    <a href="https://github.com/dimagi/commcare-hq/tree/master/corehq/apps/hqwebapp/utils/bootstrap/changes_guide"
+    target="_blank">changes_guide</a> directory.
+  </p>
+  <p>
+    In addition, a changelog for each file will be saved to a markdown file in
     <code>BOOTSTRAP_MIGRATION_LOGS_DIR</code> (ouside of repository).
-    If you want to work on migrating an application with multiple people, you can zip these markdown files and
-    share with your collaborators for future reference.
   </p>
   <div class="alert alert-primary">
     <p>
-      It is possible that you might have to run a migration multiple times on an app. It might be the case that templates
-      or javascript files have several nested dependencies.
+      If templates or javascript files have several nested dependencies, you may need to run this split files step
+      multiple times.
     </p>
     <p>
       For instance, let's suppose one template called <code>webapps_base.html</code> is
@@ -491,8 +496,8 @@ box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);</pre>
     part accurately.
   </p>
   <div class="alert alert-primary">
-    It is important to create a separate Pull Request for stylesheet changes. This PR should come after the "split files"
-    changes in the previous step.
+    Updating stylesheets is in large part a mechanical process. As always, please commit large mechanical changes
+    separately from changes that need closer review.
   </div>
   <p>
     You will have to update <code>bootstrap5_diff_config.json</code> manually when working with stylesheet files.
@@ -525,11 +530,12 @@ box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);</pre>
   </p>
   <p>
     Finally, you should make sure any javascript files needed to render that view also inherit from <code>bootstrap5</code>
-    dependencies.
+    dependencies. The migration tool should have handled updating any <code>bootstrap3</code> dependencies to their
+    <code>bootstrap5</code> versions.
   </p>
   <p>
-    Once a view's template and javascript files updated, it is now time to load that view make visual observations and
-    make adjustments to get the view to render without javascript or visual errors. The view should be as similar
+    Once a view's template and javascript files are updated, it is now time to load that view and test for
+    any javascript or visual errors. The view should be as similar
     as possible to its Bootstrap 3 version, which you can compare with on production.
   </p>
   <p>
@@ -582,15 +588,14 @@ box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);</pre>
   <h3 id="deploy-to-staging" class="pt-3">
     Deploy to Staging
   </h3>
-  <div class="alert alert-danger">
-    <strong>IMPORTANT: Do not skip this step!</strong> Please deploy to staging to avoid any fires. You have been warned.
-  </div>
   <p>
-    Once you have your migrated view working locally, it is important to deploy your view's branch to staging to ensure
-    that the requirejs build doesn't encounter any issues and that there are no other staticfiles or javascript
-    issues with this view. It is often the case that the production environment introduces front-end issues that are
-    often not discovered when testing locally, due to the complexity of the requirejs build, django compressor, caching,
-    and content distribution of static files.
+    Once you have your migrated view working locally, it is also helpful to deploy to staging and smoke test there.
+    This is particularly important for migrations that involve switching a JavaScript library from a Bootstrap 3 to
+    Bootstrap 5 version, such as switching the Bootstrap 3 date picker with Botostrap 5-compatible tempus dominus.
+  </p>
+  <p>
+    Most view migrations should also go through QA. Migrations can skip QA if they make
+    relatively superficial changes and are in low-risk areas.
   </p>
 
   <h3 id="rebuild-diffs" class="pt-3">
@@ -669,7 +674,7 @@ box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);</pre>
   <p>
     Finally, LESS files can be removed from all parts of HQ and <code>COMPRESS_PRECOMPILERS</code> in
     <code>settings.py</code> can be updated to only precompile SCSS. Any LESS-related dependencies can be removed from
-    <code>packange.json</code> and commcare-cloud, and new developer setup guides like <code>DEV_SETUP.md</code> can
+    <code>package.json</code> and commcare-cloud, and new developer setup guides like <code>DEV_SETUP.md</code> can
     be updated to remove references to LESS.
   </p>
   <p>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/migration_guide.html
@@ -49,47 +49,69 @@
     update this notice and leave this page as documentation for the next Bootstrap migration.
   </div>
   <p>
-    We are taking an app-by-app approach to migrating from Bootstrap 3 to 5. This process is summarized by the following:
+    <a href="https://getbootstrap.com/" target="_blank">Bootstrap</a> is a third-party UI library used throughout
+    HQ. It's essentially a set of stylesheets and javascript widgets. This means that migrating from one version to the
+    next involves the following kinds of work:
+
+    <ul>
+        <li>
+            <strong>Styling updates</strong>: This can be as simple as replacing a renamed CSS class, which is often handled
+            automatically by our migration tool. It can also mean updating HQ stylesheets to work harmoniously with
+            Bootstrap's new/updated styles.
+        </li>
+        <li>
+            <strong>HTML updates</strong>: Some of the new/updated Bootstrap styles correspond to HTML changes. This affects simple
+            widgets like dropdown menus, which may now need classes to be applied differently - for
+            example, the children of dropdown menus now need to use a new <code>dropdown-item</code> class.
+            Our migration tool detects widgets that need to be updated, although a developer is needed to implement
+            the changes. The tool can automatically make other HTML-related changes, such as renaming attributes
+            like <code>data-toggle</code> that have been renamed in the new version.
+        </li>
+        <li>
+            <strong>JavaScript updates</strong>: HQ uses a number of Bootstrap-provided interactive widgets, such as modal dialogs.
+            The APIs for accessing these widgets have changed, so the calling code needs to be updated.
+            There are also a few non-Bootstrap widgets that depend on a specific version of Bootstrap and need to
+            be migrated to a new version.
+            Our migration tool detects usage of widgets that need to be updated, but a developer is needed to make the
+            changes.
+        </li>
+    </ul>
   </p>
-  <ul>
-    <li>
-      <p>
-        Using an automated process, split template and javascript files that need changes into <code>bootstrap3</code>
-        and <code>bootstrap5</code> versions. This process will find/replace the straightforward changes and flag
-        more complex changes to be addressed later.
-      </p>
-    </li>
-    <li>
-      <p>
-        Migrate views in the app one-by-one by applying the <code>@use_bootstrap5</code> decorator and
-        ensuring template and javascript files for that view inherit from <code>bootstrap5</code> base templates
-        and javascript dependencies. This process will be visual in nature, and may involve updates to the
-        Bootstrap 5 stylesheet and/or restructuring HTML and javascript components to ensure the view renders properly
-        with no javascript errors.
-      </p>
-    </li>
-    <li>
-      <p>
-        Once <code>bootstrap3</code> versions of a template or javascript file are no longer referenced, the
-        <code>bootstrap5</code> version can be "un-split" and the file moved back to the original location prior to
-        the split.
-      </p>
-    </li>
-    <li>
-      <p>
-        An app will be considered fully migrated when all template and javascript files are no longer split into
-        <code>bootstrap3</code> and <code>bootstrap5</code> versions and every view in the app is decorated with
-        <code>@use_bootstrap5</code>.
-      </p>
-    </li>
-    <li>
-      <p>
-        Once all apps are fully migrated to Bootstrap 5, we can then remove the use of the any in-template splits
-        referencing <code>request.use_boostrap5</code>, so that any Bootstrap 3 related code is removed. Lastly, a final
-        cleanup should be done to remove the <code>@use_bootstrap5</code> decorator from all the views.
-      </p>
-    </li>
-  </ul>
+  <p>
+    Because the HQ codebase is large, we are taking an incremental approach to this migration.
+    For organizational purposes, we are executing and tracking this migration primarily on an app-by-app basis.
+  </p>
+  <p>
+    Multiple versions of Bootstrap cannot coexist on the same page.
+    The <code>@use_bootstrap5</code> decorator marks individual views as migrated to Bootstrap 5. This decorator
+    sets a <code>use_bootstrap5</code> attribute on the request that's used to set up the
+    relevant Bootstrap environment.
+  </p>
+  <p>
+    This means that files that are required by both migrated and unmigrated pages need to be "split" into two
+    versions: one to include on Bootstrap 3 pages and another to include on Bootstrap 5 pages. This applies largely to code that
+    is fundamental to HQ's UI and used throughout the platform, such as the <code>hqwebapp</code> app, the
+    analytics JavaScript libraries, etc.
+  </p>
+  <p>
+    It can also be helpful to "split" files in this way while migrating an app. This allows
+    Bootstrap 5 changes to be developed, reviewed, and merged in small pieces, before switching the Bootstrap
+    version used in production. It is a more complex process that adds more code during the migration,
+    although most of this code is automatically generated by the migration tool.
+    In these cases, once the app is fully migrated, the Bootstrap 3 files can be deleted.
+  </p>
+  <p>
+    To support this approach, we have tooling that facilitates "splitting" and "unsplitting" files:
+    copying files, moving them, and updating references to them. This tooling also performs the simpler migration
+    updates, such as renaming CSS classes. For updates that it cannot handle automatically, it adds a TODO comment
+    to the relevant code and writes out a changelog.
+  </p>
+  <p>
+    Once the entire platform is fully migrated to Bootstrap 5, any remaining Bootstrap 3 code can be removed:
+    the Bootstrap 3 versions of files in <code>hqwebapp</code> and similar apps, the <code>@use_bootstrap5</code>
+    decorator, any code related to <code>request.use_bootstrap5</code> or <code>window.USE_BOOTSTRAP_5</code>,
+    the Bootstrap 3 stylesheets and JavaScript library, and so forth.
+  </p>
 
   <h2 id="prepare-local-environment" class="pt-4">
     Prepare Local Environment


### PR DESCRIPTION
## Technical Summary
* Add more specific recommendations for crispy forms
* Separate out the streamlined approach to smaller apps and bring it nearer the top of the document
* Make some minor updates to reflect changes in the migration tool over the past few months, such as the addition of TODO comments

Easier to review by commit, since some of this just moves text around.

## Safety Assurance

### Safety story
Mostly docs changes, and minor changes to the migration tooling

### Automated test coverage

The migration tool does have tests, which are updated in this PR.

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
