### PR TITLE
Upgrade setuptools from 70.0.0 to 72.1.0

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -848,7 +848,7 @@ zope-interface==6.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3
     # via pip-tools
-setuptools==70.0.0
+setuptools==72.1.0
     # via
     #   django-websocket-redis
     #   opentelemetry-api

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -697,7 +697,7 @@ zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==70.0.0
+setuptools==72.1.0
     # via
     #   django-websocket-redis
     #   opentelemetry-api

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -694,7 +694,7 @@ zope-interface==6.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3
     # via -r prod-requirements.in
-setuptools==70.0.0
+setuptools==72.1.0
     # via
     #   django-websocket-redis
     #   opentelemetry-api

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -642,7 +642,7 @@ zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==70.0.0
+setuptools==72.1.0
     # via
     #   django-websocket-redis
     #   opentelemetry-api

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -702,7 +702,7 @@ zope-interface==6.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3
     # via pip-tools
-setuptools==70.0.0
+setuptools==72.1.0
     # via
     #   django-websocket-redis
     #   opentelemetry-api


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Maybe we shouldn't be in a rush to upgrade to 72.1.0 since the release just before it (72.0.0) was yanked https://pypi.org/project/setuptools/72.0.0/.

I'll let this sit for a few days to see if there is any more activity on this project given the release was just cut a couple of days ago.

[Changelog](https://setuptools.pypa.io/en/stable/history.html)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
