### PR TITLE
Updating DHIS2 system metadata

### DIFF
--- a/corehq/motech/dhis2/const.py
+++ b/corehq/motech/dhis2/const.py
@@ -64,7 +64,7 @@ DHIS2_UID_MESSAGE = _('A DHIS2 "UID" is exactly 11 alpha-numeric characters '
 # (Used for updating cases with their tracked entity instance ID.)
 XMLNS_DHIS2 = 'http://commcarehq.org/dhis2-integration'
 
-DHIS2_MAX_KNOWN_GOOD_VERSION = "2.39.0"
+DHIS2_MAX_KNOWN_GOOD_VERSION = "2.41.0"
 
 COMPLETE_DATE_EMPTY = "complete_date_empty"
 COMPLETE_DATE_COLUMN = "complete_date_column"

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -64,7 +64,7 @@ class Dhis2Instance(object):
         maximum supported version, but still saves and continues.
         """
         requests = self.connection_settings.get_requests(self)
-        metadata = fetch_metadata(requests)
+        metadata = fetch_system_metadata(requests)
         dhis2_version = metadata["system"]["version"]
         try:
             get_api_version(dhis2_version)
@@ -258,19 +258,17 @@ def get_api_version(dhis2_version):
     return api_version
 
 
-def fetch_metadata(requests):
+def fetch_system_metadata(requests):
     """
-    Fetch metadata about a DHIS2 instance.
+    Fetch the system metadata about a DHIS2 instance.
 
-    Currently only used for determining what API version it supports.
-
-    .. NOTE::
-       Metadata is large (like a 100MB JSON document), and contains the
-       IDs one would need to compile a human-readable configuration into
-       one that maps to DHIS2 IDs.
-
+    Used for determining what API version it supports.
     """
-    response = requests.get('/api/metadata', raise_for_status=True, params={'assumeTrue': 'false'})
+    response = requests.get(
+        '/api/metadata',
+        raise_for_status=True,
+        params={'filter': 'name:eq:system'}
+    )
     return response.json()
 
 

--- a/corehq/motech/dhis2/tests/test_repeaters.py
+++ b/corehq/motech/dhis2/tests/test_repeaters.py
@@ -221,7 +221,7 @@ class SlowApiVersionTest(TestCase):
 
     def test_none_fetches_metadata(self):
         self.assertIsNone(self.repeater.dhis2_version)
-        with patch('corehq.motech.dhis2.repeaters.fetch_metadata') as mock_fetch:
+        with patch('corehq.motech.dhis2.repeaters.fetch_system_metadata') as mock_fetch:
             mock_fetch.return_value = {"system": {"version": "2.31.6"}}
             self.assertEqual(self.repeater.get_api_version(), 31)
             mock_fetch.assert_called()
@@ -230,7 +230,7 @@ class SlowApiVersionTest(TestCase):
         major_ver, max_api_ver, patch_ver = LooseVersion(KNOWN_GOOD).version
         bigly_api_version = max_api_ver + 1
         bigly_dhis2_version = f"{major_ver}.{bigly_api_version}.{patch_ver}"
-        with patch('corehq.motech.dhis2.repeaters.fetch_metadata') as mock_fetch, \
+        with patch('corehq.motech.dhis2.repeaters.fetch_system_metadata') as mock_fetch, \
                 patch.object(Requests, 'notify_error') as mock_notify:
             mock_fetch.return_value = {"system": {"version": bigly_dhis2_version}}
 


### PR DESCRIPTION
## Technical Summary

Context: [SC-3791](https://dimagi.atlassian.net/browse/SC-3791)

Drastically speeds up the DHIS2 metadata request.

This change is to avoid a 500 error experienced by one of our partners.

## Feature Flag

DHIS2 integration

## Safety Assurance

### Safety story

Local testing.

### Automated test coverage

Responses from remote DHIS2 instances is not covered by automated tests

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3791]: https://dimagi.atlassian.net/browse/SC-3791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ