### PR TITLE
During reindexing user index don't move password

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -439,8 +439,19 @@ class ElasticManageAdapter(BaseAdapter):
             "conflicts": "proceed"
         }
 
-        # Should be removed after ES 5-6 migration
-        if copy_doc_ids:
+    # Should be removed after ES 5-6 migration
+        if copy_doc_ids and source == const.HQ_USERS_INDEX_NAME:
+            # Remove password from form index
+            reindex_body["script"] = {
+                "lang": "painless",
+                "source": """
+                ctx._source.remove('password');
+                if (!ctx._source.containsKey('doc_id')) {
+                    ctx._source['doc_id'] = ctx._id;
+                }
+                """
+            }
+        elif copy_doc_ids:
             reindex_body["script"] = {
                 "lang": "painless",
                 "source": """

--- a/corehq/apps/es/tests/test_client.py
+++ b/corehq/apps/es/tests/test_client.py
@@ -11,6 +11,7 @@ from nose.tools import nottest
 
 from corehq.apps.es import const
 from corehq.apps.es.utils import check_task_progress, get_es_reindex_setting_value
+from corehq.apps.users.models import CommCareUser
 from corehq.util.es.elasticsearch import (
     BulkIndexError,
     Elasticsearch,
@@ -583,6 +584,59 @@ class TestElasticManageAdapter(AdapterWithIndexTestCase):
                 )
 
                 self.assertEqual(list(self._get_all_doc_ids_in_index(SUBINDEX)), ['7'])
+
+    def test_reindex_for_users_index(self):
+        from corehq.apps.es.users import user_adapter
+
+        SECONDARY_INDEX = 'secondary_user_index'
+        domain = 'es_reindex_users_index'
+
+        # Setup Indices
+        with temporary_index(user_adapter.index_name, user_adapter.type, user_adapter.mapping):
+            with temporary_index(SECONDARY_INDEX, user_adapter.type, user_adapter.mapping):
+
+                mobile_user = CommCareUser(
+                    _id='1', username="amazing_user", domain=domain, password='**************',
+                    created_by=None, created_via=None
+                )
+
+                # Save user to the source index
+                with patch('corehq.apps.groups.dbaccessors.get_group_id_name_map_by_user', return_value=[]), \
+                     patch.object(user_adapter.model_cls, 'get_user_data', return_value={}):
+
+                    id, source = user_adapter.from_python(mobile_user)
+                    # Manually set password field because now it is removed in from_python
+                    source['password'] = '12345678'
+                    manager._es.index(
+                        user_adapter.index_name,
+                        user_adapter.type,
+                        source,
+                        id,
+                        refresh=True
+                    )
+
+                # Get the saved user from ES
+                user_es = user_adapter.get(mobile_user._id)
+
+                # Ensure that password field exists in the user dict
+                assert 'password' in user_es, "password does not exist in source index"
+                self.assertEqual(user_es['password'], '12345678')
+
+                # Reindex the user index to the secondary index
+                with patch.object(const, 'HQ_USERS_INDEX_NAME', user_adapter.index_name):
+                    manager.reindex(
+                        user_adapter.index_name, SECONDARY_INDEX,
+                        wait_for_completion=True,
+                        refresh=True,
+                        requests_per_second=2,
+                    )
+
+                # Get the saved user from the secondary index
+                user = manager._es.search(index=SECONDARY_INDEX, body={})['hits']['hits'][0]['_source']
+                # Ensure that password field does not exist in the user dict
+                print(user)
+                self.assertEqual(user['doc_id'], '1')
+                assert 'password' not in user, "password exists in source index"
 
     def _index_test_docs_for_reindex(self):
         all_ids = set([str(i) for i in range(1, 10)])


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Second part of https://github.com/dimagi/commcare-hq/pull/34974 where we stopped writing password to users index. 
Now we are going to start reindexing the environments. This PR adds script in reindex command to remove password field altogether from the index.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15872
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Has test for the change and only affects reindex command.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

NA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
