### PR TITLE
ESQuery support for search_after and point in time

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -78,6 +78,13 @@ class BaseAdapter:
             return version
         raise ESError(f"invalid elasticsearch info: {cluster_info!r}")
 
+    @property
+    def transport(self):
+        try:
+            return self._es.transport
+        except ElasticsearchException as err:
+            raise ESError("Elasticsearch is unavailable") from err
+
 
 class ElasticManageAdapter(BaseAdapter):
 

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -369,6 +369,7 @@ class ESQuery(object):
         query._size = size
         return query
 
+    # Elasticsearch 7+
     def search_after(self, last_hit):
         """
         Uses ``search_after`` instead of ``start`` for pagination.
@@ -381,12 +382,15 @@ class ESQuery(object):
         See:
         https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after
         """
+        assert self.elastic_major_version >= 7, \
+            "search_after is only available in Elasticsearch 7+"
         if not isinstance(last_hit, list):
             last_hit = [last_hit]
         query = self.clone()
         query.es_query['search_after'] = last_hit
         return query
 
+    # Elasticsearch 7+
     def pit(self, pit_id, keep_alive='1m'):
         """
         Set the point in time (PIT) for the query.
@@ -399,6 +403,8 @@ class ESQuery(object):
 
         See: https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html
         """
+        assert self.elastic_major_version >= 7, \
+            "PIT is only available in Elasticsearch 7+"
         query = self.clone()
         query.es_query['pit'] = {
             'id': pit_id,
@@ -406,6 +412,7 @@ class ESQuery(object):
         }
         return query
 
+    # Elasticsearch 7+
     @contextmanager
     def open_pit(self, keep_alive='1m'):
         """
@@ -419,6 +426,8 @@ class ESQuery(object):
         For ``keep_alive`` time units, see:
         https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#time-units
         """
+        assert self.elastic_major_version >= 7, \
+            "PIT is only available in Elasticsearch 7+"
         response = self.adapter.transport.perform_request(
             'POST',
             '/_pit',

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -1,3 +1,5 @@
+from unittest import expectedFailure
+
 from elasticsearch5.transport import Transport
 
 from unittest.mock import patch
@@ -376,6 +378,7 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
         with patch.object(query, "scroll", scroll_then_delete_one):
             self.assertEqual([doc1], list(query.scroll_ids_to_disk_and_iter_docs()))
 
+    @expectedFailure  # Requires Elasticsearch 7+
     def test_search_after(self):
         last_hit = [
             '2024-07-15T22:08:24.434748Z',  # received_on
@@ -411,6 +414,7 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
             "size": SIZE_LIMIT
         })
 
+    @expectedFailure  # Requires Elasticsearch 7+
     def test_pit(self):
         pit_id = '46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4B'
         keep_alive = '1m'
@@ -430,6 +434,7 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
             'size': SIZE_LIMIT
         })
 
+    @expectedFailure  # Requires Elasticsearch 7+
     @patch.object(Transport, 'perform_request')
     def test_open_pit_as_context_manager(self, mock_perform_request):
         expected_pit_id = '46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoB'


### PR DESCRIPTION
_Aaargh! I did not check the version of the Elasticsearch documentation! So I have written support for a feature that only arrives in Elasticsearch 7. Annoyed with myself. Annoyed with the amount of effort, and pain, involved in upgrading Elasticsearch._

_I'm going to open a draft PR anyway, because maybe one day we'll upgrade, and then this will be handy. ..._

___

## Technical Summary

For large resultsets (like iterating lots of forms) Elasticsearch [recommends using `search_after`](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html) instead of `from` (i.e. `ESQuery.start()` in our codebase).

This change implements `search_after` in `ESQuery`, along with a context manager for [point in time](https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html) so that results don't change as they are paginated.

## Safety Assurance

### Safety story

* Behavior is covered by tests
* Does not affect existing functionality
* UNTESTED ON ELASTICSEARCH !!!

### Automated test coverage

(Mocked) tests included.

### QA Plan

QA not planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
