### PR TITLE
Move location 'has users' FF to be under new flag

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -45,14 +45,15 @@ from crispy_forms.utils import flatatt
 
 class LocationSelectWidget(forms.Widget):
     def __init__(self, domain, attrs=None, id='supply-point', multiselect=False, placeholder=None,
-                 include_locations_with_no_users_allowed=True):
+                 for_user_location_selection=False):
         super(LocationSelectWidget, self).__init__(attrs)
         self.domain = domain
         self.id = id
         self.multiselect = multiselect
         self.placeholder = placeholder
         url_name = 'location_search'
-        if not include_locations_with_no_users_allowed and toggles.LOCATION_HAS_USERS.enabled(self.domain):
+        if (for_user_location_selection
+                and toggles.USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION.enabled(self.domain)):
             url_name = 'location_search_has_users_only'
         self.query_url = reverse(url_name, args=[self.domain])
         self.template = 'locations/manage/partials/autocomplete_select_widget.html'

--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -167,8 +167,6 @@
                         {% endblocktrans %}">
                   </span>
                 </th>
-              {% endif %}
-              {% if request|toggle_enabled:"LOCATION_HAS_USERS" %}
                 <th data-bind="visible: advanced_mode">
                   {% trans "Has Users" %}
                   <span class="hq-help-template"
@@ -268,8 +266,6 @@
                                     enable: view_descendants">
                   </select>
                 </td>
-              {% endif %}
-              {% if request|toggle_enabled:"LOCATION_HAS_USERS" %}
                 <td data-bind="visible: $parent.advanced_mode">
                   <input data-bind="checked: has_users_setting, disable: has_users_setting() && actually_has_users()" type="checkbox" />
                 </td>

--- a/corehq/apps/locations/tests/test_views.py
+++ b/corehq/apps/locations/tests/test_views.py
@@ -146,7 +146,7 @@ class LocationTypesViewTest(TestCase):
         with self.assertRaises(LocationConsistencyError):
             self.send_request(data)
 
-    @flag_enabled('LOCATION_HAS_USERS')
+    @flag_enabled('USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION')
     @mock.patch('corehq.apps.locations.views.does_location_type_have_users', return_value=True)
     def test_invalid_remove_has_users(self, _):
         loc_type1 = OTHER_DETAILS.copy()
@@ -203,7 +203,7 @@ class LocationsSearchViewTest(TestCase):
         self.assertEqual(results[0]['id'], self.loc1.location_id)
         self.assertEqual(results[1]['id'], self.loc2.location_id)
 
-    @flag_enabled('LOCATION_HAS_USERS')
+    @flag_enabled('USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION')
     def test_search_view_has_users_only(self):
         loc_type2 = LocationType(domain=self.domain, name='type2', code='code2')
         loc_type2.has_users = False

--- a/corehq/apps/locations/urls.py
+++ b/corehq/apps/locations/urls.py
@@ -33,7 +33,7 @@ settings_urls = [
     url(r'^list/$', LocationsListView.as_view(), name=LocationsListView.urlname),
     url(r'^location_search/$', LocationsSearchView.as_view(), name='location_search'),
     url(r'^location_search_has_users_only/$', LocationsSearchView.as_view(
-        include_locations_with_no_users_allowed=False), name='location_search_has_users_only'),
+        include_locations_with_no_users=False), name='location_search_has_users_only'),
     url(r'^location_types/$', LocationTypesView.as_view(), name=LocationTypesView.urlname),
     url(r'^import/$', waf_allow('XSS_BODY')(LocationImportView.as_view()), name=LocationImportView.urlname),
     url(r'^import/bulk_location_upload_api/$', bulk_location_upload_api, name='bulk_location_upload_api'),

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -266,9 +266,9 @@ class LocationOptionsController(EmwfOptionsController):
     namespace_locations = False
     case_sharing_only = False
 
-    def __init__(self, *args, include_locations_with_no_users_allowed=True):
-        self.include_locations_with_no_users_allowed = include_locations_with_no_users_allowed
+    def __init__(self, *args, include_locations_with_no_users=True):
         super().__init__(*args)
+        self.include_locations_with_no_users = include_locations_with_no_users
 
     @property
     def data_sources(self):
@@ -280,13 +280,13 @@ class LocationOptionsController(EmwfOptionsController):
 @method_decorator(locations_access_required, name='dispatch')
 @location_safe
 class LocationsSearchView(EmwfOptionsView):
-    include_locations_with_no_users_allowed = True
+    include_locations_with_no_users = True
 
     @property
     @memoized
     def options_controller(self):
         return LocationOptionsController(self.request, self.domain, self.search,
-            include_locations_with_no_users_allowed=self.include_locations_with_no_users_allowed)
+            include_locations_with_no_users=self.include_locations_with_no_users)
 
 
 @method_decorator(use_bootstrap5, name='dispatch')
@@ -434,7 +434,7 @@ class LocationTypesView(BaseDomainView):
             payload_loc_type_name_by_pk[loc_type['pk']] = loc_type['name']
             if loc_type.get('code'):
                 payload_loc_type_code_by_pk[loc_type['pk']] = loc_type['code']
-            if toggles.LOCATION_HAS_USERS.enabled(self.domain):
+            if toggles.USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION.enabled(self.domain):
                 _validate_has_users_config(loc_type, pk)
         names = list(payload_loc_type_name_by_pk.values())
         names_are_unique = len(names) == len(set(names))
@@ -819,7 +819,7 @@ class EditLocationView(BaseEditLocationView):
     def users_form(self):
         if not (self.can_edit_commcare_users or self.can_access_all_locations):
             return None
-        if toggles.LOCATION_HAS_USERS.enabled(self.domain) and not self.location.location_type.has_users:
+        if not self.location.location_type.has_users:
             return None
         form = UsersAtLocationForm(
             request=self.request,

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -1,6 +1,5 @@
 from memoized import memoized
 
-from corehq import toggles
 from corehq.apps.enterprise.models import EnterprisePermissions
 from corehq.apps.es import GroupES, UserES, groups
 from corehq.apps.locations.models import SQLLocation
@@ -46,6 +45,7 @@ class EmwfOptionsController(object):
         self.domain = domain
         self.search = search
         self.case_sharing_only = case_sharing_only
+        self.include_locations_with_no_users = True
 
     @property
     @memoized
@@ -97,8 +97,7 @@ class EmwfOptionsController(object):
 
         if self.case_sharing_only:
             locations = locations.filter(location_type__shares_cases=True)
-        if (toggles.LOCATION_HAS_USERS.enabled(self.domain)
-                and not self.include_locations_with_no_users_allowed):
+        if not self.include_locations_with_no_users:
             locations = locations.filter(location_type__has_users=True)
         return locations.accessible_to_user(self.domain, self.request.couch_user)
 

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -386,7 +386,7 @@ class TestLocationValidator(LocationHierarchyTestCase):
         assert validation_result == self.validator.error_message_location_access.format(
             self.locations['Suffolk'].site_code)
 
-    @flag_enabled('LOCATION_HAS_USERS')
+    @flag_enabled('USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION')
     def test_location_not_has_users(self):
         self.editable_user.reset_locations(self.domain, [self.locations['Middlesex'].location_id])
         self.locations['Cambridge'].location_type.has_users = False

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -511,7 +511,7 @@ class LocationValidator(ImportValidator):
     def validate_spec(self, spec):
         user_access_error = self._validate_uploading_user_access(spec)
         location_cannot_have_users_error = None
-        if toggles.LOCATION_HAS_USERS.enabled(self.domain):
+        if toggles.USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION.enabled(self.domain):
             location_cannot_have_users_error = self._validate_location_has_users(spec)
         return user_access_error or location_cannot_have_users_error
 

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1160,7 +1160,7 @@ class SelectUserLocationForm(forms.Form):
         self.domain = domain
         self.fields['assigned_locations'].widget = LocationSelectWidget(
             self.domain, multiselect=True, id='id_assigned_locations',
-            include_locations_with_no_users_allowed=False
+            for_user_location_selection=True
         )
         self.fields['assigned_locations'].help_text = ExpandedMobileWorkerFilter.location_search_help
         self.fields['primary_location'].widget = PrimaryLocationWidget(
@@ -1634,7 +1634,7 @@ class UserFilterForm(forms.Form):
             id='id_location_id',
             placeholder=_("All Locations"),
             attrs={'data-bind': 'value: location_id'},
-            include_locations_with_no_users_allowed=False
+            for_user_location_selection=True
         )
         self.fields['location_id'].widget.query_url = "{url}?show_all=true".format(
             url=self.fields['location_id'].widget.query_url

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -58,7 +58,6 @@ from corehq.apps.user_importer.helpers import UserChangeLogger
 from corehq.const import LOADTEST_HARD_LIMIT, USER_CHANGE_VIA_WEB
 from corehq.pillows.utils import MOBILE_USER_TYPE, WEB_USER_TYPE
 from corehq.toggles import (
-    LOCATION_HAS_USERS,
     TWO_STAGE_USER_PROVISIONING,
     TWO_STAGE_USER_PROVISIONING_BY_SMS,
 )
@@ -1178,7 +1177,7 @@ class SelectUserLocationForm(forms.Form):
             locations = get_locations_from_ids(location_ids, self.domain)
         except SQLLocation.DoesNotExist:
             raise forms.ValidationError(_('One or more of the locations was not found.'))
-        if LOCATION_HAS_USERS.enabled(self.domain) and locations.filter(location_type__has_users=False).exists():
+        if locations.filter(location_type__has_users=False).exists():
             raise forms.ValidationError(
                 _('One or more of the locations you specified cannot have users assigned.'))
         return [location.location_id for location in locations]

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2903,7 +2903,7 @@ SUPPORT_ROAD_NETWORK_DISBURSEMENT_ALGORITHM = StaticToggle(
 
 USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION = StaticToggle(
     'ush_restore_file_location_case_sync_restriction',
-    'USH: Limit the location-owned cases a user\'s restore file, and allow marking whether a '
+    'USH: Limit the location-owned cases in a user\'s restore file, and allow marking whether a '
     'location can have users assigned or not.',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2903,14 +2903,16 @@ SUPPORT_ROAD_NETWORK_DISBURSEMENT_ALGORITHM = StaticToggle(
 
 USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION = StaticToggle(
     'ush_restore_file_location_case_sync_restriction',
-    'USH: Limit the location-owned cases that show up in a user\'s restore file',
+    'USH: Limit the location-owned cases a user\'s restore file, and allow marking whether a '
+    'location can have users assigned or not.',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
     help_link='https://dimagi.atlassian.net/wiki/spaces/USH/pages/2252210196/Prevent+Syncing+of+Lower+Level+Locations',  # noqa: E501
     description="""
     In the 'Organizational Level' section of location management, web admins can specify which org level to
     expand to when syncing the location-owned cases included in a user's restore file. Limits cases in a user's
-    restore file and thus can improve performance.
+    restore file and thus can improve performance. Also allows marking whether a location can have users assigned
+    to it.
     """
 )
 
@@ -2934,12 +2936,5 @@ SMART_LINKS_FOR_WEB_USERS = StaticToggle(
     slug='smart_links_for_web_users',
     label='USH: Allow web users to use smart links without logging in as before',
     tag=TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN],
-)
-
-LOCATION_HAS_USERS = StaticToggle(
-    slug='location_has_users',
-    label='USH Dev: Allows marking whether a location should have users assigned or not.',
-    tag=TAG_PRODUCT,
     namespaces=[NAMESPACE_DOMAIN],
 )


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Removes the dev FF LOCATION_HAS_USERS and moves the functionality to the USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION feature flag.

Also does some non-user-facing refactoring.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Jira: [USH-4691](https://dimagi.atlassian.net/browse/USH-4691).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

Listed above.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Testing locally
- Automated tests cover decently well 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

`LocationsSearchViewTest` in corehq/apps/locations/tests/test_views.py tests whether location search view returns correct locations with and without the "has users" setting.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Too small for QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4691]: https://dimagi.atlassian.net/browse/USH-4691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ