### PR TITLE
Turn on custom button text for versions > 2.55

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from looseversion import LooseVersion
 
 from django.conf import settings
 from django.contrib import messages
@@ -326,6 +327,7 @@ def _get_vellum_features(request, domain, app):
         'sorted_itemsets': app.enable_sorted_itemsets,
         'advanced_itemsets': add_ons.show("advanced_itemsets", request, app),
         'markdown_tables': app.enable_markdown_tables,
+        'use_custom_repeat_button_text': app.build_version >= LooseVersion('2.55'),
     })
     return vellum_features
 


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Dovetails with the Vellum PR: https://github.com/dimagi/Vellum/pull/1119. See that PR for more details.

Only turns on the custom repeat button text feature if the app is targeting CommCare a version >= 2.55, per [the spec](https://docs.google.com/document/d/1hQnoQadLpK-SVf2OMtcCm75yjLBPRT7IWjhZpJWcNoc/edit?usp=sharing).

JIRA: https://dimagi.atlassian.net/browse/USH-4709

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Will be deployed before or in tandem with the Vellum PR.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Passes a harmless setting through, that Vellum can choose whether or not to use

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

None existing, didn't seem worth adding for this change.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

This feature will be tested by QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
