### PR TITLE
add device_id to case transactions for easy access

### DIFF
--- a/corehq/form_processor/models/cases.py
+++ b/corehq/form_processor/models/cases.py
@@ -1386,6 +1386,10 @@ class CaseTransaction(PartitionedModel, SaveStateMixin, models.Model):
     def xmlns(self):
         return self.details.get('xmlns', None) if self.details else None
 
+    @property
+    def device_id(self):
+        return self.details.get('device_id', None) if self.details else None
+
     @classmethod
     @memoized
     def case_rebuild_types(cls):
@@ -1476,7 +1480,7 @@ class CaseTransaction(PartitionedModel, SaveStateMixin, models.Model):
                 server_date=xform.received_on,
                 type=transaction_type,
                 revoked=not xform.is_normal,
-                details=FormSubmissionDetail(xmlns=xform.xmlns).to_json()
+                details=FormSubmissionDetail(xmlns=xform.xmlns, device_id=xform.device_id).to_json()
             )
 
     @classmethod
@@ -1544,6 +1548,7 @@ class CaseTransactionDetail(JsonObject):
 class FormSubmissionDetail(CaseTransactionDetail):
     _type = CaseTransaction.TYPE_FORM
     xmlns = StringProperty()
+    device_id = StringProperty()
 
 
 class RebuildWithReason(CaseTransactionDetail):

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -637,6 +637,7 @@ class XFormInstance(PartitionedModel, models.Model, RedisLockableMixIn,
         return operations
 
     @property
+    @memoized
     def metadata(self):
         from ..utils import clean_metadata
         if const.TAG_META in self.form_data:
@@ -649,6 +650,10 @@ class XFormInstance(PartitionedModel, models.Model, RedisLockableMixIn,
     @property
     def name(self):
         return self.form_data.get(const.TAG_NAME, "")
+
+    @property
+    def device_id(self):
+        return self.metadata and self.metadata.deviceID
 
     @memoized
     def get_sync_token(self):

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -653,7 +653,10 @@ class XFormInstance(PartitionedModel, models.Model, RedisLockableMixIn,
 
     @property
     def device_id(self):
-        return self.metadata and self.metadata.deviceID
+        try:
+            return self.metadata and self.metadata.deviceID
+        except MissingFormXml:
+            pass
 
     @memoized
     def get_sync_token(self):

--- a/corehq/form_processor/tests/test_basics.py
+++ b/corehq/form_processor/tests/test_basics.py
@@ -122,12 +122,14 @@ class FundamentalCaseTests(FundamentalBaseTests):
         case_id = uuid.uuid4().hex
         modified_on = datetime.utcnow()
         xmlns = 'http://commcare.org/test_xmlns'
+        device_id = "a.b.c.DemoDevice"
         _submit_case_block(
             True, case_id, user_id='user1', owner_id='owner1', case_type='demo',
             case_name='create_case', date_modified=modified_on, date_opened=modified_on, update={
                 'dynamic': '123'
             },
-            xmlns=xmlns
+            xmlns=xmlns,
+            device_id=device_id
         )
 
         case = self.casedb.get_case(case_id, DOMAIN)
@@ -149,6 +151,7 @@ class FundamentalCaseTests(FundamentalBaseTests):
         transactions = case.get_form_transactions()
         self.assertEqual(1, len(transactions))
         self.assertEqual(transactions[0].xmlns, xmlns)
+        self.assertEqual(transactions[0].device_id, device_id)
 
     def test_create_case_unicode_name(self):
         """


### PR DESCRIPTION
## Technical Summary
Adds a `device_id` field to the `CaseTransaction.details` JSON field when the transaction is a 'form transaction'.

This is useful in cases where we wish to check the device ID of a case transaction and allows us to do so without loading all the transactions, taking the last one, and loading the XForm for that transaction.

An example of where it could be useful to have a device ID is where we are doing data forwarding or other automated tasks that update a case and we want to prevent cycles where the task updates a case which triggers another update.

Up till now we have used the XMLNS to solve this problem however, since XMLNS is meant to be a static value and not include dynamic data in it, we don't have fine grained control over when to allow or block tasks.

For example, the [new feature](https://github.com/dimagi/commcare-hq/pull/35054) in Configurable Repeaters that allows us to update cases based on the data forwarding response needs to prevent update cycles. [For now it is using the XMLNS](https://github.com/dimagi/commcare-hq/pull/35054/files#diff-d3f46ed2b6c550555fd38ffea4e2a97dbac728fca1d0aaa9fc171c9f668300c5R143-R145) but this blocks all configurable repeaters instead of only the one that generated the case update.

## Safety Assurance

### Safety story
This adds a field to a JSON field on the case transaction. This is backwards compatible and does not change any of the main processing logic.

This code is well covered by unit tests.

### Automated test coverage
Updated tests to verify the change.

### QA Plan
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
