### PR TITLE
USH-4823: Fix alignment

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -1030,10 +1030,15 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
             self.labelWidth = "";
             self.questionTileWidth = `col-md-${columnWidth}`;
         } else {
-            self.controlWidth = constants.CONTROL_WIDTH;
-            self.labelWidth = constants.LABEL_WIDTH;
+            if (self.isLabel) {
+                self.controlWidth = "";
+                self.labelWidth = "";
+            } else {
+                self.controlWidth = constants.CONTROL_WIDTH;
+                self.labelWidth = constants.LABEL_WIDTH;
+            }
             self.questionTileWidth = constants.FULL_WIDTH;
-            if (!hasLabel) {
+            if (!hasLabel && !self.isLabel) {
                 self.controlWidth += ' ' + constants.LABEL_OFFSET;
             }
         }

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
@@ -20,7 +20,7 @@
       },
       visible: hasLabelContent">
       {# appearance attributes TEXT_ALIGN_CENTER TEXT_ALIGN_RIGHT #}
-      <div data-bind="css: {
+      <div class="overflow-auto" data-bind="css: {
           'text-center': stylesContains('text-align-center'),
           'text-end': stylesContains('text-align-right'),
         }">


### PR DESCRIPTION
## Product Description

* HTML tables in labels should scroll if they overflow
* Labels should not be pushed right if they just contain an image

**Before**

<img width="1183" alt="2024-08-05_13-00-55" src="https://github.com/user-attachments/assets/d0d1efae-dcb0-4319-bf15-3eb0236ff904">

<img width="1231" alt="2024-08-05_13-01-19" src="https://github.com/user-attachments/assets/0ba8b647-7633-4899-996e-006f5ab58891">

**After**

<img width="1190" alt="2024-08-05_13-06-26" src="https://github.com/user-attachments/assets/f29087ef-66e6-429d-b79f-6ebc14d9cffc">

<img width="1209" alt="2024-08-05_13-07-11" src="https://github.com/user-attachments/assets/01b20510-72d3-4f00-a3a0-ef6b2d24bd7a">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag

None

## Safety Assurance

### Safety story

Tested locally and on staging

### Automated test coverage

None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
