### PR TITLE
Fix duplicate web user invite due to case sensitive email matching

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -513,7 +513,7 @@ class AdminInvitesUserForm(SelectUserLocationForm):
                 choices = [('', '')] + list((prog.get_id, prog.name) for prog in programs)
                 self.fields['program'].choices = choices
 
-        self.excluded_emails = excluded_emails or []
+        self.excluded_emails = [x.lower() for x in excluded_emails] if excluded_emails else []
 
         if self.can_edit_tableau_config:
             self._initialize_tableau_fields(data, domain)
@@ -589,7 +589,7 @@ class AdminInvitesUserForm(SelectUserLocationForm):
 
     def clean_email(self):
         email = self.cleaned_data['email'].strip()
-        if email in self.excluded_emails:
+        if email.lower() in self.excluded_emails:
             raise forms.ValidationError(_("A user with this email address is already in "
                                           "this project or has a pending invitation."))
         return email

--- a/corehq/apps/registration/tests/test_forms.py
+++ b/corehq/apps/registration/tests/test_forms.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+from django.test import RequestFactory
+from testil import Regex
+
+from ..forms import AdminInvitesUserForm
+
+
+patch_query = patch.object(
+    AdminInvitesUserForm,
+    "_user_has_permission_to_access_locations",
+    lambda *ignore: True,
+)
+
+
+@patch_query
+def test_minimal_valid_form():
+    form = create_form()
+
+    assert form.is_valid(), form.errors
+
+
+@patch_query
+def test_form_is_invalid_when_invite_existing_email_with_case_mismatch():
+    form = create_form(
+        {"email": "test@TEST.com"},
+        excluded_emails=["TEST@test.com"],
+    )
+
+    msg = "this email address is already in this project"
+    assert not form.is_valid()
+    assert form.errors["email"] == [Regex(msg)], form.errors
+
+
+def create_form(data=None, **kw):
+    form_defaults = {"email": "test@test.com", "role": "admin"}
+    request = RequestFactory().post("/", form_defaults | (data or {}))
+    defaults = {
+        "domain": "test",
+        "request": request,
+        "excluded_emails": [],
+        "role_choices": [("admin", "admin")],
+    }
+    return AdminInvitesUserForm(request.POST, **(defaults | kw))


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-15772

## Safety Assurance

### Safety story

Change affects form validation logic only, and is covered by tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations