### PR TITLE
Updated pricing URL

### DIFF
--- a/corehq/apps/registration/templates/registration/partials/choose_your_plan.html
+++ b/corehq/apps/registration/templates/registration/partials/choose_your_plan.html
@@ -21,7 +21,7 @@
         {% include 'registration/partials/feature_list.html' with features=professional_features %}
         <p class="plan-price">
           {% blocktrans %}
-            See <a href="https://dimagi.com/commcare/pricing/" target="_blank">pricing</a> options.
+            See <a href="https://dimagi.com/commcare-pricing/" target="_blank">pricing</a> options.
           {% endblocktrans %}
         </p>
         <div class="plan-cta">


### PR DESCRIPTION
## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15759

The pricing link on the new page currently points to https://dimagi.com/commcare/pricing/. It appears that link is now expired, and should instead point to https://dimagi.com/commcare-pricing/. This occurs automatically with a server redirect. However, if the user is not using ad-block, our google analytics will inject additional parameters after the URL. This apparently breaks the redirection, and thus the link needs to be updated to point to the real destination.

## Safety Assurance

### Safety story
Verified this change locally (forcing my local configuration to believe it was a SAAS environment, and then ensuring that the link worked correctly with google analytics).

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
