### PR TITLE
UCRs: Whitelist fields available to UCR related_doc expressions

### DIFF
--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -661,8 +661,8 @@ def _get_user(domain, doc_id):
 
         # CouchUser
         # 'device_ids',
-        ('devices', lambda lst: [d.to_json() for d in lst]),
-        ('last_device', JsonObject.to_json),
+        ('devices', lambda lst: [_device_to_dict(d) for d in lst]),
+        ('last_device', _device_to_dict),
         'phone_numbers',
         'created_on',
         'last_modified',
@@ -718,6 +718,18 @@ def _get_doc(domain, doc_type, doc_id):
     if domain != doc.get('domain'):
         return None
     return doc
+
+
+def _device_to_dict(
+    device  # DeviceIdLastUsed
+):
+    whitelist = (
+        'device_id',
+        'last_used',
+        'commcare_version',
+        'app_meta',
+    )
+    return {k: v for k, v in device.to_json().items() if k in whitelist}
 
 
 class NestedExpressionSpec(JsonObject):

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -657,10 +657,10 @@ def _get_user(domain, doc_id):
         'date_joined',
 
         # EulaMixin
-        'eulas',
+        # 'eulas',
 
         # CouchUser
-        'device_ids',
+        # 'device_ids',
         ('devices', lambda lst: [d.to_json() for d in lst]),
         ('last_device', JsonObject.to_json),
         'phone_numbers',
@@ -668,12 +668,12 @@ def _get_user(domain, doc_id):
         'last_modified',
         'status',
         'language',
-        'subscribed_to_commcare_users',
-        'announcements_seen',
+        # 'subscribed_to_commcare_users',
+        # 'announcements_seen',
         'location_id',
         'assigned_location_ids',
-        'has_built_app',
-        'analytics_enabled',
+        # 'has_built_app',
+        # 'analytics_enabled',
         # two_factor_auth_disabled_until,
         # login_attempts,
         # attempt_date,
@@ -685,13 +685,13 @@ def _get_user(domain, doc_id):
 
         # CommCareUser
         'domain',
-        'registering_device_id',
+        # 'registering_device_id',
         'loadtest_factor',
         'is_loadtest_user',
         'is_demo_user',
         'demo_restore_id',
-        'is_account_confirmed',
-        'user_location_id',
+        # 'is_account_confirmed',
+        # 'user_location_id',
     )
     user = CommCareUser.get_by_user_id(doc_id, domain)
     if not user:

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -686,10 +686,10 @@ def _get_user(domain, doc_id):
         # CommCareUser
         'domain',
         # 'registering_device_id',
-        'loadtest_factor',
-        'is_loadtest_user',
-        'is_demo_user',
-        'demo_restore_id',
+        # 'loadtest_factor',
+        # 'is_loadtest_user',
+        # 'is_demo_user',
+        # 'demo_restore_id',
         # 'is_account_confirmed',
         # 'user_location_id',
     )

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -5,11 +5,13 @@ from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase, TestCase
+
 from testil import Config
 
 from casexml.apps.case.const import CASE_INDEX_EXTENSION
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
+
 from corehq.apps.groups.models import Group
 from corehq.apps.userreports.decorators import ucr_context_cache
 from corehq.apps.userreports.exceptions import BadSpecError
@@ -19,7 +21,12 @@ from corehq.apps.userreports.expressions.specs import (
     PropertyPathGetterSpec,
 )
 from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
-from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.apps.users.models import (
+    CommCareUser,
+    DeviceAppMeta,
+    LastBuild,
+    WebUser,
+)
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.util.test_utils import (
@@ -1087,6 +1094,160 @@ class RelatedDocExpressionDbTest(TestCase):
             'related_id': id,
             'domain': cls.domain,
         }
+
+
+class RelatedDocExpressionUserTest(TestCase):
+    domain = 'test-domain'
+
+    def setUp(self):
+
+        LocationTypeDuck = type('LocationType', (object,), {
+            'administrative': True,
+        })
+
+        LocationDuck = type('Location', (object,), {
+            'location_id': 'abc123',
+            'location_type': LocationTypeDuck(),
+        })
+
+        now = datetime.utcnow()
+        self.user = CommCareUser.create(
+            self.domain,
+            'testy',
+            '123',
+            created_by=None,
+            created_via=None,
+            assigned_location_ids=['location_id'],
+            doc_type='CommCareUser',
+            first_name='Testy',
+            last_name='McTestface',
+            location_id='abc123',
+            is_active=True,
+            user_data={
+                '30_day_max_bonus': 123,
+                '30_day_target': 123,
+                'dhis2_org_unit': 'dhis2_org_unit',
+            },
+        )
+        self.user.add_phone_number('123')
+        self.user.set_location(LocationDuck())
+        self.user.update_device_id_last_used(
+            'phone',
+            now,
+            device_app_meta=DeviceAppMeta(
+                build_version=123,
+                num_unsent_forms=5,
+            ),
+        )
+        last_build = LastBuild(build_version=123)
+        self.user.reporting_metadata.last_builds.append(last_build)
+        self.user.reporting_metadata.last_build_for_user = last_build
+        self.user.save()
+
+    def tearDown(self):
+        self.user.delete(None, None)
+
+    def test_value_expressions(self):
+        # Actual value expressions currently in use
+        value_expressions = [
+            {
+                'type': 'jsonpath',
+                'jsonpath': 'devices[0].app_meta[0].build_version',
+            },
+            {
+                'type': 'jsonpath',
+                'jsonpath': 'last_device.app_meta[0].num_unsent_forms',
+            },
+            {'type': 'jsonpath', 'jsonpath': 'phone_numbers[0]'},
+            {
+                'type': 'property_name',
+                'property_name': 'assigned_location_ids',
+            },
+            {'type': 'property_name', 'property_name': 'doc_type'},
+            {'type': 'property_name', 'property_name': 'first_name'},
+            {'type': 'property_name', 'property_name': 'last_name'},
+            {'type': 'property_name', 'property_name': 'location_id'},
+            {'type': 'property_name', 'property_name': 'phone_numbers'},
+            {'type': 'property_name', 'property_name': 'username'},
+            {
+                'type': 'property_path',
+                'property_path': ['domain_membership', 'location_id'],
+            },
+            {'type': 'property_path', 'property_path': ['first_name']},
+            {'type': 'property_path', 'property_path': ['is_active']},
+            {'type': 'property_path', 'property_path': ['last_name']},
+            {'type': 'property_path', 'property_path': ['phone_numbers']},
+            {
+                'type': 'property_path',
+                'property_path': [
+                    'reporting_metadata',
+                    'last_build_for_user',
+                    'build_version',
+                ],
+            },
+            {
+                'type': 'property_path',
+                'property_path': ['user_data', '30_day_max_bonus'],
+            },
+            {
+                'type': 'property_path',
+                'property_path': ['user_data', '30_day_target'],
+            },
+            {
+                'type': 'property_path',
+                'property_path': ['user_data', 'commcare_location_id'],
+            },
+            {
+                'type': 'property_path',
+                'property_path': ['user_data', 'dhis2_org_unit'],
+            },
+            {'type': 'property_path', 'property_path': ['username']},
+            {
+                'type': 'array_index',
+                'array_expression': {
+                    'type': 'property_path',
+                    'property_path': ['phone_numbers'],
+                },
+                'index_expression': {'type': 'constant', 'constant': 0},
+            },
+            {
+                'type': 'evaluator',
+                'statement': 'first_name + space + last_name',
+                'context_variables': {
+                    'first_name': {
+                        'type': 'property_name',
+                        'property_name': 'first_name',
+                    },
+                    'space': {'type': 'constant', 'constant': ' '},
+                    'last_name': {
+                        'type': 'property_name',
+                        'property_name': 'last_name',
+                    },
+                },
+            },
+        ]
+
+        doc = {
+            'related_user_id': self.user._id,
+            'domain': self.domain,
+        }
+        evaluation_context = EvaluationContext(doc, 0)
+
+        for value_expression in value_expressions:
+            expression = ExpressionFactory.from_spec({
+                'type': 'related_doc',
+                'related_doc_type': 'CommCareUser',
+                'doc_id_expression': {
+                    'type': 'property_name',
+                    'property_name': 'related_user_id'
+                },
+                'value_expression': value_expression,
+            })
+            value = expression(doc, evaluation_context)
+            self.assertIsNotNone(
+                value,
+                f'Bad value expression {value_expression!r}'
+            )
 
 
 class TestFormsExpressionSpec(TestCase):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1030,7 +1030,11 @@ class RelatedDocExpressionDbTest(TestCase):
 
     def test_other_lookups(self):
         user_id = uuid.uuid4().hex
-        CommCareUser.get_db().save_doc({'_id': user_id, 'domain': self.domain})
+        CommCareUser.get_db().save_doc({
+            '_id': user_id,
+            'doc_type': 'CommCareUser',
+            'domain': self.domain,
+        })
         expression = self._get_expression('CommCareUser')
         doc = self._get_doc(user_id)
         self.assertEqual(user_id, expression(doc, EvaluationContext(doc, 0)))

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1034,6 +1034,7 @@ class RelatedDocExpressionDbTest(TestCase):
             '_id': user_id,
             'doc_type': 'CommCareUser',
             'domain': self.domain,
+            'username': f'user@{self.domain}.commcarehq.org',
         })
         expression = self._get_expression('CommCareUser')
         doc = self._get_doc(user_id)

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1047,6 +1047,25 @@ class RelatedDocExpressionDbTest(TestCase):
         doc = self._get_doc(user._id)
         self.assertEqual('indigo', expression(doc, EvaluationContext(doc, 0)))
 
+    def test_password_lookup(self):
+        user = CommCareUser.create(self.domain, 'username', "123", None, None)
+        self.addCleanup(user.delete, None, None)
+        expression = ExpressionFactory.from_spec({
+            "type": "related_doc",
+            "related_doc_type": 'CommCareUser',
+            "doc_id_expression": {
+                "type": "property_name",
+                "property_name": "related_id"
+            },
+            "value_expression": {
+                "type": "property_name",
+                "property_name": "password",
+            },
+        })
+        doc = self._get_doc(user._id)
+        value = expression(doc, EvaluationContext(doc, 0))
+        self.assertIsNone(value)
+
     @staticmethod
     def _get_expression(doc_type):
         return ExpressionFactory.from_spec({


### PR DESCRIPTION
## Technical Summary

Context:
* Spec: [Raw User Document Access: How To Fix](https://docs.google.com/document/d/1MPTi9ZihSN_FFDPaK8aiclr5P0CojG9Xcekke1CBRlg/edit#heading=h.9vslb6ilfam6)
* Follow-up [investigation](https://docs.google.com/document/d/1MM1lOnFArfr8F6CbgQ9OvvzpWBlwZJEB780YFA7NGls/edit)
* Jira: [SC-3850](https://dimagi.atlassian.net/browse/SC-3850)

I would have preferred to take the approach of using the API to serialize CommCareUser, but the resulting doc has significant differences from the model, and the change would break a lot of existing UCRs. (I've left the commit in the branch, so that you can see what that change would look like.)

I ended up using an explicit whitelist. The obvious con is that it duplicates property names. But the pros are that the list is explicit, and that it can be modified independent of the API where the needs of API users and UCR users differ.

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Tests included.

### QA Plan

QA not planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3850]: https://dimagi.atlassian.net/browse/SC-3850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ