### PR TITLE
Fix translation string

### DIFF
--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -68,9 +68,10 @@ class CasePropertyGroup(models.Model):
 
     def unique_error_message(self, model_class, unique_check):
         if unique_check == ('case_type', 'name'):
-            return gettext_lazy('Group "{}" already exists for case type "{}"'.format(
-                self.name, self.case_type.name
-            ))
+            return gettext_lazy('Group "{group}" already exists for case type "{case_type}"').format(
+                group=self.name,
+                case_type=self.case_type.name
+            )
         else:
             return super().unique_error_message(model_class, unique_check)
 


### PR DESCRIPTION
## Technical Summary

Context: I noticed this while working on something else.

Tiny.

1. Calls `format()` on the translated string, not the English string. (If `gettext_lazy()` is called _after_ the group name and case type name have been inserted into the English string, then the translation will never be found.)

2. Calls `format()` using keys in case the word order changes in translation.

## Safety Assurance

### Safety story

Tested locally (by calling `instance.validate_unique()`).

### Automated test coverage

Not covered

### QA Plan

QA not planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
