### PR TITLE
Resolve gevent test failures

### DIFF
--- a/corehq/sql_db/management/commands/migrate.py
+++ b/corehq/sql_db/management/commands/migrate.py
@@ -11,12 +11,6 @@ class Command(migrate.Command):
         parser.add_argument('--no-reindex',
             action='store_false', dest='should_reindex', default=True,
             help='Skip Couch reindex operations, even if migrations ask for them.')
-        # NOTE: This is only enforced by migrate.py. If this command is called through code,
-        # this parameter will have no effect
-        parser.add_argument(
-            '--skip-gevent-patching', action='store_true', default=False,
-            help='when true, avoids monkey patching gevent'
-        )
 
     @no_translations
     def handle(self, *args, should_reindex, **options):

--- a/corehq/sql_db/management/commands/migrate.py
+++ b/corehq/sql_db/management/commands/migrate.py
@@ -14,7 +14,9 @@ class Command(migrate.Command):
         # NOTE: This is only enforced by migrate.py. If this command is called through code,
         # this parameter will have no effect
         parser.add_argument(
-            '--skip-gevent', action='store_true', default=False, help='when true, avoids monkey patching gevent')
+            '--skip-gevent-patching', action='store_true', default=False,
+            help='when true, avoids monkey patching gevent'
+        )
 
     @no_translations
     def handle(self, *args, should_reindex, **options):

--- a/corehq/sql_db/management/commands/migrate.py
+++ b/corehq/sql_db/management/commands/migrate.py
@@ -11,6 +11,10 @@ class Command(migrate.Command):
         parser.add_argument('--no-reindex',
             action='store_false', dest='should_reindex', default=True,
             help='Skip Couch reindex operations, even if migrations ask for them.')
+        # NOTE: This is only enforced by migrate.py. If this command is called through code,
+        # this parameter will have no effect
+        parser.add_argument(
+            '--skip-gevent', action='store_true', default=False, help='when true, avoids monkey patching gevent')
 
     @no_translations
     def handle(self, *args, should_reindex, **options):

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -211,7 +211,7 @@ function _run_tests {
     }
 
     function _test_javascript {
-        ./manage.py migrate --noinput --skip-gevent-patching
+        SKIP_GEVENT_PATCHING=1 ./manage.py migrate --noinput
         ./manage.py runserver 0.0.0.0:8000 &> commcare-hq.log &
         _wait_for_runserver
         logmsg INFO "grunt test ${js_test_args[*]}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -211,7 +211,7 @@ function _run_tests {
     }
 
     function _test_javascript {
-        ./manage.py migrate --noinput
+        ./manage.py migrate --noinput --skip-gevent
         ./manage.py runserver 0.0.0.0:8000 &> commcare-hq.log &
         _wait_for_runserver
         logmsg INFO "grunt test ${js_test_args[*]}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -211,7 +211,7 @@ function _run_tests {
     }
 
     function _test_javascript {
-        ./manage.py migrate --noinput --skip-gevent
+        ./manage.py migrate --noinput --skip-gevent-patching
         ./manage.py runserver 0.0.0.0:8000 &> commcare-hq.log &
         _wait_for_runserver
         logmsg INFO "grunt test ${js_test_args[*]}"

--- a/manage.py
+++ b/manage.py
@@ -19,7 +19,7 @@ def main():
         GeventCommand('run_blob_migration'),
         GeventCommand('check_blob_logs'),
         GeventCommand('preindex_everything'),
-        GeventCommand('migrate', exclude=['--skip-gevent']),
+        GeventCommand('migrate', exclude=['--skip-gevent-patching']),
         GeventCommand('migrate_multi'),
         GeventCommand('prime_views'),
         GeventCommand('ptop_preindex'),

--- a/manage.py
+++ b/manage.py
@@ -62,12 +62,12 @@ def _patch_gevent_if_required(args, gevent_commands):
     for gevent_command in gevent_commands:
         should_patch = args[1] == gevent_command.command
         contains = set(gevent_command.contains or [])
-        env_exclude = set(gevent_command.env_exclude or [])
+        env_exclude = gevent_command.env_exclude or []
         arg_set = set(args)
 
         should_include = contains.issubset(arg_set)
         should_exclude = any(
-            [env_var in os.environ and os.environ[env_var] != '0' for env_var in env_exclude]
+            [os.environ.get(env_var, '0') != '0' for env_var in env_exclude]
         )
 
         should_patch = should_patch and should_include and not should_exclude

--- a/manage.py
+++ b/manage.py
@@ -67,7 +67,7 @@ def _patch_gevent_if_required(args, gevent_commands):
 
         should_include = contains.issubset(arg_set)
         should_exclude = any(
-            [os.environ.get(env_var, '0') != '0' for env_var in env_exclude]
+            [os.environ.get(env_var) == '1' for env_var in env_exclude]
         )
 
         should_patch = should_patch and should_include and not should_exclude


### PR DESCRIPTION
## Technical Summary
We've run into a lot of intermittent failures with our test build recently, where all the failures seem to be in the `python-sharded-and-javascript` section. The main difference here is that this is the only test runner that runs javascript tests, and those javascript tests perform migrations differently than the python tests do. Because python tests construct the database on running the `test` command, there is no need to call `migrate` explicitly. And, because of this, the monkey patching code in `manage.py` never gets applied. The javascript tests, on the other hand, need to call `migrate` explicitly, and that does use monkey patching.

While it doesn't get at the underlying issue with gevent, I was able to resolve the testing errors by skipping monkey patching for the javascript tests. I added a new argument so that monkey patching will still apply in general, but specifically for our javascript tests, we will skip it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
The scope of this change should be restricted to the test runner -- it should not affect production code

### Automated test coverage

No tests

### QA Plan

No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
