### PR TITLE
Hide users tab on location edit page if location's type does not allow having users

### DIFF
--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -807,6 +807,8 @@ class EditLocationView(BaseEditLocationView):
     def users_form(self):
         if not (self.can_edit_commcare_users or self.can_access_all_locations):
             return None
+        if toggles.LOCATION_HAS_USERS.enabled(self.domain) and not self.location.location_type.has_users:
+            return None
         form = UsersAtLocationForm(
             request=self.request,
             domain_object=self.domain_object,


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Part of an [epic](https://dimagi.atlassian.net/browse/USH-4629?atlOrigin=eyJpIjoiZmVmMGZiZWFkNGVhNDc1MDlhZjZhMTY4ZjE4OWQ0YjQiLCJwIjoiaiJ9) to allow users to specify which locations have users or not. All work including this PR is behind a FF until release.

Here is [the individual ticket](https://dimagi.atlassian.net/jira/software/c/projects/USH/boards/143).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Original migration PR](https://github.com/dimagi/commcare-hq/pull/34785).

Straightforward change. Notice that backend validation is built in since the form cannot be processed if it is `None`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

LOCATION_HAS_USERS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tested locally
- Very small and simple change
- Behind a FF

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

No automated tests exist for this view, didn't feel like adding any.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Will be done at the end of this feature's dev.


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [X] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
