### PR TITLE
Skip tests for PRs which only contain translation changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ on:
     - mjr/add-change-meta-context
     - mjr/new_dedupe_model
     - mjr/dedupe_handle_closed_cases
+    paths-ignore:
+      - 'locale/**'
   schedule:
     # see corehq/apps/hqadmin/management/commands/static_analysis.py
     - cron: '47 12 * * *'


### PR DESCRIPTION
## Technical Summary
We've run into deployments being held up by the translation PRs. This change skips running tests for PRs that only contain changes to our translation files. PRs that contained a mixture of translation changes and other files would still need tests to pass.

I do not think we should be running code on translation changes, because translations are dynamic, user-configurable data. While they live in our codebase, they are overwritten by an automated process, and we do not perform checking on which translations changed. 

This would be similar to running tests against someone's local settings. While translations or settings _can_ affect test output, because both are not really under our control, tests written against these things should not rely on what happens to be in those files at the time. With settings, for example, tests that want to verify behavior with a specific setting explicitly set that setting, regardless of localsetting's configuration, via [overriding settings](https://docs.djangoproject.com/en/5.0/topics/testing/tools/#overriding-settings). For tests that verified translations, a similar test would [explicitly set the intended translation](https://gist.github.com/marteinn/b39379463b4a6a8dce5b)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
This is only a github configuration change

### Automated test coverage

No tests necessary

### QA Plan

No QA necessary

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
