### PR TITLE
let user know about deprecated groups/properties for duplicate error

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -391,7 +391,11 @@
             </button>
             <div class="help-block">
               <span class="text-danger" data-bind="visible: !newGroupNameUnique()">
-                {% trans "A case property group with this name already exists." %}
+                {% blocktrans %}
+                  A case property group with this name already exists.
+                  If you don’t see it on the page, please click ‘Show Deprecated’ button to reveal deprecated
+                  groups.
+                {% endblocktrans %}
               </span>
               <span class="text-danger" data-bind="visible: !newGroupNameValid()">
                 {% trans "Invalid case group name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -375,7 +375,11 @@
             </button>
             <div class="help-block">
               <span class="text-danger" data-bind="visible: !newPropertyNameUnique()">
-                {% trans "A case property with this name already exists." %}
+                {% blocktrans %}
+                  A case property with this name already exists.
+                  If you don’t see it on the page, please click ‘Show Deprecated’ button to reveal deprecated
+                  properties.
+                {% endblocktrans %}
               </span>
               <span class="text-danger" data-bind="visible: !newPropertyNameValid()">
                 {% trans "Invalid case property name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
On Data dictionary,
Deprecated groups are hidden on the page and can block users from creating a group with a name that is already used by a deprecated group.
Minor change to update the error message to let user know about revealing deprecated groups in case they don't see the duplicate.

Same change being done for error message for properties.

-----
Before
![image](https://github.com/dimagi/commcare-hq/assets/3864163/5e3d01ec-9548-4ee4-9b08-9e55a9d506b1)

-----
After
![image](https://github.com/dimagi/commcare-hq/assets/3864163/5e606171-54ec-4f5a-a620-1761cd38f20c)



## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3744

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
