### PR TITLE
Add unsubscribe data source endpoint

### DIFF
--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -720,29 +720,28 @@ class TestSubscribeToDataSource(TestCase):
 
 class TestUnsubscribeFromDataSource(TestCase):
 
-    urlname = "unsubscribe_from_configurable_data_source"
-    domain = "test-domain"
-    client_id = "client_id"
+    DOMAIN = "test-domain"
+    CLIENT_ID = "client_id"
     USERNAME = "username"
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.project = Domain.get_or_create_with_name(cls.domain, is_active=True)
+        cls.project = Domain.get_or_create_with_name(cls.DOMAIN, is_active=True)
 
         cls.api_user_role = UserRole.create(
-            cls.domain, 'api-user', permissions=HqPermissions(access_api=True, view_reports=True)
+            cls.DOMAIN, 'api-user', permissions=HqPermissions(access_api=True, view_reports=True)
         )
-        cls.user = WebUser.create(cls.domain, cls.USERNAME, "password", None, None,
+        cls.user = WebUser.create(cls.DOMAIN, cls.USERNAME, "password", None, None,
                                   role_id=cls.api_user_role.get_id)
         cls.api_key, _ = HQApiKey.objects.get_or_create(user=WebUser.get_django_user(cls.user))
         cls.domain_api_key, _ = HQApiKey.objects.get_or_create(user=WebUser.get_django_user(cls.user),
                                                                name='domain-scoped',
-                                                               domain=cls.domain)
+                                                               domain=cls.DOMAIN)
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(deleted_by_domain=cls.domain, deleted_by=None)
+        cls.user.delete(deleted_by_domain=cls.DOMAIN, deleted_by=None)
         cls.project.delete()
         super().tearDownClass()
 
@@ -750,18 +749,18 @@ class TestUnsubscribeFromDataSource(TestCase):
         return f'ApiKey {self.USERNAME}:{api_key.key}'
 
     def _post_request(self, domain, data_source_id, data=None, **extras):
-        path = reverse(self.urlname, args=(domain, data_source_id,))
+        path = reverse("unsubscribe_from_configurable_data_source", args=(domain, data_source_id,))
         return self.client.post(path, data=data, **extras)
 
     def _subscribe_to_datasource(self, datasource_id):
         post_data = {
             'webhook_url': 'https://hostname.com/webhook',
-            'client_id': self.client_id,
+            'client_id': self.CLIENT_ID,
             'client_secret': 'client_secret',
             'token_url': 'https://hostname.com/token',
             'refresh_url': 'https://hostname.com/refresh',
         }
-        path = reverse("subscribe_to_configurable_data_source", args=(self.domain, datasource_id,))
+        path = reverse("subscribe_to_configurable_data_source", args=(self.DOMAIN, datasource_id,))
         return self.client.post(
             path,
             data=post_data,
@@ -774,15 +773,15 @@ class TestUnsubscribeFromDataSource(TestCase):
         data_source_id = "data_source_id"
         self._subscribe_to_datasource(data_source_id)
 
-        conn_settings = ConnectionSettings.objects.get(client_id=self.client_id)
+        conn_settings = ConnectionSettings.objects.get(client_id=self.CLIENT_ID)
         connection_settings_id = conn_settings.id
 
         repeaters = DataSourceRepeater.objects.filter(connection_settings_id=connection_settings_id)
         self.assertEqual(repeaters.count(), 1)
 
         response = self._post_request(
-            domain=self.domain,
-            data={"client_id": self.client_id},
+            domain=self.DOMAIN,
+            data={"client_id": self.CLIENT_ID},
             data_source_id=data_source_id,
             HTTP_AUTHORIZATION=self._construct_api_auth_header(self.domain_api_key),
         )
@@ -800,15 +799,15 @@ class TestUnsubscribeFromDataSource(TestCase):
         self._subscribe_to_datasource(data_source_id_1)
         self._subscribe_to_datasource(data_source_id_2)
 
-        conn_settings = ConnectionSettings.objects.get(client_id=self.client_id)
+        conn_settings = ConnectionSettings.objects.get(client_id=self.CLIENT_ID)
         connection_settings_id = conn_settings.id
 
         repeaters = DataSourceRepeater.objects.filter(connection_settings_id=connection_settings_id)
         self.assertEqual(repeaters.count(), 2)
 
         response = self._post_request(
-            domain=self.domain,
-            data={"client_id": self.client_id},
+            domain=self.DOMAIN,
+            data={"client_id": self.CLIENT_ID},
             data_source_id=data_source_id_1,
             HTTP_AUTHORIZATION=self._construct_api_auth_header(self.domain_api_key),
         )
@@ -822,7 +821,7 @@ class TestUnsubscribeFromDataSource(TestCase):
     @flag_enabled('API_THROTTLE_WHITELIST')
     def test_missing_client_id(self):
         response = self._post_request(
-            domain=self.domain,
+            domain=self.DOMAIN,
             data={},
             data_source_id='datasource_id',
             HTTP_AUTHORIZATION=self._construct_api_auth_header(self.domain_api_key),
@@ -834,7 +833,7 @@ class TestUnsubscribeFromDataSource(TestCase):
     @flag_enabled('API_THROTTLE_WHITELIST')
     def test_invalid_client_id(self):
         response = self._post_request(
-            domain=self.domain,
+            domain=self.DOMAIN,
             data={'client_id': 'client_id'},
             data_source_id='datasource_id',
             HTTP_AUTHORIZATION=self._construct_api_auth_header(self.domain_api_key),
@@ -848,7 +847,7 @@ class TestUnsubscribeFromDataSource(TestCase):
         self._subscribe_to_datasource('datasource_id')
 
         response = self._post_request(
-            domain=self.domain,
+            domain=self.DOMAIN,
             data={'client_id': 'client_id'},
             data_source_id='invalid_datasource_id',
             HTTP_AUTHORIZATION=self._construct_api_auth_header(self.domain_api_key),

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -753,18 +753,22 @@ class TestUnsubscribeFromDataSource(TestCase):
         return self.client.post(path, data=data, **extras)
 
     def _subscribe_to_datasource(self, datasource_id):
-        post_data = {
-            'webhook_url': 'https://hostname.com/webhook',
-            'client_id': self.CLIENT_ID,
-            'client_secret': 'client_secret',
-            'token_url': 'https://hostname.com/token',
-            'refresh_url': 'https://hostname.com/refresh',
-        }
-        path = reverse("subscribe_to_configurable_data_source", args=(self.DOMAIN, datasource_id,))
-        return self.client.post(
-            path,
-            data=post_data,
-            HTTP_AUTHORIZATION=self._construct_api_auth_header(self.domain_api_key),
+        conn_settings, __ = ConnectionSettings.objects.update_or_create(
+            client_id=self.CLIENT_ID,
+            defaults={
+                'domain': self.DOMAIN,
+                'name': "testy",
+                'auth_type': "oauth2_client",
+                'client_secret': 'client_secret',
+                'url': "",
+                'token_url': 'token_url',
+            }
+        )
+        DataSourceRepeater.objects.create(
+            name=f"{datasource_id} name",
+            domain=self.DOMAIN,
+            data_source_id=datasource_id,
+            connection_settings_id=conn_settings.id,
         )
 
     @flag_enabled('SUPERSET_ANALYTICS')

--- a/corehq/apps/userreports/urls.py
+++ b/corehq/apps/userreports/urls.py
@@ -31,6 +31,7 @@ from corehq.apps.userreports.views import (
     undelete_report,
     update_report_description,
     subscribe_to_data_source_changes,
+    unsubscribe_from_data_source,
 )
 
 urlpatterns = [
@@ -72,6 +73,8 @@ urlpatterns = [
         name='export_configurable_data_source'),
     url(r'^data_sources/subscribe/(?P<config_id>[\w-]+)/$', subscribe_to_data_source_changes,
         name='subscribe_to_configurable_data_source'),
+    url(r'^data_sources/unsubscribe/(?P<config_id>[\w-]+)/$', unsubscribe_from_data_source,
+        name='unsubscribe_from_configurable_data_source'),
     url(r'^expression_debugger/$', ExpressionDebuggerView.as_view(),
         name='expression_debugger'),
     url(r'^data_source_debugger/$', DataSourceDebuggerView.as_view(),

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1665,11 +1665,6 @@ def subscribe_to_data_source_changes(request, domain, config_id):
 @toggles.SUPERSET_ANALYTICS.required_decorator()
 @api_throttle
 def unsubscribe_from_data_source(request, domain, config_id):
-    repeater = DataSourceRepeater.objects.filter(
-        domain=domain,
-        options={"data_source_id": config_id},
-    )
-
     if 'client_id' not in request.POST:
         return HttpResponse(
             status=422,

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1696,13 +1696,10 @@ def unsubscribe_from_data_source(request, domain, config_id):
             content="Invalid data source ID"
         )
     repeater.delete()
+    conn_settings.clear_caches()
 
-    subscriber_repeaters_query = DataSourceRepeater.objects.filter(
-        connection_settings_id=conn_settings.id
-    )
-
-    if subscriber_repeaters_query.count() == 0:
-        ConnectionSettings.objects.filter(id=conn_settings.id).delete()
+    if not conn_settings.used_by:
+        conn_settings.delete()
 
     return HttpResponse(status=200)
 

--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -279,6 +279,12 @@ class ConnectionSettings(models.Model):
         self.is_deleted = True
         self.save()
 
+    def clear_caches(self):
+        try:
+            del self.used_by
+        except AttributeError:
+            pass
+
 
 class RequestLog(models.Model):
     """


### PR DESCRIPTION
## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3771)

The unsubscribe data source endpoint will do the following:
- Remove the data source repeater by using the config_id (extracted from URL) and the client_id (in POST body, used to locate the ConnectionSettings).
- If there's no repeaters left (effectively having a redundant ConnectionSettings record) the ConnectionSettings record will be removed as well. I think this is safe as we're simply removing the specific ConnectionSettings record that was created for the repeaters during the subscribe routine. 

## Feature Flag
SUPERSET_ANALYTICS

## Safety Assurance

### Safety story
Unit tests

### Automated test coverage
Added unit tests

### QA Plan
QA not planned for this ticket and will be done as part of [this ticket](https://dimagi.atlassian.net/browse/SC-3772).


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
