### PR TITLE
upgrade django to patched version to address CVE

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -136,7 +136,7 @@ diff-match-patch==20230430
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==4.2.14
+django==4.2.15
     # via
     #   -r base-requirements.in
     #   crispy-bootstrap3to5

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -118,7 +118,7 @@ diff-match-patch==20230430
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==4.2.14
+django==4.2.15
     # via
     #   -r base-requirements.in
     #   crispy-bootstrap3to5

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -121,7 +121,7 @@ diff-match-patch==20230430
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==4.2.14
+django==4.2.15
     # via
     #   -r base-requirements.in
     #   crispy-bootstrap3to5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -114,7 +114,7 @@ diff-match-patch==20230430
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==4.2.14
+django==4.2.15
     # via
     #   -r base-requirements.in
     #   crispy-bootstrap3to5

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -121,7 +121,7 @@ diff-match-patch==20230430
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in
-django==4.2.14
+django==4.2.15
     # via
     #   -r base-requirements.in
     #   crispy-bootstrap3to5


### PR DESCRIPTION
## Technical Summary
We were alerted about a CVE for our current django version. Dependabot couldn't automatically generate a PR, so I'm attempting to manually generate one here. Going to deploy to staging as well to see if there any deploy issues

here is the alert
https://github.com/dimagi/commcare-hq/security/dependabot/536

## Safety Assurance

### Safety story
Test failures should raise any issues. Also deploying this branch to staging to see if deploy is affected.

### Automated test coverage
Yes

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
