### PR TITLE
Drop unused Repeater code

### DIFF
--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -13,9 +13,6 @@ CHECK_REPEATERS_KEY = 'check-repeaters-key'
 MAX_ATTEMPTS = 3
 # Number of exponential backoff attempts to an offline endpoint
 MAX_BACKOFF_ATTEMPTS = 6
-# Limit the number of records to forward at a time so that one repeater
-# can't hold up the rest.
-RECORDS_AT_A_TIME = 1000
 
 
 class State(IntegerChoices):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -352,6 +352,9 @@ class Repeater(RepeaterSuperProxy):
 
     @property
     def is_ready(self):
+        """
+        Returns True if there are repeat records to be sent.
+        """
         if self.is_paused or toggles.PAUSE_DATA_FORWARDING.enabled(self.domain):
             return False
         if not (self.next_attempt_at is None
@@ -1275,16 +1278,6 @@ def _get_retry_interval(last_checked, now):
     interval = max(MIN_RETRY_WAIT, interval)
     interval = min(MAX_RETRY_WAIT, interval)
     return interval
-
-
-def attempt_forward_now(repeater: Repeater):  # unused
-    from corehq.motech.repeaters.tasks import process_repeater
-
-    if not domain_can_forward(repeater.domain):
-        return
-    if not repeater.is_ready:  # only place that uses Repeater.is_ready
-        return
-    process_repeater.delay(repeater.id.hex)
 
 
 def get_payload(repeater: Repeater, repeat_record: RepeatRecord) -> str:

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -5,8 +5,9 @@ from django.conf import settings
 from celery.schedules import crontab
 from celery.utils.log import get_task_logger
 
-from dimagi.utils.couch import CriticalSection, get_redis_lock
+from dimagi.utils.couch import get_redis_lock
 
+from corehq import toggles
 from corehq.apps.celery import periodic_task, task
 from corehq.motech.models import RequestLog
 from corehq.util.metrics import (
@@ -23,17 +24,9 @@ from .const import (
     CHECK_REPEATERS_KEY,
     CHECK_REPEATERS_PARTITION_COUNT,
     MAX_RETRY_WAIT,
-    RECORDS_AT_A_TIME,
     State,
 )
-from .models import (
-    Repeater,
-    RepeatRecord,
-    domain_can_forward,
-    get_payload,
-    send_request,
-)
-from corehq import toggles
+from .models import RepeatRecord, domain_can_forward
 
 _check_repeaters_buckets = make_buckets_from_timedeltas(
     timedelta(seconds=10),
@@ -179,29 +172,3 @@ metrics_gauge_task(
     run_every=crontab(),  # every minute
     multiprocess_mode=MPM_MAX
 )
-
-
-@task(queue=settings.CELERY_REPEAT_RECORD_QUEUE)
-def process_repeater(repeater_id):
-    """
-    Worker task to send RepeatRecords in chronological order.
-
-    This function assumes that ``repeater`` checks have already
-    been performed. Call via ``models.attempt_forward_now()``.
-    """
-    repeater = Repeater.objects.get(id=repeater_id)
-    with CriticalSection(
-        [f'process-repeater-{repeater.repeater_id}'],
-        fail_hard=False, block=False, timeout=5 * 60 * 60,
-    ):
-        for repeat_record in repeater.repeat_records_ready[:RECORDS_AT_A_TIME]:
-            try:
-                payload = get_payload(repeater, repeat_record)
-            except Exception:
-                # The repeat record is cancelled if there is an error
-                # getting the payload. We can safely move to the next one.
-                continue
-            should_retry = not send_request(repeater,
-                                            repeat_record, payload)
-            if should_retry:
-                break

--- a/corehq/motech/repeaters/tests/test_display.py
+++ b/corehq/motech/repeaters/tests/test_display.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django.test import TestCase
 
 import pytz
@@ -7,9 +5,7 @@ import pytz
 from corehq.motech.models import ConnectionSettings
 
 from ..const import RECORD_SUCCESS_STATE
-from ..models import (
-    FormRepeater,
-)
+from ..models import FormRepeater
 from ..views.repeat_record_display import RepeatRecordDisplay
 from .test_models import make_repeat_record
 
@@ -29,23 +25,25 @@ class RepeaterTestCase(TestCase):
         )
         self.repeater.save()
         self.date_format = "%Y-%m-%d %H:%M:%S"
-        self.last_checked_str = "2022-01-12 09:04:15"
-        self.next_check_str = "2022-01-12 11:04:15"
-        self.last_checked = datetime.strptime(self.last_checked_str, self.date_format)
-        self.next_check = datetime.strptime(self.next_check_str, self.date_format)
-        self.repeater.next_attempt_at = self.next_check
-        self.repeater.last_attempt_at = self.last_checked
-        self.repeater.save()
 
     def test_record_display_sql(self):
         with make_repeat_record(self.repeater, RECORD_SUCCESS_STATE) as record:
-            record.attempt_set.create(state=RECORD_SUCCESS_STATE, created_at=self.last_checked)
+            response = ResponseDuck()
+            record.add_success_attempt(response)
+            last_checked = record.attempts[0].created_at
+            self.last_checked_str = last_checked.strftime(self.date_format)
+
             self._check_display(record)
 
     def _check_display(self, record):
         display = RepeatRecordDisplay(record, pytz.UTC, date_format=self.date_format)
         self.assertEqual(display.record_id, record.id)
         self.assertEqual(display.last_checked, self.last_checked_str)
-        self.assertEqual(display.next_attempt_at, self.next_check_str)
+        self.assertEqual(display.next_check, '---')
         self.assertEqual(display.url, self.url)
         self.assertEqual(display.state, '<span class="label label-success">Success</span>')
+
+
+class ResponseDuck:
+    status_code = 200
+    reason = 'Success'

--- a/corehq/motech/repeaters/tests/test_tasks.py
+++ b/corehq/motech/repeaters/tests/test_tasks.py
@@ -1,11 +1,9 @@
 from contextlib import contextmanager
 from datetime import datetime, timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from django.test import TestCase
-from django.utils import timezone
 
-from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.form_processor.models import XFormInstance
 from corehq.form_processor.utils.xform import (
@@ -13,12 +11,12 @@ from corehq.form_processor.utils.xform import (
     TestFormMetadata,
 )
 from corehq.motech.models import ConnectionSettings, RequestLog
-from corehq.motech.repeaters.models import FormRepeater, RepeatRecord, Repeater
+from corehq.motech.repeaters.models import Repeater, RepeatRecord
 from corehq.motech.repeaters.tasks import (
     _process_repeat_record,
     delete_old_request_logs,
-    process_repeater,
 )
+
 from ..const import State
 
 DOMAIN = 'gaidhlig'
@@ -66,64 +64,6 @@ class TestDeleteOldRequestLogs(TestCase):
 
         count = RequestLog.objects.filter(domain=DOMAIN).count()
         self.assertEqual(count, 0)
-
-
-class TestProcessRepeater(TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.domain = create_domain(DOMAIN)
-        cls.addClassCleanup(cls.domain.delete)
-        cls.connection_settings = ConnectionSettings.objects.create(
-            domain=DOMAIN,
-            name='Test API',
-            url="http://localhost/api/"
-        )
-
-    def setUp(self):
-        self.repeater = FormRepeater.objects.create(
-            domain=DOMAIN,
-            format='form_xml',
-            connection_settings=self.connection_settings
-        )
-        just_now = timezone.now() - timedelta(seconds=10)
-        for payload_id in PAYLOAD_IDS:
-            self.repeater.repeat_records.create(
-                domain=self.repeater.domain,
-                payload_id=payload_id,
-                registered_at=just_now,
-            )
-            just_now += timedelta(seconds=1)
-
-    def test_get_payload_fails(self):
-        # If the payload of a repeat record is missing, it should be
-        # cancelled, and process_repeater() should continue to the next
-        # payload
-        with patch('corehq.motech.repeaters.models.log_repeater_error_in_datadog'), \
-                patch('corehq.motech.repeaters.tasks.metrics_counter'):
-            process_repeater(self.repeater.id)
-
-        # All records were tried and cancelled
-        records = list(self.repeater.repeat_records.all())
-        self.assertEqual(len(records), 10)
-        self.assertTrue(all(r.state == State.Cancelled for r in records))
-        # All records have a cancelled Attempt
-        self.assertTrue(all(len(r.attempts) == 1 for r in records))
-        self.assertTrue(all(r.attempts[0].state == State.Cancelled for r in records))
-
-    def test_send_request_fails(self):
-        # If send_request() should be retried with the same repeat
-        # record, process_repeater() should exit
-        with patch('corehq.motech.repeaters.models.simple_request') as post_mock, \
-                patch('corehq.motech.repeaters.tasks.metrics_counter'), \
-                form_context(PAYLOAD_IDS):
-            post_mock.return_value = Mock(status_code=400, reason='Bad request', text='')
-            process_repeater(self.repeater.id)
-
-        # Only the first record was attempted, the rest are still pending
-        states = [r.state for r in self.repeater.repeat_records.all()]
-        self.assertListEqual(states, ([State.Fail] + [State.Pending] * 9))
 
 
 @contextmanager

--- a/corehq/motech/repeaters/views/repeat_record_display.py
+++ b/corehq/motech/repeaters/views/repeat_record_display.py
@@ -28,8 +28,8 @@ class RepeatRecordDisplay:
         return self._format_date(self.record.last_checked)
 
     @property
-    def next_attempt_at(self):
-        return self._format_date(self.record.next_attempt_at)
+    def next_check(self):
+        return self._format_date(self.record.next_check)
 
     @property
     def url(self):

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -194,7 +194,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
             checkbox,
             display.state,
             display.remote_service,
-            display.next_attempt_at,
+            display.next_check,
             self._make_view_attempts_button(record.id),
             self._make_view_payload_button(record.id),
             self._make_resend_payload_button(record.id),


### PR DESCRIPTION
## Technical Summary

In January 2021 (!) we were laying the groundwork for refactoring the repeat records queue to process Repeaters instead of RepeatRecords. Since then, that code has only caused confusion. This PR is to drop some of it.

This change touches the value shown as "Retry Date" in the Repeat Record Report. It sets it to `next_check`, which is the value used for determining whether to resend the repeat record.

I have kept the following Repeater methods, even though they are currently unused, in the hope that they will be useful soon:
* is_ready()
* set_next_attempt()
* reset_next_attempt()

## Safety Assurance

### Safety story

* Tested locally
* Checking on Staging

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
