### PR TITLE
Adds more Dimagi apps to Android dependencies settting

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
@@ -357,6 +357,11 @@
     - ['org.commcare.dalvik.reminders', 'CommCare Reminders']
     - ['callout.commcare.org.sendussd', 'CommCare USSD']
     - ['org.commcare.dalvik.abha', 'CommCare ABHA']
+    - ['com.dimagi.biometric', 'Biometrics Capture']
+    - ['org.rdtoolkit', 'CommCare Toolkit']
+    - ['richard.chard.lu.android.areamapper', 'Area Calculator for CommCare']
+    - ['org.commcare.respiratory', 'Breath Counter']
+    - ['com.simprints.id', 'Simprints ID']
   default: []  # multiSelect default takes a list
   since: '2.53'
   force: true

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
@@ -356,7 +356,6 @@
   values:
     - ['org.commcare.dalvik.reminders', 'CommCare Reminders']
     - ['callout.commcare.org.sendussd', 'CommCare USSD']
-    - ['org.commcare.dalvik.abha', 'CommCare ABHA']
     - ['com.dimagi.biometric', 'Biometrics Capture']
     - ['org.rdtoolkit', 'CommCare Toolkit']
     - ['richard.chard.lu.android.areamapper', 'Area Calculator for CommCare']

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yml
@@ -363,5 +363,5 @@
     - ['org.commcare.respiratory', 'Breath Counter']
     - ['com.simprints.id', 'Simprints ID']
   default: []  # multiSelect default takes a list
-  since: '2.53'
+  since: '2.54'
   force: true


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/SC-3803
https://dimagi.atlassian.net/browse/SC-3901

- Adds more Dimagi apps to Android dependencies settting [as per the doc](https://docs.google.com/document/d/1Hg0wyZZpqwbjUf3Xcf9F9qU-9jqNKO-D-MN88HaqXQk/edit#heading=h.dxbefyjyoobw)

- Also bumps the CC version requirement to 2.54 for this feature as some of these dependencies are only added in 2.54 on mobile code. 

- Removes ABHA app as per https://dimagi.atlassian.net/browse/SC-3901

## Feature Flag

APP_DEPENDENCIES

## Safety Assurance

### Safety story

Locally tested, Only adds more options to existing settting. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
