### PR TITLE
Fix unable to resolve field errors in Domain Settings Form

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -545,6 +545,8 @@ class DomainGlobalSettingsForm(forms.Form):
                 'logo',
                 hqcrispy.CheckboxField('delete_logo'),
             ])
+        if self.system_emails_logo_enabled:
+            extra_fields.append('logo_for_system_emails')
         if self.project.call_center_config.enabled:
             extra_fields.extend([
                 hqcrispy.CheckboxField('call_center_enabled'),

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -351,6 +351,11 @@ class DomainGlobalSettingsForm(forms.Form):
     delete_logo = BooleanField(
         label=gettext_lazy("Delete Logo"),
         required=False,
+        widget=BootstrapCheckboxInput(
+            inline_label=gettext_lazy(
+                "Delete Logo after Submitting this Form"
+            ),
+        ),
         help_text=gettext_lazy("Delete your custom logo and use the standard one.")
     )
     logo_for_system_emails = ImageField(
@@ -364,6 +369,11 @@ class DomainGlobalSettingsForm(forms.Form):
     call_center_enabled = BooleanField(
         label=gettext_lazy("Call Center Application"),
         required=False,
+        widget=BootstrapCheckboxInput(
+            inline_label=gettext_lazy(
+                "Enable Call Center Application"
+            ),
+        ),
         help_text=gettext_lazy("Call Center mode is a CommCare HQ module for managing "
                     "call center workflows. It is still under "
                     "active development. Do not enable for your domain unless "
@@ -436,8 +446,13 @@ class DomainGlobalSettingsForm(forms.Form):
     )
 
     release_mode_visibility = BooleanField(
-        label=gettext_lazy("Enable Release Mode"),
+        label=gettext_lazy("Release Mode"),
         required=False,
+        widget=BootstrapCheckboxInput(
+            inline_label=gettext_lazy(
+                "Enable Release Mode"
+            ),
+        ),
         help_text=gettext_lazy(
             """
             Check this box to enable release mode setting on the app release page.
@@ -449,8 +464,13 @@ class DomainGlobalSettingsForm(forms.Form):
     )
 
     orphan_case_alerts_warning = BooleanField(
-        label=gettext_lazy("Show Orphan Case Alerts on Mobile Worker Edit Page"),
+        label=gettext_lazy("Orphan Case Alerts"),
         required=False,
+        widget=BootstrapCheckboxInput(
+            inline_label=gettext_lazy(
+                "Show Orphan Case Alerts on Mobile Worker Edit Page"
+            ),
+        ),
         help_text=gettext_lazy(
             """
             Displays a warning message on the mobile worker location edit page
@@ -466,21 +486,6 @@ class DomainGlobalSettingsForm(forms.Form):
         self.domain = self.project.name
         self.can_use_custom_logo = kwargs.pop('can_use_custom_logo', False)
         super(DomainGlobalSettingsForm, self).__init__(*args, **kwargs)
-        self.helper = hqcrispy.HQFormHelper(self)
-        self.helper[5] = twbscrispy.PrependedText('delete_logo', '')
-        self.helper[7] = twbscrispy.PrependedText('call_center_enabled', '')
-        self.helper[15] = twbscrispy.PrependedText('release_mode_visibility', '')
-        self.helper[16] = twbscrispy.PrependedText('orphan_case_alerts_warning', '')
-        self.helper.all().wrap_together(crispy.Fieldset, _('Edit Basic Information'))
-        self.helper.layout.append(
-            hqcrispy.FormActions(
-                StrictButton(
-                    _("Update Basic Info"),
-                    type="submit",
-                    css_class='btn-primary',
-                )
-            )
-        )
         self.fields['default_timezone'].label = gettext_lazy('Default timezone')
 
         if not self.can_use_custom_logo:
@@ -510,6 +515,46 @@ class DomainGlobalSettingsForm(forms.Form):
         self._handle_account_confirmation_by_sms_settings()
         self._handle_release_mode_setting_value()
         self._handle_orphan_case_alerts_setting_value()
+
+        self.helper = hqcrispy.HQFormHelper(self)
+        self.helper.layout = crispy.Layout(
+            crispy.Fieldset(
+                _("Edit Basic Information"),
+                'hr_name',
+                'project_description',
+                'default_timezone',
+                crispy.Div(*self.get_extra_fields()),
+                hqcrispy.CheckboxField('release_mode_visibility'),
+                hqcrispy.CheckboxField('orphan_case_alerts_warning'),
+            ),
+            hqcrispy.FormActions(
+                StrictButton(
+                    _("Update Basic Info"),
+                    type="submit",
+                    css_class='btn-primary',
+                )
+            )
+        )
+
+    def get_extra_fields(self):
+        extra_fields = [
+            'default_geocoder_location',  # might be removed in subclass (only following original logic)
+        ]
+        if self.can_use_custom_logo:
+            extra_fields.extend([
+                'logo',
+                hqcrispy.CheckboxField('delete_logo'),
+            ])
+        if self.project.call_center_config.enabled:
+            extra_fields.extend([
+                hqcrispy.CheckboxField('call_center_enabled'),
+                'call_center_type',
+                'call_center_case_owner',
+                'call_center_case_type',
+            ])
+        if MOBILE_UCR.enabled(self.domain):
+            extra_fields.append('mobile_ucr_sync_interval')
+        return extra_fields
 
     def _handle_account_confirmation_by_sms_settings(self):
         if not TWO_STAGE_USER_PROVISIONING_BY_SMS.enabled(self.domain):
@@ -749,6 +794,16 @@ class DomainMetadataForm(DomainGlobalSettingsForm):
             del self.fields['cloudcare_releases']
         if not domain_has_privilege(self.domain, privileges.GEOCODER):
             del self.fields['default_geocoder_location']
+
+    def get_extra_fields(self):
+        extra_fields = super().get_extra_fields()
+        if not (self.project.cloudcare_releases == 'default'
+                or not domain_has_privilege(self.domain, privileges.CLOUDCARE)):
+            extra_fields.append('cloudcare_releases')
+        if (not domain_has_privilege(self.domain, privileges.GEOCODER)
+                and 'default_geocoder_location' in extra_fields):
+            extra_fields.remove('default_geocoder_location')
+        return extra_fields
 
     def save(self, request, domain):
         res = DomainGlobalSettingsForm.save(self, request, domain)

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -547,7 +547,7 @@ class DomainGlobalSettingsForm(forms.Form):
             ])
         if self.system_emails_logo_enabled:
             extra_fields.append('logo_for_system_emails')
-        if self.project.call_center_config.enabled:
+        if self.project and self.project.call_center_config.enabled:
             extra_fields.extend([
                 hqcrispy.CheckboxField('call_center_enabled'),
                 'call_center_type',


### PR DESCRIPTION


## Technical Summary
Not sure how this EVER worked, but the crispy forms helper should **never** be defined before fields are deleted from `self.fields`.

By default, the crispy layout is generated by all the available fields in `self.fields`. However, when fields from `self.fields` are deleted after establishing the crispy layout, "unable to resolve field" errors will be thrown when trying to render that form with crispy forms.

When I moved the helper definition to after the field deletion, the form loaded fine, but I also commented out all the
```
self.helper[x] = ....
```
assignments. I have no idea why this was decided as a good idea, as it's a VERY brittle way to overwrite fields in the crispy forms helper. I instead defined the crispy forms layout explicitly, as is recommended in our styleguide. I also updated the checkbox field usages to use the recommended widget and `crispy` `Field` subclass so that the checkboxes display correctly. Tested locally and on staging with no errors.

I intentionally left the order of the display logic alone as much as possible. Meaning that I didn't dig into why the `default_geocoder_location` was defined in `DomainGlobalSettingsForm` but removed in its subclass `DomainMetadataForm` if a condition was not met. This setup is a bit weird to me, however I just wanted to focus on fixing the errors with the crispy forms error here.

## Safety Assurance

### Safety story
Tested locally and on staging to make sure this form loads without errors (with all the feature flag options there or not)

### Automated test coverage
No

### QA Plan
Not needed. Fairly straightforward to test locally


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
