### PR TITLE
add toggle for error details for occasions when the list is quite long

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
@@ -55,10 +55,23 @@
       </p>
       <p data-bind="visible: sample, text: sample">
       </p>
-      <p data-bind="visible: rows.length">
-        <span>{% trans "Row(s):" %}</span>
-        <span data-bind="text: rows.join(', ')"></span>
-      </p>
+      <div data-bind="visible: rows.length">
+        <button type="button"
+                class="btn btn-outline-primary btn-sm"
+                data-bs-toggle="collapse"
+                data-bind="attr: {
+                  'data-bs-target': '#rowDetailsCollapse-' + $index(),
+                  'aria-controls': 'rowDetailsCollapse-' + $index()
+                }"
+                aria-expanded="false">
+          {% trans "Toggle Affected Row(s)" %}
+        </button>
+        <div class="collapse"
+             data-bind="attr: { id: 'rowDetailsCollapse-' + $index() }">
+          <div class="card card-body mt-3"
+               data-bind="text: rows.join(', ')"></div>
+        </div>
+      </div>
     </li>
     <!--/ko-->
     <!--/ko-->


### PR DESCRIPTION
## Product Description
This addresses a UI issue raised in the following DEET Week ticket:
https://dimagi.atlassian.net/browse/SAAS-15834

Default (row ids are hidden with option to toggle)
![Screen Shot 2024-08-28 at 2 19 29 PM](https://github.com/user-attachments/assets/3443faab-84ea-49d2-978a-5ab91eaaa57e)

After toggling (the button in the screen shot is the hovered state with the mouse, which is hidden)
![Screen Shot 2024-08-28 at 2 19 43 PM](https://github.com/user-attachments/assets/a1285233-4915-4e10-b264-64767544f3d7)

## Safety Assurance

### Safety story
Very safe UI change. Tested on staging with a real alert

### Automated test coverage
N/A

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
