### PR TITLE
Add operational toggle PAUSE_DATA_FORWARDING

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -352,7 +352,7 @@ class Repeater(RepeaterSuperProxy):
 
     @property
     def is_ready(self):
-        if self.is_paused:
+        if self.is_paused or toggles.PAUSE_DATA_FORWARDING.enabled(self.domain):
             return False
         if not (self.next_attempt_at is None
                 or self.next_attempt_at < timezone.now()):

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -33,6 +33,7 @@ from .models import (
     get_payload,
     send_request,
 )
+from corehq import toggles
 
 _check_repeaters_buckets = make_buckets_from_timedeltas(
     timedelta(seconds=10),
@@ -161,7 +162,7 @@ def _process_repeat_record(repeat_record):
         return
 
     try:
-        if repeat_record.repeater.is_paused:
+        if repeat_record.repeater.is_paused or toggles.PAUSE_DATA_FORWARDING.enabled(repeat_record.domain):
             # postpone repeat record by MAX_RETRY_WAIT so that it is not fetched
             # in the next check to process repeat records, which helps to avoid
             # clogging the queue

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1138,6 +1138,13 @@ HIDE_SYNC_BUTTON = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
+PAUSE_DATA_FORWARDING = StaticToggle(
+    'pause_data_forwarding',
+    "Pause all data forwarding from this domain",
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 PERSISTENT_MENU_SETTING = StaticToggle(
     "persistent_menu_setting",
     "Show Persistent Menu option in Web Apps settings",


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-15734

## Technical Summary

This flag makes the system treat all repeaters in a domain as paused.

This _does not_ mark the repeater as paused in the UI (as a user has no agency to unpause it through the UI).

## Feature Flag
PAUSE_DATA_FORWARDING

## Safety Assurance

### Safety story
This piggy backs off on existing functionality, and simply creates a new way to activate it. Most of the ways it could fail would be easily detectable by tests (like a syntax error or such). The other way would be if it behaves subtly differently from then a single repeater is paused, but I searched for all usages so I think that's covered.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
