### PR TITLE
Location Type 'has users' levels config frontend

### DIFF
--- a/corehq/apps/locations/static/locations/js/location_types.js
+++ b/corehq/apps/locations/static/locations/js/location_types.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine('locations/js/location_types', [
     'jquery',
     'knockout',
@@ -12,7 +13,6 @@ hqDefine('locations/js/location_types', [
     initialPageData,
     googleAnalytics
 ) {
-    'use strict';
     var ROOT_LOCATION_ID = -1;
 
     function locationSettingsViewModel(locTypes, commtrackEnabled) {
@@ -204,6 +204,8 @@ hqDefine('locations/js/location_types', [
         self.expand_from = ko.observable(locType.expand_from_root ? ROOT_LOCATION_ID : locType.expand_from);
         self.expand_to = ko.observable(locType.expand_to);
         self.expand_view_child_data_to = ko.observable(locType.expand_view_child_data_to);
+        self.has_users_setting = ko.observable(locType.has_users_setting || locType.has_users_setting === undefined); // new loc types default to true
+        self.actually_has_users = ko.observable(locType.actually_has_users);
         self.include_without_expanding = ko.observable(locType.include_without_expanding);
         self.include_only = ko.observableArray(locType.include_only || []);
 
@@ -365,6 +367,7 @@ hqDefine('locations/js/location_types', [
                 expand_from_root: self.expand_from() === ROOT_LOCATION_ID,
                 expand_to: self.expand_to() || null,
                 expand_view_child_data_to: self.expand_view_child_data_to() || null,
+                has_users: self.has_users_setting() === true,
                 include_without_expanding: self.include_without_expanding() || null,
                 include_only: self.include_only() || [],
             };

--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -168,6 +168,18 @@
                   </span>
                 </th>
               {% endif %}
+              {% if request|toggle_enabled:"LOCATION_HAS_USERS" %}
+                <th data-bind="visible: advanced_mode">
+                  {% trans "Has Users" %}
+                  <span class="hq-help-template"
+                        data-title="{% trans "Has Users" %}"
+                        data-content="{% blocktrans %}
+                            <p>Indicates whether locations of this level can have users assigned.</p>
+                            <p>You cannot turn this setting off if there are users assigned to one of the locations.</p>
+                        {% endblocktrans %}">
+                  </span>
+                </th>
+              {% endif %}
               <th></th>
             </tr>
             </thead>
@@ -255,6 +267,11 @@
                                     optionsCaption: '\u2013{% trans 'default' %}\u2013',
                                     enable: view_descendants">
                   </select>
+                </td>
+              {% endif %}
+              {% if request|toggle_enabled:"LOCATION_HAS_USERS" %}
+                <td data-bind="visible: $parent.advanced_mode">
+                  <input data-bind="checked: has_users_setting, disable: has_users_setting() && actually_has_users()" type="checkbox" />
                 </td>
               {% endif %}
               <td>

--- a/corehq/apps/locations/tests/test_views.py
+++ b/corehq/apps/locations/tests/test_views.py
@@ -11,6 +11,7 @@ from corehq.apps.locations.exceptions import LocationConsistencyError
 from corehq.apps.locations.models import LocationType
 from corehq.apps.locations.views import LocationTypesView
 from corehq.apps.users.models import WebUser
+from corehq.util.test_utils import flag_enabled
 
 OTHER_DETAILS = {
     'expand_from': None,
@@ -23,6 +24,7 @@ OTHER_DETAILS = {
     'shares_cases': False,
     'view_descendants': False,
     'expand_view_child_data_to': None,
+    'has_users': True,
 }
 
 
@@ -116,7 +118,7 @@ class LocationTypesViewTest(TestCase):
         loc_type2 = OTHER_DETAILS.copy()
         loc_type1.update({'name': "new name", 'pk': self.loc_type1.pk,
                           'view_descendants': True, 'expand_view_child_data_to': self.loc_type2.pk,
-                          'code': self.loc_type1.code})
+                          'code': self.loc_type1.code, 'shares_cases': True, 'has_users': True})
         loc_type2.update({'name': "new name 2", 'pk': self.loc_type2.pk, 'parent_type': self.loc_type1.pk,
                           'code': self.loc_type2.code})
         data = {'loc_types': [loc_type1, loc_type2]}
@@ -130,6 +132,19 @@ class LocationTypesViewTest(TestCase):
         loc_type1.update({'name': "new name", 'pk': self.loc_type1.pk, 'code': self.loc_type1.code})
         loc_type2.update({'name': "new name 2", 'pk': self.loc_type2.pk, 'parent_type': self.loc_type1.pk,
                           'view_descendants': True, 'expand_view_child_data_to': self.loc_type1.pk,
+                          'code': self.loc_type2.code})
+        data = {'loc_types': [loc_type1, loc_type2]}
+        with self.assertRaises(LocationConsistencyError):
+            self.send_request(data)
+
+    @flag_enabled('LOCATION_HAS_USERS')
+    @mock.patch('corehq.apps.locations.views.does_location_type_have_users', return_value=True)
+    def test_invalid_remove_has_users(self, _):
+        loc_type1 = OTHER_DETAILS.copy()
+        loc_type2 = OTHER_DETAILS.copy()
+        loc_type1.update({'name': "new name", 'pk': self.loc_type1.pk, 'code': self.loc_type1.code,
+                          'has_users': False})
+        loc_type2.update({'name': "new name 2", 'pk': self.loc_type2.pk, 'parent_type': self.loc_type1.pk,
                           'code': self.loc_type2.code})
         data = {'loc_types': [loc_type1, loc_type2]}
         with self.assertRaises(LocationConsistencyError):

--- a/corehq/apps/locations/tests/test_views.py
+++ b/corehq/apps/locations/tests/test_views.py
@@ -7,6 +7,8 @@ from django.urls import reverse
 from unittest import mock
 
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.es.tests.utils import es_test
+from corehq.apps.es.users import user_adapter
 from corehq.apps.locations.exceptions import LocationConsistencyError
 from corehq.apps.locations.models import LocationType
 from corehq.apps.locations.views import LocationTypesView
@@ -28,6 +30,7 @@ OTHER_DETAILS = {
 }
 
 
+@es_test(requires=[user_adapter])
 class LocationTypesViewTest(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -345,6 +345,8 @@ class LocationTypesView(BaseDomainView):
                                           if loc_type.include_without_expanding_id else None),
             'include_only': list(loc_type.include_only.values_list('pk', flat=True)),
             'expand_view_child_data_to': loc_type.expand_view_child_data_to_id,
+            'has_users_setting': loc_type.has_users,
+            'actually_has_users': does_location_type_have_users(loc_type),
         } for loc_type in LocationType.objects.by_domain(self.domain)]
 
     @method_decorator(lock_locations)
@@ -372,6 +374,7 @@ class LocationTypesView(BaseDomainView):
             loc_type.parent_type = parent
             loc_type.shares_cases = shares_cases
             loc_type.view_descendants = view_descendants
+            loc_type.has_users = kwargs.get('has_users')
             loc_type.code = unicode_slug(code)
             sql_loc_types[pk] = loc_type
             loc_type.save()

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -72,6 +72,9 @@ from corehq.apps.locations.dbaccessors import get_filtered_locations_count
 
 logger = logging.getLogger(__name__)
 
+VALID_LOCATION_TYPE_PROPERTIES = ['name', 'parent_type', 'administrative', 'shares_cases', 'view_descendants',
+                                  'pk', 'expand_view_child_data_to', 'has_users']
+
 
 @location_safe
 @locations_access_required
@@ -352,7 +355,7 @@ class LocationTypesView(BaseDomainView):
         def _is_fake_pk(pk):
             return isinstance(pk, str) and pk.startswith("fake-pk-")
 
-        def mk_loctype(name, parent_type, administrative,
+        def _mk_loctype(name, parent_type, administrative,
                        shares_cases, view_descendants, pk, code, **kwargs):
             parent = sql_loc_types[parent_type] if parent_type else None
 
@@ -373,7 +376,7 @@ class LocationTypesView(BaseDomainView):
             sql_loc_types[pk] = loc_type
             loc_type.save()
 
-        def unique_name_and_code():
+        def _unique_name_and_code():
             current_location_types = LocationType.objects.by_domain(request.domain)
             for location_type in current_location_types:
                 if location_type.pk in payload_loc_type_name_by_pk:
@@ -389,7 +392,12 @@ class LocationTypesView(BaseDomainView):
                         return False
             return True
 
-        def _verify_has_users_config(loc_type_payload, pk):
+        def _validate_properties(loc_type):
+            for prop in VALID_LOCATION_TYPE_PROPERTIES:
+                if prop not in loc_type:
+                    raise LocationConsistencyError("Missing an organization level property!")
+
+        def _validate_has_users_config(loc_type_payload, pk):
             if not loc_type.get('has_users'):
                 if _is_fake_pk(pk):
                     return
@@ -403,10 +411,7 @@ class LocationTypesView(BaseDomainView):
         payload_loc_type_name_by_pk = {}
         payload_loc_type_code_by_pk = {}
         for loc_type in loc_types:
-            for prop in ['name', 'parent_type', 'administrative',
-                         'shares_cases', 'view_descendants', 'pk', 'expand_view_child_data_to']:
-                if prop not in loc_type:
-                    raise LocationConsistencyError("Missing an organization level property!")
+            _validate_properties(loc_type)
             pk = loc_type['pk']
             if not _is_fake_pk(pk):
                 pks.append(loc_type['pk'])
@@ -415,7 +420,7 @@ class LocationTypesView(BaseDomainView):
             if loc_type.get('code'):
                 payload_loc_type_code_by_pk[loc_type['pk']] = loc_type['code']
             if toggles.LOCATION_HAS_USERS.enabled(self.domain):
-                _verify_has_users_config(loc_type, pk)
+                _validate_has_users_config(loc_type, pk)
         names = list(payload_loc_type_name_by_pk.values())
         names_are_unique = len(names) == len(set(names))
         codes = list(payload_loc_type_code_by_pk.values())
@@ -423,7 +428,7 @@ class LocationTypesView(BaseDomainView):
         if not names_are_unique or not codes_are_unique:
             raise LocationConsistencyError("'name' and 'code' are supposed to be unique")
 
-        if not unique_name_and_code():
+        if not _unique_name_and_code():
             messages.error(request, LocationConsistencyError(_(
                 "Looks like you are assigning a location name/code to a different location "
                 "in the same request. Please do this in two separate updates by using a "
@@ -437,7 +442,7 @@ class LocationTypesView(BaseDomainView):
 
         for loc_type in hierarchy:
             # make all locations in order
-            mk_loctype(**loc_type)
+            _mk_loctype(**loc_type)
 
         for loc_type in hierarchy:
             # apply sync boundaries (expand_from, expand_to and include_without_expanding) after the


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

[Jira](https://dimagi.atlassian.net/browse/USH-4655)

No user facing effects, this is just part of a feature that's in dev behind a FF until ready for release.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Think it's mostly straightforward. Please feel free to suggest better names for the variables, `has_users_setting` and `actually_has_users`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

Dev feature flag, LOCATION_HAS_USERS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- All changes should be behind a dev FF
- Tested locally with and without FF enabled
- There is some existing automated test coverage for the view

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

corehq/apps/locations/tests/test_views.py

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

QA will happen when dev for this feature finishes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
