### PR TITLE
Only return user whose account is enabled

### DIFF
--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -70,7 +70,7 @@ def _get_user_principal_names(user_ids, token):
                 {
                     "id": str(i),
                     "method": "GET",
-                    "url": f"/users/{principal_id}?$select=userPrincipalName"
+                    "url": f"/users/{principal_id}?$select=userPrincipalName,accountEnabled"
                 } for i, principal_id in enumerate(chunk)
             ]
         }
@@ -96,7 +96,8 @@ def _get_user_principal_names(user_ids, token):
 
         # Extract userPrincipalName from batch response
         for resp in batch_result['responses']:
-            if 'body' in resp and 'userPrincipalName' in resp['body']:
+            if ('body' in resp and 'userPrincipalName' in resp['body']
+            and resp['body'].get('accountEnabled') is True):
                 user_principal_names.append(resp['body']['userPrincipalName'])
 
     return user_principal_names


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15766

If the client disable a user, the user will still showed as part of the Entra application and returned by Microsoft. So I filter those out, only return user whose `accountEnabled` is `True`.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
