### PR TITLE
Remove unnecessary "embed Tablea report by user" FF

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2482,15 +2482,6 @@ FORMPLAYER_INCLUDE_STATE_HASH = FeatureRelease(
     owner='Simon Kelly'
 )
 
-EMBED_TABLEAU_REPORT_BY_USER = StaticToggle(
-    'embed_tableau_report_by_user',
-    'Use a Tableau username "HQ/{username}" to embed reports instead of "HQ/{role name}"',
-    TAG_DEPRECATED,
-    namespaces=[NAMESPACE_DOMAIN],
-    description='This flag is now deprecated and will be removed.',
-    parent_toggles=[EMBEDDED_TABLEAU]
-)
-
 APPLICATION_RELEASE_LOGS = StaticToggle(
     'application_release_logs',
     'Show Application release logs',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

As a follow-up to #34970, this PR removes the now-redundant feature flag EMBED_TABLEAU_REPORT_BY_USER. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

This FF was migrated into a checkbox setting in #34970. It is now redundant. 

Part of [USH-4836](https://dimagi.atlassian.net/browse/USH-4836?atlOrigin=eyJpIjoiZGQ0NzBhMzkwNmM3NDNjODkzODQ5YzgxZTI1NjFkMTIiLCJwIjoiaiJ9).

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

This flag isn't referenced anywhere other than the already-deployed migration.

### Automated test coverage

None necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4836]: https://dimagi.atlassian.net/browse/USH-4836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ