### PR TITLE
allow deleting UCR expressions

### DIFF
--- a/corehq/apps/userreports/templates/userreports/ucr_expressions.html
+++ b/corehq/apps/userreports/templates/userreports/ucr_expressions.html
@@ -33,11 +33,60 @@
                 data-bind="attr: {href: edit_url}">
             {% trans "Update Expression" %}
         </a>
+        <button type="button"
+                data-toggle="modal"
+                data-bind="attr: {'data-target': '#delete-expression-' + id}"
+                class="btn btn-danger">
+          <i class="fa fa-remove"></i> {% trans 'Remove' %}
+        </button>
         <a class="btn btn-primary"
                 href="{% url 'domain_links' domain %}"
                 data-bind="visible: upstream_id">
             {% trans "Linked Project Spaces" %}
         </a>
+
+        <div class="modal fade" data-bind="attr: {id: 'delete-expression-' + id}">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title">
+                  {% blocktrans %}
+                    Delete expression <strong data-bind="text: name"></strong>?
+                  {% endblocktrans %}
+                </h4>
+              </div>
+              <div class="modal-body">
+                <p>
+                  {% blocktrans %}
+                    Yes, delete the <strong data-bind="text: name"></strong> expression.
+                  {% endblocktrans %}
+                </p>
+              </div>
+              <div class="modal-footer">
+                <button type="button"
+                        class="btn btn-default"
+                        data-dismiss="modal">
+                  {% trans 'Cancel' %}
+                </button>
+                <button type="button"
+                        class="btn btn-danger delete-item-confirm"
+                        data-loading-text="{% trans 'Deleting Expression...' %}">
+                  <i class="fa fa-remove"></i> {% trans 'Delete Expression' %}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
     </td>
+</script>
+
+<script type="text/html" id="deleted-ucr-statement-template">
+  <td class="col-sm-8">
+    <a data-bind="text: name"></a>
+  </td>
+  <td class="col-sm-4">
+    <span class="label label-default">{% trans 'Deleted' %}</span>
+  </td>
 </script>
 {% endblock %}

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1899,6 +1899,16 @@ class UCRExpressionListView(BaseProjectDataView, CRUDPaginatedViewMixin):
             "template": "base-ucr-statement-template",
         }
 
+    def get_deleted_item_data(self, item_id):
+        deleted_expression = self.base_query.get(id=item_id)
+        deleted_expression.delete()
+        return {
+            'itemData': {
+                'name': deleted_expression.name,
+            },
+            'template': 'deleted-ucr-statement-template',
+        }
+
 
 @method_decorator(toggles.UCR_EXPRESSION_REGISTRY.required_decorator(), name='dispatch')
 class UCRExpressionEditView(BaseProjectDataView):


### PR DESCRIPTION
## Product Description
Add buttons to delete user defined UCR expressions.

![Peek 2024-08-22 12-26](https://github.com/user-attachments/assets/735c6b9b-e316-41b0-8709-559c50014914)


## Technical Summary
UI updates to add delete button, confirmation dialogue, delete view method and response template.

## Feature Flag
UCR_EXPRESSION_REGISTRY

## Safety Assurance

### Safety story
Changes follow an existing pattern.
Changes to FF feature. Tested locally.

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
