### PR TITLE
Change type of button back to submit

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_geo.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_geo.html
@@ -27,7 +27,7 @@
                  type="text"
                  data-bind="css: { 'is-invalid': $parent.hasError() }"
           />
-          <button type="button" class="btn btn-outline-primary search">{% trans "Search" %}</button>
+          <button class="btn btn-outline-primary search">{% trans "Search" %}</button>
         </div>
       </div>
     </form>


### PR DESCRIPTION
## Product Description

Previously we changed a bunch of buttons to type button so they would not capture the enter key. For the gps question however we have a nested form and it should have stayed of type submit. Without that clicking the button will not submit the inner form.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-4828

## Feature Flag

None

## Safety Assurance

### Safety story

Tested locally and on staging

### Automated test coverage

No

### QA Plan

Follow the steps in the bug

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
