### PR TITLE
Specify UTF-8 encoding for enterprise report downloads

### DIFF
--- a/corehq/apps/enterprise/tests/test_views.py
+++ b/corehq/apps/enterprise/tests/test_views.py
@@ -39,10 +39,6 @@ class EnterpriseDashboardDownloadTests(SimpleTestCase):
         reload(views)
 
     def setUp(self):
-        super().setUp()
-        self._patch_decorators()
-        reload(views)
-
         filename_patcher = patch.object(views, '_get_export_filename', return_value='test_file.csv')
         self.mock_get_filename = filename_patcher.start()
         self.addCleanup(filename_patcher.stop)

--- a/corehq/apps/enterprise/tests/test_views.py
+++ b/corehq/apps/enterprise/tests/test_views.py
@@ -1,0 +1,64 @@
+from django.test import SimpleTestCase, RequestFactory
+from importlib import reload
+from unittest.mock import patch
+
+from corehq.apps.enterprise import views
+
+from corehq.apps.enterprise import decorators as enterprise_decorators
+from corehq.apps.domain import decorators as domain_decorators
+
+from codecs import BOM_UTF8
+
+
+class EnterpriseDashboardDownloadTests(SimpleTestCase):
+    def test_bom_is_inserted_at_start_of_file(self):
+        request = RequestFactory().get('/')
+        self.mock_get_export_content.return_value = '1234'
+
+        response = views.enterprise_dashboard_download(request, 'test-domain', 'test-report', 'some-hash-id')
+        self.assertEqual(response.content, BOM_UTF8 + b'1234')
+
+    def test_mimetype_is_set_to_csv(self):
+        request = RequestFactory().get('/')
+        response = views.enterprise_dashboard_download(request, 'test-domain', 'test-report', 'some-hash-id')
+
+        self.assertEqual(response.headers['Content-Type'], 'text/csv; charset=UTF-8')
+
+    def test_filename_is_set_correctly(self):
+        request = RequestFactory().get('/')
+        self.mock_get_filename.return_value = 'myreport.csv'
+
+        response = views.enterprise_dashboard_download(request, 'test-domain', 'test-report', 'some-hash-id')
+
+        self.assertEqual(response.headers['Content-Disposition'], 'attachment; filename="myreport.csv"')
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._patch_decorators()
+        reload(views)
+
+    def setUp(self):
+        super().setUp()
+        self._patch_decorators()
+        reload(views)
+
+        filename_patcher = patch.object(views, '_get_export_filename', return_value='test_file.csv')
+        self.mock_get_filename = filename_patcher.start()
+        self.addCleanup(filename_patcher.stop)
+
+        content_patcher = patch.object(views, '_get_export_content', return_value='some_content')
+        self.mock_get_export_content = content_patcher.start()
+        self.addCleanup(content_patcher.stop)
+
+    @classmethod
+    def _patch_decorators(cls):
+        require_enterprise_admin_patcher = patch.object(
+            enterprise_decorators, 'require_enterprise_admin', lambda x: x)
+        require_enterprise_admin_patcher.start()
+        cls.addClassCleanup(require_enterprise_admin_patcher.stop)
+
+        login_and_domain_required_patcher = patch.object(
+            domain_decorators, 'login_and_domain_required', lambda x: x)
+        login_and_domain_required_patcher.start()
+        cls.addClassCleanup(login_and_domain_required_patcher.stop)


### PR DESCRIPTION
## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15743

Django, by default, encodes its HTTP responses with UTF-8. Excel, by default, reads files as if they were using ASCII. This means that, when a CSV includes a character like `é`, Excel reads it as `√©`. Specifying a leading Byte Order Marker (BOM) allows Excel to detect the UTF-8 encoding automatically and display everything correctly.

In addition, it appears that the MIME-type for these downloads has never been correct (it was a dictionary), so I've corrected to it 'text/csv; charset=UTF-8'.

While adding tests, I noticed how awkward it was that we only create an enterprise report in order to determine it's filename. I feel like it would make a lot of sense to simply store the filename along with its contents, and thus we'd only need to pull from redis. However, I think that kind of change would be kind of tricky, as it would mean we'd risk any existing download links would break. Since this functionality wasn't broken, I opted not to fix it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Verified this change by performing local downloads, verifying their response headers in the Chrome Inspector, and then verifying the downloaded contents within Excel.

### Automated test coverage

I've corrected my laziness and added the appropriate tests in the new test suite _test_views_

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
