### PR TITLE
Wait for serverup

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -46,21 +46,19 @@ hqDefine("cloudcare/js/formplayer/app", [
     TemplateCache
 ) {
     Marionette.setRenderer(TemplateCache.render);
-    var FormplayerFrontend = new Marionette.Application();
 
-    FormplayerFrontend.on("before:start", function (app, options) {
-        const xsrfRequest = new $.Deferred();
-        this.xsrfRequest = xsrfRequest.promise();
-        // Make a get call if the csrf token isn't available when the page loads.
-        if ($.cookie('XSRF-TOKEN') === undefined) {
-            $.get(
-                {url: options.formplayer_url + '/serverup', global: false, xhrFields: { withCredentials: true }}
-            ).always(() => { xsrfRequest.resolve(); });
-        } else {
-            // resolve immediately
-            xsrfRequest.resolve();
-        }
+    const WebApp = Marionette.Application.extend({
+        getXSRF: function (options) {
+            return $.get({
+                url: options.formplayer_url + '/serverup',
+                global: false, xhrFields: {withCredentials: true},
+            });
+        },
+    });
 
+    const FormplayerFrontend = new WebApp();
+
+    FormplayerFrontend.on("before:start", function () {
         if (!FormplayerFrontend.regions) {
             FormplayerFrontend.regions = CloudcareUtils.getRegionContainer();
         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
@@ -24,7 +24,9 @@ hqDefine("cloudcare/js/formplayer/main", [
             singleAppMode: false,
             environment: initialPageData.get('environment'),
         };
-        FormplayerFrontEnd.start(options);
+        FormplayerFrontEnd.getXSRF(options).then(() =>
+            FormplayerFrontEnd.start(options)
+        );
 
         var $menuToggle = $('#commcare-menu-toggle'),
             $navbar = $('#hq-navigation'),

--- a/corehq/apps/cloudcare/static/cloudcare/js/preview_app/preview_app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/preview_app/preview_app.js
@@ -13,7 +13,9 @@ hqDefine('cloudcare/js/preview_app/preview_app', [
             $(this).attr('target', '_parent');
         });
 
-        FormplayerFrontend.start(options);
+        FormplayerFrontend.getXSRF(options).then(() =>
+            FormplayerFrontend.start(options)
+        );
 
         if (localStorage.getItem("preview-tablet")) {
             FormplayerFrontend.trigger('view:tablet');


### PR DESCRIPTION
## Product Description

Some time after the xsfRequest promise was introduced the code
that awaits it was removed. Looking further into the issue, I
realized the original bug was caused by $.get returning a promise
itself. So instead of creating a wrapping promise we can just wait
for it directly. The best place is right before we call .start.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-4763

## Feature Flag

No

## Safety Assurance

### Safety story

Tested on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
