### PR TITLE
Persist Mobile User Filters on Case Management Map

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -288,6 +288,20 @@ hqDefine("geospatial/js/geospatial_map", [
         self.hasErrors = ko.observable(false);
         self.selectedLocation = null;
 
+        self.setUserFiltersFromUrl = function () {
+            const shouldShowUsers = utils.fetchQueryParam(SHOW_USERS_QUERY_PARAM) || false;
+            self.shouldShowUsers(shouldShowUsers);
+            const userLocationId = utils.fetchQueryParam(USER_LOCATION_ID_QUERY_PARAM);
+            self.selectedLocation = userLocationId;
+            if (userLocationId) {
+                const userLocationName = utils.fetchQueryParam(USER_LOCATION_NAME_QUERY_PARAM);
+                const $filterSelect = $("#location-filter-select");
+                $filterSelect.append(new Option(userLocationName, self.selectedLocation));
+                $filterSelect.val(self.selectedLocation).trigger('change');
+                self.loadUsers();
+            }
+        };
+
         self.loadUsers = function () {
             mapModel.removeMarkersFromMap(mapModel.userMapItems());
             mapModel.userMapItems([]);
@@ -389,6 +403,7 @@ hqDefine("geospatial/js/geospatial_map", [
                     },
                 },
             });
+            userFiltersInstance.setUserFiltersFromUrl();
         }
     }
 

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -292,8 +292,8 @@ hqDefine("geospatial/js/geospatial_map", [
             const shouldShowUsers = utils.fetchQueryParam(SHOW_USERS_QUERY_PARAM) || false;
             self.shouldShowUsers(shouldShowUsers);
             const userLocationId = utils.fetchQueryParam(USER_LOCATION_ID_QUERY_PARAM);
-            self.selectedLocation = userLocationId;
             if (userLocationId) {
+                self.selectedLocation = userLocationId;
                 const userLocationName = utils.fetchQueryParam(USER_LOCATION_NAME_QUERY_PARAM);
                 const $filterSelect = $("#location-filter-select");
                 $filterSelect.append(new Option(userLocationName, self.selectedLocation));

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -27,6 +27,8 @@ hqDefine("geospatial/js/geospatial_map", [
 
     const MAP_CONTAINER_ID = 'geospatial-map';
     const SHOW_USERS_QUERY_PARAM = 'show_users';
+    const USER_LOCATION_ID_QUERY_PARAM = 'user_location_id';
+    const USER_LOCATION_NAME_QUERY_PARAM = 'user_location_name';
 
     var runDisbursementUrl = initialPageData.reverse('case_disbursement');
     var disbursementRunner;
@@ -328,6 +330,22 @@ hqDefine("geospatial/js/geospatial_map", [
 
         self.onFiltersChange = function () {
             self.hasFiltersChanged(true);
+            self.setLocationQueryParams();
+        };
+
+        self.setLocationQueryParams = function () {
+            if (self.selectedLocation) {
+                utils.setQueryParam(USER_LOCATION_ID_QUERY_PARAM, self.selectedLocation);
+                const selectedLocationData = $("#location-filter-select").select2('data');
+                if (selectedLocationData.length) {
+                    // We shouldn't have more than 1, since this select2 doesn't have multi-select enabled
+                    const userLocationName = selectedLocationData[0].text;
+                    utils.setQueryParam(USER_LOCATION_NAME_QUERY_PARAM, userLocationName);
+                }
+            } else {
+                utils.clearQueryParam(USER_LOCATION_ID_QUERY_PARAM);
+                utils.clearQueryParam(USER_LOCATION_NAME_QUERY_PARAM);
+            }
         };
 
         self.toggleFilterMenu = function () {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -5,6 +5,7 @@ hqDefine("geospatial/js/geospatial_map", [
     "hqwebapp/js/initial_page_data",
     "knockout",
     'geospatial/js/models',
+    'geospatial/js/utils',
     'hqwebapp/js/bootstrap3/alert_user',
     'select2/dist/js/select2.full.min',
 ], function (
@@ -12,6 +13,7 @@ hqDefine("geospatial/js/geospatial_map", [
     initialPageData,
     ko,
     models,
+    utils,
     alertUser
 ) {
     const caseMarkerColors = {
@@ -24,6 +26,7 @@ hqDefine("geospatial/js/geospatial_map", [
     };
 
     const MAP_CONTAINER_ID = 'geospatial-map';
+    const SHOW_USERS_QUERY_PARAM = 'show_users';
 
     var runDisbursementUrl = initialPageData.reverse('case_disbursement');
     var disbursementRunner;
@@ -332,6 +335,14 @@ hqDefine("geospatial/js/geospatial_map", [
             const shouldShow = self.showFilterMenu() ? 'show' : 'hide';
             $("#user-filters-panel .panel-body").collapse(shouldShow);
         };
+
+        self.shouldShowUsers.subscribe(function (shouldShowUsers) {
+            if (shouldShowUsers) {
+                utils.setQueryParam(SHOW_USERS_QUERY_PARAM, true);
+            } else {
+                utils.clearQueryParam(SHOW_USERS_QUERY_PARAM);
+            }
+        });
 
         return self;
     };

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -17,7 +17,6 @@ hqDefine('geospatial/js/models', [
     const DOWNPLAY_OPACITY = 0.2;
     const FEATURE_QUERY_PARAM = 'features';
     const SELECTED_FEATURE_ID_QUERY_PARAM = 'selected_feature_id';
-    const MAX_URL_LENGTH = 4500;
     const DEFAULT_CENTER_COORD = [-20.0, -0.0];
     const DISBURSEMENT_LAYER_PREFIX = 'route-';
     const saveGeoPolygonUrl = initialPageData.reverse('geo_polygons');
@@ -572,24 +571,14 @@ hqDefine('geospatial/js/models', [
         };
 
         function updatePolygonQueryParam() {
-            const url = new URL(window.location.href);
+            let success;
             if (Object.keys(self.polygons)) {
-                url.searchParams.set(FEATURE_QUERY_PARAM, JSON.stringify(self.polygons));
+                success = utils.setQueryParam(FEATURE_QUERY_PARAM, JSON.stringify(self.polygons));
             } else {
-                url.searchParams.delete(FEATURE_QUERY_PARAM);
+                success = utils.clearQueryParam(FEATURE_QUERY_PARAM);
             }
-            updateUrl(url);
-        }
-
-        function updateUrl(url) {
-            if (url.href.length <= MAX_URL_LENGTH) {
-                window.history.replaceState({ path: url.href }, '', url.href);
-                self.shouldRefreshPage(true);
-                self.hasUrlError(false);
-            } else {
-                self.shouldRefreshPage(false);
-                self.hasUrlError(true);
-            }
+            self.shouldRefreshPage(success);
+            self.hasUrlError(!success);
         }
 
         function updateSelectedSavedPolygonParam() {
@@ -600,17 +589,18 @@ hqDefine('geospatial/js/models', [
                 return;
             }
 
+            let success;
             if (self.selectedSavedPolygonId()) {
-                url.searchParams.set(SELECTED_FEATURE_ID_QUERY_PARAM, self.selectedSavedPolygonId());
+                success = utils.setQueryParam(SELECTED_FEATURE_ID_QUERY_PARAM, self.selectedSavedPolygonId());
             } else {
-                url.searchParams.delete(SELECTED_FEATURE_ID_QUERY_PARAM);
+                success = utils.clearQueryParam(SELECTED_FEATURE_ID_QUERY_PARAM);
             }
-            updateUrl(url);
+            self.shouldRefreshPage(success);
+            self.hasUrlError(!success);
         }
 
         self.loadPolygonFromQueryParam = function () {
-            const url = new URL(window.location.href);
-            const featureParam = url.searchParams.get(FEATURE_QUERY_PARAM);
+            const featureParam = utils.fetchQueryParam(FEATURE_QUERY_PARAM);
             if (featureParam) {
                 const features = JSON.parse(featureParam);
                 for (const featureId in features) {
@@ -622,8 +612,7 @@ hqDefine('geospatial/js/models', [
         };
 
         self.loadSelectedPolygonFromQueryParam = function () {
-            const url = new URL(window.location.href);
-            const selectedFeatureParam = url.searchParams.get(SELECTED_FEATURE_ID_QUERY_PARAM);
+            const selectedFeatureParam = utils.fetchQueryParam(SELECTED_FEATURE_ID_QUERY_PARAM);
             if (selectedFeatureParam) {
                 self.selectedSavedPolygonId(selectedFeatureParam);
             }

--- a/corehq/apps/geospatial/static/geospatial/js/utils.js
+++ b/corehq/apps/geospatial/static/geospatial/js/utils.js
@@ -1,6 +1,7 @@
 hqDefine('geospatial/js/utils', [], function () {
 
     const DEFAULT_MARKER_OPACITY = 1.0;
+    const MAX_URL_LENGTH = 4500;
 
     var getRandomRGBColor = function () { // TODO: Ensure generated colors looks different!
         var r = Math.floor(Math.random() * 256); // Random value between 0 and 255 for red
@@ -32,10 +33,38 @@ hqDefine('geospatial/js/utils', [], function () {
         return popup;
     };
 
+    var setQueryParam = function (paramName, paramVal) {
+        const url = new URL(window.location.href);
+        url.searchParams.set(paramName, paramVal);
+        return updateUrl(url);
+    };
+
+    var clearQueryParam = function (paramName) {
+        const url = new URL(window.location.href);
+        url.searchParams.delete(paramName);
+        return updateUrl(url);
+    };
+
+    var fetchQueryParam = function (paramName) {
+        const url = new URL(window.location.href);
+        return url.searchParams.get(paramName);
+    };
+
+    function updateUrl(url) {
+        if (url.href.length > MAX_URL_LENGTH) {
+            return false;
+        }
+        window.history.replaceState({ path: url.href }, '', url.href);
+        return true;
+    }
+
     return {
         getRandomRGBColor: getRandomRGBColor,
         uuidv4: uuidv4,
         getTodayDate: getTodayDate,
         createMapPopup: createMapPopup,
+        setQueryParam: setQueryParam,
+        clearQueryParam: clearQueryParam,
+        fetchQueryParam: fetchQueryParam,
     };
 });


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The "Show mobile workers on the map" and "Location" mobile worker filters will now persist on page refresh for the Case Management Geospatial page.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3793).

Updating/changing the polygon filters on the Case Management page prompts the user to do a page refresh. Upon doing so all the mobile worker filters are reset and have to be applied again. This PR addresses this issue by persisting the selected mobile worker filters in the URL as query params. Specifically, the following query params have been added:

- **show_users**: Only holds a value of `True` and indicates that the "Show mobile workers on the map" filter needs to be checked. When this filter is unchecked the query param is removed entirely.
- **user_location_id**: Holds the `location_id` of the selected location to filter mobile workers by. When the filter is set to "All locations" then this query param is removed entirely.
- **user_location_name**: Holds the text name of the selected location to filter mobile workers by. When the filter is set to "All locations" then this query param is removed entirely.

The `user_location_name` query param is added so that the selected location option can be created, added to the select2 widget, and then selected. This needs to be done because the list of locations for the select2 widget are fetched async and, at the time of a page load, no locations have been fetched yet. Please note that adding in an extra option does not create a duplicate location once the list of locations are finally loaded into the widget.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

Only domains that have the `GEOSPATIAL` feature flag enabled will be affected by this change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
All changes have been done in JS, so no automated tests exist.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
