### PR TITLE
Improve case import UX

### DIFF
--- a/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
+++ b/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
@@ -79,8 +79,7 @@ hqDefine('case_importer/js/excel_fields', [
                     row.isCustom(false);
                     row.selectedCaseField(field);
                 } else {
-                    var spec = _(caseFieldSpecs).findWhere({field});
-                    row.isCustom(_.isEmpty(spec) && !systemFields.contains(field));
+                    row.isCustom(!systemFields.contains(field));
                     row.selectedCaseField(null);
                 }
             };

--- a/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
+++ b/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
@@ -30,6 +30,9 @@ hqDefine('case_importer/js/excel_fields', [
                 customCaseField: ko.observable(excelField),
                 isCustom: ko.observable(false),
             };
+            row.hasValue = ko.computed(function () {
+                return row.isCustom() || row.selectedCaseField();
+            });
             row.selectedCaseFieldOrBlank = ko.computed({
                 read: function () {
                     return row.isCustom() ? '' : row.selectedCaseField();

--- a/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
+++ b/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
@@ -66,12 +66,6 @@ hqDefine('case_importer/js/excel_fields', [
             row.valuesHints = ko.computed(function () {
                 return row.caseFieldSpec().values_hints || [];
             });
-            row.createNewChecked = ko.computed({
-                read: function () {
-                    return row.isCustom();
-                },
-                write: row.isCustom,
-            });
             row.isDeprecated = ko.computed(function () {
                 return row.caseFieldSpec().deprecated === true;
             });

--- a/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
+++ b/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
@@ -11,6 +11,7 @@ hqDefine('case_importer/js/excel_fields', [
     levenshtein
 ) {
     function excelFieldRows(excelFields, caseFieldSpecs, systemFields) {
+        systemFields = _(systemFields);
         var self = {
             excelFields: excelFields,
             caseFieldSpecs: caseFieldSpecs,
@@ -79,7 +80,7 @@ hqDefine('case_importer/js/excel_fields', [
                     row.selectedCaseField(field);
                 } else {
                     var spec = _(caseFieldSpecs).findWhere({field});
-                    row.isCustom(_.isEmpty(spec) && !_(systemFields).contains(field));
+                    row.isCustom(_.isEmpty(spec) && !systemFields.contains(field));
                     row.selectedCaseField(null);
                 }
             };
@@ -99,6 +100,9 @@ hqDefine('case_importer/js/excel_fields', [
                     return suggestion.distance < 4;
                 });
                 return _.chain(suggestions).sortBy('distance').pluck('field').value();
+            });
+            row.isSystemProperty = ko.computed(function () {
+                return row.isCustom() && systemFields.contains(row.customCaseField());
             });
 
             self.mappingRows.push(row);

--- a/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
+++ b/corehq/apps/case_importer/static/case_importer/js/excel_fields.js
@@ -10,7 +10,7 @@ hqDefine('case_importer/js/excel_fields', [
     _,
     levenshtein
 ) {
-    function excelFieldRows(excelFields, caseFieldSpecs) {
+    function excelFieldRows(excelFields, caseFieldSpecs, systemFields) {
         var self = {
             excelFields: excelFields,
             caseFieldSpecs: caseFieldSpecs,
@@ -65,7 +65,7 @@ hqDefine('case_importer/js/excel_fields', [
             });
             row.createNewChecked = ko.computed({
                 read: function () {
-                    return _.isEmpty(row.caseFieldSpec());
+                    return row.isCustom();
                 },
                 write: row.isCustom,
             });
@@ -81,7 +81,8 @@ hqDefine('case_importer/js/excel_fields', [
                     row.isCustom(false);
                     row.selectedCaseField(field);
                 } else {
-                    row.isCustom(true);
+                    var spec = _(caseFieldSpecs).findWhere({field});
+                    row.isCustom(_.isEmpty(spec) && !_(systemFields).contains(field));
                     row.selectedCaseField(null);
                 }
             };

--- a/corehq/apps/case_importer/static/case_importer/js/main.js
+++ b/corehq/apps/case_importer/static/case_importer/js/main.js
@@ -61,6 +61,7 @@ hqDefine("case_importer/js/main", [
     var behaviorForExcelMappingPage = function () {
         var excelFields = initialPageData.get('excel_fields');
         var caseFieldSpecs = initialPageData.get('case_field_specs');
+        var systemFields = initialPageData.get('system_fields');
         if (!excelFields && !caseFieldSpecs) {
             // We're not on the excel mapping page
             return;
@@ -78,7 +79,7 @@ hqDefine("case_importer/js/main", [
             return;
         }
 
-        var excelFieldRows = excelFieldsModule.excelFieldRowsModel(excelFields, caseFieldSpecs);
+        var excelFieldRows = excelFieldsModule.excelFieldRowsModel(excelFields, caseFieldSpecs, systemFields);
         $('#excel-field-rows').koApplyBindings(excelFieldRows);
 
         $('#js-add-mapping').click(function (e) {

--- a/corehq/apps/case_importer/suggested_fields.py
+++ b/corehq/apps/case_importer/suggested_fields.py
@@ -118,5 +118,6 @@ def get_special_fields(domain=None):
     return special_fields
 
 
-def get_system_fields():
-    return [x.label for x in MAIN_CASE_TABLE_PROPERTIES]
+def get_non_discoverable_system_properties():
+    discoverable = {s.field for s in get_special_fields() if s.description and s.discoverable}
+    return [p.label for p in MAIN_CASE_TABLE_PROPERTIES if p.label not in discoverable]

--- a/corehq/apps/case_importer/suggested_fields.py
+++ b/corehq/apps/case_importer/suggested_fields.py
@@ -9,6 +9,7 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
 )
 from corehq.apps.case_importer.util import RESERVED_FIELDS
 from corehq.apps.data_dictionary.util import get_values_hints_dict, get_deprecated_fields
+from corehq.apps.export.system_properties import MAIN_CASE_TABLE_PROPERTIES
 from corehq.toggles import BULK_UPLOAD_DATE_OPENED
 
 
@@ -115,3 +116,7 @@ def get_special_fields(domain=None):
             )
         )
     return special_fields
+
+
+def get_system_fields():
+    return [x.label for x in MAIN_CASE_TABLE_PROPERTIES]

--- a/corehq/apps/case_importer/templates/case_importer/excel_config.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_config.html
@@ -84,7 +84,7 @@
         <div class="col-md-6">
           <select class="form-control hqwebapp-select2" name="search_column" id="search_column" {% if is_bulk_import %}disabled="disabled"{% endif %}>
             {% for column in columns %}
-              <option value="{{column|escape}}">
+              <option value="{{column|escape}}" {% if column == "caseid" %}selected{% endif %}>
                 {{column|escape}}
               </option>
             {% endfor %}

--- a/corehq/apps/case_importer/templates/case_importer/excel_fields.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_fields.html
@@ -21,6 +21,7 @@
 
   {% initial_page_data 'excel_fields' excel_fields %}
   {% initial_page_data 'case_field_specs' case_field_specs %}
+  {% initial_page_data 'system_fields' system_fields %}
   {% initial_page_data 'is_bulk_import' is_bulk_import %}
 
   <form action="{% url "excel_commit" domain %}"

--- a/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
@@ -65,6 +65,16 @@
         {% endblocktrans %}
       </p>
     <!--/ko-->
+    <!--ko if: isSystemProperty-->
+      <p class="help-block text-warning">
+        <i class="fa fa-question-circle"></i>
+        {% blocktrans %}
+          Importing a system property may have unexpected results such as
+          adding a duplicate field to case exports. Consider using a
+          different property name.
+        {% endblocktrans %}
+      </p>
+    <!--/ko-->
   </td>
 
   <td>

--- a/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
@@ -18,7 +18,7 @@
   </td>
 
   <td class="text-center">
-    <i class="fa fa-arrow-right"></i>
+    <!-- ko if: hasValue --><i class="fa fa-arrow-right"></i><!--/ko-->
   </td>
 
   <td class="col-md-3">

--- a/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
@@ -58,7 +58,7 @@
         </p>
     </div>
     <!--ko if: caseFieldSuggestions().length-->
-      <p class="help-block text-warning">
+      <p class="help-block text-info">
         <i class="fa fa-question-circle"></i>
         {% blocktrans with '<!--ko foreach: caseFieldSuggestions--><!--ko if: $index() !== 0-->, <!--/ko--><strong data-bind="text: $data"></strong><!--/ko-->' as suggestion %}
           Did you mean "{{ suggestion }}" instead?

--- a/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/excel_field_rows.html
@@ -68,7 +68,7 @@
   </td>
 
   <td>
-    <input type="checkbox" class="form-check-input mt-2" class="new_property" data-bind="checked: createNewChecked"/>
+    <input type="checkbox" class="form-check-input mt-2" class="new_property" data-bind="checked: isCustom"/>
   </td>
 
   {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}

--- a/corehq/apps/case_importer/tests/test_suggested_fields.py
+++ b/corehq/apps/case_importer/tests/test_suggested_fields.py
@@ -6,6 +6,7 @@ from unittest import mock
 from corehq.apps.case_importer.suggested_fields import (
     FieldSpec,
     get_suggested_case_fields,
+    get_non_discoverable_system_properties,
 )
 from corehq.util.test_utils import DocTestMixin
 
@@ -68,3 +69,26 @@ class SuggestedFieldTest(SimpleTestCase, DocTestMixin):
                 FieldSpec(field='weight', show_in_menu=True),
             ]
         )
+
+
+class TestSystemProperties(SimpleTestCase):
+
+    def test_get_non_discoverable_system_properties(self):
+        self.assertEqual(get_non_discoverable_system_properties(), [
+            'number',
+            'caseid',
+            'case_type',
+            'closed',
+            'closed_by_user_id',
+            'closed_by_username',
+            'closed_date',
+            'last_modified_by_user_id',
+            'last_modified_by_user_username',
+            'last_modified_date',
+            'opened_by_user_id',
+            'opened_by_username',
+            'opened_date',
+            'server_last_modified_date',
+            'state',
+            'case_link',
+        ])

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -32,6 +32,7 @@ from corehq.apps.case_importer.extension_points import (
 )
 from corehq.apps.case_importer.suggested_fields import (
     get_suggested_case_fields,
+    get_system_fields,
 )
 from corehq.apps.case_importer.tracking.case_upload_tracker import CaseUpload
 from corehq.apps.case_importer.util import (
@@ -372,6 +373,7 @@ def excel_fields(request, domain):
         'columns': columns,
         'excel_fields': excel_fields,
         'case_field_specs': case_field_specs,
+        'system_fields': get_system_fields(),
         'domain': domain,
         'mirroring_enabled': mirroring_enabled,
         'is_bulk_import': request.POST.get('is_bulk_import', 'False') == 'True',

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -32,7 +32,7 @@ from corehq.apps.case_importer.extension_points import (
 )
 from corehq.apps.case_importer.suggested_fields import (
     get_suggested_case_fields,
-    get_system_fields,
+    get_non_discoverable_system_properties,
 )
 from corehq.apps.case_importer.tracking.case_upload_tracker import CaseUpload
 from corehq.apps.case_importer.util import (
@@ -373,7 +373,7 @@ def excel_fields(request, domain):
         'columns': columns,
         'excel_fields': excel_fields,
         'case_field_specs': case_field_specs,
-        'system_fields': get_system_fields(),
+        'system_fields': get_non_discoverable_system_properties(),
         'domain': domain,
         'mirroring_enabled': mirroring_enabled,
         'is_bulk_import': request.POST.get('is_bulk_import', 'False') == 'True',


### PR DESCRIPTION
Addresses a probable cause of https://dimagi.atlassian.net/browse/SAAS-14825: importing system properties results in duplicate properties in OData feeds.

Behavioral changes:
- System case properties are no longer selected for import by default.
  ![image](https://github.com/user-attachments/assets/2c686204-fd6e-49dd-b3c8-28bb4ce89440)
- (minor) Select "caseid" as default search column if present in the worksheet. The previous default of the first column in the worksheet ("number" if using an export sheet as template) was undesirable.
  ![image](https://github.com/user-attachments/assets/d936b448-7c82-4abe-bde9-8229060a9b84)

Other minor visual UX changes:
- Hide Excel Field **->** Case Property arrow when field will not be imported (see screenshot above).

- Case property suggestions are now presented as info messages rather than warnings.
  **Before**
  ![image](https://github.com/user-attachments/assets/20cbaee5-74bb-4f3e-a89e-a83dcbc241b1)
  **After**
  ![image](https://github.com/user-attachments/assets/0a1da3b6-8a61-47d0-bf79-b4d62902ed38)

- Warn when importing to a system property since that can result in undesirable outcomes such as duplicate columns in case exports, some of which will be ineffective because system and user property namespacing is not handled consistently.
  ![image](https://github.com/user-attachments/assets/16cde2b7-5d58-47d1-b59f-7660a724926a)

:blowfish: Review by commit.

The original discovery and the first commit were done as a group with @jingcheng16 and @mjriley 

## Safety Assurance

### Safety story

This changes the default behavior of the case importer. Most of the changes are minor visual tweaks.

### Automated test coverage

No. Tested in local dev environment.

### QA Plan

Does this need QA?

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations