### PR TITLE
Make enterprise admin match case insensitive

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -532,7 +532,8 @@ class BillingAccount(ValidateModelMixin, models.Model):
                     'subscriber__domain', flat=True))
 
     def has_enterprise_admin(self, email):
-        return self.is_customer_billing_account and email in self.enterprise_admin_emails
+        lower_emails = [e.lower() for e in self.enterprise_admin_emails]
+        return self.is_customer_billing_account and email.lower() in lower_emails
 
     def update_autopay_user(self, new_user, domain):
         if self.auto_pay_enabled and new_user != self.auto_pay_user:

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 from django.core import mail
 from django.db import models
+from django.test import SimpleTestCase
 
 from unittest import mock
 
@@ -343,3 +344,9 @@ class TestStripePaymentMethod(BaseAccountingTest):
         self.assertEqual(self.fake_card.metadata, {"auto_pay_{}".format(self.billing_account.id): 'False'})
         self.assertIsNone(self.billing_account.auto_pay_user)
         self.assertFalse(self.billing_account.auto_pay_enabled)
+
+
+class SimpleBillingAccountTest(SimpleTestCase):
+    def test_has_enterprise_admin_does_case_insensitive_match(self):
+        account = BillingAccount(is_customer_billing_account=True, enterprise_admin_emails=['TEST@dimagi.com'])
+        self.assertTrue(account.has_enterprise_admin('test@DIMAGI.com'))


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
The enterprise admin emails field will allow user put email with uppercase letters. So if we put a email like `TEST@dimagi.com` in enterprise admin emails, when user `test@dimagi.com` log in, that user won't be considered as enterprise admin, because we treat emails case sensitive and consider it is not a match.
<img width="718" alt="image" src="https://github.com/user-attachments/assets/e81deb74-8879-4c3c-9d3d-e0c2364a294e">

This PR will fix this issue.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-14290

When compare emails, make all email lowercased.


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Safe as we're not changing what we stored in database, we convert emails to lowercase when we need to compare.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Add `SimpleBillingAccountTest` in `corehq/apps/accounting/tests/test_models`



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
