### PR TITLE
Rework repeater rate limiting by attempts logic

### DIFF
--- a/corehq/motech/rate_limiter.py
+++ b/corehq/motech/rate_limiter.py
@@ -76,9 +76,9 @@ SHOULD_RATE_LIMIT_REPEATERS = not settings.UNIT_TESTING
 @run_only_when(SHOULD_RATE_LIMIT_REPEATERS)
 @silence_and_report_error("Exception raised in the repeater rate limiter",
                           'commcare.repeaters.rate_limiter_errors')
-def rate_limit_repeater(domain):
+def rate_limit_repeater(domain, repeater_id):
     limit_attempts = RATE_LIMIT_REPEATER_ATTEMPTS.enabled(domain, namespace=NAMESPACE_DOMAIN)
-    is_under_attempt_limit = repeater_attempts_rate_limiter.allow_usage(domain) if limit_attempts else True
+    is_under_attempt_limit = repeater_attempts_rate_limiter.allow_usage(repeater_id) if limit_attempts else True
 
     if global_repeater_rate_limiter.allow_usage() and is_under_attempt_limit:
         allow_usage = True
@@ -110,8 +110,8 @@ def report_repeater_usage(domain, milliseconds):
 @run_only_when(SHOULD_RATE_LIMIT_REPEATERS)
 @silence_and_report_error("Exception raised reporting usage to the repeater attempt rate limiter",
                           'commcare.repeaters.report_usage_errors')
-def report_repeater_attempt(domain):
-    repeater_attempts_rate_limiter.report_usage(domain)
+def report_repeater_attempt(repeater_id):
+    repeater_attempts_rate_limiter.report_usage(repeater_id)
 
 
 @quickcache([], timeout=60)  # Only report up to once a minute

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -163,13 +163,13 @@ def _process_repeat_record(repeat_record):
                 # clogging the queue
                 repeat_record.postpone_by(MAX_RETRY_WAIT)
                 action = 'paused'
-            elif rate_limit_repeater(repeat_record.domain):
+            elif rate_limit_repeater(repeat_record.domain, repeat_record.repeater.repeater_id):
                 # Spread retries evenly over the range defined by RATE_LIMITER_DELAY_RANGE
                 # with the intent of avoiding clumping and spreading load
                 repeat_record.postpone_by(random.uniform(*RATE_LIMITER_DELAY_RANGE))
                 action = 'rate_limited'
             elif repeat_record.is_queued():
-                report_repeater_attempt(repeat_record.domain)
+                report_repeater_attempt(repeat_record.repeater.repeater_id)
                 with timer('fire_timing') as fire_timer:
                     repeat_record.fire(timing_context=fire_timer)
                 # round up to the nearest millisecond, meaning always at least 1ms

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -138,7 +138,7 @@ def retry_process_repeat_record(repeat_record_id, domain):
 
 
 def _process_repeat_record(repeat_record):
-    request_duration = None
+    request_duration = action = None
     with TimingContext('process_repeat_record') as timer:
         if repeat_record.state == State.Cancelled:
             return
@@ -182,18 +182,19 @@ def _process_repeat_record(repeat_record):
             logging.exception('Failed to process repeat record: {}'.format(repeat_record.id))
             return
 
-    processing_time = timer.duration - request_duration if request_duration else timer.duration
-    metrics_histogram(
-        'commcare.repeaters.repeat_record_processing.timing',
-        processing_time * 1000,
-        buckets=(100, 500, 1000, 5000),
-        bucket_tag='duration',
-        bucket_unit='ms',
-        tags={
-            'domain': repeat_record.domain,
-            'action': action,
-        },
-    )
+    if action:
+        processing_time = timer.duration - request_duration if request_duration else timer.duration
+        metrics_histogram(
+            'commcare.repeaters.repeat_record_processing.timing',
+            processing_time * 1000,
+            buckets=(100, 500, 1000, 5000),
+            bucket_tag='duration',
+            bucket_unit='ms',
+            tags={
+                'domain': repeat_record.domain,
+                'action': action,
+            },
+        )
 
 
 metrics_gauge_task(


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Previously, the attempts rate limiting only came into play when global usage was exceeded. This meant that once global usage dipped back below the threshold, celery workers would pick up a bunch of very slow repeat record tasks without being rate limited.

By making this change, if a domain has exceeded it's allowed wait times, repeaters within that domain will be limited to a certain number of attempts. This will prevent slow repeat record tasks from being queued in bulk and clogging celery workers.

I don't view this as the final version of how this should be implemented, but rather a POC to show that it works.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The behavior change is still hidden behind a feature flag, since it defaults to True if the feature flag is not enabled.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
