### PR TITLE
add domain to `FactoryContext` to support loading DB expressions

### DIFF
--- a/corehq/motech/generic_inbound/models.py
+++ b/corehq/motech/generic_inbound/models.py
@@ -67,14 +67,14 @@ class ConfigurableAPI(models.Model):
     @property
     @memoized
     def parsed_expression(self):
-        return self.transform_expression.wrapped_definition(FactoryContext.empty())
+        return self.transform_expression.wrapped_definition(FactoryContext.empty(domain=self.domain))
 
     @property
     @memoized
     def parsed_filter(self):
         if not self.filter_expression:
             return None
-        return self.filter_expression.wrapped_definition(FactoryContext.empty())
+        return self.filter_expression.wrapped_definition(FactoryContext.empty(domain=self.domain))
 
     @cached_property
     def backend_class(self):
@@ -107,7 +107,7 @@ class ConfigurableApiValidation(models.Model):
     @property
     @memoized
     def parsed_expression(self):
-        return self.expression.wrapped_definition(FactoryContext.empty())
+        return self.expression.wrapped_definition(FactoryContext.empty(domain=self.api.domain))
 
     def get_error_context(self):
         return {

--- a/corehq/motech/generic_inbound/tests/test_api_processing.py
+++ b/corehq/motech/generic_inbound/tests/test_api_processing.py
@@ -89,7 +89,10 @@ class TestGenericInboundAPI(SimpleTestCase):
                 "property_value": "client"
             })
         validations.append(ConfigurableApiValidation(
-            name="is also patient", message="must be patient again", expression=client_validation_expression
+            api=api_model,
+            name="is also patient",
+            message="must be patient again",
+            expression=client_validation_expression,
         ))
         user = MockUser()
         # 1st validation should fail, 2nd should succeed
@@ -165,6 +168,12 @@ class TestGenericInboundAPINamedExpression(TestCase):
 
 
 def _get_api_with_validation(domain_name, expression=None):
+    api_model = ConfigurableAPI(
+        domain=domain_name,
+        transform_expression=UCRExpression(definition={
+            'type': 'dict', 'properties': {'case_type': 'patient'}
+        }),
+    )
     validation_expression = UCRExpression(
         expression_type=UCR_NAMED_FILTER,
         definition={
@@ -175,15 +184,12 @@ def _get_api_with_validation(domain_name, expression=None):
         })
     validations = [
         ConfigurableApiValidation(
-            name="is patient", message="must be patient", expression=validation_expression
+            api=api_model,
+            name="is patient",
+            message="must be patient",
+            expression=validation_expression,
         )
     ]
-    api_model = ConfigurableAPI(
-        domain=domain_name,
-        transform_expression=UCRExpression(definition={
-            'type': 'dict', 'properties': {'case_type': 'patient'}
-        }),
-    )
     # mock 'get_validations'
     api_model.get_validations = lambda: validations
     return api_model

--- a/corehq/motech/generic_inbound/tests/test_api_processing.py
+++ b/corehq/motech/generic_inbound/tests/test_api_processing.py
@@ -1,9 +1,9 @@
 import dataclasses
 from datetime import datetime
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
-from corehq.apps.userreports.const import UCR_NAMED_FILTER
+from corehq.apps.userreports.const import UCR_NAMED_EXPRESSION, UCR_NAMED_FILTER
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.models import UCRExpression
 from corehq.motech.generic_inbound.backend.base import (
@@ -20,6 +20,7 @@ from corehq.motech.generic_inbound.models import (
     ConfigurableApiValidation,
 )
 from corehq.motech.generic_inbound.utils import get_evaluation_context
+from corehq.util.test_utils import flag_enabled
 
 
 @dataclasses.dataclass
@@ -101,7 +102,69 @@ class TestGenericInboundAPI(SimpleTestCase):
         ])
 
 
-def _get_api_with_validation(domain_name):
+@flag_enabled("UCR_EXPRESSION_REGISTRY")
+class TestGenericInboundAPINamedExpression(TestCase):
+    """Test that named expressions can be used with ConfigurableAPI"""
+    domain_name = "test_named"
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.filter = UCRExpression.objects.create(
+            domain=cls.domain_name,
+            name="patient_case_filter",
+            expression_type=UCR_NAMED_FILTER,
+            definition={
+                "type": "boolean_expression",
+                "expression": {"type": "jsonpath", "jsonpath": "body.resource.type"},
+                "operator": "not_eq",
+                "property_value": "client"
+            }
+        )
+
+        cls.expression = UCRExpression.objects.create(
+            domain=cls.domain_name,
+            name="patient_case_create",
+            expression_type=UCR_NAMED_EXPRESSION,
+            definition={"type": "dict", "properties": {"case_type": "patient"}}
+        )
+
+    def test_named_filter(self):
+        api_model = ConfigurableAPI(
+            domain=self.domain_name,
+            filter_expression=UCRExpression(
+                expression_type=UCR_NAMED_FILTER,
+                definition={"type": "named", "name": "patient_case_filter"}
+            ),
+        )
+        # this also tests that an exception isn't raised
+        self.assertIsNotNone(api_model.parsed_filter)
+
+    def test_named_expression(self):
+        api_model = ConfigurableAPI(
+            domain=self.domain_name,
+            transform_expression=UCRExpression(
+                expression_type=UCR_NAMED_EXPRESSION,
+                definition={"type": "named", "name": "patient_case_create"}
+            ),
+        )
+        # this also tests that an exception isn't raised
+        self.assertIsNotNone(api_model.parsed_expression)
+
+    def test_named_expression_in_validation(self):
+        validation_expression = UCRExpression.objects.create(
+            expression_type=UCR_NAMED_FILTER,
+            definition={"type": "named", "name": "patient_case_filter"}
+        )
+
+        api_model = ConfigurableAPI.objects.create(domain=self.domain_name, transform_expression=self.expression)
+        ConfigurableApiValidation.objects.create(
+            api=api_model, name="is patient", message="must be patient", expression=validation_expression
+        )
+        # this also tests that an exception isn't raised
+        self.assertIsNotNone(api_model.get_validations()[0].parsed_expression)
+
+
+def _get_api_with_validation(domain_name, expression=None):
     validation_expression = UCRExpression(
         expression_type=UCR_NAMED_FILTER,
         definition={

--- a/corehq/motech/repeaters/expression/forms.py
+++ b/corehq/motech/repeaters/expression/forms.py
@@ -25,7 +25,7 @@ class CaseExpressionRepeaterForm(GenericRepeaterForm):
     def clean_configured_expression(self):
         try:
             ExpressionFactory.from_spec(
-                self.cleaned_data['configured_expression'], FactoryContext.empty()
+                self.cleaned_data['configured_expression'], FactoryContext.empty(domain=self.domain)
             )
         except BadSpecError as e:
             raise ValidationError(e)

--- a/corehq/motech/repeaters/expression/repeaters.py
+++ b/corehq/motech/repeaters/expression/repeaters.py
@@ -29,12 +29,12 @@ class BaseExpressionRepeater(Repeater):
     @property
     @memoized
     def parsed_filter(self):
-        return FilterFactory.from_spec(self.configured_filter, FactoryContext.empty())
+        return FilterFactory.from_spec(self.configured_filter, FactoryContext.empty(domain=self.domain))
 
     @property
     @memoized
     def parsed_expression(self):
-        return ExpressionFactory.from_spec(self.configured_expression, FactoryContext.empty())
+        return ExpressionFactory.from_spec(self.configured_expression, FactoryContext.empty(domain=self.domain))
 
     @classmethod
     def available_for_domain(cls, domain):


### PR DESCRIPTION
## Product Description
Make it possible to use 'named_expressions' stored in the DB in other places:

* Generic inbound API
* Configurable Case Repeater

## Technical Summary
Passing the current domain to the `FactoryContext` allows it to load the domain's expressions from the DB.

## Feature Flag
EXPRESSION_REPEATER, GENERIC_INBOUND_API, UCR_EXPRESSION_REGISTRY

## Safety Assurance

### Safety story
Passing the domain to `FactoryContext.empty` is well tested and supported. Each change in this PR is using the domain from a domain specific view or model.

### Automated test coverage
Added in the PR.

### QA Plan
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
