### PR TITLE
don't clear fields on initial change event

### DIFF
--- a/corehq/motech/static/motech/js/connection_settings_detail.js
+++ b/corehq/motech/static/motech/js/connection_settings_detail.js
@@ -33,7 +33,7 @@ hqDefine("motech/js/connection_settings_detail", [
 
         });
 
-        $authTypeSelect.change(function () {
+        $authTypeSelect.change(function (e, fromInitial) {
             let visible = {},
                 allFields = {
                     'username': gettext("Username"),
@@ -82,7 +82,7 @@ hqDefine("motech/js/connection_settings_detail", [
                     div.removeClass("d-none");
                     let label = visible[field] || allFields[field];
                     let labelElement = div.find('label');
-                    if (label && labelElement.length > 0 && labelElement.text() !== label) {
+                    if (!fromInitial && label && labelElement.length > 0 && labelElement.text() !== label) {
                         labelElement.text(label);
                         let fieldElement = $('#id_' + field);
                         fieldElement.val('');  // clear current value
@@ -162,7 +162,7 @@ hqDefine("motech/js/connection_settings_detail", [
         });
 
         // Set initial state
-        $authTypeSelect.trigger('change');
+        $authTypeSelect.trigger('change', [true]);
         $authPreset.trigger('change');
         $('#id_url').trigger('change');
     });


### PR DESCRIPTION
## Product Description
Bug fix for Connection Settings edit page.

## Technical Summary
Changes [here](https://github.com/dimagi/commcare-hq/pull/34905/files#diff-658e550d25d14260fa07d122a8ce8157cd24ec85538bd9a84b1f64c4ac3cf750R85-R89) broke the edit view since an initial event clears out the values when loading the view.

This PR resolves that by adding a custom event parameter when firing the initial event.

## Safety Assurance

### Safety story
Changes confined to the JS for that one page.

Changes tested locally.

### QA Plan
Tested locally

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
