### PR TITLE
Decrease repeater timeout (behind feature flag)

### DIFF
--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -24,7 +24,7 @@ from corehq.motech.utils import (
     pformat_json,
     unpack_request_args,
 )
-from corehq.toggles import DECREASE_REPEATER_TIMEOUT, NAMESPACE_DOMAIN
+from corehq.toggles import DECREASE_REPEATER_TIMEOUT
 from corehq.util.metrics import metrics_counter
 from corehq.util.timer import TimingContext
 from corehq.util.urlvalidate.urlvalidate import (
@@ -141,7 +141,7 @@ class Requests(object):
         if not self.verify:
             kwargs['verify'] = False
         request_timeout = REQUEST_TIMEOUT
-        if DECREASE_REPEATER_TIMEOUT.enabled(self.domain_name, namespace=NAMESPACE_DOMAIN):
+        if DECREASE_REPEATER_TIMEOUT.enabled(self.domain_name):
             request_timeout = 60
         kwargs.setdefault('timeout', request_timeout)
         if self._session:

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -24,6 +24,7 @@ from corehq.motech.utils import (
     pformat_json,
     unpack_request_args,
 )
+from corehq.toggles import DECREASE_REPEATER_TIMEOUT, NAMESPACE_DOMAIN
 from corehq.util.metrics import metrics_counter
 from corehq.util.timer import TimingContext
 from corehq.util.urlvalidate.urlvalidate import (
@@ -139,7 +140,10 @@ class Requests(object):
         raise_for_status = kwargs.pop('raise_for_status', False)
         if not self.verify:
             kwargs['verify'] = False
-        kwargs.setdefault('timeout', REQUEST_TIMEOUT)
+        request_timeout = REQUEST_TIMEOUT
+        if DECREASE_REPEATER_TIMEOUT.enabled(self.domain_name, namespace=NAMESPACE_DOMAIN):
+            request_timeout = 60
+        kwargs.setdefault('timeout', request_timeout)
         if self._session:
             response = self._session.request(method, url, *args, **kwargs)
         else:

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1993,7 +1993,7 @@ RATE_LIMIT_REPEATER_ATTEMPTS = DynamicallyPredictablyRandomToggle(
     """
 )
 
-DECREASE_REPEATER_TIMEOUT = DynamicallyPredictablyRandomToggle(
+DECREASE_REPEATER_TIMEOUT = StaticToggle(
     'decrease_repeater_timeout',
     'Decrease the request timeout value when forwarding data to external endpoints.',
     TAG_INTERNAL,

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1993,6 +1993,16 @@ RATE_LIMIT_REPEATER_ATTEMPTS = DynamicallyPredictablyRandomToggle(
     """
 )
 
+DECREASE_REPEATER_TIMEOUT = DynamicallyPredictablyRandomToggle(
+    'decrease_repeater_timeout',
+    'Decrease the request timeout value when forwarding data to external endpoints.',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN],
+    description="""
+    Decreases the request timeout from 5 minutes to 1 minute for repeater endpoints when enabled.
+    """
+)
+
 TEST_FORM_SUBMISSION_RATE_LIMIT_RESPONSE = StaticToggle(
     'test_form_submission_rate_limit_response',
     "Respond to all form submissions with a 429 response",


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
I have no intention of enabling this for all domains. I'd want to collect data on typical data forwarding endpoint request times before decreasing the timeout value.

However reducing the timeout has the potential to improve our rate limiting (by reporting timing metrics sooner), and I'm curious to see how it performs on the current problematic domains.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
DECREASE_REPEATER_TIMEOUT
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Behind a feature flag.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
