### PR TITLE
Allow our middleware to control enterprise console download sizes

### DIFF
--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -101,7 +101,6 @@ def enterprise_dashboard_download(request, domain, slug, export_hash):
     if content:
         file = ContentFile(content)
         response = HttpResponse(file, Format.FORMAT_DICT[Format.UNZIPPED_CSV])
-        response['Content-Length'] = file.size
         response['Content-Disposition'] = 'attachment; filename="{}"'.format(report.filename)
         return response
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
Ticket: https://dimagi.atlassian.net/browse/SAAS-15714 

A bug was observed with Enterprise Console reports, whereby any report containing UTF-8-specific characters (such as é, ë, or ê) would lead to truncated report output. This was due to explicitly setting the content-length header to be the size of the string buffer (which was the number of characters) rather than the size of the binary content. Because those characters require more than 1 byte, the resulting size is too small and the end of the file is truncated.

Rather than manually calculating the size (requiring us to create a new binary buffer), I discovered that we can rely on our existing middleware to calculate the content-size for us. Despite removing the line, downloads still include the content-length header, this time populated with the binary size.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Verified this fix both locally and on staging, where I created domain names with UTF-8 characters and witnessed that the fix included the whole file and that the content-length header was still present.

### Automated test coverage

No automated tests. Its hard to state what this kind of test should look like, as we're trying to rely on the middleware to populate the content length. A test put in just to ensure that the raw `enterprise_dashboard_download` view does not populate content length doesn't seem useful, nor does a test that verifies that the middleware adds content length headers to response that lack them. I felt a full integration test that created a client in order to send the request through both the middleware and the view was excessive.

### QA Plan

No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
