### PR TITLE
Move "Add Case Property" to group

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -122,6 +122,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.description = ko.observable(description);
         self.caseType = caseType;
         self.properties = ko.observableArray();
+        self.newPropertyName = ko.observable();
         self.expanded = ko.observable(true);
         self.toggleExpanded = () => self.expanded(!self.expanded());
         self.deprecated = deprecated;
@@ -138,6 +139,27 @@ hqDefine("data_dictionary/js/data_dictionary", [
         self.showGroupPropertyTransferWarning = ko.computed(function () {
             return self.toBeDeprecated() && !deprecated && self.properties().length > 0;
         });
+
+        self.newCaseProperty = function () {
+            if (_.isString(self.newPropertyName()) && self.newPropertyName().trim()) {
+                const prop = {
+                    'name': self.newPropertyName(),
+                    'label': self.newPropertyName(),
+                    'allowedValues': {},
+                };
+                let propObj = propertyListItem(
+                    prop,
+                    false,
+                    self.name(),
+                    self.caseType,
+                    false,
+                    self.name(),
+                    changeSaveButton
+                );
+                self.newPropertyName(undefined);
+                self.properties.push(propObj);
+            }
+        };
 
         self.name.subscribe(changeSaveButton);
         self.description.subscribe(changeSaveButton);
@@ -521,19 +543,19 @@ hqDefine("data_dictionary/js/data_dictionary", [
             return pattern.test(nameStr);
         }
 
-        self.newPropertyNameValid = ko.computed(function () {
-            if (!self.newPropertyName()) {
+        self.newPropertyNameValid = function (name) {
+            if (!name) {
                 return true;
             }
-            return isNameValid(self.newPropertyName());
-        });
+            return isNameValid(name);
+        };
 
-        self.newPropertyNameUnique = ko.computed(function () {
-            if (!self.newPropertyName()) {
+        self.newPropertyNameUnique = function (name) {
+            if (!name) {
                 return true;
             }
 
-            const propertyNameFormatted = self.newPropertyName().toLowerCase().trim();
+            const propertyNameFormatted = name.toLowerCase().trim();
             const activeCaseTypeData = self.activeCaseTypeData();
             for (const group of activeCaseTypeData) {
                 if (group.properties().find(v => v.name.toLowerCase() === propertyNameFormatted)) {
@@ -541,7 +563,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
                 }
             }
             return true;
-        });
+        };
 
         self.newGroupNameValid = ko.computed(function () {
             if (!self.newGroupName()) {
@@ -564,28 +586,6 @@ hqDefine("data_dictionary/js/data_dictionary", [
             }
             return true;
         });
-
-        self.newCaseProperty = function () {
-            if (_.isString(self.newPropertyName()) && self.newPropertyName().trim()) {
-                let lastGroup = self.activeCaseTypeData()[self.activeCaseTypeData().length - 1];
-                const prop = {
-                    'name': self.newPropertyName(),
-                    'label': self.newPropertyName(),
-                    'allowedValues': {},
-                };
-                let propObj = propertyListItem(
-                    prop,
-                    false,
-                    lastGroup.name(),
-                    self.activeCaseType(),
-                    false,
-                    lastGroup.name(),
-                    changeSaveButton
-                );
-                self.newPropertyName(undefined);
-                lastGroup.properties.push(propObj);
-            }
-        };
 
         self.newGroup = function () {
             if (_.isString(self.newGroupName()) && self.newGroupName().trim()) {

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -141,7 +141,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
         });
 
         self.newCaseProperty = function () {
-            if (_.isString(self.newPropertyName()) && self.newPropertyName().trim()) {
+            if (self.newPropertyName().trim()) {
                 const prop = {
                     'name': self.newPropertyName(),
                     'label': self.newPropertyName(),

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -224,9 +224,9 @@
                           }">
           <div>
           <div class="group-deprecated" data-bind="visible: showGroupPropertyTransferWarning" style="display: none;">
-            <b data-bind="text: name()"></b>
-            {% trans "group's properties will be moved to" %}
-            <b>{% trans "No Group" %}</b>
+            {% blocktrans %}
+            <b data-bind="text: name()"></b> group's properties will be moved to <b>No Group</b>
+            {% endblocktrans %}
           </div>
           <div class="table-row group" data-bind="css: { 'group-deprecated': toBeDeprecated() }, visible: !deprecated || $root.showAll()">
             <div class="row-item-small">

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -217,7 +217,11 @@
             <div class="row-item-small"></div>
           {% endif %}
           </div>
-          <div data-bind="sortable: { data: activeCaseTypeData(), connectClass: 'groups', options: { handle: 'i.sortable-handle' } }">
+          <div data-bind="sortable: {
+                            data: activeCaseTypeData(),
+                            connectClass: 'groups',
+                            options: { handle: 'i.sortable-handle' }
+                          }">
           <div>
           <div class="group-deprecated" data-bind="visible: showGroupPropertyTransferWarning" style="display: none;">
             <b data-bind="text: name()"></b>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -369,30 +369,51 @@
             {% endif %}
             </div>
           </div>
+
+          {% if not request.is_view_only %}
+            <div class="table-row"
+                 data-bind="visible: !deprecated">
+              <div class="row-item">
+                <form class="form-inline"
+                      data-bind="css: {
+                                   'has-error': !$root.newPropertyNameUnique(newPropertyName())
+                                                || !$root.newPropertyNameValid(newPropertyName())
+                                 }">
+                  <input class="form-control"
+                         placeholder="Case Property"
+                         data-bind="value: newPropertyName">
+                  <button class="btn btn-default"
+                          id="gtm-add-case-property"
+                          data-bind="click: newCaseProperty,
+                                     enable: $root.newPropertyNameUnique(newPropertyName())
+                                             && $root.newPropertyNameValid(newPropertyName())">
+                    <i class="fa fa-plus"></i>
+                    {% trans "Add Case Property" %}
+                  </button>
+                  <div class="help-block">
+                    <span class="text-danger"
+                          data-bind="visible: !$root.newPropertyNameUnique(newPropertyName())">
+                      {% blocktrans %}
+                        A case property with this name already exists.
+                        If you don’t see it on the page, please click ‘Show Deprecated’ button to reveal deprecated
+                        properties.
+                      {% endblocktrans %}
+                    </span>
+                    <span class="text-danger" data-bind="visible: !$root.newPropertyNameValid(newPropertyName())">
+                      {% trans "Invalid case property name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
+                    </span>
+                  </div>
+
+                </form>
+              </div>
+            </div>
+          {% endif %}
+
           </div>
           </div>
         </div>
+
         {% if not request.is_view_only %}
-          <form class="form-inline" data-bind="css: { 'has-error': !newPropertyNameUnique() || !newPropertyNameValid() }">
-            <input class="form-control" placeholder="Case Property" data-bind="value: newPropertyName">
-            <button class="btn btn-default" id="gtm-add-case-property" data-bind="click: $root.newCaseProperty, enable: newPropertyNameUnique() && newPropertyNameValid()">
-              <i class="fa fa-plus"></i>
-              {% trans "Add Case Property" %}
-            </button>
-            <div class="help-block">
-              <span class="text-danger" data-bind="visible: !newPropertyNameUnique()">
-                {% blocktrans %}
-                  A case property with this name already exists.
-                  If you don’t see it on the page, please click ‘Show Deprecated’ button to reveal deprecated
-                  properties.
-                {% endblocktrans %}
-              </span>
-              <span class="text-danger" data-bind="visible: !newPropertyNameValid()">
-                {% trans "Invalid case property name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
-              </span>
-            </div>
-          </form>
-          <br />
           <form class="form-inline" data-bind="css: {'has-error': !newGroupNameUnique() || !newGroupNameValid()}">
             <input class="form-control" placeholder="Group Name" data-bind="value: newGroupName">
             <button class="btn btn-default" id="gtm-add-case-property-group" data-bind="click: $root.newGroup, enable: newGroupNameUnique() && newGroupNameValid()">


### PR DESCRIPTION
## Product Description

The Data Dictionary interface now allows users to add case properties to case property groups more easily by offering an input field for a new case property below each case property group, instead of only at the bottom of the page.

#### Before

![image](https://github.com/user-attachments/assets/64efa223-f2a1-4f9d-b222-69e7d0c13a25)

#### After

![image](https://github.com/user-attachments/assets/dc550892-1662-488e-9f9a-88807c6516e1)


## Technical Summary

Context: [SC-3699](https://dimagi.atlassian.net/browse/SC-3699)

Easier to :blowfish: :fish: :tropical_fish: review by commit, because the first two are tiny refactors.

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

This UI change is not covered by tests

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3699]: https://dimagi.atlassian.net/browse/SC-3699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ