### PR TITLE
Bump djangorestframework to 3.15.2

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -224,7 +224,7 @@ django-user-agents==0.4.0
     # via -r base-requirements.in
 django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
     # via -r base-requirements.in
-djangorestframework==3.13.1
+djangorestframework==3.15.2
     # via -r base-requirements.in
 docutils==0.18.1
     # via
@@ -588,7 +588,6 @@ pytz==2024.1
     #   -r base-requirements.in
     #   babel
     #   celery
-    #   djangorestframework
     #   twilio
 pyyaml==6.0
     # via

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -200,7 +200,7 @@ django-user-agents==0.4.0
     # via -r base-requirements.in
 django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
     # via -r base-requirements.in
-djangorestframework==3.13.1
+djangorestframework==3.15.2
     # via -r base-requirements.in
 docutils==0.18.1
     # via
@@ -484,7 +484,6 @@ pytz==2024.1
     #   -r base-requirements.in
     #   babel
     #   celery
-    #   djangorestframework
     #   twilio
 pyyaml==6.0
     # via

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -199,7 +199,7 @@ django-user-agents==0.4.0
     # via -r base-requirements.in
 django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
     # via -r base-requirements.in
-djangorestframework==3.13.1
+djangorestframework==3.15.2
     # via -r base-requirements.in
 dropbox==11.36.2
     # via -r base-requirements.in
@@ -493,7 +493,6 @@ pytz==2024.1
     # via
     #   -r base-requirements.in
     #   celery
-    #   djangorestframework
     #   flower
     #   twilio
 pyyaml==6.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -192,7 +192,7 @@ django-user-agents==0.4.0
     # via -r base-requirements.in
 django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
     # via -r base-requirements.in
-djangorestframework==3.13.1
+djangorestframework==3.15.2
     # via -r base-requirements.in
 dropbox==11.36.2
     # via -r base-requirements.in
@@ -456,7 +456,6 @@ pytz==2024.1
     # via
     #   -r base-requirements.in
     #   celery
-    #   djangorestframework
     #   twilio
 pyyaml==6.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -201,7 +201,7 @@ django-user-agents==0.4.0
     # via -r base-requirements.in
 django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl
     # via -r base-requirements.in
-djangorestframework==3.13.1
+djangorestframework==3.15.2
     # via -r base-requirements.in
 dropbox==11.36.2
     # via -r base-requirements.in
@@ -491,7 +491,6 @@ pytz==2024.1
     # via
     #   -r base-requirements.in
     #   celery
-    #   djangorestframework
     #   twilio
 pyyaml==6.0
     # via -r base-requirements.in


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15704

[Changelog](https://www.django-rest-framework.org/community/release-notes/)

We only use djangorestframework in two ways.

#### from djangorestframework import status
Only used in corehq.apps.receiverwrapper.tests.test_submissions, so tests would fail if this were an issue.

#### from djangorestframework import serializers
We use various objects from `serializers`:
- ModelSerializer
- CharField
- JSONField
- ChoiceField
- DictField
- DateTimeField
- IntegerField

Looking closer at the changelog, I don't see any change specifically calling out these objects that are of concern.

We have a number of classes that inherit from ModelSerializer and appear to be used in the `to_json` method for classes like XFormInstance. I tested this in a staging shell with this upgrade deployed (got a form and ran `form.to_json()` on it), and it didn't have any issues. Not the most comprehensive test.

3.13.1 was released on December 15th, 2021, so I also looked at the change history for [this class](https://github.com/encode/django-rest-framework/blame/master/rest_framework/serializers.py) and the recent changes do not look like they would have impacted our use case.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
