### PR TITLE
Reorganize and Restyle Web Apps Navbar

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -121,14 +121,6 @@ hqDefine('cloudcare/js/debugger/debugger', [
                 $('.debugger-content').outerHeight(contentHeight);
             }
         };
-
-        // Called afterRender, ensures that the debugger takes the whole screen
-        self.adjustWidth = function () {
-            var $debug = $('#instance-xml-home'),
-                $body = $('body');
-
-            $debug.width($body.width());
-        };
     };
 
     // By default do nothing when updating the debugger

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -251,7 +251,7 @@ hqDefine("cloudcare/js/formplayer/app", [
                     });
                 }
 
-                if (user.environment === Const.PREVIEW_APP_ENVIRONMENT) {
+                if (user.isAppPreview) {
                     Kissmetrics.track.event("[app-preview] User submitted a form");
                     GGAnalytics.track.event("App Preview", "User submitted a form");
                     appcues.trackEvent(appcues.EVENT_TYPES.FORM_SUBMIT, { success: true });
@@ -279,7 +279,7 @@ hqDefine("cloudcare/js/formplayer/app", [
                     FormplayerUtils.navigate('/apps', { trigger: true });
                 }
             } else {
-                if (user.environment === Const.PREVIEW_APP_ENVIRONMENT) {
+                if (user.isAppPreview) {
                     appcues.trackEvent(appcues.EVENT_TYPES.FORM_SUBMIT, { success: false });
                 }
                 CloudcareUtils.showError(resp.output, $("#cloudcare-notifications"));

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -3,7 +3,6 @@ hqDefine("cloudcare/js/formplayer/apps/controller", [
     'jquery',
     'backbone',
     'hqwebapp/js/toggles',
-    'cloudcare/js/formplayer/constants',
     'cloudcare/js/formplayer/app',
     'cloudcare/js/formplayer/layout/views/settings',
     'cloudcare/js/formplayer/apps/api',
@@ -13,7 +12,6 @@ hqDefine("cloudcare/js/formplayer/apps/controller", [
     $,
     Backbone,
     Toggles,
-    constants,
     FormplayerFrontend,
     settingsViews,
     AppsAPI,
@@ -61,7 +59,7 @@ hqDefine("cloudcare/js/formplayer/apps/controller", [
                 settings = [],
                 collection,
                 settingsView;
-            if (currentUser.environment === constants.PREVIEW_APP_ENVIRONMENT) {
+            if (currentUser.isAppPreview) {
                 settings = settings.concat([
                     new Backbone.Model({ slug: slugs.SET_LANG }),
                     new Backbone.Model({ slug: slugs.SET_DISPLAY }),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
@@ -29,13 +29,13 @@ hqDefine("cloudcare/js/formplayer/main", [
         var $menuToggle = $('#commcare-menu-toggle'),
             $navbar = $('#hq-navigation'),
             $trialBanner = $('#cta-trial-banner');
-        var hideMenu = function () {
+        var hideMainMenu = function () {
             $menuToggle.data('minimized', 'yes');
             $navbar.addClass("d-none");
             $trialBanner.addClass("d-none");
             $menuToggle.text(gettext('Show Full Menu'));
         };
-        var showMenu = function () {
+        var showMainMenu = function () {
             $menuToggle.data('minimized', 'no');
             $navbar.removeClass("d-none");
             $trialBanner.removeClass("d-none");
@@ -46,15 +46,15 @@ hqDefine("cloudcare/js/formplayer/main", [
         // Show the top HQ nav for new users, so they know how to get back to HQ,
         // but hide it for more mature users so it's out of the way
         if (initialPageData.get("domain_is_on_trial")) {
-            showMenu();
+            showMainMenu();
         } else {
-            hideMenu();
+            hideMainMenu();
         }
         $menuToggle.click(function (e) {
             if ($menuToggle.data('minimized') === 'yes') {
-                showMenu();
+                showMainMenu();
             } else {
-                hideMenu();
+                hideMainMenu();
             }
             e.preventDefault();
         });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -98,7 +98,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", [
                             }
                         } else {
                             if (response.smartLinkRedirect) {
-                                if (user.environment === constants.PREVIEW_APP_ENVIRONMENT) {
+                                if (user.isAppPreview) {
                                     FormplayerFrontend.trigger('showSuccess', gettext("You have selected a case in a different domain. App Preview does not support this feature.", 5000));
                                     FormplayerFrontend.trigger('navigateHome');
                                     return;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -108,7 +108,7 @@ hqDefine("cloudcare/js/formplayer/menus/utils", [
             langCollection;
 
         FormplayerFrontend.regions.addRegions({
-            breadcrumbMenuDropdown: "#breadcrumb__menu-dropdown",
+            breadcrumbMenuDropdown: "#navbar-menu-region",
         });
 
         if (langs && langs.length > 1) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -148,10 +148,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             return _.template($(id).html() || "");
         },
         templateContext: function () {
-            const environment = UsersModels.getCurrentUser().environment;
             return {
                 title: this.options.title,
-                isAppPreview: environment === constants.PREVIEW_APP_ENVIRONMENT,
+                isAppPreview: UsersModels.getCurrentUser().isAppPreview,
             };
         },
         childViewOptions: function (model) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1390,15 +1390,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
                 languageOptionsEnabled: languageOptionsEnabled,
             };
         },
-        events: {
-            "keydown": "expandDropdown",
-        },
-        expandDropdown: function (e) {
-            if (e.keyCode === 13 || e.keyCode === 32) {
-                e.preventDefault();
-                $(this.ui.dropdownMenu).toggleClass("open");
-            }
-        },
     });
 
     const DetailView = Marionette.View.extend({

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1280,15 +1280,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
         template: _.template($("#breadcrumb-item-template").html() || ""),
         className: "breadcrumb-item",
         attributes: function () {
-            let attributes = {
-                "role": "link",
-                "tabindex": "0",
-                "style": this.buildMaxWidth(),
-            };
-            if (this.options.model.get('ariaCurrentPage')) {
-                attributes['aria-current'] = 'page';
-            }
-            return attributes;
+            return {"style": this.buildMaxWidth()};
         },
         events: {
             "click": "crumbClick",
@@ -1308,6 +1300,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             if (e.keyCode === 13) {
                 this.crumbClick(e);
             }
+        },
+        templateContext: function () {
+            return {isCurrentPage: this.options.model.get('ariaCurrentPage')};
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -5,7 +5,6 @@ hqDefine("cloudcare/js/formplayer/sessions/views", [
     'backbone',
     'backbone.marionette',
     'moment',
-    'cloudcare/js/formplayer/constants',
     'cloudcare/js/formplayer/app',
     'cloudcare/js/formplayer/users/models',
     'cloudcare/js/formplayer/utils/utils',
@@ -16,7 +15,6 @@ hqDefine("cloudcare/js/formplayer/sessions/views", [
     Backbone,
     Marionette,
     moment,
-    constants,
     FormplayerFrontend,
     UsersModels,
     utils
@@ -150,7 +148,7 @@ hqDefine("cloudcare/js/formplayer/sessions/views", [
                 totalPages: this.options.totalPages,
                 currentPage: this.model.get('page') - 1,
                 limit: this.model.get("limit"),
-                isPreviewEnv: user.environment === constants.PREVIEW_APP_ENVIRONMENT,
+                isPreviewEnv: user.isAppPreview,
             });
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/views.js
@@ -137,8 +137,7 @@ hqDefine("cloudcare/js/formplayer/sessions/views", [
             }
         },
         templateContext: function () {
-            var user = UsersModels.getCurrentUser(),
-                paginationConfig = utils.paginateOptions(
+            var paginationConfig = utils.paginateOptions(
                     this.options.pageNumber,
                     this.options.totalPages,
                     this.collection.totalSessions
@@ -148,7 +147,7 @@ hqDefine("cloudcare/js/formplayer/sessions/views", [
                 totalPages: this.options.totalPages,
                 currentPage: this.model.get('page') - 1,
                 limit: this.model.get("limit"),
-                isPreviewEnv: user.isAppPreview,
+                isAppPreview: UsersModels.getCurrentUser().isAppPreview,
             });
         },
     });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/models.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/models.js
@@ -85,6 +85,7 @@ hqDefine("cloudcare/js/formplayer/users/models", [
         userInstance.formplayer_url = options.formplayer_url;
         userInstance.debuggerEnabled = options.debuggerEnabled;
         userInstance.environment = options.environment;
+        userInstance.isAppPreview = options.environment === Const.PREVIEW_APP_ENVIRONMENT;
         userInstance.changeFormLanguage = options.changeFormLanguage;
 
         var savedDisplayOptions = _.pick(

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -29,13 +29,22 @@ hqDefine("cloudcare/js/formplayer/users/views", [
      * currently logged in (or restoring) as.
      */
     var RestoreAsBanner = Marionette.View.extend({
-        template: _.template($("#restore-as-banner-template").html() || ""),
         className: 'restore-as-banner-container',
         ui: {
             clear: '.js-clear-user',
         },
         events: {
             'click @ui.clear': 'onClickClearUser',
+        },
+        getTemplate: function () {
+            if (this.model.restoreAs) {
+                const templateId = (usersModels.getCurrentUser().isAppPreview ?
+                                    "#app-preview-restore-as-template" :
+                                    "#webapps-restore-as-template");
+                return _.template($(templateId).html() || "");
+            } else {
+                return "";
+            }
         },
         templateContext: function () {
             var template = "";
@@ -45,15 +54,12 @@ hqDefine("cloudcare/js/formplayer/users/views", [
                 template = gettext("Working as <b><%- restoreAs %></b>.");
             }
             template += " <a class='js-clear-user'>" + gettext("Use <%- username %>.") + "</a>";
-
-            var message = _.template(template)({
-                restoreAs: this.model.restoreAs,
-                username: this.model.getDisplayUsername(),
-                domain: usersModels.getCurrentUser().domain,
-            });
             return {
-                message: message,
-                restoreAs: this.model.restoreAs,
+                message: _.template(template)({
+                    restoreAs: this.model.restoreAs,
+                    username: this.model.getDisplayUsername(),
+                    domain: usersModels.getCurrentUser().domain,
+                }),
             };
         },
         onClickClearUser: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -6,7 +6,6 @@ hqDefine("cloudcare/js/formplayer/users/views", [
     'backbone.marionette',
     'hqwebapp/js/toggles',
     'cloudcare/js/formplayer/app',
-    'cloudcare/js/formplayer/constants',
     'cloudcare/js/formplayer/utils/utils',
     'cloudcare/js/formplayer/users/models',
     'cloudcare/js/formplayer/users/utils',
@@ -17,7 +16,6 @@ hqDefine("cloudcare/js/formplayer/users/views", [
     Marionette,
     toggles,
     FormplayerFrontend,
-    constants,
     formplayerUtils,
     usersModels,
     usersUtils
@@ -161,14 +159,13 @@ hqDefine("cloudcare/js/formplayer/users/views", [
             'keypress @ui.paginationGoTextBox': 'paginationGoKeyAction',
         },
         templateContext: function () {
-            const environment = usersModels.getCurrentUser().environment;
             const paginationOptions = formplayerUtils.paginateOptions(
                 this.model.get('page') - 1,
                 this.totalPages(),
                 this.collection.total
             );
             return _.extend(paginationOptions, {
-                isAppPreview: environment === constants.PREVIEW_APP_ENVIRONMENT,
+                isAppPreview: usersModels.getCurrentUser().isAppPreview,
                 total: this.collection.total,
                 totalPages: this.totalPages(),
                 limit: this.limit,

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -93,6 +93,8 @@
           <ul class="nav navbar-nav navbar-right">
             <li class="nav-item"><a href="#" class="nav-link" id="commcare-menu-toggle">{% trans 'Show Full Menu' %}</a></li>
           </ul>
+          <div id="navbar-menu-region">
+          </div>
         </div>
       </nav>
       <div id="breadcrumb-region" class="print-container"></div>

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -86,8 +86,10 @@
       <section id="formplayer-progress-container"></section>
       <nav class="navbar navbar-cloudcare">
         <div class="d-flex container-fluid">
-          <a class="navbar-brand flex-grow-1" href="{{ home_url }}"><i class="fcc fcc-flower"></i> {% trans "Web Apps" %}</a>
-          <div class="navbar-link flex-grow-1">
+          <div class="flex-grow-1">
+            <a class="navbar-brand" href="{{ home_url }}"><i class="fcc fcc-flower"></i> {% trans "Web Apps" %}</a>
+          </div>
+          <div class="flex-grow-1">
             <div id="restore-as-region"></div>
           </div>
           <ul class="nav navbar-nav navbar-right">

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -19,17 +19,6 @@
   <style id="list-cell-container-style"></style>
 {% endblock %}
 
-{% block navigation %}{{ block.super }}
-  <div class="navbar navbar-cloudcare">
-    <div class="container-fluid">
-      <a class="navbar-brand" href="{{ home_url }}"><i class="fcc fcc-flower"></i> {% trans "Web Apps" %}</a>
-      <ul class="nav navbar-nav navbar-right">
-        <li class="nav-item"><a href="#" class="nav-link" id="commcare-menu-toggle">{% trans 'Show Full Menu' %}</a></li>
-      </ul>
-    </div>
-  </div>
-{% endblock navigation %}
-
 {% block stylesheets %}
   {% compress css %}
     <link rel="stylesheet" href="{% static 'nprogress/nprogress.css' %}">
@@ -97,6 +86,14 @@
     <section id="cases"></section>
     <div id="menu-container">
       <section id="formplayer-progress-container"></section>
+      <div class="navbar navbar-cloudcare">
+        <div class="container-fluid">
+          <a class="navbar-brand" href="{{ home_url }}"><i class="fcc fcc-flower"></i> {% trans "Web Apps" %}</a>
+          <ul class="nav navbar-nav navbar-right">
+            <li class="nav-item"><a href="#" class="nav-link" id="commcare-menu-toggle">{% trans 'Show Full Menu' %}</a></li>
+          </ul>
+        </div>
+      </div>
       <div id="restore-as-region"></div>
       <div id="breadcrumb-region" class="print-container"></div>
       <section id="cloudcare-notifications" class="container notifications-container"></section>

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -115,12 +115,8 @@
     <div role="region" id="sr-notification-region" class="sr-only" aria-live="assertive" aria-relevant="all"></div>
     <small id="version-info"></small>
     {% if request.couch_user.can_edit_data %}
-      <section id="cloudcare-debugger" data-bind="
-          template: {
-              name: 'instance-viewer-ko-template',
-              afterRender: adjustWidth
-          }
-        "></section>
+      <section data-bind="template: { name: 'instance-viewer-ko-template' }"
+               id="cloudcare-debugger"></section>
     {% endif %}
   </div>
   {% if not request.session.secure_session %}

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -80,21 +80,21 @@
     {% registerurl 'gaen_otp_view' request.domain %}
   {% endif %}
 
-  <!-- For now we won't touch this since the form entry code is coupled with it  -->
-
   <div id="cloudcare-main" class="cloudcare-home-content">
     <section id="cases"></section>
     <div id="menu-container">
       <section id="formplayer-progress-container"></section>
-      <div class="navbar navbar-cloudcare">
-        <div class="container-fluid">
-          <a class="navbar-brand" href="{{ home_url }}"><i class="fcc fcc-flower"></i> {% trans "Web Apps" %}</a>
+      <nav class="navbar navbar-cloudcare">
+        <div class="d-flex container-fluid">
+          <a class="navbar-brand flex-grow-1" href="{{ home_url }}"><i class="fcc fcc-flower"></i> {% trans "Web Apps" %}</a>
+          <div class="navbar-link flex-grow-1">
+            <div id="restore-as-region"></div>
+          </div>
           <ul class="nav navbar-nav navbar-right">
             <li class="nav-item"><a href="#" class="nav-link" id="commcare-menu-toggle">{% trans 'Show Full Menu' %}</a></li>
           </ul>
         </div>
-      </div>
-      <div id="restore-as-region"></div>
+      </nav>
       <div id="breadcrumb-region" class="print-container"></div>
       <section id="cloudcare-notifications" class="container notifications-container"></section>
       <div class="container case-tile-container">

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/breadcrumbs.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/breadcrumbs.html
@@ -1,14 +1,14 @@
 {% load i18n %}
 
 <script type="text/template" id="breadcrumb-item-template">
-  <%- data %>
+  <a href="#"><%- data %></a>
 </script>
 
 <script type="text/template" id="breadcrumb-list-template">
-  <nav class="breadcrumb-nav" aria-label="Breadcrumb">
+  <nav style="--bsbreadcrumb-divider: '\f054';" class="breadcrumb-nav" aria-label="Breadcrumb">
     <ol class="breadcrumb">
       <li class="js-home breadcrumb-item" role="link" tabindex="0">
-        {% trans 'Home' %}
+        <a href="#">{% trans 'Home' %}</a>
       </li>
     </ol>
   </nav>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/breadcrumbs.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/breadcrumbs.html
@@ -1,13 +1,15 @@
 {% load i18n %}
 
 <script type="text/template" id="breadcrumb-item-template">
-  <a href="#"><%- data %></a>
+  <a href="#" <% if (isCurrentPage) { %> aria-current="page" <% } %>>
+    <%- data %>
+  </a>
 </script>
 
 <script type="text/template" id="breadcrumb-list-template">
   <nav style="--bsbreadcrumb-divider: '\f054';" class="breadcrumb-nav" aria-label="Breadcrumb">
     <ol class="breadcrumb">
-      <li class="js-home breadcrumb-item" role="link" tabindex="0">
+      <li class="js-home breadcrumb-item">
         <a href="#">{% trans 'Home' %}</a>
       </li>
     </ol>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/breadcrumbs.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/breadcrumbs.html
@@ -11,7 +11,5 @@
         {% trans 'Home' %}
       </li>
     </ol>
-    <div class="float-end dropdown dropdown-menu-right" id="breadcrumb__menu-dropdown">
-    </div>
   </nav>
 </script>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/dropdown.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/dropdown.html
@@ -2,7 +2,7 @@
 
 <script type="text/template" id="menu-dropdown-template">
   <div class="btn-group" id="menu-dropdown">
-    <button class="btn text-light dropdown-toggle nav-link ps-4" role="button"
+    <button class="btn text-light dropdown-toggle nav-link ms-4" role="button"
             data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <i class="fa fa-bars"></i>
       <span class="sr-only">{% trans 'Dropdown toggle' %}</span>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/dropdown.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/dropdown.html
@@ -2,12 +2,12 @@
 
 <script type="text/template" id="menu-dropdown-template">
   <div class="btn-group" id="menu-dropdown">
-    <button class="btn btn-dark dropdown-toggle" role="button"
+    <button class="btn text-light dropdown-toggle nav-link ps-4" role="button"
             data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <i class="fa fa-bars"></i>
       <span class="sr-only">{% trans 'Dropdown toggle' %}</span>
     </button>
-    <ul class="dropdown-menu dropdown-menu-right noprint-sub-container" aria-label="Dropdown">
+    <ul class="dropdown-menu dropdown-menu-end noprint-sub-container" aria-label="Dropdown">
       <li tabindex="0" class="print-button">
         <a href="#" class="dropdown-item">
           {% trans "Print" %}

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/sessions/list.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/sessions/list.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <script type="text/template" id="session-view-list-template">
-  <% if(isPreviewEnv) { %>
+  <% if(isAppPreview) { %>
   <div class="breadcrumb-form-container">
     <ol class="breadcrumb breadcrumb-form">
       <li class="breadcrumb-item">
@@ -20,7 +20,7 @@
   </div>
   <% } %>
   <div class="module-menu-container module-menu-bar-offset">
-    <% if (!isPreviewEnv) { %>
+    <% if (!isAppPreview) { %>
     <div class="page-header menu-header d-none d-md-block">
       <h1 class="page-title">{% trans "Incomplete Forms" %}</h1>
     </div>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users/restore_as_banner.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users/restore_as_banner.html
@@ -3,9 +3,9 @@
 <script type="text/template" id="restore-as-banner-template">
   {% if request|can_use_restore_as %}
     <% if (restoreAs) { %>
-    <div class="restore-as-banner module-banner">
-      <%= message %>
-    </div>
+      <span class="badge rounded-pill text-dark bg-cc-light-warm-accent-extra-hi">
+        <%= message %>
+      </span>
     <% } %>
   {% endif %}
 </script>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users/restore_as_banner.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users/restore_as_banner.html
@@ -1,11 +1,13 @@
 {% load hq_shared_tags %}
 
-<script type="text/template" id="restore-as-banner-template">
-  {% if request|can_use_restore_as %}
-    <% if (restoreAs) { %>
-      <span class="badge rounded-pill text-dark bg-cc-light-warm-accent-extra-hi">
-        <%= message %>
-      </span>
-    <% } %>
-  {% endif %}
+<script type="text/template" id="app-preview-restore-as-template">
+  <div class="restore-as-banner module-banner">
+    <%= message %>
+  </div>
+</script>
+
+<script type="text/template" id="webapps-restore-as-template">
+  <span class="badge rounded-pill text-dark bg-cc-light-warm-accent-extra-hi">
+    <%= message %>
+  </span>
 </script>

--- a/corehq/apps/cloudcare/templates/cloudcare/preview_app.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/preview_app.html
@@ -72,12 +72,8 @@
       </section>
     </div>
     {% if request.couch_user.can_edit_data %}
-      <section id="cloudcare-debugger" data-bind="
-        template: {
-            name: 'instance-viewer-ko-template',
-            afterRender: adjustWidth
-        }
-    "></section>
+      <section data-bind="template: { name: 'instance-viewer-ko-template' }"
+               id="cloudcare-debugger"></section>
     {% endif %}
   </div>
 {% endblock %}

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/debugger/debugger.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/debugger/debugger.scss
@@ -1,5 +1,5 @@
 .debugger {
-  width: 800px;
+  width: 100%;
   position: fixed;
   bottom: 0;
   left: 0;

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/debugger/debugger.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/debugger/debugger.scss
@@ -27,7 +27,7 @@
   .debugger-tab-title {
     line-height: 18px;
     color: white;
-    background-color: $cc-brand-low;
+    background-color: $cc-brand-mid;
     border-bottom: #ddd solid 4px;
     border-top: 0;
     border-left: 0;

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/breadcrumbs.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/breadcrumbs.scss
@@ -1,12 +1,10 @@
+// These styles are overridden in preview_app/breadcrumbs.scss and
+// formplayer-webapp/breadcrumbs.scss
 #breadcrumb-region {
     position: sticky;
     position: -webkit-sticky;
     top: 0;
     z-index: $zindex-navbar-cloudcare - 1;
-}
-
-#breadcrumb-region .breadcrumb-item, .single-app-view .breadcrumb-item {
-    cursor: pointer;
 }
 
 #breadcrumb-region .breadcrumb,
@@ -19,24 +17,11 @@
 
   .breadcrumb-item {
     color: white;
-
     &:before {
-      padding: 0 6px 0 0;
-      content: '\f054';
-      font-family: 'FontAwesome';
+      font-family: "FontAwesome";  // supports bsbreadcrumb-divider: \f054
     }
-
     a {
       color: white;
     }
   }
-  .breadcrumb-item:first-child {
-    &:before {
-      display: none;
-    }
-  }
-}
-
-#breadcrumb__menu-dropdown {
-    cursor: pointer;
 }

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/breadcrumbs.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/breadcrumbs.scss
@@ -2,7 +2,7 @@
     position: sticky;
     position: -webkit-sticky;
     top: 0;
-    z-index: $zindex-navbar-cloudcare;
+    z-index: $zindex-navbar-cloudcare - 1;
 }
 
 #breadcrumb-region .breadcrumb-item, .single-app-view .breadcrumb-item {

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/breadcrumbs.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/breadcrumbs.scss
@@ -10,18 +10,11 @@
 #breadcrumb-region .breadcrumb,
 .single-app-view .breadcrumb,
 .breadcrumb-form-container .breadcrumb {
-  background-color: $cc-brand-mid;
   border-radius: 0;
   box-shadow: 0 0 5px 2px rgba(0,0,0,.3);
   border: none;
 
-  .breadcrumb-item {
-    color: white;
-    &:before {
-      font-family: "FontAwesome";  // supports bsbreadcrumb-divider: \f054
-    }
-    a {
-      color: white;
-    }
+  .breadcrumb-item::before {
+    font-family: "FontAwesome";  // supports bsbreadcrumb-divider: \f054
   }
 }

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/navigation.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/navigation.scss
@@ -13,3 +13,7 @@
 #hq-navigation {
   transition: all 1s;
 }
+
+.bg-cc-light-warm-accent-extra-hi {
+  background-color: $cc-light-warm-accent-hi;
+}

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp-main.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp-main.scss
@@ -10,7 +10,7 @@ If you want to make changes relevant for BOTH app preview and the main
 formplayer, please make changes to the cloudcare styles.
 **/
 
-$breadcrumb-height-cloudcare: 46px;
+$breadcrumb-height-cloudcare: 36px;
 
 @import "formplayer-webapp/content";
 @import "formplayer-webapp/navbar";

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/breadcrumbs.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/breadcrumbs.scss
@@ -1,15 +1,8 @@
+// Only webapps
 #breadcrumb-region .breadcrumb,
 .single-app-view .breadcrumb,
 .breadcrumb-form-container .breadcrumb {
-  font-size: 1.2rem;
-  margin-top: -1px;
   .breadcrumb-item {
-    &:before {
-      color: #ffffff;
-      font-size: 12px;
-      vertical-align: top;
-      line-height: 28px;
-    }
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden
@@ -46,11 +39,5 @@
     font-size: 12px;
     margin-bottom: 0px;
     padding-left: 33px;
-    .breadcrumb-item {
-      &:before {
-        font-size: 7px;
-        line-height: 17px;
-      }
-    }
   }
 }

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/breadcrumbs.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/breadcrumbs.scss
@@ -22,7 +22,7 @@
   .breadcrumb {
     box-shadow: none;
     background-color: unset;
-    padding: 0 0 0 10px;
+    padding: 0 0 0 $grid-gutter-width / 2;
     margin-bottom: 0;
     flex-grow: 1;
   }

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/breadcrumbs.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/breadcrumbs.scss
@@ -5,12 +5,15 @@
   .breadcrumb-item {
     text-overflow: ellipsis;
     white-space: nowrap;
-    overflow: hidden
+    overflow: hidden;
+    &::before {
+        color: $cc-neutral-hi;
+    }
   }
 }
 
 #breadcrumb-region .breadcrumb-nav {
-  background-color: $cc-brand-mid;
+  background-color: white;
   box-shadow: 0 0 5px 2px rgba(0,0,0,.3);
   display: flex;
   align-items: center;

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/breadcrumbs.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/breadcrumbs.scss
@@ -14,11 +14,14 @@
     flex-grow: 1;
 
     .breadcrumb-item {
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
       &::before {
         color: $cc-neutral-hi;
+      }
+      a {
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        display: block;
       }
     }
   }

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/breadcrumbs.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/breadcrumbs.scss
@@ -1,17 +1,4 @@
 // Only webapps
-#breadcrumb-region .breadcrumb,
-.single-app-view .breadcrumb,
-.breadcrumb-form-container .breadcrumb {
-  .breadcrumb-item {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-    &::before {
-        color: $cc-neutral-hi;
-    }
-  }
-}
-
 #breadcrumb-region .breadcrumb-nav {
   background-color: white;
   box-shadow: 0 0 5px 2px rgba(0,0,0,.3);
@@ -25,10 +12,15 @@
     padding: 0 0 0 $grid-gutter-width / 2;
     margin-bottom: 0;
     flex-grow: 1;
-  }
 
-  .btn-group {
-    padding-right: 10px;
+    .breadcrumb-item {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      &::before {
+        color: $cc-neutral-hi;
+      }
+    }
   }
 }
 

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/menu.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/menu.scss
@@ -15,7 +15,7 @@
 
 .persistent-menu-toggle {
   color: white;
-  background-color: $cc-brand-low;
+  background-color: $cc-brand-mid;
   padding: $spacer / 2;
 }
 

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/menu.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/menu.scss
@@ -17,6 +17,9 @@
   color: white;
   background-color: $cc-brand-mid;
   padding: $spacer / 2;
+  &:hover {
+    background-color: $cc-brand-low;
+  }
 }
 
 $persistent-menu-image-size: 2rem;

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/navbar.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/navbar.scss
@@ -3,7 +3,7 @@ $cloudcare-nav-height: 30px;
 .navbar-cloudcare {
   margin-bottom: 0;
   border: none;
-  background-color: $cc-brand-low;
+  background-color: $cc-brand-mid;
   min-height: $cloudcare-nav-height;
   transition: 1s all;
   z-index: $zindex-navbar-cloudcare;

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/navbar.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/navbar.scss
@@ -11,10 +11,8 @@ $cloudcare-nav-height: 30px;
 
 .navbar-cloudcare .navbar-brand {
   color: $cc-bg;
-  height: $cloudcare-nav-height;
-  padding: 6.5px 15px;
+  padding: 6.5px 0;
   text-transform: uppercase;
-  font-size: 11px;
 }
 
 .navbar-cloudcare .navbar-nav {

--- a/corehq/apps/hqwebapp/static/preview_app/scss/preview_app-main.scss
+++ b/corehq/apps/hqwebapp/static/preview_app/scss/preview_app-main.scss
@@ -11,7 +11,7 @@ $transition-speed: .5s;
 @import "preview_app/navigation";
 @import "preview_app/grid";
 @import "preview_app/appicon";
-@import "preview_app/breadcrumb";
+@import "preview_app/breadcrumbs";
 @import "preview_app/module";
 @import "preview_app/form";
 @import "preview_app/formnav";

--- a/corehq/apps/hqwebapp/static/preview_app/scss/preview_app/breadcrumbs.scss
+++ b/corehq/apps/hqwebapp/static/preview_app/scss/preview_app/breadcrumbs.scss
@@ -11,9 +11,6 @@
     display: none;
     &:before {
       color: white;
-      vertical-align: middle;
-      font-size: 8px;
-      padding: 0 4px;
     }
   }
   li:first-child {

--- a/corehq/apps/hqwebapp/static/preview_app/scss/preview_app/breadcrumbs.scss
+++ b/corehq/apps/hqwebapp/static/preview_app/scss/preview_app/breadcrumbs.scss
@@ -1,17 +1,22 @@
 #breadcrumb-region .breadcrumb,
 .single-app-view .breadcrumb,
 .breadcrumb-form-container .breadcrumb {
+  background-color: $cc-brand-mid;
+  color: white;
   text-transform: uppercase;
   margin: 0;
   padding: 0 10px;
   line-height: 30px;
   font-size: 11px;
 
+  li:before,
+  .breadcrumb-item a {
+      color: white;
+  }
+
+  // Show only the first and last breadcrumb item
   li {
     display: none;
-    &:before {
-      color: white;
-    }
   }
   li:first-child {
     display: inline-block;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/debugger_debugger.debugger_debugger.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/debugger_debugger.debugger_debugger.style.diff.txt
@@ -1,6 +1,9 @@
 --- 
 +++ 
-@@ -3,74 +3,61 @@
+@@ -1,76 +1,63 @@
+ .debugger {
+-  width: 800px;
++  width: 100%;
    position: fixed;
    bottom: 0;
    left: 0;
@@ -40,7 +43,7 @@
 +  .debugger-tab-title {
 +    line-height: 18px;
 +    color: white;
-+    background-color: $cc-brand-low;
++    background-color: $cc-brand-mid;
 +    border-bottom: #ddd solid 4px;
 +    border-top: 0;
 +    border-left: 0;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-common_breadcrumbs.formplayer-common_breadcrumbs.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-common_breadcrumbs.formplayer-common_breadcrumbs.style.diff.txt
@@ -1,16 +1,18 @@
 --- 
 +++ 
-@@ -2,30 +2,35 @@
+@@ -1,37 +1,20 @@
++// These styles are overridden in preview_app/breadcrumbs.scss and
++// formplayer-webapp/breadcrumbs.scss
+ #breadcrumb-region {
      position: sticky;
      position: -webkit-sticky;
      top: 0;
 -    z-index: @zindex-navbar-cloudcare;
-+    z-index: $zindex-navbar-cloudcare;
- }
- 
+-}
+-
 -#breadcrumb-region .breadcrumb-text, .single-app-view .breadcrumb-text {
-+#breadcrumb-region .breadcrumb-item, .single-app-view .breadcrumb-item {
-     cursor: pointer;
+-    cursor: pointer;
++    z-index: $zindex-navbar-cloudcare - 1;
  }
  
  #breadcrumb-region .breadcrumb,
@@ -21,27 +23,25 @@
 -  .border-top-radius(0);
 -  .border-bottom-radius(0);
 -  .box-shadow(0 0 5px 2px rgba(0,0,0,.3));
-+  background-color: $cc-brand-mid;
 +  border-radius: 0;
 +  box-shadow: 0 0 5px 2px rgba(0,0,0,.3);
    border: none;
  
 -  .breadcrumb-text {
-+  .breadcrumb-item {
-+    color: white;
-+
-     &:before {
-+      padding: 0 6px 0 0;
-       content: '\f054';
-       font-family: 'FontAwesome';
-     }
-+
-+    a {
-+      color: white;
-+    }
-   }
+-    &:before {
+-      content: '\f054';
+-      font-family: 'FontAwesome';
+-    }
+-  }
 -  .breadcrumb-text:first-child {
-+  .breadcrumb-item:first-child {
-     &:before {
-       display: none;
-     }
+-    &:before {
+-      display: none;
+-    }
++  .breadcrumb-item::before {
++    font-family: "FontAwesome";  // supports bsbreadcrumb-divider: \f054
+   }
+ }
+-
+-#breadcrumb__menu-dropdown {
+-    cursor: pointer;
+-}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-common_navigation.formplayer-common_navigation.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-common_navigation.formplayer-common_navigation.style.diff.txt
@@ -16,3 +16,11 @@
  #hq-navigation .navbar {
    margin-bottom: 0;
  }
+@@ -22,3 +13,7 @@
+ #hq-navigation {
+   transition: all 1s;
+ }
++
++.bg-cc-light-warm-accent-extra-hi {
++  background-color: $cc-light-warm-accent-hi;
++}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-webapp-main.formplayer-webapp-main.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-webapp-main.formplayer-webapp-main.style.diff.txt
@@ -13,7 +13,7 @@
  formplayer, please make changes to the cloudcare styles.
  **/
 +
-+$breadcrumb-height-cloudcare: 46px;
++$breadcrumb-height-cloudcare: 36px;
  
  @import "formplayer-webapp/content";
  @import "formplayer-webapp/navbar";

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-webapp_breadcrumbs.formplayer-webapp_breadcrumbs.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-webapp_breadcrumbs.formplayer-webapp_breadcrumbs.style.diff.txt
@@ -1,30 +1,39 @@
 --- 
 +++ 
-@@ -1,16 +1,10 @@
+@@ -1,38 +1,28 @@
++// Only webapps
  #breadcrumb-region .breadcrumb,
  .single-app-view .breadcrumb,
  .breadcrumb-form-container .breadcrumb {
 -  font-size: 2rem;
 -  padding-top: 1rem;
 -  padding-bottom: 1rem;
-+  font-size: 1.2rem;
-   margin-top: -1px;
+-  margin-top: -1px;
 -  .breadcrumb-text {
 -    &.js-home {
 -      margin-right: -5px;
 -    }
-+  .breadcrumb-item {
-     &:before {
+-    &:before {
 -      padding: 0 6px 0 12px;
-       color: #ffffff;
-       font-size: 12px;
-       vertical-align: top;
-@@ -23,16 +17,16 @@
+-      color: #ffffff;
+-      font-size: 12px;
+-      vertical-align: top;
+-      line-height: 28px;
+-    }
++  .breadcrumb-item {
+     text-overflow: ellipsis;
+     white-space: nowrap;
+-    overflow: hidden
++    overflow: hidden;
++    &::before {
++        color: $cc-neutral-hi;
++    }
+   }
  }
  
  #breadcrumb-region .breadcrumb-nav {
 -  background-color: @cc-brand-mid;
-+  background-color: $cc-brand-mid;
++  background-color: white;
    box-shadow: 0 0 5px 2px rgba(0,0,0,.3);
    display: flex;
    align-items: center;
@@ -35,16 +44,19 @@
      box-shadow: none;
      background-color: unset;
 -    padding: 10px 10px 0 10px;
-+    padding: 0 0 0 10px;
++    padding: 0 0 0 $grid-gutter-width / 2;
      margin-bottom: 0;
      flex-grow: 1;
    }
-@@ -52,7 +46,7 @@
+@@ -52,11 +42,5 @@
      font-size: 12px;
      margin-bottom: 0px;
      padding-left: 33px;
 -    .breadcrumb-text {
-+    .breadcrumb-item {
-       &:before {
-         font-size: 7px;
-         line-height: 17px;
+-      &:before {
+-        font-size: 7px;
+-        line-height: 17px;
+-      }
+-    }
+   }
+ }

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-webapp_menu.formplayer-webapp_menu.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-webapp_menu.formplayer-webapp_menu.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -5,10 +5,46 @@
+@@ -5,10 +5,49 @@
  #menu-region .module-menu-container,
  #menu-region .module-case-list-container {
    background-color: white;
@@ -15,8 +15,11 @@
 +
 +.persistent-menu-toggle {
 +  color: white;
-+  background-color: $cc-brand-low;
++  background-color: $cc-brand-mid;
 +  padding: $spacer / 2;
++  &:hover {
++    background-color: $cc-brand-low;
++  }
 +}
 +
 +$persistent-menu-image-size: 2rem;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-webapp_navbar.formplayer-webapp_navbar.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/formplayer-webapp_navbar.formplayer-webapp_navbar.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,17 +1,17 @@
+@@ -1,20 +1,18 @@
 -@cloudcare-nav-height: 30px;
 +$cloudcare-nav-height: 30px;
  
@@ -11,7 +11,7 @@
 -  min-height: @cloudcare-nav-height;
 -  .transition(1s all);
 -  z-index: @zindex-navbar-cloudcare;
-+  background-color: $cc-brand-low;
++  background-color: $cc-brand-mid;
 +  min-height: $cloudcare-nav-height;
 +  transition: 1s all;
 +  z-index: $zindex-navbar-cloudcare;
@@ -20,12 +20,15 @@
  .navbar-cloudcare .navbar-brand {
 -  color: @cc-bg;
 -  height: @cloudcare-nav-height;
+-  padding: 6.5px 15px;
 +  color: $cc-bg;
-+  height: $cloudcare-nav-height;
-   padding: 6.5px 15px;
++  padding: 6.5px 0;
    text-transform: uppercase;
-   font-size: 11px;
-@@ -22,6 +22,7 @@
+-  font-size: 11px;
+ }
+ 
+ .navbar-cloudcare .navbar-nav {
+@@ -22,6 +20,7 @@
    margin: 0;
  
    > li > a {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/preview_app-main.preview_app-main.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/preview_app-main.preview_app-main.style.diff.txt
@@ -21,7 +21,8 @@
  @import "preview_app/grid";
  @import "preview_app/appicon";
 -@import "preview_app/menu";
- @import "preview_app/breadcrumb";
+-@import "preview_app/breadcrumb";
++@import "preview_app/breadcrumbs";
  @import "preview_app/module";
  @import "preview_app/form";
  @import "preview_app/formnav";

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/preview_app_breadcrumb.preview_app_breadcrumb.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/preview_app_breadcrumb.preview_app_breadcrumb.style.diff.txt
@@ -1,25 +1,58 @@
 --- 
 +++ 
-@@ -35,7 +35,7 @@
- 
- .breadcrumb-form {
-   width: 100%;
+@@ -1,55 +0,0 @@
+-#breadcrumb-region .breadcrumb,
+-.single-app-view .breadcrumb,
+-.breadcrumb-form-container .breadcrumb {
+-  text-transform: uppercase;
+-  margin: 0;
+-  padding: 0 10px;
+-  line-height: 30px;
+-  font-size: 11px;
+-
+-  li {
+-    display: none;
+-    &:before {
+-      color: white;
+-      vertical-align: middle;
+-      font-size: 8px;
+-      padding: 0 4px;
+-    }
+-  }
+-  li:first-child {
+-    display: inline-block;
+-    white-space: nowrap;
+-  }
+-  li:last-child {
+-    display: inline-block;
+-    white-space: nowrap;
+-    text-overflow: ellipsis;
+-  }
+-}
+-
+-#breadcrumb-region {
+-  overflow: hidden;
+-  max-height: 30px;
+-  width: 100%;
+-}
+-
+-.breadcrumb-form {
+-  width: 100%;
 -  .box-shadow(none);
-+  box-shadow: none;
- 
-   li {
-     padding-top: 1px;
-@@ -46,10 +46,10 @@
-   position: fixed;
-   z-index: 10;
-   width: 100%;
+-
+-  li {
+-    padding-top: 1px;
+-  }
+-}
+-
+-.breadcrumb-form-container {
+-  position: fixed;
+-  z-index: 10;
+-  width: 100%;
 -  height: @webforms-breadcrumb-height;
 -  .box-shadow(0 0 5px 2px rgba(0,0,0,.3));
-+  height: $webforms-breadcrumb-height;
-+  box-shadow: 0 0 5px 2px rgba(0,0,0,.3);
- }
- 
- .webforms-nav-single-question {
+-}
+-
+-.webforms-nav-single-question {
 -  height: @webforms-nav-height;
-+  height: $webforms-nav-height;
- }
+-}

--- a/docs/web_apps.rst
+++ b/docs/web_apps.rst
@@ -241,7 +241,7 @@ This contains logic specific to app preview.
 
 There isn't much here: some initialization code and a plugin that lets you scroll by grabbing and dragging the app preview screen.
 
-The app preview and web apps UIs are largely identical, but a few places do distinguish between them, using the ``environment`` attribute of the current user. Search for the constants ``PREVIEW_APP_ENVIRONMENT`` and ``WEB_APPS_ENVIRONMENT`` for examples.
+The app preview and web apps UIs are largely identical, but a few places do distinguish between them, using the ``environment`` attribute of the current user. Search for the constants ``PREVIEW_APP_ENVIRONMENT`` and ``WEB_APPS_ENVIRONMENT`` for examples.  You may also reference ``user.isAppPreview`` for convenience.
 
 `hq_events.js <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/cloudcare/static/cloudcare/js/formplayer/hq_events.js>`_, although not in this directory, is only really relevant to app preview. It controls the ability to communicate with HQ, which is used for the "phone icons" on app preview: back, refresh, and switching between the standard "phone" mode and the larger "tablet" mode.
 


### PR DESCRIPTION
## Product Description
Moves the "login as" banner and the hamburger menu into the navbar.  Also changes the dark blue navbar and persistent menu handle to a medium blue, and breadcrumbs to white:

![image](https://github.com/user-attachments/assets/620e6fc8-134e-410d-8817-3e81a6da941f)

## Technical Summary
PRs into https://github.com/dimagi/commcare-hq/pull/34872

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan
In QA with the persistent menu work

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
