### PR TITLE
Smartlink Error with Inline Case Search Fix

### DIFF
--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -33,9 +33,9 @@ class TestCaseSearchEndpoint(TestCase):
         super().setUpClass()
         cls.user = create_user("admin", "123")
         CaseSearchConfig.objects.create(domain=cls.domain, enabled=True)
-        household_1 = str(uuid.uuid4())
+        cls.household_1 = str(uuid.uuid4())
         case_blocks = [CaseBlock(
-            case_id=household_1,
+            case_id=cls.household_1,
             case_type='household',
             case_name="Villanueva",
             create=True,
@@ -48,10 +48,10 @@ class TestCaseSearchEndpoint(TestCase):
             update=properties,
             index={'parent': IndexAttrs('household', household_id, 'child')} if household_id else None,
         ) for name, properties, household_id in [
-            ("Jane", {"family": "Villanueva"}, household_1),
-            ("Xiomara", {"family": "Villanueva"}, household_1),
-            ("Alba", {"family": "Villanueva"}, household_1),
-            ("Rogelio", {"family": "de la Vega"}, household_1),
+            ("Jane", {"family": "Villanueva"}, cls.household_1),
+            ("Xiomara", {"family": "Villanueva"}, cls.household_1),
+            ("Alba", {"family": "Villanueva"}, cls.household_1),
+            ("Rogelio", {"family": "de la Vega"}, cls.household_1),
             ("Jane", {"family": "Ramos"}, None),
         ]])
         case_search_es_setup(cls.domain, case_blocks)
@@ -76,6 +76,10 @@ class TestCaseSearchEndpoint(TestCase):
         self.assertItemsEqual(["Jane", "Xiomara", "Alba", "Rogelio", "Jane"], [
             case.name for case in res
         ])
+
+    def test_case_id_criteia(self):
+        res = get_case_search_results(self.domain, ['household'], [SearchCriteria('case_id', self.household_1)])
+        self.assertItemsEqual(["Villanueva"], [case.name for case in res])
 
     def test_dynamic_property(self):
         res = get_case_search_results(self.domain, ['person'], [SearchCriteria('family', 'Ramos')])

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -16,6 +16,7 @@ from dimagi.utils.logging import notify_exception
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_app_cached
 from corehq.apps.app_manager.util import module_offers_search
+from corehq.apps.es import cases as case_es
 from corehq.apps.case_search.const import (
     CASE_SEARCH_MAX_RESULTS,
     COMMCARE_PROJECT,
@@ -269,6 +270,8 @@ class CaseSearchQueryBuilder:
                 for xpath in xpaths:
                     search_es = search_es.filter(self._build_filter_from_xpath(xpath))
                 return search_es
+        elif criteria.key == 'case_id':
+            return search_es.filter(case_es.case_ids(criteria.value))
         elif criteria.key == 'owner_id':
             if not criteria.is_empty:
                 return search_es.filter(case_search.owner(criteria.value))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Addresses error that is encountered when smartlinking to a module that also uses inline case search.


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Related [Jira Ticket](https://dimagi.atlassian.net/browse/USH-3709)

example of current `endpoint` block:
```
 <endpoint id="update_store">
    <argument id="case_id"/>
    <stack>
      <push>
        <command value="'m1'"/>
        <query id="results:inline" value="https://www.commcarehq.org/a/jonathantangtest/phone/case_fixture/fcd6a07be33442168d88a23d85294880/">
          <data key="case_type" ref="'case'"/>
          <data key="case_id" ref="$case_id"/>
        </query>
        <datum id="case_id" value="$case_id"/>
      </push>
    </stack>
  </endpoint>
```

while following a smart link to an inline case search module, `case_id` is used for both "Case Fixture API" (phone/case_fixture) and "Case Search API" (phone/search). However, for "Case Search API", `case_id` is indexed as `@case_id` so using `case_id` as the parameter incorrectly returned no results.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[Session Endpoints
](https://www.commcarehq.org/hq/flags/edit/session_endpoints/)
[Inline Case Search
](https://www.commcarehq.org/hq/flags/edit/inline_case_search/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Locally tested

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
add tests that "case_id" criteria key returns expected cases

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
