### PR TITLE
Improve explicit disable flag UI (and additional fix)

### DIFF
--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -106,6 +106,9 @@ hqDefine('toggle_ui/js/edit-flag', [
         self.saveButtonBottom = self.createSaveButton();
 
         self.getNamespaceHtml = function (namespace, value) {
+            if (value && value[0] === '!') {
+                value = value.replace(/^!/, '');
+            }
             if (namespace === 'domain') {
                 return '<a href="' + initialPageData.reverse('domain_internal_settings', value) + '">domain <i class="fa fa-external-link"></i></a>';
             } else {

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -169,6 +169,12 @@
                   </button>
                 </span>
                 <input class="form-control" type="text" data-bind="value: value">
+                <!-- ko if: value() && value()[0] == '!' -->
+                <span class="input-group-addon"><i class="fa fa-circle-xmark"></i></span>
+                <!-- /ko -->
+                <!-- ko ifnot: value() && value()[0] == '!' -->
+                <span class="input-group-addon"><i class="fa fa-check"></i></span>
+                <!-- /ko -->
               </div>
             </td>
             <!-- B5: replace inline styles with vertical alignment class: https://getbootstrap.com/docs/5.3/utilities/vertical-align/#css -->

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -22,7 +22,7 @@
 
 {% block page_content %}
   {% registerurl 'edit_toggle' toggle.slug %}
-  {% registerurl 'domain_internal_settings' '___' %}
+  {% registerurl 'domain_internal_settings' '---' %}
   {% initial_page_data 'items' toggle.enabled_users %}
   {% initial_page_data 'namespaces' namespaces %}
   {% initial_page_data 'last_used' last_used %}

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -155,7 +155,7 @@
         {% trans "Enabled toggle items" %}
         {% if is_random %}
         <span data-bind="makeHqHelp: {
-            description: '{% trans "Items added here will be enabled regardless of the randomness" %}'}"></span>
+            description: '{% trans "Items added here will be enabled regardless of the randomness (or disabled if preceded by `!`)" %}'}"></span>
         {% endif %}
       </h4>
       <table class="table table-condensed"><!-- B5: add table-borderless and remove `border: none` inline styles on table cells -->


### PR DESCRIPTION
## Product Description
None

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-15765

Followup to https://github.com/dimagi/commcare-hq/pull/34890. In the meantime I also noticed that the "domain" links all had `___` as the domain, and I made the easy fix for that as well.

## Feature Flag
None

## Safety Assurance

### Safety story
Nothing particularly big or new here, but I did test it locally and it works how I expect it.

### Automated test coverage

None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
