### PR TITLE
Create label column, squash description

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -93,7 +93,8 @@
                       {% trans "Description" %}
                   </label>
                   <div class="col-xs-12 col-sm-6 col-md-6 col-lg-8 controls">
-                    <textarea name="description" class="form-control vertical-resize"></textarea>
+                    <textarea name="description"
+                              class="form-control std-height vertical-resize"></textarea>
                   </div>
                 </div>
               </fieldset>
@@ -200,6 +201,7 @@
           <div class="table-row table-header">
           <div class="row-item-small"></div>
           <div class="row-item">{% trans "Case Property" %}</div>
+          <div class="row-item">{% trans "Label" %}</div>
           {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
             <div class="row-item">{% trans "Data Type" %}</div>
           {% endif %}
@@ -244,10 +246,9 @@
             {% endif %}
             <div class="row-item">
               <!-- ko if: name() !== ''-->
-              <textarea class="form-control vertical-resize" data-bind="
-                    value: $data.description,
-                    rows: 1"
-                    placeholder='{% trans "Click here to add a description" %}'></textarea>
+              <textarea class="form-control std-height vertical-resize"
+                        data-bind="value: $data.description, rows: 1"
+                        placeholder='{% trans "Click here to add a description" %}'></textarea>
               <!-- /ko -->
             </div>
             {% if fhir_integration_enabled %}
@@ -278,16 +279,14 @@
               <div class="row-item">
                 <div class="w-100">
                 <span data-bind="text: name"></span>
-                <div class="row mt-3">
-                  <label class="col-xs-2 py-2" for="prop-label">Label </label>
-                  <span class="col-xs-9">
-                    <input class="form-control"
-                          data-bind="value: $data.label, attr: {'placeholder': 'Click here to add Label'}"
-                          id="prop-label"
-                    />
-                  </span>
                 </div>
-                </div>
+              </div>
+              <div class="row-item">
+                <input class="form-control"
+                       id="prop-label"
+                       data-bind="
+                         value: $data.label,
+                         attr: {'placeholder': 'Click here to add a label'}" />
               </div>
               {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
                 <div class="row-item main-form">
@@ -310,11 +309,11 @@
                   </span>
                 </div>
               {% endif %}
-              <div class="row-item main-form">
-                              <textarea class="form-control vertical-resize" data-bind="
-                                value: $data.description,
-                                rows: 1"
-                                placeholder='{% trans "Click here to add a description" %}'></textarea>
+              <div class="row-item-big main-form">
+                <textarea class="form-control std-height vertical-resize"
+                          placeholder="{% trans 'Click here to add a description' %}"
+                          data-bind=" value: $data.description, rows: 1">
+                </textarea>
               </div>
             {% if fhir_integration_enabled %}
               <div class="row-item fhir-path">

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -205,7 +205,7 @@
           {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
             <div class="row-item">{% trans "Data Type" %}</div>
           {% endif %}
-          <div class="row-item">{% trans "Description" %}</div>
+          <div class="row-item-big">{% trans "Description" %}</div>
           {% if fhir_integration_enabled %}
             <div class="row-item">{% trans "FHIR Resource Property Path" %}</div>
           {% endif %}
@@ -241,10 +241,13 @@
                             attr: {'placeholder': name}" id="group-name" />
               <!-- /ko -->
             </div>
+            <div class="row-item">
+              &nbsp;{# Empty cell where "Label" is in case property rows #}
+            </div>
             {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
               <div class="row-item">{% trans "Case Property Group" %}</div>
             {% endif %}
-            <div class="row-item">
+            <div class="row-item-big">
               <!-- ko if: name() !== ''-->
               <textarea class="form-control std-height vertical-resize"
                         data-bind="value: $data.description, rows: 1"

--- a/corehq/apps/hqwebapp/static/data_dictionary/less/data_dictionary.less
+++ b/corehq/apps/hqwebapp/static/data_dictionary/less/data_dictionary.less
@@ -67,6 +67,17 @@
     padding: 8px 4px;
   }
 
+  .row-item-big {
+    display: flex;
+    flex: 1.4;
+    padding: 8px 4px;
+  }
+
+  .std-height {
+    // Set height to the same as an input field
+    height: 31px;
+  }
+
   .w-100 {
     width: 100%;
   }


### PR DESCRIPTION
## Product Description

This is a small change that changes the appearance of the Data Dictionary page.

The "Label" field moves inline with the row, and the "Description" field gets a uniform height.

#### Before
![image](https://github.com/user-attachments/assets/e17db177-0ea4-4fb8-b629-5478475d3116)

#### After
![image](https://github.com/user-attachments/assets/25719ea2-37b1-4f58-afc2-fc0ff837d047)

## Technical Summary

Context: [SC-3699](https://dimagi.atlassian.net/browse/SC-3699)

## Safety Assurance

### Safety story

Tested locally.

### Automated test coverage

UI change. Not covered by tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3699]: https://dimagi.atlassian.net/browse/SC-3699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ