### PR TITLE
Show Header for Display Group even without Display Text

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -732,7 +732,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
         });
 
         // Header and captions
-        self.showHeader = oneQuestionPerScreen || ko.utils.unwrapObservable(self.caption) || ko.utils.unwrapObservable(self.caption_markdown);
+        self.showHeader = oneQuestionPerScreen || ko.utils.unwrapObservable(self.caption) || ko.utils.unwrapObservable(self.caption_markdown) || self.showDelete;
 
         if (_.has(json, 'domain_meta') && _.has(json, 'style')) {
             self.domain_meta = parseMeta(json.datatype, json.style);


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
Restores the header for user-configured repeat groups, even when no display text is set. This fix addresses the issue where the delete button was not appearing, preventing users from deleting these groups.

**Before:**
![Screen Shot 2024-08-20 at 11 19 53 AM](https://github.com/user-attachments/assets/0b6ebaa4-6a66-4755-87e0-8b2e9f867a8c)

**New:**
![Screen Shot 2024-08-20 at 11 17 12 AM](https://github.com/user-attachments/assets/685052b0-3559-4b59-be15-005529f58e11)
![Screen Shot 2024-08-20 at 11 17 25 AM](https://github.com/user-attachments/assets/de4b1841-2174-40af-9464-15e844602f40)


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-4876](https://dimagi.atlassian.net/browse/USH-4874?atlOrigin=eyJpIjoiOTE1OWQxYWQyYTY5NGMyYWE5OWZmNjE5ZDdjZjVkYjMiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No Feature Flag

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Change is limited to repeat group and limited to UI.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no related test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
