### PR TITLE
Auto deactivation in test mode will only deactivate SSO Test Users

### DIFF
--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -439,13 +439,19 @@ class IdentityProvider(models.Model):
             return idp
         return None
 
-    def get_all_usernames_of_the_idp(self):
+    def get_remote_member_usernames(self):
+        '''
+        return a list of member emails in the Identity Provider
+        '''
         if self.idp_type == IdentityProviderType.ENTRA_ID:
             return get_all_usernames_of_the_idp_from_entra(self)
         else:
             raise NotImplementedError("Not implemented")
 
-    def get_webuser_names_goverened_by_idp(self):
+    def get_local_member_usernames(self):
+        '''
+        returns a list of WebUser usernames that is governed by the idp
+        '''
         usernames_in_account = set(self.owner.get_web_user_usernames())
 
         if self.login_enforcement_type == LoginEnforcementType.GLOBAL:
@@ -462,7 +468,7 @@ class IdentityProvider(models.Model):
                     usernames.append(username)
             return usernames
 
-        elif self.login_enforcement_type == LoginEnforcementType.TEST:
+        if self.login_enforcement_type == LoginEnforcementType.TEST:
             test_usernames = set(SsoTestUser.objects.filter(email_domain__identity_provider__slug=self.slug
                                                             ).values_list('username', flat=True))
             return list(test_usernames.intersection(usernames_in_account))

--- a/corehq/apps/sso/tasks.py
+++ b/corehq/apps/sso/tasks.py
@@ -128,7 +128,7 @@ def auto_deactivate_removed_sso_users():
         idp_type=IdentityProviderType.ENTRA_ID,
     ).all():
         try:
-            usernames_in_idp = set(convert_emails_to_lowercase(idp.get_all_usernames_of_the_idp()))
+            usernames_in_idp = set(convert_emails_to_lowercase(idp.get_remote_member_usernames()))
         except EntraVerificationFailed as e:
             notify_exception(None, f"Failed to get members of the IdP. {str(e)}")
             send_deactivation_skipped_email(idp=idp, failure_code=MSGraphIssue.VERIFICATION_ERROR,
@@ -154,7 +154,7 @@ def auto_deactivate_removed_sso_users():
             send_deactivation_skipped_email(idp=idp, failure_code=MSGraphIssue.EMPTY_ERROR)
             continue
 
-        usernames_governed_by_idp = set(idp.get_webuser_names_goverened_by_idp())
+        usernames_governed_by_idp = set(idp.get_local_member_usernames())
 
         # Deactivate user that is not returned by Graph Users API
         for username in usernames_governed_by_idp:

--- a/corehq/apps/sso/tasks.py
+++ b/corehq/apps/sso/tasks.py
@@ -8,12 +8,9 @@ from corehq.apps.celery import periodic_task, task
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.sso.exceptions import EntraVerificationFailed, EntraUnsupportedType
 from corehq.apps.sso.models import (
-    AuthenticatedEmailDomain,
     IdentityProvider,
     IdentityProviderProtocol,
     IdentityProviderType,
-    UserExemptFromSingleSignOn,
-    LoginEnforcementType,
 )
 from corehq.apps.sso.utils.context_helpers import (
     get_api_secret_expiration_email_context,
@@ -21,7 +18,7 @@ from corehq.apps.sso.utils.context_helpers import (
     get_sso_deactivation_skip_email_context,
 )
 from corehq.apps.sso.utils.entra import MSGraphIssue
-from corehq.apps.sso.utils.user_helpers import convert_emails_to_lowercase, get_email_domain_from_username
+from corehq.apps.sso.utils.user_helpers import convert_emails_to_lowercase
 from corehq.apps.users.models import WebUser
 from corehq.apps.users.models import HQApiKey
 from django.contrib.auth.models import User
@@ -129,10 +126,9 @@ def auto_deactivate_removed_sso_users():
     for idp in IdentityProvider.objects.filter(
         enable_user_deactivation=True,
         idp_type=IdentityProviderType.ENTRA_ID,
-        login_enforcement_type=LoginEnforcementType.GLOBAL,
     ).all():
         try:
-            usernames_in_idp = convert_emails_to_lowercase(idp.get_all_usernames_of_the_idp())
+            usernames_in_idp = set(convert_emails_to_lowercase(idp.get_all_usernames_of_the_idp()))
         except EntraVerificationFailed as e:
             notify_exception(None, f"Failed to get members of the IdP. {str(e)}")
             send_deactivation_skipped_email(idp=idp, failure_code=MSGraphIssue.VERIFICATION_ERROR,
@@ -158,28 +154,15 @@ def auto_deactivate_removed_sso_users():
             send_deactivation_skipped_email(idp=idp, failure_code=MSGraphIssue.EMPTY_ERROR)
             continue
 
-        usernames_in_account = idp.owner.get_web_user_usernames()
-
-        # Get criteria for exempting usernames and email domains from the deactivation list
-        authenticated_domains = AuthenticatedEmailDomain.objects.filter(identity_provider=idp)
-        exempt_usernames = UserExemptFromSingleSignOn.objects.filter(email_domain__in=authenticated_domains
-                                                                     ).values_list('username', flat=True)
-
-        usernames_to_deactivate = []
-        authenticated_email_domains = authenticated_domains.values_list('email_domain', flat=True)
-
-        for username in usernames_in_account:
-            if username not in usernames_in_idp and username not in exempt_usernames:
-                email_domain = get_email_domain_from_username(username)
-                if email_domain in authenticated_email_domains:
-                    usernames_to_deactivate.append(username)
+        usernames_governed_by_idp = set(idp.get_webuser_names_goverened_by_idp())
 
         # Deactivate user that is not returned by Graph Users API
-        for username in usernames_to_deactivate:
-            user = WebUser.get_by_username(username)
-            if user and user.is_active:
-                user.is_active = False
-                user.save()
+        for username in usernames_governed_by_idp:
+            if username not in usernames_in_idp:
+                user = WebUser.get_by_username(username)
+                if user and user.is_active:
+                    user.is_active = False
+                    user.save()
 
 
 def send_deactivation_skipped_email(idp, failure_code, error=None, error_description=None):

--- a/corehq/apps/sso/tests/test_models.py
+++ b/corehq/apps/sso/tests/test_models.py
@@ -1,6 +1,18 @@
+import datetime
 from unittest.mock import patch
-from corehq.apps.sso.models import IdentityProvider
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.apps.accounting.tests import generator as accounting_generator
+from corehq.apps.domain.models import Domain
+from corehq.apps.sso.models import (
+    AuthenticatedEmailDomain,
+    IdentityProvider,
+    LoginEnforcementType,
+    SsoTestUser,
+    UserExemptFromSingleSignOn,
+)
 from corehq.apps.sso.tests import generator
+from corehq.apps.users.models import WebUser
+
 from django.test import TestCase
 
 
@@ -55,3 +67,84 @@ class IdentityProviderTests(TestCase):
             last_modified_by='admin@dimagi.com',
             max_days_until_user_api_key_expiration=max_days_until_user_api_key_expiration,
         )
+
+
+class IdentityProviderGovernanceScopeTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+
+        super().setUpClass()
+        cls.email_domain_str = 'vaultwax.com'
+
+        cls.account = generator.get_billing_account_for_idp()
+        cls.account.enterprise_admin_emails = [f'admin@{cls.email_domain_str}']
+        cls.account.save()
+        cls.domain = Domain.get_or_create_with_name("vaultwax-001", is_active=True)
+        cls.addClassCleanup(cls.domain.delete)
+
+        enterprise_plan = accounting_generator.subscribable_plan_version(edition=SoftwarePlanEdition.ENTERPRISE)
+        accounting_generator.generate_domain_subscription(
+            cls.account,
+            cls.domain,
+            date_start=datetime.date.today(),
+            date_end=None,
+            plan_version=enterprise_plan,
+            is_active=True,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.idp = generator.create_idp('vaultwax', self.account)
+        self.email_domain = AuthenticatedEmailDomain.objects.create(
+            email_domain=self.email_domain_str,
+            identity_provider=self.idp,
+        )
+
+        self.web_user_a = self._create_web_user(f'a@{self.email_domain_str}')
+        self.web_user_b = self._create_web_user(f'b@{self.email_domain_str}')
+        self.web_user_c = self._create_web_user(f'c@{self.email_domain_str}')
+        self.test_user_a = self._create_test_sso_user(f'test_a@{self.email_domain_str}')
+        self.test_user_b = self._create_test_sso_user(f'test_b@{self.email_domain_str}')
+
+    def _create_web_user(self, username):
+        user = WebUser.create(
+            self.domain.name, username, 'testpwd', None, None
+        )
+        self.addCleanup(user.delete, self.domain.name, deleted_by=None)
+        return user
+
+    def _create_test_sso_user(self, username):
+        SsoTestUser.objects.create(
+            email_domain=self.email_domain,
+            username=username,
+        )
+        return self._create_web_user(username)
+
+    def test_get_webuser_names_goverened_by_idp_returns_everyone_when_login_enforcement_is_global(self):
+        self.assertCountEqual(self.idp.get_webuser_names_goverened_by_idp(),
+                              [self.web_user_a.username, self.web_user_b.username, self.web_user_c.username,
+                               self.test_user_a.username, self.test_user_b.username])
+
+    def test_get_webuser_names_goverened_by_idp_returns_test_user_only_when_login_enforcement_is_test(self):
+        self.idp.login_enforcement_type = LoginEnforcementType.TEST
+        self.idp.save()
+
+        self.assertCountEqual(self.idp.get_webuser_names_goverened_by_idp(),
+                              [self.test_user_a.username, self.test_user_b.username])
+
+    def test_get_webuser_names_goverened_by_idp_excludes_exempt_user(self):
+        # exempt user cannot be test user, so this idp must be in global mode
+        UserExemptFromSingleSignOn.objects.create(
+            email_domain=self.email_domain,
+            username=f'exempt{self.email_domain}'
+        )
+        self.assertCountEqual(self.idp.get_webuser_names_goverened_by_idp(),
+                              [self.web_user_a.username, self.web_user_b.username, self.web_user_c.username,
+                               self.test_user_a.username, self.test_user_b.username])
+
+    def test_get_webuser_names_governed_by_idp_excludes_users_have_different_email_domain(self):
+        self.other_email_domain_user = self._create_web_user('a@gmail.com')
+
+        self.assertCountEqual(self.idp.get_webuser_names_goverened_by_idp(),
+                              [self.web_user_a.username, self.web_user_b.username, self.web_user_c.username,
+                               self.test_user_a.username, self.test_user_b.username])

--- a/corehq/apps/sso/tests/test_models.py
+++ b/corehq/apps/sso/tests/test_models.py
@@ -120,31 +120,31 @@ class IdentityProviderGovernanceScopeTests(TestCase):
         )
         return self._create_web_user(username)
 
-    def test_get_webuser_names_goverened_by_idp_returns_everyone_when_login_enforcement_is_global(self):
-        self.assertCountEqual(self.idp.get_webuser_names_goverened_by_idp(),
+    def test_idp_governance_scope_returns_everyone_when_login_enforcement_is_global(self):
+        self.assertCountEqual(self.idp.get_local_member_usernames(),
                               [self.web_user_a.username, self.web_user_b.username, self.web_user_c.username,
                                self.test_user_a.username, self.test_user_b.username])
 
-    def test_get_webuser_names_goverened_by_idp_returns_test_user_only_when_login_enforcement_is_test(self):
+    def test_idp_governance_scope_returns_test_user_only_when_login_enforcement_is_test(self):
         self.idp.login_enforcement_type = LoginEnforcementType.TEST
         self.idp.save()
 
-        self.assertCountEqual(self.idp.get_webuser_names_goverened_by_idp(),
+        self.assertCountEqual(self.idp.get_local_member_usernames(),
                               [self.test_user_a.username, self.test_user_b.username])
 
-    def test_get_webuser_names_goverened_by_idp_excludes_exempt_user(self):
+    def test_idp_governance_scope_excludes_exempt_user(self):
         # exempt user cannot be test user, so this idp must be in global mode
         UserExemptFromSingleSignOn.objects.create(
             email_domain=self.email_domain,
             username=f'exempt{self.email_domain}'
         )
-        self.assertCountEqual(self.idp.get_webuser_names_goverened_by_idp(),
+        self.assertCountEqual(self.idp.get_local_member_usernames(),
                               [self.web_user_a.username, self.web_user_b.username, self.web_user_c.username,
                                self.test_user_a.username, self.test_user_b.username])
 
-    def test_get_webuser_names_governed_by_idp_excludes_users_have_different_email_domain(self):
+    def test_idp_governance_scope_excludes_users_have_different_email_domain(self):
         self.other_email_domain_user = self._create_web_user('a@gmail.com')
 
-        self.assertCountEqual(self.idp.get_webuser_names_goverened_by_idp(),
+        self.assertCountEqual(self.idp.get_local_member_usernames(),
                               [self.web_user_a.username, self.web_user_b.username, self.web_user_c.username,
                                self.test_user_a.username, self.test_user_b.username])

--- a/corehq/apps/sso/tests/test_tasks.py
+++ b/corehq/apps/sso/tests/test_tasks.py
@@ -331,8 +331,8 @@ class TestAutoDeactivationTask(TestCase):
             is_active=True,
         )
 
-        idp_patcher = patch('corehq.apps.sso.models.IdentityProvider.get_all_usernames_of_the_idp')
-        cls.mock_get_all_usernames_of_the_idp = idp_patcher.start()
+        idp_patcher = patch('corehq.apps.sso.models.IdentityProvider.get_remote_member_usernames')
+        cls.mock_get_remote_member_usernames = idp_patcher.start()
         cls.addClassCleanup(idp_patcher.stop)
 
     def setUp(self):
@@ -351,7 +351,7 @@ class TestAutoDeactivationTask(TestCase):
 
     def test_user_is_deactivated_if_not_member_of_idp(self):
         self.assertTrue(self.web_user_c.is_active)
-        self.mock_get_all_usernames_of_the_idp.return_value = [self.web_user_a.username, self.web_user_b.username]
+        self.mock_get_remote_member_usernames.return_value = [self.web_user_a.username, self.web_user_b.username]
 
         auto_deactivate_removed_sso_users()
 
@@ -365,7 +365,7 @@ class TestAutoDeactivationTask(TestCase):
             username=sso_exempt.username,
             email_domain=self.email_domain,
         )
-        self.mock_get_all_usernames_of_the_idp.return_value = [self.web_user_a.username, self.web_user_b.username]
+        self.mock_get_remote_member_usernames.return_value = [self.web_user_a.username, self.web_user_b.username]
 
         auto_deactivate_removed_sso_users()
 
@@ -375,7 +375,7 @@ class TestAutoDeactivationTask(TestCase):
 
     @patch('corehq.apps.sso.tasks.send_html_email_async.delay')
     def test_deactivation_skipped_if_entra_return_empty_sso_user(self, mock_send):
-        self.mock_get_all_usernames_of_the_idp.return_value = []
+        self.mock_get_remote_member_usernames.return_value = []
 
         auto_deactivate_removed_sso_users()
 
@@ -390,7 +390,7 @@ class TestAutoDeactivationTask(TestCase):
 
     def test_deactivation_skip_members_who_do_not_have_an_email_domain_controlled_by_the_idp(self):
         dimagi_user = self._create_web_user('superuser@dimagi.com')
-        self.mock_get_all_usernames_of_the_idp.return_value = [self.web_user_a.username, self.web_user_b.username]
+        self.mock_get_remote_member_usernames.return_value = [self.web_user_a.username, self.web_user_b.username]
 
         auto_deactivate_removed_sso_users()
 
@@ -403,7 +403,7 @@ class TestAutoDeactivationTask(TestCase):
     def test_auto_deactivation_skipped_for_idp_whose_auto_deactivation_is_off(self):
         self.idp.enable_user_deactivation = False
         self.idp.save()
-        self.mock_get_all_usernames_of_the_idp.return_value = [self.web_user_a.username, self.web_user_b.username]
+        self.mock_get_remote_member_usernames.return_value = [self.web_user_a.username, self.web_user_b.username]
 
         auto_deactivate_removed_sso_users()
 
@@ -419,7 +419,7 @@ class TestAutoDeactivationTask(TestCase):
             username='test@vaultwax.com',
         )
         self._create_web_user(test_user.username)
-        self.mock_get_all_usernames_of_the_idp.return_value = [self.web_user_a.username, self.web_user_b.username]
+        self.mock_get_remote_member_usernames.return_value = [self.web_user_a.username, self.web_user_b.username]
 
         auto_deactivate_removed_sso_users()
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15603

Instead of disable auto deactivation for idp that is in test mode, we will enable it, partially - Only deactivate user if a user is removed from idp application, and is a SSO Test User.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Added new tests for it.
Will request QA to test on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
corehq.apps.sso.tests.test_models:IdentityProviderGovernanceScopeTests
corehq.apps.sso.tests.test_tasks:TestAutoDeactivationTask

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Ticket: https://dimagi.atlassian.net/browse/QA-6746
Set up some SSO Test User: T-a, T-b, add both to idp.
1. When idp's login enforcement type is global, run a regression test for auto deactivation:
- Users should be deactivated if removed from Microsoft Entra, even if the user is SSO Test User. 
- Exempt SSO User won't be deactivated. 
- User with different email domain ( in our staging case, if user's email is not from `dimagi.org`, then that user shouldn't be deactivated)

2. When idp's login enforcement type is test, remove a normal user, and a test sso user (eg, T-b) from the idp application, only T-b should be deactivated.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
