### PR TITLE
Remove commcare.repeaters.new_record metric

### DIFF
--- a/corehq/motech/repeaters/management/commands/find_missing_repeat_records.py
+++ b/corehq/motech/repeaters/management/commands/find_missing_repeat_records.py
@@ -18,7 +18,6 @@ from corehq.util.argparse_types import date_type
 
 from dimagi.utils.parsing import string_to_utc_datetime
 
-from corehq.util.metrics import metrics_counter
 
 logger = logging.getLogger(__name__)
 
@@ -523,10 +522,6 @@ def create_case_repeater_register(repeater, domain, payload):
         next_check=now,
         payload_id=payload.get_id
     )
-    metrics_counter('commcare.repeaters.new_record', tags={
-        'domain': domain,
-        'doc_type': repeater.repeater_type
-    })
     repeat_record.attempt_forward_now()
     return repeat_record
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -400,11 +400,6 @@ class Repeater(RepeaterSuperProxy):
             next_check=now,
             payload_id=payload.get_id
         )
-        metrics_counter('commcare.repeaters.new_record', tags={
-            'domain': self.domain,
-            'doc_type': self.repeater_type,
-            'mode': 'sync' if fire_synchronously else 'async'
-        })
         repeat_record.save()
 
         if fire_synchronously:


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This was initially added in https://dimagi.atlassian.net/browse/SAAS-12090, but my reasoning for removing it is that we can get this information by looking `process_repeat_record` tasks, since we send all initial tries through that task and all retries through `retry_process_repeat_record`. Here's [the graph](https://app.datadoghq.com/dashboard/u88-px4-jra/repeaters-dashboard?fromUser=true&fullscreen_end_ts=1724102354281&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1724015954281&fullscreen_widget=3731768267564626&refresh_mode=sliding&view=spans&from_ts=1724015767000&to_ts=1724102167000&live=true) that would replace [this graph](https://app.datadoghq.com/dashboard/u88-px4-jra/repeaters-dashboard?fromUser=true&fullscreen_end_ts=1724102383063&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1724015983063&fullscreen_widget=7956003668264950&refresh_mode=sliding&view=spans&from_ts=1724015767000&to_ts=1724102167000&live=true). We would lose the included tag on repeater type, but given we tag repeater successes/errors/timeouts with repeater type, I think that is enough to identify any repeater specific issues.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Very safe, just removing metrics that we report to datadog. I've doubled checked that this metric is only used in the repeaters dashboard, and no monitors. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
