### PR TITLE
Allow explicit disable with `!` for random toggles 

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -390,10 +390,13 @@ class PredictablyRandomToggle(StaticToggle):
             return False
         elif namespace is not Ellipsis and namespace not in self.namespaces:
             return False
-        return (
-            (item and deterministic_random(self._get_identifier(item)) < self.randomness)
-            or super(PredictablyRandomToggle, self).enabled(item, namespace)
-        )
+        elif item and super(PredictablyRandomToggle, self).enabled(f'!{item}', namespace):
+            # if there is an explicit entry for the item preceded by '!', always disable
+            return False
+        elif item and deterministic_random(self._get_identifier(item)) < self.randomness:
+            return True
+        else:
+            return super(PredictablyRandomToggle, self).enabled(item, namespace)
 
 
 class DynamicallyPredictablyRandomToggle(PredictablyRandomToggle):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -390,13 +390,13 @@ class PredictablyRandomToggle(StaticToggle):
             return False
         elif namespace is not Ellipsis and namespace not in self.namespaces:
             return False
-        elif item and super(PredictablyRandomToggle, self).enabled(f'!{item}', namespace):
+        elif item and super().enabled(f'!{item}', namespace):
             # if there is an explicit entry for the item preceded by '!', always disable
             return False
         elif item and deterministic_random(self._get_identifier(item)) < self.randomness:
             return True
         else:
-            return super(PredictablyRandomToggle, self).enabled(item, namespace)
+            return super().enabled(item, namespace)
 
 
 class DynamicallyPredictablyRandomToggle(PredictablyRandomToggle):

--- a/corehq/toggles/tests.py
+++ b/corehq/toggles/tests.py
@@ -193,11 +193,12 @@ class PredictablyRandomToggleTests(TestCase):
         super(PredictablyRandomToggleTests, cls).setUpClass()
         cls.user_toggle = Toggle(
             slug='user_toggle',
-            enabled_users=['arthur', 'diana'])
+            enabled_users=['arthur', 'diana', '!frank'])
         cls.user_toggle.save()
         cls.domain_toggle = Toggle(
             slug='domain_toggle',
-            enabled_users=[namespaced_item('dc', NAMESPACE_DOMAIN)])
+            enabled_users=[namespaced_item('dc', NAMESPACE_DOMAIN),
+                           namespaced_item('!darkhorse', NAMESPACE_DOMAIN)])
         cls.domain_toggle.save()
 
     @classmethod
@@ -217,6 +218,18 @@ class PredictablyRandomToggleTests(TestCase):
         )
         self.assertTrue(toggle.enabled('diana', namespace=NAMESPACE_USER))
         self.assertFalse(toggle.enabled('jessica', namespace=NAMESPACE_USER))
+        self.assertFalse(toggle.enabled('frank', namespace=NAMESPACE_USER))
+        # update randomness to 100%
+        toggle = PredictablyRandomToggle(
+            'user_toggle',
+            'A toggle for testing',
+            TAG_CUSTOM,
+            [NAMESPACE_USER],
+            randomness=1.00
+        )
+        self.assertTrue(toggle.enabled('diana', namespace=NAMESPACE_USER))
+        self.assertTrue(toggle.enabled('jessica', namespace=NAMESPACE_USER))
+        self.assertFalse(toggle.enabled('frank', namespace=NAMESPACE_USER))
 
     @override_settings(DISABLE_RANDOM_TOGGLES=False)
     def test_domain_namespace_disabled(self):
@@ -229,6 +242,18 @@ class PredictablyRandomToggleTests(TestCase):
         )
         self.assertTrue(toggle.enabled('dc', namespace=NAMESPACE_DOMAIN))
         self.assertFalse(toggle.enabled('marvel', namespace=NAMESPACE_DOMAIN))
+        self.assertFalse(toggle.enabled('darkhorse', namespace=NAMESPACE_DOMAIN))
+        # update randomness to 100%
+        toggle = PredictablyRandomToggle(
+            'domain_toggle',
+            'A toggle for testing',
+            TAG_CUSTOM,
+            [NAMESPACE_DOMAIN],
+            randomness=1.00
+        )
+        self.assertTrue(toggle.enabled('dc', namespace=NAMESPACE_DOMAIN))
+        self.assertTrue(toggle.enabled('marvel', namespace=NAMESPACE_DOMAIN))
+        self.assertFalse(toggle.enabled('darkhorse', namespace=NAMESPACE_DOMAIN))
 
 
 class DyanmicPredictablyRandomToggleTests(TestCase):


### PR DESCRIPTION
## Product Description
No change for end users.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-15765
This change allows us (administrators) to explicit disable random toggles using `!`, e.g. `!mydomain` or `user:!myuser`. This will allow us to, with a single toggle, specify a set of (say) domains to enable for, a set of domains to _disable_ for, and the ability to dynamically change the default for all other domains not specified to disabled (0), enabled (1), or predictably-randomly enabled or disabled at any percentage. Previously everything there was possible except for the ability to explicitly disable specific domains when the randomness was set to anything other than 0.

## Feature Flag
Not specific to a particular feature flag, but does add possible functionality to every `DynamicallyPredictablyRandomToggle` and `FeatureRelease` feature flag.

## Safety Assurance

### Safety story
This is a pretty straightforward tack-on that shouldn't interrupt any existing behavior, unless someone has been using the prefix `!` with some other intended meaning, which I don't believe is the case. This also only affects random toggles (`DynamicallyPredictablyRandomToggle` and `FeatureRelease`), and only those that do not have `NAMESPACE_OTHER` (or technically any namespace not in `ALL_NAMESPACES`) in their namespaces list. That narrows it down to:
- WEB_APPS_UPLOAD_QUESTIONS / web_apps_upload_questions
- SAVE_ONLY_EDITED_FORM_FIELDS / save-only-edited-form-fields
- SMS_USE_LATEST_DEV_APP / sms_use_latest_dev_app
- FORMPLAYER_INCLUDE_STATE_HASH / formplayer_include_state_hash
- SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL / sort_out_of_order_form_submissions_sql
- RATE_LIMIT_RESTORES / rate_limit_restores
- LIVEQUERY_READ_FROM_STANDBYS / livequery_read_from_standbys

None of these toggles have any items containing `!`.

### Automated test coverage

I extended existing tests to cover this change, and there are fairly good tests for this area in general. I made sure new test additions failed before any related code changes, and that the code changes made them pass.
### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
