### PR TITLE
Remove location fields in SQLUserData

### DIFF
--- a/corehq/apps/users/migrations/0072_remove_location_fields_in_user_data.py
+++ b/corehq/apps/users/migrations/0072_remove_location_fields_in_user_data.py
@@ -22,7 +22,6 @@ def remove_keys_from_data(apps, schema_editor):
                 modified = True
 
         if modified:
-            user_data.data = data
             user_data.save()
 
 
@@ -48,7 +47,6 @@ def revert_keys_in_data(apps, schema_editor):
         if assigned_location_ids:
             data['commcare_location_ids'] = user_location_data(assigned_location_ids)
 
-        user_data.data = data
         user_data.save()
 
 

--- a/corehq/apps/users/migrations/0072_remove_location_fields_in_user_data.py
+++ b/corehq/apps/users/migrations/0072_remove_location_fields_in_user_data.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def remove_keys_from_data(apps, schema_editor):
+    SQLUserData = apps.get_model('users', 'SQLUserData')
+
+    for user_data in SQLUserData.objects.all():
+        data = user_data.data
+        keys_to_remove = ['commcare_location_id', 'commcare_location_ids', 'commcare_primary_case_sharing_id']
+
+        modified = False
+        for key in keys_to_remove:
+            if key in data:
+                del data[key]
+                modified = True
+
+        if modified:
+            user_data.data = data
+            user_data.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0071_rm_user_data'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_keys_from_data),
+    ]

--- a/corehq/apps/users/migrations/0072_remove_location_fields_in_user_data.py
+++ b/corehq/apps/users/migrations/0072_remove_location_fields_in_user_data.py
@@ -1,5 +1,7 @@
 from django.db import migrations
 
+from corehq.apps.users.util import user_location_data
+from corehq.apps.users.models import CommCareUser
 from corehq.util.django_migrations import skip_on_fresh_install
 
 
@@ -22,6 +24,29 @@ def remove_keys_from_data(apps, schema_editor):
             user_data.save()
 
 
+def revert_keys_in_data(apps, schema_editor):
+    SQLUserData = apps.get_model('users', 'SQLUserData')
+    CommCareUserCouch = CommCareUser.get_db()
+
+    for user_data in SQLUserData.objects.all():
+        user_id = user_data.user_id
+
+        commcare_user = CommCareUserCouch.get(user_id)
+
+        data = user_data.data
+        location_id = commcare_user.get('location_id')
+        assigned_location_ids = commcare_user.get('assigned_location_ids', [])
+
+        if location_id:
+            data['commcare_location_id'] = location_id
+            data['commcare_primary_case_sharing_id'] = location_id
+        if assigned_location_ids:
+            data['commcare_location_ids'] = user_location_data(assigned_location_ids)
+
+        user_data.data = data
+        user_data.save()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -29,5 +54,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(remove_keys_from_data),
+        migrations.RunPython(remove_keys_from_data, revert_keys_in_data),
     ]

--- a/corehq/apps/users/migrations/0072_remove_location_fields_in_user_data.py
+++ b/corehq/apps/users/migrations/0072_remove_location_fields_in_user_data.py
@@ -1,5 +1,7 @@
 from django.db import migrations
 
+from couchdbkit import ResourceNotFound
+
 from corehq.apps.users.util import user_location_data
 from corehq.apps.users.models import CommCareUser
 from corehq.util.django_migrations import skip_on_fresh_install
@@ -31,7 +33,10 @@ def revert_keys_in_data(apps, schema_editor):
     for user_data in SQLUserData.objects.all():
         user_id = user_data.user_id
 
-        commcare_user = CommCareUserCouch.get(user_id)
+        try:
+            commcare_user = CommCareUserCouch.get(user_id)
+        except ResourceNotFound:
+            continue
 
         data = user_data.data
         location_id = commcare_user.get('location_id')

--- a/migrations.lock
+++ b/migrations.lock
@@ -1245,6 +1245,7 @@ users
  0069_alter_invitation_custom_user_data_and_more
  0070_alter_invitation_tableau_role
  0071_rm_user_data
+ 0072_remove_location_fields_in_user_data
 util
  0001_initial
  0002_complaintbouncemeta_permanentbouncemeta_transientbounceemail


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15717


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

We used to store location info in two places: on `CouchUser` model and in `SQLUserData`. In previous PR, we have stopped writing location info to and reading location info from `SQLUserData`. This PR is just a follow up step to clean up some data we no longer needed.

I tested applying the migration and reverting it locally and on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

Past code changes that are coordinated with this migration: https://github.com/dimagi/commcare-hq/pull/34852.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
