### PR TITLE
Use `--default--` as placeholder text for "View Child Data to Level"

### DIFF
--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -252,7 +252,7 @@
                                     optionsText: 'name',
                                     optionsValue: 'pk',
                                     value: expand_view_child_data_to,
-                                    optionsCaption: '\u2013{% trans 'none' %}\u2013',
+                                    optionsCaption: '\u2013{% trans 'default' %}\u2013',
                                     enable: view_descendants">
                   </select>
                 </td>


### PR DESCRIPTION
## Product Description
Change default text from `--none--` to `--default--` for the "View Child Data to Level" location types option:
![image](https://github.com/dimagi/commcare-hq/assets/2367539/30fa6f6a-e3ba-4bc3-8734-3a6a0e79815c)


## Technical Summary
https://dimagi.atlassian.net/browse/USH-4647
Followup from https://github.com/dimagi/commcare-hq/pull/34427

## Feature Flag
`USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION`
USH: Limit the location-owned cases that show up in a user's restore file

## Safety Assurance

### Safety story
Local testing seems sufficient for this

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
