### PR TITLE
Add check for the case type passed in the URL

### DIFF
--- a/corehq/apps/export/tests/test_export_views.py
+++ b/corehq/apps/export/tests/test_export_views.py
@@ -152,6 +152,14 @@ class ExportViewTest(ViewTestCase):
         self.assertEqual(resp.status_code, 200)
 
     @patch("corehq.apps.export.views.new.get_case_types_for_domain", lambda *a: ['random_case'])
+    def test_create_case_export_with_invalid_case(self):
+        resp = self.client.get(
+            reverse(CreateNewCustomCaseExportView.urlname, args=[self.domain.name]),
+            {'export_tag': 'some_case'}
+        )
+        self.assertEqual(resp.status_code, 302)
+
+    @patch("corehq.apps.export.views.new.get_case_types_for_domain", lambda *a: ['random_case'])
     def test_create_case_export(self):
         resp = self.client.get(
             reverse(CreateNewCustomCaseExportView.urlname, args=[self.domain.name]),

--- a/corehq/apps/export/tests/test_export_views.py
+++ b/corehq/apps/export/tests/test_export_views.py
@@ -151,6 +151,7 @@ class ExportViewTest(ViewTestCase):
         )
         self.assertEqual(resp.status_code, 200)
 
+    @patch("corehq.apps.export.views.new.get_case_types_for_domain", lambda *a: ['random_case'])
     def test_create_case_export(self):
         resp = self.client.get(
             reverse(CreateNewCustomCaseExportView.urlname, args=[self.domain.name]),

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -15,6 +15,7 @@ from django_prbac.utils import has_privilege
 from memoized import memoized
 
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
+from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain
 from dimagi.utils.web import json_response
 
 from corehq import privileges, toggles
@@ -412,6 +413,21 @@ class CreateNewCustomCaseExportView(BaseExportView):
     def get(self, request, *args, **kwargs):
         case_type = request.GET.get('export_tag').strip('"')
 
+        if (
+            case_type not in get_case_types_for_domain(request.domain)
+            and case_type != ALL_CASE_TYPE_EXPORT
+        ):
+            messages.error(
+                request,
+                _(
+                    "Case type '%(case_type)' does not exist in domain %(domain)"
+                ) % {
+                    'case_type': case_type,
+                    'domain': self.domain
+                }
+            )
+            url = self.export_home_url
+            return HttpResponseRedirect(url)
         # First check if project is allowed to do a bulk export and redirect if necessary
         if case_type == ALL_CASE_TYPE_EXPORT and case_type_or_app_limit_exceeded(self.domain):
             messages.error(

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -419,12 +419,7 @@ class CreateNewCustomCaseExportView(BaseExportView):
         ):
             messages.error(
                 request,
-                _(
-                    "Case type '%(case_type)' does not exist for this project."
-                ) % {
-                    'case_type': case_type,
-                    'domain': self.domain
-                }
+                _("Case type '{case_type}' does not exist for this project.").format(case_type=case_type)
             )
             url = self.export_home_url
             return HttpResponseRedirect(url)

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -420,7 +420,7 @@ class CreateNewCustomCaseExportView(BaseExportView):
             messages.error(
                 request,
                 _(
-                    "Case type '%(case_type)' does not exist in domain %(domain)"
+                    "Case type '%(case_type)' does not exist for this project."
                 ) % {
                     'case_type': case_type,
                     'domain': self.domain


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
While creating exports it was possible to change the export type by changing the value of `export_tag` in the URL. The change ensures that we check if the passed in value is actually a valid case for the domain.
Now if someone updates the `export_tag` and passes in a invalid `case_type` an error will be shown to the user.
Paired with @biyeun and @avazirna 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15728
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
Tested locally
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Very small change, one additional check and does not alter the functionality in any way.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
