### PR TITLE
Refresh Warning After Saving Polygon (Geospatial)

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -34,7 +34,7 @@ hqDefine("geospatial/js/geospatial_map", [
     function showMapControls(state) {
         $("#geospatial-map").toggle(state);
         $("#case-buttons").toggle(state);
-        $("#mapControls").toggle(state);
+        $("#polygon-filters").toggle(state);
         $("#user-filters-panel").toggle(state);
     }
 
@@ -233,7 +233,7 @@ hqDefine("geospatial/js/geospatial_map", [
 
     function initPolygonFilters() {
         // Assumes `map` var is initialized
-        const $mapControlDiv = $("#mapControls");
+        const $mapControlDiv = $("#polygon-filters");
         polygonFilterModel = new models.PolygonFilter(mapModel, false, true);
         polygonFilterModel.loadPolygons(initialPageData.get('saved_polygons'));
         if ($mapControlDiv.length) {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -800,6 +800,7 @@ hqDefine('geospatial/js/models', [
                         );
                         // redraw using mapControlsModelInstance
                         self.selectedSavedPolygonId(ret.id);
+                        self.shouldRefreshPage(true);
                     },
                     error: function () {
                         alertUser.alert_user(gettext(unexpectedErrorMessage), 'danger');

--- a/corehq/apps/geospatial/templates/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/case_grouping_map.html
@@ -30,24 +30,7 @@
   </div>
 </div>
 
-<div class="panel" id="polygon-filters">
-  <div class="row">
-    {% include 'geospatial/partials/saved_polygon_filter.html' %}
-  </div>
-  <div class="alert alert-info" style="margin-top:10px;" data-bind="visible: shouldRefreshPage">
-    {% blocktrans %}
-      Please
-      <a href="">refresh the page</a>
-      to apply the polygon filtering changes.
-    {% endblocktrans %}
-  </div>
-  <div class="alert alert-warning" data-bind="visible: hasUrlError">
-    {% blocktrans %}
-      There are too many polygons on the map. Please remove some before refreshing the page, otherwise the
-      newly added polygons will be lost.
-    {% endblocktrans %}
-  </div>
-</div>
+{% include 'geospatial/partials/saved_polygon_filter.html' with uses_disbursement='false' %}
 <div id="case-grouping-map" style="height: 500px"></div>
 
 <div class="panel-body-datatable">

--- a/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
+++ b/corehq/apps/geospatial/templates/geospatial/partials/saved_polygon_filter.html
@@ -1,33 +1,54 @@
 {% load i18n %}
-
-<div class="col-sm-8">
-    <div class="row form-horizontal">
-        <label for="saved-polygons" class="control-label col-sm-2">
-          {% trans "Filter by Saved Area" %}
-        </label>
-        <div class="col-sm-5" style="display:flex">
-            <select id="saved-polygons"
-                    class="form-control"
-                    data-bind="select2: savedPolygons,value: selectedSavedPolygonId,">
-            </select>
-            <button class="btn btn-default" data-bind="click: clearSelectedPolygonFilter, visible: selectedSavedPolygonId">
-              <i class="fa fa-remove"></i>
-            </button>
+<div class="panel" id="polygon-filters">
+    <div class="row">
+        <div class="col-sm-8">
+            <div class="row form-horizontal">
+                <label for="saved-polygons" class="control-label col-sm-2">
+                  {% trans "Filter by Saved Area" %}
+                </label>
+                <div class="col-sm-5" style="display:flex">
+                    <select id="saved-polygons"
+                            class="form-control"
+                            data-bind="select2: savedPolygons,value: selectedSavedPolygonId,">
+                    </select>
+                    <button class="btn btn-default" data-bind="click: clearSelectedPolygonFilter, visible: selectedSavedPolygonId">
+                      <i class="fa fa-remove"></i>
+                    </button>
+                </div>
+                <div class="col-sm-5">
+                    <a class="btn btn-default" data-bind="click: exportSelectedPolygonGeoJson, visible: selectedSavedPolygonId">
+                        {% trans 'Export Area' %}
+                    </a>
+                    <button class="btn btn-danger" data-toggle="modal" data-target="#delete-saved-area-modal"
+                            data-bind="visible: selectedSavedPolygonId">
+                        <i class="fa fa-trash"></i>
+                        {% trans 'Delete Area' %}
+                    </button>
+                </div>
+            </div>
         </div>
-        <div class="col-sm-5">
-            <a class="btn btn-default" data-bind="click: exportSelectedPolygonGeoJson, visible: selectedSavedPolygonId">
-                {% trans 'Export Area' %}
-            </a>
-            <button class="btn btn-danger" data-toggle="modal" data-target="#delete-saved-area-modal"
-                    data-bind="visible: selectedSavedPolygonId">
-                <i class="fa fa-trash"></i>
-                {% trans 'Delete Area' %}
-            </button>
-        </div>
+        <button id="btnSaveDrawnArea" class="btn btn-default" style="float:right; margin-right:1em"
+                data-bind="attr: { disabled: btnSaveDisabled }, click: saveGeoPolygon">
+           {% trans 'Save Area' %}
+       </button>
+       {% include 'geospatial/partials/delete_saved_area_modal.html' %}
+       {% if uses_disbursement == 'true' %}
+           <a id="btnRunDisbursement" class="col-sm-2 btn btn-primary" style="float:right; margin-right:1em" data-bind="attr: { disabled: btnRunDisbursementDisabled }">
+               {% trans 'Run Disbursement' %}
+           </a>
+       {% endif %}
     </div>
+    <div class="alert alert-info" style="margin-top:10px;" data-bind="visible: shouldRefreshPage">
+        {% blocktrans %}
+          Please
+          <a href="">refresh the page</a>
+          to apply the polygon filtering changes.
+        {% endblocktrans %}
+      </div>
+      <div class="alert alert-warning" data-bind="visible: hasUrlError">
+        {% blocktrans %}
+          There are too many polygons on the map. Please remove some before refreshing the page, otherwise the
+          newly added polygons will be lost.
+        {% endblocktrans %}
+      </div>
 </div>
- <button id="btnSaveDrawnArea" class="btn btn-default" style="float:right; margin-right:1em"
-         data-bind="attr: { disabled: btnSaveDisabled }, click: saveGeoPolygon">
-    {% trans 'Save Area' %}
-</button>
-{% include 'geospatial/partials/delete_saved_area_modal.html' %}

--- a/corehq/apps/geospatial/templates/map_visualization.html
+++ b/corehq/apps/geospatial/templates/map_visualization.html
@@ -67,12 +67,7 @@
         </button>
     </div>
 </div>
-<div class="row panel" id="mapControls">
-    {% include 'geospatial/partials/saved_polygon_filter.html' %}
-    <a id="btnRunDisbursement" class="col-sm-2 btn btn-primary" style="float:right; margin-right:1em" data-bind="attr: { disabled: btnRunDisbursementDisabled }">
-        {% trans 'Run Disbursement' %}
-    </a>
-</div>
+{% include 'geospatial/partials/saved_polygon_filter.html' with uses_disbursement='true' %}
 <div id="disbursement-spinner">
   <h4 id="loading" class="hide"
       data-bind="visible: isBusy(), css: {hide: false}">


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
An info banner is shown on the page when the user saves a new polygon, requesting a page refresh:
![Screenshot from 2024-07-01 16-57-39](https://github.com/dimagi/commcare-hq/assets/122617251/74642ca6-e38c-4474-83f4-100ec72e19f2)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3717).

After saving a new polygon in the UI, an info banner will be shown asking the user to refresh the page. Currently, when a user saves a new polygon and applies new report filters, we fetch and replace the list of saved polygons with the one given in `initialPageData`. This becomes outdated after saving a new polygon since `initialPageData` is only loaded on page load, and not when report filters are changed. Getting the user to refresh the page ensures that the latest list of saved polygons can be retrieved from the back-end.

As an alternative, I looked into using the `select2` component to fetch the latest list of saved polygons on demand. This would avoid requiring a refresh, however it will end up making the code more complex. This is because we also store and keep track of unsaved polygons drawn on the map, so that they can be added back to the map on a page refresh. Fetching saved polygons on demand using a `select2` widget would mean keeping track of two arrays, one for saved polygons and one for unsaved polygons.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

This change will only affect domains that have the Geospatial feature flag enabled.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A as changes are mostly limited to HTML templates.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
