### PR TITLE
Ensure all repeater timeouts, errors, and failures are logged to datadog

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1204,9 +1204,11 @@ class RepeatRecord(models.Model):
         self.add_success_attempt(response)
 
     def handle_failure(self, response):
+        log_repeater_error_in_datadog(self.domain, response.status_code, self.repeater_type)
         self.add_server_failure_attempt(format_response(response))
 
     def handle_exception(self, exception):
+        log_repeater_error_in_datadog(self.domain, None, self.repeater_type)
         self.add_client_failure_attempt(str(exception))
 
     def handle_payload_exception(self, exception):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1157,8 +1157,6 @@ class RepeatRecord(models.Model):
             try:
                 self.repeater.fire_for_record(self, timing_context=timing_context)
             except Exception as e:
-                log_repeater_error_in_datadog(self.domain, status_code=None,
-                                              repeater_type=self.repeater_type)
                 self.handle_payload_exception(e)
                 raise
 
@@ -1212,6 +1210,7 @@ class RepeatRecord(models.Model):
         self.add_client_failure_attempt(str(exception))
 
     def handle_payload_exception(self, exception):
+        log_repeater_error_in_datadog(self.domain, status_code=None, repeater_type=self.repeater_type)
         self.add_client_failure_attempt(str(exception), retry=False)
 
     def cancel(self):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Minimal amount of changes needed to get timeouts, errors, and failures logged in datadog, instead of https://github.com/dimagi/commcare-hq/pull/34994 which tried to do too much in one go.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The only behavior changes here are whether we actually log something to datadog or not. Apart from that, error handling remains the same. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
