### PR TITLE
Drop soft asserts

### DIFF
--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -19,7 +19,6 @@ from corehq.util.metrics import (
     metrics_histogram_timer,
 )
 from corehq.util.metrics.const import MPM_MAX
-from corehq.util.soft_assert import soft_assert
 from corehq.util.timer import TimingContext
 
 from .const import (
@@ -47,8 +46,6 @@ _check_repeaters_buckets = make_buckets_from_timedeltas(
     timedelta(hours=5),
     timedelta(hours=10),
 )
-MOTECH_DEV = '@'.join(('nhooper', 'dimagi.com'))
-_soft_assert = soft_assert(to=MOTECH_DEV)
 logging = get_task_logger(__name__)
 
 DELETE_CHUNK_SIZE = 5000
@@ -112,20 +109,12 @@ def check_repeaters_in_partition(partition):
         ):
             for record in RepeatRecord.objects.iter_partition(
                     start, partition, CHECK_REPEATERS_PARTITION_COUNT):
-                if not _soft_assert(
-                    datetime.utcnow() < twentythree_hours_later,
-                    "I've been iterating repeat records for 23 hours. I quit!"
-                ):
+
+                if datetime.utcnow() > twentythree_hours_later:
                     break
 
                 metrics_counter("commcare.repeaters.check.attempt_forward")
                 record.attempt_forward_now(is_retry=True)
-            else:
-                iterating_time = datetime.utcnow() - start
-                _soft_assert(
-                    iterating_time < timedelta(hours=6),
-                    f"It took {iterating_time} to iterate repeat records."
-                )
     finally:
         check_repeater_lock.release()
 


### PR DESCRIPTION
## Technical Summary

Small.

This code was once used for flagging when the repeat record queue was in a terrible state. We use Datadog for monitoring repeaters now. These soft asserts have not been triggered for years.

## Safety Assurance

### Safety story

Drops unused code. We have better ways of achieving the same objectives.

### Automated test coverage

This change is not covered by tests

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
