### PR TITLE
truncate location names in dropdown

### DIFF
--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -11,7 +11,9 @@ hqDefine("locations/js/widgets", [
     function updateSelect2($source, $select) {
         $select.find("option").remove();
         _.each($source.select2('data'), function (result) {
-            $select.append(new Option(result.text || result.name, result.id));
+            const fullLengthName = result.text || result.name;
+            const truncatedName = truncateLocationName(fullLengthName, $select);
+            $select.append(new Option(truncatedName, result.id));
         });
     }
 

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -18,16 +18,42 @@ hqDefine("locations/js/widgets", [
     }
 
     function truncateLocationName(name, select) {
-        const fontSize = select.css('font-size');
-        const fontSizePixels = parseInt(fontSize.substring(0, fontSize.indexOf('px')));
-        const containerWidthPixels = select.parent().parent().width();
-        const containerWidthChars = Math.floor(containerWidthPixels / fontSizePixels);
-        let truncatedName = name;
-        if (name.length > containerWidthChars) {
-            const charLengthDiff = name.length - containerWidthChars;
-            truncatedName = `${name.substring(0, 5)}...${name.substring(charLengthDiff + 12, name.length)}`;
+        const nameWidthPixels = getSelectTextWidth(name, select);
+        const containerWidthPixels = select.parent().width();
+        let truncatedName;
+        if (nameWidthPixels > containerWidthPixels) {
+            // Conservative calc of the number of chars that will fit the container
+            const averagePixelWidthPerChar = Math.ceil(nameWidthPixels / name.length);
+            const maxCharCount = Math.floor(containerWidthPixels / averagePixelWidthPerChar);
+            const charLengthDiff = name.length - maxCharCount;
+
+            truncatedName = `${name.substring(0, 5)}...${name.substring(charLengthDiff + 16, name.length)}`;
+
+            return truncatedName
         }
-        return truncatedName;
+
+        return name;
+    }
+
+    function getSelectTextWidth(text, select) {
+        const fontSize = select.css('font-size');
+        const fontFamily = select.css('font-family');
+        const fontWeight = select.css('font-weight');
+        // Create an invisible div to get accurate measure of text width
+        const textDiv = $('<div id="select-text-div"></div>').text(text).css({'position': 'absolute',
+            'float': 'left',
+            'white-space': 'nowrap',
+            'visibility': 'hidden',
+            'font-size': fontSize,
+            'font-weight': fontWeight,
+            'font-family': fontFamily,
+        });
+
+        textDiv.appendTo('body');
+        const textWidth = textDiv.width();
+        textDiv.remove();
+
+        return textWidth;
     }
 
     function initAutocomplete($select) {

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -53,8 +53,14 @@ hqDefine("locations/js/widgets", [
                     };
                 },
             },
-            templateResult: function (result) { return result.text || result.name; },
-            templateSelection: function (result) { return result.text || result.name; },
+            templateResult: function (result) {
+                return result.text || result.name;
+            },
+            templateSelection: function (result) {
+                const fullLengthName = result.text || result.name;
+                const truncatedName = truncateLocationName(fullLengthName, $select);
+                return truncatedName;
+            },
         });
 
         var initial = options.initial;

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -15,6 +15,19 @@ hqDefine("locations/js/widgets", [
         });
     }
 
+    function truncateLocationName(name, select) {
+        const fontSize = select.css('font-size');
+        const fontSizePixels = parseInt(fontSize.substring(0, fontSize.indexOf('px')));
+        const containerWidthPixels = select.parent().parent().width();
+        const containerWidthChars = Math.floor(containerWidthPixels / fontSizePixels);
+        let truncatedName = name;
+        if (name.length > containerWidthChars) {
+            const charLengthDiff = name.length - containerWidthChars;
+            truncatedName = `${name.substring(0, 5)}...${name.substring(charLengthDiff + 12, name.length)}`;
+        }
+        return truncatedName;
+    }
+
     function initAutocomplete($select) {
         var options = $select.data();
         $select.select2({

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -1,3 +1,4 @@
+'use strict';
 hqDefine("locations/js/widgets", [
     'jquery',
     'underscore',
@@ -29,7 +30,7 @@ hqDefine("locations/js/widgets", [
 
             truncatedName = `${name.substring(0, 5)}...${name.substring(charLengthDiff + 16, name.length)}`;
 
-            return truncatedName
+            return truncatedName;
         }
 
         return name;


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
On the Web User invitation page, location names that don't fit inside of the select area will not be truncated at the end with an ellipsis. That is the default select2 behavior. This makes it so that location names that don't fit will display the first 5 chars followed by an ellipsis followed by the remaining characters that will fit inside the select are starting from the end. 
`Start...the rest of the location name including what's on the END`
<img width="1063" alt="Screenshot 2024-08-09 at 3 48 52 PM" src="https://github.com/user-attachments/assets/a66a5cb2-929c-4d9e-b4c8-46f320ff6dd3">

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4677) 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and on staging. 
Changes the text that is displayed only.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
not covered by automated testing

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

no QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
