### PR TITLE
Use Locations Display Name

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -61,10 +61,9 @@ class LocationSelectWidget(forms.Widget):
         location_ids = to_list(value) if value else []
         locations = list(SQLLocation.active_objects
                          .filter(domain=self.domain, location_id__in=location_ids))
-
         initial_data = [{
             'id': loc.location_id,
-            'text': loc.get_path_display(),
+            'text': loc.display_name if True else loc.get_path_display(),
         } for loc in locations]
 
         return get_template(self.template).render({

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -64,6 +64,7 @@ class LocationSelectWidget(forms.Widget):
         initial_data = [{
             'id': loc.location_id,
             'text': loc.display_name if True else loc.get_path_display(),
+            'tooltip': loc.get_path_display(),
         } for loc in locations]
 
         return get_template(self.template).render({

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -14,6 +14,7 @@ from memoized import memoized
 from dimagi.utils.couch.database import iter_docs
 
 from corehq import toggles
+from corehq.feature_previews import USE_LOCATION_DISPLAY_NAME
 from corehq.apps.custom_data_fields.edit_entity import (
     CUSTOM_DATA_FIELD_PREFIX,
     CustomDataEditor,
@@ -32,6 +33,7 @@ from corehq.apps.locations.util import (
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import user_display_string
 from corehq.util.quickcache import quickcache
+from corehq.util.global_request import get_request_domain
 
 from .models import (
     LocationFixtureConfiguration,
@@ -61,10 +63,11 @@ class LocationSelectWidget(forms.Widget):
         location_ids = to_list(value) if value else []
         locations = list(SQLLocation.active_objects
                          .filter(domain=self.domain, location_id__in=location_ids))
+        use_location_display_name = USE_LOCATION_DISPLAY_NAME.enabled(get_request_domain())
         initial_data = [{
             'id': loc.location_id,
-            'text': loc.display_name if True else loc.get_path_display(),
-            'tooltip': loc.get_path_display(),
+            'text': loc.display_name if use_location_display_name else loc.get_path_display(),
+            'tooltip': loc.get_path_display() if use_location_display_name else loc.display_name,
         } for loc in locations]
 
         return get_template(self.template).render({

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -85,7 +85,9 @@ hqDefine("locations/js/widgets", [
                 },
             },
             templateResult: function (result) {
-                return result.text || result.name;
+                var $option = new Option(result.text);
+                $option.setAttribute('title', result.tooltip);
+                return $option;
             },
             templateSelection: function (result) {
                 const fullLengthName = result.text || result.name;

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -14,7 +14,9 @@ hqDefine("locations/js/widgets", [
         _.each($source.select2('data'), function (result) {
             const fullLengthName = result.text || result.name;
             const truncatedName = truncateLocationName(fullLengthName, $select);
-            $select.append(new Option(truncatedName, result.id));
+            var $option = new Option(truncatedName, result.id);
+            $option.setAttribute('title', result.tooltip || result.title);
+            $select.append($option);
         });
     }
 
@@ -98,7 +100,9 @@ hqDefine("locations/js/widgets", [
                 initial = [initial];
             }
             _.each(initial, function (result) {
-                $select.append(new Option(result.text, result.id));
+                var $option = new Option(result.text, result.id);
+                $option.setAttribute('title', result.tooltip);
+                $select.append($option);
             });
             $select.val(_.pluck(initial, 'id')).trigger('change');
         }
@@ -125,7 +129,9 @@ hqDefine("locations/js/widgets", [
             // This custom event is fired in autocomplete_select_widget.html
             if ($source.hasClass("select2-hidden-accessible")) {
                 updateSelect2($source, $select);
-                $select.append(new Option(value.text, value.id));
+                var $option = new Option(value.text, value.id);
+                $option.setAttribute('title', value.tooltip);
+                $select.append($option);
                 $select.val(value.id).trigger("change");
             } else {
                 $source.on('select-ready', function () {

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -199,7 +199,8 @@ class EmwfOptionsController(object):
         )
         results = [
             {'id': entry[0], 'text': entry[1]} if len(entry) == 2 else
-            {'id': entry[0], 'text': entry[1], 'is_active': entry[2]} for entry
+            {'id': entry[0], 'text': entry[1], 'is_active': entry[2]} if len(entry) == 3 else
+            {'id': entry[0], 'text': entry[1], 'is_active': entry[2], 'tooltip': entry[3]} for entry
             in options
         ]
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -138,7 +138,7 @@ class EmwfUtils(object):
 
     def location_tuple(self, location):
         location_id = location.location_id
-        text = location.get_path_display()
+        text = location.display_name if True else location.get_path_display(),
         if self.namespace_locations:
             location_id = f'l__{location_id}'
             text = f'{text} [location]'

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -138,11 +138,12 @@ class EmwfUtils(object):
 
     def location_tuple(self, location):
         location_id = location.location_id
-        text = location.display_name if True else location.get_path_display(),
+        text = location.display_name if True else location.get_path_display()
+        path = location.get_path_display()
         if self.namespace_locations:
             location_id = f'l__{location_id}'
             text = f'{text} [location]'
-        return (location_id, text)
+        return (location_id, text, None, path)
 
     @property
     @memoized

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy, gettext_noop
 from memoized import memoized
 
 from corehq import toggles
+from corehq.feature_previews import USE_LOCATION_DISPLAY_NAME
 from corehq.apps.domain.models import Domain
 from corehq.apps.enterprise.models import EnterprisePermissions
 from corehq.apps.es import filters
@@ -20,6 +21,7 @@ from corehq.apps.users.cases import get_wrapped_owner
 from corehq.apps.users.models import CommCareUser, UserHistory, WebUser
 from corehq.apps.users.util import cached_user_id_to_user_display
 from corehq.const import USER_DATETIME_FORMAT
+from corehq.util.global_request import get_request_domain
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
 
@@ -138,12 +140,13 @@ class EmwfUtils(object):
 
     def location_tuple(self, location):
         location_id = location.location_id
-        text = location.display_name if True else location.get_path_display()
-        path = location.get_path_display()
+        use_location_display_name = USE_LOCATION_DISPLAY_NAME.enabled(get_request_domain())
+        text = location.display_name if use_location_display_name else location.get_path_display()
+        tooltip = location.get_path_display() if use_location_display_name else location.display_name
         if self.namespace_locations:
             location_id = f'l__{location_id}'
             text = f'{text} [location]'
-        return (location_id, text, None, path)
+        return (location_id, text, None, tooltip)
 
     @property
     @memoized

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1129,6 +1129,7 @@ class PrimaryLocationWidget(forms.Widget):
                 initial_data = {
                     'id': loc.location_id,
                     'text': text,
+                    'tooltip': loc.get_path_display(),
                 }
             except SQLLocation.DoesNotExist:
                 pass

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1125,9 +1125,10 @@ class PrimaryLocationWidget(forms.Widget):
         if value:
             try:
                 loc = SQLLocation.objects.get(location_id=value)
+                text = loc.display_name if True else loc.get_path_display()
                 initial_data = {
                     'id': loc.location_id,
-                    'text': loc.get_path_display(),
+                    'text': text,
                 }
             except SQLLocation.DoesNotExist:
                 pass

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -57,11 +57,13 @@ from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from corehq.apps.user_importer.helpers import UserChangeLogger
 from corehq.const import LOADTEST_HARD_LIMIT, USER_CHANGE_VIA_WEB
 from corehq.pillows.utils import MOBILE_USER_TYPE, WEB_USER_TYPE
+from corehq.feature_previews import USE_LOCATION_DISPLAY_NAME
 from corehq.toggles import (
     LOCATION_HAS_USERS,
     TWO_STAGE_USER_PROVISIONING,
     TWO_STAGE_USER_PROVISIONING_BY_SMS,
 )
+from corehq.util.global_request import get_request_domain
 
 from ..hqwebapp.signals import clear_login_attempts
 from .audit.change_messages import UserChangeMessage
@@ -1125,11 +1127,11 @@ class PrimaryLocationWidget(forms.Widget):
         if value:
             try:
                 loc = SQLLocation.objects.get(location_id=value)
-                text = loc.display_name if True else loc.get_path_display()
+                use_location_display_name = USE_LOCATION_DISPLAY_NAME.enabled(get_request_domain())
                 initial_data = {
                     'id': loc.location_id,
-                    'text': text,
-                    'tooltip': loc.get_path_display(),
+                    'text': loc.display_name if use_location_display_name else loc.get_path_display(),
+                    'tooltip': loc.get_path_display() if use_location_display_name else loc.display_name,
                 }
             except SQLLocation.DoesNotExist:
                 pass

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -134,6 +134,15 @@ SPLIT_MULTISELECT_CASE_EXPORT = FeaturePreview(
     )
 )
 
+USE_LOCATION_DISPLAY_NAME = FeaturePreview(
+    slug='use_location_display_name',
+    label=_('Use location name'),
+    description=_(
+        "This setting changes the location dropdown to display location name instead of "
+        "the full location path."
+    )
+)
+
 
 def enable_callcenter(domain_name, checked):
     from corehq.apps.domain.models import Domain


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
- Adds a "Use Location Name" Feature Preview Flag. When enabled, location dropdown shows the location display name instead of the location path. When hovering over an option, it shows the location path.
- Nongated change: When hovering over a location option, it shows the location name.

<img width="950" alt="Screen Shot 2024-08-22 at 2 02 57 PM" src="https://github.com/user-attachments/assets/a7814093-5468-4327-b4a7-40948dc9838b">

Feature Preview Flag on:

https://github.com/user-attachments/assets/43cc2b4f-a6dc-4c41-82a5-96a100f25582


Feature Preview Flag off:
<img width="765" alt="Screen Shot 2024-08-22 at 2 17 31 PM" src="https://github.com/user-attachments/assets/1bbb8859-28d7-4611-a26f-8963c4eaea40">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-4676
](https://dimagi.atlassian.net/browse/USH-4676)
[Design Doc
](https://docs.google.com/document/d/1RQZ7R5QBblIOgfypcOGaOKv_yAxIZqsj1SJttaDSnqc/edit#heading=h.aa3877h1g9ke)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Use Location Name" Feature Preview Flag

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and on staging. The change is limited to location dropdowns and affects only display text.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
