### PR TITLE
Minor keyboard navigation fixes

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/bootstrap3/menu_header.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/bootstrap3/menu_header.html
@@ -17,7 +17,7 @@
     <% } %>
   </div>
   <% if (title.length > 0) { %>
-    <h1  aria-label="<%- title %>" tabindex="0" class="page-title"><%- title %></h1>
+    <h1 aria-label="<%- title %>" class="page-title"><%- title %></h1>
   <% } %>
   <% if (sidebarEnabled && description.length > 0) { %>
     <div aria-label="<%- description %>" tabindex="0" class="query-description"><%= description %></div>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/bootstrap5/menu_header.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/bootstrap5/menu_header.html
@@ -17,9 +17,9 @@
     <% } %>
   </div>
   <% if (title.length > 0) { %>
-    <h1 aria-label="<%- title %>" tabindex="0" class="page-title d-none d-md-block"><%- title %></h1>
+    <h1 aria-label="<%- title %>" class="page-title d-none d-md-block"><%- title %></h1>
   <% } %>
   <% if (sidebarEnabled && description.length > 0) { %>
-    <div aria-label="<%- description %>" tabindex="0" class="query-description"><%= description %></div>
+    <div aria-label="<%- description %>" class="query-description"><%= description %></div>
   <% } %>
 </div>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/query/bootstrap3/item.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/query/bootstrap3/item.html
@@ -13,7 +13,7 @@
       <% if (typeof hint !== "undefined" && hint !== null) { %>
       <div class="hq-help">
         <a href="#" tabindex="-1"  data-title="<%- text ? text : "" %>" data-content="<%- hint ? hint : "" %>">
-          <i class="fa fa-question-circle icon-question-sign"></i>
+          <i class="fa fa-question-circle icon-question-sign" tabindex="0"></i>
         </a>
       </div>
       <% } %>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/query/bootstrap3/list.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/query/bootstrap3/list.html
@@ -24,7 +24,7 @@
         <%= description %>
       </div>
     <% } %>
-    <table class="table table-hover <%= grouped ? '' : 'table-striped table-bordered' %>" role="presentation">
+    <table class="table table-hover <%= grouped ? '' : 'table-striped table-bordered' %>">
       <tbody id="query-properties">
       </tbody>
     </table>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/query/bootstrap5/item.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/query/bootstrap5/item.html
@@ -13,7 +13,7 @@
       <% if (typeof hint !== "undefined" && hint !== null) { %>
       <div class="hq-help" data-bs-toggle="popover">
         <a href="#" tabindex="-1" title="<%- text ? text : "" %>" data-bs-content="<%- hint ? hint : "" %>">
-          <i class="fa fa-question-circle icon-question-sign"></i>
+          <i class="fa fa-question-circle icon-question-sign" tabindex="0"></i>
         </a>
       </div>
       <% } %>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/case_list/menu_header.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/case_list/menu_header.html.diff.txt
@@ -23,10 +23,11 @@
      <% } %>
    </div>
    <% if (title.length > 0) { %>
--    <h1  aria-label="<%- title %>" tabindex="0" class="page-title"><%- title %></h1>
-+    <h1 aria-label="<%- title %>" tabindex="0" class="page-title d-none d-md-block"><%- title %></h1>
+-    <h1 aria-label="<%- title %>" class="page-title"><%- title %></h1>
++    <h1 aria-label="<%- title %>" class="page-title d-none d-md-block"><%- title %></h1>
    <% } %>
    <% if (sidebarEnabled && description.length > 0) { %>
-     <div aria-label="<%- description %>" tabindex="0" class="query-description"><%= description %></div>
+-    <div aria-label="<%- description %>" tabindex="0" class="query-description"><%= description %></div>
++    <div aria-label="<%- description %>" class="query-description"><%= description %></div>
    <% } %>
 -</div>+</div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/query/item.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/query/item.html.diff.txt
@@ -20,7 +20,7 @@
 -        <a href="#" tabindex="-1"  data-title="<%- text ? text : "" %>" data-content="<%- hint ? hint : "" %>">
 +      <div class="hq-help" data-bs-toggle="popover">
 +        <a href="#" tabindex="-1" title="<%- text ? text : "" %>" data-bs-content="<%- hint ? hint : "" %>">
-           <i class="fa fa-question-circle icon-question-sign"></i>
+           <i class="fa fa-question-circle icon-question-sign" tabindex="0"></i>
          </a>
        </div>
 @@ -20,8 +20,7 @@

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/query/list.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/cloudcare/partials/query/list.html.diff.txt
@@ -20,7 +20,7 @@
          <%= description %>
        </div>
      <% } %>
--    <table class="table table-hover <%= grouped ? '' : 'table-striped table-bordered' %>" role="presentation">
+-    <table class="table table-hover <%= grouped ? '' : 'table-striped table-bordered' %>">
 +    <table class="table <%= grouped ? '' : 'table-striped table-bordered' %>" role="presentation">
        <tbody id="query-properties">
        </tbody>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This PR resolves 2 issues:
- Search screen titles are no longer tabbable
- Help/hint text bubbles are now tabbable

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4221)

Tested locally (using Bootstrap 3) and on staging (which is currently using Bootstrap 5) and and confirmed working (on staging) by Kaleb, who reported the issues. I believe the B5 migration for WebApps will go out shortly which means the changes I made to the Bootstrap 3 files won't really matter as much.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Very safe, only html changes/only affects what elements are tabbable or not. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
n/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
