### PR TITLE
Don't default to a role in web user invite

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -495,7 +495,7 @@ class AdminInvitesUserForm(BaseLocationForm):
         super(AdminInvitesUserForm, self).__init__(domain=domain, data=data, **kwargs)
         self.can_edit_tableau_config = can_edit_tableau_config
         domain_obj = Domain.get_by_name(domain)
-        self.fields['role'].choices = role_choices
+        self.fields['role'].choices = [('', _("Select a role"))] + role_choices
         if domain_obj:
             if domain_has_privilege(domain_obj.name, privileges.APP_USER_PROFILES):
                 self.fields['profile'] = forms.ChoiceField(choices=(), label="Profile", required=False)


### PR DESCRIPTION
## Product Description

Instead of defaulting the role field "admin", show the user the text "Select a role":

![image](https://github.com/user-attachments/assets/8f99a877-2936-4365-aa73-7b1c581d535b)

And if you don't change the selection, browser validation kicks in on submit (attempt).

![image](https://github.com/user-attachments/assets/ea798002-b346-418e-a4ff-d45fc4bdfaf9)


## Technical Summary
https://dimagi.atlassian.net/browse/USH-4738

Adds an empty default selection to the dropdown.  If the HTML5 validation is removed or non-functional, this is also validated server-side and re-renders the form with a validation error message.

## Feature Flag


## Safety Assurance


### Safety story
local testing only

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
 