### PR TITLE
Validate Unique Saved GeoPolygon Names (Geospatial)

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -771,12 +771,8 @@ hqDefine('geospatial/js/models', [
         self.saveGeoPolygon = function () {
             let data = self.mapObj.drawControls.getAll();
             if (data.features.length) {
-                let name = window.prompt(gettext("Name of the Area"));
-                if (name === null) {
-                    return;
-                }
-                if (name === '') {
-                    alertUser.alert_user(gettext("Please enter the name for the area!"), 'warning', false, true);
+                const name = window.prompt(gettext("Name of the Area"));
+                if (!validateSavedPolygonName(name)) {
                     return;
                 }
                 data['name'] = name;
@@ -808,6 +804,16 @@ hqDefine('geospatial/js/models', [
             }
         };
 
+        function validateSavedPolygonName(name) {
+            if (name === null) {
+                return false;
+            }
+            if (name === '') {
+                alertUser.alert_user(gettext("Please enter the name for the area!"), 'warning', false, true);
+                return false;
+            }
+            return true;
+        }
     };
 
     return {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -797,8 +797,13 @@ hqDefine('geospatial/js/models', [
                         // redraw using mapControlsModelInstance
                         self.selectedSavedPolygonId(ret.id);
                     },
-                    error: function () {
-                        alertUser.alert_user(gettext(unexpectedErrorMessage), 'danger');
+                    error: function (response) {
+                        const responseText = response.responseText;
+                        if (responseText) {
+                            alertUser.alert_user(gettext(responseText), 'danger');
+                        } else {
+                            alertUser.alert_user(gettext(unexpectedErrorMessage), 'danger');
+                        }
                     },
                 });
             }

--- a/corehq/apps/geospatial/tests/test_views.py
+++ b/corehq/apps/geospatial/tests/test_views.py
@@ -453,7 +453,7 @@ class TestGeoPolygonListView(BaseGeospatialViewClass):
             del feature['id']
         self.assertEqual(saved_polygons[0].geo_json, geo_json_data)
 
-    def _validate_error_message(self, response, message):
+    def _assert_error_message(self, response, message):
         error = response.content.decode("utf-8")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(error, message,)
@@ -461,17 +461,17 @@ class TestGeoPolygonListView(BaseGeospatialViewClass):
     @flag_enabled('GEOSPATIAL')
     def test_geo_json_validation(self):
         response = self.client.generic('POST', self.endpoint, 'foobar')
-        self._validate_error_message(
+        self._assert_error_message(
             response,
             message='POST Body must be a valid json in {"geo_json": <geo_json>} format'
         )
         response = self._make_post_request({'foo': 'bar'})
-        self._validate_error_message(
+        self._assert_error_message(
             response,
             message='Empty geo_json POST field'
         )
         response = self._make_post_request({'geo_json': {'foo': 'bar'}})
-        self._validate_error_message(
+        self._assert_error_message(
             response,
             message='Invalid GeoJSON, geo_json must be a FeatureCollection of Polygons'
         )
@@ -484,7 +484,7 @@ class TestGeoPolygonListView(BaseGeospatialViewClass):
             name='foobar',
         )
         response = self._make_post_request({'geo_json': _sample_geojson_data(name='FooBAR')})
-        self._validate_error_message(
+        self._assert_error_message(
             response,
             message='GeoPolygon with given name already exists! Please use a different name.'
         )

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -91,6 +91,13 @@ class GeoPolygonListView(BaseDomainView):
             return HttpResponseBadRequest(
                 'Invalid GeoJSON, geo_json must be a FeatureCollection of Polygons'
             )
+
+        geo_polygon_name = geo_json.pop('name')
+        if GeoPolygon.objects.filter(domain=self.domain, name__iexact=geo_polygon_name).exists():
+            return HttpResponseBadRequest(
+                'GeoPolygon with given name already exists! Please use a different name.'
+            )
+
         # Drop ids since they are specific to the Mapbox draw event
         for feature in geo_json["features"]:
             del feature['id']

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -103,7 +103,7 @@ class GeoPolygonListView(BaseDomainView):
             del feature['id']
 
         geo_polygon = GeoPolygon.objects.create(
-            name=geo_json.pop('name'),
+            name=geo_polygon_name,
             domain=self.domain,
             geo_json=geo_json
         )

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -78,17 +78,17 @@ class GeoPolygonListView(BaseDomainView):
         try:
             geo_json = json.loads(request.body).get('geo_json', None)
         except json.decoder.JSONDecodeError:
-            raise HttpResponseBadRequest(
+            return HttpResponseBadRequest(
                 'POST Body must be a valid json in {"geo_json": <geo_json>} format'
             )
 
         if not geo_json:
-            raise HttpResponseBadRequest('Empty geo_json POST field')
+            return HttpResponseBadRequest('Empty geo_json POST field')
 
         try:
             jsonschema.validate(geo_json, POLYGON_COLLECTION_GEOJSON_SCHEMA)
         except jsonschema.exceptions.ValidationError:
-            raise HttpResponseBadRequest(
+            return HttpResponseBadRequest(
                 'Invalid GeoJSON, geo_json must be a FeatureCollection of Polygons'
             )
         # Drop ids since they are specific to the Mapbox draw event


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
An error message will be shown in the UI if the user tries to save a GeoPolygon with the same name as one that already exists in the domain:
![Screenshot from 2024-07-03 11-05-45](https://github.com/dimagi/commcare-hq/assets/122617251/fed46952-4714-4f80-a944-8983ab159727)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3718).

A straightforward PR where validation is being added to the POST Django view for GeoPolygons to ensure that the given GeoPolygon name is unique. This validation is case-insensitive, so even if the same name with different capitalization is used, an error will still be shown.

Originally I wanted to do this validation in JS, however I ended up implementing the validation in the back-end to prevent the following bug:
If a user saves a new polygon and then changes the report filters, the newly saved polygon will not be available on the front-end and so the user will be able to save a polygon with the same name. This is because we fetch the list of saved polygons from `initialPageData` on page load or when changing report filters. Since this list comes from `initialPageData` which gets set in the template on page load, changing report filters means we will have a list of saved polygons which does not include the newly saved polygon.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Unit tests

This change will only affect domains that have the Geospatial feature flag enabled.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests have been implemented to verify all validation checks implemented in the `GeoPolygonListView` view.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
