### PR TITLE
Location bulk import "has users" validation

### DIFF
--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -22,7 +22,7 @@ from corehq.apps.user_importer.validation import (
     UsernameValidator,
     BooleanColumnValidator,
     ConfirmationSmsValidator,
-    LocationAccessValidator,
+    LocationValidator,
     _get_invitation_or_editable_user,
 )
 from corehq.apps.users.dbaccessors import delete_all_users
@@ -300,7 +300,7 @@ def test_validating_sms_confirmation_entry():
         "is_active and is_account_confirmed must be either empty or set to False."
 
 
-class TestLocationAccessValidator(LocationHierarchyTestCase):
+class TestLocationValidator(LocationHierarchyTestCase):
 
     domain = 'test-domain'
     location_type_names = ['state', 'county', 'city']
@@ -319,13 +319,13 @@ class TestLocationAccessValidator(LocationHierarchyTestCase):
     @classmethod
     def setUpClass(cls):
         delete_all_users()
-        super(TestLocationAccessValidator, cls).setUpClass()
+        super(TestLocationValidator, cls).setUpClass()
         cls.upload_user = WebUser.create(cls.domain, 'username', 'password', None, None)
         cls.upload_user.set_location(cls.domain, cls.locations['Middlesex'])
         restrict_user_by_location(cls.domain, cls.upload_user)
         cls.editable_user = WebUser.create(cls.domain, 'editable-user', 'password', None, None)
-        cls.validator = LocationAccessValidator(cls.domain, cls.upload_user,
-                                                SiteCodeToLocationCache(cls.domain), True)
+        cls.validator = LocationValidator(cls.domain, cls.upload_user,
+                                          SiteCodeToLocationCache(cls.domain), True)
 
     def testSuccess(self):
         self.editable_user.reset_locations(self.domain, [self.locations['Cambridge'].location_id])
@@ -345,7 +345,7 @@ class TestLocationAccessValidator(LocationHierarchyTestCase):
                                      "invitation")
 
     def testCantEditCommCareUser(self):
-        self.cc_user_validator = LocationAccessValidator(self.domain, self.upload_user,
+        self.cc_user_validator = LocationValidator(self.domain, self.upload_user,
                                                 SiteCodeToLocationCache(self.domain), False)
         self.editable_cc_user = CommCareUser.create(self.domain, 'cc-username', 'password', None, None)
         self.editable_cc_user.reset_locations([self.locations['Suffolk'].location_id])

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -386,6 +386,18 @@ class TestLocationValidator(LocationHierarchyTestCase):
         assert validation_result == self.validator.error_message_location_access.format(
             self.locations['Suffolk'].site_code)
 
+    @flag_enabled('LOCATION_HAS_USERS')
+    def test_location_not_has_users(self):
+        self.editable_user.reset_locations(self.domain, [self.locations['Middlesex'].location_id])
+        self.locations['Cambridge'].location_type.has_users = False
+        self.locations['Cambridge'].location_type.save()
+        user_spec = {'username': self.editable_user.username,
+                     'location_code': [self.locations['Cambridge'].site_code,
+                                       self.locations['Middlesex'].site_code]}
+        validation_result = self.validator.validate_spec(user_spec)
+        assert validation_result == self.validator.error_message_location_not_has_users.format(
+            self.locations['Cambridge'].site_code)
+
     @classmethod
     def tearDownClass(cls):
         super(LocationHierarchyTestCase, cls).tearDownClass()

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -327,7 +327,7 @@ class TestLocationValidator(LocationHierarchyTestCase):
         cls.validator = LocationValidator(cls.domain, cls.upload_user,
                                           SiteCodeToLocationCache(cls.domain), True)
 
-    def testSuccess(self):
+    def test_success(self):
         self.editable_user.reset_locations(self.domain, [self.locations['Cambridge'].location_id])
         user_spec = {'username': self.editable_user.username,
                      'location_code': [self.locations['Middlesex'].site_code,
@@ -335,7 +335,7 @@ class TestLocationValidator(LocationHierarchyTestCase):
         validation_result = self.validator.validate_spec(user_spec)
         assert validation_result is None
 
-    def testCantEditWebUser(self):
+    def test_cant_edit_web_user(self):
         self.editable_user.reset_locations(self.domain, [self.locations['Suffolk'].location_id])
         user_spec = {'username': self.editable_user.username,
                      'location_code': [self.locations['Middlesex'].site_code,
@@ -344,7 +344,7 @@ class TestLocationValidator(LocationHierarchyTestCase):
         assert validation_result == ("Based on your locations do not have permission to edit this user or user "
                                      "invitation")
 
-    def testCantEditCommCareUser(self):
+    def test_cant_edit_commcare_user(self):
         self.cc_user_validator = LocationValidator(self.domain, self.upload_user,
                                                 SiteCodeToLocationCache(self.domain), False)
         self.editable_cc_user = CommCareUser.create(self.domain, 'cc-username', 'password', None, None)
@@ -356,7 +356,7 @@ class TestLocationValidator(LocationHierarchyTestCase):
         assert validation_result == ("Based on your locations do not have permission to edit this user or user "
                                      "invitation")
 
-    def testCantEditInvitation(self):
+    def test_cant_edit_invitation(self):
         self.invitation = Invitation.objects.create(
             domain=self.domain,
             email='invite-user@dimagi.com',
@@ -371,7 +371,7 @@ class TestLocationValidator(LocationHierarchyTestCase):
         assert validation_result == ("Based on your locations do not have permission to edit this user or user "
                                      "invitation")
 
-    def testCantAddLocation(self):
+    def test_cant_add_location(self):
         self.editable_user.reset_locations(self.domain, [self.locations['Cambridge'].location_id])
         user_spec = {'username': self.editable_user.username,
                      'location_code': [self.locations['Suffolk'].site_code,
@@ -380,7 +380,7 @@ class TestLocationValidator(LocationHierarchyTestCase):
         assert validation_result == ("You do not have permission to assign or remove these locations: "
                                      "suffolk")
 
-    def testCantRemoveLocation(self):
+    def test_cant_remove_location(self):
         self.editable_user.reset_locations(self.domain, [self.locations['Suffolk'].location_id,
                                                          self.locations['Cambridge'].location_id])
         user_spec = {'username': self.editable_user.username,

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -4,12 +4,9 @@ from typing import NamedTuple, Optional
 
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.utils.translation import gettext as _
-
-from corehq.apps.user_importer.helpers import spec_value_to_boolean_or_none
-from corehq.apps.users.dbaccessors import get_existing_usernames
 from dimagi.utils.chunked import chunked
 from dimagi.utils.parsing import string_to_boolean
+from django.utils.translation import gettext as _
 
 from corehq.apps.domain.forms import clean_password
 from corehq.apps.enterprise.models import EnterprisePermissions
@@ -18,6 +15,8 @@ from corehq.apps.reports.util import get_allowed_tableau_groups_for_domain
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import user_can_access_other_user, user_can_change_locations
 from corehq.apps.user_importer.exceptions import UserUploadError
+from corehq.apps.user_importer.helpers import spec_value_to_boolean_or_none
+from corehq.apps.users.dbaccessors import get_existing_usernames
 from corehq.apps.users.forms import get_mobile_worker_max_username_length
 from corehq.apps.users.models import CouchUser, Invitation
 from corehq.apps.users.util import normalize_username, raw_username
@@ -456,7 +455,7 @@ class ConfirmationSmsValidator(ImportValidator):
 
 
 class LocationValidator(ImportValidator):
-    error_message_user_access = _("Based on your locations do not have permission to edit this user or user "
+    error_message_user_access = _("Based on your locations you do not have permission to edit this user or user "
                                   "invitation")
     error_message_location_access = _("You do not have permission to assign or remove these locations: {}")
 

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -46,7 +46,7 @@ def get_user_import_validators(domain_obj, all_specs, is_web_user_import, all_us
         ExistingUserValidator(domain, all_specs),
         TargetDomainValidator(upload_domain),
         ProfileValidator(domain, upload_user, is_web_user_import, all_user_profiles_by_name),
-        LocationAccessValidator(domain, upload_user, location_cache, is_web_user_import)
+        LocationValidator(domain, upload_user, location_cache, is_web_user_import)
     ]
     if is_web_user_import:
         return validators + [RequiredWebFieldsValidator(domain), DuplicateValidator(domain, 'email', all_specs),
@@ -455,7 +455,7 @@ class ConfirmationSmsValidator(ImportValidator):
                     return self.error_existing_user.format(self.confirmation_sms_header, errors_formatted)
 
 
-class LocationAccessValidator(ImportValidator):
+class LocationValidator(ImportValidator):
     error_message_user_access = _("Based on your locations do not have permission to edit this user or user "
                                   "invitation")
     error_message_location_access = _("You do not have permission to assign or remove these locations: {}")


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

[Jira](https://dimagi.atlassian.net/browse/USH-4659?atlOrigin=eyJpIjoiODVhMjIzMzZlOTk0NGU2MDk0ODE5NzU1MjA1OTUxNWMiLCJwIjoiaiJ9).

Part of an epic to add a "has users" setting for locations. Adds validation that a location can have users to bulk import. User-facing changes should be behind a feature flag.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

You'll see in the commit story I did a bit of refactoring as well.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

LOCATION_HAS_USERS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- I think automated tests do a pretty good job in this area
- New changes are behind a FF
- Played a little with it locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

corehq.apps.user_importer.tests.test_validators:TestLocationValidator

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Will be done at the end of this feature's dev

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
