### PR TITLE
send window width in formplayer query

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -40,6 +40,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", [
                 lastRecordedLocation = FormplayerFrontend.getChannel().request('lastRecordedLocation'),
                 timezoneOffsetMillis = (new Date()).getTimezoneOffset() * 60 * 1000 * -1,
                 tzFromBrowser = Intl.DateTimeFormat().resolvedOptions().timeZone,
+                screenSize = String(window.innerWidth),
                 formplayerUrl = user.formplayer_url,
                 displayOptions = user.displayOptions || {},
                 defer = $.Deferred(),
@@ -184,6 +185,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", [
                     "isShortDetail": params.isShortDetail,
                     "isRefreshCaseSearch": params.isRefreshCaseSearch,
                     "requestInitiatedByTag": params.requestInitiatedByTag,
+                    "screen_size": screenSize,
                 };
                 options.data = JSON.stringify(data);
                 options.url = formplayerUrl + '/' + route;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -40,7 +40,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", [
                 lastRecordedLocation = FormplayerFrontend.getChannel().request('lastRecordedLocation'),
                 timezoneOffsetMillis = (new Date()).getTimezoneOffset() * 60 * 1000 * -1,
                 tzFromBrowser = Intl.DateTimeFormat().resolvedOptions().timeZone,
-                screenSize = String(window.innerWidth),
+                windowWidth = String(window.innerWidth),
                 formplayerUrl = user.formplayer_url,
                 displayOptions = user.displayOptions || {},
                 defer = $.Deferred(),
@@ -185,7 +185,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", [
                     "isShortDetail": params.isShortDetail,
                     "isRefreshCaseSearch": params.isRefreshCaseSearch,
                     "requestInitiatedByTag": params.requestInitiatedByTag,
-                    "screen_size": screenSize,
+                    "windowWidth": windowWidth,
                 };
                 options.data = JSON.stringify(data);
                 options.url = formplayerUrl + '/' + route;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This is part of the body of work to allow showing different content (forms, menus) depending on the user's screen size.
This example below shows a menu with a display condition that check that the `windowWidth` is >= 992.
In a real-world implementation there would be another for whose display condition would check that the `windowWidth` was < 992. That way the menu and forms that are optimized for a particular screen size would be displayed to the user.
![content_based_on_window_width](https://github.com/dimagi/commcare-hq/assets/42388648/4bfaef7a-896a-44b3-b49a-b516cc4ab109)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira ticket](https://dimagi.atlassian.net/browse/USH-4415)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
this simply sends an additional query param to Formplayer, so is unlikely to cause any issues. 
tested locally and will go through QA along with the FP component.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
