### PR TITLE
Reduce errors preventing role, field from passing from invitation to user

### DIFF
--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -48,7 +48,8 @@ _soft_assert_registration_issues = soft_assert(
 )
 
 
-def activate_new_user_via_reg_form(form, created_by, created_via, is_domain_admin=False, domain=None, ip=None):
+def activate_new_user_via_reg_form(form, created_by, created_via, is_domain_admin=False, domain=None, ip=None,
+                                   commit=True):
     full_name = form.cleaned_data['full_name']
     new_user = activate_new_user(
         username=form.cleaned_data['email'],
@@ -61,13 +62,14 @@ def activate_new_user_via_reg_form(form, created_by, created_via, is_domain_admi
         domain=domain,
         ip=ip,
         atypical_user=form.cleaned_data.get('atypical_user', False),
+        commit=commit
     )
     return new_user
 
 
 def activate_new_user(
     username, password, created_by, created_via, first_name=None, last_name=None,
-    is_domain_admin=False, domain=None, ip=None, atypical_user=False
+    is_domain_admin=False, domain=None, ip=None, atypical_user=False, commit=True
 ):
     now = datetime.utcnow()
 
@@ -79,6 +81,7 @@ def activate_new_user(
         created_via,
         is_admin=is_domain_admin,
         by_domain_required_for_log=bool(domain),
+        commit=commit
     )
     new_user.first_name = first_name
     new_user.last_name = last_name
@@ -97,7 +100,8 @@ def activate_new_user(
     new_user.date_joined = now
     new_user.last_password_set = now
     new_user.atypical_user = atypical_user
-    new_user.save()
+    if commit:
+        new_user.save()
 
     return new_user
 

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -512,7 +512,7 @@ def get_matching_tableau_users_from_other_domains(user):
 
 
 @atomic
-def add_tableau_user(domain, username, blocking_exception=False):
+def add_tableau_user(domain, username):
     '''
     Creates a TableauUser object with the given username and a default role of Viewer, and adds a new user with
     these details to the Tableau instance.
@@ -531,10 +531,8 @@ def add_tableau_user(domain, username, blocking_exception=False):
                 if e.code != 409017:  # This is the "user already added to site" code.
                     raise
     except TableauAPIError as e:
-        if blocking_exception:
-            raise
-        else:
-            _notify_tableau_exception(e, domain)
+        # Don't block main thread
+        _notify_tableau_exception(e, domain)
 
 
 def _add_tableau_user_local(session, username, role=DEFAULT_TABLEAU_ROLE):

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -512,23 +512,29 @@ def get_matching_tableau_users_from_other_domains(user):
 
 
 @atomic
-def add_tableau_user(domain, username):
+def add_tableau_user(domain, username, blocking_exception=False):
     '''
     Creates a TableauUser object with the given username and a default role of Viewer, and adds a new user with
     these details to the Tableau instance.
     '''
     try:
-        session = TableauAPISession.create_session_for_domain(domain)
-    except TableauConnectedApp.DoesNotExist as e:
-        _notify_tableau_exception(e, domain)
-        return
-    user, created, matching_tableau_users_from_other_domains_exist = _add_tableau_user_local(session, username)
-    if created and not matching_tableau_users_from_other_domains_exist:
         try:
-            _add_tableau_user_remote(session, user)
-        except TableauAPIError as e:
-            if e.code != 409017:  # This is the "user already added to site" code.
-                raise
+            session = TableauAPISession.create_session_for_domain(domain)
+        except TableauConnectedApp.DoesNotExist as e:
+            _notify_tableau_exception(e, domain)
+            return
+        user, created, matching_tableau_users_from_other_domains_exist = _add_tableau_user_local(session, username)
+        if created and not matching_tableau_users_from_other_domains_exist:
+            try:
+                _add_tableau_user_remote(session, user)
+            except TableauAPIError as e:
+                if e.code != 409017:  # This is the "user already added to site" code.
+                    raise
+    except TableauAPIError as e:
+        if blocking_exception:
+            raise
+        else:
+            _notify_tableau_exception(e, domain)
 
 
 def _add_tableau_user_local(session, username, role=DEFAULT_TABLEAU_ROLE):
@@ -589,31 +595,38 @@ def _delete_user_remote(session, deleted_user_id):
 
 
 @atomic
-def update_tableau_user(domain, username, role=None, groups: List[TableauGroupTuple] = None, session=None):
+def update_tableau_user(domain, username, role=None, groups: List[TableauGroupTuple] = None, session=None,
+                        blocking_exception=True):
     '''
     Update the TableauUser object to have the given role and new group details. The `groups` arg should be a list
     of TableauGroupTuples.
     '''
-    groups = groups or []
-    session = session or TableauAPISession.create_session_for_domain(domain)
-    user = TableauUser.objects.filter(
-        server=session.tableau_connected_app.server
-    ).get(username=username)
-    if role:
-        for local_tableau_user in [user] + get_matching_tableau_users_from_other_domains(user):
-            local_tableau_user.role = role
-            local_tableau_user.save()
+    try:
+        groups = groups or []
+        session = session or TableauAPISession.create_session_for_domain(domain)
+        user = TableauUser.objects.filter(
+            server=session.tableau_connected_app.server
+        ).get(username=username)
+        if role:
+            for local_tableau_user in [user] + get_matching_tableau_users_from_other_domains(user):
+                local_tableau_user.role = role
+                local_tableau_user.save()
 
-    # Group management
-    allowed_groups_for_domain = get_allowed_tableau_groups_for_domain(domain)
-    existing_groups = _group_json_to_tuples(session.get_groups_for_user_id(user.tableau_user_id))
-    edited_groups_list = list(filter(lambda group: group.name in allowed_groups_for_domain, groups))
-    other_groups = [group for group in existing_groups if group.name not in allowed_groups_for_domain]
-    # The list of groups for the user should be a combination of those edited by the web admin and the existing
-    # groups the user belongs to that are not editable on that domain.
-    new_groups = edited_groups_list + other_groups
+        # Group management
+        allowed_groups_for_domain = get_allowed_tableau_groups_for_domain(domain)
+        existing_groups = _group_json_to_tuples(session.get_groups_for_user_id(user.tableau_user_id))
+        edited_groups_list = list(filter(lambda group: group.name in allowed_groups_for_domain, groups))
+        other_groups = [group for group in existing_groups if group.name not in allowed_groups_for_domain]
+        # The list of groups for the user should be a combination of those edited by the web admin and the existing
+        # groups the user belongs to that are not editable on that domain.
+        new_groups = edited_groups_list + other_groups
 
-    _update_user_remote(session, user, groups=new_groups)
+        _update_user_remote(session, user, groups=new_groups)
+    except TableauAPIError as e:
+        if blocking_exception:
+            raise
+        else:
+            _notify_tableau_exception(e, domain)
 
 
 def _update_user_remote(session, user, groups=[]):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -571,8 +571,9 @@ class _AuthorizableMixin(IsMemberOfMixin):
             if tableau_group_ids is None:
                 tableau_group_ids = []
             from corehq.apps.reports.util import get_tableau_groups_by_ids, update_tableau_user
-            update_tableau_user(domain=domain, username=self.username,
-                    role=tableau_role, groups=get_tableau_groups_by_ids(tableau_group_ids, domain))
+            update_tableau_user(domain=domain, username=self.username, role=tableau_role,
+                                groups=get_tableau_groups_by_ids(tableau_group_ids, domain),
+                                blocking_exception=False)
         self.save()
 
     def delete_domain_membership(self, domain, create_record=False):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -562,8 +562,8 @@ class _AuthorizableMixin(IsMemberOfMixin):
             self.get_domain_membership(domain).program_id = program_id
         if domain_obj.uses_locations:
             if primary_location_id:
-                self.set_location(domain, primary_location_id)
-            self.reset_locations(domain, assigned_location_ids)
+                self.set_location(domain, primary_location_id, commit=False)
+            self.reset_locations(domain, assigned_location_ids, commit=False)
         if domain_has_privilege(domain_obj.name, privileges.APP_USER_PROFILES) and profile:
             user_data = self.get_user_data(domain_obj.name)
             user_data.update({}, profile_id=profile.id)
@@ -2556,7 +2556,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
         else:
             self.set_location(domain, location)
 
-    def set_location(self, domain, location_object_or_id):
+    def set_location(self, domain, location_object_or_id, commit=True):
         # set the primary location for user's domain_membership
         if isinstance(location_object_or_id, str):
             location_id = location_object_or_id
@@ -2572,7 +2572,8 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
             membership.assigned_location_ids.append(location_id)
             self.get_sql_locations.reset_cache(self)
         self.get_sql_location.reset_cache(self)
-        self.save()
+        if commit:
+            self.save()
 
     def unset_location(self, domain, fall_back_to_next=False, commit=True):
         """

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2446,14 +2446,15 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
 
     @classmethod
     def create(cls, domain, username, password, created_by, created_via, email=None, uuid='', date='',
-               user_data=None, by_domain_required_for_log=True, **kwargs):
+               user_data=None, by_domain_required_for_log=True, commit=True, **kwargs):
         web_user = super(WebUser, cls).create(domain, username, password, created_by, created_via, email, uuid,
                                               date, user_data, **kwargs)
         if domain:
             web_user.add_domain_membership(domain, **kwargs)
-        web_user.save()
-        web_user.log_user_create(domain, created_by, created_via,
-                                 by_domain_required_for_log=by_domain_required_for_log)
+        if commit:
+            web_user.save()
+            web_user.log_user_create(domain, created_by, created_via,
+                                     by_domain_required_for_log=by_domain_required_for_log)
         return web_user
 
     def add_domain_membership(self, domain, timezone=None, **kwargs):

--- a/corehq/apps/users/tests/test_location_assignment.py
+++ b/corehq/apps/users/tests/test_location_assignment.py
@@ -23,7 +23,7 @@ class CCUserLocationAssignmentTest(TestCase):
 
         cls.loc1 = make_loc('1', 'loc1', cls.domain)
         cls.loc2 = make_loc('2', 'loc2', cls.domain)
-        cls.loc_ids = [l.location_id for l in [cls.loc1, cls.loc2]]
+        cls.loc_ids = [loc.location_id for loc in [cls.loc1, cls.loc2]]
 
     @classmethod
     def tearDownClass(cls):
@@ -155,7 +155,7 @@ class WebUserLocationAssignmentTest(TestCase):
 
         cls.loc1 = make_loc('1', 'loc1', cls.domain)
         cls.loc2 = make_loc('2', 'loc2', cls.domain)
-        cls.loc_ids = [l.location_id for l in [cls.loc1, cls.loc2]]
+        cls.loc_ids = [loc.location_id for loc in [cls.loc1, cls.loc2]]
 
     @classmethod
     def tearDownClass(cls):
@@ -188,6 +188,19 @@ class WebUserLocationAssignmentTest(TestCase):
         self.assertAssignedLocations(self.loc_ids)
         self.assertPrimaryLocation(self.loc1.location_id)
         self.assertNonPrimaryLocation(self.loc2.location_id)
+
+    def test_no_commit(self):
+        self.user.set_location(self.domain, self.loc1, commit=False)
+        saved_user = WebUser.get(self.user._id)
+        self.assertEqual(saved_user.get_sql_location(self.domain), None)
+
+    def test_reset_locations_doesnt_ovewrite_set_location_uncomitted(self):
+        # Even if the primary location change isn't committed, reset_locations shouldn't overwrite it
+        self.user.set_location(self.domain, self.loc2, commit=False)
+        self.user.reset_locations(self.domain, self.loc_ids, commit=False)
+        self.user.save()
+        saved_user = WebUser.get(self.user._id)
+        self.assertEqual(saved_user.get_sql_location(self.domain).location_id, self.loc2.location_id)
 
     def test_location_append(self):
         self.user.add_to_assigned_locations(self.domain, self.loc1)

--- a/corehq/apps/users/tests/test_user_invitation.py
+++ b/corehq/apps/users/tests/test_user_invitation.py
@@ -1,13 +1,16 @@
 import datetime
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from django.test import TestCase
-
-from corehq.apps.users.models import Invitation
+from corehq.apps.users.models import Invitation, WebUser
 from corehq.apps.users.views.web import UserInvitationView, WebUserInvitationForm
 
 from django import forms
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory, TestCase
+from corehq.apps.commtrack.tests.util import bootstrap_domain
+from corehq.apps.users.dbaccessors import delete_all_users
+from corehq.apps.users.models_role import UserRole
 
 
 class StubbedWebUserInvitationForm(WebUserInvitationForm):
@@ -23,30 +26,45 @@ class StubbedWebUserInvitationForm(WebUserInvitationForm):
 
 class TestUserInvitation(TestCase):
 
+    @classmethod
+    def setUpTestData(cls):
+        # super(TestCase, cls).setUpTestData()
+        cls.domain = "domain"
+        cls.factory = RequestFactory()
+        cls.project = bootstrap_domain(cls.domain)
+        cls.role1 = UserRole.objects.create(
+            domain=cls.domain,
+            name="role1"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.delete()
+        delete_all_users()
+        return super().tearDownClass()
+
     def test_redirect_if_invite_does_not_exist(self):
         request = Mock()
         non_existing_uuid = "e1bd37f5-9ff8-4853-b953-fd75483a0ec7"
-        domain = "domain"
 
-        response = UserInvitationView()(request, non_existing_uuid, domain=domain)
+        response = UserInvitationView()(request, non_existing_uuid, domain=self.domain)
         self.assertEqual(302, response.status_code)
         self.assertEqual("/accounts/login/", response.url)
 
     def test_redirect_if_invite_is_already_accepted(self):
         request = Mock()
         invite_uuid = "e1bd37f5-9ff8-4853-b953-fd75483a0ec7"
-        domain = "domain"
 
         Invitation.objects.create(
             email='test@dimagi.com',
             uuid=invite_uuid,
-            domain=domain,
+            domain=self.domain,
             is_accepted=True,
             invited_on=datetime.date(2023, 9, 1),
             invited_by="system@dimagi.com",
         )
 
-        response = UserInvitationView()(request, invite_uuid, domain=domain)
+        response = UserInvitationView()(request, invite_uuid, domain=self.domain)
         self.assertEqual(302, response.status_code)
         self.assertEqual("/accounts/login/", response.url)
 
@@ -98,3 +116,31 @@ class TestUserInvitation(TestCase):
         )
 
         self.assertTrue(form.is_valid())
+
+    @patch('corehq.apps.users.models.Invitation._send_confirmation_email')
+    @patch('corehq.apps.users.views.web.login')
+    @patch('corehq.apps.users.views.web.messages')
+    def test_successful_accept_invite_and_user_created(self, mock_messages, mock_login,
+                                                       mock_confirmation_email):
+        self.assertIsNone(WebUser.get_by_username('test5@dimagi.com'))
+        invite_uuid = "e1bd37f5-9ff8-4853-b953-fd75483a0ec7"
+        request = self.factory.post(f"/join/{invite_uuid}")
+        request.user = AnonymousUser()
+        request.POST = {
+            "email": "test5@dimagi.com",
+            "full_name": "Testy Tester",
+            "password": "pass12342&*LKJ",
+            "eula_confirmed": True
+        }
+        Invitation.objects.create(
+            email='test5@dimagi.com',
+            uuid=invite_uuid,
+            domain=self.domain,
+            is_accepted=False,
+            invited_on=(datetime.datetime.now() - datetime.timedelta(days=1)),
+            invited_by="system@dimagi.com",
+            role=self.role1.get_qualified_id()
+        )
+        response = UserInvitationView()(request, invite_uuid, domain=self.domain)
+        self.assertEqual(302, response.status_code)
+        self.assertTrue(WebUser.get_by_username('test5@dimagi.com'))

--- a/corehq/apps/users/tests/test_user_invitation.py
+++ b/corehq/apps/users/tests/test_user_invitation.py
@@ -32,7 +32,6 @@ class TestUserInvitation(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        # super(TestCase, cls).setUpTestData()
         cls.domain = "domain"
         cls.factory = RequestFactory()
         cls.project = bootstrap_domain(cls.domain)

--- a/corehq/apps/users/tests/test_user_model.py
+++ b/corehq/apps/users/tests/test_user_model.py
@@ -317,4 +317,4 @@ class TestWebUserTableauIntegration(BaseCommCareUserTestSetup):
                             tableau_role="Viewer", tableau_group_ids=["u908e", "1a2b3"])
         mock_add_tableau_user.assert_called_once_with(self.domain, user.username)
         mock_update_tableau_user.assert_called_once_with(domain=self.domain, username=user.username,
-                                                        role="Viewer", groups=groups)
+                                                        role="Viewer", groups=groups, blocking_exception=False)

--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -181,10 +181,11 @@ class UserInvitationView(object):
                         created_via=USER_CHANGE_VIA_INVITATION,
                         domain=invitation.domain,
                         is_domain_admin=False,
+                        commit=False
                     )
-                    user.save()
-                    messages.success(request, _("User account for %s created!") % form.cleaned_data["email"])
                     invitation.accept_invitation_and_join_domain(user)
+                    user.log_user_create(invitation.domain, invited_by_user, USER_CHANGE_VIA_INVITATION)
+                    messages.success(request, _("User account for %s created!") % form.cleaned_data["email"])
                     messages.success(
                         self.request,
                         _('You have been added to the "{}" project space.').format(self.domain)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

[Jira](https://dimagi.atlassian.net/browse/USH-4727?atlOrigin=eyJpIjoiODE0ZDcxYWFlODE0NDAzZGJmNDVjNTFkMGE0MzlhZWEiLCJwIjoiaiJ9).

This PR aims to reduce the frequency of a problem where invited web users are created without a role, profile, etc.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

When a user accepts an invite, an exception is sometimes triggered. In [the past 90 days](https://dimagi.sentry.io/issues/?environment=production&project=136860&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+settings%2Fusers%2Fjoin&referrer=issue-list&statsPeriod=90d&utc=true), this has been due to either:

1. A ResourceConflict when saving the user/interacting with Couch
2. An issue communicating with the Tableau server

When an error is triggered in `add_as_web_user`, it seems to stop execution _after_ the `CouchUser` was created but _before_ the fields were populated from the invitation object, causing the end-user issue. So this PR attempts to reduce those errors by 1) reducing the number of saves to couch and 2) passing over any issues communicating with Tableau, since those discrepancies should be cleaned up on the next hourly sync anyways.

There seems to be an existing history of these `ResourceConflict` issues (possibly specific to _users_), and I think is all a bit beyond my knowledge of Couch/couchdbkit. I do think reducing the calls to couch has a good chance of reducing or completely eliminating these errors, though. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

None, though some changes are behind TABLEAU_USER_SYNCING

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tested locally to ensure user and associated Tableau user is created with proper information
- Existing tests cover Tableau user syncing methods well I think, and added new automated tests for user invitation view/workflow
- Should be mostly a refactor. I expect the main risks are with the live prod environment--the `ResourceConflict`s are still partially a mystery to me
- If a `ResourceConflict` is triggered upon initial user save, it will block the user from logging in (because they will have Django user associated with their email but no `CouchUser`). But this should be an existing issue

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

- Some exist for the Tableau user syncing methods
- Added new test(s) for the invitation workflow

### QA Plan

<!--
- Describe the QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Not planning to do QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
