### PR TITLE
Ignore failing dedupe records with long stale ES data

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1158,7 +1158,13 @@ class CaseDeduplicationActionDefinition(BaseUpdateCaseDefinition):
                 # We've decided skipping this record and recording an error is likely the safest way to handle this
                 # Hopefully, these errors allow us to track down the underlying bug or infrastructure issue
                 # and fix the issue at the source
-                raise ValueError(f'Unable to find current ElasticSearch data for: {case.case_id}')
+
+                # TODO: Commenting this line out, as it has caused us to surpass our sentry error quota
+                # we should figure out whether this can be safely handled, or what truly constitutes an error,
+                # but disabling this to avoid further quota issues.
+                # raise ValueError(f'Unable to find current ElasticSearch data for: {case.case_id}')
+                # Ignore this result for now
+                return CaseRuleActionResult(num_errors=1)
             else:
                 # Normal processing can involve latency between when a case is written to the database and when
                 # it arrives in ElasticSearch. If this case was modified within the acceptable latency window,


### PR DESCRIPTION
## Technical Summary
We've surpassed our sentry error quota due to stale elasticsearch data, specifically with its interaction with deduplication, so for now, we'd like to prevent this error from being raised.

Instead, I'm returning `CaseRuleActionResults(num_errors=1)`. It does mean that these records won't get processed as duplicates, and so the results will be incomplete. However, this is likely what is happening now. I do see that pillows retry failed changes, but after a certain number of attempts, these changes will be lost

## Safety Assurance

### Safety story
I believe this to be safe, because I don't believe deduplication cares about these response codes. The two entry points for this change would be `tasks.backfill_deduplicate_rule`, which doesn't pay attention to the returned result of `iter_cases_and_run_rules`. `iter_cases_and_run_rules` ultimately calls `DomainCaseRuleRun.done()`, which just means the backfill task will display that it encountered errors (but will still process the other results as it would have).

The other entry point is from the `CaseDeduplicationProcessor`, where it returns the results of `run_rules_for_case()`. I believe what ultimately calls the pillow is [PillowBase code](https://github.com/dimagi/commcare-hq/blob/08285ccece6da4928094e71a937c502d4066e704/corehq/ex-submodules/pillowtop/pillow/interface.py#L252) which doesn't appear to do anything with the returned value. 

This does slightly change behavior that would happen in bulk -- if one case change was responsible for multiple changes, and only the first one failed, before this fix, the others would never be processed, whereas now they are. This is probably just a good thing, as more data can be successfully processed by the deduplication processor. 

Again, it is unfortunate that these case changes will be labelled as 'done' without properly going through dedupe, but that's already occurring when errors are raised, because we just don't know what to do with data that has been stale this long. In the worst scenario, we can backfill rules, or possibly create a task that will re-examine cases that have been submitted recently, to try to process this kind of stale data.

### Automated test coverage

No tests

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
