### PR TITLE
Fix bug preventing reports from disabling pagination

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -1114,7 +1114,7 @@ class GenericTabularReport(GenericReportView):
                 },
                 'bad_request_error_text': report_table['bad_request_error_text'],
                 'pagination': {
-                    'hide': getattr(report_table['pagination'], 'hide', False),
+                    'hide': report_table['pagination'].get('hide', False),
                     'is_on': pagination_on,
                     'source': report_table['pagination']['source'] if pagination_on else None,
                     'params': report_table['pagination']['params'] if pagination_on else None,


### PR DESCRIPTION
## Technical Summary
Came across this while looking at potential pagination options we could use in future designs. It looks like this functionality has been broken for at least 6 years, although it doesn't appear that any reports currently set `disable_pagination` to `True`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Locally verified that the existing code did not disable pagination for reports with the `disable_pagination` attribute set to `True`. Confirmed that these changes fix the issue.

### Automated test coverage

No tests -- testing for this feature would either mean creating UI tests, which I don't think would be appropriate, or writing a test against the report's context to ensure that the `pagination` dictionary contains the right properties. Given that reports is looking at an eventual refactor anyway (and there aren't tests surrounding all the other properties on the context), it didn't feel like a great test to write.

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
