### PR TITLE
Gracefully removes mobile ucr version drop down from app advanced settings

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -157,7 +157,7 @@
     - ['2.0', '2.0']
   default: '2.0'
   disabled: true
-  disabled_txt: Oops! This setting has been discontinued. We recommend you change this setting to Version 2, and it will no longer appear on your settings page.
+  disabled_txt: This setting has been discontinued. We recommend you change this setting to Version 2. Upon doing so this setting will no longer appear on this page.
 
 
 - id: location_fixture_restore

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -154,10 +154,8 @@
   description: Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR+V2">Help Site</a>
   toggle: MOBILE_UCR
   values:
-    - ['1.0', '1.0']
-    - ['1.5', '1.5']
     - ['2.0', '2.0']
-  default: '1.0'
+  default: '2.0'
 
 - id: location_fixture_restore
   name: App Aware Location Fixture Format

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -156,6 +156,9 @@
   values:
     - ['2.0', '2.0']
   default: '2.0'
+  disabled: true
+  disabled_txt: Oops! This setting has been discontinued. We recommend you change this setting to Version 2, and it will no longer appear on your settings page.
+
 
 - id: location_fixture_restore
   name: App Aware Location Fixture Format

--- a/corehq/apps/app_manager/static_strings.py
+++ b/corehq/apps/app_manager/static_strings.py
@@ -142,6 +142,8 @@ STATICALLY_ANALYZABLE_TRANSLATIONS = [
     gettext_noop('Only Flat Fixture'),
     gettext_noop('Only Hierarchical Fixture'),
     gettext_noop('Oops! This setting has been discontinued. We recommend you change this setting to Version 2, and it will no longer appear on your settings page.'),
+    gettext_noop('This setting has been discontinued. We recommend you change this setting to Version 2.'
+                 ' Upon doing so this setting will no longer appear on this page.'),
     gettext_noop('Practice Mobile Worker'),
     gettext_noop('Prevents mobile workers from using a CommCare app until the '
                  'Android apps that it needs have been installed on the '


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

> NOTE: This PR will not be merged unless all apps are migrated to v2 first. The migration work is planned and will be picked up soon.

This is only UI change where it gracefully removes mobile ucr version drop down from app advanced settings.

This uses an existing way to disable a setting and works as below
- if the app is on the intended version, then the setting is not shown.
- f the app is not on the intended version , the setting is shown with a user friendly message to ask user to select the correct version.

**Demo:**

https://github.com/user-attachments/assets/2e214274-d9c3-462a-af05-95b58ced8aeb


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-3760)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Mobile UCR Feature Flag

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing done. Small UI change which is safe and non-breaking.
Also tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
