### PR TITLE
Form Expression Repeater

### DIFF
--- a/corehq/motech/repeaters/expression/forms.py
+++ b/corehq/motech/repeaters/expression/forms.py
@@ -10,7 +10,7 @@ from corehq.apps.userreports.ui.fields import JsonField
 from corehq.motech.repeaters.forms import GenericRepeaterForm
 
 
-class CaseExpressionRepeaterForm(GenericRepeaterForm):
+class BaseExpressionRepeaterForm(GenericRepeaterForm):
     configured_filter = JsonField(expected_type=dict, help_text=help_text.CONFIGURED_FILTER)
     configured_expression = JsonField(expected_type=dict)
     url_template = CharField(

--- a/corehq/motech/repeaters/expression/repeater_generators.py
+++ b/corehq/motech/repeaters/expression/repeater_generators.py
@@ -41,7 +41,17 @@ class ExpressionPayloadGenerator(BasePayloadGenerator):
         )
 
 
-class ArcGISFormExpressionPayloadGenerator(ExpressionPayloadGenerator):
+class FormExpressionPayloadGenerator(ExpressionPayloadGenerator):
+    def get_payload(self, repeat_record, payload_doc, parsed_expression):
+        result = self._parse_payload(payload_doc, parsed_expression)
+        return json.dumps(result, cls=DjangoJSONEncoder)
+
+    def _parse_payload(self, payload_doc, parsed_expression):
+        payload_doc_json = payload_doc.to_json()
+        return parsed_expression(payload_doc_json, EvaluationContext(payload_doc_json))
+
+
+class ArcGISFormExpressionPayloadGenerator(FormExpressionPayloadGenerator):
 
     def get_url(self, repeat_record, url_template, payload_doc):
         if not (
@@ -55,8 +65,7 @@ class ArcGISFormExpressionPayloadGenerator(ExpressionPayloadGenerator):
         return 'application/x-www-form-urlencoded'
 
     def get_payload(self, repeat_record, payload_doc, parsed_expression):
-        payload_doc_json = payload_doc.to_json()
-        payload = parsed_expression(payload_doc_json, EvaluationContext(payload_doc_json))
+        payload = self._parse_payload(payload_doc, parsed_expression)
         conn_settings = repeat_record.repeater.connection_settings
         api_token = conn_settings.plaintext_password
         formatted_payload = {

--- a/corehq/motech/repeaters/expression/repeaters.py
+++ b/corehq/motech/repeaters/expression/repeaters.py
@@ -10,7 +10,10 @@ from corehq.motech.repeaters.expression.repeater_generators import (
     ExpressionPayloadGenerator,
 )
 from corehq.motech.repeaters.models import OptionValue, Repeater
-from corehq.motech.repeaters.expression.repeater_generators import ArcGISFormExpressionPayloadGenerator
+from corehq.motech.repeaters.expression.repeater_generators import (
+    ArcGISFormExpressionPayloadGenerator,
+    FormExpressionPayloadGenerator,
+)
 from corehq.toggles import EXPRESSION_REPEATER, ARCGIS_INTEGRATION
 
 
@@ -84,6 +87,7 @@ class CaseExpressionRepeater(BaseExpressionRepeater):
 class FormExpressionRepeater(BaseExpressionRepeater):
 
     friendly_name = _("Configurable Form Repeater")
+    payload_generator_classes = (FormExpressionPayloadGenerator,)
 
     class Meta:
         app_label = 'repeaters'

--- a/corehq/motech/repeaters/expression/views.py
+++ b/corehq/motech/repeaters/expression/views.py
@@ -1,13 +1,12 @@
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from corehq.motech.repeaters.expression.forms import CaseExpressionRepeaterForm
+from corehq.motech.repeaters.expression.forms import BaseExpressionRepeaterForm
 from corehq.motech.repeaters.views import AddRepeaterView, EditRepeaterView
 
 
-class AddCaseExpressionRepeaterView(AddRepeaterView):
-    urlname = 'add_case_expression_repeater'
-    repeater_form_class = CaseExpressionRepeaterForm
+class BaseExpressionRepeaterView(AddRepeaterView):
+    repeater_form_class = BaseExpressionRepeaterForm
 
     @property
     def page_url(self):
@@ -23,15 +22,19 @@ class AddCaseExpressionRepeaterView(AddRepeaterView):
         return repeater
 
 
-class EditCaseExpressionRepeaterView(EditRepeaterView, AddCaseExpressionRepeaterView):
+class AddCaseExpressionRepeaterView(BaseExpressionRepeaterView):
+    urlname = 'add_case_expression_repeater'
+
+
+class EditCaseExpressionRepeaterView(EditRepeaterView, BaseExpressionRepeaterView):
     urlname = 'edit_case_expression_repeater'
     page_title = _("Edit Case Repeater")
 
 
-class AddArcGISFormExpressionRepeaterView(AddCaseExpressionRepeaterView):
+class AddArcGISFormExpressionRepeaterView(BaseExpressionRepeaterView):
     urlname = 'add_arcgis_form_expression_repeater'
 
 
-class EditArcGISFormExpressionRepeaterView(EditRepeaterView, AddCaseExpressionRepeaterView):
+class EditArcGISFormExpressionRepeaterView(EditRepeaterView, BaseExpressionRepeaterView):
     urlname = 'edit_arcgis_form_expression_repeater'
     page_title = _("Edit ArcGIS Form Repeater")

--- a/corehq/motech/repeaters/expression/views.py
+++ b/corehq/motech/repeaters/expression/views.py
@@ -31,6 +31,15 @@ class EditCaseExpressionRepeaterView(EditRepeaterView, BaseExpressionRepeaterVie
     page_title = _("Edit Case Repeater")
 
 
+class AddFormExpressionRepeaterView(BaseExpressionRepeaterView):
+    urlname = 'add_form_expression_repeater'
+
+
+class EditFormExpressionRepeaterView(EditRepeaterView, BaseExpressionRepeaterView):
+    urlname = 'edit_form_expression_repeater'
+    page_title = _('Edit Form Repeater')
+
+
 class AddArcGISFormExpressionRepeaterView(BaseExpressionRepeaterView):
     urlname = 'add_arcgis_form_expression_repeater'
 

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -26,9 +26,10 @@ ucr_data_source_updated = dispatcher.Signal()
 
 def create_form_repeat_records(sender, xform, **kwargs):
     from corehq.motech.repeaters.models import FormRepeater
-    from corehq.motech.repeaters.expression.repeaters import ArcGISFormExpressionRepeater
+    from corehq.motech.repeaters.expression.repeaters import ArcGISFormExpressionRepeater, FormExpressionRepeater
     if not xform.is_duplicate:
         create_repeat_records(FormRepeater, xform)
+        create_repeat_records(FormExpressionRepeater, xform)
         create_repeat_records(ArcGISFormExpressionRepeater, xform)
 
 

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -24,6 +24,8 @@ from corehq.motech.openmrs.views import (
 from corehq.motech.repeaters.expression.views import (
     AddCaseExpressionRepeaterView,
     EditCaseExpressionRepeaterView,
+    AddFormExpressionRepeaterView,
+    EditFormExpressionRepeaterView,
     AddArcGISFormExpressionRepeaterView,
     EditArcGISFormExpressionRepeaterView,
 )
@@ -80,6 +82,8 @@ urlpatterns = [
         {'repeater_type': 'DataRegistryCaseUpdateRepeater'}, name=AddCaseRepeaterView.urlname),
     url(r'^forwarding/new/CaseExpressionRepeater/$', AddCaseExpressionRepeaterView.as_view(),
         {'repeater_type': 'CaseExpressionRepeater'}, name=AddCaseExpressionRepeaterView.urlname),
+    url(r'^forwarding/new/FormExpressionRepeater/$', AddFormExpressionRepeaterView.as_view(),
+        {'repeater_type': 'FormExpressionRepeater'}, name=AddFormExpressionRepeaterView.urlname),
     url(r'^forwarding/new/ArcGISFormExpressionRepeater/$', AddArcGISFormExpressionRepeaterView.as_view(),
         {'repeater_type': 'ArcGISFormExpressionRepeater'}, name=AddArcGISFormExpressionRepeaterView.urlname),
     url(r'^forwarding/new/(?P<repeater_type>\w+)/$', AddRepeaterView.as_view(), name=AddRepeaterView.urlname),
@@ -108,6 +112,12 @@ urlpatterns = [
         EditCaseExpressionRepeaterView.as_view(),
         {'repeater_type': 'CaseExpressionRepeater'},
         name=EditCaseExpressionRepeaterView.urlname
+    ),
+    url(
+        r'^forwarding/edit/FormExpressionRepeater/(?P<repeater_id>\w+)/$',
+        EditFormExpressionRepeaterView.as_view(),
+        {'repeater_type': 'FormExpressionRepeater'},
+        name=EditFormExpressionRepeaterView.urlname
     ),
     url(
         r'^forwarding/edit/ArcGISFormExpressionRepeater/(?P<repeater_id>\w+)/$',

--- a/settings.py
+++ b/settings.py
@@ -833,6 +833,7 @@ REPEATER_CLASSES = [
     'custom.cowin.repeaters.BeneficiaryRegistrationRepeater',
     'custom.cowin.repeaters.BeneficiaryVaccinationRepeater',
     'corehq.motech.repeaters.expression.repeaters.CaseExpressionRepeater',
+    'corehq.motech.repeaters.expression.repeaters.FormExpressionRepeater',
     'corehq.motech.repeaters.expression.repeaters.ArcGISFormExpressionRepeater',
 ]
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
A new Form Expression repeater has been added to the UI:
![Screenshot from 2024-08-22 11-50-16](https://github.com/user-attachments/assets/71e90f17-2264-4462-8566-13459a39ddfa)

The UI for this repeater is identical to the one for the ArcGIS form expression repeater, looking as follows:
![Screenshot from 2024-08-22 11-51-14](https://github.com/user-attachments/assets/3c72ed07-2842-48b4-89e2-302d25085adc)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3865).

This PR exposes the `FormExpressionRepeater` class to the UI. This repeater already exists in the code, and was implemented as a base class to the ArcGIS form repeater in [this](https://github.com/dimagi/commcare-hq/pull/34929) PR.

Apart from making the form repeater visible to the UI, a new form payload generator was implemented which also serves as the base class for the ArcGIS payload generator.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`EXPRESSION_REPEATER`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing done
- Tested on staging
- QA completed

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests have been created for the `FormExpressionRepeater` class.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA has been completed. QA ticket is available [here](https://dimagi.atlassian.net/browse/QA-7018).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
