### PR TITLE
Do not save passwords in user index

### DIFF
--- a/corehq/apps/es/mappings/user_mapping.py
+++ b/corehq/apps/es/mappings/user_mapping.py
@@ -297,6 +297,7 @@ USER_MAPPING = {
         "location_id": {
             "type": "keyword"
         },
+        # TODO: Remove password field when creating new mappings for this index.
         "password": {
             "type": "text"
         },

--- a/corehq/apps/es/tests/test_user_adapter.py
+++ b/corehq/apps/es/tests/test_user_adapter.py
@@ -33,6 +33,18 @@ class TestFromPythonInElasticUser(TestCase):
         user_adapter.from_python(self.user.to_json())
         user_adapter.from_python(self.web_user.to_json())
 
+    def test_from_python_removes_password_field(self):
+        user_obj = self.user.to_json()
+        self.assertIn('password', user_obj)
+        user_es_obj = user_adapter.from_python(user_obj)
+        self.assertNotIn('password', user_es_obj)
+
+    def test_from_python_works_fine_if_password_field_not_present(self):
+        user_obj = self.user.to_json()
+        user_obj.pop('password')
+        user_es_obj = user_adapter.from_python(user_obj)
+        self.assertNotIn('password', user_es_obj)
+
     def test_from_python_raises_for_other_objects(self):
         self.assertRaises(TypeError, user_adapter.from_python, set)
 

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -104,6 +104,7 @@ class ElasticUser(ElasticDocumentAdapter):
         user_dict['__group_ids'] = [res.id for res in results]
         user_dict['__group_names'] = [res.name for res in results]
         user_dict['user_data_es'] = []
+        user_dict.pop('password', None)
         if user_dict.get('base_doc') == 'CouchUser' and user_dict['doc_type'] == 'CommCareUser':
             user_obj = self.model_cls.wrap_correctly(user_dict)
             user_data = user_obj.get_user_data(user_obj.domain)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

We are removing password fields from Users index in Elasticsearch, this is a step towards that. Next PRs will introduce changes in reindex command to remove passwords during reindex and then finally a PR to remove password field from mappings.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15871


## Safety Assurance
Small change, have tests in place. HQ working fine locally after the changes.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
Have required tests.
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
