### PR TITLE
Allow multiselect widget to grow vertically

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
@@ -77,7 +77,7 @@
 .select2-container--default .select2-selection--single,
 .select2-container--default .select2-selection--multiple {
   border-color: $border-color !important;
-  height: 32px !important;
+  min-height: 32px !important;
   border-radius: $input-border-radius !important;
 }
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
@@ -90,7 +90,7 @@
 +.select2-container--default .select2-selection--single,
 +.select2-container--default .select2-selection--multiple {
 +  border-color: $border-color !important;
-+  height: 32px !important;
++  min-height: 32px !important;
 +  border-radius: $input-border-radius !important;
 +}
 +


### PR DESCRIPTION
## Product Description


#### Before

![image](https://github.com/user-attachments/assets/82ea586a-1dd1-4bda-a024-7cebf7b58053)

![image](https://github.com/user-attachments/assets/1e111c28-2788-4b8b-a3de-72f54706ff36)


#### After

![image](https://github.com/user-attachments/assets/d76fff00-65ac-404e-9616-3eea56315c94)

![image](https://github.com/user-attachments/assets/204a5584-f549-4619-9985-32cdb9f6ae30)

I also confirmed that the single select gets truncated with narrow screens and/or really long labels - it doesn't wrap.

I'm very tempted to fix that placeholder text alignment and clipping, but this fix is pretty urgent, so I'll table it for now.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-15784

The `less` version of this uses `height` for single select and `min-height` for multiple select:
https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/select2s.less#L60-L66
This one uses the same for both.  I tried it out and it seems fine to use `min-height` in both (see screenshots), but I'm certainly open to second opinions.

FWIW there's a little discussion of this line on the PR where it was introduced, though not with regards to `min-height` vs `height`
https://github.com/dimagi/commcare-hq/pull/33754/files#r1393476293

## Feature Flag


## Safety Assurance

I've only tested this locally


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
