### PR TITLE
Always Store ES Geopoint Value

### DIFF
--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -1,6 +1,8 @@
 from django.core.mail import mail_admins
 from django.db import ProgrammingError
 
+from corehq.privileges import DATA_DICTIONARY
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.case_search.const import (
     GEOPOINT_VALUE,
     INDEXED_METADATA_BY_KEY,
@@ -89,8 +91,9 @@ def _add_smart_types(dynamic_properties, domain, case_type):
     # Properties are stored in a dict like {"key": "dob", "value": "1900-01-01"}
     # `value` is a multi-field property that duck types numeric and date values
     # We can't do that for properties like geo_points in ES v2, as `ignore_malformed` is broken
-    gps_props = get_gps_properties(domain, case_type)
-    gps_props.add(get_geo_case_property(domain))
+    gps_props = set({get_geo_case_property(domain)})
+    if domain_has_privilege(domain, DATA_DICTIONARY):
+        gps_props |= get_gps_properties(domain, case_type)
     _add_gps_smart_types(dynamic_properties, gps_props)
 
 

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -19,10 +19,6 @@ from corehq.apps.es.client import manager
 from corehq.apps.geospatial.utils import get_geo_case_property
 from corehq.form_processor.backends.sql.dbaccessors import CaseReindexAccessor
 from corehq.pillows.base import is_couch_change_for_sql_domain
-from corehq.toggles import (
-    GEOSPATIAL,
-    USH_CASE_CLAIM_UPDATES,
-)
 from corehq.util.doc_processor.sql import SqlDocumentProvider
 from corehq.util.log import get_traceback_string
 from corehq.util.quickcache import quickcache
@@ -84,8 +80,7 @@ def _get_case_properties(doc_dict):
     dynamic_properties = [_format_property(key, value, case_id)
                           for key, value in doc_dict['case_json'].items()]
 
-    if USH_CASE_CLAIM_UPDATES.enabled(domain) or GEOSPATIAL.enabled(domain):
-        _add_smart_types(dynamic_properties, domain, doc_dict['type'])
+    _add_smart_types(dynamic_properties, domain, doc_dict['type'])
 
     return base_case_properties + dynamic_properties
 
@@ -94,12 +89,9 @@ def _add_smart_types(dynamic_properties, domain, case_type):
     # Properties are stored in a dict like {"key": "dob", "value": "1900-01-01"}
     # `value` is a multi-field property that duck types numeric and date values
     # We can't do that for properties like geo_points in ES v2, as `ignore_malformed` is broken
-    if USH_CASE_CLAIM_UPDATES.enabled(domain):
-        gps_props = get_gps_properties(domain, case_type)
-        _add_gps_smart_types(dynamic_properties, gps_props)
-    if GEOSPATIAL.enabled(domain):
-        gps_props = [get_geo_case_property(domain)]
-        _add_gps_smart_types(dynamic_properties, gps_props)
+    gps_props = get_gps_properties(domain, case_type)
+    gps_props.add(get_geo_case_property(domain))
+    _add_gps_smart_types(dynamic_properties, gps_props)
 
 
 def _add_gps_smart_types(dynamic_properties, gps_props):

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -183,7 +183,8 @@ class privilege_enabled:
         'corehq.apps.users.permissions.domain_has_privilege',
         'corehq.apps.users.views.mobile.users.domain_has_privilege',
         'django_prbac.decorators.has_privilege',
-        'corehq.apps.export.views.list.domain_has_privilege'
+        'corehq.apps.export.views.list.domain_has_privilege',
+        'corehq.pillows.case_search.domain_has_privilege'
     )
 
     def __init__(self, privilege_slug):

--- a/testapps/test_pillowtop/tests/test_case_search_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_search_pillow.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
+from corehq import privileges
 from corehq.apps.case_search.const import INDEXED_METADATA_BY_KEY
-from corehq.apps.case_search.exceptions import CaseSearchNotEnabledException
 from corehq.apps.case_search.models import CaseSearchConfig
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import (
@@ -23,7 +23,7 @@ from corehq.pillows.case_search import (
     CaseSearchReindexerFactory,
     delete_case_search_cases,
 )
-from corehq.util.test_utils import create_and_save_a_case, flag_enabled
+from corehq.util.test_utils import create_and_save_a_case
 
 
 @es_test(requires=[case_search_adapter])
@@ -98,8 +98,10 @@ class CaseSearchPillowTest(TestCase):
     def _get_kafka_seq(self):
         return get_topic_offset(topics.CASE_SQL)
 
-    @flag_enabled('USH_CASE_CLAIM_UPDATES')
     def test_geopoint_property(self):
+        def mock_handler(domain, privilege):
+            return privilege == privileges.DATA_DICTIONARY
+
         CaseSearchConfig.objects.get_or_create(pk=self.domain, enabled=True)
         self._make_data_dictionary(gps_properties=['coords', 'short_coords', 'other_coords'])
         case = self._make_case(case_properties={
@@ -108,7 +110,9 @@ class CaseSearchPillowTest(TestCase):
             'other_coords': '42 Wallaby Way',
             'not_coords': '-33.8561 151.2152 0 0',
         })
-        CaseSearchReindexerFactory(domain=self.domain).build().reindex()
+        with patch('corehq.pillows.case_search.domain_has_privilege') as mock_domain_has_privilege:
+            mock_domain_has_privilege.side_effect = mock_handler
+            CaseSearchReindexerFactory(domain=self.domain).build().reindex()
         manager.index_refresh(case_search_adapter.index_name)
         es_case = CaseSearchES().doc_id(case.case_id).run().hits[0]
         self.assertEqual(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
No visible user-facing changes.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3860).
Link to tech spec [here](https://docs.google.com/document/d/1bLg-pTzLrd62ExNAb9Fdh6zCJzJ11gWUZTtlz1L7HY8/edit).

This is a small PR that simply removes the feature flag constraints for storing case property geopoint values in ES. This is being done so that even if the feature flags are enabled at a later point, the required geopoint data will already exist in ES and will not have to be added in bulk upon enabling the relevant feature flag. Currently, only new cases added after enabling the feature flag will have a geopoint value added to ES. This would require all old cases to have to be manually added to ES in bulk.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Small change

Adding a geopoint value adds around ~56 additional bytes to the ES doc, which has been deemed to be relatively minimal.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests exist.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
