### PR TITLE
Add can_change_subscription check to SelectPlanView

### DIFF
--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -971,6 +971,17 @@ class SelectPlanView(DomainAccountingSettings):
     edition = None
     lead_text = gettext_lazy("Please select a plan below that fits your organization's needs.")
 
+    def dispatch(self, request, *args, **kwargs):
+        if not self.can_change_subscription:
+            raise Http404()
+        return super().dispatch(request, *args, **kwargs)
+
+    @property
+    def can_change_subscription(self):
+        subscription = self.current_subscription
+        is_annual_plan = subscription.plan_version.plan.is_annual_plan
+        return not is_annual_plan
+
     @property
     @memoized
     def can_domain_unpause(self):

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -963,24 +963,10 @@ PlanOption = namedtuple(
 )
 
 
-class SelectPlanView(DomainAccountingSettings):
-    template_name = 'domain/select_plan.html'
-    urlname = 'domain_select_plan'
+class PlanViewBase(DomainAccountingSettings):
     page_title = gettext_lazy("Change Plan")
-    step_title = gettext_lazy("Select Plan")
-    edition = None
     lead_text = gettext_lazy("Please select a plan below that fits your organization's needs.")
-
-    def dispatch(self, request, *args, **kwargs):
-        if not self.can_change_subscription:
-            raise Http404()
-        return super().dispatch(request, *args, **kwargs)
-
-    @property
-    def can_change_subscription(self):
-        subscription = self.current_subscription
-        is_annual_plan = subscription.plan_version.plan.is_annual_plan
-        return not is_annual_plan
+    edition = None
 
     @property
     @memoized
@@ -1071,7 +1057,7 @@ class SelectPlanView(DomainAccountingSettings):
 
     @property
     def main_context(self):
-        context = super(SelectPlanView, self).main_context
+        context = super().main_context
         context.update({
             'steps': self.steps,
             'step_title': self.step_title,
@@ -1115,7 +1101,24 @@ class SelectPlanView(DomainAccountingSettings):
         }
 
 
-class SelectedEnterprisePlanView(SelectPlanView):
+class SelectPlanView(PlanViewBase):
+    template_name = 'domain/select_plan.html'
+    urlname = 'domain_select_plan'
+    step_title = gettext_lazy("Select Plan")
+
+    def dispatch(self, request, *args, **kwargs):
+        if not self.can_change_subscription:
+            raise Http404()
+        return super().dispatch(request, *args, **kwargs)
+
+    @property
+    def can_change_subscription(self):
+        subscription = self.current_subscription
+        is_annual_plan = subscription.plan_version.plan.is_annual_plan
+        return not is_annual_plan
+
+
+class SelectedEnterprisePlanView(PlanViewBase):
     template_name = 'domain/selected_enterprise_plan.html'
     urlname = 'enterprise_request_quote'
     step_title = gettext_lazy("Contact Dimagi")
@@ -1157,7 +1160,7 @@ class SelectedEnterprisePlanView(SelectPlanView):
         return self.get(request, *args, **kwargs)
 
 
-class SelectedAnnualPlanView(SelectPlanView):
+class SelectedAnnualPlanView(PlanViewBase):
     template_name = 'domain/selected_annual_plan.html'
     urlname = 'annual_plan_request_quote'
     step_title = gettext_lazy("Contact Dimagi")
@@ -1219,7 +1222,7 @@ class SelectedAnnualPlanView(SelectPlanView):
         return self.get(request, *args, **kwargs)
 
 
-class ConfirmSelectedPlanView(SelectPlanView):
+class ConfirmSelectedPlanView(PlanViewBase):
     template_name = 'domain/confirm_plan.html'
     urlname = 'confirm_selected_plan'
 
@@ -1540,7 +1543,7 @@ class SubscriptionMixin(object):
         return subscription
 
 
-class SubscriptionRenewalView(SelectPlanView, SubscriptionMixin):
+class SubscriptionRenewalView(PlanViewBase, SubscriptionMixin):
     urlname = "domain_subscription_renewal"
     page_title = gettext_lazy("Renew Plan")
     step_title = gettext_lazy("Renew Plan")
@@ -1594,7 +1597,7 @@ class SubscriptionRenewalView(SelectPlanView, SubscriptionMixin):
         return context
 
 
-class ConfirmSubscriptionRenewalView(SelectPlanView, DomainAccountingSettings,
+class ConfirmSubscriptionRenewalView(PlanViewBase, DomainAccountingSettings,
                                      AsyncHandlerMixin, SubscriptionMixin):
     template_name = 'domain/confirm_subscription_renewal.html'
     urlname = 'domain_subscription_renewal_confirmation'


### PR DESCRIPTION
## Product Description
Disallows access to the Select Plan page when on a pay annually subscription, mirroring logic for when the "Change Plan" button option appears.

## Technical Summary
[SAAS-15914](https://dimagi.atlassian.net/browse/SAAS-15914)
Previously there was no specific plan check on the `SelectPlanView`, meaning someone could manipulate the url to access that page and change their plan when they should not have been able to. This adds a check in the view and returns a `404` if the plan is not user-changeable (specifically if it is an annual plan, but could add more/different criteria in the future).

There is an existing check on subscription URLs for whether the _user_ is able to access billing that returns a `403` if they simply don't have access, so that condition isn't checked here because it would be redundant.

This also moves the vast majority of `SelectPlanView` into a new base class, `PlanViewBase`, because it was subclassed by about half a dozen other views and I only wanted to add this check to the `SelectPlanView`.

## Safety Assurance

### Safety story
The change is fairly small, tested locally and on staging that this _does_ block access to the page when on a pay annually plan, but not on any other types of plans. Also visited/interacted all the views subclassing `PlanViewBase` to ensure they still work.

### Automated test coverage
No existing automated tests specifically for this view, and none added here.

Tests for `SubscriptionRenewalView` and `ConfirmSubscriptionRenewalView` are implicitly affected by the change in base class.
 
### QA Plan
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-15914]: https://dimagi.atlassian.net/browse/SAAS-15914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ