### PR TITLE
Locations Incremental Sync Bug Fix

### DIFF
--- a/corehq/apps/saved_reports/tests/test_models.py
+++ b/corehq/apps/saved_reports/tests/test_models.py
@@ -82,7 +82,7 @@ class TestReportConfig(TestCase):
         self.assertEqual(self.config.filters.get('enddate'), None)
 
 
-class TestReportNotification(SimpleTestCase):
+class TestReportNotification(TestCase):
     def test_unauthorized_user_cannot_view_report(self):
         report = ReportNotification(owner_id='5', domain='test_domain', recipient_emails=[])
         bad_user = self._create_user(id='3', is_domain_admin=False)

--- a/corehq/apps/users/tests/fixture_status.py
+++ b/corehq/apps/users/tests/fixture_status.py
@@ -122,7 +122,7 @@ class TestFixtureStatus(TestCase):
         fake_location1 = MagicMock()
         fake_location2 = MagicMock()
         fake_location1.location_id = "misty_mountains"
-        fake_location2.location_id = "lonely_mountains"
+        fake_location2.location_id = "lonely_mountain"
 
         self.web_user.set_location(self.domain.name, fake_location1)
         self.web_user.reset_locations(self.domain.name, [fake_location1.location_id, fake_location2.location_id])

--- a/corehq/apps/users/tests/fixture_status.py
+++ b/corehq/apps/users/tests/fixture_status.py
@@ -8,7 +8,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import clear_domain_names
 from corehq.apps.fixtures.models import UserLookupTableStatus, UserLookupTableType
 from corehq.apps.users.dbaccessors import delete_all_users
-from corehq.apps.users.models import CommCareUser, get_fixture_statuses
+from corehq.apps.users.models import CommCareUser, WebUser, get_fixture_statuses
 
 
 class TestFixtureStatus(TestCase):
@@ -21,6 +21,8 @@ class TestFixtureStatus(TestCase):
         self.domain.save()
         self.couch_user = CommCareUser.create(self.domain.name, self.username, password, None, None)
         self.couch_user.save()
+        self.web_user = WebUser.create(self.domain.name, "bob@example.com", "123", None, None)
+        self.web_user.save()
 
     def tearDown(self):
         self._delete_everything()
@@ -58,38 +60,75 @@ class TestFixtureStatus(TestCase):
         )
         self.assertEqual(couch_user.fixture_status(UserLookupTableType.CHOICES[0][0]), now)
 
+        UserLookupTableStatus(
+            user_id=self.web_user._id,
+            fixture_type=UserLookupTableType.CHOICES[0][0],
+            last_modified=now,
+        ).save()
+        self.assertEqual(self.web_user.fixture_status(UserLookupTableType.CHOICES[0][0]), now)
+
     def test_update_status_set_location(self):
         fake_location = MagicMock()
         fake_location.location_id = "the_depths_of_khazad_dum"
         self.assertEqual(UserLookupTableStatus.objects.all().count(), 0)
 
         self.couch_user.set_location(fake_location)
+        self.web_user.set_location(self.domain.name, fake_location)
 
-        self.assertEqual(UserLookupTableStatus.objects.all().count(), 1)
-        user_fixture_status = UserLookupTableStatus.objects.first()
+        self.assertEqual(UserLookupTableStatus.objects.all().count(), 2)
 
+        user_fixture_status = UserLookupTableStatus.objects.get(user_id=self.couch_user._id)
         self.assertEqual(user_fixture_status.user_id, self.couch_user._id)
+        self.assertEqual(user_fixture_status.fixture_type, UserLookupTableType.LOCATION)
+
+        user_fixture_status = UserLookupTableStatus.objects.get(user_id=self.web_user._id)
+        self.assertEqual(user_fixture_status.user_id, self.web_user._id)
         self.assertEqual(user_fixture_status.fixture_type, UserLookupTableType.LOCATION)
 
     def test_update_status_unset_location(self):
         fake_location = MagicMock()
         fake_location.location_id = "the_mines_of_moria"
         self.couch_user.set_location(fake_location)
-        previously_updated_time = UserLookupTableStatus.objects.get(user_id=self.couch_user._id).last_modified
+        self.web_user.set_location(self.domain.name, fake_location)
+        couch_user_prev_updated_time = UserLookupTableStatus.objects.get(user_id=self.couch_user._id).last_modified
+        web_user_prev_updated_time = UserLookupTableStatus.objects.get(user_id=self.web_user._id).last_modified
 
         self.couch_user.unset_location()
+        self.web_user.unset_location(self.domain.name)
 
-        new_updated_time = UserLookupTableStatus.objects.get(user_id=self.couch_user._id).last_modified
-        self.assertTrue(new_updated_time > previously_updated_time)
+        couch_user_new_updated_time = UserLookupTableStatus.objects.get(user_id=self.couch_user._id).last_modified
+        self.assertTrue(couch_user_new_updated_time > couch_user_prev_updated_time)
+        web_user_new_updated_time = UserLookupTableStatus.objects.get(user_id=self.web_user._id).last_modified
+        self.assertTrue(web_user_new_updated_time > web_user_prev_updated_time)
 
     def test_update_status_reset_location(self):
         fake_location = MagicMock()
         fake_location.location_id = "misty_mountains"
         self.couch_user.set_location(fake_location)
-        previously_updated_time = UserLookupTableStatus.objects.get(user_id=self.couch_user._id).last_modified
+        self.web_user.set_location(self.domain.name, fake_location)
+        couch_user_prev_updated_time = UserLookupTableStatus.objects.get(user_id=self.couch_user._id).last_modified
+        web_user_prev_updated_time = UserLookupTableStatus.objects.get(user_id=self.web_user._id).last_modified
 
         fake_location.location_id = "lonely_mountain"
         self.couch_user.set_location(fake_location)
+        self.web_user.reset_locations(self.domain.name, [fake_location.location_id])
 
-        new_updated_time = UserLookupTableStatus.objects.get(user_id=self.couch_user._id).last_modified
+        couch_user_new_updated_time = UserLookupTableStatus.objects.get(user_id=self.couch_user._id).last_modified
+        self.assertTrue(couch_user_new_updated_time > couch_user_prev_updated_time)
+        web_user_new_updated_time = UserLookupTableStatus.objects.get(user_id=self.web_user._id).last_modified
+        self.assertTrue(web_user_new_updated_time > web_user_prev_updated_time)
+
+    def test_unset_location_by_id(self):
+        fake_location1 = MagicMock()
+        fake_location2 = MagicMock()
+        fake_location1.location_id = "misty_mountains"
+        fake_location2.location_id = "lonely_mountains"
+
+        self.web_user.set_location(self.domain.name, fake_location1)
+        self.web_user.reset_locations(self.domain.name, [fake_location1.location_id, fake_location2.location_id])
+
+        previously_updated_time = UserLookupTableStatus.objects.get(user_id=self.web_user._id).last_modified
+
+        self.web_user.unset_location_by_id(self.domain.name, fake_location1.location_id)
+        new_updated_time = UserLookupTableStatus.objects.get(user_id=self.web_user._id).last_modified
         self.assertTrue(new_updated_time > previously_updated_time)

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -179,9 +179,9 @@ class OTARestoreWebUser(OTARestoreUser):
         return None
 
     def get_fixture_last_modified(self):
-        from corehq.apps.fixtures.models import UserLookupTableStatus
+        from corehq.apps.fixtures.models import UserLookupTableType
 
-        return UserLookupTableStatus.DEFAULT_LAST_MODIFIED
+        return self._couch_user.fixture_status(UserLookupTableType.LOCATION)
 
     def get_usercase_id(self):
         return self._couch_user.get_usercase_id(self.domain)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Previously, when incrementally syncing a Web User, the system did not check whether the set of currently assigned locations had changed. As a result, any additional locations assigned to a Web User were not correctly populated in the fixture during the incremental sync.

Fix Implemented: This PR addresses the issue by ensuring that any new locations assigned to a Web User are now correctly added to the fixture during incremental sync.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira Ticket: https://dimagi.atlassian.net/browse/USH-4764
The strategy implemented for WebUser is the same as that used for `CommCareUser`. It involves storing a timestamp to track any changes in a `WebUsers`'s assigned location. During incremental sync, this timestamp is compared against the last sync time to determine if any locations need to be synced.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and on staging. The design and underlying logic has already been used for `CommCareUser`. This PR only expands to also encompass webUsers.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
test exists that checks `UserLookupTableStatus` is updated properly. This PR adds tests that change to `WebUser` locations also updates the `UserLookupTableStatus` model.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
