### PR TITLE
Count overdue repeat records by partition

### DIFF
--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -11,7 +11,6 @@ RATE_LIMITER_DELAY_RANGE = (
     timedelta(minutes=getattr(settings, 'MAX_REPEATER_RATE_LIMIT_DELAY', 15)),
 )
 CHECK_REPEATERS_INTERVAL = timedelta(minutes=5)
-CHECK_REPEATERS_PARTITION_COUNT = settings.CHECK_REPEATERS_PARTITION_COUNT
 CHECK_REPEATERS_KEY = 'check-repeaters-key'
 ENDPOINT_TIMER = 'endpoint_timer'
 # Number of attempts to an online endpoint before cancelling payload

--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -17,6 +17,8 @@ ENDPOINT_TIMER = 'endpoint_timer'
 MAX_ATTEMPTS = 3
 # Number of exponential backoff attempts to an offline endpoint
 MAX_BACKOFF_ATTEMPTS = 6
+# Minutes past next_check time that make a record "overdue"
+OVERDUE_THRESHOLD = 10
 
 
 class State(IntegerChoices):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -71,6 +71,7 @@ from contextlib import nullcontext
 from datetime import datetime, timedelta
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
+from django.conf import settings
 from django.db import models, router
 from django.db.models.base import Deferred
 from django.dispatch import receiver
@@ -107,7 +108,6 @@ from corehq.motech.const import (
 from corehq.motech.models import ConnectionSettings
 from corehq.motech.repeater_helpers import RepeaterResponse
 from corehq.motech.repeaters.apps import REPEATER_CLASS_MAP
-from corehq.motech.repeaters.const import CHECK_REPEATERS_PARTITION_COUNT
 from corehq.motech.repeaters.optionvalue import OptionValue
 from corehq.motech.requests import simple_request
 from corehq.privileges import DATA_FORWARDING, ZAPIER_INTEGRATION
@@ -918,7 +918,7 @@ class RepeatRecordManager(models.Manager):
 
     def count_overdue_by_partition(self, threshold=timedelta(minutes=10)):
         return (
-            self.annotate(partition_id=models.F("id") % CHECK_REPEATERS_PARTITION_COUNT)
+            self.annotate(partition_id=models.F("id") % settings.CHECK_REPEATERS_PARTITION_COUNT)
             .filter(next_check__isnull=False, next_check__lt=datetime.utcnow() - threshold)
             .values("partition_id")
             .annotate(count=models.Count("partition_id"))

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -24,7 +24,6 @@ from corehq.util.timer import TimingContext
 from .const import (
     CHECK_REPEATERS_INTERVAL,
     CHECK_REPEATERS_KEY,
-    CHECK_REPEATERS_PARTITION_COUNT,
     ENDPOINT_TIMER,
     MAX_RETRY_WAIT,
     RATE_LIMITER_DELAY_RANGE,
@@ -77,22 +76,23 @@ def delete_old_request_logs():
 def check_repeaters():
     # this creates a task for all partitions
     # the Nth child task determines if a lock is available for the Nth partition
-    for current_partition in range(CHECK_REPEATERS_PARTITION_COUNT):
+    for current_partition in range(settings.CHECK_REPEATERS_PARTITION_COUNT):
         check_repeaters_in_partition.delay(current_partition)
 
 
 @task(queue=settings.CELERY_PERIODIC_QUEUE)
 def check_repeaters_in_partition(partition):
     """
-    The CHECK_REPEATERS_PARTITION_COUNT constant dictates the total number of partitions
+    The CHECK_REPEATERS_PARTITION_COUNT value dictates the total number of partitions
     :param partition: index of partition to check
+
     """
     start = datetime.utcnow()
     twentythree_hours_sec = 23 * 60 * 60
     twentythree_hours_later = start + timedelta(hours=23)
 
     # Long timeout to allow all waiting repeat records to be iterated
-    lock_key = f"{CHECK_REPEATERS_KEY}_{partition}_in_{CHECK_REPEATERS_PARTITION_COUNT}"
+    lock_key = f"{CHECK_REPEATERS_KEY}_{partition}_in_{settings.CHECK_REPEATERS_PARTITION_COUNT}"
     check_repeater_lock = get_redis_lock(
         lock_key,
         timeout=twentythree_hours_sec,
@@ -108,7 +108,7 @@ def check_repeaters_in_partition(partition):
             timing_buckets=_check_repeaters_buckets,
         ):
             for record in RepeatRecord.objects.iter_partition(
-                    start, partition, CHECK_REPEATERS_PARTITION_COUNT):
+                    start, partition, settings.CHECK_REPEATERS_PARTITION_COUNT):
 
                 if datetime.utcnow() > twentythree_hours_later:
                     break

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -199,7 +199,7 @@ def _process_repeat_record(repeat_record):
 
 metrics_gauge_task(
     'commcare.repeaters.overdue',
-    RepeatRecord.objects.count_overdue,
+    RepeatRecord.objects.count_overdue_by_partition,
     run_every=crontab(),  # every minute
     multiprocess_mode=MPM_MAX
 )

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -589,6 +589,16 @@ class TestRepeatRecordManager(RepeaterTestCase):
         self.assertEqual(counts[missing_id][State.Cancelled], 0)
         self.assertEqual(counts[missing_id][State.Success], 0)
 
+    def test_count_overdue(self):
+        now = datetime.utcnow()
+        self.new_record(next_check=now - timedelta(hours=2))
+        self.new_record(next_check=now - timedelta(hours=1))
+        self.new_record(next_check=now - timedelta(minutes=15))
+        self.new_record(next_check=now - timedelta(minutes=5))
+        self.new_record(next_check=None, state=State.Success)
+        overdue = RepeatRecord.objects.count_overdue()
+        self.assertEqual(overdue, 3)
+
     @override_settings(CHECK_REPEATERS_PARTITION_COUNT=2)
     def test_count_overdue_for_partition(self):
         from collections import defaultdict

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -9,6 +9,7 @@ from dateutil.parser import isoparse
 from django.conf import settings
 from django.db.models.deletion import ProtectedError
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import override_settings
 from django.utils import timezone
 
 from freezegun import freeze_time
@@ -588,15 +589,25 @@ class TestRepeatRecordManager(RepeaterTestCase):
         self.assertEqual(counts[missing_id][State.Cancelled], 0)
         self.assertEqual(counts[missing_id][State.Success], 0)
 
-    def test_count_overdue(self):
+    @override_settings(CHECK_REPEATERS_PARTITION_COUNT=2)
+    @patch('corehq.motech.repeaters.models.CHECK_REPEATERS_PARTITION_COUNT', 2)
+    def test_count_overdue_for_partition(self):
+        from collections import defaultdict
         now = datetime.utcnow()
-        self.new_record(next_check=now - timedelta(hours=2))
-        self.new_record(next_check=now - timedelta(hours=1))
-        self.new_record(next_check=now - timedelta(minutes=15))
-        self.new_record(next_check=now - timedelta(minutes=5))
-        self.new_record(next_check=None, state=State.Success)
-        overdue = RepeatRecord.objects.count_overdue()
-        self.assertEqual(overdue, 3)
+        expected_records_by_partition = defaultdict(int)
+        # add overdue records
+        for _ in range(5):
+            record = self.new_record(next_check=now - timedelta(hours=2))
+            partition = record.id % settings.CHECK_REPEATERS_PARTITION_COUNT
+            expected_records_by_partition[partition] += 1
+
+        # add not yet due records
+        for _ in range(5):
+            self.new_record(next_check=now - timedelta(minutes=1))
+
+        overdue_by_partition = RepeatRecord.objects.count_overdue_by_partition()
+        for result in overdue_by_partition:
+            self.assertEqual(result['count'], expected_records_by_partition[result['partition_id']])
 
     iter_partition = RepeatRecord.objects.iter_partition
 

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -590,7 +590,6 @@ class TestRepeatRecordManager(RepeaterTestCase):
         self.assertEqual(counts[missing_id][State.Success], 0)
 
     @override_settings(CHECK_REPEATERS_PARTITION_COUNT=2)
-    @patch('corehq.motech.repeaters.models.CHECK_REPEATERS_PARTITION_COUNT', 2)
     def test_count_overdue_for_partition(self):
         from collections import defaultdict
         now = datetime.utcnow()

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -8,6 +8,7 @@ from corehq.util.json import CommCareJSONEncoder
 from corehq.util.test_utils import flag_enabled
 
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import override_settings
 from corehq.apps.userreports.pillow import ConfigurableReportPillowProcessor, ConfigurableReportTableManager
 import attr
 from requests import RequestException
@@ -361,15 +362,16 @@ class RepeaterTest(BaseRepeaterTest):
         self.assertEqual(repeat_record.max_possible_tries - repeat_record.num_attempts, MAX_BACKOFF_ATTEMPTS)
         self.assertNotEqual(None, repeat_record.next_check)
 
+    @override_settings(CHECK_REPEATERS_PARTITION_COUNT=10)
     def test_check_repeat_records_ignores_future_retries_using_multiple_partitions(self):
         self._create_additional_repeat_records(9)
         self.assertEqual(len(self.repeat_records()), 20)
 
-        with patch('corehq.motech.repeaters.models.simple_request') as mock_retry, \
-             patch('corehq.motech.repeaters.tasks.CHECK_REPEATERS_PARTITION_COUNT', 10):
+        with patch('corehq.motech.repeaters.models.simple_request') as mock_retry:
             check_repeaters()
             self.assertEqual(mock_retry.delay.call_count, 0)
 
+    @override_settings(CHECK_REPEATERS_PARTITION_COUNT=10)
     def test_repeat_record_status_check_using_multiple_partitions(self):
         self._create_additional_repeat_records(9)
         self.assertEqual(len(self.repeat_records()), 20)
@@ -379,8 +381,7 @@ class RepeaterTest(BaseRepeaterTest):
             repeat_record.state = State.Cancelled
             repeat_record.next_check = None
             repeat_record.save()
-        with patch('corehq.motech.repeaters.models.simple_request') as mock_fire, \
-             patch('corehq.motech.repeaters.tasks.CHECK_REPEATERS_PARTITION_COUNT', 10):
+        with patch('corehq.motech.repeaters.models.simple_request') as mock_fire:
             check_repeaters()
             self.assertEqual(mock_fire.call_count, 0)
 
@@ -398,19 +399,18 @@ class RepeaterTest(BaseRepeaterTest):
             self.assertEqual(repeat_record.num_attempts, 1)
 
         # not trigger records succeeded triggered after cancellation
-        with patch('corehq.motech.repeaters.models.simple_request') as mock_fire, \
-             patch('corehq.motech.repeaters.tasks.CHECK_REPEATERS_PARTITION_COUNT', 10):
+        with patch('corehq.motech.repeaters.models.simple_request') as mock_fire:
             check_repeaters()
             self.assertEqual(mock_fire.call_count, 0)
             for repeat_record in self.repeat_records():
                 self.assertEqual(repeat_record.state, State.Success)
 
+    @override_settings(CHECK_REPEATERS_PARTITION_COUNT=10)
     def test_check_repeaters_successfully_retries_using_multiple_partitions(self):
         self._create_additional_repeat_records(9)
         self.assertEqual(len(self.repeat_records()), 20)
 
-        with patch('corehq.motech.repeaters.tasks.retry_process_repeat_record') as mock_process, \
-             patch('corehq.motech.repeaters.tasks.CHECK_REPEATERS_PARTITION_COUNT', 10):
+        with patch('corehq.motech.repeaters.tasks.retry_process_repeat_record') as mock_process:
             check_repeaters()
             self.assertEqual(mock_process.delay.call_count, 0)
 
@@ -419,8 +419,7 @@ class RepeaterTest(BaseRepeaterTest):
             record.next_check = datetime.utcnow() - timedelta(hours=1)
             record.save()
 
-        with patch('corehq.motech.repeaters.tasks.retry_process_repeat_record') as mock_process, \
-             patch('corehq.motech.repeaters.tasks.CHECK_REPEATERS_PARTITION_COUNT', 10):
+        with patch('corehq.motech.repeaters.tasks.retry_process_repeat_record') as mock_process:
             check_repeaters()
             self.assertEqual(mock_process.delay.call_count, 20)
 

--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -203,8 +203,11 @@ def metrics_gauge_task(name, fn, run_every, multiprocess_mode=MPM_ALL, value_key
         result = fn()
         if isinstance(result, Iterable):
             for obj in result:
+                assert isinstance(obj, dict)
                 value = obj.pop(value_key)
                 tags = obj
+                # tags can be expensive so add conservatively
+                assert len(tags) <= 1
                 metrics_gauge(name, value, multiprocess_mode=multiprocess_mode, tags=tags)
         else:
             metrics_gauge(name, result, multiprocess_mode=multiprocess_mode)

--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -177,7 +177,7 @@ def metrics_histogram(
     )
 
 
-def metrics_gauge_task(name, fn, run_every, multiprocess_mode=MPM_ALL):
+def metrics_gauge_task(name, fn, run_every, multiprocess_mode=MPM_ALL, value_key='count'):
     """
     Helper for easily registering gauges to run periodically
 
@@ -192,6 +192,7 @@ def metrics_gauge_task(name, fn, run_every, multiprocess_mode=MPM_ALL):
 
     kwargs:
         multiprocess_mode: See PrometheusMetrics._gauge for documentation.
+        value_key: if fn returns an Iterable, treat this key as the value to gauge and the rest as tags
     """
     _enforce_prefix(name, 'commcare')
 
@@ -199,7 +200,14 @@ def metrics_gauge_task(name, fn, run_every, multiprocess_mode=MPM_ALL):
     @wraps(fn)
     def inner():
         from corehq.util.metrics import metrics_gauge
-        metrics_gauge(name, fn(), multiprocess_mode=multiprocess_mode)
+        result = fn()
+        if isinstance(result, Iterable):
+            for obj in result:
+                value = obj.pop(value_key)
+                tags = obj
+                metrics_gauge(name, value, multiprocess_mode=multiprocess_mode, tags=tags)
+        else:
+            metrics_gauge(name, result, multiprocess_mode=multiprocess_mode)
 
     return inner
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Shockingly cumbersome change to make, initially I was just going to iterate over partitions and report the metric with a tag for each, but this way feels a bit more elegant (or complex 🤔).

Rather than hit the db 4 times it would be nice to still have one db query fire each minute that we then parse and report the results to datadog. My main concern is that the addition of this to `metrics_gauge_task` adds the ability to add a potentially large number of tags to a metric without realizing it, so I'm inclined to put some limit on the amount of tags allowed. I could even default it to 1 and make the caller override that default.

The other sad thing is to lose the simple, faster `count_overdue` query which is nice for debugging but is unused apart from this metric. I'm inclined to add it back just to have it available when debugging.
 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
