### PR TITLE
RelatedCaseExpression allows UCR case lookups using external_id

### DIFF
--- a/corehq/apps/change_feed/tests/test_data_sources.py
+++ b/corehq/apps/change_feed/tests/test_data_sources.py
@@ -6,13 +6,14 @@ from django.test import SimpleTestCase, TestCase
 from decorator import contextmanager
 
 from casexml.apps.phone.document_store import SyncLogDocumentStore
-from corehq.apps.domain.tests.test_utils import test_domain
 from dimagi.utils.couch.database import get_db
 from pillowtop.dao.couch import CouchDocumentStore
+from pillowtop.dao.exceptions import DocumentNotFoundError
 
 from corehq.apps.change_feed import data_sources
 from corehq.apps.change_feed.data_sources import get_document_store
 from corehq.apps.change_feed.exceptions import UnknownDocumentStore
+from corehq.apps.domain.tests.test_utils import test_domain
 from corehq.apps.locations.document_store import LocationDocumentStore
 from corehq.apps.sms.document_stores import SMSDocumentStore
 from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
@@ -117,10 +118,12 @@ def form_data():
 
 @contextmanager
 def location_data():
-    from corehq.apps.locations.tests.util import LocationTypeStructure
-    from corehq.apps.locations.tests.util import LocationStructure
-    from corehq.apps.locations.tests.util import setup_location_types_with_structure
-    from corehq.apps.locations.tests.util import setup_locations_with_structure
+    from corehq.apps.locations.tests.util import (
+        LocationStructure,
+        LocationTypeStructure,
+        setup_location_types_with_structure,
+        setup_locations_with_structure,
+    )
     location_type_structure = [LocationTypeStructure('t1', [])]
 
     location_structure = [
@@ -138,9 +141,8 @@ def location_data():
 
 @contextmanager
 def ledger_data():
-    from casexml.apps.stock.mock import Balance
     from casexml.apps.case.mock import CaseFactory
-    from casexml.apps.stock.mock import Entry
+    from casexml.apps.stock.mock import Balance, Entry
 
     factory = CaseFactory('domain')
     with case_data() as case_ids:
@@ -224,3 +226,49 @@ def _test_document_store(self, doc_store_cls, doc_store_args, data_context, id_f
 ], DocumentStoreDbTests)
 def test_documet_store(*args):
     _test_document_store(*args)
+
+
+class CaseDocumentStoreTests(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        domain = 'test-domain'
+        cls.store = CaseDocumentStore(domain)
+
+        cls.case_ids = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
+        external_ids = ['external-id', 'external-id-dup', 'external-id-dup']
+        now = datetime.utcnow()
+        for case_id, external_id in zip(cls.case_ids, external_ids):
+            case = CommCareCase(
+                domain=domain,
+                case_id=case_id,
+                external_id=external_id,
+                modified_on=now,
+                server_modified_on=now,
+            )
+            case.save()
+            cls.addClassCleanup(case.delete)
+
+    def test_get_doc_by_case_id(self):
+        case_id = self.case_ids[0]
+        doc = self.store.get_document(case_id)
+        self.assertEqual(doc['case_id'], case_id)
+
+    def test_get_doc_by_external_id(self):
+        external_id = 'external-id'
+        doc = self.store.get_document(None, external_id=external_id)
+        self.assertEqual(doc['external_id'], external_id)
+
+    def test_external_id_not_found(self):
+        with self.assertRaises(DocumentNotFoundError):
+            self.store.get_document(None, external_id='external-id-not-found')
+
+    def test_case_not_found(self):
+        with self.assertRaises(DocumentNotFoundError):
+            self.store.get_document('case-id-not-found')
+
+    def test_get_doc_by_duplicate_external_id(self):
+        with self.assertRaises(DocumentNotFoundError):
+            self.store.get_document(None, external_id='external-id-dup')

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -6,21 +6,20 @@ from django.utils.translation import gettext as _
 
 from jsonobject.exceptions import BadValueError
 
-from corehq.apps.userreports.specs import FactoryContext
 from dimagi.utils.parsing import json_format_date, json_format_datetime
 from dimagi.utils.web import json_handler
 
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.date_specs import (
     AddDaysExpressionSpec,
+    AddHoursExpressionSpec,
     AddMonthsExpressionSpec,
     DiffDaysExpressionSpec,
     EthiopianDateToGregorianDateSpec,
     GregorianDateToEthiopianDateSpec,
     MonthEndDateExpressionSpec,
     MonthStartDateExpressionSpec,
-    AddHoursExpressionSpec,
-    UTCNow
+    UTCNow,
 )
 from corehq.apps.userreports.expressions.list_specs import (
     FilterItemsExpressionSpec,
@@ -46,6 +45,7 @@ from corehq.apps.userreports.expressions.specs import (
     NestedExpressionSpec,
     PropertyNameGetterSpec,
     PropertyPathGetterSpec,
+    RelatedCaseExpressionSpec,
     RelatedDocExpressionSpec,
     ReportingGroupsExpressionSpec,
     RootDocExpressionSpec,
@@ -53,6 +53,7 @@ from corehq.apps.userreports.expressions.specs import (
     SubcasesExpressionSpec,
     SwitchExpressionSpec,
 )
+from corehq.apps.userreports.specs import FactoryContext
 
 
 def _make_filter(spec, factory_context):
@@ -129,6 +130,26 @@ def _related_doc_expression(spec, factory_context):
         doc_id_expression=ExpressionFactory.from_spec(wrapped.doc_id_expression, factory_context),
         value_expression=ExpressionFactory.from_spec(wrapped.value_expression, factory_context),
     )
+    return wrapped
+
+
+def _related_case_expression(spec, factory_context):
+    wrapped = RelatedCaseExpressionSpec.wrap(spec)
+    kwargs = {'value_expression': ExpressionFactory.from_spec(
+        wrapped.value_expression,
+        factory_context
+    )}
+    if getattr(wrapped, 'case_id_expression', None):
+        kwargs['case_id_expression'] = ExpressionFactory.from_spec(
+            wrapped.case_id_expression,
+            factory_context
+        )
+    if getattr(wrapped, 'external_id_expression', None):
+        kwargs['external_id_expression'] = ExpressionFactory.from_spec(
+            wrapped.external_id_expression,
+            factory_context,
+        )
+    wrapped.configure(**kwargs)
     return wrapped
 
 
@@ -359,6 +380,7 @@ class ExpressionFactory(object):
         'property_name': _property_name_expression,
         'property_path': _property_path_expression,
         'reduce_items': _reduce_items_expression,
+        'related_case': _related_case_expression,
         'related_doc': _related_doc_expression,
         'root_doc': _root_doc_expression,
         'sort_items': _sort_items_expression,

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -735,6 +735,84 @@ def _device_to_dict(
     return {k: v for k, v in device.to_json().items() if k in whitelist}
 
 
+class RelatedCaseExpressionSpec(JsonObject):
+    """
+    Similar to ``RelatedDocExpressionSpec``, this can be used to look up
+    a property in a related case. Related cases can be identified either
+    by their case ID or by ``external_id``. This example looks up the
+    full name of a patient identified by their external ID:
+
+    .. code:: json
+
+       {
+           "type": "related_case",
+           "external_id_expression": {
+               "type": "property_name",
+               "property_name": "patient_external_id"
+           },
+           "value_expression": {
+               "type": "property_name",
+               "property_name": "full_name"
+           }
+       }
+    """
+    type = TypeProperty('related_case')
+    case_id_expression = DictProperty()
+    external_id_expression = DictProperty()
+    value_expression = DictProperty(required=True)
+
+    def configure(
+        self,
+        *,
+        value_expression,
+        case_id_expression=None,
+        external_id_expression=None,
+    ):
+        if not (case_id_expression or external_id_expression):
+            raise BadSpecError(
+                'RelatedCaseExpression must have either case_id_expression '
+                'or external_id_expression'
+            )
+        self._case_id_expression = case_id_expression
+        self._external_id_expression = external_id_expression
+        self._value_expression = value_expression
+
+    def __call__(self, item, evaluation_context=None):
+        if self._case_id_expression:
+            case_id = self._case_id_expression(item, evaluation_context)
+            external_id = None
+        else:
+            case_id = None
+            external_id = self._external_id_expression(item, evaluation_context)
+        if case_id or external_id:
+            return self.get_value(case_id, external_id, evaluation_context)
+
+    def get_value(self, case_id, external_id, evaluation_context):
+        case = self._get_document(case_id, external_id, evaluation_context)
+        # Use a new evaluation context since this is a new document
+        return self._value_expression(case, EvaluationContext(case, 0))
+
+    @staticmethod
+    @ucr_context_cache(vary_on=('case_id', 'external_id',))
+    def _get_document(case_id, external_id, evaluation_context):
+        domain = evaluation_context.root_doc['domain']
+        assert domain
+
+        # Call get_document_store_for_doc_type() so that load counter tracks load.
+        case_document_store = get_document_store_for_doc_type(
+            domain,
+            'CommCareCase',
+            load_source='related_case_expression'
+        )
+        try:
+            doc = case_document_store.get_document(case_id, external_id=external_id)
+        except DocumentNotFoundError:
+            return None
+        if domain != doc.get('domain'):
+            return None
+        return doc
+
+
 class NestedExpressionSpec(JsonObject):
     """
     These can be used to nest expressions. This can be used, e.g. to pull a

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -769,6 +769,8 @@ class RelatedCaseExpressionSpec(JsonObject):
         external_id_expression=None,
     ):
         if bool(case_id_expression) == bool(external_id_expression):
+            # Both case_id_expression and external_id_expression are
+            # present or both are missing
             raise BadSpecError(
                 'RelatedCaseExpression must have either case_id_expression '
                 'or external_id_expression'

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -768,7 +768,7 @@ class RelatedCaseExpressionSpec(JsonObject):
         case_id_expression=None,
         external_id_expression=None,
     ):
-        if not (case_id_expression or external_id_expression):
+        if bool(case_id_expression) == bool(external_id_expression):
             raise BadSpecError(
                 'RelatedCaseExpression must have either case_id_expression '
                 'or external_id_expression'

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1398,6 +1398,36 @@ class RelatedCaseExpressionTest(SimpleTestCase):
         my_context = EvaluationContext(my_case, 0)
         self.assertEqual(ext_id_expression(my_case, my_context), 'foo')
 
+    def test_both_ids_spec(self):
+        both_ids_spec = {
+            'type': 'related_case',
+            'case_id_expression': {
+                'type': 'property_name',
+                'property_name': 'parent_id'
+            },
+            'external_id_expression': {
+                'type': 'property_name',
+                'property_name': 'parent_external_id'
+            },
+            'value_expression': {
+                'type': 'property_name',
+                'property_name': 'related_property'
+            }
+        }
+        with self.assertRaises(BadSpecError):
+            ExpressionFactory.from_spec(both_ids_spec)
+
+    def test_neither_ids_spec(self):
+        neither_ids_spec = {
+            'type': 'related_case',
+            'value_expression': {
+                'type': 'property_name',
+                'property_name': 'related_property'
+            }
+        }
+        with self.assertRaises(BadSpecError):
+            ExpressionFactory.from_spec(neither_ids_spec)
+
     def test_related_case_id_not_found(self):
         case_id_expression = ExpressionFactory.from_spec(self.case_id_expr_spec)
         my_case = {

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1289,6 +1289,242 @@ class TestRelatedDocExpressionWebUser(TestCase):
         self.assertIsNone(value)
 
 
+class RelatedCaseExpressionTest(SimpleTestCase):
+
+    case_id_expr_spec = {
+        'type': 'related_case',
+        'case_id_expression': {
+            'type': 'property_name',
+            'property_name': 'parent_id'
+        },
+        'value_expression': {
+            'type': 'property_name',
+            'property_name': 'related_property'
+        }
+    }
+
+    ext_id_expr_spec = {
+        'type': 'related_case',
+        'external_id_expression': {
+            'type': 'property_name',
+            'property_name': 'parent_external_id'
+        },
+        'value_expression': {
+            'type': 'property_name',
+            'property_name': 'related_property'
+        }
+    }
+
+    nested_expr_spec = {
+        "type": "related_case",
+        "case_id_expression": {
+            "type": "property_name",
+            "property_name": "parent_id"
+        },
+        "value_expression": {
+            "type": "related_case",
+            "external_id_expression": {
+                "type": "property_name",
+                "property_name": "parent_external_id"
+            },
+            "value_expression": {
+                "type": "property_name",
+                "property_name": "related_property"
+            }
+        }
+    }
+
+    def setUp(self):
+
+        def get_case(case_id, domain):
+            doc = self.database.get(case_id)
+            if doc is None:
+                raise CaseNotFound
+            return Config(to_json=lambda: doc)
+
+        def get_case_by_external_id(domain, external_id, raise_multiple):
+            doc = self.database.get(external_id)
+            if doc is None:
+                raise CaseNotFound
+            return Config(to_json=lambda: doc)
+
+        get_case_patch = patch.object(CommCareCase.objects, 'get_case', get_case)
+        get_case_patch.start()
+        self.addCleanup(get_case_patch.stop)
+
+        get_case_by_external_id_patch = patch.object(
+            CommCareCase.objects,
+            'get_case_by_external_id',
+            get_case_by_external_id,
+        )
+        get_case_by_external_id_patch.start()
+        self.addCleanup(get_case_by_external_id_patch.stop)
+
+        self.database = {}
+
+    def test_lookup_by_case_id(self):
+        case_id_expression = ExpressionFactory.from_spec(self.case_id_expr_spec)
+        related_case_id = 'related-case-id'
+        related_case = {
+            'domain': 'test-domain',
+            'related_property': 'foo'
+        }
+        my_case = {
+            'domain': 'test-domain',
+            'parent_id': related_case_id,
+        }
+        self.database = {
+            'my-id': my_case,
+            related_case_id: related_case
+        }
+        my_context = EvaluationContext(my_case, 0)
+        self.assertEqual(case_id_expression(my_case, my_context), 'foo')
+
+    def test_lookup_by_external_id(self):
+        ext_id_expression = ExpressionFactory.from_spec(self.ext_id_expr_spec)
+        related_external_id = 'related-external-id'
+        related_case = {
+            'domain': 'test-domain',
+            'related_property': 'foo'
+        }
+        my_case = {
+            'domain': 'test-domain',
+            'parent_external_id': related_external_id,
+        }
+        self.database = {
+            'my-id': my_case,
+            related_external_id: related_case
+        }
+        my_context = EvaluationContext(my_case, 0)
+        self.assertEqual(ext_id_expression(my_case, my_context), 'foo')
+
+    def test_related_case_id_not_found(self):
+        case_id_expression = ExpressionFactory.from_spec(self.case_id_expr_spec)
+        my_case = {
+            'domain': 'test-domain',
+            'parent_id': 'some-missing-id',
+        }
+        my_context = EvaluationContext(my_case, 0)
+        self.assertIsNone(case_id_expression(my_case, my_context))
+
+    def test_related_external_id_not_found(self):
+        ext_id_expression = ExpressionFactory.from_spec(self.ext_id_expr_spec)
+        my_case = {
+            'domain': 'test-domain',
+            'parent_external_id': 'some-missing-id',
+        }
+        my_context = EvaluationContext(my_case, 0)
+        self.assertIsNone(ext_id_expression(my_case, my_context))
+
+    def test_cross_domain_case_id_lookup(self):
+        case_id_expression = ExpressionFactory.from_spec(self.case_id_expr_spec)
+        related_id = 'cross-domain-id'
+        related_case = {
+            'domain': 'wrong-domain',
+            'related_property': 'foo'
+        }
+        my_case = {
+            'domain': 'test-domain',
+            'parent_id': related_id,
+        }
+        self.database = {
+            'my-id': my_case,
+            related_id: related_case
+        }
+        my_context = EvaluationContext(my_case, 0)
+        self.assertIsNone(case_id_expression(my_case, my_context))
+
+    def test_cross_domain_external_id_lookup(self):
+        ext_id_expression = ExpressionFactory.from_spec(self.ext_id_expr_spec)
+        related_id = 'cross-domain-id'
+        related_case = {
+            'domain': 'wrong-domain',
+            'related_property': 'foo'
+        }
+        my_case = {
+            'domain': 'test-domain',
+            'parent_external_id': related_id,
+        }
+        self.database = {
+            'my-id': my_case,
+            related_id: related_case
+        }
+        my_context = EvaluationContext(my_case, 0)
+        self.assertIsNone(ext_id_expression(my_case, my_context))
+
+    def test_nested_lookup(self):
+        nested_expression = ExpressionFactory.from_spec(self.nested_expr_spec)
+
+        related_external_id = 'nested-external-id'
+        related_case_2 = {
+            'domain': 'test-domain',
+            'related_property': 'bar',
+        }
+
+        related_case_id = 'nested-case-id'
+        related_case_1 = {
+            'domain': 'test-domain',
+            'parent_external_id': related_external_id,
+            'related_property': 'foo',
+        }
+
+        my_case = {
+            'domain': 'test-domain',
+            'parent_id': related_case_id,
+        }
+
+        self.database = {
+            'my-id': my_case,
+            related_case_id: related_case_1,
+            related_external_id: related_case_2
+        }
+
+        my_context = EvaluationContext(my_case, 0)
+        self.assertEqual('bar', nested_expression(my_case, my_context))
+
+    def test_nested_lookup_cross_domains(self):
+        nested_expression = ExpressionFactory.from_spec(self.nested_expr_spec)
+
+        related_external_id = 'nested-external-id'
+        related_case_2 = {
+            'domain': 'wrong-domain',
+            'related_property': 'bar',
+        }
+
+        related_case_id = 'nested-case-id'
+        related_case_1 = {
+            'domain': 'test-domain',
+            'parent_external_id': related_external_id,
+            'related_property': 'foo',
+        }
+
+        my_case = {
+            'domain': 'test-domain',
+            'parent_id': related_case_id,
+        }
+
+        self.database = {
+            'my-id': my_case,
+            related_case_id: related_case_1,
+            related_external_id: related_case_2
+        }
+
+        my_context = EvaluationContext(my_case, 0)
+        self.assertIsNone(nested_expression(my_case, my_context))
+
+    def test_caching(self):
+        case_id_expression = ExpressionFactory.from_spec(self.case_id_expr_spec)
+        self.test_lookup_by_case_id()
+
+        my_case = self.database.get('my-id')
+        my_context = EvaluationContext(my_case, 0)
+        self.assertEqual('foo', case_id_expression(my_case, my_context))
+
+        my_case = self.database.get('my-id')
+        self.database.clear()
+        self.assertEqual('foo', case_id_expression(my_case, my_context))
+
+
 class TestFormsExpressionSpec(TestCase):
 
     @classmethod

--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -72,7 +72,7 @@ class CaseDocumentStore(DocumentStore):
                 )
                 if case:
                     return case.to_json()
-                raise CaseNotFound(f'external_id: {external_id!r}')
+                raise CaseNotFound(f"external_id: '{external_id}'")
         except (CaseNotFound, CommCareCase.MultipleObjectsReturned) as e:
             raise DocumentNotFoundError(e)
 

--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -65,11 +65,14 @@ class CaseDocumentStore(DocumentStore):
             if external_id is None:
                 return CommCareCase.objects.get_case(doc_id, self.domain).to_json()
             else:
-                return CommCareCase.objects.get_case_by_external_id(
+                case = CommCareCase.objects.get_case_by_external_id(
                     self.domain,
                     external_id,
                     raise_multiple=True
-                ).to_json()
+                )
+                if case:
+                    return case.to_json()
+                raise CaseNotFound(f'external_id: {external_id!r}')
         except (CaseNotFound, CommCareCase.MultipleObjectsReturned) as e:
             raise DocumentNotFoundError(e)
 

--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -60,10 +60,17 @@ class CaseDocumentStore(DocumentStore):
         self.domain = domain
         self.case_type = case_type
 
-    def get_document(self, doc_id):
+    def get_document(self, doc_id, *, external_id=None):
         try:
-            return CommCareCase.objects.get_case(doc_id, self.domain).to_json()
-        except CaseNotFound as e:
+            if external_id is None:
+                return CommCareCase.objects.get_case(doc_id, self.domain).to_json()
+            else:
+                return CommCareCase.objects.get_case_by_external_id(
+                    self.domain,
+                    external_id,
+                    raise_multiple=True
+                ).to_json()
+        except (CaseNotFound, CommCareCase.MultipleObjectsReturned) as e:
             raise DocumentNotFoundError(e)
 
     def iter_document_ids(self):
@@ -112,9 +119,9 @@ class DocStoreLoadTracker(object):
         self.store = store
         self.track_load = track_load
 
-    def get_document(self, doc_id):
+    def get_document(self, doc_id, *args, **kwargs):
         self.track_load()
-        return self.store.get_document(doc_id)
+        return self.store.get_document(doc_id, *args, **kwargs)
 
     def iter_documents(self, ids):
         for doc in self.store.iter_documents(ids):

--- a/corehq/motech/generic_inbound/backend/base.py
+++ b/corehq/motech/generic_inbound/backend/base.py
@@ -60,6 +60,7 @@ class BaseApiBackend:
 
     def get_context(self):
         return get_evaluation_context(
+            domain=self.request_data.domain,
             restore_user=self.request_data.restore_user,
             method=self.request_data.request_method,
             query=self.request_data.query,

--- a/corehq/motech/generic_inbound/tests/test_api_processing.py
+++ b/corehq/motech/generic_inbound/tests/test_api_processing.py
@@ -44,6 +44,7 @@ class TestGenericInboundAPI(SimpleTestCase):
         configurable_api.get_validations = lambda: []
         user = MockUser()
         context = get_evaluation_context(
+            domain=self.domain_name,
             restore_user=user,
             method='post',
             query={},
@@ -62,6 +63,7 @@ class TestGenericInboundAPI(SimpleTestCase):
         )
         user = MockUser()
         context = get_evaluation_context(
+            domain=self.domain_name,
             restore_user=user,
             method='post',
             query={},
@@ -74,6 +76,7 @@ class TestGenericInboundAPI(SimpleTestCase):
         configurable_api = _get_api_with_filter(self.domain_name)
         user = MockUser()
         context = get_evaluation_context(
+            domain=self.domain_name,
             restore_user=user,
             method='post',
             query={},
@@ -86,6 +89,7 @@ class TestGenericInboundAPI(SimpleTestCase):
         configurable_api = _get_api_with_filter(self.domain_name)
         user = MockUser()
         context = get_evaluation_context(
+            domain=self.domain_name,
             restore_user=user,
             method='post',
             query={},
@@ -99,6 +103,7 @@ class TestGenericInboundAPI(SimpleTestCase):
         configurable_api = _get_api_with_validation(self.domain_name)
         user = MockUser()
         context = get_evaluation_context(
+            domain=self.domain_name,
             restore_user=user,
             method='post',
             query={},
@@ -127,6 +132,7 @@ class TestGenericInboundAPI(SimpleTestCase):
         user = MockUser()
         # 1st validation should fail, 2nd should succeed
         context = get_evaluation_context(
+            domain=self.domain_name,
             restore_user=user,
             method='post',
             query={},

--- a/corehq/motech/generic_inbound/utils.py
+++ b/corehq/motech/generic_inbound/utils.py
@@ -128,8 +128,9 @@ def make_processing_attempt(response, request_log, is_retry=False):
     )
 
 
-def get_evaluation_context(restore_user, method, query, headers, body):
+def get_evaluation_context(domain, restore_user, method, query, headers, body):
     return EvaluationContext({
+        'domain': domain,
         'request': {
             'method': method,
             'query': query,


### PR DESCRIPTION
## Technical Summary

Context: [SC-3822](https://dimagi.atlassian.net/browse/SC-3822)

Based on draft PR https://github.com/dimagi/commcare-hq/pull/34963

This change allows `CaseDocumentStore.get_document()` to accept an `external_id` keyword argument.

I chose this approach because I preferred that `get_document_store_for_doc_type()` should not need to know what kind of identifier the caller intends to use with one specific kind of document store. I also preferred not to have two CaseDocumentStore classes.

This change also adds a RelatedCaseExpression UCR expression that can retrieve related cases by either case_id or external_id. This is important for inbound API users to be able to identify cases by their own identifier.

I chose to make RelatedCaseExpression independent of RelatedDocExpression so that it doesn't inherit the behavior for other doc types.

**NOTE:** The base branch is `mk/3822-refactor` until PR https://github.com/dimagi/commcare-hq/pull/35002 is merged.

## Feature Flag

`GENERIC_INBOUND_API` / "configurable_api" / Generic inbound APIs

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Includes test coverage.

CaseDocumentStore changes are verified by "external_id_expression" tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3822]: https://dimagi.atlassian.net/browse/SC-3822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ