### PR TITLE
Fix connection settings layout + crispy fail loud in DEBUG mode

### DIFF
--- a/corehq/motech/forms.py
+++ b/corehq/motech/forms.py
@@ -183,7 +183,6 @@ class ConnectionSettingsForm(forms.ModelForm):
                 ),
             ),
             crispy.Div(
-                "",
                 css_id='test-connection-result',
                 css_class='text-success d-none mb-3',
             ),

--- a/settings.py
+++ b/settings.py
@@ -247,6 +247,7 @@ RECAPTCHA_PUBLIC_KEY = ''
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3to5'
 CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap3to5"
+CRISPY_FAIL_SILENTLY = not DEBUG
 
 FIELD_AUDIT_AUDITORS = [
     "corehq.apps.users.auditors.HQAuditor",


### PR DESCRIPTION
## Technical Summary
This removes an empty field from the connection settings form crispy layout which cases a warning to be logged. (The empty field was added [here](https://github.com/dimagi/commcare-hq/commit/4e19da06f2bed9d6c1dfa5a410575cd8d1bf1bb3#diff-fecab6b7c61a7d46e0a6fc503a118f494e48b2ba6696aaa0f3289eca33cc4780R186))

By default Crispy fails silently when encountering field errors but this can be changed with the `CRISPY_FAIL_SILENTLY` setting.

I think it would be useful to have this fail more loudly in dev environments since warning logs aren't visible easily on prod and although some errors may be benign, others may not e.g. field mispelling, so I've set it to `CRISPY_FAIL_SILENTLY = not DEBUG`.

## Safety Assurance

### Safety story
The form loads correctly with the change and the settings change won't affect production because `DEBUG=False` in production environments.

### Automated test coverage
None

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
