### PR TITLE
Handle AccountTypeError exception

### DIFF
--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -692,7 +692,11 @@ def _get_user(domain, doc_id):
         # 'is_account_confirmed',
         # 'user_location_id',
     )
-    user = CommCareUser.get_by_user_id(doc_id, domain)
+    try:
+        user = CommCareUser.get_by_user_id(doc_id, domain)
+    except CouchUser.AccountTypeError:
+        # user is a WebUser not a CommCareUser
+        return None
     if not user:
         return None
 

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1257,7 +1257,7 @@ class RelatedDocExpressionUserTest(TestCase):
 
 
 class TestRelatedDocExpressionWebUser(TestCase):
-    domain = 'test-domain'
+    domain = 'test-webuser-domain'
 
     def setUp(self):
         domain_obj = Domain(name=self.domain, is_active=True)


### PR DESCRIPTION
## Technical Summary

Gracefully handles when a related_doc UCR expression refers to a WebUser instead of a CommCareUser.

The error was introduce by PR https://github.com/dimagi/commcare-hq/pull/34945 This change falls back to previous behavior of returning `None`.

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Includes coverage.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
