### PR TITLE
Handle Filtering by Groups Containing Single User

### DIFF
--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -115,7 +115,15 @@ def get_case_owners(request, domain, mobile_user_and_group_slugs):
                     )).fields(["users"])
             )
             user_lists = [group["users"] for group in report_group_q.run().hits]
-            selected_reporting_group_users = list(set().union(*user_lists))
+            selected_reporting_group_users = set()
+            for element in user_lists:
+                if isinstance(element, list):
+                    # Groups containing multiple users will be returned as a list.
+                    selected_reporting_group_users |= set(element)
+                else:
+                    # Groups containing a single user will be returned as single elements in query.
+                    selected_reporting_group_users.add(element)
+            selected_reporting_group_users = list(selected_reporting_group_users)
 
     # Get user ids for each user that was specifically selected
     selected_user_ids = EMWF.selected_user_ids(mobile_user_and_group_slugs)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Filtering by groups on reports that support owner filtering (e.g. Case List) should now correctly show results if the group only contains a single user.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3400).

Currently, when a user filters a report by a group containing only a single user the report will incorrectly show no results, even if there are cases associated with the user in the group. This is because the group ES query returns groups containing a single user as a string of the user ID and not a list containing the user ID as is with groups containing multiple users. When we parse the query results using `list(set().union(*user_lists))`, the user ID incorrectly gets split up as individual characters into a list, causing no results to be returned in the report.

This PR addresses the above problem by correctly handling both scenarios in which results from the query could either be single user ID strings, or a list of user ID strings.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
