### PR TITLE
Added form limits for enterprise form reports

### DIFF
--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -211,7 +211,7 @@ class EnterpriseMobileWorkerReport(EnterpriseReport):
 
 class EnterpriseFormReport(EnterpriseReport):
     title = _('Mobile Form Submissions')
-    MAXIMUM_USERS_PER_DOMAIN = getattr(settings, 'ENTERPRISE_REPORT_DOMAIN_USER_LIMIT', 20000)
+    MAXIMUM_USERS_PER_DOMAIN = getattr(settings, 'ENTERPRISE_REPORT_DOMAIN_USER_LIMIT', 20_000)
     MAXIMUM_ROWS_PER_REQUEST = getattr(settings, 'ENTERPRISE_REPORT_ROW_LIMIT', 1_000_000)
 
     def __init__(self, account, couch_user, start_date=None, end_date=None, num_days=30, include_form_id=False):

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -212,7 +212,7 @@ class EnterpriseMobileWorkerReport(EnterpriseReport):
 class EnterpriseFormReport(EnterpriseReport):
     title = _('Mobile Form Submissions')
     MAXIMUM_USERS_PER_DOMAIN = getattr(settings, 'ENTERPRISE_REPORT_DOMAIN_USER_LIMIT', 20000)
-    MAXIMUM_ROWS_PER_REQUEST = getattr(settings, 'ENTERPRISE_REPORT_ROW_LIMIT', 1000000)
+    MAXIMUM_ROWS_PER_REQUEST = getattr(settings, 'ENTERPRISE_REPORT_ROW_LIMIT', 1_000_000)
 
     def __init__(self, account, couch_user, start_date=None, end_date=None, num_days=30, include_form_id=False):
         super().__init__(account, couch_user)

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -250,7 +250,7 @@ class EnterpriseFormReport(EnterpriseReport):
             .values_list('_id', flat=True)
         )
 
-        if len(users_filter) == self.MAXIMUM_USERS_PER_DOMAIN:
+        if len(users_filter) > self.MAXIMUM_USERS_PER_DOMAIN:
             raise TooMuchRequestedDataError(
                 _('Domain {name} has too many users. Maximum allowed is: {amount}')
                 .format(name=domain_name, amount=self.MAXIMUM_USERS_PER_DOMAIN)

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -3,13 +3,15 @@ from datetime import datetime, timedelta
 
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
+from django.conf import settings
 
 from memoized import memoized
 
 from couchforms.analytics import get_last_form_submission_received
 from dimagi.utils.dates import DateSpan
 
-from corehq.apps.enterprise.exceptions import EnterpriseReportError
+from corehq.apps.enterprise.exceptions import EnterpriseReportError, TooMuchRequestedDataError
+from corehq.apps.enterprise.iterators import raise_after_max_elements
 from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.accounting.utils import get_default_domain_url
 from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
@@ -209,6 +211,8 @@ class EnterpriseMobileWorkerReport(EnterpriseReport):
 
 class EnterpriseFormReport(EnterpriseReport):
     title = _('Mobile Form Submissions')
+    MAXIMUM_USERS_PER_DOMAIN = getattr(settings, 'ENTERPRISE_REPORT_DOMAIN_USER_LIMIT', 20000)
+    MAXIMUM_ROWS_PER_DOMAIN = getattr(settings, 'ENTERPRISE_REPORT_DOMAIN_ROW_LIMIT', 1000000)
 
     def __init__(self, account, couch_user, start_date=None, end_date=None, num_days=30, include_form_id=False):
         super().__init__(account, couch_user)
@@ -241,23 +245,41 @@ class EnterpriseFormReport(EnterpriseReport):
     def _query(self, domain_name):
         time_filter = form_es.submitted
 
-        users_filter = form_es.user_id(UserES().domain(domain_name).mobile_users().show_inactive()
-                                    .values_list('_id', flat=True))
+        users_filter = form_es.user_id(
+            UserES().domain(domain_name).mobile_users().show_inactive().size(self.MAXIMUM_USERS_PER_DOMAIN + 1)
+            .values_list('_id', flat=True)
+        )
 
-        query = (form_es.FormES()
-                 .domain(domain_name)
-                 .filter(time_filter(gte=self.datespan.startdate,
-                                     lt=self.datespan.enddate_adjusted))
-                 .filter(users_filter))
+        if len(users_filter) == self.MAXIMUM_USERS_PER_DOMAIN:
+            raise TooMuchRequestedDataError(
+                _('Domain {name} has too many users. Maximum allowed is: {amount}')
+                .format(name=domain_name, amount=self.MAXIMUM_USERS_PER_DOMAIN)
+            )
+
+        query = (
+            form_es.FormES()
+            .domain(domain_name)
+            .filter(time_filter(gte=self.datespan.startdate, lt=self.datespan.enddate_adjusted))
+            .filter(users_filter)
+        )
         return query
 
     def hits(self, domain_name):
-        return self._query(domain_name).run().hits
+        exception = TooMuchRequestedDataError(
+            _('Domain {name} has too many rows. Maximum allowed is: {amount}')
+            .format(name=domain_name, amount=self.MAXIMUM_ROWS_PER_DOMAIN)
+        )
+        return raise_after_max_elements(
+            self._query(domain_name).scroll(),
+            self.MAXIMUM_ROWS_PER_DOMAIN,
+            exception
+        )
 
     def rows_for_domain(self, domain_obj):
         apps = get_brief_apps_in_domain(domain_obj.name)
         apps = {a.id: a.name for a in apps}
         rows = []
+
         for hit in self.hits(domain_obj.name):
             if hit['form'].get('#type') == 'system':
                 continue

--- a/corehq/apps/enterprise/exceptions.py
+++ b/corehq/apps/enterprise/exceptions.py
@@ -1,2 +1,6 @@
 class EnterpriseReportError(Exception):
     pass
+
+
+class TooMuchRequestedDataError(Exception):
+    pass

--- a/corehq/apps/enterprise/iterators.py
+++ b/corehq/apps/enterprise/iterators.py
@@ -1,0 +1,9 @@
+def raise_after_max_elements(it, max_elements, exception=None):
+    total_yielded = 0
+    for ele in it:
+        if total_yielded >= max_elements:
+            exception = exception or Exception('Too Many Elements')
+            raise exception
+
+        yield ele
+        total_yielded += 1

--- a/corehq/apps/enterprise/iterators.py
+++ b/corehq/apps/enterprise/iterators.py
@@ -1,9 +1,7 @@
 def raise_after_max_elements(it, max_elements, exception=None):
-    total_yielded = 0
-    for ele in it:
+    for total_yielded, ele in enumerate(it):
         if total_yielded >= max_elements:
             exception = exception or Exception('Too Many Elements')
             raise exception
 
         yield ele
-        total_yielded += 1

--- a/corehq/apps/enterprise/tests/test_iterators.py
+++ b/corehq/apps/enterprise/tests/test_iterators.py
@@ -4,16 +4,16 @@ from corehq.apps.enterprise.iterators import raise_after_max_elements
 
 
 class TestRaiseAfterMaxElements(SimpleTestCase):
-    def test_fully_iterating_will_raise_the_default_exception(self):
+    def test_iterating_beyond_max_items_will_raise_the_default_exception(self):
         it = raise_after_max_elements([1, 2, 3], 2)
         with self.assertRaisesMessage(Exception, 'Too Many Elements'):
             list(it)
 
-    def test_fully_iterating_will_raise_provided_exception(self):
+    def test_iterating_beyond_max_items_will_raise_provided_exception(self):
         it = raise_after_max_elements([1, 2, 3], 2, Exception('Test Message'))
         with self.assertRaisesMessage(Exception, 'Test Message'):
             list(it)
 
-    def test_slicing_iterator_can_avoid_error(self):
+    def test_can_iterate_through_all_elements_with_no_exception(self):
         it = raise_after_max_elements([1, 2, 3], 3)
         self.assertEqual(list(it), [1, 2, 3])

--- a/corehq/apps/enterprise/tests/test_iterators.py
+++ b/corehq/apps/enterprise/tests/test_iterators.py
@@ -1,0 +1,19 @@
+from django.test import SimpleTestCase
+
+from corehq.apps.enterprise.iterators import raise_after_max_elements
+
+
+class TestRaiseAfterMaxElements(SimpleTestCase):
+    def test_fully_iterating_will_raise_the_default_exception(self):
+        it = raise_after_max_elements([1, 2, 3], 2)
+        with self.assertRaisesMessage(Exception, 'Too Many Elements'):
+            list(it)
+
+    def test_fully_iterating_will_raise_provided_exception(self):
+        it = raise_after_max_elements([1, 2, 3], 2, Exception('Test Message'))
+        with self.assertRaisesMessage(Exception, 'Test Message'):
+            list(it)
+
+    def test_slicing_iterator_can_avoid_error(self):
+        it = raise_after_max_elements([1, 2, 3], 3)
+        self.assertEqual(list(it), [1, 2, 3])


### PR DESCRIPTION
## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15857

Our existing enterprise sizes can be seen [here](https://docs.google.com/spreadsheets/d/1fxB_KGVvEE0NmBHMQhVJMjsj3aop5IJLu6k1bdKHYt4/edit?gid=0#gid=0).  When I was performing testing, I had rough numbers for fetching as follows:
300K records in 28.9 seconds
500K records in 1:46 minutes
1 million records in 1:44 minutes
2 million records in 4:27 minutes

I'd chalk up the unusual 500K/1 million results as due to recent caching or variable load. That said, the previous implementation attempted to fetch all elasticsearch records, and would timeout after 30 seconds. To maintain this behavior, we'd need to restrict our clients to ~300K records, which, based on the linked ticket, would prohibit 8 of our partners from being able to fetch data by quarter. However, if we did not remove the existing 30 day limit, all but 1 of our partners have less than 300K records.

The major change here was changing from fetching all records at once, and trying to keep them all in memory, to using the `scroll` API, which gives us an iterator. I've set the initial limits to 1 million records, which can be more costly than our current 30-second timeout, but it is easily configurable if this places too much load on our celery workers. The above tests were in production, and it seems our production machines had no issues processing 1 million records. And, with our current usage numbers, this limit means that all but one of our partners can retrieve reports for a full quarter.

In terms of the user limit, this limit is enforced per domain, and the most populous domains we're seeing have less than five thousand users. 20K is just a safeguard in case a domain rises that high.

This does mean that some of our current domains will generate errors trying to use the enterprise form report. I've been told we're ok with this behavior, although I need to see if there's a good way to communicate why these feeds error'd out, as APIs don't have great error reporting mechanisms.


Worth noting is that I'm using Elasticsearch's `scroll` API here, despite the current Elasticsearch documentation recommending using Point-In-Times and the `search_after` method instead. The reason for this is that these features were only introduced in more recent ElasticSearch versions. While ElasticSearch 5 does support [search_after](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/search-request-search-after.html), this lacks the features of the more recent versions -- there is no ability to create a point-in-time, and you can see at the bottom of the documentation that `search_after` always runs against the current state of the index. I'm guessing that the `scroll` API uses index-based pagination, which has poor performance for large data sets. I'd imagine this is the reason `search_after` queries are now recommended for this scenario. Nevertheless, I think the performance we're seeing for 1 million scrolled records is acceptable.

## Safety Assurance

### Safety story
Locally tested. This improves the code's current status-quo, as our existing enterprise form report does not place any restrictions on the amount of rows fetched -- the query will simply time out.

### Automated test coverage

Added a new test suite for the new iterator. Tests *should* be added to ensure that fetching more than the established limits cause errors. However, I did not want to create end-to-end tests to verify this behavior, and doing it without end-to-end tests requires either extreme mocking (which will lead to brittle tests) or significant refactoring (which probably should be handled in another ticket).

### QA Plan

I verified that I can still retrieve the Forms Report via the API and through the normal Download option when the data is below the given limits. I also verified that the report returns an error when above the limits. Given that I think those would basically be the instructions I'd give to QA, I think we can skip QA here.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
