### PR TITLE
Make search button sticky

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -65,11 +65,9 @@ hqDefine("cloudcare/js/formplayer/app", [
         let sidebar = FormplayerFrontend.regions.getRegion('sidebar');
         sidebar.on('show', function () {
             $('#content-container').addClass('full-width');
-            $('#menu-region').addClass('sidebar-push');
         });
         sidebar.on('hide empty', function () {
             $('#content-container').removeClass('full-width');
-            $('#menu-region').removeClass('sidebar-push');
         });
 
         hqRequire(["cloudcare/js/formplayer/router"], function (Router) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1326,6 +1326,13 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
                 this.onClickHome();
             }
         },
+        onAttach: function () {
+            // Add class to #cloudcare-main so other elements can offset with CSS
+            FormplayerFrontend.regions.el.classList.add('has-breadcrumbs');
+        },
+        onBeforeDetach: function () {
+            FormplayerFrontend.regions.el.classList.remove('has-breadcrumbs');
+        },
     });
 
     const LanguageOptionView = Marionette.View.extend({

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -107,10 +107,10 @@
       <div class="container case-tile-container">
         <div id="persistent-case-tile" class="print-container"></div>
       </div>
-      <div id="content-container" class="container">
+      <div id="content-container" class="container d-lg-flex">
         <div id="sidebar-region" class="noprint-sub-container"></div>
-        <div id="menu-region" class="print-container"></div>
-        <section id="webforms" data-bind="
+        <div id="menu-region" class="print-container flex-grow-if-not-empty"></div>
+        <section id="webforms" class="flex-grow-if-not-empty" data-bind="
                   template: {
                       name: 'form-fullform-ko-template',
                       afterRender: afterRender

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/query/list.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/query/list.html
@@ -3,16 +3,14 @@
 <script type="text/template" id="query-view-list-template">
   <form>
     <% if (sidebarEnabled) { %>
-      <button type="button" class="btn-close d-block d-lg-none float-end" aria-label="{% trans "Close" %}"
-        data-bs-toggle="collapse" data-bs-target="#sidebar-region" aria-expanded="false" aria-controls="sidebar-region">
-      </button>
-      <div class="query-button-container">
-        <button class="btn btn-outline-primary" type="button" id="query-clear-button">
-          <div>{% trans "Clear" %}</div>
-        </button>
-        <button class="btn btn-primary" type="submit" id="query-submit-button">
-          <div>{% trans "Search" %}</div>
-        </button>
+      <div class="query-button-container border bg-white p-2 sticky-top shadow-sm">
+        <div class="d-flex flex-row-reverse d-block d-lg-none">
+          <button type="button" class="btn-close" aria-label="{% trans "Close" %}"
+            data-bs-toggle="collapse" data-bs-target="#sidebar-region" aria-expanded="false" aria-controls="sidebar-region">
+          </button>
+        </div>
+        <button class="btn btn-outline-primary" type="button" id="query-clear-button">{% trans "Clear" %}</button>
+        <button class="btn btn-primary" type="submit" id="query-submit-button">{% trans "Search" %}</button>
       </div>
     <% } %>
     <% if (title.length > 0 && !sidebarEnabled) { %>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/query/list.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/query/list.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <script type="text/template" id="query-view-list-template">
-  <div id="sidebar-contents" class="me-lg-2">
+  <div id="query-list-contents">
   <form>
     <% if (sidebarEnabled) { %>
       <div class="query-button-container border bg-white p-2 sticky-top shadow-sm">

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/query/list.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/query/list.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 
 <script type="text/template" id="query-view-list-template">
+  <div id="sidebar-contents" class="me-lg-2">
   <form>
     <% if (sidebarEnabled) { %>
       <div class="query-button-container border bg-white p-2 sticky-top shadow-sm">
@@ -34,4 +35,5 @@
       </button>
     <% } %>
   </form>
+  </div>
 </script>

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/module.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/module.scss
@@ -96,14 +96,6 @@ button.clickable-icon {
   }
 }
 
-.query-button-container {
-  padding: 8px;
-  text-align: center;
-}
-.query-button-container .btn{
-  width: 48%;
-}
-
 .module-table .module-case-list-header {
   background-color: $cc-brand-low;
   color: white;

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/menu.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/menu.scss
@@ -51,3 +51,7 @@ $persistent-menu-image-size: 2rem;
     background-color: darken($cc-bg, 5);
   }
 }
+
+.flex-grow-if-not-empty:not(:empty) {
+  flex-grow: 1;
+}

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/module.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/module.scss
@@ -4,6 +4,13 @@
   }
 }
 
+.has-breadcrumbs .query-button-container {
+  top: $breadcrumb-height-cloudcare;
+}
+
+.query-button-container .btn{
+  width: 48%;
+}
 
 @media print {
   .module-banner {

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/query.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/query.scss
@@ -5,10 +5,12 @@
   max-width: none;  // clear any max-widths set by bootstrap, such as in .container
 }
 
-#sidebar-contents {
+// Applies only to split-screen case search
+#sidebar-region #query-list-contents {
   background: transparent;
   @include media-breakpoint-up(lg) {
     width: 300px;
+    margin-right: 10px;
   }
   @include media-breakpoint-down(lg) {
     max-width: 600px;

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/query.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/query.scss
@@ -5,17 +5,10 @@
   max-width: none;  // clear any max-widths set by bootstrap, such as in .container
 }
 
-.sidebar-push {
-  @include media-breakpoint-up(lg) {
-    margin-left: 310px;
-  }
-}
-
-#sidebar-region {
+#sidebar-contents {
   background: transparent;
   @include media-breakpoint-up(lg) {
     width: 300px;
-    position: absolute;
   }
   @include media-breakpoint-down(lg) {
     max-width: 600px;


### PR DESCRIPTION
## Product Description

I stuck the search buttons on a white background with a little border and made that sticky:

![image](https://github.com/user-attachments/assets/9d2610aa-85c9-49c2-95f3-5fffec42c1c4)

![image](https://github.com/user-attachments/assets/bd55dff6-e4cb-4c42-bb2f-b74d98fb1182)

In mobile mode:
![image](https://github.com/user-attachments/assets/02c75abb-ce5e-4b26-a5f7-f61381a8eb6a)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/USH-4682

The second commit was added to address a specific edge case.  If the main content is much shorter than the list of filters, you can scroll entirely past it, which means the breadcrumbs disappear, making the position no longer appropriate:
![image](https://github.com/user-attachments/assets/5f9934bd-e3a8-4aec-88c8-333a37df84e2)

I think the problem was that the sidebar overflows the main container because it uses `position: absolute;` rather than flexbox or similar to display in a column next to the rest of it.  The DOM is structured like this:
```
div #menu-container
  div #breadcrumb-region
  div #content-container
    div #sidebar-region - contains the search sidebar, has `position: absolute`
    div #menu-region - contains the case list and the main body of the page.  Has a left margin to leave space for the sidebar
```

I addressed it by using flexbox columns there instead, and it seems to work well, though it needs more testing.

## Feature Flag
Split screen case search

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi.atlassian.net/browse/QA-7019

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
