### PR TITLE
Make feature flag enabled by domain

### DIFF
--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -21,7 +21,7 @@ from casexml.apps.case.exceptions import PhoneDateValueError, IllegalCaseId, Use
 from corehq.apps.receiverwrapper.rate_limiter import report_case_usage, report_submission_usage
 from corehq.const import OPENROSA_VERSION_3
 from corehq.middleware import OPENROSA_VERSION_HEADER
-from corehq.toggles import ASYNC_RESTORE, NAMESPACE_OTHER, SUMOLOGIC_LOGS, SUMOLOGIC_LOGS_PER_DOMAIN
+from corehq.toggles import ASYNC_RESTORE, NAMESPACE_OTHER, SUMOLOGIC_LOGS, BLOCK_SUMOLOGIC_LOGS
 from corehq.apps.app_manager.dbaccessors import get_current_app
 from corehq.apps.cloudcare.const import DEVICE_ID as FORMPLAYER_DEVICE_ID
 from corehq.apps.commtrack.exceptions import MissingProductId
@@ -397,8 +397,8 @@ class SubmissionPost(object):
 
     def _conditionally_send_device_logs_to_sumologic(self, instance):
         url = getattr(settings, 'SUMOLOGIC_URL', None)
-        if url and (SUMOLOGIC_LOGS.enabled(instance.form_data.get('device_id'), NAMESPACE_OTHER)
-                    or SUMOLOGIC_LOGS_PER_DOMAIN.enabled(instance.form_data.get('device_id'), self.domain)):
+        if (url and SUMOLOGIC_LOGS.enabled(instance.form_data.get('device_id'), NAMESPACE_OTHER)
+                and not BLOCK_SUMOLOGIC_LOGS.enabled(instance.form_data.get('device_id'), self.domain)):
             SumoLogicLog(self.domain, instance).send_data(url)
 
     def _invalidate_caches(self, xform):

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -21,7 +21,7 @@ from casexml.apps.case.exceptions import PhoneDateValueError, IllegalCaseId, Use
 from corehq.apps.receiverwrapper.rate_limiter import report_case_usage, report_submission_usage
 from corehq.const import OPENROSA_VERSION_3
 from corehq.middleware import OPENROSA_VERSION_HEADER
-from corehq.toggles import ASYNC_RESTORE, SUMOLOGIC_LOGS, NAMESPACE_OTHER
+from corehq.toggles import ASYNC_RESTORE, NAMESPACE_DOMAIN, SUMOLOGIC_LOGS
 from corehq.apps.app_manager.dbaccessors import get_current_app
 from corehq.apps.cloudcare.const import DEVICE_ID as FORMPLAYER_DEVICE_ID
 from corehq.apps.commtrack.exceptions import MissingProductId
@@ -397,7 +397,7 @@ class SubmissionPost(object):
 
     def _conditionally_send_device_logs_to_sumologic(self, instance):
         url = getattr(settings, 'SUMOLOGIC_URL', None)
-        if url and SUMOLOGIC_LOGS.enabled(instance.form_data.get('device_id'), NAMESPACE_OTHER):
+        if url and SUMOLOGIC_LOGS.enabled(instance.form_data.get('device_id'), NAMESPACE_DOMAIN):
             SumoLogicLog(self.domain, instance).send_data(url)
 
     def _invalidate_caches(self, xform):

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -21,7 +21,7 @@ from casexml.apps.case.exceptions import PhoneDateValueError, IllegalCaseId, Use
 from corehq.apps.receiverwrapper.rate_limiter import report_case_usage, report_submission_usage
 from corehq.const import OPENROSA_VERSION_3
 from corehq.middleware import OPENROSA_VERSION_HEADER
-from corehq.toggles import ASYNC_RESTORE, NAMESPACE_DOMAIN, SUMOLOGIC_LOGS
+from corehq.toggles import ASYNC_RESTORE, NAMESPACE_OTHER, SUMOLOGIC_LOGS, SUMOLOGIC_LOGS_PER_DOMAIN
 from corehq.apps.app_manager.dbaccessors import get_current_app
 from corehq.apps.cloudcare.const import DEVICE_ID as FORMPLAYER_DEVICE_ID
 from corehq.apps.commtrack.exceptions import MissingProductId
@@ -397,7 +397,8 @@ class SubmissionPost(object):
 
     def _conditionally_send_device_logs_to_sumologic(self, instance):
         url = getattr(settings, 'SUMOLOGIC_URL', None)
-        if url and SUMOLOGIC_LOGS.enabled(instance.form_data.get('device_id'), NAMESPACE_DOMAIN):
+        if url and (SUMOLOGIC_LOGS.enabled(instance.form_data.get('device_id'), NAMESPACE_OTHER)
+                    or SUMOLOGIC_LOGS_PER_DOMAIN.enabled(instance.form_data.get('device_id'), self.domain)):
             SumoLogicLog(self.domain, instance).send_data(url)
 
     def _invalidate_caches(self, xform):

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -21,7 +21,7 @@ from casexml.apps.case.exceptions import PhoneDateValueError, IllegalCaseId, Use
 from corehq.apps.receiverwrapper.rate_limiter import report_case_usage, report_submission_usage
 from corehq.const import OPENROSA_VERSION_3
 from corehq.middleware import OPENROSA_VERSION_HEADER
-from corehq.toggles import ASYNC_RESTORE, NAMESPACE_OTHER, SUMOLOGIC_LOGS, BLOCK_SUMOLOGIC_LOGS
+from corehq.toggles import ASYNC_RESTORE, BLOCK_SUMOLOGIC_LOGS, NAMESPACE_OTHER, SUMOLOGIC_LOGS
 from corehq.apps.app_manager.dbaccessors import get_current_app
 from corehq.apps.cloudcare.const import DEVICE_ID as FORMPLAYER_DEVICE_ID
 from corehq.apps.commtrack.exceptions import MissingProductId

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1786,9 +1786,9 @@ SUMOLOGIC_LOGS = DynamicallyPredictablyRandomToggle(
     namespaces=[NAMESPACE_OTHER],
 )
 
-SUMOLOGIC_LOGS_PER_DOMAIN = DynamicallyPredictablyRandomToggle(
-    'sumologic_logs_per_domain',
-    'Send logs to sumologic per domain',
+BLOCK_SUMOLOGIC_LOGS = StaticToggle(
+    'block_sumologic_logs',
+    'Block sending logs to sumologic per domain',
     TAG_INTERNAL,
     namespaces=[NAMESPACE_DOMAIN],
 )

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1783,6 +1783,13 @@ SUMOLOGIC_LOGS = DynamicallyPredictablyRandomToggle(
     'sumologic_logs',
     'Send logs to sumologic',
     TAG_INTERNAL,
+    namespaces=[NAMESPACE_OTHER],
+)
+
+SUMOLOGIC_LOGS_PER_DOMAIN = DynamicallyPredictablyRandomToggle(
+    'sumologic_logs_per_domain',
+    'Send logs to sumologic per domain',
+    TAG_INTERNAL,
     namespaces=[NAMESPACE_DOMAIN],
 )
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1783,7 +1783,7 @@ SUMOLOGIC_LOGS = DynamicallyPredictablyRandomToggle(
     'sumologic_logs',
     'Send logs to sumologic',
     TAG_INTERNAL,
-    namespaces=[NAMESPACE_OTHER],
+    namespaces=[NAMESPACE_DOMAIN],
 )
 
 TARGET_COMMCARE_FLAVOR = StaticToggle(


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
We have an existing FF that will send sumologic logs when enabled. 
This PR allows us to have a new FF for a single domain, that will block sending sumologic logs even when sumologic logs is enabled globally.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
SUMOLOGIC_LOGS 
BLOCK_SUMOLOGIC_LOGS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
