### PR TITLE
Fix flaky test DomainPillowTest.test_reverted_domain_pillow_deletion

### DIFF
--- a/testapps/test_pillowtop/tests/test_domain_pillow.py
+++ b/testapps/test_pillowtop/tests/test_domain_pillow.py
@@ -63,11 +63,11 @@ class DomainPillowTest(TestCase):
     def test_reverted_domain_pillow_deletion(self):
         domain_name = 'domain-pillow-delete'
         with drop_connected_signals(commcare_domain_post_save):
-            domain = create_domain(domain_name)
+            domain_obj = create_domain(domain_name)
 
         # send to kafka
         since = get_topic_offset(topics.DOMAIN)
-        publish_domain_saved(domain)
+        publish_domain_saved(domain_obj)
 
         # send to elasticsearch
         pillow = get_domain_kafka_to_elasticsearch_pillow()
@@ -77,7 +77,6 @@ class DomainPillowTest(TestCase):
         # verify there
         self._verify_domain_in_es(domain_name)
 
-        domain_obj = Domain.get_by_name(domain_name)
         domain_obj.doc_type = 'Domain-DUPLICATE'
         domain_obj.save()
 

--- a/testapps/test_pillowtop/tests/test_domain_pillow.py
+++ b/testapps/test_pillowtop/tests/test_domain_pillow.py
@@ -86,7 +86,6 @@ class DomainPillowTest(TestCase):
         publish_domain_saved(domain_obj)
 
         # undelete
-        domain_obj = Domain.get_by_name(domain_name)
         domain_obj.doc_type = 'Domain'
         domain_obj.save()
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I was getting this failure when running this test:
```
ERROR: testapps.test_pillowtop.tests.test_domain_pillow:DomainPillowTest.test_reverted_domain_pillow_deletion                                                              
----------------------------------------------------------------------                                                                                                     
Traceback (most recent call last):                                                                                                                                         
  File "/home/gherceg/dimagi/code/commcare-hq/testapps/test_pillowtop/tests/test_domain_pillow.py", line 90, in test_reverted_domain_pillow_deletion                       
    domain_obj.doc_type = 'Domain'                                                                                                                                         
AttributeError: 'NoneType' object has no attribute 'doc_type' 
```

Upon closer inspection, it made sense since we were updating the domain's doc_type to Domain-DUPLICATE [here](https://github.com/dimagi/commcare-hq/blob/07c20c306165687ca451f057d473914307ffd116/testapps/test_pillowtop/tests/test_domain_pillow.py#L80-L82), and then attempting to use the `Domain.get_by_name` method to retrieve the domain from couch, which [uses the domains view](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/domain/models.py#L627-L627), which will [not include any domains with a doc_type other than "Domain"](https://github.com/dimagi/commcare-hq/blob/07c20c306165687ca451f057d473914307ffd116/corehq/apps/domain/_design/views/domains/map.js#L3-L3).
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
