### PR TITLE
Select host case as messaging recipient if the case has no parent

### DIFF
--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -621,7 +621,7 @@ class CaseScheduleInstanceMixin(object):
             return None
         elif self.recipient_type == self.RECIPIENT_TYPE_PARENT_CASE:
             if self.case:
-                return self.case.parent
+                return self.case.parent or self.case.host
 
             return None
         elif self.recipient_type == self.RECIPIENT_TYPE_ALL_CHILD_CASES:

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -315,6 +315,34 @@ class SchedulingRecipientTest(TestCase):
                 recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE)
             self.assertEqual(instance.recipient.case_id, parent.case_id)
 
+    def test_host_parent_case_recipient(self):
+        with (
+            create_case(self.domain, 'person') as child,
+            create_case(self.domain, 'person') as parent,
+            create_case(self.domain, 'person') as host
+        ):
+            instance = CaseTimedScheduleInstance(
+                domain=self.domain, case_id=child.case_id,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE
+            )
+            self.assertIsNone(instance.recipient)
+
+            # host case selected when there is no parent case
+            set_parent_case(self.domain, child, host, relationship='extension', identifier='host')
+            instance = CaseTimedScheduleInstance(
+                domain=self.domain, case_id=child.case_id,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE
+            )
+            self.assertEqual(instance.recipient.case_id, host.case_id)
+
+            # parent selected when both parent and host cases are present
+            set_parent_case(self.domain, child, parent, relationship='child', identifier='parent')
+            instance = CaseTimedScheduleInstance(
+                domain=self.domain, case_id=child.case_id,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE
+            )
+            self.assertEqual(instance.recipient.case_id, parent.case_id)
+
     def test_child_case_recipient(self):
         with create_case(self.domain, 'person') as child_1, \
                 create_case(self.domain, 'person') as child_2, \


### PR DESCRIPTION
## Product Description
When "The Case's Parent Case" is selected as the messaging recipient fall back to the case's host if the case has no parent.

In most instances a case would have either a parent or a host and not both. This allows the same recipient type to be used in both instances. In the instance when there is a host and parent the parent will be selected which preserves current behaviour.

## Motivation
This may be needed for a project integrating CommCare with Open Chat Studio.

## Technical Summary
Select host case if case has no parent

## Safety Assurance

### Safety story
Small change using existing functions and backed up by tests.

### Automated test coverage
Added a test that confirms the described behaviour

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
