### PR TITLE
Fix rate limiting for unlimited domains

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1336,6 +1336,11 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         ).all()
 
     @classmethod
+    def total_by_domain(cls, domain, is_active=True):
+        data = cls.by_domain(domain, is_active, reduce=True)
+        return data[0].get('value', 0) if data else 0
+
+    @classmethod
     def ids_by_domain(cls, domain, is_active=True):
         flag = "active" if is_active else "inactive"
         if cls.__name__ == "CouchUser":
@@ -1348,11 +1353,6 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             reduce=False,
             include_docs=False,
         )]
-
-    @classmethod
-    def total_by_domain(cls, domain, is_active=True):
-        data = cls.by_domain(domain, is_active, reduce=True)
-        return data[0].get('value', 0) if data else 0
 
     @classmethod
     def phone_users_by_domain(cls, domain):

--- a/corehq/project_limits/rate_counter/rate_counter.py
+++ b/corehq/project_limits/rate_counter/rate_counter.py
@@ -53,6 +53,9 @@ class SlidingWindowRateCounter(AbstractRateCounter):
             memoize_timeout=memoize_timeout
         )
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(key='{self.key}')"
+
     def get(self, scope, timestamp=None):
         if timestamp is None:
             timestamp = time.time()
@@ -102,6 +105,9 @@ class FixedWindowRateCounter(AbstractRateCounter):
         self.window_duration = window_duration
         self.window_offset = window_offset
         self.counter = _CounterCache(memoize_timeout, timeout=keep_windows * window_duration)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(key='{self.key}')"
 
     @staticmethod
     def _digest(string):

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -3,7 +3,7 @@ import time
 
 import attr
 
-from corehq.apps.users.models import CommCareUser
+from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.project_limits.models import DynamicRateDefinition
 from corehq.project_limits.rate_counter.presets import (
     day_rate_counter,
@@ -126,7 +126,12 @@ class RateLimiter(object):
 
 @quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)
 def get_n_users_in_domain(domain):
-    return CommCareUser.total_by_domain(domain, is_active=True)
+    from corehq.apps.accounting.models import Subscription
+    total = CommCareUser.total_by_domain(domain, is_active=True)
+    subscription = Subscription.get_active_subscription_by_domain(domain)
+    if subscription and subscription.account.bill_web_user:
+        total += WebUser.total_by_domain(domain, is_active=True)
+    return total
 
 
 @quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -131,11 +131,12 @@ def get_n_users_in_domain(domain):
 
 @quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)
 def get_n_users_in_subscription(domain):
-    from corehq.apps.accounting.models import Subscription
+    from corehq.apps.accounting.models import Subscription, UNLIMITED_FEATURE_USAGE
     subscription = Subscription.get_active_subscription_by_domain(domain)
     if subscription:
-        plan_version = subscription.plan_version
-        return plan_version.feature_rates.get(feature__feature_type='User').monthly_limit
+        limit = subscription.plan_version.feature_rates.get(feature__feature_type='User').monthly_limit
+        # Advanced plans get 500 users/mo, let's arbitrarily double that as the fallback max.
+        return 1000 if limit == UNLIMITED_FEATURE_USAGE else limit
     else:
         return 0
 

--- a/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
+++ b/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
@@ -64,9 +64,14 @@ class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
         # domain_2 still has full subscription allocation
         self._assert_subscription_value_equals(domain_2, 8)
 
-    def _setup_domain(self, domain):
+    def test_no_user_limit(self):
+        domain = 'enterprise-domain'
+        self._setup_domain(domain, SoftwarePlanEdition.ENTERPRISE)
+        self._assert_subscription_value_equals(domain, 1000)
+
+    def _setup_domain(self, domain, software_plan=SoftwarePlanEdition.ADVANCED):
         domain_obj = create_domain(domain)
-        self.setup_subscription(domain_obj.name, SoftwarePlanEdition.ADVANCED)
+        self.setup_subscription(domain_obj.name, software_plan)
         self.addCleanup(lambda: self.teardown_subscription(domain))
         self.addCleanup(domain_obj.delete)
         assert CommCareUser.total_by_domain(domain, is_active=True) == 0

--- a/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
+++ b/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
-from corehq.apps.accounting.bootstrap.config.testing import BOOTSTRAP_CONFIG_TESTING
-from corehq.apps.accounting.models import SoftwarePlanEdition, FeatureType, Subscription
+from corehq.apps.accounting.models import SoftwarePlanEdition, Subscription
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, WebUser


### PR DESCRIPTION
## Product Description
API access is rate limited based on two scopes, domain, and subscription.  Access is allowed if either of the two scopes allow access.  The domain scope is based on the number of mobile workers, and the account scope is based on the number of mobile workers the plan allows to be created in a month.

As of this writing, Standard plans get 125 mobile workers per month, Pro plans get 250, and Advanced get 500.  Enterprise plans get `UNLIMITED_FEATURE_USAGE`, which is stored as `-1`.  The rate limiting code interprets this value literally, meaning that highest tier plan gets the lowest level of access.  We don't actually want to remove rate limiting, even for enterprise plans, so here I'm adding a somewhat arbitrary limit - double the current level of the plan below it.

The last commit factors web users into the domain scope's count of users when those users are paid for.  This isn't applicable to BHA, but is good to do for the future.

None of this should decrease any existing project’s effective rate limits, and would only increase rate limits for projects where the number of mobile workers is less than this fallback value.

## Technical Summary

https://dimagi.atlassian.net/browse/SUPPORT-20037

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Tested exclusively through automated tests

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
--> 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
