### PR TITLE
Fix Bulk Actions on Repeat Records Report

### DIFF
--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -214,25 +214,11 @@ def task_generate_ids_and_operate_on_payloads(
     domain: str,
     action,  # type: Literal['resend', 'cancel', 'requeue']  # 3.8+
 ) -> dict:
-    repeat_record_ids = _get_repeat_record_ids(payload_id, repeater_id, domain)
+    repeat_record_ids = RepeatRecord.objects.get_repeat_record_ids(
+        domain, repeater_id=repeater_id, payload_id=payload_id
+    )
     return operate_on_payloads(repeat_record_ids, domain, action,
                                task=task_generate_ids_and_operate_on_payloads)
-
-
-def _get_repeat_record_ids(payload_id, repeater_id, domain):
-    if payload_id:
-        queryset = RepeatRecord.objects.filter(
-            domain=domain,
-            payload_id=payload_id,
-        )
-    elif repeater_id:
-        queryset = RepeatRecord.objects.filter(
-            domain=domain,
-            repeater__id=repeater_id,
-        )
-    else:
-        return []
-    return list(queryset.order_by().values_list("id", flat=True))
 
 
 @task

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -213,9 +213,10 @@ def task_generate_ids_and_operate_on_payloads(
     repeater_id: Optional[str],
     domain: str,
     action,  # type: Literal['resend', 'cancel', 'requeue']  # 3.8+
+    state=None,
 ) -> dict:
     repeat_record_ids = RepeatRecord.objects.get_repeat_record_ids(
-        domain, repeater_id=repeater_id, payload_id=payload_id
+        domain, repeater_id=repeater_id, state=state, payload_id=payload_id,
     )
     return operate_on_payloads(repeat_record_ids, domain, action,
                                task=task_generate_ids_and_operate_on_payloads)

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -20,6 +20,7 @@ from corehq.apps.hqcase.utils import AUTO_UPDATE_XMLNS
 from corehq.apps.users.models import CouchUser
 from corehq.form_processor.models import XFormInstance
 from corehq.apps.case_importer.do_import import SubmitCaseBlockHandler, RowAndCase
+from corehq.motech.repeaters.const import State
 from corehq.motech.repeaters.models import RepeatRecord
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from corehq.toggles import DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK
@@ -212,8 +213,8 @@ def task_generate_ids_and_operate_on_payloads(
     payload_id: Optional[str],
     repeater_id: Optional[str],
     domain: str,
-    action,  # type: Literal['resend', 'cancel', 'requeue']  # 3.8+
-    state=None,
+    action: Literal['resend', 'cancel', 'requeue'],
+    state: Literal[None, State.Pending, State.Cancelled] = None,
 ) -> dict:
     repeat_record_ids = RepeatRecord.objects.get_repeat_record_ids(
         domain, repeater_id=repeater_id, state=state, payload_id=payload_id,

--- a/corehq/apps/data_interfaces/tests/test_tasks.py
+++ b/corehq/apps/data_interfaces/tests/test_tasks.py
@@ -1,4 +1,4 @@
-from unittest.case import TestCase
+from django.test import SimpleTestCase
 from unittest.mock import patch
 
 from corehq.apps.data_interfaces.tasks import (
@@ -7,7 +7,7 @@ from corehq.apps.data_interfaces.tasks import (
 )
 
 
-class TestTasks(TestCase):
+class TestTasks(SimpleTestCase):
 
     @patch('corehq.apps.data_interfaces.utils.DownloadBase')
     @patch('corehq.apps.data_interfaces.utils._get_sql_repeat_record')
@@ -43,13 +43,14 @@ class TestTasks(TestCase):
 
     @patch('corehq.apps.data_interfaces.utils.DownloadBase')
     @patch('corehq.apps.data_interfaces.utils._get_sql_repeat_record')
-    @patch('corehq.apps.data_interfaces.tasks._get_repeat_record_ids')
+    @patch('corehq.apps.data_interfaces.tasks.RepeatRecord.objects.get_repeat_record_ids')
     def test_task_generate_ids_and_operate_on_payloads_no_action(
         self,
         get_repeat_record_ids_mock,
         unused_1,
         unused_2,
     ):
+
         get_repeat_record_ids_mock.return_value = ['c0ffee', 'deadbeef']
         response = task_generate_ids_and_operate_on_payloads(
             payload_id='c0ffee',
@@ -70,7 +71,9 @@ class TestTasks(TestCase):
             }
         })
 
-    def test_task_generate_ids_and_operate_on_payloads_no_data(self):
+    @patch('corehq.apps.data_interfaces.tasks.RepeatRecord.objects.get_repeat_record_ids')
+    def test_task_generate_ids_and_operate_on_payloads_no_data(self, get_repeat_record_ids_mock):
+        get_repeat_record_ids_mock.return_value = []
         response = task_generate_ids_and_operate_on_payloads(
             payload_id=None,
             repeater_id=None,

--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -32,7 +32,7 @@ class TestTasks(TestCase):
 
         mock_get_repeat_record_ids.assert_called_once()
         mock_get_repeat_record_ids.assert_called_with(
-            'test_domain', repeater_id='deadbeef', payload_id='c0ffee')
+            'test_domain', repeater_id='deadbeef', state=None, payload_id='c0ffee')
 
         mock_operate_on_payloads.assert_called_once()
         mock_operate_on_payloads.assert_called_with(

--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -1,70 +1,12 @@
-from datetime import datetime
 from unittest.mock import Mock, patch
-from uuid import uuid4
 
-from django.test import SimpleTestCase, TestCase
+from django.test import TestCase
 
-from corehq.apps.data_interfaces.tasks import (
-    _get_repeat_record_ids,
-    task_generate_ids_and_operate_on_payloads,
-)
-from corehq.apps.data_interfaces.utils import (
-    _get_sql_repeat_record,
-    operate_on_payloads,
-)
-from corehq.motech.models import ConnectionSettings
-from corehq.motech.repeaters.models import FormRepeater, RepeatRecord
+from corehq.apps.data_interfaces.tasks import task_generate_ids_and_operate_on_payloads
+from corehq.apps.data_interfaces.utils import operate_on_payloads
+
 
 DOMAIN = 'test-domain'
-
-
-class TestUtils(SimpleTestCase):
-
-    def test__get_ids_no_data(self):
-        response = _get_repeat_record_ids(None, None, 'test_domain')
-        self.assertEqual(response, [])
-
-    @patch('corehq.apps.data_interfaces.tasks.RepeatRecord.objects.filter')
-    def test__get_ids_payload_id_in_data(self, get_by_payload_id):
-        payload_id = Mock()
-        _get_repeat_record_ids(payload_id, None, 'test_domain')
-
-        self.assertEqual(get_by_payload_id.call_count, 1)
-        get_by_payload_id.assert_called_with(domain='test_domain', payload_id=payload_id)
-
-    @patch('corehq.apps.data_interfaces.tasks.RepeatRecord.objects.filter')
-    def test__get_ids_payload_id_not_in_data(self, iter_by_repeater):
-        REPEATER_ID = 'c0ffee'
-        _get_repeat_record_ids(None, REPEATER_ID, 'test_domain')
-
-        iter_by_repeater.assert_called_with(domain='test_domain', repeater__id=REPEATER_ID)
-        self.assertEqual(iter_by_repeater.call_count, 1)
-
-    @patch('corehq.motech.repeaters.models.RepeatRecord.objects')
-    def test__validate_record_record_does_not_exist(self, mock_objects):
-        mock_objects.get.side_effect = [RepeatRecord.DoesNotExist]
-        response = _get_sql_repeat_record('test_domain', '1234')
-
-        mock_objects.get.assert_called_once_with(domain='test_domain', id='1234')
-        self.assertIsNone(response)
-
-    @patch('corehq.motech.repeaters.models.RepeatRecord.objects')
-    def test__validate_record_invalid_domain(self, mock_objects):
-        mock_objects.get.side_effect = RepeatRecord.DoesNotExist
-        response = _get_sql_repeat_record('test_domain', '1234')
-
-        mock_objects.get.assert_called_once_with(domain='test_domain', id='1234')
-        self.assertIsNone(response)
-
-    @patch('corehq.motech.repeaters.models.RepeatRecord.objects')
-    def test__validate_record_success(self, mock_objects):
-        mock_record = Mock()
-        mock_record.domain = 'test_domain'
-        mock_objects.get.return_value = mock_record
-        response = _get_sql_repeat_record('test_domain', '1234')
-
-        mock_objects.get.assert_called_once_with(domain='test_domain', id='1234')
-        self.assertEqual(response, mock_record)
 
 
 class TestTasks(TestCase):
@@ -75,22 +17,22 @@ class TestTasks(TestCase):
         self.mock_payload_ids = [self.mock_payload_one.id,
                                  self.mock_payload_two.id]
 
-    @patch('corehq.apps.data_interfaces.tasks._get_repeat_record_ids')
+    @patch('corehq.apps.data_interfaces.tasks.RepeatRecord.objects.get_repeat_record_ids')
     @patch('corehq.apps.data_interfaces.tasks.operate_on_payloads')
     def test_generate_ids_and_operate_on_payloads_success(
         self,
         mock_operate_on_payloads,
-        mock__get_ids,
+        mock_get_repeat_record_ids,
     ):
-        mock__get_ids.return_value = record_ids = [1, 2, 3]
+        mock_get_repeat_record_ids.return_value = record_ids = [1, 2, 3]
         payload_id = 'c0ffee'
         repeater_id = 'deadbeef'
         task_generate_ids_and_operate_on_payloads(
             payload_id, repeater_id, 'test_domain', 'test_action')
 
-        mock__get_ids.assert_called_once()
-        mock__get_ids.assert_called_with(
-            'c0ffee', 'deadbeef', 'test_domain')
+        mock_get_repeat_record_ids.assert_called_once()
+        mock_get_repeat_record_ids.assert_called_with(
+            'test_domain', repeater_id='deadbeef', payload_id='c0ffee')
 
         mock_operate_on_payloads.assert_called_once()
         mock_operate_on_payloads.assert_called_with(
@@ -469,43 +411,3 @@ class TestTasks(TestCase):
         self.assertEqual(mock_payload_one.requeue.call_count, 1)
         self.assertEqual(mock_payload_two.requeue.call_count, 0)
         self.assertEqual(response, expected_response)
-
-
-class TestGetRepeatRecordIDs(TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.instance_id = str(uuid4())
-        url = 'https://www.example.com/api/'
-        conn = ConnectionSettings.objects.create(domain=DOMAIN, name=url, url=url)
-        cls.repeater = FormRepeater(
-            domain=DOMAIN,
-            connection_settings_id=conn.id,
-            include_app_id_param=False,
-        )
-        cls.repeater.save()
-        cls.create_repeat_records()
-
-    @classmethod
-    def create_repeat_records(cls):
-        now = datetime.now()
-        cls.sql_records = [RepeatRecord(
-            domain=DOMAIN,
-            repeater_id=cls.repeater.id,
-            payload_id=cls.instance_id,
-            registered_at=now,
-        ) for __ in range(3)]
-        RepeatRecord.objects.bulk_create(cls.sql_records)
-
-    def test_no_payload_id_no_repeater_id_sql(self):
-        result = _get_repeat_record_ids(payload_id=None, repeater_id=None, domain=DOMAIN)
-        self.assertEqual(result, [])
-
-    def test_payload_id_sql(self):
-        result = _get_repeat_record_ids(payload_id=self.instance_id, repeater_id=None, domain=DOMAIN)
-        self.assertEqual(set(result), {r.pk for r in self.sql_records})
-
-    def test_repeater_id_sql(self):
-        result = _get_repeat_record_ids(payload_id=None, repeater_id=self.repeater.repeater_id, domain=DOMAIN)
-        self.assertEqual(set(result), {r.pk for r in self.sql_records})

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/repeaters/js/repeat_record_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/repeaters/js/repeat_record_report.js.diff.txt
@@ -1,36 +1,37 @@
 --- 
 +++ 
-@@ -1,5 +1,5 @@
+@@ -1,6 +1,6 @@
  /* globals ace */
+ 'use strict';
 -hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
 +hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
-     var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+     const initialPageData = hqImport("hqwebapp/js/initial_page_data"),
          selectAll = document.getElementById('select-all'),
-         cancelAll = document.getElementById('cancel-all'),
-@@ -138,7 +138,7 @@
-         $('#confirm-button').on('click', function () {
-             var itemsToSend = getCheckboxes(), action = getAction(), $btn;
+         selectPending = document.getElementById('select-pending'),
+@@ -142,7 +142,7 @@
+                 action = getAction();
+             let $btn;
  
 -            $popUp.modal('hide');
 +            $popUp.modal('hide');  /* todo B5: plugin:modal */
-             if (action == 'resend') {
+             if (action === 'resend') {
                  $btn = $('#resend-all-button');
                  $btn.disableButton();
-@@ -159,7 +159,7 @@
+@@ -166,7 +166,7 @@
+                 // leaving as is to preserve behavior
                  if (isActionPossibleForCheckedItems(action)) {
-                     $('#warning').addClass('hide');
-                     $('#not-allowed').addClass('hide');
+                     hideAllWarnings();
 -                    $popUp.modal('show');
 +                    $popUp.modal('show');  /* todo B5: plugin:modal */
                  } else {
-                     $('#warning').addClass('hide');
-                     $('#not-allowed').removeClass('hide');
-@@ -244,7 +244,7 @@
+                     showWarning('not-allowed');
+                 }
+@@ -251,7 +251,7 @@
                      } else {
                          btn.text(gettext('Failed'));
                          btn.addClass('btn-danger');
 -                        $('#payload-error-modal').modal('show');
 +                        $('#payload-error-modal').modal('show');  /* todo B5: plugin:modal */
-                         $('#payload-error-modal .error-message').text(data.failure_reason);
+                         $('#payload-error-modal .error-message').text(response.failure_reason);
                      }
                  },

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/repeaters/js/repeat_record_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/repeaters/js/repeat_record_report.js.diff.txt
@@ -17,16 +17,16 @@
              if (action === 'resend') {
                  $btn = $('#resend-all-button');
                  $btn.disableButton();
-@@ -166,7 +166,7 @@
+@@ -167,7 +167,7 @@
                  // leaving as is to preserve behavior
-                 if (isActionPossibleForCheckedItems(action)) {
+                 if (isActionPossibleForCheckedItems(action, checkedRecords)) {
                      hideAllWarnings();
 -                    $popUp.modal('show');
 +                    $popUp.modal('show');  /* todo B5: plugin:modal */
                  } else {
                      showWarning('not-allowed');
                  }
-@@ -251,7 +251,7 @@
+@@ -240,7 +240,7 @@
                      } else {
                          btn.text(gettext('Failed'));
                          btn.addClass('btn-danger');

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/repeaters/repeat_record_report.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/repeaters/repeat_record_report.html.diff.txt
@@ -50,29 +50,29 @@
                {% trans 'Requeue' %}
              </button>
 -            <label class="checkbox" >
--              <input type="checkbox" id="select-all" data-id="{{ form_query_string|urlencode }}">
+-              <input type="checkbox" id="select-all">
 +            <label class="checkbox" >  {# todo B5: css:checkbox #}
-+              <input type="checkbox" id="select-all" data-id="{{ form_query_string|urlencode }}">  {# todo B5: css:checkbox #}
++              <input type="checkbox" id="select-all">  {# todo B5: css:checkbox #}
                  {% blocktrans %}Select all {{ total }} payloads{% endblocktrans %}
              </label>
 -            <label class="checkbox" >
--              <input type="checkbox" id="cancel-all" data-id="{{ form_query_string_pending|urlencode }}">
+-              <input type="checkbox" id="select-pending">
 +            <label class="checkbox" >  {# todo B5: css:checkbox #}
-+              <input type="checkbox" id="cancel-all" data-id="{{ form_query_string_pending|urlencode }}">  {# todo B5: css:checkbox #}
++              <input type="checkbox" id="select-pending">  {# todo B5: css:checkbox #}
                  {% blocktrans %}Select {{ total_pending }} pending payloads{% endblocktrans %}
              </label>
 -            <label class="checkbox" >
--              <input type="checkbox" id="requeue-all" data-id="{{ form_query_string_cancelled|urlencode }}">
+-              <input type="checkbox" id="select-cancelled">
 +            <label class="checkbox" >  {# todo B5: css:checkbox #}
-+              <input type="checkbox" id="requeue-all" data-id="{{ form_query_string_cancelled|urlencode }}">  {# todo B5: css:checkbox #}
++              <input type="checkbox" id="select-cancelled">  {# todo B5: css:checkbox #}
                  {% blocktrans %}Select {{ total_cancelled }} cancelled payloads{% endblocktrans %}
              </label>
            </div>
          </div>
        {% endif %}
    </div>
--  <div id="warning" class="alert alert-warning hide">
-+  <div id="warning" class="alert alert-warning d-none">
+-  <div id="no-selection" class="alert alert-warning hide">
++  <div id="no-selection" class="alert alert-warning d-none">
      {% blocktrans %}Please select at least one payload{% endblocktrans %}
    </div>
 -  <div id="not-allowed" class="alert alert-warning hide">
@@ -98,7 +98,7 @@
              {% blocktrans %}No{% endblocktrans %}
            </button>
            <button type="button" id="confirm-button" data-action="" data-flag="" class="btn btn-primary">
-@@ -98,8 +98,8 @@
+@@ -100,8 +100,8 @@
      <div class="modal fade full-screen-modal" id="view-record-payload-modal" tabindex="-1" role="dialog">
          <div class="modal-dialog" role="document">
              <div class="modal-content">
@@ -109,7 +109,7 @@
                      </button>
                      <h4 class="modal-title">{% trans "Payload" %}</h4>
                  </div>
-@@ -107,7 +107,7 @@
+@@ -109,7 +109,7 @@
                      <div class="payload"></div>
                  </div>
                  <div class="modal-footer">
@@ -118,7 +118,7 @@
                      {% trans "Close" %}
                      </button>
                  </div>
-@@ -119,8 +119,8 @@
+@@ -121,8 +121,8 @@
      <div class="modal fade" id="payload-error-modal" tabindex="-1" role="dialog">
          <div class="modal-dialog" role="document">
              <div class="modal-content">
@@ -127,9 +127,9 @@
 +                <div class="modal-header">  {# todo B5: css:modal-header #}
 +                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span>  {# todo B5: css:close #}
                      </button>
-                     <h4 class="modal-title">{% trans "Payload Error" %}</h4>
+                     <h4 class="modal-title">{% trans "Error" %}</h4>
                  </div>
-@@ -128,7 +128,7 @@
+@@ -130,7 +130,7 @@
                      <div class="error-message"></div>
                  </div>
                  <div class="modal-footer">

--- a/corehq/motech/repeaters/exceptions.py
+++ b/corehq/motech/repeaters/exceptions.py
@@ -23,3 +23,7 @@ class UnknownRepeater(Exception):
 
     def __str__(self):
         return self.message
+
+
+class BulkActionMissingParameters(Exception):
+    pass

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -965,6 +965,17 @@ class RepeatRecordManager(models.Manager):
     def get_domains_with_records(self):
         return self.order_by().values_list("domain", flat=True).distinct()
 
+    def get_repeat_record_ids(self, domain, repeater_id=None, state=None, payload_id=None):
+        where = models.Q(domain=domain)
+        if repeater_id:
+            where &= models.Q(repeater__id=repeater_id)
+        if state:
+            where &= models.Q(state=state)
+        if payload_id:
+            where &= models.Q(payload_id=payload_id)
+
+        return list(self.filter(where).order_by().values_list("id", flat=True))
+
 
 class RepeatRecord(models.Model):
     domain = models.CharField(max_length=126)

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
@@ -4,7 +4,7 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         selectAll = document.getElementById('select-all'),
         cancelAll = document.getElementById('cancel-all'),
         requeueAll = document.getElementById('requeue-all'),
-        $popUp = $('#are-you-sure');
+        $popUp = $('#are-you-sure'),
         $confirmButton = $('#confirm-button');
 
     $(function () {
@@ -136,18 +136,19 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         });
 
         $('#confirm-button').on('click', function () {
-            var itemsToSend = getCheckboxes(), action = getAction(), $btn;
-
+            var itemsToSend = getCheckboxes(),
+                action = getAction(),
+                $btn;
             $popUp.modal('hide');
-            if (action == 'resend') {
+            if (action === 'resend') {
                 $btn = $('#resend-all-button');
                 $btn.disableButton();
                 postResend($btn, itemsToSend);
-            } else if (action == 'cancel') {
+            } else if (action === 'cancel') {
                 $btn = $('#cancel-all-button');
                 $btn.disableButton();
                 postOther($btn, itemsToSend, action);
-            } else if (action == 'requeue') {
+            } else if (action === 'requeue') {
                 $btn = $('#requeue-all-button');
                 $btn.disableButton();
                 postOther($btn, itemsToSend, action);

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
@@ -1,6 +1,7 @@
 /* globals ace */
+'use strict';
 hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
-    var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+    const initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         selectAll = document.getElementById('select-all'),
         selectPending = document.getElementById('select-pending'),
         selectCancelled = document.getElementById('select-cancelled'),
@@ -48,16 +49,17 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
                 },
             });
         });
-        var editor = null;
+
+        let editor = null;
         $('#view-record-payload-modal').on('shown.bs.modal', function (event) {
-            var recordData = $(event.relatedTarget).data(),
+            const recordData = $(event.relatedTarget).data(),
                 $modal = $(this);
 
             $.get({
                 url: initialPageData.reverse("repeat_record"),
                 data: { record_id: recordData.recordId },
                 success: function (data) {
-                    var $payload = $modal.find('.payload'),
+                    const $payload = $modal.find('.payload'),
                         contentType = data.content_type;
 
                     if (editor === null) {
@@ -82,7 +84,7 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
                     editor.session.setValue(data.payload);
                 },
                 error: function (data) {
-                    var defaultText = gettext('Failed to fetch payload'),
+                    const defaultText = gettext('Failed to fetch payload'),
                         errorMessage = data.responseJSON ? data.responseJSON.error : null;
 
                     $modal.find('.modal-body').text(errorMessage || defaultText);
@@ -97,7 +99,7 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         });
 
         $('#report-content').on('click', '.resend-record-payload', function () {
-            var $btn = $(this),
+            const $btn = $(this),
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
@@ -110,7 +112,7 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         });
 
         $('#report-content').on('click', '.cancel-record-payload', function () {
-            var $btn = $(this),
+            const $btn = $(this),
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
@@ -123,7 +125,7 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         });
 
         $('#report-content').on('click', '.requeue-record-payload', function () {
-            var $btn = $(this),
+            const $btn = $(this),
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
@@ -136,9 +138,10 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         });
 
         $('#confirm-button').on('click', function () {
-            var requestBody = getRequestBody(),
-                action = getAction(),
-                $btn;
+            const requestBody = getRequestBody(),
+                action = getAction();
+            let $btn;
+
             $popUp.modal('hide');
             if (action === 'resend') {
                 $btn = $('#resend-all-button');
@@ -156,7 +159,7 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         });
 
         function performAction(action) {
-            var bulkSelection = bulkSelectionChecked();
+            const bulkSelection = bulkSelectionChecked();
             if (bulkSelection || areRecordsChecked()) {
                 if (bulkSelection) { setFlag(bulkSelection); }
                 // only applies to checked items, not bulk selections
@@ -183,8 +186,8 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         }
 
         function areRecordsChecked() {
-            var items = document.getElementsByName('xform_ids');
-            for (var item of items) {
+            const items = document.getElementsByName('xform_ids');
+            for (const item of items) {
                 if (item.checked) {
                     return true;
                 }
@@ -193,13 +196,13 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         }
 
         function isActionPossibleForCheckedItems(action) {
-            var items = document.getElementsByName('xform_ids');
-            for (var item of items) {
+            const items = document.getElementsByName('xform_ids');
+            for (const item of items) {
                 if (item.checked) {
-                    var id = item.getAttribute('data-id');
-                    var query = '[data-record-id="' + id + '"][class="btn btn-default ' + action + '-record-payload"]';
-                    var button = document.querySelector(query);
-                    if (button == null) {
+                    const id = item.getAttribute('data-id');
+                    const query = `[data-record-id="${id}"][class="btn btn-default ${action}-record-payload"]`;
+                    const button = document.querySelector(query);
+                    if (!button) {
                         return false;
                     }
                 }
@@ -226,10 +229,10 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         }
 
         function getRecordIds() {
-            var records = document.getElementsByName('xform_ids'),
-                recordIds = '';
-            for (var record of records) {
-                if (record.type == 'checkbox' && record.checked == true) {
+            const recordEls = document.getElementsByName('xform_ids');
+            let recordIds = '';
+            for (const record of recordEls) {
+                if (record.type === 'checkbox' && record.checked) {
                     recordIds += record.getAttribute('data-id') + ' ';
                 }
             }

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
@@ -160,11 +160,12 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
 
         function performAction(action) {
             const bulkSelection = bulkSelectionChecked();
-            if (bulkSelection || areRecordsChecked()) {
+            const checkedRecords = getCheckedRecords();
+            if (bulkSelection || checkedRecords.length > 0) {
                 if (bulkSelection) { setFlag(bulkSelection); }
                 // only applies to checked items, not bulk selections
                 // leaving as is to preserve behavior
-                if (isActionPossibleForCheckedItems(action)) {
+                if (isActionPossibleForCheckedItems(action, checkedRecords)) {
                     hideAllWarnings();
                     $popUp.modal('show');
                 } else {
@@ -185,26 +186,17 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
             }
         }
 
-        function areRecordsChecked() {
-            const items = document.getElementsByName('xform_ids');
-            for (const item of items) {
-                if (item.checked) {
-                    return true;
-                }
-            }
-            return false;
+        function getCheckedRecords() {
+            return $.find('input[type=checkbox][name=xform_ids]:checked');
         }
 
-        function isActionPossibleForCheckedItems(action) {
-            const items = document.getElementsByName('xform_ids');
+        function isActionPossibleForCheckedItems(action, items) {
             for (const item of items) {
-                if (item.checked) {
-                    const id = item.getAttribute('data-id');
-                    const query = `[data-record-id="${id}"][class="btn btn-default ${action}-record-payload"]`;
-                    const button = document.querySelector(query);
-                    if (!button) {
-                        return false;
-                    }
+                const id = item.getAttribute('data-id');
+                const query = `[data-record-id="${id}"][class="btn btn-default ${action}-record-payload"]`;
+                const button = document.querySelector(query);
+                if (!button) {
+                    return false;
                 }
             }
 
@@ -229,13 +221,10 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         }
 
         function getRecordIds() {
-            const recordEls = document.getElementsByName('xform_ids');
-            let recordIds = '';
-            for (const record of recordEls) {
-                if (record.type === 'checkbox' && record.checked) {
-                    recordIds += record.getAttribute('data-id') + ' ';
-                }
-            }
+            const recordEls = getCheckedRecords();
+            const recordIds = recordEls.map(
+                record => record.getAttribute('data-id')
+            ).join(' ');
             return {record_id: recordIds};
         }
 

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
@@ -156,49 +156,47 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         });
 
         function performAction(action) {
-            if (isAnythingChecked()) {
+            var bulkSelection = bulkSelectionChecked();
+            if (bulkSelection || areRecordsChecked()) {
+                if (bulkSelection) { setFlag(bulkSelection); }
+                // only applies to checked items, not bulk selections
+                // leaving as is to preserve behavior
                 if (isActionPossibleForCheckedItems(action)) {
-                    $('#warning').addClass('hide');
-                    $('#not-allowed').addClass('hide');
+                    hideAllWarnings();
                     $popUp.modal('show');
                 } else {
-                    $('#warning').addClass('hide');
-                    $('#not-allowed').removeClass('hide');
+                    showWarning('not-allowed');
                 }
             } else {
-                $('#warning').removeClass('hide');
-                $('#not-allowed').addClass('hide');
+                showWarning('no-selection');
             }
         }
 
-        function isAnythingChecked() {
-            var items = document.getElementsByName('xform_ids');
-
+        function bulkSelectionChecked() {
             if (selectAll.checked) {
-                setFlag('select_all');
-                return true;
+                return 'select_all';
             } else if (selectPending.checked) {
-                setFlag('select_pending');
-                return true;
+                return 'select_pending';
             } else if (selectCancelled.checked) {
-                setFlag('select_cancelled');
-                return true;
+                return 'select_cancelled';
             }
+        }
 
-            for (var i = 0; i < items.length; i++) {
-                if (items[i].checked) {
+        function areRecordsChecked() {
+            var items = document.getElementsByName('xform_ids');
+            for (var item of items) {
+                if (item.checked) {
                     return true;
                 }
             }
-
             return false;
         }
 
         function isActionPossibleForCheckedItems(action) {
             var items = document.getElementsByName('xform_ids');
-            for (var i = 0; i < items.length; i++) {
-                if (items[i].checked) {
-                    var id = items[i].getAttribute('data-id');
+            for (var item of items) {
+                if (item.checked) {
+                    var id = item.getAttribute('data-id');
                     var query = '[data-record-id="' + id + '"][class="btn btn-default ' + action + '-record-payload"]';
                     var button = document.querySelector(query);
                     if (button == null) {
@@ -291,6 +289,21 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
 
         function getFlag() {
             return $confirmButton.attr('data-flag');
+        }
+
+        function showWarning(reason) {
+            if (reason === 'no-selection') {
+                $('#no-selection').removeClass('hide');
+                $('#not-allowed').addClass('hide');
+            } else if (reason === 'not-allowed') {
+                $('#not-allowed').removeClass('hide');
+                $('#no-selection').addClass('hide');
+            }
+        }
+
+        function hideAllWarnings() {
+            $('#no-selection').addClass('hide');
+            $('#not-allowed').addClass('hide');
         }
     });
 });

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
@@ -103,7 +103,7 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
-            postResend($btn, recordId);
+            postResend($btn, {'record_id': recordId});
         });
 
         $('#resend-all-button').on('click', function () {
@@ -116,7 +116,7 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
-            postOther($btn, recordId, 'cancel');
+            postOther($btn, {'record_id': recordId}, 'cancel');
         });
 
         $('#cancel-all-button').on('click', function () {
@@ -129,7 +129,7 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
-            postOther($btn, recordId, 'requeue');
+            postOther($btn, {'record_id': recordId}, 'requeue');
         });
 
         $('#requeue-all-button').on('click', function () {

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
@@ -2,8 +2,8 @@
 hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
     var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         selectAll = document.getElementById('select-all'),
-        cancelAll = document.getElementById('cancel-all'),
-        requeueAll = document.getElementById('requeue-all'),
+        selectPending = document.getElementById('select-pending'),
+        selectCancelled = document.getElementById('select-cancelled'),
         $popUp = $('#are-you-sure'),
         $confirmButton = $('#confirm-button');
 
@@ -177,11 +177,11 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
             if (selectAll.checked) {
                 setFlag('select_all');
                 return true;
-            } else if (cancelAll.checked) {
-                setFlag('cancel_all');
+            } else if (selectPending.checked) {
+                setFlag('select_pending');
                 return true;
-            } else if (requeueAll.checked) {
-                setFlag('requeue_all');
+            } else if (selectCancelled.checked) {
+                setFlag('select_cancelled');
                 return true;
             }
 
@@ -213,10 +213,10 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
         function getCheckboxes() {
             if (selectAll.checked) {
                 return selectAll.getAttribute('data-id');
-            } else if (cancelAll.checked) {
-                return cancelAll.getAttribute('data-id');
-            } else if (requeueAll.checked) {
-                return requeueAll.getAttribute('data-id');
+            } else if (selectPending.checked) {
+                return selectPending.getAttribute('data-id');
+            } else if (selectCancelled.checked) {
+                return selectCancelled.getAttribute('data-id');
             } else {
                 var items = document.getElementsByName('xform_ids'),
                     itemsToSend = '';

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
@@ -1,6 +1,7 @@
 /* globals ace */
+'use strict';
 hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
-    var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+    const initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         selectAll = document.getElementById('select-all'),
         selectPending = document.getElementById('select-pending'),
         selectCancelled = document.getElementById('select-cancelled'),
@@ -48,16 +49,17 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
                 },
             });
         });
-        var editor = null;
+
+        let editor = null;
         $('#view-record-payload-modal').on('shown.bs.modal', function (event) {
-            var recordData = $(event.relatedTarget).data(),
+            const recordData = $(event.relatedTarget).data(),
                 $modal = $(this);
 
             $.get({
                 url: initialPageData.reverse("repeat_record"),
                 data: { record_id: recordData.recordId },
                 success: function (data) {
-                    var $payload = $modal.find('.payload'),
+                    const $payload = $modal.find('.payload'),
                         contentType = data.content_type;
 
                     if (editor === null) {
@@ -82,7 +84,7 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
                     editor.session.setValue(data.payload);
                 },
                 error: function (data) {
-                    var defaultText = gettext('Failed to fetch payload'),
+                    const defaultText = gettext('Failed to fetch payload'),
                         errorMessage = data.responseJSON ? data.responseJSON.error : null;
 
                     $modal.find('.modal-body').text(errorMessage || defaultText);
@@ -97,7 +99,7 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         });
 
         $('#report-content').on('click', '.resend-record-payload', function () {
-            var $btn = $(this),
+            const $btn = $(this),
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
@@ -110,7 +112,7 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         });
 
         $('#report-content').on('click', '.cancel-record-payload', function () {
-            var $btn = $(this),
+            const $btn = $(this),
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
@@ -123,7 +125,7 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         });
 
         $('#report-content').on('click', '.requeue-record-payload', function () {
-            var $btn = $(this),
+            const $btn = $(this),
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
@@ -136,9 +138,9 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         });
 
         $('#confirm-button').on('click', function () {
-            var requestBody = getRequestBody(),
-                action = getAction(),
-                $btn;
+            const requestBody = getRequestBody(),
+                action = getAction();
+            let $btn;
 
             $popUp.modal('hide');  /* todo B5: plugin:modal */
             if (action === 'resend') {
@@ -157,7 +159,7 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         });
 
         function performAction(action) {
-            var bulkSelection = bulkSelectionChecked();
+            const bulkSelection = bulkSelectionChecked();
             if (bulkSelection || areRecordsChecked()) {
                 if (bulkSelection) { setFlag(bulkSelection); }
                 // only applies to checked items, not bulk selections
@@ -184,8 +186,8 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         }
 
         function areRecordsChecked() {
-            var items = document.getElementsByName('xform_ids');
-            for (var item of items) {
+            const items = document.getElementsByName('xform_ids');
+            for (const item of items) {
                 if (item.checked) {
                     return true;
                 }
@@ -194,13 +196,13 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         }
 
         function isActionPossibleForCheckedItems(action) {
-            var items = document.getElementsByName('xform_ids');
-            for (var item of items) {
+            const items = document.getElementsByName('xform_ids');
+            for (const item of items) {
                 if (item.checked) {
-                    var id = item.getAttribute('data-id');
-                    var query = '[data-record-id="' + id + '"][class="btn btn-default ' + action + '-record-payload"]';
-                    var button = document.querySelector(query);
-                    if (button == null) {
+                    const id = item.getAttribute('data-id');
+                    const query = `[data-record-id="${id}"][class="btn btn-default ${action}-record-payload"]`;
+                    const button = document.querySelector(query);
+                    if (!button) {
                         return false;
                     }
                 }
@@ -227,10 +229,10 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         }
 
         function getRecordIds() {
-            var records = document.getElementsByName('xform_ids'),
-                recordIds = '';
-            for (var record of records) {
-                if (record.type == 'checkbox' && record.checked == true) {
+            const recordEls = document.getElementsByName('xform_ids');
+            let recordIds = '';
+            for (const record of recordEls) {
+                if (record.type === 'checkbox' && record.checked) {
                     recordIds += record.getAttribute('data-id') + ' ';
                 }
             }

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
@@ -4,7 +4,7 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         selectAll = document.getElementById('select-all'),
         cancelAll = document.getElementById('cancel-all'),
         requeueAll = document.getElementById('requeue-all'),
-        $popUp = $('#are-you-sure');
+        $popUp = $('#are-you-sure'),
         $confirmButton = $('#confirm-button');
 
     $(function () {
@@ -136,18 +136,20 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         });
 
         $('#confirm-button').on('click', function () {
-            var itemsToSend = getCheckboxes(), action = getAction(), $btn;
+            var itemsToSend = getCheckboxes(),
+                action = getAction(),
+                $btn;
 
             $popUp.modal('hide');  /* todo B5: plugin:modal */
-            if (action == 'resend') {
+            if (action === 'resend') {
                 $btn = $('#resend-all-button');
                 $btn.disableButton();
                 postResend($btn, itemsToSend);
-            } else if (action == 'cancel') {
+            } else if (action === 'cancel') {
                 $btn = $('#cancel-all-button');
                 $btn.disableButton();
                 postOther($btn, itemsToSend, action);
-            } else if (action == 'requeue') {
+            } else if (action === 'requeue') {
                 $btn = $('#requeue-all-button');
                 $btn.disableButton();
                 postOther($btn, itemsToSend, action);

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
@@ -136,7 +136,7 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         });
 
         $('#confirm-button').on('click', function () {
-            var itemsToSend = getCheckboxes(),
+            var requestBody = getRequestBody(),
                 action = getAction(),
                 $btn;
 
@@ -144,15 +144,15 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
             if (action === 'resend') {
                 $btn = $('#resend-all-button');
                 $btn.disableButton();
-                postResend($btn, itemsToSend);
+                postResend($btn, requestBody);
             } else if (action === 'cancel') {
                 $btn = $('#cancel-all-button');
                 $btn.disableButton();
-                postOther($btn, itemsToSend, action);
+                postOther($btn, requestBody, action);
             } else if (action === 'requeue') {
                 $btn = $('#requeue-all-button');
                 $btn.disableButton();
-                postOther($btn, itemsToSend, action);
+                postOther($btn, requestBody, action);
             }
         });
 
@@ -209,43 +209,48 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
             return true;
         }
 
-        function getCheckboxes() {
-            if (selectAll.checked) {
-                return selectAll.getAttribute('data-id');
-            } else if (selectPending.checked) {
-                return selectPending.getAttribute('data-id');
-            } else if (selectCancelled.checked) {
-                return selectCancelled.getAttribute('data-id');
+        function getRequestBody() {
+            const bulkSelectors = [selectAll, selectPending, selectCancelled];
+            if (bulkSelectors.some(selector => selector.checked)) {
+                return getBulkSelectionProperties();
             } else {
-                var items = document.getElementsByName('xform_ids'),
-                    itemsToSend = '';
-                for (var i = 0; i < items.length; i++) {
-                    if (items[i].type == 'checkbox' && items[i].checked == true) {
-                        itemsToSend += items[i].getAttribute('data-id') + ' '
-                    }
-                }
-
-                return itemsToSend;
+                return getRecordIds();
             }
         }
 
-        function postResend(btn, arg) {
+        function getBulkSelectionProperties() {
+            return {
+                payload_id: initialPageData.get('payload_id'),
+                repeater_id: initialPageData.get('repeater_id'),
+                flag: getFlag(),
+            };
+        }
+
+        function getRecordIds() {
+            var records = document.getElementsByName('xform_ids'),
+                recordIds = '';
+            for (var record of records) {
+                if (record.type == 'checkbox' && record.checked == true) {
+                    recordIds += record.getAttribute('data-id') + ' ';
+                }
+            }
+            return {record_id: recordIds};
+        }
+
+        function postResend(btn, data) {
             $.post({
                 url: initialPageData.reverse("repeat_record"),
-                data: {
-                    record_id: arg,
-                    flag: getFlag(),
-                },
-                success: function (data) {
+                data: data,
+                success: function (response) {
                     btn.removeSpinnerFromButton();
-                    if (data.success) {
+                    if (response.success) {
                         btn.text(gettext('Success!'));
                         btn.addClass('btn-success');
                     } else {
                         btn.text(gettext('Failed'));
                         btn.addClass('btn-danger');
                         $('#payload-error-modal').modal('show');  /* todo B5: plugin:modal */
-                        $('#payload-error-modal .error-message').text(data.failure_reason);
+                        $('#payload-error-modal .error-message').text(response.failure_reason);
                     }
                 },
                 error: function () {
@@ -256,13 +261,10 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
             });
         }
 
-        function postOther(btn, arg, action) {
+        function postOther(btn, data, action) {
             $.post({
                 url: initialPageData.reverse(action + '_repeat_record'),
-                data: {
-                    record_id: arg,
-                    flag: getFlag(),
-                },
+                data: data,
                 success: function () {
                     btn.removeSpinnerFromButton();
                     btn.text(gettext('Success!'));

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
@@ -157,49 +157,47 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         });
 
         function performAction(action) {
-            if (isAnythingChecked()) {
+            var bulkSelection = bulkSelectionChecked();
+            if (bulkSelection || areRecordsChecked()) {
+                if (bulkSelection) { setFlag(bulkSelection); }
+                // only applies to checked items, not bulk selections
+                // leaving as is to preserve behavior
                 if (isActionPossibleForCheckedItems(action)) {
-                    $('#warning').addClass('hide');
-                    $('#not-allowed').addClass('hide');
+                    hideAllWarnings();
                     $popUp.modal('show');  /* todo B5: plugin:modal */
                 } else {
-                    $('#warning').addClass('hide');
-                    $('#not-allowed').removeClass('hide');
+                    showWarning('not-allowed');
                 }
             } else {
-                $('#warning').removeClass('hide');
-                $('#not-allowed').addClass('hide');
+                showWarning('no-selection');
             }
         }
 
-        function isAnythingChecked() {
-            var items = document.getElementsByName('xform_ids');
-
+        function bulkSelectionChecked() {
             if (selectAll.checked) {
-                setFlag('select_all');
-                return true;
+                return 'select_all';
             } else if (selectPending.checked) {
-                setFlag('select_pending');
-                return true;
+                return 'select_pending';
             } else if (selectCancelled.checked) {
-                setFlag('select_cancelled');
-                return true;
+                return 'select_cancelled';
             }
+        }
 
-            for (var i = 0; i < items.length; i++) {
-                if (items[i].checked) {
+        function areRecordsChecked() {
+            var items = document.getElementsByName('xform_ids');
+            for (var item of items) {
+                if (item.checked) {
                     return true;
                 }
             }
-
             return false;
         }
 
         function isActionPossibleForCheckedItems(action) {
             var items = document.getElementsByName('xform_ids');
-            for (var i = 0; i < items.length; i++) {
-                if (items[i].checked) {
-                    var id = items[i].getAttribute('data-id');
+            for (var item of items) {
+                if (item.checked) {
+                    var id = item.getAttribute('data-id');
                     var query = '[data-record-id="' + id + '"][class="btn btn-default ' + action + '-record-payload"]';
                     var button = document.querySelector(query);
                     if (button == null) {
@@ -292,6 +290,21 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
 
         function getFlag() {
             return $confirmButton.attr('data-flag');
+        }
+
+        function showWarning(reason) {
+            if (reason === 'no-selection') {
+                $('#no-selection').removeClass('hide');
+                $('#not-allowed').addClass('hide');
+            } else if (reason === 'not-allowed') {
+                $('#not-allowed').removeClass('hide');
+                $('#no-selection').addClass('hide');
+            }
+        }
+
+        function hideAllWarnings() {
+            $('#no-selection').addClass('hide');
+            $('#not-allowed').addClass('hide');
         }
     });
 });

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
@@ -160,11 +160,12 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
 
         function performAction(action) {
             const bulkSelection = bulkSelectionChecked();
-            if (bulkSelection || areRecordsChecked()) {
+            const checkedRecords = getCheckedRecords();
+            if (bulkSelection || checkedRecords.length > 0) {
                 if (bulkSelection) { setFlag(bulkSelection); }
                 // only applies to checked items, not bulk selections
                 // leaving as is to preserve behavior
-                if (isActionPossibleForCheckedItems(action)) {
+                if (isActionPossibleForCheckedItems(action, checkedRecords)) {
                     hideAllWarnings();
                     $popUp.modal('show');  /* todo B5: plugin:modal */
                 } else {
@@ -185,26 +186,17 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
             }
         }
 
-        function areRecordsChecked() {
-            const items = document.getElementsByName('xform_ids');
-            for (const item of items) {
-                if (item.checked) {
-                    return true;
-                }
-            }
-            return false;
+        function getCheckedRecords() {
+            return $.find('input[type=checkbox][name=xform_ids]:checked');
         }
 
-        function isActionPossibleForCheckedItems(action) {
-            const items = document.getElementsByName('xform_ids');
+        function isActionPossibleForCheckedItems(action, items) {
             for (const item of items) {
-                if (item.checked) {
-                    const id = item.getAttribute('data-id');
-                    const query = `[data-record-id="${id}"][class="btn btn-default ${action}-record-payload"]`;
-                    const button = document.querySelector(query);
-                    if (!button) {
-                        return false;
-                    }
+                const id = item.getAttribute('data-id');
+                const query = `[data-record-id="${id}"][class="btn btn-default ${action}-record-payload"]`;
+                const button = document.querySelector(query);
+                if (!button) {
+                    return false;
                 }
             }
 
@@ -229,13 +221,10 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         }
 
         function getRecordIds() {
-            const recordEls = document.getElementsByName('xform_ids');
-            let recordIds = '';
-            for (const record of recordEls) {
-                if (record.type === 'checkbox' && record.checked) {
-                    recordIds += record.getAttribute('data-id') + ' ';
-                }
-            }
+            const recordEls = getCheckedRecords();
+            const recordIds = recordEls.map(
+                record => record.getAttribute('data-id')
+            ).join(' ');
             return {record_id: recordIds};
         }
 

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
@@ -103,7 +103,7 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
-            postResend($btn, recordId);
+            postResend($btn, {'record_id': recordId});
         });
 
         $('#resend-all-button').on('click', function () {
@@ -116,7 +116,7 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
-            postOther($btn, recordId, 'cancel');
+            postOther($btn, {'record_id': recordId}, 'cancel');
         });
 
         $('#cancel-all-button').on('click', function () {
@@ -129,7 +129,7 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
                 recordId = $btn.data().recordId;
             $btn.disableButton();
 
-            postOther($btn, recordId, 'requeue');
+            postOther($btn, {'record_id': recordId}, 'requeue');
         });
 
         $('#requeue-all-button').on('click', function () {

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap5/repeat_record_report.js
@@ -2,8 +2,8 @@
 hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
     var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         selectAll = document.getElementById('select-all'),
-        cancelAll = document.getElementById('cancel-all'),
-        requeueAll = document.getElementById('requeue-all'),
+        selectPending = document.getElementById('select-pending'),
+        selectCancelled = document.getElementById('select-cancelled'),
         $popUp = $('#are-you-sure'),
         $confirmButton = $('#confirm-button');
 
@@ -178,11 +178,11 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
             if (selectAll.checked) {
                 setFlag('select_all');
                 return true;
-            } else if (cancelAll.checked) {
-                setFlag('cancel_all');
+            } else if (selectPending.checked) {
+                setFlag('select_pending');
                 return true;
-            } else if (requeueAll.checked) {
-                setFlag('requeue_all');
+            } else if (selectCancelled.checked) {
+                setFlag('select_cancelled');
                 return true;
             }
 
@@ -214,10 +214,10 @@ hqDefine('repeaters/js/bootstrap5/repeat_record_report', function () {
         function getCheckboxes() {
             if (selectAll.checked) {
                 return selectAll.getAttribute('data-id');
-            } else if (cancelAll.checked) {
-                return cancelAll.getAttribute('data-id');
-            } else if (requeueAll.checked) {
-                return requeueAll.getAttribute('data-id');
+            } else if (selectPending.checked) {
+                return selectPending.getAttribute('data-id');
+            } else if (selectCancelled.checked) {
+                return selectCancelled.getAttribute('data-id');
             } else {
                 var items = document.getElementsByName('xform_ids'),
                     itemsToSend = '';

--- a/corehq/motech/repeaters/static/repeaters/js/repeat_record_report_selects.js
+++ b/corehq/motech/repeaters/static/repeaters/js/repeat_record_report_selects.js
@@ -1,6 +1,6 @@
-/* globals ace */
-hqDefine('repeaters/js/repeat_record_report_selects', function() {
-    var items = document.getElementsByName('xform_ids'),
+'use strict';
+hqDefine('repeaters/js/repeat_record_report_selects', function () {
+    const items = document.getElementsByName('xform_ids'),
         selectAll = document.getElementById('select-all'),
         selectPending = document.getElementById('select-pending'),
         selectCancelled = document.getElementById('select-cancelled'),
@@ -53,22 +53,24 @@ hqDefine('repeaters/js/repeat_record_report_selects', function() {
     });
 
     $('body').on('DOMNodeInserted', 'tbody', function () {
-      for (var i = 0; i < items.length; i++) {
-            $(items[i]).on('click', uncheckSelects);
+        for (const item of items) {
+            $(item).on('click', uncheckSelects);
         }
     });
 
     function selectItems() {
-        for (var i = 0; i < items.length; i++) {
-            if (items[i].type == 'checkbox')
-                items[i].checked = true;
+        for (const item of items) {
+            if (item.type === 'checkbox') {
+                item.checked = true;
+            }
         }
     }
 
     function unSelectItems() {
-        for (var i = 0; i < items.length; i++) {
-            if (items[i].type == 'checkbox')
-                items[i].checked = false;
+        for (const item of items) {
+            if (item.type === 'checkbox') {
+                item.checked = false;
+            }
         }
     }
 
@@ -95,15 +97,15 @@ hqDefine('repeaters/js/repeat_record_report_selects', function() {
     }
 
     function checkMultipleItems(action) {
-        for (var i = 0; i < items.length; i++) {
-            var id = items[i].getAttribute('data-id');
-            var query = '[data-record-id="' + id + '"][class="btn btn-default ' + action + '-record-payload"]';
-            var button = document.querySelector(query);
-            if (button != null && items[i].type == 'checkbox') {
-                if (items[i].checked) {
-                    items[i].checked = false;
+        for (const item of items) {
+            const id = item.getAttribute('data-id');
+            const query = `[data-record-id="${id}"][class="btn btn-default ${action}-record-payload"]`;
+            const button = document.querySelector(query);
+            if (!!button && item.type === 'checkbox') {
+                if (item.checked) {
+                    item.checked = false;
                 } else {
-                    items[i].checked = true;
+                    item.checked = true;
                 }
             }
         }

--- a/corehq/motech/repeaters/static/repeaters/js/repeat_record_report_selects.js
+++ b/corehq/motech/repeaters/static/repeaters/js/repeat_record_report_selects.js
@@ -1,9 +1,9 @@
 /* globals ace */
 hqDefine('repeaters/js/repeat_record_report_selects', function() {
     var items = document.getElementsByName('xform_ids'),
-        all = document.getElementById('select-all'),
-        allCancel = document.getElementById('cancel-all'),
-        allRequeue = document.getElementById('requeue-all'),
+        selectAll = document.getElementById('select-all'),
+        selectPending = document.getElementById('select-pending'),
+        selectCancelled = document.getElementById('select-cancelled'),
         buttonCancel = document.getElementById('cancel-all-button'),
         buttonRequeue = document.getElementById('requeue-all-button');
 
@@ -18,9 +18,9 @@ hqDefine('repeaters/js/repeat_record_report_selects', function() {
     });
 
     $('#select-all').on('click', function () {
-        if (all.checked) {
+        if (selectAll.checked) {
             selectItems();
-            uncheck(allCancel, allRequeue);
+            uncheck(selectPending, selectCancelled);
             turnOffCancelRequeue();
         } else {
             unSelectItems();
@@ -28,11 +28,11 @@ hqDefine('repeaters/js/repeat_record_report_selects', function() {
         }
     });
 
-    $('#cancel-all').on('click', function () {
+    $('#select-pending').on('click', function () {
         unSelectItems();
-        uncheck(all, allRequeue);
+        uncheck(selectAll, selectCancelled);
         turnOnCancelRequeue();
-        if (allCancel.checked) {
+        if (selectPending.checked) {
             buttonRequeue.disabled = true;
             checkMultipleItems('cancel');
         } else {
@@ -40,11 +40,11 @@ hqDefine('repeaters/js/repeat_record_report_selects', function() {
         }
     });
 
-    $('#requeue-all').on('click', function () {
+    $('#select-cancelled').on('click', function () {
         unSelectItems();
-        uncheck(all, allCancel);
+        uncheck(selectAll, selectPending);
         turnOnCancelRequeue();
-        if (allRequeue.checked) {
+        if (selectCancelled.checked) {
             buttonCancel.disabled = true;
             checkMultipleItems('requeue');
         } else {
@@ -78,9 +78,9 @@ hqDefine('repeaters/js/repeat_record_report_selects', function() {
     }
 
     function uncheckSelects() {
-        all.checked = false;
-        allCancel.checked = false;
-        allRequeue.checked = false;
+        selectAll.checked = false;
+        selectPending.checked = false;
+        selectCancelled.checked = false;
         turnOnCancelRequeue();
     }
 

--- a/corehq/motech/repeaters/templates/repeaters/bootstrap3/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/bootstrap3/repeat_record_report.html
@@ -117,14 +117,14 @@
         </div>
     </div>
 
-    <!-- Modal for "Resend Payload" errors -->
+    <!-- Modal for error messages from server -->
     <div class="modal fade" id="payload-error-modal" tabindex="-1" role="dialog">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span>
                     </button>
-                    <h4 class="modal-title">{% trans "Payload Error" %}</h4>
+                    <h4 class="modal-title">{% trans "Error" %}</h4>
                 </div>
                 <div class="modal-body">
                     <div class="error-message"></div>

--- a/corehq/motech/repeaters/templates/repeaters/bootstrap3/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/bootstrap3/repeat_record_report.html
@@ -91,6 +91,8 @@
     {% registerurl 'repeat_record' domain %}
     {% registerurl 'cancel_repeat_record' domain %}
     {% registerurl 'requeue_repeat_record' domain %}
+    {% initial_page_data 'payload_id' payload_id %}
+    {% initial_page_data 'repeater_id' repeater_id %}
 {% endblock %}
 
 {% block modals %}{{ block.super }}

--- a/corehq/motech/repeaters/templates/repeaters/bootstrap3/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/bootstrap3/repeat_record_report.html
@@ -57,7 +57,7 @@
         </div>
       {% endif %}
   </div>
-  <div id="warning" class="alert alert-warning hide">
+  <div id="no-selection" class="alert alert-warning hide">
     {% blocktrans %}Please select at least one payload{% endblocktrans %}
   </div>
   <div id="not-allowed" class="alert alert-warning hide">

--- a/corehq/motech/repeaters/templates/repeaters/bootstrap3/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/bootstrap3/repeat_record_report.html
@@ -42,15 +42,15 @@
               {% trans 'Requeue' %}
             </button>
             <label class="checkbox" >
-              <input type="checkbox" id="select-all" data-id="{{ form_query_string|urlencode }}">
+              <input type="checkbox" id="select-all">
                 {% blocktrans %}Select all {{ total }} payloads{% endblocktrans %}
             </label>
             <label class="checkbox" >
-              <input type="checkbox" id="select-pending" data-id="{{ form_query_string_pending|urlencode }}">
+              <input type="checkbox" id="select-pending">
                 {% blocktrans %}Select {{ total_pending }} pending payloads{% endblocktrans %}
             </label>
             <label class="checkbox" >
-              <input type="checkbox" id="select-cancelled" data-id="{{ form_query_string_cancelled|urlencode }}">
+              <input type="checkbox" id="select-cancelled">
                 {% blocktrans %}Select {{ total_cancelled }} cancelled payloads{% endblocktrans %}
             </label>
           </div>

--- a/corehq/motech/repeaters/templates/repeaters/bootstrap3/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/bootstrap3/repeat_record_report.html
@@ -46,11 +46,11 @@
                 {% blocktrans %}Select all {{ total }} payloads{% endblocktrans %}
             </label>
             <label class="checkbox" >
-              <input type="checkbox" id="cancel-all" data-id="{{ form_query_string_pending|urlencode }}">
+              <input type="checkbox" id="select-pending" data-id="{{ form_query_string_pending|urlencode }}">
                 {% blocktrans %}Select {{ total_pending }} pending payloads{% endblocktrans %}
             </label>
             <label class="checkbox" >
-              <input type="checkbox" id="requeue-all" data-id="{{ form_query_string_cancelled|urlencode }}">
+              <input type="checkbox" id="select-cancelled" data-id="{{ form_query_string_cancelled|urlencode }}">
                 {% blocktrans %}Select {{ total_cancelled }} cancelled payloads{% endblocktrans %}
             </label>
           </div>

--- a/corehq/motech/repeaters/templates/repeaters/bootstrap5/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/bootstrap5/repeat_record_report.html
@@ -57,7 +57,7 @@
         </div>
       {% endif %}
   </div>
-  <div id="warning" class="alert alert-warning d-none">
+  <div id="no-selection" class="alert alert-warning d-none">
     {% blocktrans %}Please select at least one payload{% endblocktrans %}
   </div>
   <div id="not-allowed" class="alert alert-warning d-none">

--- a/corehq/motech/repeaters/templates/repeaters/bootstrap5/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/bootstrap5/repeat_record_report.html
@@ -91,6 +91,8 @@
     {% registerurl 'repeat_record' domain %}
     {% registerurl 'cancel_repeat_record' domain %}
     {% registerurl 'requeue_repeat_record' domain %}
+    {% initial_page_data 'payload_id' payload_id %}
+    {% initial_page_data 'repeater_id' repeater_id %}
 {% endblock %}
 
 {% block modals %}{{ block.super }}

--- a/corehq/motech/repeaters/templates/repeaters/bootstrap5/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/bootstrap5/repeat_record_report.html
@@ -46,11 +46,11 @@
                 {% blocktrans %}Select all {{ total }} payloads{% endblocktrans %}
             </label>
             <label class="checkbox" >  {# todo B5: css:checkbox #}
-              <input type="checkbox" id="cancel-all" data-id="{{ form_query_string_pending|urlencode }}">  {# todo B5: css:checkbox #}
+              <input type="checkbox" id="select-pending" data-id="{{ form_query_string_pending|urlencode }}">  {# todo B5: css:checkbox #}
                 {% blocktrans %}Select {{ total_pending }} pending payloads{% endblocktrans %}
             </label>
             <label class="checkbox" >  {# todo B5: css:checkbox #}
-              <input type="checkbox" id="requeue-all" data-id="{{ form_query_string_cancelled|urlencode }}">  {# todo B5: css:checkbox #}
+              <input type="checkbox" id="select-cancelled" data-id="{{ form_query_string_cancelled|urlencode }}">  {# todo B5: css:checkbox #}
                 {% blocktrans %}Select {{ total_cancelled }} cancelled payloads{% endblocktrans %}
             </label>
           </div>

--- a/corehq/motech/repeaters/templates/repeaters/bootstrap5/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/bootstrap5/repeat_record_report.html
@@ -117,14 +117,14 @@
         </div>
     </div>
 
-    <!-- Modal for "Resend Payload" errors -->
+    <!-- Modal for error messages from server -->
     <div class="modal fade" id="payload-error-modal" tabindex="-1" role="dialog">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">  {# todo B5: css:modal-header #}
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span>  {# todo B5: css:close #}
                     </button>
-                    <h4 class="modal-title">{% trans "Payload Error" %}</h4>
+                    <h4 class="modal-title">{% trans "Error" %}</h4>
                 </div>
                 <div class="modal-body">
                     <div class="error-message"></div>

--- a/corehq/motech/repeaters/templates/repeaters/bootstrap5/repeat_record_report.html
+++ b/corehq/motech/repeaters/templates/repeaters/bootstrap5/repeat_record_report.html
@@ -42,15 +42,15 @@
               {% trans 'Requeue' %}
             </button>
             <label class="checkbox" >  {# todo B5: css:checkbox #}
-              <input type="checkbox" id="select-all" data-id="{{ form_query_string|urlencode }}">  {# todo B5: css:checkbox #}
+              <input type="checkbox" id="select-all">  {# todo B5: css:checkbox #}
                 {% blocktrans %}Select all {{ total }} payloads{% endblocktrans %}
             </label>
             <label class="checkbox" >  {# todo B5: css:checkbox #}
-              <input type="checkbox" id="select-pending" data-id="{{ form_query_string_pending|urlencode }}">  {# todo B5: css:checkbox #}
+              <input type="checkbox" id="select-pending">  {# todo B5: css:checkbox #}
                 {% blocktrans %}Select {{ total_pending }} pending payloads{% endblocktrans %}
             </label>
             <label class="checkbox" >  {# todo B5: css:checkbox #}
-              <input type="checkbox" id="select-cancelled" data-id="{{ form_query_string_cancelled|urlencode }}">  {# todo B5: css:checkbox #}
+              <input type="checkbox" id="select-cancelled">  {# todo B5: css:checkbox #}
                 {% blocktrans %}Select {{ total_cancelled }} cancelled payloads{% endblocktrans %}
             </label>
           </div>

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -374,6 +374,7 @@ def _schedule_task_with_flag(
     task_ref = expose_cached_download(payload=None, expiry=1 * 60 * 60, file_extension=None)
     payload_id = request.POST.get('payload_id', None)
     repeater_id = request.POST.get('repeater_id', None)
+    #TODO: validate that at least a repeater id or payload id is specified before scheduling task
     task = task_generate_ids_and_operate_on_payloads.delay(
         payload_id, repeater_id, domain, action)
     task_ref.set_task(task)

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -386,6 +386,15 @@ def _get_flag(request: HttpRequest) -> str:
     return request.POST.get('flag') or ''
 
 
+def _get_state_from_request(request):
+    flag = _get_flag(request)
+    return {
+        'select_all': None,
+        'select_pending': State.Pending,
+        'select_cancelled': State.Cancelled,
+    }[flag]
+
+
 def _schedule_task_with_flag(
     request: HttpRequest,
     domain: str,
@@ -396,8 +405,9 @@ def _schedule_task_with_flag(
     repeater_id = request.POST.get('repeater_id', None)
     if not any([repeater_id, payload_id]):
         raise BulkActionMissingParameters
+    state = _get_state_from_request(request)
     task = task_generate_ids_and_operate_on_payloads.delay(
-        payload_id, repeater_id, domain, action)
+        payload_id, repeater_id, domain, action, state=state)
     task_ref.set_task(task)
 
 

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -244,6 +244,8 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         where = Q(domain=self.domain)
         if self.repeater_id:
             where &= Q(repeater_id=self.repeater_id)
+        if self.payload_id:
+            where &= Q(payload_id=self.payload_id)
         total = RepeatRecord.objects.filter(where).count()
         total_pending = RepeatRecord.objects.filter(where, state=State.Pending).count()  # include State.Fail?
         total_cancelled = RepeatRecord.objects.filter(where, state=State.Cancelled).count()

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -1,5 +1,6 @@
 import json
 import re
+from typing import Literal
 
 from django.db.models import Q
 from django.http import (
@@ -400,7 +401,7 @@ def _get_state_from_request(request):
 def _schedule_task_with_flag(
     request: HttpRequest,
     domain: str,
-    action,  # type: Literal['resend', 'cancel', 'requeue']  # 3.8+
+    action: Literal['resend', 'cancel', 'requeue']
 ):
     task_ref = expose_cached_download(payload=None, expiry=1 * 60 * 60, file_extension=None)
     payload_id = request.POST.get('payload_id', None)
@@ -416,7 +417,7 @@ def _schedule_task_with_flag(
 def _schedule_task_without_flag(
     request: HttpRequest,
     domain: str,
-    action,  # type: Literal['resend', 'cancel', 'requeue']  # 3.8+
+    action: Literal['resend', 'cancel', 'requeue']
 ):
     record_ids = _get_record_ids_from_request(request)
     task_ref = expose_cached_download(payload=None, expiry=1 * 60 * 60, file_extension=None)

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -261,6 +261,8 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
             form_query_string=form_query_string,
             form_query_string_pending=form_query_string_pending,
             form_query_string_cancelled=form_query_string_cancelled,
+            payload_id=self.payload_id,
+            repeater_id=self.repeater_id,
         )
         return context
 
@@ -390,8 +392,8 @@ def _schedule_task_with_flag(
     action,  # type: Literal['resend', 'cancel', 'requeue']  # 3.8+
 ):
     task_ref = expose_cached_download(payload=None, expiry=1 * 60 * 60, file_extension=None)
-    payload_id = request.POST.get('payload_id') or None
-    repeater_id = request.POST.get('repeater') or None
+    payload_id = request.POST.get('payload_id', None)
+    repeater_id = request.POST.get('repeater_id', None)
     task = task_generate_ids_and_operate_on_payloads.delay(
         payload_id, repeater_id, domain, action)
     task_ref.set_task(task)

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -345,7 +345,7 @@ class RepeatRecordView(View):
 @require_can_edit_web_users
 @requires_privilege_with_fallback(privileges.DATA_FORWARDING)
 def cancel_repeat_record(request, domain):
-    if _get_flag(request) == 'cancel_all':
+    if _get_flag(request) == 'select_pending':
         _schedule_task_with_flag(request, domain, 'cancel')
     else:
         _schedule_task_without_flag(request, domain, 'cancel')
@@ -357,7 +357,7 @@ def cancel_repeat_record(request, domain):
 @require_can_edit_web_users
 @requires_privilege_with_fallback(privileges.DATA_FORWARDING)
 def requeue_repeat_record(request, domain):
-    if _get_flag(request) == 'requeue_all':
+    if _get_flag(request) == 'select_cancelled':
         _schedule_task_with_flag(request, domain, 'requeue')
     else:
         _schedule_task_without_flag(request, domain, 'requeue')

--- a/corehq/motech/repeaters/views/tests/test_repeat_records.py
+++ b/corehq/motech/repeaters/views/tests/test_repeat_records.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from django.http import QueryDict
 from django.test import SimpleTestCase, TestCase
 from nose.tools import assert_equal
 from unittest.mock import Mock
@@ -43,46 +42,6 @@ class TestUtilities(SimpleTestCase):
             mock_request.POST.get.return_value = value
             result = repeat_records._get_flag(mock_request)
             assert_equal(result, expected_result)
-
-    def test__change_record_state(self):
-        query_strings = [
-            None,
-            '',
-            'repeater=&record_state=&payload_id=payload_3',
-            'repeater=repeater_3&record_state=STATUS_2&payload_id=payload_2',
-            'repeater=&record_state=&payload_id=',
-            'repeater=repeater_1&record_state=STATUS_2&payload_id=payload_1',
-            'repeater=&record_state=STATUS&payload_id=payload_2',
-            'repeater=repeater_2&record_state=STATUS&payload_id=',
-        ]
-        strings_to_add = [
-            'NO_STATUS',
-            'NO_STATUS',
-            None,
-            '',
-            'STATUS',
-            'STATUS_2',
-            'STATUS_3',
-            'STATUS_4',
-        ]
-        desired_strings = [
-            '',
-            '',
-            'repeater=&record_state=&payload_id=payload_3',
-            'repeater=repeater_3&record_state=STATUS_2&payload_id=payload_2',
-            'repeater=&record_state=STATUS&payload_id=',
-            'repeater=repeater_1&record_state=STATUS_2&payload_id=payload_1',
-            'repeater=&record_state=STATUS_3&payload_id=payload_2',
-            'repeater=repeater_2&record_state=STATUS_4&payload_id=',
-        ]
-
-        for qs, str_to_add, expected_result in zip(query_strings,
-                                                   strings_to_add,
-                                                   desired_strings):
-            query_dict = QueryDict(qs)
-            result = repeat_records._change_record_state(
-                query_dict, str_to_add).urlencode()
-            self.assertEqual(result, expected_result)
 
 
 class TestDomainForwardingOptionsView(TestCase):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The changes made in this PR are intended to make interacting with this widget in the repeat record report function properly.

![image](https://github.com/user-attachments/assets/cdc3371b-e821-4940-9157-0906a03aab34)

## Technical Summary
Review by commit 🐟 

[SAAS-15905](https://dimagi.atlassian.net/browse/SAAS-15905)

The bulk actions that a user can take on repeat records are dependent on the repeater and payload filters set above in the repeat record report. To get the values of these filters, we were passing context variables into the django template and setting the `data-id` attribute for each checkbox (i.e. bulk selection -  all, pending, cancelled). When attempting to perform a bulk action (i.e. resend, cancel, requeue), we would then read the `data-id` attribute from the selected checkbox, and pass that url encoded dictionary up in the `record_id` field. This is where things went wrong, as the backend did not properly parse the `record_id` field if a "flag" was set, meaning a bulk selection checkbox was selected. So we ended up not applying any of the filters in the repeat record query, and getting back an empty list due to the behavior described in https://github.com/dimagi/commcare-hq/pull/35047/commits/d04d84aa53dc17c5926c5a6e9f948049a7c5cdf2.

We opted to remove the `data-id` attribute on the checkboxes entirely, instead opting to make use of initial page data, setting the repeater_id and payload_id there. This way, when we attempting to perform a bulk action, we would just grab the flag based on the checkbox selected, and pass the repeater_id and payload_id back up to the server. This does mean that the endpoints for resending, cancelling, and requeueing repeat records in bulk support multiple request body formats, depending on if the `flag` key is provided in the body. Not sure if this is bad practice, but it feels like an easier to understand solution.

Once we were passing up this new request body format to the server, we needed to support this new format on the backend. It looks like the server was already setup to attempt to fetch the repeater and payload IDs from the post request anyway, so we really just needed to add state to this. Now we pass in all three of these parameters into the bulk action task to determine which repeat records to run the action on.

There was also an implicit condition where the server would not actually perform the bulk action if both a repeater_id and payload_id were not set to avoid running the action on all repeat records for a domain. This is now an explicit condition that the backend validates and returns an error response if neither filter is being used. This takes care of https://dimagi.atlassian.net/browse/SAAS-15903. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Will test on staging. Generally speaking, this page has a very confusing UI that has silent failure modes, and can be very unclear which records will actually be processed. The changes made here are an effort to improve this, and in the worst case, would only block users from viewing/using this report, but would not disrupt anything with their data forwarding otherwise.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not be a bad idea. Will test on staging and see how we feel.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[SAAS-15905]: https://dimagi.atlassian.net/browse/SAAS-15905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ