### PR TITLE
Made "Bad SMS Config" error message more specific

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1913,9 +1913,10 @@ class SQLMobileBackend(UUIDGeneratorMixin, models.Model):
             backend = cls.load_default_backend(backend_type, phone_number)
 
         if not backend:
-            raise BadSMSConfigException("No suitable backend found for phone "
-                                        "number and domain %s, %s" %
-                                        (phone_number, domain))
+            raise BadSMSConfigException("No gateway found "
+                                        "for phone number %s and domain %s. "
+                                        "To configure a gateway, please visit the SMS Connectivity Settings."
+                                        % (phone_number, domain))
 
         return backend
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This modifies the error message that appears when verifying a registered phone number anytime there is no gateway set as Default. The new message is intended to point admins towards the SMS Connectivity settings so that they can select a new gateway.

<img width="1440" alt="Screenshot 2024-08-01 at 11 45 51 AM" src="https://github.com/user-attachments/assets/e72a3212-4cf5-48c6-a43e-eaa15417d54b">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This was prompted because after removing an SMS gateway (Unicel), admins trying to verify a number will see this message if they had no other gateways selected. Kishan pointed out that this message does not provide a lot of detail. We thought that admins might be confused to see this message and not know how to resolve it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I tested this locally. This is also a small change that has a similar structure to the original message.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
