### PR TITLE
Fix saved report for data forwarding records being deleted

### DIFF
--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -48,6 +48,7 @@ from corehq.apps.reports.daterange import (
 )
 from corehq.apps.reports.dispatcher import (
     CustomProjectReportDispatcher,
+    DomainReportDispatcher,
     ProjectReportDispatcher,
     ReleaseManagementReportDispatcher,
 )
@@ -203,7 +204,8 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
             CustomProjectReportDispatcher,
             EnterpriseReportDispatcher,
             ReleaseManagementReportDispatcher,
-            CaseManagementMapDispatcher
+            CaseManagementMapDispatcher,
+            DomainReportDispatcher,
         ]
 
         for dispatcher in dispatchers:

--- a/corehq/apps/saved_reports/tests/test_models.py
+++ b/corehq/apps/saved_reports/tests/test_models.py
@@ -81,6 +81,15 @@ class TestReportConfig(TestCase):
         self.assertEqual(self.config.filters.get('startdate'), None)
         self.assertEqual(self.config.filters.get('enddate'), None)
 
+    def test_report_config_for_type_domain_report_is_not_deleted_when_access_dispatcher(self):
+        # The dispatcher property surprisingly deletes the report config when the report type
+        # doesn't match any of the list of dispatcher's prefix
+        config = ReportConfig(report_type='domain_report')
+        config.save()
+        self.addCleanup(config.delete)
+        config._dispatcher
+        self.assertEqual(config.doc_type, 'ReportConfig')
+
 
 class TestReportNotification(TestCase):
     def test_unauthorized_user_cannot_view_report(self):


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
In Project Settings > Data Forwarding Records, if you save a report, then refresh the page, the report won't show up in favorites. After the fix, the report will show both in the favorites tab and in the saved reports.
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/3b9152a9-1a5d-4e29-ad3b-dbf6c8994b94">
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/eb84a509-c5c4-47c4-ae9c-a266bd6179b0">


## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15397

The `ReportConfig` is created, but then got deleted, because the corresponding dispatcher is not added [here](https://github.com/dimagi/commcare-hq/blob/6a78832b0795c156f83a70bc77eb10c744f7731a/corehq/apps/saved_reports/models.py#L201-L211), so we thought this is [an unsupported report and should be deleted](https://github.com/dimagi/commcare-hq/blob/6a78832b0795c156f83a70bc77eb10c744f7731a/corehq/apps/saved_reports/models.py#L219-L229).

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is an oversight that the corresponding dispatcher is not included in the array of dispatchers, so we just add it to the list.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Add `test_report_config_for_type_domain_report_is_not_deleted_when_access_dispatcher`


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
