### PR TITLE
Disable previously selected location from the location dropdown

### DIFF
--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -2,10 +2,12 @@
 hqDefine("locations/js/widgets", [
     'jquery',
     'underscore',
+    'hqwebapp/js/toggles',
     'select2/dist/js/select2.full.min',
 ], function (
     $,
-    _
+    _,
+    toggles
 ) {
     // Update the options available to one select2 to be
     // the selected values from another (multiselect) select2
@@ -76,14 +78,16 @@ hqDefine("locations/js/widgets", [
                 },
                 processResults: function (data, params) {
                     var more = (params.page || 1) * 10 < data.total;
-                    let selectedLocations = Array.from($select[0].selectedOptions);
-                    if (selectedLocations.length > 0) {
-                        let locIds = selectedLocations.map(option => option.value);
-                        data.results.forEach(result => {
-                            if (locIds.includes(result.id)) {
-                                result.disabled = true;
-                            }
-                        });
+                    if (toggles.toggleEnabled('LOCATION_FIELD_USER_PROVISIONING')) {
+                        let selectedLocations = Array.from($select[0].selectedOptions);
+                        if (selectedLocations.length > 0) {
+                            let locIds = selectedLocations.map(option => option.value);
+                            data.results.forEach(result => {
+                                if (locIds.includes(result.id)) {
+                                    result.disabled = true;
+                                }
+                            });
+                        }
                     }
                     return {
                         results: data.results,

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -76,6 +76,18 @@ hqDefine("locations/js/widgets", [
                 },
                 processResults: function (data, params) {
                     var more = (params.page || 1) * 10 < data.total;
+                    var selected_locations = $select[0].selectedOptions
+                    if (selected_locations.length > 0) {
+                        var loc_ids = []
+                        for (var i in selected_locations) {
+                            loc_ids.push(selected_locations[i].value)
+                        }
+                        for (var i in data.results) {
+                            if (loc_ids.indexOf(data.results[i].id) > -1) {
+                                data.results[i].disabled = "disabled"
+                            }
+                        }
+                    }
                     return {
                         results: data.results,
                         pagination: { more: more },

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -76,15 +76,17 @@ hqDefine("locations/js/widgets", [
                 },
                 processResults: function (data, params) {
                     var more = (params.page || 1) * 10 < data.total;
-                    var selected_locations = $select[0].selectedOptions
-                    if (selected_locations.length > 0) {
-                        var loc_ids = []
-                        for (var i in selected_locations) {
-                            loc_ids.push(selected_locations[i].value)
+                    var selectedLocations = $select[0].selectedOptions;
+                    if (selectedLocations.length > 0) {
+                        var locIds = [];
+                        for (var i in selectedLocations) {
+                            if (selectedLocations[i].value) {
+                                locIds.push(selectedLocations[i].value);
+                            }
                         }
-                        for (var i in data.results) {
-                            if (loc_ids.indexOf(data.results[i].id) > -1) {
-                                data.results[i].disabled = "disabled"
+                        for (var j in data.results) {
+                            if (locIds.indexOf(data.results[j].id) > -1) {
+                                data.results[j].disabled = "disabled";
                             }
                         }
                     }

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -76,19 +76,14 @@ hqDefine("locations/js/widgets", [
                 },
                 processResults: function (data, params) {
                     var more = (params.page || 1) * 10 < data.total;
-                    var selectedLocations = $select[0].selectedOptions;
+                    let selectedLocations = Array.from($select[0].selectedOptions);
                     if (selectedLocations.length > 0) {
-                        var locIds = [];
-                        for (var i in selectedLocations) {
-                            if (selectedLocations[i].value) {
-                                locIds.push(selectedLocations[i].value);
+                        let locIds = selectedLocations.map(option => option.value);
+                        data.results.forEach(result => {
+                            if (locIds.includes(result.id)) {
+                                result.disabled = true;
                             }
-                        }
-                        for (var j in data.results) {
-                            if (locIds.indexOf(data.results[j].id) > -1) {
-                                data.results[j].disabled = "disabled";
-                            }
-                        }
+                        });
                     }
                     return {
                         results: data.results,

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -976,6 +976,14 @@ WEB_APPS_UPLOAD_QUESTIONS = FeatureRelease(
     owner='Jenny Schweers',
 )
 
+LOCATION_FIELD_USER_PROVISIONING = FeatureRelease(
+    'location_field_user_provisioning',
+    'USH: Holding feature flag for various works relating to the location field',
+    TAG_RELEASE,
+    namespaces=[NAMESPACE_DOMAIN],
+    owner='Minha Lee',
+)
+
 WEB_APPS_ANCHORED_SUBMIT = StaticToggle(
     'web_apps_anchored_submit',
     'USH: Keep submit button anchored at the bottom of screen for forms in Web Apps',


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

When choosing multiple locations to assign to a new web user it can be confusing to know which options have already been selected and too easy to accidentally unselect a previously selected location. This PR disabled those locations from the dropdown and makes clicking the 'x' in the selection bar the only way to remove a selected option.

Dropdown with no selection:
<img width="619" alt="Screen Shot 2024-08-23 at 3 38 44 PM" src="https://github.com/user-attachments/assets/f129ee6f-2976-4e27-800b-14bd9d4351cd">

Dropdown with one selection (the focus skips over the first option, which was already selected):
<img width="626" alt="Screen Shot 2024-08-23 at 3 38 55 PM" src="https://github.com/user-attachments/assets/ff277b36-49bd-4569-b3fb-4a69ed65242f">

Last minute addition: This and other related changes to the locations field will be put behind a new feature flag introduced in this PR `location_field_user_provisioning`

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4675)

All this does is compare selected options in selectedOptions and adds a 'disabled' attribute to dropdown menu items that match the ids of those options. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and in staging. This doesn't impact existing data at all, just how it's shown. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
