### PR TITLE
Skip repeat records for paused repeaters

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -402,10 +402,15 @@ class Repeater(RepeaterSuperProxy):
         )
         repeat_record.save()
 
+        if self.is_paused or toggles.PAUSE_DATA_FORWARDING.enabled(repeat_record.domain):
+            # no need to go any further if the repeater or domain is paused
+            return repeat_record
+
         if fire_synchronously:
             # Prime the cache to prevent unnecessary lookup. Only do this for synchronous repeaters
             # to prevent serializing the repeater in the celery task payload
             repeat_record.__dict__["repeater"] = self
+
         repeat_record.attempt_forward_now(fire_synchronously=fire_synchronously)
         return repeat_record
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -918,7 +918,8 @@ class RepeatRecordManager(models.Manager):
     def count_overdue(self, threshold=timedelta(minutes=10)):
         return self.filter(
             next_check__isnull=False,
-            next_check__lt=datetime.utcnow() - threshold
+            next_check__lt=datetime.utcnow() - threshold,
+            repeater__is_paused=False,
         ).count()
 
     def iterate(self, domain, repeater_id=None, state=None, chunk_size=1000):

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -113,6 +113,9 @@ def check_repeaters_in_partition(partition):
                 if datetime.utcnow() > twentythree_hours_later:
                     break
 
+                if toggles.PAUSE_DATA_FORWARDING.enabled(record.domain):
+                    continue
+
                 metrics_counter("commcare.repeaters.check.attempt_forward")
                 record.attempt_forward_now(is_retry=True)
     finally:

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -157,7 +157,7 @@ def _process_repeat_record(repeat_record):
             return
 
         try:
-            if toggles.PAUSE_DATA_FORWARDING.enabled(repeat_record.domain):
+            if repeat_record.repeater.is_paused or toggles.PAUSE_DATA_FORWARDING.enabled(repeat_record.domain):
                 # postpone repeat record by MAX_RETRY_WAIT so that it is not fetched
                 # in the next check to process repeat records, which helps to avoid
                 # clogging the queue

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -157,7 +157,7 @@ def _process_repeat_record(repeat_record):
             return
 
         try:
-            if repeat_record.repeater.is_paused or toggles.PAUSE_DATA_FORWARDING.enabled(repeat_record.domain):
+            if toggles.PAUSE_DATA_FORWARDING.enabled(repeat_record.domain):
                 # postpone repeat record by MAX_RETRY_WAIT so that it is not fetched
                 # in the next check to process repeat records, which helps to avoid
                 # clogging the queue

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -601,6 +601,7 @@ class TestRepeatRecordManager(RepeaterTestCase):
         self.new_record(next_check=now - timedelta(minutes=15))
         self.new_record(next_check=now - timedelta(minutes=5))
         self.new_record(next_check=None, state=State.Success)
+        self.new_record(next_check=now - timedelta(hours=2), is_paused=True)
         overdue = RepeatRecord.objects.count_overdue()
         self.assertEqual(overdue, 3)
 
@@ -659,10 +660,11 @@ class TestRepeatRecordManager(RepeaterTestCase):
             {'alex', 'alice'},
         )
 
-    def new_record(self, next_check=before_now, state=State.Pending, domain="test"):
+    def new_record(self, next_check=before_now, state=State.Pending, domain="test", is_paused=False):
+        repeater_id = self.paused_repeater.repeater_id if is_paused else self.repeater.repeater_id
         return RepeatRecord.objects.create(
             domain=domain,
-            repeater_id=self.repeater.repeater_id,
+            repeater_id=repeater_id,
             payload_id="c0ffee",
             registered_at=self.before_now,
             next_check=next_check,

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -65,22 +65,22 @@ class RepeaterTestCase(TestCase):
         self.paused_repeater.save()
 
 
-class TestSoftDeleteRepeaters(RepeaterTestCase):
+class TestSoftDeleteRepeaters(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.all_repeaters = [self.repeater]
+        url = 'https://www.example.com/api/'
+        self.conn = ConnectionSettings.objects.create(domain=DOMAIN, name=url, url=url)
+        self.repeaters = []
         for i in range(5):
             r = FormRepeater(
                 domain=DOMAIN,
                 connection_settings=self.conn,
             )
             r.save()
-            self.all_repeaters.append(r)
+            self.repeaters.append(r)
 
     def test_soft_deletion(self):
-        self.assertEqual(FormRepeater.objects.all().count(), 6)
-        self.all_repeaters[1].is_deleted = True
-        self.all_repeaters[1].save()
+        self.assertEqual(FormRepeater.objects.all().count(), 5)
         self.all_repeaters[0].is_deleted = True
         self.all_repeaters[0].save()
         self.assertEqual(FormRepeater.objects.all().count(), 4)
@@ -89,11 +89,10 @@ class TestSoftDeleteRepeaters(RepeaterTestCase):
             set([r.id for r in self.all_repeaters if not r.is_deleted])
         )
 
-    def test_repeatrs_retired_from_sql(self):
-        self.all_repeaters[0].retire()
-        self.all_repeaters[4].retire()
-        repeater_count = Repeater.objects.all().count()
-        self.assertEqual(repeater_count, 4)
+    def test_repeaters_retired_from_sql(self):
+        self.assertEqual(Repeater.objects.all().count(), 5)
+        self.repeaters[0].retire()
+        self.assertEqual(Repeater.objects.all().count(), 4)
 
 
 class TestRepeaterName(RepeaterTestCase):

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -81,12 +81,12 @@ class TestSoftDeleteRepeaters(TestCase):
 
     def test_soft_deletion(self):
         self.assertEqual(FormRepeater.objects.all().count(), 5)
-        self.all_repeaters[0].is_deleted = True
-        self.all_repeaters[0].save()
+        self.repeaters[0].is_deleted = True
+        self.repeaters[0].save()
         self.assertEqual(FormRepeater.objects.all().count(), 4)
         self.assertEqual(
             set(FormRepeater.objects.all().values_list('id', flat=True)),
-            set([r.id for r in self.all_repeaters if not r.is_deleted])
+            set([r.id for r in self.repeaters if not r.is_deleted])
         )
 
     def test_repeaters_retired_from_sql(self):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
We probably should have done this awhile ago. 

Query explain in its current form:
```
Gather Merge  (cost=4254837.94..4254982.85 rows=1242 width=104)
  Workers Planned: 2
  ->  Sort  (cost=4253837.91..4253839.46 rows=621 width=104)
        Sort Key: next_check, id
        ->  Parallel Seq Scan on repeaters_repeatrecord  (cost=0.00..4253809.10 rows=621 width=104)
              Filter: ((next_check IS NOT NULL) AND (next_check < '2024-08-20 21:20:08.217872'::timestamp without time zone) AND ((id % '4'::bigint) = 1))
```

Query explain for the updated version:
```
Gather Merge  (cost=4255240.93..4255383.74 rows=1224 width=104)
  Workers Planned: 2
  ->  Sort  (cost=4254240.90..4254242.43 rows=612 width=104)
        Sort Key: repeaters_repeatrecord.next_check, repeaters_repeatrecord.id
        ->  Hash Anti Join  (cost=395.75..4254212.58 rows=612 width=104)
              Hash Cond: (repeaters_repeatrecord.repeater_id_ = u0.id_)
              ->  Parallel Seq Scan on repeaters_repeatrecord  (cost=0.00..4253807.55 rows=616 width=96)
                    Filter: ((next_check IS NOT NULL) AND (next_check < '2024-08-20 21:09:48.251549'::timestamp without time zone) AND ((id % '4'::bigint) = 1))
              ->  Hash  (cost=395.15..395.15 rows=48 width=16)
                    ->  Bitmap Heap Scan on repeaters_repeater u0  (cost=34.23..395.15 rows=48 width=16)
                          Filter: ((NOT is_deleted) AND is_paused)
                          ->  Bitmap Index Scan on repeaters_repeater_is_deleted_08441bf0  (cost=0.00..34.22 rows=2392 width=0)
                                Index Cond: (is_deleted = false)
```

The general takeaway is that this is already a very expensive query, and adding this subquery isn't very costly and well worth the benefit of not queueing repeat records that are just going to be postponed anyway.

This will mean that our overdue metric needs to be updated to not factor in repeat records associated with paused repeaters, so that is done here as well.


If we really wanted to, I PRed a partial index on the repeater table (https://github.com/dimagi/commcare-hq/pull/35006), but given how small of a dataset we are dealing with, that is likely overkill. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I've explained the performance implications above, and in the worst case, our check repeater task is setup to lock if a query runs longer than expected. We also track how often check_repeaters tasks are locked out, so we can see if there is a sharp increase in that metric after rolling this out to decide if we need to take any action.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests ensure records with unpaused repeaters are returned, and records for paused repeaters are not.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
