### PR TITLE
Load data dictionary case properties in chunks

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -32,6 +32,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         geoCaseProp,
         isSafeToDelete,
         changeSaveButton,
+        resetSaveButton,
         dataUrl
     ) {
         var self = {};
@@ -44,6 +45,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.geoCaseProp = geoCaseProp;
         self.canDelete = isSafeToDelete;
         self.changeSaveButton = changeSaveButton;
+        self.resetSaveButton = resetSaveButton;
         self.dataUrl = dataUrl;
 
         self.fetchCaseProperties = function () {
@@ -56,6 +58,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         const recurseChunks = function (nextUrl) {
             $.getJSON(nextUrl, function (data) {
                 setCaseProperties(data.groups);
+                self.resetSaveButton();
                 nextUrl = data._links.next;
                 if (nextUrl) {
                     recurseChunks(nextUrl);
@@ -369,6 +372,10 @@ hqDefine("data_dictionary/js/data_dictionary", [
             self.saveButton.fire('change');
         };
 
+        const resetSaveButton = function () {
+            self.saveButton.setState('saved');
+        }
+
         self.init = function (callback) {
             // Get list of case types
             $.getJSON(dataUrl, {load_deprecated_case_types: self.showDeprecatedCaseTypes()})
@@ -382,6 +389,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                             data.geo_case_property,
                             caseTypeData.is_safe_to_delete,
                             changeSaveButton,
+                            resetSaveButton,
                             dataUrl
                         );
                         self.caseTypes.push(caseTypeObj);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -68,14 +68,21 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
         const setCaseProperties = function (groupData) {
             for (let group of groupData) {
-                let groupObj = groupsViewModel(
-                    self.name,
-                    group.id,
-                    group.name,
-                    group.description,
-                    group.deprecated,
-                    self.changeSaveButton
-                );
+                let groupObj = _.find(self.groups(), function (g) {
+                    return g.id === group.id;
+                });
+                if (!groupObj) {
+                    groupObj = groupsViewModel(
+                        self.name,
+                        group.id,
+                        group.name,
+                        group.description,
+                        group.deprecated,
+                        self.changeSaveButton
+                    );
+                    groupObj.properties.subscribe(self.changeSaveButton);
+                    self.groups.push(groupObj);
+                }
 
                 for (let prop of group.properties) {
                     const isGeoCaseProp = (self.geoCaseProp === prop.name && prop.data_type === 'gps');
@@ -94,8 +101,6 @@ hqDefine("data_dictionary/js/data_dictionary", [
                 );
                     groupObj.properties.push(propObj);
                 }
-                groupObj.properties.subscribe(self.changeSaveButton);
-                self.groups.push(groupObj);
             }
         };
 

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -48,6 +48,8 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.resetSaveButton = resetSaveButton;
         self.dataUrl = dataUrl;
 
+        self.groups.subscribe(changeSaveButton)
+
         self.fetchCaseProperties = function () {
             if (self.groups().length === 0) {
                 let caseTypeUrl = self.dataUrl + self.name + '/';
@@ -408,7 +410,6 @@ hqDefine("data_dictionary/js/data_dictionary", [
                         // to fetch the case properties of the first case type
                         let caseType = self.caseTypes()[0]
                         self.goToCaseType(caseType);
-                        caseType.groups.subscribe(changeSaveButton)
                     }
                     self.fhirResourceType.subscribe(changeSaveButton);
                     self.removefhirResourceType.subscribe(changeSaveButton);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -387,7 +387,11 @@ hqDefine("data_dictionary/js/data_dictionary", [
                         );
                         self.caseTypes.push(caseTypeObj);
                     });
-                    if (self.caseTypes().length) {
+                    if (
+                        self.caseTypes().length
+                        // Check that hash navigation has not already loaded the first case type
+                        && self.caseTypes()[0] !== self.getHashNavigationCaseType()
+                    ) {
                         // `self.goToCaseType()` calls `caseType.fetchCaseProperties()`
                         // to fetch the case properties of the first case type
                         self.goToCaseType(self.caseTypes()[0]);
@@ -398,6 +402,14 @@ hqDefine("data_dictionary/js/data_dictionary", [
                     callback();
                 });
         };
+
+        self.getHashNavigationCaseType = function () {
+            let fullHash = window.location.hash.split('?')[0],
+                hash = fullHash.substring(1);
+            return _.find(self.caseTypes(), function (prop) {
+                return prop.name === hash;
+            });
+        }
 
         self.getActiveCaseType = function () {
             return _.find(self.caseTypes(), function (prop) {
@@ -670,11 +682,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
             viewModel = dataDictionaryModel(dataUrl, casePropertyUrl, typeChoices, fhirResourceTypes);
 
         function doHashNavigation() {
-            let fullHash = window.location.hash.split('?')[0],
-                hash = fullHash.substring(1);
-            let caseType = _.find(viewModel.caseTypes(), function (prop) {
-                return prop.name === hash;
-            });
+            let caseType = viewModel.getHashNavigationCaseType();
             if (caseType) {
                 viewModel.goToCaseType(caseType);
             }

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -46,7 +46,24 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.changeSaveButton = changeSaveButton;
         self.dataUrl = dataUrl;
 
-        self.init = function (groupData) {
+        self.fetchCaseProperties = function () {
+            if (self.groups().length === 0) {
+                let caseTypeUrl = self.dataUrl + self.name + '/';
+                recurseChunks(caseTypeUrl);
+            }
+        }
+
+        const recurseChunks = function (nextUrl) {
+            $.getJSON(nextUrl, function (data) {
+                setCaseProperties(data.groups);
+                nextUrl = data._links.next;
+                if (nextUrl) {
+                    recurseChunks(nextUrl);
+                }
+            });
+        }
+
+        const setCaseProperties = function (groupData) {
             for (let group of groupData) {
                 let groupObj = groupsViewModel(
                     self.name,
@@ -78,15 +95,6 @@ hqDefine("data_dictionary/js/data_dictionary", [
                 self.groups.push(groupObj);
             }
         };
-
-        self.fetchCaseProperties = function () {
-            if (self.groups().length === 0) {
-                const caseTypeUrl = self.dataUrl + self.name + '/';
-                $.getJSON(caseTypeUrl, function (data) {
-                    self.init(data.groups);
-                });
-            }
-        }
 
         return self;
     };

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -64,21 +64,11 @@ hqDefine("data_dictionary/js/data_dictionary", [
                     }
 
                     var propObj = propertyListItem(
-                        prop.name,
-                        prop.label,
+                        prop,
                         false,
                         group.name,
                         self.name,
-                        prop.data_type,
-                        prop.description,
-                        prop.allowed_values,
-                        prop.fhir_resource_prop_path,
-                        prop.deprecated,
-                        prop.removeFHIRResourcePropertyPath,
                         isGeoCaseProp,
-                        prop.is_safe_to_delete,
-                        prop.id,
-                        prop.index,
                         groupObj.name(),
                         self.changeSaveButton
                 );
@@ -141,42 +131,32 @@ hqDefine("data_dictionary/js/data_dictionary", [
     };
 
     var propertyListItem = function (
-        name,
-        label,
+        prop,
         isGroup,
         groupName,
         caseType,
-        dataType,
-        description,
-        allowedValues,
-        fhirResourcePropPath,
-        deprecated,
-        removeFHIRResourcePropertyPath,
         isGeoCaseProp,
-        isSafeToDelete,
-        id,
-        index,
         loadedGroup,
         changeSaveButton
     ) {
         var self = {};
-        self.id = id;
-        self.name = name;
-        self.label = ko.observable(label);
+        self.id = prop.id;
+        self.name = prop.name;
+        self.label = ko.observable(prop.label);
         self.expanded = ko.observable(true);
         self.isGroup = isGroup;
         self.group = ko.observable(groupName);
         self.caseType = caseType;
-        self.dataType = ko.observable(dataType);
-        self.description = ko.observable(description);
-        self.fhirResourcePropPath = ko.observable(fhirResourcePropPath);
-        self.originalResourcePropPath = fhirResourcePropPath;
-        self.deprecated = ko.observable(deprecated || false);
+        self.dataType = ko.observable(prop.data_type);
+        self.description = ko.observable(prop.description);
+        self.fhirResourcePropPath = ko.observable(prop.fhir_resource_prop_path);
+        self.originalResourcePropPath = prop.fhir_resource_prop_path;
+        self.deprecated = ko.observable(prop.deprecated || false);
         self.isGeoCaseProp = ko.observable(isGeoCaseProp);
-        self.isSafeToDelete = ko.observable(isSafeToDelete);
+        self.isSafeToDelete = ko.observable(prop.isSafeToDelete);
         self.deleted = ko.observable(false);
         self.hasChanges = false;
-        self.index = index;
+        self.index = prop.index;
         self.loadedGroup = loadedGroup;  // The group this case property is part of when page was loaded. Used to identify group changes
 
         self.trackObservableChange = function (observable) {
@@ -200,7 +180,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
             self.hasChanges = true;
         };
 
-        self.removeFHIRResourcePropertyPath = ko.observable(removeFHIRResourcePropertyPath || false);
+        self.removeFHIRResourcePropertyPath = ko.observable(prop.removeFHIRResourcePropertyPath || false);
         let subTitle;
         if (toggles.toggleEnabled("CASE_IMPORT_DATA_DICTIONARY_VALIDATION")) {
             subTitle = gettext("When importing data, CommCare will not save a row if its cells don't match these valid values.");
@@ -214,7 +194,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
             {"key": gettext("valid value"), "value": gettext("description")}, /* placeholders */
             10 /* maxDisplay */
         );
-        self.allowedValues.val(allowedValues);
+        self.allowedValues.val(prop.allowedValues);
         if (initialPageData.get('read_only_mode')) {
             self.allowedValues.setEdit(false);
         }
@@ -556,19 +536,22 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.newCaseProperty = function () {
             if (_.isString(self.newPropertyName()) && self.newPropertyName().trim()) {
                 let lastGroup = self.caseGroupList()[self.caseGroupList().length - 1];
-                var prop = propertyListItem(
-                    self.newPropertyName(),
-                    self.newPropertyName(),
+                const prop = {
+                    'name': self.newPropertyName(),
+                    'label': self.newPropertyName(),
+                    'allowedValues': {}
+                }
+                let propObj = propertyListItem(
+                    prop,
                     false,
                     lastGroup.name(),
                     self.activeCaseType(),
-                    '',
-                    '',
-                    {},
+                    false,
+                    lastGroup.name(),
                     changeSaveButton
                 );
                 self.newPropertyName(undefined);
-                lastGroup.properties.push(prop);
+                lastGroup.properties.push(propObj);
             }
         };
 

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -99,7 +99,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                         isGeoCaseProp,
                         groupObj.name(),
                         self.changeSaveButton
-                );
+                    );
                     groupObj.properties.push(propObj);
                 }
             }

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -48,7 +48,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.resetSaveButton = resetSaveButton;
         self.dataUrl = dataUrl;
 
-        self.groups.subscribe(changeSaveButton)
+        self.groups.subscribe(changeSaveButton);
 
         self.fetchCaseProperties = function () {
             if (self.groups().length === 0) {
@@ -379,7 +379,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
 
         const resetSaveButton = function () {
             self.saveButton.setState('saved');
-        }
+        };
 
         self.init = function (callback) {
             // Get list of case types
@@ -421,7 +421,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
             return _.find(self.caseTypes(), function (prop) {
                 return prop.name === hash;
             });
-        }
+        };
 
         self.getActiveCaseType = function () {
             return _.find(self.caseTypes(), function (prop) {
@@ -572,7 +572,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                     'name': self.newPropertyName(),
                     'label': self.newPropertyName(),
                     'allowedValues': {},
-                }
+                };
                 let propObj = propertyListItem(
                     prop,
                     false,

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -55,7 +55,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                 let caseTypeUrl = self.dataUrl + self.name + '/';
                 recurseChunks(caseTypeUrl);
             }
-        }
+        };
 
         const recurseChunks = function (nextUrl) {
             $.getJSON(nextUrl, function (data) {
@@ -66,7 +66,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                     recurseChunks(nextUrl);
                 }
             });
-        }
+        };
 
         const setCaseProperties = function (groupData) {
             for (let group of groupData) {
@@ -408,7 +408,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                     ) {
                         // `self.goToCaseType()` calls `caseType.fetchCaseProperties()`
                         // to fetch the case properties of the first case type
-                        let caseType = self.caseTypes()[0]
+                        let caseType = self.caseTypes()[0];
                         self.goToCaseType(caseType);
                     }
                     self.fhirResourceType.subscribe(changeSaveButton);
@@ -573,7 +573,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                 const prop = {
                     'name': self.newPropertyName(),
                     'label': self.newPropertyName(),
-                    'allowedValues': {}
+                    'allowedValues': {},
                 }
                 let propObj = propertyListItem(
                     prop,

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -274,7 +274,6 @@ hqDefine("data_dictionary/js/data_dictionary", [
         subscribePropObservable(self.removeFHIRResourcePropertyPath);
         self.allowedValues.on('change', changeSaveButton);
         self.allowedValues.on('change', self.allowedValuesChanged);
-        self.hasChanges = true;
 
         function subscribePropObservable(prop) {
             prop.subscribe(changeSaveButton);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -211,7 +211,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
             {"key": gettext("valid value"), "value": gettext("description")}, /* placeholders */
             10 /* maxDisplay */
         );
-        self.allowedValues.val(prop.allowedValues);
+        self.allowedValues.val(prop.allowed_values);
         if (initialPageData.get('read_only_mode')) {
             self.allowedValues.setEdit(false);
         }

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -82,7 +82,6 @@ hqDefine("data_dictionary/js/data_dictionary", [
                         group.deprecated,
                         self.changeSaveButton
                     );
-                    groupObj.properties.subscribe(self.changeSaveButton);
                     self.groups.push(groupObj);
                 }
 
@@ -143,7 +142,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.name.subscribe(changeSaveButton);
         self.description.subscribe(changeSaveButton);
         self.toBeDeprecated.subscribe(changeSaveButton);
-        // Don't subscribe self.properties until they have been loaded
+        self.properties.subscribe(changeSaveButton);
 
         return self;
     };

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -170,7 +170,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.originalResourcePropPath = prop.fhir_resource_prop_path;
         self.deprecated = ko.observable(prop.deprecated || false);
         self.isGeoCaseProp = ko.observable(isGeoCaseProp);
-        self.isSafeToDelete = ko.observable(prop.isSafeToDelete);
+        self.isSafeToDelete = ko.observable(prop.is_safe_to_delete);
         self.deleted = ko.observable(false);
         self.hasChanges = false;
         self.index = prop.index;

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -215,7 +215,7 @@
             <div class="row-item-small"></div>
           {% endif %}
           </div>
-          <div data-bind="sortable: { data: caseGroupList, connectClass: 'groups', options: { handle: 'i.sortable-handle' } }">
+          <div data-bind="sortable: { data: activeCaseTypeData(), connectClass: 'groups', options: { handle: 'i.sortable-handle' } }">
           <div>
           <div class="group-deprecated" data-bind="visible: showGroupPropertyTransferWarning" style="display: none;">
             <b data-bind="text: name()"></b>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -124,7 +124,7 @@
 {% endblock %}
 
 {% block page_content %}
-  {% registerurl 'data_dictionary_json' domain %}
+  {% registerurl 'data_dictionary_json_case_types' domain %}
   {% registerurl 'update_case_property' domain %}
   {% registerurl 'deprecate_or_restore_case_type' domain '---' %}
   {% registerurl 'delete_case_type' domain '---' %}

--- a/corehq/apps/data_dictionary/tests/test_views.py
+++ b/corehq/apps/data_dictionary/tests/test_views.py
@@ -1,7 +1,6 @@
 import json
 import random
 import string
-import uuid
 from unittest.mock import patch
 
 from django.test import Client, TestCase
@@ -21,18 +20,31 @@ from corehq.apps.users.models_role import UserRole
 from corehq.util.test_utils import flag_enabled, privilege_enabled
 
 
-@privilege_enabled(privileges.DATA_DICTIONARY)
-@flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
-class UpdateCasePropertyViewTest(TestCase):
-    domain_name = uuid.uuid4().hex
+class DataDictionaryViewTestBase(TestCase):
+    domain_name = 'data-dictionary-view-test'
 
     @classmethod
     def setUpClass(cls):
-        super(UpdateCasePropertyViewTest, cls).setUpClass()
-        cls.domain = create_domain(cls.domain_name)
-        cls.couch_user = WebUser.create(None, "test", "foobar", None, None)
-        cls.couch_user.add_domain_membership(cls.domain_name, is_admin=True)
-        cls.couch_user.save()
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain_name)
+        cls.user = WebUser.create(None, 'username', 'Passw0rd!', None, None)
+        cls.user.add_domain_membership(cls.domain_name, is_admin=True)
+        cls.user.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(cls.domain_name, deleted_by=None)
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+
+@privilege_enabled(privileges.DATA_DICTIONARY)
+@flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
+class UpdateCasePropertyViewTest(DataDictionaryViewTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         cls.case_type_obj = CaseType(name='caseType', domain=cls.domain_name)
         cls.case_type_obj.save()
         CaseProperty(case_type=cls.case_type_obj, name='property').save()
@@ -44,14 +56,12 @@ class UpdateCasePropertyViewTest(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.case_type_obj.delete()
-        cls.couch_user.delete(cls.domain_name, deleted_by=None)
-        cls.domain.delete()
-        super(UpdateCasePropertyViewTest, cls).tearDownClass()
+        super().tearDownClass()
 
     def setUp(self):
         self.url = reverse('update_case_property', args=[self.domain_name])
         self.client = Client()
-        self.client.login(username='test', password='foobar')
+        self.client.login(username='username', password='Passw0rd!')
 
     def _get_property(self):
         return CaseProperty.objects.filter(
@@ -97,7 +107,10 @@ class UpdateCasePropertyViewTest(TestCase):
                         case_property=prop,
                         allowed_value=allowed_value,
                         description=description).exists())
-        self.assertEqual(valid_count, CasePropertyAllowedValue.objects.filter(case_property=prop).count())
+        self.assertEqual(
+            valid_count,
+            CasePropertyAllowedValue.objects.filter(case_property=prop).count()
+        )
 
     def test_new_case_type(self):
         self._assert_type()
@@ -194,7 +207,11 @@ class UpdateCasePropertyViewTest(TestCase):
 
     def test_update_with_no_group_name(self):
         prop = self._get_property()
-        group = CasePropertyGroup.objects.filter(case_type=self.case_type_obj, name='group').first()
+        group = (
+            CasePropertyGroup.objects
+            .filter(case_type=self.case_type_obj, name='group')
+            .first()
+        )
         prop.group = group
         prop.save()
         post_data = {
@@ -220,82 +237,84 @@ class UpdateCasePropertyViewTest(TestCase):
 
 @privilege_enabled(privileges.DATA_DICTIONARY)
 class DataDictionaryViewTest(TestCase):
-    domain_name = uuid.uuid4().hex
+    domain_name = 'data-dictionary-view-test'
 
-    @classmethod
-    def make_web_user_with_data_dict_role(cls, email, domain, has_data_dict_access=False):
-        web_user = WebUser.create(
-            domain=domain.name,
+    @staticmethod
+    def make_user_with_data_dict_role(email, domain_obj, has_data_dict_access=False):
+        user = WebUser.create(
+            domain=domain_obj.name,
             username=email,
-            password="foobar",
+            password='Passw0rd!',
             created_by=None,
             created_via=None
         )
         role = UserRole.create(
-            domain=domain,
+            domain=domain_obj,
             name='Data Dictionary Access',
             permissions=HqPermissions(view_data_dict=has_data_dict_access),
         )
-        web_user.set_role(domain.name, role.get_qualified_id())
-        web_user.save()
-        return web_user
+        user.set_role(domain_obj.name, role.get_qualified_id())
+        user.save()
+        return user
 
     @classmethod
     def setUpClass(cls):
         super(DataDictionaryViewTest, cls).setUpClass()
-        cls.domain = create_domain(cls.domain_name)
-        cls.web_user_data_dict_access = cls.make_web_user_with_data_dict_role('has_data_dict@ex.com', cls.domain,
-                                                                            has_data_dict_access=True)
-        cls.web_user_no_data_dict_access = cls.make_web_user_with_data_dict_role('no_data_dict@ex.com', cls.domain)
+        cls.domain_obj = create_domain(cls.domain_name)
+        cls.user_data_dict_access = cls.make_user_with_data_dict_role(
+            'has_data_dict@ex.com',
+            cls.domain_obj,
+            has_data_dict_access=True,
+        )
+        cls.user_no_data_dict_access = cls.make_user_with_data_dict_role(
+            'no_data_dict@ex.com',
+            cls.domain_obj,
+        )
         cls.client = Client()
         cls.url = reverse('data_dictionary', args=[cls.domain_name])
 
     @classmethod
     def tearDownClass(cls):
-        cls.web_user_data_dict_access.delete(cls.domain_name, deleted_by=None)
-        cls.web_user_no_data_dict_access.delete(cls.domain_name, deleted_by=None)
-        cls.domain.delete()
+        cls.user_data_dict_access.delete(cls.domain_name, deleted_by=None)
+        cls.user_no_data_dict_access.delete(cls.domain_name, deleted_by=None)
+        cls.domain_obj.delete()
         super(DataDictionaryViewTest, cls).tearDownClass()
 
     def test_has_view_access(self):
-        self.client.login(username='has_data_dict@ex.com', password='foobar')
+        self.client.login(username='has_data_dict@ex.com', password='Passw0rd!')
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_no_view_access(self):
-        self.client.login(username='no_data_dict@ex.com', password='foobar')
+        self.client.login(username='no_data_dict@ex.com', password='Passw0rd!')
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 403)
 
 
 @privilege_enabled(privileges.DATA_DICTIONARY)
-class TestDeprecateOrRestoreCaseTypeView(TestCase):
-
-    urlname = 'deprecate_or_restore_case_type'
-    domain = 'test-domain'
+class TestDeprecateOrRestoreCaseTypeView(DataDictionaryViewTestBase):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.domain_obj = create_domain(cls.domain)
-        cls.admin_webuser = WebUser.create(cls.domain, 'test', 'foobar', None, None, is_admin=True)
         cls.case_type_name = 'caseType'
-        cls.case_type_obj = CaseType(name=cls.case_type_name, domain=cls.domain)
+        cls.case_type_obj = CaseType(name=cls.case_type_name, domain=cls.domain_name)
         cls.case_type_obj.save()
 
         CaseProperty(case_type=cls.case_type_obj, name='property').save()
         CasePropertyGroup(case_type=cls.case_type_obj, name='group').save()
 
     def setUp(self):
-        self.endpoint = reverse(self.urlname, args=(self.domain, self.case_type_obj.name))
+        self.endpoint = reverse(
+            'deprecate_or_restore_case_type',
+            args=(self.domain_name, self.case_type_obj.name),
+        )
         self.client = Client()
-        self.client.login(username='test', password='foobar')
+        self.client.login(username='username', password='Passw0rd!')
 
     @classmethod
     def tearDownClass(cls):
         cls.case_type_obj.delete()
-        cls.admin_webuser.delete(cls.domain, None)
-        cls.domain_obj.delete()
         return super().tearDownClass()
 
     def _update_deprecate_state(self, is_deprecated):
@@ -312,9 +331,17 @@ class TestDeprecateOrRestoreCaseTypeView(TestCase):
         case_type_obj = CaseType.objects.get(name=self.case_type_name)
         self.assertTrue(case_type_obj.is_deprecated)
 
-        case_prop_count = CaseProperty.objects.filter(case_type=case_type_obj, deprecated=False).count()
+        case_prop_count = (
+            CaseProperty.objects
+            .filter(case_type=case_type_obj, deprecated=False)
+            .count()
+        )
         self.assertEqual(case_prop_count, 0)
-        case_prop_group_count = CasePropertyGroup.objects.filter(case_type=case_type_obj, deprecated=False).count()
+        case_prop_group_count = (
+            CasePropertyGroup.objects
+            .filter(case_type=case_type_obj, deprecated=False)
+            .count()
+        )
         self.assertEqual(case_prop_group_count, 0)
 
     def test_restore_case_type(self):
@@ -326,28 +353,34 @@ class TestDeprecateOrRestoreCaseTypeView(TestCase):
         case_type_obj = CaseType.objects.get(name=self.case_type_name)
         self.assertFalse(case_type_obj.is_deprecated)
 
-        case_prop_count = CaseProperty.objects.filter(case_type=case_type_obj, deprecated=True).count()
+        case_prop_count = (
+            CaseProperty.objects
+            .filter(case_type=case_type_obj, deprecated=True)
+            .count()
+        )
         self.assertEqual(case_prop_count, 0)
-        case_prop_group_count = CasePropertyGroup.objects.filter(case_type=case_type_obj, deprecated=True).count()
+        case_prop_group_count = (
+            CasePropertyGroup.objects
+            .filter(case_type=case_type_obj, deprecated=True)
+            .count()
+        )
         self.assertEqual(case_prop_group_count, 0)
 
 
 # TODO Remove this Test Class once we migrate to the new view
 @flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
 @privilege_enabled(privileges.DATA_DICTIONARY)
-class DataDictionaryJsonTest(TestCase):
-    domain_name = uuid.uuid4().hex
+class DataDictionaryJsonTest(DataDictionaryViewTestBase):
 
     @classmethod
     def setUpClass(cls):
         super(DataDictionaryJsonTest, cls).setUpClass()
-        cls.domain = create_domain(cls.domain_name)
-        cls.couch_user = WebUser.create(None, "test", "foobar", None, None)
-        cls.couch_user.add_domain_membership(cls.domain_name, is_admin=True)
-        cls.couch_user.save()
         cls.case_type_obj = CaseType(name='caseType', domain=cls.domain_name)
         cls.case_type_obj.save()
-        cls.case_prop_group = CasePropertyGroup(case_type=cls.case_type_obj, name='group')
+        cls.case_prop_group = CasePropertyGroup(
+            case_type=cls.case_type_obj,
+            name='group',
+        )
         cls.case_prop_group.save()
         cls.case_prop_obj = CaseProperty(
             case_type=cls.case_type_obj,
@@ -356,7 +389,11 @@ class DataDictionaryJsonTest(TestCase):
             group=cls.case_prop_group
         )
         cls.case_prop_obj.save()
-        cls.deprecated_case_type_obj = CaseType(name='depCaseType', domain=cls.domain_name, is_deprecated=True)
+        cls.deprecated_case_type_obj = CaseType(
+            name='depCaseType',
+            domain=cls.domain_name,
+            is_deprecated=True,
+        )
         cls.deprecated_case_type_obj.save()
         cls.client = Client()
 
@@ -364,8 +401,6 @@ class DataDictionaryJsonTest(TestCase):
     def tearDownClass(cls):
         cls.case_type_obj.delete()
         cls.deprecated_case_type_obj.delete()
-        cls.couch_user.delete(cls.domain_name, deleted_by=None)
-        cls.domain.delete()
         super(DataDictionaryJsonTest, cls).tearDownClass()
 
     def setUp(self):
@@ -435,7 +470,7 @@ class DataDictionaryJsonTest(TestCase):
     @patch('corehq.apps.data_dictionary.views.get_case_type_app_module_count', return_value={})
     @patch('corehq.apps.data_dictionary.views.get_used_props_by_case_type', return_value={})
     def test_get_json_success(self, *args):
-        self.client.login(username='test', password='foobar')
+        self.client.login(username='username', password='Passw0rd!')
         response = self.client.get(self.endpoint)
         self.assertEqual(response.status_code, 200)
         expected_response = self._get_case_type_json()
@@ -444,7 +479,7 @@ class DataDictionaryJsonTest(TestCase):
     @patch('corehq.apps.data_dictionary.views.get_case_type_app_module_count', return_value={})
     @patch('corehq.apps.data_dictionary.views.get_used_props_by_case_type', return_value={})
     def test_get_json_success_with_deprecated_case_types(self, *args):
-        self.client.login(username='test', password='foobar')
+        self.client.login(username='username', password='Passw0rd!')
         response = self.client.get(self.endpoint, data={'load_deprecated_case_types': 'true'})
         expected_response = self._get_case_type_json(with_deprecated=True)
         self.assertEqual(response.json(), expected_response)
@@ -454,22 +489,19 @@ class DataDictionaryJsonTest(TestCase):
 @patch('corehq.apps.data_dictionary.views.get_used_props_by_case_type', return_value={})
 @flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
 @privilege_enabled(privileges.DATA_DICTIONARY)
-class DataDictionaryJsonV2Test(TestCase):
-    domain_name = uuid.uuid4().hex
-    case_types_view_name = "data_dictionary_json_case_types"
-    case_properties_view_name = "data_dictionary_json_case_properties"
+class DataDictionaryJsonV2Test(DataDictionaryViewTestBase):
 
     @classmethod
     def setUpClass(cls):
-        super(DataDictionaryJsonV2Test, cls).setUpClass()
-        cls.domain = create_domain(cls.domain_name)
-
-        cls.couch_user = WebUser.create(None, "test", "foobar", None, None)
-        cls.couch_user.add_domain_membership(cls.domain_name, is_admin=True)
-        cls.couch_user.save()
-
-        cls.case_type_obj = CaseType.objects.create(name="case_type", domain=cls.domain_name)
-        cls.group_obj = CasePropertyGroup.objects.create(case_type=cls.case_type_obj, name="group")
+        super().setUpClass()
+        cls.case_type_obj = CaseType.objects.create(
+            name="case_type",
+            domain=cls.domain_name,
+        )
+        cls.group_obj = CasePropertyGroup.objects.create(
+            case_type=cls.case_type_obj,
+            name="group",
+        )
         cls.case_properties_with_group = cls._create_properties_for_case_type(
             case_type=cls.case_type_obj,
             properties_count=2,
@@ -488,24 +520,28 @@ class DataDictionaryJsonV2Test(TestCase):
 
         cls.fhir_resource_name = "fhir-sample"
         cls.fhir_json_path = "sample.json.path"
-        cls.case_types_endpoint = reverse(cls.case_types_view_name, args=[cls.domain_name])
+        cls.case_types_endpoint = reverse(
+            "data_dictionary_json_case_types",
+            args=[cls.domain_name],
+        )
 
     @classmethod
     def tearDownClass(cls):
         cls.case_type_obj.delete()
         cls.deprecated_case_type_obj.delete()
-        cls.couch_user.delete(cls.domain_name, deleted_by=None)
-        cls.domain.delete()
-        super(DataDictionaryJsonV2Test, cls).tearDownClass()
+        super().tearDownClass()
 
     def setUp(self):
-        self.client.login(username='test', password='foobar')
+        self.client.login(username='username', password='Passw0rd!')
 
     @classmethod
     def case_properties_endpoint(cls, case_type=None):
         if not case_type:
             case_type = cls.case_type_obj.name
-        return reverse(cls.case_properties_view_name, args=[cls.domain_name, case_type])
+        return reverse(
+            "data_dictionary_json_case_properties",
+            args=[cls.domain_name, case_type],
+        )
 
     @classmethod
     def _create_properties_for_case_type(cls, case_type, properties_count, group=None):
@@ -550,24 +586,35 @@ class DataDictionaryJsonV2Test(TestCase):
         return expected_output
 
     @classmethod
-    def _get_case_properties_json(cls, case_type_obj, groups_properties_dict=None, skip=0, limit=500,
-                                  fhir_enabled=False):
+    def _get_case_properties_json(
+        cls,
+        case_type_obj,
+        groups_properties_dict=None,
+        skip=0,
+        limit=500,
+        fhir_enabled=False,
+    ):
         expected_output = {
             "name": case_type_obj.name,
             "properties_count": case_type_obj.properties.count(),
             "_links": {
-                "self": f"http://testserver/a/{cls.domain_name}/data_dictionary/json_v2/{case_type_obj.name}/"
+                "self": f"http://testserver/a/{cls.domain_name}"
+                        f"/data_dictionary/json_v2/{case_type_obj.name}/"
                         f"?skip={skip}&limit={limit}"
             },
             "groups": []
         }
         if skip:
-            expected_output["_links"]["previous"] = (f"http://testserver/a/{cls.domain_name}/data_dictionary/"
-                                                     f"json_v2/{case_type_obj.name}/?skip={skip - limit}"
-                                                     f"&limit={limit}")
+            expected_output["_links"]["previous"] = (
+                f"http://testserver/a/{cls.domain_name}/data_dictionary/"
+                f"json_v2/{case_type_obj.name}/?skip={skip - limit}"
+                f"&limit={limit}"
+            )
         if case_type_obj.properties.count() > (skip + limit):
-            expected_output["_links"]["next"] = (f"http://testserver/a/{cls.domain_name}/data_dictionary/json_v2/"
-                                                 f"{case_type_obj.name}/?skip={skip + limit}&limit={limit}")
+            expected_output["_links"]["next"] = (
+                f"http://testserver/a/{cls.domain_name}/data_dictionary/json_v2/"
+                f"{case_type_obj.name}/?skip={skip + limit}&limit={limit}"
+            )
         if groups_properties_dict:
             for group, properties in groups_properties_dict.items():
                 group_data = {
@@ -619,7 +666,8 @@ class DataDictionaryJsonV2Test(TestCase):
     ):
         mocked_load_fhir_case_type_mapping.return_value = {self.case_type_obj: self.fhir_resource_name}
         mocked_load_fhir_case_properties_mapping.return_value = {
-            case_property: self.fhir_json_path for case_property in self.case_type_obj.properties.all()
+            case_property: self.fhir_json_path
+            for case_property in self.case_type_obj.properties.all()
         }
         response = self.client.get(self.case_types_endpoint)
         self.assertEqual(response.status_code, 200)
@@ -627,7 +675,10 @@ class DataDictionaryJsonV2Test(TestCase):
         self.assertEqual(response.json(), expected_response)
 
     def test_get_case_types_with_deprecated(self, *args):
-        response = self.client.get(self.case_types_endpoint, data={'load_deprecated_case_types': 'true'})
+        response = self.client.get(
+            self.case_types_endpoint,
+            data={'load_deprecated_case_types': 'true'}
+        )
         self.assertEqual(response.status_code, 200)
         expected_response = self._get_case_types_json(with_deprecated=True)
         self.assertEqual(response.json(), expected_response)
@@ -646,7 +697,10 @@ class DataDictionaryJsonV2Test(TestCase):
         self.assertEqual(response.status_code, 200)
         expected_response = self._get_case_properties_json(
             self.case_type_obj,
-            {self.group_obj: self.case_properties_with_group, None: self.case_properties_without_group},
+            {
+                self.group_obj: self.case_properties_with_group,
+                None: self.case_properties_without_group,
+            },
         )
         self.assertEqual(response.json(), expected_response)
 
@@ -661,19 +715,26 @@ class DataDictionaryJsonV2Test(TestCase):
     ):
         mocked_load_fhir_case_type_mapping.return_value = {self.case_type_obj: self.fhir_resource_name}
         mocked_load_fhir_case_properties_mapping.return_value = {
-            case_property: self.fhir_json_path for case_property in self.case_type_obj.properties.all()
+            case_property: self.fhir_json_path
+            for case_property in self.case_type_obj.properties.all()
         }
         response = self.client.get(self.case_properties_endpoint())
         self.assertEqual(response.status_code, 200)
         expected_response = self._get_case_properties_json(
             self.case_type_obj,
-            {self.group_obj: self.case_properties_with_group, None: self.case_properties_without_group},
+            {
+                self.group_obj: self.case_properties_with_group,
+                None: self.case_properties_without_group,
+            },
             fhir_enabled=True
         )
         self.assertEqual(response.json(), expected_response)
 
     def test_get_case_properties_with_skip_limit(self, *args):
-        response = self.client.get(self.case_properties_endpoint(), data={"skip": 2, "limit": 2})
+        response = self.client.get(
+            self.case_properties_endpoint(),
+            data={"skip": 2, "limit": 2}
+        )
         self.assertEqual(response.status_code, 200)
         expected_response = self._get_case_properties_json(
             self.case_type_obj,
@@ -684,11 +745,17 @@ class DataDictionaryJsonV2Test(TestCase):
         self.assertEqual(response.json(), expected_response)
 
     def test_get_case_properties_with_skip_limit_error(self, *args):
-        response = self.client.get(self.case_properties_endpoint(), data={"skip": -1, "limit": 2})
+        response = self.client.get(
+            self.case_properties_endpoint(),
+            data={"skip": -1, "limit": 2}
+        )
         self.assertEqual(response.status_code, 400)
 
     def test_get_case_properties_multi_page(self, *args):
-        response = self.client.get(self.case_properties_endpoint(), data={"skip": 0, "limit": 2})
+        response = self.client.get(
+            self.case_properties_endpoint(),
+            data={"skip": 0, "limit": 2}
+        )
         self.assertEqual(response.status_code, 200)
         expected_response = self._get_case_properties_json(
             self.case_type_obj,
@@ -718,32 +785,28 @@ class DataDictionaryJsonV2Test(TestCase):
 
 
 @privilege_enabled(privileges.DATA_DICTIONARY)
-class TestDeleteCaseType(TestCase):
-
-    urlname = 'delete_case_type'
-    domain = 'test'
+class TestDeleteCaseType(DataDictionaryViewTestBase):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.domain_obj = create_domain(cls.domain)
-        cls.admin_webuser = WebUser.create(cls.domain, 'test', 'foobar', None, None, is_admin=True)
         cls.case_type_name = 'caseType'
-        cls.case_type_obj = CaseType(name=cls.case_type_name, domain=cls.domain)
+        cls.case_type_obj = CaseType(name=cls.case_type_name, domain=cls.domain_name)
         cls.case_type_obj.save()
 
         CaseProperty(case_type=cls.case_type_obj, name='property').save()
 
     def setUp(self):
-        self.endpoint = reverse(self.urlname, args=(self.domain, self.case_type_obj.name))
+        self.endpoint = reverse(
+            'delete_case_type',
+            args=(self.domain_name, self.case_type_obj.name),
+        )
         self.client = Client()
-        self.client.login(username='test', password='foobar')
+        self.client.login(username='username', password='Passw0rd!')
 
     @classmethod
     def tearDownClass(cls):
         cls.case_type_obj.delete()
-        cls.admin_webuser.delete(cls.domain, None)
-        cls.domain_obj.delete()
         return super().tearDownClass()
 
     def test_delete_case_type(self):
@@ -751,7 +814,11 @@ class TestDeleteCaseType(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'status': 'success'})
 
-        case_prop = CaseProperty.objects.filter(case_type__name=self.case_type_name, name='property').first()
+        case_prop = (
+            CaseProperty.objects
+            .filter(case_type__name=self.case_type_name, name='property')
+            .first()
+        )
         self.assertIsNone(case_prop)
         case_type = CaseType.objects.filter(name=self.case_type_name).first()
         self.assertIsNone(case_type)

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -272,6 +272,22 @@ def data_dictionary_json_case_properties(request, domain, case_type_name):
             "properties": []
         })
 
+    # properties_queryset skips groups with no properties. Add them here
+    empty_groups = (
+        CasePropertyGroup.objects
+        .annotate(properties_count=Count('property'))
+        .filter(case_type=case_type)
+        .filter(properties_count=0)
+    )
+    for group in empty_groups:
+        case_type_data["groups"].append({
+            "id": group.id,
+            "name": group.name,
+            "description": group.description,
+            "deprecated": group.deprecated,
+            "properties": []
+        })
+
     return JsonResponse(case_type_data)
 
 


### PR DESCRIPTION
## Product Description

Improves the performance of the Data Dictionary page for projects with high numbers of case types and case properties.


## Technical Summary

Context:
* [SC-3698](https://dimagi.atlassian.net/browse/SC-3698)
* [Spec](https://docs.google.com/document/d/1caSTWA7Bs0fSJ9AHj1vj025hb_ORcyzyuwWDvQ16Dhk/edit)

This change allows the data dictionary to support tens of thousands of case properties. It does this by fetching only the case properties of the selected case type, and by chunking the case properties over multiple requests if there are a lot.

This change builds on work currently in open PRs. Commits are rebased as follows:

1. master
2. ze/dd-only-save-changed-props (PR #34781 )
3. ay/data-dict-chunk-load (PR #34787 )
4. These new commits, starting with "propertyListItem and groupsViewModel subscribe"

## Feature Flag
N/A. Available on all plans with Data Dictionary.

## Safety Assurance

### Safety story

* Tested locally
* Tested on Staging

### Automated test coverage

Code changes are in JavaScript viewmodels and not covered by tests.

### QA Plan

QA ticket: [QA-6727](https://dimagi.atlassian.net/browse/QA-6727)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3698]: https://dimagi.atlassian.net/browse/SC-3698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QA-6727]: https://dimagi.atlassian.net/browse/QA-6727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ