### PR TITLE
Hit new endpoint to limit locations when creating new mobile workers

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -785,7 +785,7 @@ class NewMobileWorkerForm(forms.Form):
             location_field = crispy.Field(
                 'location_id',
                 data_bind='value: location_id',
-                data_query_url=reverse('location_search', args=[self.domain]),
+                data_query_url=reverse('location_search_has_users_only', args=[self.domain]),
             )
         else:
             location_field = crispy.Hidden(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Fixes [QA-6985](https://dimagi.atlassian.net/browse/QA-6985).

USH feature epic: [link](https://dimagi.atlassian.net/browse/USH-4629).

Original related PR: [link](https://github.com/dimagi/commcare-hq/pull/34912).

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

The form to create mobile workers is not using the `LocationSelectWidget`, and was hitting the old, `location_search` endpoint.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

Technically the code isn't behind a FF, but in order for locations to be limited in the dropdown a project would need to turn on the LOCATION_HAS_USERS and configure locations in accordance with this feature.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tested locally, looks good
- This endpoint has been tested thoroughly by QA

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

This endpoint is tested in `corehq/apps/locations/tests/test_views.py`

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[QA-6985]: https://dimagi.atlassian.net/browse/QA-6985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ