### PR TITLE
Enforce API key restrictions

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -215,7 +215,11 @@ class ApiKeyFallbackBackend(object):
             return None
 
         try:
-            user = User.objects.get(username=username, api_keys__key=password)
+            api_domain_filter = Q(api_keys__domain='') | Q(api_keys__domain=request.domain)
+            ip = get_ip(request)
+            api_whitelist_filter = Q(api_keys__ip_allowlist=[]) | Q(api_keys__ip_allowlist__contains=[ip])
+            user = User.objects.get(api_domain_filter, api_whitelist_filter,
+                username=username, api_keys__key=password, api_keys__is_active=True)
         except (User.DoesNotExist, User.MultipleObjectsReturned):
             return None
         else:
@@ -273,8 +277,9 @@ class HQApiKeyAuthentication(ApiKeyAuthentication):
             return False
 
         # ensure API Key exists
+        domain_accessible = Q(domain='') | Q(domain=request.domain)
         try:
-            key = user.api_keys.get(key=api_key)
+            key = user.api_keys.get(domain_accessible, key=api_key)
         except HQApiKey.DoesNotExist:
             return self._unauthorized()
 

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -215,7 +215,11 @@ class ApiKeyFallbackBackend(object):
             return None
 
         try:
-            api_domain_filter = Q(api_keys__domain='') | Q(api_keys__domain=request.domain)
+            api_domain_filter = Q(api_keys__domain='')
+            domain = getattr(request, 'domain', '')
+            if domain:
+                api_domain_filter = api_domain_filter | Q(api_keys__domain=domain)
+
             ip = get_ip(request)
             api_whitelist_filter = Q(api_keys__ip_allowlist=[]) | Q(api_keys__ip_allowlist__contains=[ip])
             user = User.objects.get(api_domain_filter, api_whitelist_filter,
@@ -277,7 +281,10 @@ class HQApiKeyAuthentication(ApiKeyAuthentication):
             return False
 
         # ensure API Key exists
-        domain_accessible = Q(domain='') | Q(domain=request.domain)
+        domain_accessible = Q(domain='')
+        domain = getattr(request, 'domain', '')
+        if domain:
+            domain_accessible = domain_accessible | Q(domain=domain)
         try:
             key = user.api_keys.get(domain_accessible, key=api_key)
         except HQApiKey.DoesNotExist:

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -1,6 +1,6 @@
 import base64
 import binascii
-from datetime import datetime
+from datetime import datetime, timezone as tz
 import logging
 import requests
 from functools import wraps
@@ -217,7 +217,7 @@ class ApiKeyFallbackBackend(object):
 
         try:
             is_unexpired_filter = (
-                Q(api_keys__expiration_date__isnull=True) | Q(api_keys__expiration_date__gte=datetime.now())
+                Q(api_keys__expiration_date__isnull=True) | Q(api_keys__expiration_date__gte=datetime.now(tz.utc))
             )
             api_domain_filter = Q(api_keys__domain='')
             domain = getattr(request, 'domain', '')

--- a/corehq/apps/domain/tests/test_auth.py
+++ b/corehq/apps/domain/tests/test_auth.py
@@ -1,11 +1,13 @@
 from django.http.request import HttpRequest
-from django.test import SimpleTestCase
+from django.contrib.auth.models import User
+from django.test import SimpleTestCase, TestCase
 
 from unittest.mock import patch
 
 from corehq.apps.domain.auth import user_can_access_domain_specific_pages
 from corehq.apps.domain.models import Domain
-from corehq.apps.users.models import CouchUser
+from corehq.apps.users.models import CouchUser, HQApiKey
+from corehq.apps.domain.auth import ApiKeyFallbackBackend, HQApiKeyAuthentication
 
 
 class TestUserCanAccessDomainSpecificPages(SimpleTestCase):
@@ -64,3 +66,183 @@ class TestUserCanAccessDomainSpecificPages(SimpleTestCase):
 
         with patch('corehq.apps.users.models.CouchUser.is_member_of', return_value=True):
             self.assertTrue(user_can_access_domain_specific_pages(request))
+
+
+class ApiKeyFallbackTests(TestCase):
+    def test_fails_if_does_not_allow_api_keys_as_passwords(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234')
+
+        request = self._create_request(can_use_api_key=False)
+
+        self.assertIsNone(self.backend.authenticate(request, 'test@dimagi.com', '1234'))
+
+    def test_returns_user_on_successful_auth(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234')
+
+        request = self._create_request()
+
+        self.assertEqual(self.backend.authenticate(request, 'test@dimagi.com', '1234'), user)
+
+    def test_does_not_authenticate_against_inactive_keys(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', is_active=False)
+
+        request = self._create_request()
+
+        self.assertIsNone(self.backend.authenticate(request, 'test@dimagi.com', '1234'))
+
+    def test_allows_access_via_domain_restricted_keys(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', domain='test-domain')
+
+        request = self._create_request(for_domain='test-domain')
+
+        self.assertEqual(self.backend.authenticate(request, 'test@dimagi.com', '1234'), user)
+
+    def test_does_not_allow_cross_domain_access(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', domain='test-domain1')
+
+        request = self._create_request(for_domain='test-domain2')
+
+        self.assertIsNone(self.backend.authenticate(request, 'test@dimagi.com', '1234'))
+
+    def test_allows_access_to_ips_on_whitelist(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', allowed_ips=['127.0.0.1'])
+
+        request = self._create_request(for_domain='test-domain2', ip='127.0.0.1')
+
+        self.assertEqual(self.backend.authenticate(request, 'test@dimagi.com', '1234'), user)
+
+    def test_does_not_allow_ips_not_on_whitelist(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', allowed_ips=['127.0.0.1'])
+
+        request = self._create_request(for_domain='test-domain2', ip='5.5.5.5')
+
+        self.assertIsNone(self.backend.authenticate(request, 'test@dimagi.com', '1234'))
+
+    def setUp(self):
+        self.backend = ApiKeyFallbackBackend()
+
+    @classmethod
+    def _create_user(cls, username):
+        return User.objects.create_user(username=username, password='password')
+
+    @classmethod
+    def _create_api_key_for_user(
+            cls, user, name='ApiKey', key='1234', is_active=True, allowed_ips=None, domain=''):
+        allowed_ips = allowed_ips or []
+        return HQApiKey.objects.create(
+            user=user, key=key, name=name, ip_allowlist=allowed_ips, domain=domain, is_active=is_active)
+
+    @classmethod
+    def _create_request(cls, can_use_api_key=True, for_domain='test-domain', ip=None):
+        request = HttpRequest()
+        request.domain = for_domain
+
+        if ip:
+            request.META['HTTP_X_FORWARDED_FOR'] = ip
+
+        if can_use_api_key:
+            request.check_for_password_as_api_key = True
+
+        return request
+
+
+class HQApiKeyAuthenticationTests(TestCase):
+    def test_successful_attempt_returns_true(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234')
+        request = self._create_request(username='test@dimagi.com', api_key='1234')
+
+        auth = HQApiKeyAuthentication()
+
+        self.assertTrue(auth.is_authenticated(request))
+
+    def test_bad_api_key_returns_unauthorized(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234')
+        request = self._create_request(username='test@dimagi.com', api_key='5678')
+
+        auth = HQApiKeyAuthentication()
+
+        response = auth.is_authenticated(request)
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_cannot_authenticate_with_inactive_key(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', is_active=False)
+        request = self._create_request(username='test@dimagi.com', api_key='1234')
+
+        auth = HQApiKeyAuthentication()
+
+        response = auth.is_authenticated(request)
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_can_authenticate_with_domain_restricted_key(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', domain='test-domain')
+        request = self._create_request(username='test@dimagi.com', api_key='1234', for_domain='test-domain')
+
+        auth = HQApiKeyAuthentication()
+
+        self.assertTrue(auth.is_authenticated(request))
+
+    def test_does_not_allow_cross_domain_access(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', domain='test-domain1')
+        request = self._create_request(username='test@dimagi.com', api_key='1234', for_domain='test-domain2')
+
+        auth = HQApiKeyAuthentication()
+
+        response = auth.is_authenticated(request)
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_user_can_authenticate_if_ip_is_on_whitelist(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', allowed_ips=['127.0.0.1'])
+        request = self._create_request(username='test@dimagi.com', api_key='1234', ip='127.0.0.1')
+
+        auth = HQApiKeyAuthentication()
+
+        self.assertTrue(auth.is_authenticated(request))
+
+    def test_user_cannot_authenticate_with_an_ip_not_in_whitelist(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', allowed_ips=['127.0.0.1'])
+        request = self._create_request(username='test@dimagi.com', api_key='1234', ip='5.5.5.5')
+
+        auth = HQApiKeyAuthentication()
+
+        response = auth.is_authenticated(request)
+
+        self.assertEqual(response.status_code, 401)
+
+    @classmethod
+    def _create_user(cls, username):
+        return User.objects.create_user(username=username, password='password')
+
+    @classmethod
+    def _create_api_key_for_user(
+            cls, user, name='ApiKey', key='1234', is_active=True, allowed_ips=None, domain=''):
+        allowed_ips = allowed_ips or []
+        return HQApiKey.objects.create(
+            user=user, key=key, name=name, ip_allowlist=allowed_ips, domain=domain, is_active=is_active)
+
+    @classmethod
+    def _create_request(cls, username='test@dimagi.com', api_key='1234', for_domain='test-domain', ip=None):
+        request = HttpRequest()
+        request.domain = for_domain
+        request.META['HTTP_AUTHORIZATION'] = f'ApiKey {username}:{api_key}'
+
+        if ip:
+            request.META['HTTP_X_FORWARDED_FOR'] = ip
+
+        return request

--- a/corehq/apps/domain/tests/test_auth.py
+++ b/corehq/apps/domain/tests/test_auth.py
@@ -119,7 +119,7 @@ class ApiKeyFallbackTests(TestCase):
         user = self._create_user('test@dimagi.com')
         self._create_api_key_for_user(user, key='1234', allowed_ips=['127.0.0.1'])
 
-        request = self._create_request(for_domain='test-domain2', ip='127.0.0.1')
+        request = self._create_request(ip='127.0.0.1')
 
         self.assertEqual(self.backend.authenticate(request, 'test@dimagi.com', '1234'), user)
 
@@ -127,7 +127,7 @@ class ApiKeyFallbackTests(TestCase):
         user = self._create_user('test@dimagi.com')
         self._create_api_key_for_user(user, key='1234', allowed_ips=['127.0.0.1'])
 
-        request = self._create_request(for_domain='test-domain2', ip='5.5.5.5')
+        request = self._create_request(ip='5.5.5.5')
 
         self.assertIsNone(self.backend.authenticate(request, 'test@dimagi.com', '1234'))
 
@@ -135,7 +135,7 @@ class ApiKeyFallbackTests(TestCase):
         user = self._create_user('test@dimagi.com')
         self._create_api_key_for_user(user, key='1234', allowed_ips=[])
 
-        request = self._create_request(for_domain='test-domain2', ip=None)
+        request = self._create_request(ip=None)
 
         self.assertEqual(self.backend.authenticate(request, 'test@dimagi.com', '1234'), user)
 

--- a/corehq/apps/domain/tests/test_auth.py
+++ b/corehq/apps/domain/tests/test_auth.py
@@ -1,13 +1,16 @@
-from django.http.request import HttpRequest
-from django.contrib.auth.models import User
-from django.test import SimpleTestCase, TestCase
-
 from unittest.mock import patch
 
-from corehq.apps.domain.auth import user_can_access_domain_specific_pages
+from django.contrib.auth.models import User
+from django.http.request import HttpRequest
+from django.test import SimpleTestCase, TestCase
+
+from corehq.apps.domain.auth import (
+    ApiKeyFallbackBackend,
+    HQApiKeyAuthentication,
+    user_can_access_domain_specific_pages,
+)
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CouchUser, HQApiKey
-from corehq.apps.domain.auth import ApiKeyFallbackBackend, HQApiKeyAuthentication
 
 
 class TestUserCanAccessDomainSpecificPages(SimpleTestCase):

--- a/corehq/apps/domain/tests/test_auth.py
+++ b/corehq/apps/domain/tests/test_auth.py
@@ -200,7 +200,7 @@ class HQApiKeyAuthenticationTests(TestCase):
 
         auth = HQApiKeyAuthentication()
 
-        self.assertTrue(auth.is_authenticated(request))
+        self.assertIs(auth.is_authenticated(request), True)
 
     def test_bad_api_key_returns_unauthorized(self):
         user = self._create_user('test@dimagi.com')
@@ -231,7 +231,7 @@ class HQApiKeyAuthenticationTests(TestCase):
 
         auth = HQApiKeyAuthentication()
 
-        self.assertTrue(auth.is_authenticated(request))
+        self.assertIs(auth.is_authenticated(request), True)
 
     def test_does_not_allow_cross_domain_access(self):
         user = self._create_user('test@dimagi.com')
@@ -251,7 +251,7 @@ class HQApiKeyAuthenticationTests(TestCase):
 
         auth = HQApiKeyAuthentication()
 
-        self.assertTrue(auth.is_authenticated(request))
+        self.assertIs(auth.is_authenticated(request), True)
 
     def test_user_cannot_authenticate_with_an_ip_not_in_whitelist(self):
         user = self._create_user('test@dimagi.com')
@@ -272,7 +272,7 @@ class HQApiKeyAuthenticationTests(TestCase):
         auth = HQApiKeyAuthentication()
 
         with freeze_time(datetime(year=2020, month=3, day=9)):
-            self.assertTrue(auth.is_authenticated(request))
+            self.assertIs(auth.is_authenticated(request), True)
 
     def test_user_cannot_authenticate_with_expired_key(self):
         user = self._create_user('test@dimagi.com')

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3,7 +3,7 @@ import json
 import logging
 import re
 from collections import namedtuple
-from datetime import datetime, date
+from datetime import datetime, date, timezone as tz
 from hashlib import sha1
 from typing import List
 from uuid import uuid4
@@ -3080,7 +3080,7 @@ class ApiKeyManager(models.Manager):
     def get_queryset(self):
         return super().get_queryset()\
             .filter(is_active=True)\
-            .exclude(expiration_date__lt=datetime.now())
+            .exclude(expiration_date__lt=datetime.now(tz.utc))
 
 
 class HQApiKey(models.Model):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15770.

Please read the ticket for description. I do want to mention that there's a lot of similarity between these two authentication methods. Ideally, we can spin up a further ticket to refactor this code so a common path exists between them that ensures both methods protect against all vulnerabilities. I did not do so here, because I felt the fix probably needed to get out sooner rather than later (and there are notable differences between the two).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Tested via unit tests

### Automated test coverage

New test suites created.

### QA Plan

Given that this code affects all API authentication, it should probably receive QA, time-permitting. Otherwise, I will handle this via local/staging testing.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
