### PR TITLE
Close web user usercases when user is removed

### DIFF
--- a/corehq/apps/callcenter/sync_usercase.py
+++ b/corehq/apps/callcenter/sync_usercase.py
@@ -105,7 +105,7 @@ def _domain_has_new_fields(domain, field_names):
 def _get_sync_usercase_helper(user, domain, case_type, owner_id, case=None):
     fields = _get_user_case_fields(user, case_type, owner_id, domain)
     case = case or CommCareCase.objects.get_case_by_external_id(domain, user.user_id, case_type)
-    close = user.to_be_deleted() or not user.is_active
+    close = user.to_be_deleted() or not user.is_active or domain not in user.get_domains()
     user_case_helper = _UserCaseHelper(domain, owner_id, user.user_id)
 
     def case_should_be_reopened(case, user_case_should_be_closed):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2440,6 +2440,8 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
         super().add_domain_membership(domain, timezone, **kwargs)
 
     def delete_domain_membership(self, domain, create_record=False):
+        self._leaving_domains = getattr(self, '_leaving_domains', []) + [domain]
+
         if TABLEAU_USER_SYNCING.enabled(domain):
             from corehq.apps.reports.util import delete_tableau_user
             delete_tableau_user(domain, self.username)
@@ -2518,8 +2520,10 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
         super().save(fire_signals=fire_signals, **params)
         if fire_signals and not self.to_be_deleted():
             from corehq.apps.callcenter.tasks import sync_web_user_usercases_if_applicable
-            for domain in self.get_domains():
+            # We need to sync to all domains, even those the user is leaving
+            for domain in self.get_domains() + getattr(self, '_leaving_domains', []):
                 sync_web_user_usercases_if_applicable(self, domain)
+        self._leaving_domains = []
 
     def add_to_assigned_locations(self, domain, location):
         membership = self.get_domain_membership(domain)


### PR DESCRIPTION
## Product Description
At present, web user usercases are not closed when the user is removed from the domain.  This PR ensures that they will be.

## Technical Summary
https://dimagi.atlassian.net/browse/USH-4784

## Feature Flag
USH: Enable the creation of usercases for web users.

## Safety Assurance
Automated tests seem like the best way to verify this, so that's what I did.  Also double checked with local testing.

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
