### PR TITLE
Drop `send_request()`

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -70,7 +70,6 @@ import uuid
 from collections import defaultdict
 from contextlib import nullcontext
 from datetime import datetime, timedelta
-from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from django.db import models, router
@@ -1290,68 +1289,6 @@ def get_payload(repeater: Repeater, repeat_record: RepeatRecord) -> str:
             tb_str=traceback.format_exc()
         )
         raise
-
-
-def send_request(
-    repeater: Repeater,
-    repeat_record: RepeatRecord,
-    payload: Any,
-) -> bool:
-    """
-    Calls ``repeater.send_request()`` and handles the result.
-
-    Returns True on success or cancelled, which means the caller should
-    not retry. False means a retry should be attempted later.
-    """
-
-    def is_success(resp):
-        return (
-            is_response(resp)
-            and 200 <= resp.status_code < 300
-            # `response` is `True` if the payload did not need to be
-            # sent. (This can happen, for example, with DHIS2 if the
-            # form that triggered the forwarder doesn't contain data
-            # for a DHIS2 Event.)
-            or resp is True
-        )
-
-    def allow_retries(response):
-        # respect the `retry` field of RepeaterResponse
-        return getattr(response, 'retry', True)
-
-    def later_might_be_better(resp):
-        return is_response(resp) and resp.status_code in (
-            502,  # Bad Gateway
-            503,  # Service Unavailable
-            504,  # Gateway Timeout
-        )
-
-    try:
-        response = repeater.send_request(repeat_record, payload)
-    except (Timeout, ConnectionError) as err:
-        log_repeater_timeout_in_datadog(repeat_record.domain)
-        message = str(RequestConnectionError(err))
-        repeat_record.add_server_failure_attempt(message)
-    except Exception as err:
-        repeat_record.add_client_failure_attempt(str(err))
-    else:
-        if is_success(response):
-            if is_response(response):
-                # Log success in Datadog if the payload was sent.
-                log_repeater_success_in_datadog(
-                    repeater.domain,
-                    response.status_code,
-                    repeater_type=repeater.__class__.__name__
-                )
-            repeat_record.add_success_attempt(response)
-        else:
-            message = format_response(response)
-            if later_might_be_better(response):
-                repeat_record.add_server_failure_attempt(message)
-            else:
-                retry = allow_retries(response)
-                repeat_record.add_client_failure_attempt(message, retry)
-    return repeat_record.state in (State.Success, State.Cancelled, State.Empty)  # Don't retry
 
 
 def has_failed(record):

--- a/corehq/motech/repeaters/tests/test_models_slow.py
+++ b/corehq/motech/repeaters/tests/test_models_slow.py
@@ -19,7 +19,7 @@ from corehq.motech.repeaters.const import (
     RECORD_FAILURE_STATE,
     RECORD_SUCCESS_STATE,
 )
-from corehq.motech.repeaters.models import FormRepeater, send_request
+from corehq.motech.repeaters.models import FormRepeater
 from corehq.util.test_utils import timelimit
 
 DOMAIN = ''.join([random.choice(string.ascii_lowercase) for __ in range(20)])
@@ -67,8 +67,7 @@ class ServerErrorTests(TestCase, DomainSubscriptionMixin):
         with patch('corehq.motech.repeaters.models.simple_request') as simple_request:
             simple_request.return_value = resp
 
-            payload = self.repeater.get_payload(self.repeat_record)
-            send_request(self.repeater, self.repeat_record, payload)
+            self.repeat_record.fire()
 
             self.assertEqual(self.repeat_record.attempts.last().state,
                              RECORD_SUCCESS_STATE)
@@ -81,8 +80,7 @@ class ServerErrorTests(TestCase, DomainSubscriptionMixin):
         with patch('corehq.motech.repeaters.models.simple_request') as simple_request:
             simple_request.return_value = resp
 
-            payload = self.repeater.get_payload(self.repeat_record)
-            send_request(self.repeater, self.repeat_record, payload)
+            self.repeat_record.fire()
 
             self.assertEqual(self.repeat_record.attempts.last().state,
                              RECORD_FAILURE_STATE)
@@ -96,8 +94,7 @@ class ServerErrorTests(TestCase, DomainSubscriptionMixin):
         with patch('corehq.motech.repeaters.models.simple_request') as simple_request:
             simple_request.return_value = resp
 
-            payload = self.repeater.get_payload(self.repeat_record)
-            send_request(self.repeater, self.repeat_record, payload)
+            self.repeat_record.fire()
 
             self.assertEqual(self.repeat_record.attempts.last().state,
                              RECORD_FAILURE_STATE)
@@ -133,8 +130,7 @@ class ServerErrorTests(TestCase, DomainSubscriptionMixin):
         with patch('corehq.motech.repeaters.models.simple_request') as simple_request:
             simple_request.return_value = resp
 
-            payload = self.repeater.get_payload(self.repeat_record)
-            send_request(self.repeater, self.repeat_record, payload)
+            self.repeat_record.fire()
 
             self.assertEqual(self.repeat_record.attempts.last().state,
                              RECORD_FAILURE_STATE)
@@ -146,8 +142,7 @@ class ServerErrorTests(TestCase, DomainSubscriptionMixin):
         with patch('corehq.motech.repeaters.models.simple_request') as simple_request:
             simple_request.side_effect = ConnectionError()
 
-            payload = self.repeater.get_payload(self.repeat_record)
-            send_request(self.repeater, self.repeat_record, payload)
+            self.repeat_record.fire()
 
             self.assertEqual(self.repeat_record.attempts.last().state,
                              RECORD_FAILURE_STATE)


### PR DESCRIPTION
## Technical Summary

Drops a function that is unused outside of tests.

(The function was originally intended to be part of a simplified workflow for sending payloads.)

## Safety Assurance

### Safety story

Unused outside of tests

### Automated test coverage

The tests have been updated, and continue to pass.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
