### PR TITLE
Add repeater rate limiter based on number of attempts

### DIFF
--- a/corehq/motech/rate_limiter.py
+++ b/corehq/motech/rate_limiter.py
@@ -18,7 +18,7 @@ repeater_rate_limiter = RateLimiter(
 
 repeater_attempts_rate_limiter = RateLimiter(
     feature_key='repeater_attempts',
-    get_rate_limits=lambda domain: _get_per_user_repeater_attempt_rate_definition(domain),
+    get_rate_limits=lambda: _get_repeater_attempt_rate_definition(),
 )
 
 
@@ -60,18 +60,15 @@ global_repeater_rate_limiter = RateLimiter(
 )
 
 
-def _get_per_user_repeater_attempt_rate_definition(domain):
-
-    return PerUserRateDefinition(
-        per_user_rate_definition=get_dynamic_rate_definition(
-            "repeater_attempts_per_user",
-            default=RateDefinition(
-                per_week=None,
-                per_day=None,
-                per_hour=6000,
-                per_minute=100,
-                per_second=10,
-            ),
+def _get_repeater_attempt_rate_definition(domain):
+    return get_dynamic_rate_definition(
+        "repeater_attempts",
+        default=RateDefinition(
+            per_week=None,
+            per_day=None,
+            per_hour=360000,
+            per_minute=6000,
+            per_second=100,
         ),
     )
 

--- a/corehq/motech/rate_limiter.py
+++ b/corehq/motech/rate_limiter.py
@@ -6,7 +6,7 @@ from corehq.project_limits.rate_limiter import (
     PerUserRateDefinition,
     RateLimiter,
 )
-from corehq.toggles import RATE_LIMIT_REPEATERS, NAMESPACE_DOMAIN
+from corehq.toggles import RATE_LIMIT_REPEATERS, RATE_LIMIT_REPEATER_ATTEMPTS, NAMESPACE_DOMAIN
 from corehq.util.decorators import silence_and_report_error, run_only_when
 from corehq.util.metrics import metrics_gauge, metrics_counter
 from corehq.util.quickcache import quickcache
@@ -14,6 +14,11 @@ from corehq.util.quickcache import quickcache
 repeater_rate_limiter = RateLimiter(
     feature_key='repeater_wait_milliseconds',
     get_rate_limits=lambda domain: _get_per_user_repeater_wait_milliseconds_rate_definition(domain)
+)
+
+repeater_attempts_rate_limiter = RateLimiter(
+    feature_key='repeater_attempts',
+    get_rate_limits=lambda domain: _get_per_user_repeater_attempt_rate_definition(domain),
 )
 
 
@@ -55,6 +60,22 @@ global_repeater_rate_limiter = RateLimiter(
 )
 
 
+def _get_per_user_repeater_attempt_rate_definition(domain):
+
+    return PerUserRateDefinition(
+        per_user_rate_definition=get_dynamic_rate_definition(
+            "repeater_attempts_per_user",
+            default=RateDefinition(
+                per_week=None,
+                per_day=None,
+                per_hour=6000,
+                per_minute=100,
+                per_second=10,
+            ),
+        ),
+    )
+
+
 SHOULD_RATE_LIMIT_REPEATERS = not settings.UNIT_TESTING
 
 
@@ -62,7 +83,11 @@ SHOULD_RATE_LIMIT_REPEATERS = not settings.UNIT_TESTING
 @silence_and_report_error("Exception raised in the repeater rate limiter",
                           'commcare.repeaters.rate_limiter_errors')
 def rate_limit_repeater(domain):
-    if global_repeater_rate_limiter.allow_usage() or repeater_rate_limiter.allow_usage(domain):
+    is_domain_allowed_usage = repeater_rate_limiter.allow_usage(domain)
+    if RATE_LIMIT_REPEATER_ATTEMPTS.enabled(domain, namespace=NAMESPACE_DOMAIN):
+        is_domain_allowed_usage = is_domain_allowed_usage and repeater_attempts_rate_limiter.allow_usage(domain)
+
+    if global_repeater_rate_limiter.allow_usage() or is_domain_allowed_usage:
         allow_usage = True
     elif not RATE_LIMIT_REPEATERS.enabled(domain, namespace=NAMESPACE_DOMAIN):
         allow_usage = True
@@ -85,6 +110,13 @@ def report_repeater_usage(domain, milliseconds):
     repeater_rate_limiter.report_usage(domain, delta=milliseconds)
     global_repeater_rate_limiter.report_usage(delta=milliseconds)
     _report_current_global_repeater_thresholds()
+
+
+@run_only_when(SHOULD_RATE_LIMIT_REPEATERS)
+@silence_and_report_error("Exception raised reporting usage to the repeater attempt rate limiter",
+                          'commcare.repeaters.report_usage_errors')
+def report_repeater_attempt(domain):
+    repeater_attempts_rate_limiter.report_usage(domain)
 
 
 @quickcache([], timeout=60)  # Only report up to once a minute

--- a/corehq/motech/rate_limiter.py
+++ b/corehq/motech/rate_limiter.py
@@ -55,7 +55,7 @@ global_repeater_rate_limiter = RateLimiter(
 )
 
 
-def _get_repeater_attempt_rate_definition(domain):
+def _get_repeater_attempt_rate_definition():
     return get_dynamic_rate_definition(
         "repeater_attempts",
         default=RateDefinition(

--- a/corehq/motech/rate_limiter.py
+++ b/corehq/motech/rate_limiter.py
@@ -16,11 +16,6 @@ repeater_rate_limiter = RateLimiter(
     get_rate_limits=lambda domain: _get_per_user_repeater_wait_milliseconds_rate_definition(domain)
 )
 
-repeater_attempts_rate_limiter = RateLimiter(
-    feature_key='repeater_attempts',
-    get_rate_limits=lambda: _get_repeater_attempt_rate_definition(),
-)
-
 
 def _get_per_user_repeater_wait_milliseconds_rate_definition(domain):
     return PerUserRateDefinition(
@@ -71,6 +66,12 @@ def _get_repeater_attempt_rate_definition(domain):
             per_second=100,
         ),
     )
+
+
+repeater_attempts_rate_limiter = RateLimiter(
+    feature_key='repeater_attempts',
+    get_rate_limits=_get_repeater_attempt_rate_definition
+)
 
 
 SHOULD_RATE_LIMIT_REPEATERS = not settings.UNIT_TESTING

--- a/corehq/motech/rate_limiter.py
+++ b/corehq/motech/rate_limiter.py
@@ -77,7 +77,7 @@ repeater_attempts_rate_limiter = RateLimiter(
 SHOULD_RATE_LIMIT_REPEATERS = not settings.UNIT_TESTING
 
 
-@run_only_when(lambda: SHOULD_RATE_LIMIT_REPEATERS)
+@run_only_when(SHOULD_RATE_LIMIT_REPEATERS)
 @silence_and_report_error("Exception raised in the repeater rate limiter",
                           'commcare.repeaters.rate_limiter_errors')
 def rate_limit_repeater(domain):

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -31,7 +31,11 @@ from .const import (
 )
 from .models import RepeatRecord, domain_can_forward
 
-from ..rate_limiter import report_repeater_usage, rate_limit_repeater
+from ..rate_limiter import (
+    rate_limit_repeater,
+    report_repeater_attempt,
+    report_repeater_usage,
+)
 
 _check_repeaters_buckets = make_buckets_from_timedeltas(
     timedelta(seconds=10),
@@ -170,6 +174,7 @@ def _process_repeat_record(repeat_record):
             # with the intent of avoiding clumping and spreading load
             repeat_record.postpone_by(random.uniform(*RATE_LIMITER_DELAY_RANGE))
         elif repeat_record.is_queued():
+            report_repeater_attempt(repeat_record.domain)
             with TimingContext() as timer:
                 repeat_record.fire()
             # round up to the nearest millisecond, meaning always at least 1ms

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1982,6 +1982,17 @@ RATE_LIMIT_REPEATERS = DynamicallyPredictablyRandomToggle(
     """
 )
 
+RATE_LIMIT_REPEATER_ATTEMPTS = DynamicallyPredictablyRandomToggle(
+    'rate_limit_repeater_attempts',
+    'Apply rate limiting to attempts for data forwarding (repeaters)',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN],
+    description="""
+    In addition to the rate limits based on time spent waiting, these rate limits ensure a project
+    is limited to how many workers they can use at a time.
+    """
+)
+
 TEST_FORM_SUBMISSION_RATE_LIMIT_RESPONSE = StaticToggle(
     'test_form_submission_rate_limit_response',
     "Respond to all form submissions with a 429 response",

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1989,7 +1989,7 @@ RATE_LIMIT_REPEATER_ATTEMPTS = DynamicallyPredictablyRandomToggle(
     [NAMESPACE_DOMAIN],
     description="""
     In addition to the rate limits based on time spent waiting, these rate limits ensure a project
-    is limited to how many workers they can use at a time.
+    is limited to how many records they can attempt to forward in a given time window.
     """
 )
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
When a project has both slow repeater endpoints _and_ a lot of records to forward, our workers are unable to keep up with the backlog despite aggressive rate limiting. This is because in order to rate limit based on wait time, we (HQ) has to wait for the repeater attempts to return before reporting the amount of time it took to the rate limiter. This means as soon as the window opens up for a project with high volume to attempt forwarding, most of the workers will pickup a task for that project, and start attempt to hit the slow endpoint simultaneously, leaving no room for another project for potentially up to 5 minutes (repeater attempt request timeout). 

By combining this rate limiting technique with rate limiting the sheer number of attempts, we can report the usage of an attempt before actually sending the request, which should make it so that more requests from the specific problematic project are rate limited.

The downside of this code is that it could impact projects that have fast endpoints but high volume, since as soon as the global rate limit thresholds are exceeded, surpassing either the project level wait times or attempt limits will result in being rate limited.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The functional change to rate limiting is stuck behind a feature flag, giving us the ability to completely bypass this change if needed.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
