### PR TITLE
USH-4826: Fix alignment of button

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -1030,13 +1030,8 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
             self.labelWidth = "";
             self.questionTileWidth = `col-md-${columnWidth}`;
         } else {
-            if (self.isLabel || self.isButton) {
-                self.controlWidth = "";
-                self.labelWidth = "";
-            } else {
-                self.controlWidth = constants.CONTROL_WIDTH;
-                self.labelWidth = constants.LABEL_WIDTH;
-            }
+            self.controlWidth = constants.CONTROL_WIDTH;
+            self.labelWidth = constants.LABEL_WIDTH;
             self.questionTileWidth = constants.FULL_WIDTH;
             if (!hasLabel) {
                 self.controlWidth += ' ' + constants.LABEL_OFFSET;

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
@@ -8,6 +8,8 @@
                 error: error,
                 required: $data.required,
                 on: $root.forceRequiredVisible,
+                'text-center': isButton && stylesContains('text-align-center'),
+                'text-end': isButton && stylesContains('text-align-right'),
             }
         ">
     <label class="caption form-label" data-bind="


### PR DESCRIPTION
## Product Description

https://github.com/dimagi/commcare-hq/commit/f9e6bcae2373a047cc7eb8b75b9dbbb03968a2a4 made changes that broke the appearance attribute combination `button-select text-align-right`. Revert some of the changes in a simplified manner.

Specifically the css classes `text-center` and `text-end` where not set anymore on the question if it was of type button. Furthermore, the width of the column was not reduced, the case of a missing label causing the cell to overflow

## Technical Summary

https://dimagi.atlassian.net/browse/USH-4826

## Feature Flag

No

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
