### PR TITLE
Display Case Search Errors on Case Management Page

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -419,7 +419,15 @@ hqDefine("geospatial/js/geospatial_map", [
         // Hide the datatable rows but not the pagination bar
         $('.dataTables_scroll').hide();
 
-        if (xhr.responseJSON.aaData.length && mapModel.mapInstance) {
+        if (xhr.status !== 200) {
+            if (xhr.responseText.length) {
+                alertUser.alert_user(xhr.responseText, 'danger');
+            } else {
+                alertUser.alertUser(
+                    gettext('Oops! Something went wrong! Please report an issue if the problem persists.')
+                );
+            }
+        } else if (xhr.responseJSON.aaData.length && mapModel.mapInstance) {
             loadCases(xhr.responseJSON.aaData);
         }
     });

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -424,7 +424,8 @@ hqDefine("geospatial/js/geospatial_map", [
                 alertUser.alert_user(xhr.responseText, 'danger');
             } else {
                 alertUser.alert_user(
-                    gettext('Oops! Something went wrong! Please report an issue if the problem persists.')
+                    gettext('Oops! Something went wrong! Please report an issue if the problem persists.'),
+                    'danger'
                 );
             }
         } else if (xhr.responseJSON.aaData.length && mapModel.mapInstance) {

--- a/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geospatial_map.js
@@ -423,7 +423,7 @@ hqDefine("geospatial/js/geospatial_map", [
             if (xhr.responseText.length) {
                 alertUser.alert_user(xhr.responseText, 'danger');
             } else {
-                alertUser.alertUser(
+                alertUser.alert_user(
                     gettext('Oops! Something went wrong! Please report an issue if the problem persists.')
                 );
             }


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
If the response is not 200 when fetching case data, the related error message will be shown as an alert to the user:
![Screenshot from 2024-07-22 16-08-17](https://github.com/user-attachments/assets/92a5a9d5-07fb-4831-b11d-e80b4b5d8414)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3792).

If there are errors when Case Search Filters are applied, these will now be shown as an alert to the user. This also extends to any other errors that may occur when fetching case data after case filters have been applied. If there is no response text given in the response, then a generic message will be displayed to the user.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

This change will only affect domains that have the Geospatial feature flag enabled.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
All changes are done in JS, so no automated tests exist.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
