### PR TITLE
Fix *RateCounter expiry when delta != 1

### DIFF
--- a/corehq/project_limits/rate_counter/rate_counter.py
+++ b/corehq/project_limits/rate_counter/rate_counter.py
@@ -137,7 +137,7 @@ class CounterCache(object):
 
     def incr(self, key, delta=1):
         value = self.shared_cache.incr(key, delta, ignore_key_check=True)
-        if value == 1:
+        if value == delta:
             self.shared_cache.expire(key, timeout=self.timeout)
         self.local_cache.set(key, value, timeout=self.memoized_timeout)
         return value


### PR DESCRIPTION
## Product Description
No change

## Technical Summary
Just fixing something that hasn't bit us but is technically incorrect.

## Safety Assurance

### Safety story
This method isn't actually ever called with anything other than the default `delta=1`, so this has never been an issue. But I have an upcoming potential use case where we would want to use a variable `delta`, so this little fix may be helpful.

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
