### PR TITLE
Expand tests on inbound configurable API

### DIFF
--- a/corehq/motech/generic_inbound/tests/test_api.py
+++ b/corehq/motech/generic_inbound/tests/test_api.py
@@ -30,6 +30,7 @@ from corehq.motech.generic_inbound.utils import (
     revert_api_request_from_form,
 )
 from corehq.util.test_utils import flag_enabled, privilege_enabled
+from corehq.form_processor.tests.utils import create_case
 
 
 class GenericInboundAPIViewBaseTest(TestCase):
@@ -122,7 +123,7 @@ class GenericInboundAPIViewBaseTest(TestCase):
             HTTP_USER_AGENT="user agent string",
         )
         return response
-    
+
     def _get_post_data(self):
         """Return request POST data as a tuple(data, content_type)"""
         raise NotImplementedError
@@ -136,13 +137,14 @@ class GenericInboundAPIViewBaseTest(TestCase):
 @privilege_enabled(privileges.API_ACCESS)
 @flag_enabled('API_THROTTLE_WHITELIST')
 class TestGenericInboundAPIView(GenericInboundAPIViewBaseTest):
+    additional_post_data = {}
 
     def _get_post_data(self):
         return (
-            json.dumps({'name': 'cricket', 'is_team_sport': True}),
+            json.dumps({'name': 'cricket', 'is_team_sport': True, **self.additional_post_data}),
             "application/json"
         )
-    
+
     def test_post_denied(self):
         generic_api = self._make_api({})
         url = reverse('generic_inbound_api', args=[self.domain_name, generic_api.url_key])
@@ -404,3 +406,107 @@ class TestGenericInboundAPIView(GenericInboundAPIViewBaseTest):
         revert_api_request_from_form(xform.form_id)
         log.refresh_from_db()
         self.assertEqual(log.status, RequestLog.Status.REVERTED)
+
+    def test_create_duplicate_cases_with_external_id_create(self):
+        case = create_case(self.domain_name, save=True, external_id="external_id")
+
+        self.additional_post_data = {
+            'external_id': case.external_id,
+        }
+
+        expression = UCRExpression.objects.create(
+            name='create_sport',
+            domain=self.domain_name,
+            expression_type=UCR_NAMED_EXPRESSION,
+            definition=self._expression_definition_with_external_id(should_create=True),
+        )
+
+        api = ConfigurableAPI.objects.create(
+            domain=self.domain_name,
+            filter_expression=None,
+            transform_expression=expression,
+            backend=ApiBackendOptions.json,
+        )
+        response = self._call_api_advanced(api, None)
+        new_case = response.json()['cases'][0]
+        self.assertEqual(new_case['external_id'], case.external_id)
+        first_case_id = new_case['case_id']
+
+        response = self._call_api_advanced(api, None)
+        new_case = response.json()['cases'][0]
+        self.assertEqual(new_case['external_id'], case.external_id)
+        self.assertNotEqual(new_case['case_id'], first_case_id)
+
+    def test_create_case_with_external_id_update(self):
+        case = create_case(self.domain_name, save=True, external_id="external_id")
+
+        self.additional_post_data = {
+            'external_id': case.external_id,
+        }
+
+        expression = UCRExpression.objects.create(
+            name='create_sport',
+            domain=self.domain_name,
+            expression_type=UCR_NAMED_EXPRESSION,
+            definition=self._expression_definition_with_external_id(should_create=False),
+        )
+
+        api = ConfigurableAPI.objects.create(
+            domain=self.domain_name,
+            filter_expression=None,
+            transform_expression=expression,
+            backend=ApiBackendOptions.json,
+        )
+        response = self._call_api_advanced(api, None)
+        new_case = response.json()['cases'][0]
+        self.assertEqual(new_case['external_id'], case.external_id)
+
+    def test_does_not_create_duplicate_cases_with_external_id_update(self):
+        case = create_case(self.domain_name, save=True, external_id="external_id")
+
+        self.additional_post_data = {
+            'external_id': case.external_id,
+        }
+
+        expression = UCRExpression.objects.create(
+            name='create_sport',
+            domain=self.domain_name,
+            expression_type=UCR_NAMED_EXPRESSION,
+            definition=self._expression_definition_with_external_id(should_create=False),
+        )
+
+        api = ConfigurableAPI.objects.create(
+            domain=self.domain_name,
+            filter_expression=None,
+            transform_expression=expression,
+            backend=ApiBackendOptions.json,
+        )
+        response = self._call_api_advanced(api, None)
+        new_case = response.json()['cases'][0]
+        self.assertEqual(new_case['external_id'], case.external_id)
+        first_case_id = new_case['case_id']
+
+        response = self._call_api_advanced(api, None)
+        new_case = response.json()['cases'][0]
+        self.assertEqual(new_case['external_id'], case.external_id)
+        self.assertEqual(new_case['case_id'], first_case_id)
+
+    def _expression_definition_with_external_id(self, should_create):
+        property_expressions = {
+            "type": "dict",
+            "name": {
+                "type": "jsonpath",
+                "datatype": "string",
+                "jsonpath": "body.name"
+            },
+        }
+        expression = self._get_ucr_case_expression(property_expressions)
+        expression["properties"].update({
+            "external_id": {
+                "type": "jsonpath",
+                "datatype": "string",
+                "jsonpath": "body.external_id"
+            }
+        })
+        expression["properties"]["create"] = should_create
+        return expression


### PR DESCRIPTION
## Technical Summary
Only adding more tests to verify a certain behaviour as part of debugging [this ticket](https://dimagi.atlassian.net/browse/SC-3822).

It was observed that having the inbound API configured to create a case whilst specifying an external_id will do exactly that. Problem is, if for some reason the same record comes in again, a new case will be created with the same external id but with a different case id. 

An easy way to get around this is to configure the incoming api to not create, but update, such that any duplicate incoming records will simply update the existing case.

The added tests simply verify that this is so.

Open question: when configuring the incoming API one should specify whether the action is a create or not; since it's rather niche to not specify a create when an external id is present, would it not make sense if we support an "upsert" action? Not sure if the lemon is worth the squeeze for this niche case.

## Feature Flag
Configurable Inboud API 

## Safety Assurance

### Safety story
Added tests

### Automated test coverage
Yes, added tests

### QA Plan
No QA


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
