### PR TITLE
Fixes the issue of adblocker blocking the tag manager HQ script

### DIFF
--- a/corehq/apps/analytics/README.md
+++ b/corehq/apps/analytics/README.md
@@ -106,7 +106,7 @@ Their script is included in [signup](https://github.com/dimagi/commcare-hq/blob/
 
 ### Google Tag Manager (GTM)
 
-Its script is available in the [gtm.js](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/analytics/static/analytix/js/gtm.js) which loads the GTM tracking script and sends the desired user properties to GTM.
+Its script is available in the [gtx.js](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/analytics/static/analytix/js/gtx.js) which loads the GTM tracking script and sends the desired user properties to GTM.
 Any tracking of events should be configured at the GTM console end in tandem with the desired analytics tooling. The goal is to track specific features in HQ and also disable them when there is no need via the GTM console itself.
 Any `id` attribute added to html element for tracking through console should be prefixed with `gtm-` to indicate that this element is likely being tracked in GTM.
 This should potentially avoid accidental removal of id attribute from these elements. (Similar approach may be followed for any tooling in case of tracking of elements through console.)

--- a/corehq/apps/analytics/static/analytix/js/gtx.js
+++ b/corehq/apps/analytics/static/analytix/js/gtx.js
@@ -1,7 +1,7 @@
 "use strict";
 /**
  *  Handles communication with the google tag manager API.
- *  gtx is the filename because some ad blockers regex *gtm*
+ *  gtx is the filename because some ad blockers blocks 'gtm.js'*
  */
 hqDefine('analytix/js/gtx', [
     'jquery',

--- a/corehq/apps/analytics/static/analytix/js/gtx.js
+++ b/corehq/apps/analytics/static/analytix/js/gtx.js
@@ -1,8 +1,9 @@
 "use strict";
 /**
- *  Handles communication with the google tag manager API. 
+ *  Handles communication with the google tag manager API.
+ *  gtx is the filename because some ad blockers regex *gtm*
  */
-hqDefine('analytix/js/gtm', [
+hqDefine('analytix/js/gtx', [
     'jquery',
     'underscore',
     'analytix/js/initial',

--- a/corehq/apps/analytics/templates/analytics/analytics_js.html
+++ b/corehq/apps/analytics/templates/analytics/analytics_js.html
@@ -12,6 +12,6 @@
   <script src="{% static 'analytix/js/hubspot.js' %}"></script>
   <script src="{% static 'analytix/js/drift.js' %}"></script>
   <script src="{% static 'analytix/js/appcues.js' %}"></script>
-  {# gtx is the filename because some adblockers regex *gtm* #}
+  {# gtx is the filename because some adblockers blocks 'gtm.js' #}
   <script src="{% static 'analytix/js/gtx.js' %}"></script>
 {% endcompress %}

--- a/corehq/apps/analytics/templates/analytics/analytics_js.html
+++ b/corehq/apps/analytics/templates/analytics/analytics_js.html
@@ -12,5 +12,6 @@
   <script src="{% static 'analytix/js/hubspot.js' %}"></script>
   <script src="{% static 'analytix/js/drift.js' %}"></script>
   <script src="{% static 'analytix/js/appcues.js' %}"></script>
-  <script src="{% static 'analytix/js/gtm.js' %}"></script>
+  {# gtx is the filename because some adblockers regex *gtm* #}
+  <script src="{% static 'analytix/js/gtx.js' %}"></script>
 {% endcompress %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/base_main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/base_main.js
@@ -13,7 +13,7 @@ hqDefine("hqwebapp/js/bootstrap3/base_main", [
     'analytix/js/google',
     'analytix/js/hubspot',
     'analytix/js/kissmetrix',
-    'analytix/js/gtm',
+    'analytix/js/gtx',
     'hqwebapp/js/bootstrap3/mobile_experience_warning',
 ], function () {
     // nothing to do, this is just to define the dependencies for hqwebapp/base.html

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/base_main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/base_main.js
@@ -13,7 +13,7 @@ hqDefine("hqwebapp/js/bootstrap5/base_main", [
     'analytix/js/google',
     'analytix/js/hubspot',
     'analytix/js/kissmetrix',
-    'analytix/js/gtm',
+    'analytix/js/gtx',
     'hqwebapp/js/bootstrap5/mobile_experience_warning',
 ], function () {
     // nothing to do, this is just to define the dependencies for hqwebapp/base.html

--- a/corehq/apps/hqwebapp/templatetags/tests/rendered/javascript_libraries_hq.html
+++ b/corehq/apps/hqwebapp/templatetags/tests/rendered/javascript_libraries_hq.html
@@ -24,7 +24,7 @@
 <script src="{% static 'analytix/js/hubspot.js' %}"></script>
 <script src="{% static 'analytix/js/drift.js' %}"></script>
 <script src="{% static 'analytix/js/appcues.js' %}"></script>
-<script src="{% static 'analytix/js/gtm.js' %}"></script>
+<script src="{% static 'analytix/js/gtx.js' %}"></script>
 
 <script src="{% static 'knockout/build/output/knockout-latest.js' %}"></script>
 <script src="{% static 'hqwebapp/js/lib/knockout_plugins/knockout_mapping.ko.min.js' %}"></script>

--- a/corehq/apps/hqwebapp/templatetags/tests/rendered/javascript_libraries_hq_bootstrap5.html
+++ b/corehq/apps/hqwebapp/templatetags/tests/rendered/javascript_libraries_hq_bootstrap5.html
@@ -24,7 +24,7 @@
 <script src="{% static 'analytix/js/hubspot.js' %}"></script>
 <script src="{% static 'analytix/js/drift.js' %}"></script>
 <script src="{% static 'analytix/js/appcues.js' %}"></script>
-<script src="{% static 'analytix/js/gtm.js' %}"></script>
+<script src="{% static 'analytix/js/gtx.js' %}"></script>
 
 <script src="{% static 'knockout/build/output/knockout-latest.js' %}"></script>
 <script src="{% static 'hqwebapp/js/lib/knockout_plugins/knockout_mapping.ko.min.js' %}"></script>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/base_main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/base_main.js.diff.txt
@@ -25,7 +25,7 @@
      'analytix/js/google',
      'analytix/js/hubspot',
      'analytix/js/kissmetrix',
-     'analytix/js/gtm',
+     'analytix/js/gtx',
 -    'hqwebapp/js/bootstrap3/mobile_experience_warning',
 +    'hqwebapp/js/bootstrap5/mobile_experience_warning',
  ], function () {


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This is a simple rename which fixes the issue of adblockers blocking the tag manager HQ script. The file is renamed from `gtm.js` to `gtx.js`. Issue only appears on local when the static files are not being compressed.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This was tested on local.
Sanity testing on staging to be done before merging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
