### PR TITLE
Show reports tab for location-restricted users who can access Tableau reports

### DIFF
--- a/corehq/apps/reports/standard/tableau.py
+++ b/corehq/apps/reports/standard/tableau.py
@@ -41,6 +41,7 @@ class TableauView(BaseDomainView):
     def page_url(self):
         return reverse(self.urlname, args=(self.domain, self.visualization.id,))
 
+    @method_decorator(login_and_domain_required)
     @method_decorator(toggles.EMBEDDED_TABLEAU.required_decorator())
     def dispatch(self, request, *args, **kwargs):
         if not self._authenticate_request(request):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1645,11 +1645,8 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         return False
 
     def can_view_some_tableau_viz(self, domain):
-        if not self.can_access_all_locations(domain):
-            return False
-
         from corehq.apps.reports.models import TableauVisualization
-        return self.can_view_tableau(domain) or bool(TableauVisualization.for_user(domain, self))
+        return bool(TableauVisualization.for_user(domain, self))
 
     def can_login_as(self, domain):
         return (


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Even though #34958 gave location-restricted users access to location-safe embedded Tableau reports, the reports tab is still hidden for location-restricted users who do not have any other kind of reports. This PR shows the reports tab to LRUs who do not have reports access but _can_ view location-safe tableau reports.

We noticed this just a little before [a jira ticket](https://dimagi.atlassian.net/issues/USH-4857?jql=ORDER%20BY%20created%20DESC) arose.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Pretty much just totally missed `can_view_some_tableau_viz` with the previous PR. And I tested locally with an LRU that had reports access, so the reports tab showed for me. Updated to have the logic one would expect--you can view the reports tab if you have access to any Tableau report.

Also includes small commit to fix [this](https://dimagi.sentry.io/issues/5709587272/?project=136860&referrer=github-pr-bot) Senty error.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

EMBEDDED_TABLEAU

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Everything looks good locally, for LRUs and non-LRUs

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
