### PR TITLE
Send DataSourceRepeater records to different queue

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1158,7 +1158,9 @@ class RepeatRecord(models.Model):
     def attempt_forward_now(self, *, is_retry=False, fire_synchronously=False):
         from corehq.motech.repeaters.tasks import (
             process_repeat_record,
+            process_datasource_repeat_record,
             retry_process_repeat_record,
+            retry_process_datasource_repeat_record,
         )
 
         if self.next_check is None or self.next_check > datetime.utcnow():
@@ -1178,8 +1180,12 @@ class RepeatRecord(models.Model):
             # data from overwriting the work of another.
             return
 
-        # separated for improved datadog reporting
-        task = retry_process_repeat_record if is_retry else process_repeat_record
+        if self.repeater_type in ['DataSourceRepeater']:
+            # separated for improved datadog reporting
+            task = retry_process_datasource_repeat_record if is_retry else process_datasource_repeat_record
+        else:
+            # separated for improved datadog reporting
+            task = retry_process_repeat_record if is_retry else process_repeat_record
         if fire_synchronously:
             task(self.id, self.domain)
         else:

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -137,6 +137,24 @@ def retry_process_repeat_record(repeat_record_id, domain):
     _process_repeat_record(RepeatRecord.objects.get(id=repeat_record_id))
 
 
+@task(queue=settings.CELERY_REPEAT_RECORD_DATASOURCE_QUEUE)
+def process_datasource_repeat_record(repeat_record_id, domain):
+    """
+    NOTE: Keep separate from retry_process_datasource_repeat_record for monitoring purposes
+    Domain is present here for domain tagging in datadog
+    """
+    _process_repeat_record(RepeatRecord.objects.get(id=repeat_record_id))
+
+
+@task(queue=settings.CELERY_REPEAT_RECORD_DATASOURCE_QUEUE)
+def retry_process_datasource_repeat_record(repeat_record_id, domain):
+    """
+    NOTE: Keep separate from process_datasource_repeat_record for monitoring purposes
+    Domain is present here for domain tagging in datadog
+    """
+    _process_repeat_record(RepeatRecord.objects.get(id=repeat_record_id))
+
+
 def _process_repeat_record(repeat_record):
     request_duration = action = None
     with TimingContext('process_repeat_record') as timer:

--- a/settings.py
+++ b/settings.py
@@ -583,6 +583,7 @@ CELERY_REMINDER_RULE_QUEUE = 'reminder_rule_queue'
 CELERY_REMINDER_CASE_UPDATE_QUEUE = 'reminder_case_update_queue'
 CELERY_REMINDER_CASE_UPDATE_BULK_QUEUE = 'reminder_rule_queue'  # override in localsettings
 CELERY_REPEAT_RECORD_QUEUE = 'repeat_record_queue'
+CELERY_REPEAT_RECORD_DATASOURCE_QUEUE = 'repeat_record_queue'  # override in localsettings
 CELERY_LOCATION_REASSIGNMENT_QUEUE = 'celery'
 
 # Will cause a celery task to raise a SoftTimeLimitExceeded exception if


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15906

Goes with this cloud PR: https://github.com/dimagi/commcare-cloud/pull/6376

This is meant as a temporary solution to give Solutions better control over repeaters sending data to CCA, and SaaS time to implement necessary changes without the existing problems repeaters have been facing.

 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
