### PR TITLE
Cache Enterprise OData requests

### DIFF
--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -18,6 +18,7 @@ from corehq.apps.api.odata.utils import FieldMetadata
 from corehq.apps.api.odata.views import add_odata_headers
 from corehq.apps.api.resources import HqBaseResource
 from corehq.apps.api.resources.auth import ODataAuthentication
+from corehq.apps.api.resources.meta import get_hq_throttle
 from corehq.apps.enterprise.enterprise import (
     EnterpriseReport,
 )
@@ -48,6 +49,7 @@ class ODataResource(HqBaseResource):
         include_resource_uri = False
         collection_name = 'value'
         authentication = ODataAuthentication()
+        throttle = get_hq_throttle()
         limit = 2000
         max_limit = 10000
 

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -303,6 +303,10 @@ class ODataFeedResource(ODataEnterpriseReportResource):
 
 
 class FormSubmissionResource(ODataEnterpriseReportResource):
+    class Meta(ODataEnterpriseReportResource.Meta):
+        limit = 10000
+        max_limit = 20000
+
     form_id = fields.CharField()
     form_name = fields.CharField()
     submitted = fields.DateTimeField()

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -162,9 +162,12 @@ class ODataEnterpriseReportResource(ODataResource):
     def get_object_list(self, request):
         query_id = request.GET.get('query_id', None)
         report = CacheableReport(self.get_report(request), query_id)
-        # HACK: Tastypie doesn't provide a hook to easily pass data to the paginator
-        # it is not ideal to perform a side effect within this get method, but the paginator
-        # assembles link data from the GET dictionary, so we are forced to modify the request somewhere
+        # Because we are using a cacheable report, we need some way to tell tastypie to use
+        # the generated report for future page requests.
+        # By adding the report's query id to the request, the tastypie paginator will be able to
+        # use it when generating 'next page' links
+        # HACK: This is not ideal, as we are creeating a side effect within a 'get' method,
+        # but it doesn't seem that Tastypie provides an alternate means of modifying links
         self._add_query_id_to_request(request, report.query_id)
 
         return report.rows

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -68,6 +68,13 @@ class ODataResource(HqBaseResource):
         del result['meta']
         return result
 
+    def get_object_list(self, request):
+        '''Intended to be overwritten in subclasses with query logic'''
+        raise NotImplementedError()
+
+    def obj_get_list(self, bundle, **kwargs):
+        return self.get_object_list(bundle.request)
+
     def determine_format(self, request):
         # Currently a hack to force JSON. XML is supported by OData, but "Control Information" fields
         # (https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#_Toc38457735)
@@ -157,9 +164,6 @@ class DomainResource(ODataEnterpriseResource):
         report = EnterpriseDomainReport(account, request.couch_user)
         return report.rows
 
-    def obj_get_list(self, bundle, **kwargs):
-        return self.get_object_list(bundle.request)
-
     def dehydrate(self, bundle):
         bundle.data['domain'] = bundle.obj[6]
         bundle.data['created_on'] = self.convert_datetime(bundle.obj[0])
@@ -188,9 +192,6 @@ class WebUserResource(ODataEnterpriseResource):
         account = BillingAccount.get_account_by_domain(request.domain)
         report = EnterpriseWebUserReport(account, request.couch_user)
         return report.rows
-
-    def obj_get_list(self, bundle, **kwargs):
-        return self.get_object_list(bundle.request)
 
     def dehydrate(self, bundle):
         bundle.data['email'] = bundle.obj[0]
@@ -228,9 +229,6 @@ class MobileUserResource(ODataEnterpriseResource):
         report = EnterpriseMobileWorkerReport(account, request.couch_user)
         return report.rows
 
-    def obj_get_list(self, bundle, **kwargs):
-        return self.get_object_list(bundle.request)
-
     def dehydrate(self, bundle):
         bundle.data['username'] = bundle.obj[0]
         bundle.data['name'] = bundle.obj[1]
@@ -266,9 +264,6 @@ class ODataFeedResource(ODataEnterpriseResource):
         report = EnterpriseODataReport(account, request.couch_user)
         return report.rows
 
-    def obj_get_list(self, bundle, **kwargs):
-        return self.get_object_list(bundle.request)
-
     def dehydrate(self, bundle):
         bundle.data['num_feeds_used'] = bundle.obj[0]
         bundle.data['num_feeds_available'] = bundle.obj[1]
@@ -297,9 +292,6 @@ class FormSubmissionResource(ODataEnterpriseResource):
         report = EnterpriseFormReport(
             account, request.couch_user, start_date=startdate, end_date=enddate, include_form_id=True)
         return report.rows
-
-    def obj_get_list(self, bundle, **kwargs):
-        return self.get_object_list(bundle.request)
 
     def dehydrate(self, bundle):
         bundle.data['form_id'] = bundle.obj[0]

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -366,13 +366,11 @@ class CacheableReport:
         if self._new_query:
             rows = self.report.rows
             self.redis_client.set(self.query_id, rows, timeout=self.CACHE_TIMEOUT)
-            print('##### stored new resuls at: ', self.query_id)
         else:
             rows = self.redis_client.get(self.query_id)
             if rows is None:
                 raise ExpiredCacheException(self.query_id)
             self.redis_client.touch(self.query_id, timeout=self.CACHE_TIMEOUT)
-            print(f'######### Retrieved existing results from {self.query_id}')
 
         return rows
 

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -1,8 +1,6 @@
 import re
-import uuid
 from datetime import datetime, timedelta
 
-from dimagi.utils.couch.cache.cache_core import get_redis_client
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
@@ -345,44 +343,3 @@ class EnterpriseODataReport(EnterpriseReport):
             )
 
         return rows
-
-
-class CacheableReport:
-    CACHE_TIMEOUT = 600  # 10 minutes
-
-    def __init__(self, report, query_id=None):
-        self.report = report
-        self._new_query = query_id is None
-        self.query_id = query_id or uuid.uuid4().hex
-        self.redis_client = get_redis_client()
-
-    @property
-    def headers(self):
-        return self.report.headers
-
-    @property
-    def filename(self):
-        return self.report.filename
-
-    @property
-    def rows(self):
-        rows = None
-        if self._new_query:
-            rows = self.report.rows
-            self.redis_client.set(self.query_id, rows, timeout=self.CACHE_TIMEOUT)
-        else:
-            rows = self.redis_client.get(self.query_id)
-            if rows is None:
-                raise ExpiredCacheException(self.query_id)
-            self.redis_client.touch(self.query_id, timeout=self.CACHE_TIMEOUT)
-
-        return rows
-
-    @property
-    def total(self):
-        return self.report.total
-
-
-class ExpiredCacheException(Exception):
-    def __init__(self, cache_id):
-        super().__init__(f'Cache {cache_id} has expired')

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -40,7 +40,7 @@ class EnterpriseReport:
     title = _('Enterprise Report')
     subtitle = ''
 
-    def __init__(self, account, couch_user):
+    def __init__(self, account, couch_user, **kwargs):
         self.account = account
         self.couch_user = couch_user
         self.slug = None
@@ -54,19 +54,19 @@ class EnterpriseReport:
         return "{} ({}) {}.csv".format(self.account.name, self.title, datetime.utcnow().strftime('%Y%m%d %H%M%S'))
 
     @classmethod
-    def create(cls, slug, account_id, couch_user):
+    def create(cls, slug, account_id, couch_user, **kwargs):
         account = BillingAccount.objects.get(id=account_id)
         report = None
         if slug == cls.DOMAINS:
-            report = EnterpriseDomainReport(account, couch_user)
+            report = EnterpriseDomainReport(account, couch_user, **kwargs)
         elif slug == cls.WEB_USERS:
-            report = EnterpriseWebUserReport(account, couch_user)
+            report = EnterpriseWebUserReport(account, couch_user, **kwargs)
         elif slug == cls.MOBILE_USERS:
-            report = EnterpriseMobileWorkerReport(account, couch_user)
+            report = EnterpriseMobileWorkerReport(account, couch_user, **kwargs)
         elif slug == cls.FORM_SUBMISSIONS:
-            report = EnterpriseFormReport(account, couch_user)
+            report = EnterpriseFormReport(account, couch_user, **kwargs)
         elif slug == cls.ODATA_FEEDS:
-            report = EnterpriseODataReport(account, couch_user)
+            report = EnterpriseODataReport(account, couch_user, **kwargs)
 
         if report:
             report.slug = slug
@@ -216,8 +216,12 @@ class EnterpriseFormReport(EnterpriseReport):
         super().__init__(account, couch_user)
         if not end_date:
             end_date = datetime.utcnow()
+        elif isinstance(end_date, str):
+            end_date = datetime.fromisoformat(end_date)
 
         if start_date:
+            if isinstance(start_date, str):
+                start_date = datetime.fromisoformat(start_date)
             self.datespan = DateSpan(start_date, end_date)
             self.subtitle = _("{} to {}").format(
                 start_date.date(),

--- a/corehq/apps/enterprise/tasks.py
+++ b/corehq/apps/enterprise/tasks.py
@@ -177,6 +177,6 @@ class TaskProgress:
 
 
 class ReportTaskProgress(TaskProgress):
-    def __init__(self, slug, username, query_id=None, **kwargs):
+    def __init__(self, slug, username, query_id=None):
         key = f'report-gen-status-{slug}.{username}'
         super().__init__(key, query_id=query_id)

--- a/corehq/apps/enterprise/tasks.py
+++ b/corehq/apps/enterprise/tasks.py
@@ -129,7 +129,6 @@ class TaskProgress:
         status_dict = {
             'status': self.STATUS_IN_PROGRESS,
             'query_id': None,
-            'error': None,
             'task': task,
         }
 

--- a/corehq/apps/enterprise/tasks.py
+++ b/corehq/apps/enterprise/tasks.py
@@ -157,6 +157,9 @@ class TaskProgress:
 
     def get_data(self):
         query_id = self.get_query_id()
+        if not query_id:
+            raise ValueError('cannot retrieve data without a query ID')
+
         data = self.redis_client.get(query_id)
         if data is None:
             # Before raising an error for a missing value, ensure that the 'None' wasn't deliberately set

--- a/corehq/apps/enterprise/tests/test_enterprise.py
+++ b/corehq/apps/enterprise/tests/test_enterprise.py
@@ -1,7 +1,7 @@
 from django.test import SimpleTestCase, override_settings
 from datetime import datetime
 from freezegun import freeze_time
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, MagicMock
 
 from corehq.apps.export.models.new import FormExportInstance
 from corehq.apps.accounting.models import BillingAccount
@@ -10,10 +10,7 @@ from corehq.apps.export.dbaccessors import ODataExportFetcher
 from corehq.apps.enterprise.enterprise import (
     EnterpriseODataReport,
     EnterpriseFormReport,
-    CacheableReport,
-    ExpiredCacheException,
 )
-from corehq.apps.enterprise import enterprise
 
 
 @override_settings(BASE_ADDRESS='localhost:8000')
@@ -181,65 +178,3 @@ class EnterpriseFormReportTests(SimpleTestCase):
     def test_specifying_timespans_up_to_90_days_works(self):
         end_date = datetime(month=10, day=1, year=2020)
         EnterpriseFormReport(self.billing_account, None, end_date=end_date, num_days=90)
-
-
-class CacheableReportTests(SimpleTestCase):
-    def setUp(self):
-        self.mock_redis = MagicMock()
-        redis_mocker = patch.object(enterprise, 'get_redis_client', lambda: self.mock_redis)
-        redis_mocker.start()
-        self.addCleanup(redis_mocker.stop)
-
-    def test_passes_through_properties(self):
-        base_report = self.make_report(headers=['header1'], rows=['row1'], filename='test.file', total=7)
-        report = CacheableReport(base_report)
-
-        self.assertEqual(report.headers, ['header1'])
-        self.assertEqual(report.rows, ['row1'])
-        self.assertEqual(report.filename, 'test.file')
-        self.assertEqual(report.total, 7)
-
-    def test_returns_cached_data_when_query_key_is_supplied(self):
-        rows_mock = PropertyMock(return_value=8)
-        base_report = self.make_report(rows=rows_mock)
-        report = CacheableReport(base_report, '12345')
-
-        self.mock_redis.get = lambda x: 'cached_value'
-
-        self.assertEqual(report.rows, 'cached_value')
-        rows_mock.assert_not_called()
-
-    def test_throws_exception_when_cache_is_empty(self):
-        base_report = self.make_report()
-        report = CacheableReport(base_report, '12345')
-
-        self.mock_redis.get = lambda x: None
-
-        with self.assertRaises(ExpiredCacheException):
-            report.rows
-
-    def test_stores_new_query_in_cache(self):
-        base_report = self.make_report()
-        report = CacheableReport(base_report)
-
-        report.rows
-        self.mock_redis.set.assert_called()
-
-    def test_accessing_previously_stored_value_updates_the_timeout(self):
-        base_report = self.make_report()
-        report = CacheableReport(base_report, '12345')
-
-        report.rows
-        self.mock_redis.touch.assert_called()
-
-    def make_report(self, headers=None, rows=None, filename='test.file', total=7):
-        headers = headers or ['header1']
-        rows = rows or ['row1']
-
-        report = MagicMock()
-        report.headers = headers
-        type(report).rows = rows
-        report.filename = filename
-        report.total = total
-
-        return report


### PR DESCRIPTION
## Technical Summary
Currently on production, the form submissions API endpoint is essentially unusable. For a specific enterprise, pulling their form submission report takes 1.5 minutes. However, attempting to use the OData endpoint for it takes ~30 minutes. This is because there was no caching and a small page size. The full report needed to be fetched on every page request, and the small page size meant there were many requests.

This fixes the issue by caching the initial request, adding a query id to the 'next page' link. Any future requests using that query id will fetch the previously generated report from redis. These reports are cached for 10 minutes, which is a short amount of time, but any further page requests refresh the duration back to 10 minutes, so this shouldn't be an issue for workflows that fetch all pages quickly in sequence.

I've also increased the number of records fetched per page for specifically the form submissions report. At 2000 rows, the payload was roughly 500K, but the full report needed roughly 30 MB of data. 60 page requests seems a bit excessive, so I've increased the row size by 5x. I think 2.5 MB per request should still be reasonable.

Note that this is still potentially a stopgap fix. Caching the request still means we need to generate the full report on the initial request, which gives our API the unexpected performance characteristic that the first page takes a long time, while future pages return quickly.

## Safety Assurance

### Safety story
Performed local testing. This still has the advantage that the APIs have no user-facing component yet, so they can be deployed and be dormant until we deem they have appropriate performance characteristics.

### Automated test coverage

A new test suite was created for the new `CacheableReport` class.

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
