### PR TITLE
Sync user profile permissions when pushing roles between linked project spaces

### DIFF
--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -408,13 +408,16 @@ def update_user_roles(domain_link, is_pull=False, overwrite=False):
         if role.upstream_id:
             downstream_roles_by_upstream_id[role.upstream_id] = role
 
+    # Permission lists
     downstream_apps = get_brief_apps_in_domain(domain_link.linked_domain)
     app_id_map = {app.origin_id: app.upstream_app_id for app in downstream_apps}
-
+    profiles_for_downstream_domain = CustomDataFieldsProfile.objects.filter(
+        definition__domain=domain_link.linked_domain)
     is_embedded_tableau_enabled = EMBEDDED_TABLEAU.enabled(domain_link.linked_domain)
     if is_embedded_tableau_enabled:
-        visualizations_for_linked_domain = TableauVisualization.objects.filter(
+        visualizations_for_downstream_domain = TableauVisualization.objects.filter(
             domain=domain_link.linked_domain)
+
     failed_default_updates = []
     failed_custom_updates = []
     successful_updates = []
@@ -433,15 +436,21 @@ def update_user_roles(domain_link, is_pull=False, overwrite=False):
             continue
 
         permissions = HqPermissions.wrap(upstream_role_def["permissions"])
+
+        # Permission lists
         if permissions.web_apps_list:
             permissions.web_apps_list = [
                 downstream_id for downstream_id, upstream_id in app_id_map.items()
                 if upstream_id in permissions.web_apps_list
             ]
-
+        permissions.edit_user_profile_list = _get_new_list_permissions(
+            profiles_for_downstream_domain, permissions.edit_user_profile_list,
+            role.permissions.edit_user_profile_list)
         if is_embedded_tableau_enabled:
-            permissions.view_tableau_list = _get_new_tableau_report_permissions(
-                visualizations_for_linked_domain, permissions, role.permissions)
+            permissions.view_tableau_list = _get_new_list_permissions(
+                visualizations_for_downstream_domain, permissions.view_tableau_list,
+                role.permissions.view_tableau_list)
+
         role.save()
         role.set_permissions(permissions.to_list())
         successful_updates.append(upstream_role_def)
@@ -841,13 +850,13 @@ def _convert_reports_permissions(domain_link, master_results):
         role_def['permissions']['view_report_list'] = new_report_perms
 
 
-def _get_new_tableau_report_permissions(downstream_domain_visualizations, upstream_permissions,
-                                        original_downstream_permissions):
-    new_downstream_view_tableau_list = []
-    for viz in downstream_domain_visualizations:
-        upstream_viz_enabled = viz.upstream_id and viz.upstream_id in upstream_permissions.view_tableau_list
-        no_upstream_viz_and_viz_enabled_downstream = (not viz.upstream_id
-            and str(viz.id) in original_downstream_permissions.view_tableau_list)
-        if upstream_viz_enabled or no_upstream_viz_and_viz_enabled_downstream:
-            new_downstream_view_tableau_list.append(str(viz.id))
-    return new_downstream_view_tableau_list
+def _get_new_list_permissions(downstream_obj_list, upstream_permissions_list,
+                              current_downstream_permissions_list):
+    new_downstream_permissions_list = []
+    for obj in downstream_obj_list:
+        if obj.upstream_id:
+            if obj.upstream_id in upstream_permissions_list:
+                new_downstream_permissions_list.append(str(obj.id))
+        elif str(obj.id) in current_downstream_permissions_list:
+            new_downstream_permissions_list.append(str(obj.id))
+    return new_downstream_permissions_list


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

[Jira](https://dimagi.atlassian.net/browse/USH-4756).

Lists of permissions require specific attention in the code to work when roles are pushed between linked project spaces. When we added the list of user profiles a role can edit a couple months ago (here is [the first PR](https://github.com/dimagi/commcare-hq/pull/34651/files#diff-72cb8ba3bb5b51c7450986f76285fc191501fc01ba292789849e90d794fb7662) if you're curious), we forgot to give such special attention to this list of permission. This PR makes it so the permissions lists sync properly.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The code was basically identical to Tableau report permissions lists, you'll notice I essentially copied the tests and even used the same business logic (by refactoring a helper function).

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tests are pretty comprehensive
- Did a simple test locally to check nothing is amiss
- Bug would likely only affect workflows for a single client, who has a workaround of updating roles manually

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

corehq.apps.linked_domain.tests.test_update_roles:TestUpdateRoles

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Not planning to ask for QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
