### PR TITLE
Fill in missing filename after broadcast within same question tile

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -50,6 +50,7 @@ hqDefine("cloudcare/js/form_entry/const", [], function () {
         // Note it's important to differentiate these two
         NO_PENDING_ANSWER: undefined,
         NO_ANSWER: null,
+        NO_FILE_SELECTED: "No file selected.",
 
         // UI
         LABEL_WIDTH: 'col-md-4',

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -50,7 +50,6 @@ hqDefine("cloudcare/js/form_entry/const", [], function () {
         // Note it's important to differentiate these two
         NO_PENDING_ANSWER: undefined,
         NO_ANSWER: null,
-        NO_FILE_SELECTED: "No file selected.",
 
         // UI
         LABEL_WIDTH: 'col-md-4',

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -931,10 +931,10 @@ hqDefine("cloudcare/js/form_entry/entries", [
         // Tracks whether file entry has already been cleared, preventing an additional failing request to Formplayer
         self.cleared = false;
         self.buildBroadcastTopics(options);
-        self.uploadFile = function() {
+        self.uploadFile = function () {
             document.getElementById(self.entryId).click();
-        }
-        self.fileNameDisplay = ko.observable(constants.NO_FILE_SELECTED)
+        };
+        self.fileNameDisplay = ko.observable(constants.NO_FILE_SELECTED);
     }
     FileEntry.prototype = Object.create(EntrySingleAnswer.prototype);
     FileEntry.prototype.constructor = EntrySingleAnswer;
@@ -942,7 +942,7 @@ hqDefine("cloudcare/js/form_entry/entries", [
         var self = this;
         if (newValue === "" && self.question.filename()) {
             self.question.hasAnswered = true;
-            self.fileNameDisplay(self.question.filename())
+            self.fileNameDisplay(self.question.filename());
         } else if (newValue !== constants.NO_ANSWER && newValue !== "") {
             // Input has changed and validation will be checked
             if (newValue !== self.answer()) {
@@ -950,7 +950,7 @@ hqDefine("cloudcare/js/form_entry/entries", [
                 self.cleared = false;
             }
             var fixedNewValue = newValue.replace(constants.FILE_PREFIX, "");
-            self.fileNameDisplay(fixedNewValue)
+            self.fileNameDisplay(fixedNewValue);
             self.answer(fixedNewValue);
         } else {
             self.onClear();

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -931,18 +931,27 @@ hqDefine("cloudcare/js/form_entry/entries", [
         // Tracks whether file entry has already been cleared, preventing an additional failing request to Formplayer
         self.cleared = false;
         self.buildBroadcastTopics(options);
+        self.uploadFile = function() {
+            document.getElementById(self.entryId).click();
+        }
+        self.fileNameDisplay = ko.observable(constants.NO_FILE_SELECTED)
     }
     FileEntry.prototype = Object.create(EntrySingleAnswer.prototype);
     FileEntry.prototype.constructor = EntrySingleAnswer;
     FileEntry.prototype.onPreProcess = function (newValue) {
         var self = this;
-        if (newValue !== constants.NO_ANSWER && newValue !== "") {
+        if (newValue === "" && self.question.filename()) {
+            self.question.hasAnswered = true;
+            self.fileNameDisplay(self.question.filename())
+        } else if (newValue !== constants.NO_ANSWER && newValue !== "") {
             // Input has changed and validation will be checked
             if (newValue !== self.answer()) {
                 self.question.formplayerMediaRequest = $.Deferred();
                 self.cleared = false;
             }
-            self.answer(newValue.replace(constants.FILE_PREFIX, ""));
+            var fixedNewValue = newValue.replace(constants.FILE_PREFIX, "");
+            self.fileNameDisplay(fixedNewValue)
+            self.answer(fixedNewValue);
         } else {
             self.onClear();
         }
@@ -950,7 +959,7 @@ hqDefine("cloudcare/js/form_entry/entries", [
     FileEntry.prototype.onAnswerChange = function (newValue) {
         var self = this;
         // file has already been validated and assigned a unique id. another request should not be sent to formplayer
-        if (self.question.formplayerMediaRequest.state() === "resolved") {
+        if (newValue === constants.NO_ANSWER || self.question.formplayerMediaRequest.state() === "resolved") {
             return;
         }
         if (newValue !== constants.NO_ANSWER && newValue !== "") {
@@ -1004,6 +1013,7 @@ hqDefine("cloudcare/js/form_entry/entries", [
         self.question.error(null);
         self.question.onClear();
         self.broadcastMessages(self.question, constants.NO_ANSWER);
+        self.fileNameDisplay(constants.NO_FILE_SELECTED);
     };
 
     /**

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -934,7 +934,7 @@ hqDefine("cloudcare/js/form_entry/entries", [
         self.uploadFile = function () {
             document.getElementById(self.entryId).click();
         };
-        self.fileNameDisplay = ko.observable(constants.NO_FILE_SELECTED);
+        self.fileNameDisplay = ko.observable(gettext("No file selected."));
     }
     FileEntry.prototype = Object.create(EntrySingleAnswer.prototype);
     FileEntry.prototype.constructor = EntrySingleAnswer;
@@ -1013,7 +1013,7 @@ hqDefine("cloudcare/js/form_entry/entries", [
         self.question.error(null);
         self.question.onClear();
         self.broadcastMessages(self.question, constants.NO_ANSWER);
-        self.fileNameDisplay(constants.NO_FILE_SELECTED);
+        self.fileNameDisplay(gettext("No file selected."));
     };
 
     /**

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -690,6 +690,14 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                 if (element.serverError) {
                     element.serverError(null);
                 }
+
+                if (allChildren) {
+                    for (let i = 0; i < allChildren.length; i++) {
+                        if (allChildren[i].control >= constants.CONTROL_IMAGE_CHOOSE) {
+                            allChildren[i].filename = element.answer();
+                        }
+                    }
+                }
                 response.children = allChildren;
                 self.fromJS(response);
             }

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_file.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_file.html
@@ -2,7 +2,7 @@
 
 <script type="text/html" id="file-entry-ko-template">
   <div class="d-flex align-items-center">
-    <input type="file" style="display: none;" data-bind="
+    <input type="file" class="d-none" data-bind="
           value: $data.rawAnswer,
           attr: {
               id: entryId,

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_file.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_file.html
@@ -2,15 +2,20 @@
 
 <script type="text/html" id="file-entry-ko-template">
   <div class="d-flex">
-    <input type="file" data-bind="
+    <input type="file" style="display: none;" data-bind="
           value: $data.rawAnswer,
-          css: { 'is-invalid': $parent.hasError() },
           attr: {
               id: entryId,
               'aria-required': $parent.required() ? 'true' : 'false',
               accept: accept,
           },
       "/>
+    <input type="button" value="Browse..." data-bind="
+          click: uploadFile,
+          css: { 'is-invalid': $parent.hasError() },
+          attr: {id: entryId}
+      "/>
+    <p data-bind="text: fileNameDisplay"></p>
     <button class="btn btn-outline-primary btn-sm" data-bind="
       click: onClear,
       text: $root.getTranslation('upload.clear.title', '{% trans_html_attr 'Clear' %}'),

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_file.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_file.html
@@ -1,7 +1,7 @@
 {% load hq_shared_tags %}
 
 <script type="text/html" id="file-entry-ko-template">
-  <div class="d-flex">
+  <div class="d-flex align-items-center">
     <input type="file" style="display: none;" data-bind="
           value: $data.rawAnswer,
           attr: {
@@ -10,12 +10,13 @@
               accept: accept,
           },
       "/>
-    <input type="button" value="Browse..." data-bind="
+    <button id="input-button-alt" class="btn btn-outline-primary" data-bind="
           click: uploadFile,
           css: { 'is-invalid': $parent.hasError() },
-          attr: {id: entryId}
-      "/>
-    <p data-bind="text: fileNameDisplay"></p>
+      ">
+      Browse...
+    </button>
+    <p data-bind="text: fileNameDisplay" style="margin-left: 7px; margin-right: auto;"></p>
     <button class="btn btn-outline-primary btn-sm" data-bind="
       click: onClear,
       text: $root.getTranslation('upload.clear.title', '{% trans_html_attr 'Clear' %}'),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

In the very specific scenario in which there's a multimedia question and a text question that receives the broadcasted filename of the upload AND they are both placed in the same question tile, the filename will disappear from the multimedia question and then claim there is not file there at all. This fixes that to work normally.

Due to some of the workarounds used the UI is now also slightly different:
Before:
<img width="273" alt="Screen Shot 2024-08-26 at 1 59 17 PM" src="https://github.com/user-attachments/assets/264f9156-ce82-41bb-a02f-50d41199ad7b">

After:
<img width="425" alt="Screen Shot 2024-08-26 at 1 58 10 PM" src="https://github.com/user-attachments/assets/1439c3d7-aeda-41be-89c6-18037e981b69">

The difference is much less noticeable in webapps. 

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4690)

This bug gave me a lot of trouble but it boils down to 2 realizations:
1. When a hidden question's display condition is met and needs to become visible, the whole question container needs to be regenerated so that it can now display the question. When the multimedia question is in the same container, this has the unintended effect of re-creating another multimedia question, this time unanswered and un-populated by a file upload. This is why the filename disappears and if the question is required, will raise an error about the question being blank. 
2. You can not edit the text of an input element. The "No file selected" text that's replaced by the filename is handled only by the element and no amount of JS trickery can change that. 

So I went another route and made a pseudo input element by having a button that points to the actual, hidden upload element and a fully controllable in-line text element. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Basically only changes UI but may have unknown consequences because this is a niche function (will go through QA). Doesn't interact with any data (the filename that it ends up displaying is not the internal, unique filename used to keep track of the media. 

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

[QA ticket](https://dimagi.atlassian.net/browse/QA-7039)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
