### PR TITLE
Add Enterprise Report OData APIs

### DIFF
--- a/corehq/apps/api/odata/views.py
+++ b/corehq/apps/api/odata/views.py
@@ -113,7 +113,7 @@ class ODataCaseMetadataView(BaseODataView):
 
         metadata = render_to_string('api/odata_metadata.xml', {
             'fields': case_fields,
-            'primary_key': primary_key,
+            'primary_key': (primary_key,),
         })
         track_partner_access(ACCESS_ODATA, domain)
         return add_odata_headers(HttpResponse(metadata, content_type='application/xml'))
@@ -168,7 +168,7 @@ class ODataFormMetadataView(BaseODataView):
 
         metadata = render_to_string('api/odata_metadata.xml', {
             'fields': form_fields,
-            'primary_key': primary_key,
+            'primary_key': (primary_key,),
         })
         track_partner_access(ACCESS_ODATA, domain)
         return add_odata_headers(HttpResponse(metadata, content_type='application/xml'))

--- a/corehq/apps/api/odata/views.py
+++ b/corehq/apps/api/odata/views.py
@@ -113,7 +113,7 @@ class ODataCaseMetadataView(BaseODataView):
 
         metadata = render_to_string('api/odata_metadata.xml', {
             'fields': case_fields,
-            'primary_key': (primary_key,),
+            'primary_keys': (primary_key,),
         })
         track_partner_access(ACCESS_ODATA, domain)
         return add_odata_headers(HttpResponse(metadata, content_type='application/xml'))
@@ -168,7 +168,7 @@ class ODataFormMetadataView(BaseODataView):
 
         metadata = render_to_string('api/odata_metadata.xml', {
             'fields': form_fields,
-            'primary_key': (primary_key,),
+            'primary_keys': (primary_key,),
         })
         track_partner_access(ACCESS_ODATA, domain)
         return add_odata_headers(HttpResponse(metadata, content_type='application/xml'))

--- a/corehq/apps/api/templates/api/odata_metadata.xml
+++ b/corehq/apps/api/templates/api/odata_metadata.xml
@@ -4,7 +4,9 @@
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CommCare">
             <EntityType Name="feed" >
                 <Key>
-                    <PropertyRef Name="{{ primary_key }}" />
+                    {% for field in primary_key %}
+                    <PropertyRef Name="{{ field }}" />
+                    {% endfor %}
                 </Key>
                 {% for field in fields %}
                 <Property Name="{{ field.name }}" Type="{{ field.odata_type }}" />

--- a/corehq/apps/api/templates/api/odata_metadata.xml
+++ b/corehq/apps/api/templates/api/odata_metadata.xml
@@ -4,7 +4,7 @@
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CommCare">
             <EntityType Name="feed" >
                 <Key>
-                    {% for field in primary_key %}
+                    {% for field in primary_keys %}
                     <PropertyRef Name="{{ field }}" />
                     {% endfor %}
                 </Key>

--- a/corehq/apps/enterprise/api/__init__.py
+++ b/corehq/apps/enterprise/api/__init__.py
@@ -1,0 +1,1 @@
+from corehq.apps.enterprise.api.api import v1_api  # noqa: F401

--- a/corehq/apps/enterprise/api/api.py
+++ b/corehq/apps/enterprise/api/api.py
@@ -1,0 +1,5 @@
+from tastypie.api import Api
+from corehq.apps.enterprise.api.resources import DomainResource
+
+v1_api = Api(api_name='v1')
+v1_api.register(DomainResource())

--- a/corehq/apps/enterprise/api/api.py
+++ b/corehq/apps/enterprise/api/api.py
@@ -1,5 +1,13 @@
 from tastypie.api import Api
-from corehq.apps.enterprise.api.resources import DomainResource
+from corehq.apps.enterprise.api.resources import (
+    DomainResource,
+    WebUserResource,
+    MobileUserResource,
+    ODataFeedResource,
+)
 
 v1_api = Api(api_name='v1')
 v1_api.register(DomainResource())
+v1_api.register(WebUserResource())
+v1_api.register(MobileUserResource())
+v1_api.register(ODataFeedResource())

--- a/corehq/apps/enterprise/api/api.py
+++ b/corehq/apps/enterprise/api/api.py
@@ -1,10 +1,11 @@
 from tastypie.api import Api
+
 from corehq.apps.enterprise.api.resources import (
     DomainResource,
-    WebUserResource,
-    MobileUserResource,
     FormSubmissionResource,
+    MobileUserResource,
     ODataFeedResource,
+    WebUserResource,
 )
 
 v1_api = Api(api_name='v1')

--- a/corehq/apps/enterprise/api/api.py
+++ b/corehq/apps/enterprise/api/api.py
@@ -3,6 +3,7 @@ from corehq.apps.enterprise.api.resources import (
     DomainResource,
     WebUserResource,
     MobileUserResource,
+    FormSubmissionResource,
     ODataFeedResource,
 )
 
@@ -10,4 +11,5 @@ v1_api = Api(api_name='v1')
 v1_api.register(DomainResource())
 v1_api.register(WebUserResource())
 v1_api.register(MobileUserResource())
+v1_api.register(FormSubmissionResource())
 v1_api.register(ODataFeedResource())

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -96,9 +96,13 @@ class ODataResource(HqBaseResource):
         self.throttle_check(request)
         self.log_throttled_access(request)
 
+        primary_key = self.get_primary_key()
+        if not (isinstance(primary_key, list) or isinstance(primary_key, tuple)):
+            primary_key = (primary_key,)
+
         metadata = render_to_string('api/odata_metadata.xml', {
             'fields': self.get_fields(),
-            'primary_key': self.get_primary_key(),
+            'primary_key': primary_key,
         })
 
         return add_odata_headers(HttpResponse(metadata, content_type='application/xml'))

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -283,6 +283,7 @@ class ODataFeedResource(ODataEnterpriseResource):
 
 
 class FormSubmissionResource(ODataEnterpriseResource):
+    form_id = fields.CharField()
     form_name = fields.CharField()
     submitted = fields.DateTimeField()
     app_name = fields.CharField()
@@ -293,20 +294,22 @@ class FormSubmissionResource(ODataEnterpriseResource):
         enddate = datetime.strptime(request.GET['enddate'], '%Y-%m-%d') if 'enddate' in request.GET else None
         startdate = datetime.strptime(request.GET['startdate'], '%Y-%m-%d') if 'startdate' in request.GET else None
         account = BillingAccount.get_account_by_domain(request.domain)
-        report = EnterpriseFormReport(account, request.couch_user, start_date=startdate, end_date=enddate)
+        report = EnterpriseFormReport(
+            account, request.couch_user, start_date=startdate, end_date=enddate, include_form_id=True)
         return report.rows
 
     def obj_get_list(self, bundle, **kwargs):
         return self.get_object_list(bundle.request)
 
     def dehydrate(self, bundle):
-        bundle.data['form_name'] = bundle.obj[0]
-        bundle.data['submitted'] = self.convert_datetime(bundle.obj[1])
-        bundle.data['app_name'] = bundle.obj[2]
-        bundle.data['mobile_user'] = bundle.obj[3]
-        bundle.data['domain'] = bundle.obj[5]
+        bundle.data['form_id'] = bundle.obj[0]
+        bundle.data['form_name'] = bundle.obj[1]
+        bundle.data['submitted'] = self.convert_datetime(bundle.obj[2])
+        bundle.data['app_name'] = bundle.obj[3]
+        bundle.data['mobile_user'] = bundle.obj[4]
+        bundle.data['domain'] = bundle.obj[6]
 
         return bundle
 
     def get_primary_key(self):
-        return 'form_name'
+        return ('form_id', 'submitted',)

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -1,0 +1,141 @@
+from dateutil import tz
+from datetime import datetime
+from tastypie import fields
+from urllib.parse import urljoin
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+from corehq.apps.api.resources import HqBaseResource
+from corehq.apps.api.resources.auth import ODataAuthentication
+from corehq.apps.enterprise.enterprise import EnterpriseDomainReport
+from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.api.odata.views import add_odata_headers
+from corehq.apps.api.odata.utils import FieldMetadata
+
+
+class ODataResource(HqBaseResource):
+    class Meta:
+        include_resource_uri = False
+        collection_name = 'value'
+        authentication = ODataAuthentication()
+        limit = 10
+        max_limit = 20
+
+    def alter_list_data_to_serialize(self, request, data):
+        result = super().alter_list_data_to_serialize(request, data)
+
+        meta = result['meta']
+        result['@odata.count'] = meta['total_count']
+        if 'next' in meta and meta['next']:
+            result['@odata.nextLink'] = request.build_absolute_uri(meta['next'])
+
+        del result['meta']
+        return result
+
+    def determine_format(self, request):
+        # Currently a hack to force JSON. XML is supported by OData, but "Control Information" fields
+        # (https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#_Toc38457735)
+        # are not valid attribute names in XML -- instead, they need to be implemented on the object's element.
+        # https://docs.oasis-open.org/odata/odata-atom-format/v4.0/cs02/odata-atom-format-v4.0-cs02.html#_Entity
+        # provides an example.
+        # In the interrim, we forcing JSON to avoid XML is the best option
+        return 'application/json'
+
+    def create_response(self, request, data, response_class=HttpResponse, **response_kwargs):
+        response = super().create_response(request, data, response_class, **response_kwargs)
+        response['OData-Version'] = '4.0'
+        return response
+
+    def get_schema(self, request, **kwargs):
+        """
+        Returns a serialized form of the schema of the resource.
+
+        Calls ``build_schema`` to generate the data. This method only responds
+        to HTTP GET.
+
+        Should return a HttpResponse (200 OK).
+        """
+        # ripped from Tastypie Resource's get_schema, only skipping building the bundle and using create_response
+        self.method_check(request, allowed=['get'])
+        self.is_authenticated(request)
+        self.throttle_check(request)
+        self.log_throttled_access(request)
+
+        metadata = render_to_string('api/odata_metadata.xml', {
+            'fields': self.get_fields(),
+            'primary_key': self.get_primary_key(),
+        })
+
+        return add_odata_headers(HttpResponse(metadata, content_type='application/xml'))
+
+    def get_fields(self):
+        result = []
+        for field_name, field_object in self.fields.items():
+            result.append(FieldMetadata(field_name, self.get_odata_class(field_object)))
+
+        return result
+
+    @staticmethod
+    def get_odata_class(field_object):
+        mapping = {
+            fields.CharField: 'Edm.String',
+            fields.DateTimeField: 'Edm.DateTimeOffset',
+            fields.IntegerField: 'Edm.Int32'
+        }
+
+        for field_type, odata_type_name in mapping.items():
+            if isinstance(field_object, field_type):
+                return odata_type_name
+
+        raise KeyError(type(field_object))
+
+    def get_primary_key(self):
+        raise NotImplementedError()
+
+
+class DomainResource(ODataResource):
+    domain = fields.CharField()
+    created_on = fields.DateTimeField()
+    num_apps = fields.IntegerField()
+    num_mobile_users = fields.IntegerField()
+    num_web_users = fields.IntegerField()
+    num_sms_last_30_days = fields.IntegerField()
+    last_form_submission = fields.DateTimeField()
+
+    def get_object_list(self, request):
+        account = BillingAccount.get_account_by_domain(request.domain)
+        report = EnterpriseDomainReport(account, request.couch_user)
+        return report.rows
+
+    def obj_get_list(self, bundle, **kwargs):
+        return self.get_object_list(bundle.request)
+
+    def dehydrate(self, bundle):
+        bundle.data['domain'] = bundle.obj[6]
+        bundle.data['created_on'] = self.convert_date(bundle.obj[0])
+        bundle.data['num_apps'] = bundle.obj[1]
+        bundle.data['num_mobile_users'] = bundle.obj[2]
+        bundle.data['num_web_users'] = bundle.obj[3]
+        bundle.data['num_sms_last_30_days'] = bundle.obj[4]
+        bundle.data['last_form_submission'] = self.convert_date(bundle.obj[5])
+
+        return bundle
+
+    @staticmethod
+    def convert_date(date_string):
+        # OData's edm:DateTimeOffset expects datetimes in ISO format: https://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part3-csdl/odata-v4.0-errata02-os-part3-csdl-complete.html#_Toc406398065  # noqa: E501
+        if not date_string:
+            return None
+
+        time = datetime.strptime(date_string, '%Y/%m/%d %H:%M:%S')
+        time = time.astimezone(tz.gettz('UTC'))
+        return time.isoformat()
+
+    def alter_list_data_to_serialize(self, request, data):
+        result = super().alter_list_data_to_serialize(request, data)
+        path = urljoin(request.get_full_path(), 'schema/#feed')
+        result['@odata.context'] = request.build_absolute_uri(path)
+
+        return result
+
+    def get_primary_key(self):
+        return 'domain'

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -1,28 +1,30 @@
-from dateutil import tz
 from datetime import datetime
-from tastypie import fields
-from tastypie.exceptions import ImmediateHttpResponse
 from urllib.parse import urljoin
+
 from django.http import HttpResponse, HttpResponseForbidden
 from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
+
+from dateutil import tz
+from tastypie import fields
+from tastypie.exceptions import ImmediateHttpResponse
+
+from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.accounting.utils.account import (
+    get_account_or_404,
+    request_has_permissions_for_enterprise_admin,
+)
+from corehq.apps.api.odata.utils import FieldMetadata
+from corehq.apps.api.odata.views import add_odata_headers
 from corehq.apps.api.resources import HqBaseResource
 from corehq.apps.api.resources.auth import ODataAuthentication
 from corehq.apps.enterprise.enterprise import (
     EnterpriseDomainReport,
-    EnterpriseWebUserReport,
-    EnterpriseMobileWorkerReport,
     EnterpriseFormReport,
+    EnterpriseMobileWorkerReport,
     EnterpriseODataReport,
+    EnterpriseWebUserReport,
 )
-from corehq.apps.api.odata.views import add_odata_headers
-from corehq.apps.api.odata.utils import FieldMetadata
-from corehq.apps.accounting.utils.account import (
-    request_has_permissions_for_enterprise_admin,
-    get_account_or_404,
-)
-
-from corehq.apps.accounting.models import BillingAccount
 
 
 class EnterpriseODataAuthentication(ODataAuthentication):
@@ -71,7 +73,7 @@ class ODataResource(HqBaseResource):
         # are not valid attribute names in XML -- instead, they need to be implemented on the object's element.
         # https://docs.oasis-open.org/odata/odata-atom-format/v4.0/cs02/odata-atom-format-v4.0-cs02.html#_Entity
         # provides an example.
-        # In the interrim, we forcing JSON to avoid XML is the best option
+        # In the interrim, it seems forcing JSON to avoid XML is the best option
         return 'application/json'
 
     def create_response(self, request, data, response_class=HttpResponse, **response_kwargs):
@@ -273,7 +275,7 @@ class ODataFeedResource(ODataEnterpriseResource):
         return bundle
 
     def get_primary_key(self):
-        return 'report_name'
+        return 'report_name'  # very odd report that makes coming up with an actual key challenging
 
 
 class FormSubmissionResource(ODataEnterpriseResource):

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -19,6 +19,7 @@ from corehq.apps.api.odata.views import add_odata_headers
 from corehq.apps.api.resources import HqBaseResource
 from corehq.apps.api.resources.auth import ODataAuthentication
 from corehq.apps.enterprise.enterprise import (
+    EnterpriseReport,
     EnterpriseDomainReport,
     EnterpriseFormReport,
     EnterpriseMobileWorkerReport,
@@ -83,12 +84,8 @@ class ODataResource(HqBaseResource):
 
     def get_schema(self, request, **kwargs):
         """
-        Returns a serialized form of the schema of the resource.
-
-        Calls ``build_schema`` to generate the data. This method only responds
-        to HTTP GET.
-
-        Should return a HttpResponse (200 OK).
+        Returns the OData Schema Representation of this resource, in XML.
+        Only supports GET requests.
         """
         # ripped from Tastypie Resource's get_schema, only skipping building the bundle and using create_response
         self.method_check(request, allowed=['get'])
@@ -136,7 +133,7 @@ class ODataResource(HqBaseResource):
         if not datetime_string:
             return None
 
-        time = datetime.strptime(datetime_string, '%Y/%m/%d %H:%M:%S')
+        time = datetime.strptime(datetime_string, EnterpriseReport.DATE_ROW_FORMAT)
         time = time.astimezone(tz.gettz('UTC'))
         return time.isoformat()
 
@@ -253,6 +250,11 @@ class MobileUserResource(ODataEnterpriseResource):
 
 
 class ODataFeedResource(ODataEnterpriseResource):
+    '''
+    A Resource for listing all Domain-level OData feeds which belong to the Enterprise.
+    Currently includes summary rows as well as individual reports
+    '''
+
     domain = fields.CharField(null=True)
     num_feeds_used = fields.IntegerField(null=True)
     num_feeds_available = fields.IntegerField(null=True)

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -96,13 +96,11 @@ class ODataResource(HqBaseResource):
         self.throttle_check(request)
         self.log_throttled_access(request)
 
-        primary_key = self.get_primary_key()
-        if not (isinstance(primary_key, list) or isinstance(primary_key, tuple)):
-            primary_key = (primary_key,)
+        primary_keys = self.get_primary_keys()
 
         metadata = render_to_string('api/odata_metadata.xml', {
             'fields': self.get_fields(),
-            'primary_key': primary_key,
+            'primary_keys': primary_keys,
         })
 
         return add_odata_headers(HttpResponse(metadata, content_type='application/xml'))
@@ -129,7 +127,7 @@ class ODataResource(HqBaseResource):
 
         raise KeyError(type(field_object))
 
-    def get_primary_key(self):
+    def get_primary_keys(self):
         raise NotImplementedError()
 
     @classmethod
@@ -176,8 +174,8 @@ class DomainResource(ODataEnterpriseResource):
 
         return bundle
 
-    def get_primary_key(self):
-        return 'domain'
+    def get_primary_keys(self):
+        return ('domain',)
 
 
 class WebUserResource(ODataEnterpriseResource):
@@ -212,8 +210,8 @@ class WebUserResource(ODataEnterpriseResource):
     def convert_not_available(cls, value):
         return None if value == 'N/A' else value
 
-    def get_primary_key(self):
-        return 'email'
+    def get_primary_keys(self):
+        return ('email',)
 
 
 class MobileUserResource(ODataEnterpriseResource):
@@ -250,8 +248,8 @@ class MobileUserResource(ODataEnterpriseResource):
 
         return bundle
 
-    def get_primary_key(self):
-        return 'user_id'
+    def get_primary_keys(self):
+        return ('user_id',)
 
 
 class ODataFeedResource(ODataEnterpriseResource):
@@ -278,8 +276,8 @@ class ODataFeedResource(ODataEnterpriseResource):
 
         return bundle
 
-    def get_primary_key(self):
-        return 'report_name'  # very odd report that makes coming up with an actual key challenging
+    def get_primary_keys(self):
+        return ('report_name',)  # very odd report that makes coming up with an actual key challenging
 
 
 class FormSubmissionResource(ODataEnterpriseResource):
@@ -311,5 +309,5 @@ class FormSubmissionResource(ODataEnterpriseResource):
 
         return bundle
 
-    def get_primary_key(self):
+    def get_primary_keys(self):
         return ('form_id', 'submitted',)

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -33,6 +33,8 @@ class EnterpriseReport:
     FORM_SUBMISSIONS = 'form_submissions'
     ODATA_FEEDS = 'odata_feeds'
 
+    DATE_ROW_FORMAT = '%Y/%m/%d %H:%M:%S'
+
     title = _('Enterprise Report')
     subtitle = ''
 
@@ -71,7 +73,7 @@ class EnterpriseReport:
             raise EnterpriseReportError(_("Unrecognized report '{}'").format(slug))
 
     def format_date(self, date):
-        return date.strftime('%Y/%m/%d %H:%M:%S') if date else ''
+        return date.strftime(self.DATE_ROW_FORMAT) if date else ''
 
     def domain_properties(self, domain_obj):
         return [

--- a/corehq/apps/enterprise/tests/test_enterprise.py
+++ b/corehq/apps/enterprise/tests/test_enterprise.py
@@ -1,11 +1,13 @@
 from django.test import SimpleTestCase, override_settings
+from datetime import datetime
+from freezegun import freeze_time
 from unittest.mock import patch, MagicMock
 
 from corehq.apps.export.models.new import FormExportInstance
 from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.domain.models import Domain
 from corehq.apps.export.dbaccessors import ODataExportFetcher
-from corehq.apps.enterprise.enterprise import EnterpriseODataReport
+from corehq.apps.enterprise.enterprise import EnterpriseODataReport, EnterpriseFormReport
 
 
 @override_settings(BASE_ADDRESS='localhost:8000')
@@ -126,3 +128,50 @@ class EnterpriseODataReportTests(SimpleTestCase):
         report = EnterpriseODataReport(self.billing_account, None)
         report.domains = MagicMock(return_value=domains)
         return report
+
+
+@freeze_time(datetime(month=10, day=1, year=2024))
+class EnterpriseFormReportTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.billing_account = BillingAccount()
+
+    def test_constructor_with_no_datespan_defaults_to_last_30_days(self):
+        report = EnterpriseFormReport(self.billing_account, None)
+
+        self.assertEqual(report.datespan.startdate, datetime(month=9, day=1, year=2024))
+        self.assertEqual(report.datespan.enddate, datetime(month=10, day=1, year=2024))
+        self.assertEqual(report.subtitle, 'past 30 days')
+
+    def test_constructor_with_provided_dates_uses_that_datespan(self):
+        start_date = datetime(month=11, day=25, year=2023)
+        end_date = datetime(month=12, day=15, year=2023)
+        report = EnterpriseFormReport(self.billing_account, None, start_date=start_date, end_date=end_date)
+
+        self.assertEqual(report.datespan.startdate, start_date)
+        self.assertEqual(report.datespan.enddate, end_date)
+        self.assertEqual(report.subtitle, '2023-11-25 to 2023-12-15')
+
+    def test_constructor_with_only_end_date_uses_default_num_days(self):
+        end_date = datetime(month=10, day=1, year=2020)
+        report = EnterpriseFormReport(self.billing_account, None, end_date=end_date)
+
+        self.assertEqual(report.datespan.startdate, datetime(month=9, day=1, year=2020))
+        self.assertEqual(report.datespan.enddate, end_date)
+
+    def test_constructor_with_only_end_date_uses_num_days(self):
+        end_date = datetime(month=10, day=1, year=2020)
+        report = EnterpriseFormReport(self.billing_account, None, end_date=end_date, num_days=10)
+
+        self.assertEqual(report.datespan.startdate, datetime(month=9, day=21, year=2020))
+        self.assertEqual(report.datespan.enddate, end_date)
+
+    def test_specifying_timespan_greater_than_90_days_throws_error(self):
+        end_date = datetime(month=10, day=1, year=2020)
+        with self.assertRaises(ValueError):
+            EnterpriseFormReport(self.billing_account, None, end_date=end_date, num_days=91)
+
+    def test_specifying_timespans_up_to_90_days_works(self):
+        end_date = datetime(month=10, day=1, year=2020)
+        EnterpriseFormReport(self.billing_account, None, end_date=end_date, num_days=90)

--- a/corehq/apps/enterprise/urls.py
+++ b/corehq/apps/enterprise/urls.py
@@ -1,6 +1,7 @@
 from corehq.apps.enterprise.dispatcher import EnterpriseReportDispatcher
 from django.urls import include, re_path as url
 
+from corehq.apps.enterprise.api import v1_api
 from corehq.apps.enterprise.views import (
     add_enterprise_permissions_domain,
     disable_enterprise_permissions,
@@ -20,6 +21,7 @@ from corehq.apps.sso.views.enterprise_admin import (
     ManageSSOEnterpriseView,
     EditIdentityProviderEnterpriseView,
 )
+
 
 report_urls = [
     EnterpriseReportDispatcher.url_pattern(),
@@ -53,4 +55,5 @@ domain_specific = [
         name=ManageEnterpriseMobileWorkersView.urlname),
 
     url(r'^reports/', include(report_urls)),
+    url(r'^api/', include(v1_api.urls)),
 ]


### PR DESCRIPTION
## Product Description
Provides new OData endpoints for the existing enterprise reports

## Technical Summary
There's a lot of 'new' here. 

First, these APIs do not live in the `api` application. Instead, I chose to create a separate `api` folder within the `enterprise` app and expose each new endpoint off the `/enterprise/api` base. This gives us flexibility to modify the API versioning independently of the existing, unrelated APIs. It also tightly couples the API code with the model code that underpins it -- we aren't creating model code in one application and then importing all of that into another file within the `api` application. While these new APIs still have some unfortunate dependencies on code previously existing in the `api` application, the goal was to have `enterprise` be more of a self-contained app.

Second, these function differently than our existing OData APIs. Our existing two OData APIs are `ODataCaseResource` and `ODataFormResource` (found in _apps/api/odata/resources/v0_5.py_), which don't leverage much of tastypie's capabilities.  For returning data to the client, tastypie wants to grab relevant objects (`obj_get_list`), 'dehydrate' them into simple python data, and then send them to a generic serializer for tweaks due to the requested format.  Our existing APIs do not do that -- they fetch objects in `obj_get_list`, perform no dehydration, and then have a non-generic serializer which performs very specific case/form export logic as well as transforms the data to match OData requirements. While tastypie has a built-in URL intended to support data schemas, these APIs define a separate view to handle this (`ODataCaseMetadataView` and `ODataFormMetadataView`) with their own logic. Short of a few specific fields, everything is labelled as `Edm.String`, which means our clients need to transform things like integer data after importing into PowerBI.

In comparison, the new `ODataResource` class should be generic enough that any OData API can use it. The built-in schema endpoint is utilized, reading its information from the fields defined on the resource itself. Those fields are then populated during tastypie's normal dehydration process, allowing us to use the generic Serializer. I wanted to be able to use a custom `ODataPaginator`, but I ran into hiccups with reversing API URLs and had to settle for handling OData's specific pagination quirks in the resource's `alter_list_data_to_serialize`.

Finally, I recognize that the random index access in the `dehydrate` methods is brittle. Currently, the API pulls its data from a fully generated report, and thus I'm forced to dig into an array of fields. The eventual goal is to invert this process, so the API is the source of truth, used to populate the reports. When we invert this flow, we'll be able to reference the named fields on objects rather than the arbitrary column indices we have now.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
These APIs were all tested locally, both through directly accessing the URLs in a browser as well as within PowerBI.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This feature currently has no user-facing UI -- if they want to use these feeds, they will need to know the magic URLs. We intend to use this as a way for specific enterprise users to alpha test. This means the blast radius should be small.

### Automated test coverage

Only a few new tests were created, none which fully cover the new APIs.  Would it make sense to create end-to-end tests for these APIs?

### QA Plan

Because there is no user-facing interface yet, I don't think it makes sense to put this through QA -- QA will be testing this the exact same way that a developer would be (putting the URL into Power BI and ensuring that everything looks right), and thus we aren't gaining any extra confidence.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
