### PR TITLE
minor version bump for dropbox

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -231,7 +231,7 @@ docutils==0.18.1
     #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme
-dropbox==11.36.0
+dropbox==11.36.2
     # via -r base-requirements.in
 elasticsearch5==5.5.6
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -207,7 +207,7 @@ docutils==0.18.1
     #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme
-dropbox==11.36.0
+dropbox==11.36.2
     # via -r base-requirements.in
 elasticsearch5==5.5.6
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -201,7 +201,7 @@ django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websock
     # via -r base-requirements.in
 djangorestframework==3.13.1
     # via -r base-requirements.in
-dropbox==11.36.0
+dropbox==11.36.2
     # via -r base-requirements.in
 elasticsearch5==5.5.6
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -194,7 +194,7 @@ django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websock
     # via -r base-requirements.in
 djangorestframework==3.13.1
     # via -r base-requirements.in
-dropbox==11.36.0
+dropbox==11.36.2
     # via -r base-requirements.in
 elasticsearch5==5.5.6
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -203,7 +203,7 @@ django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websock
     # via -r base-requirements.in
 djangorestframework==3.13.1
     # via -r base-requirements.in
-dropbox==11.36.0
+dropbox==11.36.2
     # via -r base-requirements.in
 elasticsearch5==5.5.6
     # via -r base-requirements.in


### PR DESCRIPTION
## Technical Summary
<!-- For non-invisible changes, describe user-facing effects. -->
Jira ticket - https://dimagi.atlassian.net/browse/SAAS-15632

We recently had some troubles with the newly configured machine on India env. The issue was of some incompatibility between latest version of `pip` and the current version of `dropbox` package that we are using.
The error was happening because of a syntax used in in `setup.py` to install a dependency [here](https://github.com/dropbox/dropbox-sdk-python/blob/v11.36.0/setup.py#L30). This is fixed in the next to next patch version of the library. 
See [changes](https://github.com/dropbox/dropbox-sdk-python/compare/v11.36.0...v11.36.2). 

I have gone through the changes and the only fixes that are there are for the issue that we are facing and then some example files. There was no functionality change in any way. 

I have added the repro steps below if anyone is interested.

TLDR- 
The error that we got was 
```
WARNING: Ignoring version 11.36.0 of dropbox since it has invalid metadata:
Requested dropbox==11.36.0 from https://files.pythonhosted.org/packages/11/7e/e66327f3535cf5b58b3c152144744fc5727355357304facf61e43ab1b895/dropbox-11.36.0-py3-none-any.whl (from -r /tmp/tmp17nssqio (line 68)) has invalid metadata: .* suffix can only be used with `==` or `!=` operators
    stone (>=2.*)
           ~~~~^
Please use pip<24.1 if you need to use this version.
ERROR: Ignored the following yanked versions: 10.11.0, 11.3.0
ERROR: Ignored the following versions that require a different python version: 5.0 Requires-Python >=3.10; 5.0.1 Requires-Python >=3.10; 5.0.2 Requires-Python >=3.10; 5.0.3 Requires-Python >=3.10; 5.0.4 Requires-Python >=3.10; 5.0.5 Requires-Python >=3.10; 5.0.6 Requires-Python >=3.10; 5.0a1 Requires-Python >=3.10; 5.0b1 Requires-Python >=3.10; 5.0rc1 Requires-Python >=3.10; 5.1a1 Requires-Python >=3.10; 5.1b1 Requires-Python >=3.10
ERROR: Could not find a version that satisfies the requirement dropbox==11.36.0 (from versions: 1.1, 1.2, 1.3, 1.4, 1.5.1, 1.6, 2.0.0, 2.1.0, 2.2.0, 3.2, 3.12, 3.13, 3.14, 3.21, 3.22, 3.23, 3.24, 3.25, 3.26, 3.27, 3.28, 3.29, 3.30, 3.31, 3.32, 3.34, 3.36, 3.37, 3.38, 3.39, 3.40, 3.41, 3.42, 4.0, 5.0, 5.0.1, 5.1, 5.2, 5.2.1, 5.2.2, 6.0, 6.1, 6.2, 6.3.0, 6.4.0, 6.5.0, 6.6.0, 6.6.1, 6.6.2, 6.7.0, 6.8.0, 6.9.0, 7.1.0, 7.1.1, 7.2.0, 7.2.1, 7.3.0, 7.3.1, 8.0.0, 8.1.0, 8.2.0, 8.3.1, 8.4.0, 8.4.1, 8.5.0, 8.5.1, 8.6.0, 8.7.0, 8.7.1, 8.8.0, 8.8.1, 8.9.0, 9.0.0, 9.1.0, 9.2.0, 9.3.0, 9.4.0, 9.5.0, 10.0.0, 10.1.0, 10.1.1, 10.1.2, 10.2.0, 10.3.0, 10.3.1, 10.4.1, 10.5.0, 10.6.0, 10.7.0, 10.8.0, 10.9.0, 10.10.0, 11.0.0, 11.1.0, 11.2.0, 11.4.0, 11.4.1, 11.5.0, 11.6.0, 11.7.0, 11.8.0, 11.9.0, 11.10.0, 11.11.0, 11.12.0, 11.13.0, 11.13.1, 11.13.2, 11.13.3, 11.14.0, 11.15.0, 11.16.0, 11.17.0, 11.18.0, 11.19.0, 11.20.0, 11.21.0, 11.22.0, 11.23.0, 11.24.0, 11.25.0, 11.26.0, 11.27.0, 11.28.0, 11.29.0, 11.30.0, 11.31.0, 11.32.0, 11.33.0, 11.34.0, 11.35.0, 11.36.0, 11.36.2, 12.0.0, 12.0.1, 12.0.2)
ERROR: No matching distribution found for dropbox==11.36.0
Traceback (most recent call last):
  File "/home/cchq/www/india/releases/2024-06-26_18.46/python_env-3.9/bin/pip-sync", line 8, in <module>
    sys.exit(cli())
  File "/home/cchq/www/india/releases/2024-06-26_18.46/python_env-3.9/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/cchq/www/india/releases/2024-06-26_18.46/python_env-3.9/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/cchq/www/india/releases/2024-06-26_18.46/python_env-3.9/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/cchq/www/india/releases/2024-06-26_18.46/python_env-3.9/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/cchq/www/india/releases/2024-06-26_18.46/python_env-3.9/lib/python3.9/site-packages/piptools/scripts/sync.py", line 145, in cli
    sync.sync(
  File "/home/cchq/www/india/releases/2024-06-26_18.46/python_env-3.9/lib/python3.9/site-packages/piptools/sync.py", line 263, in sync
    run(  # nosec
  File "/usr/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/cchq/www/india/releases/2024-06-26_18.46/python_env-3.9/bin/python', '-m', 'pip', 'install', '-r', '/tmp/tmp17nssqio', '-q', '--timeout=60']' returned non-zero exit status 1.
```


* First we will see a successful installation of `dropbox==11.36.0` on  any version of `pip` smaller that `24.1`

```
$ pip install pip==24.0       
Collecting pip==24.0
  Using cached pip-24.0-py3-none-any.whl.metadata (3.6 kB)
Using cached pip-24.0-py3-none-any.whl (2.1 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 24.1
    Uninstalling pip-24.1:
      Successfully uninstalled pip-24.1
Successfully installed pip-24.0
```

* Install dropbox==11.36.0
```
$ pip install dropbox==11.36.0
Collecting dropbox==11.36.0
  Using cached dropbox-11.36.0-py3-none-any.whl.metadata (4.3 kB)
Requirement already satisfied: requests>=2.16.2 in /Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages (from dropbox==11.36.0) (2.28.2)
Requirement already satisfied: six>=1.12.0 in /Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages (from dropbox==11.36.0) (1.16.0)
Requirement already satisfied: stone>=2.* in /Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages (from dropbox==11.36.0) (3.3.1)
Requirement already satisfied: charset-normalizer<4,>=2 in /Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages (from requests>=2.16.2->dropbox==11.36.0) (3.1.0)
Requirement already satisfied: idna<4,>=2.5 in /Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages (from requests>=2.16.2->dropbox==11.36.0) (3.7)
Requirement already satisfied: urllib3<1.27,>=1.21.1 in /Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages (from requests>=2.16.2->dropbox==11.36.0) (1.26.19)
Requirement already satisfied: certifi>=2017.4.17 in /Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages (from requests>=2.16.2->dropbox==11.36.0) (2023.7.22)
Requirement already satisfied: ply>=3.4 in /Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages (from stone>=2.*->dropbox==11.36.0) (3.11)
Downloading dropbox-11.36.0-py3-none-any.whl (594 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 594.0/594.0 kB 1.9 MB/s eta 0:00:00
DEPRECATION: dropbox 11.36.0 has a non-standard dependency specifier stone>=2.*. pip 24.1 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of dropbox or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063
Installing collected packages: dropbox
Successfully installed dropbox-11.36.0

[notice] A new release of pip is available: 24.0 -> 24.1
[notice] To update, run: pip install --upgrade pip
```

* The installation was successful. Now lets try on the latest version of `pip` i.e 24.1

* Install `pip` 24.1

```
$ pip install pip==24.1
Collecting pip==24.1
  Using cached pip-24.1-py3-none-any.whl.metadata (3.6 kB)
Using cached pip-24.1-py3-none-any.whl (1.8 MB)
DEPRECATION: dropbox 11.36.0 has a non-standard dependency specifier stone>=2.*. pip 24.1 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of dropbox or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 24.0
    Uninstalling pip-24.0:
      Successfully uninstalled pip-24.0
Successfully installed pip-24.1
```
* Now install `dropbox==11.36.0` which will fail

```
$ pip install dropbox==11.36.0
Requirement already satisfied: dropbox==11.36.0 in /Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages (11.36.0)
ERROR: Exception:
Traceback (most recent call last):
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/pkg_resources/__init__.py", line 3070, in _dep_map
    return self.__dep_map
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2863, in __getattr__
    raise AttributeError(attr)
AttributeError: _DistInfoDistribution__dep_map

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/packaging/requirements.py", line 36, in __init__
    parsed = _parse_requirement(requirement_string)
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/packaging/_parser.py", line 62, in parse_requirement
    return _parse_requirement(Tokenizer(source, rules=DEFAULT_RULES))
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/packaging/_parser.py", line 80, in _parse_requirement
    url, specifier, marker = _parse_requirement_details(tokenizer)
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/packaging/_parser.py", line 118, in _parse_requirement_details
    specifier = _parse_specifier(tokenizer)
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/packaging/_parser.py", line 214, in _parse_specifier
    parsed_specifiers = _parse_version_many(tokenizer)
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/packaging/_parser.py", line 229, in _parse_version_many
    tokenizer.raise_syntax_error(
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/packaging/_tokenizer.py", line 167, in raise_syntax_error
    raise ParserSyntaxError(
pip._vendor.packaging._tokenizer.ParserSyntaxError: .* suffix can only be used with `==` or `!=` operators
    stone (>=2.*)
           ~~~~^

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 179, in exc_logging_wrapper
    status = run_func(*args)
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_internal/cli/req_command.py", line 67, in wrapper
    return func(self, options, args)
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_internal/commands/install.py", line 377, in run
    requirement_set = resolver.resolve(
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 95, in resolve
    result = self._result = resolver.resolve(
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/resolvelib/resolvers.py", line 546, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/resolvelib/resolvers.py", line 427, in resolve
    failure_causes = self._attempt_to_pin_criterion(name)
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/resolvelib/resolvers.py", line 239, in _attempt_to_pin_criterion
    criteria = self._get_updated_criteria(candidate)
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/resolvelib/resolvers.py", line 229, in _get_updated_criteria
    for requirement in self._p.get_dependencies(candidate=candidate):
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/provider.py", line 247, in get_dependencies
    return [r for r in candidate.iter_dependencies(with_requires) if r is not None]
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/provider.py", line 247, in <listcomp>
    return [r for r in candidate.iter_dependencies(with_requires) if r is not None]
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 401, in iter_dependencies
    for r in self.dist.iter_dependencies():
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_internal/metadata/pkg_resources.py", line 247, in iter_dependencies
    return self._dist.requires(extras)
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2786, in requires
    dm = self._dep_map
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/pkg_resources/__init__.py", line 3072, in _dep_map
    self.__dep_map = self._compute_dependencies()
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/pkg_resources/__init__.py", line 3082, in _compute_dependencies
    reqs.extend(parse_requirements(req))
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/pkg_resources/__init__.py", line 3135, in __init__
    super().__init__(requirement_string)
  File "/Users/amitphulera/.pyenv/versions/3.9.16/envs/hqa/lib/python3.9/site-packages/pip/_vendor/packaging/requirements.py", line 38, in __init__
    raise InvalidRequirement(str(e)) from e
pip._vendor.packaging.requirements.InvalidRequirement: .* suffix can only be used with `==` or `!=` operators
    stone (>=2.*)
           ~~~~^
```


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Just a patch version upgrade. I have gone through the [commit history](https://github.com/dropbox/dropbox-sdk-python/compare/v11.36.0...v11.36.2) and no observerd no functionality change.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I have tested that the version is installed successfully with newer version of pip. 
### Automated test coverage
I saw some tests for dropbox. If they pass we should be good.
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
