### PR TITLE
Visually Denote Active Persistent Menu Item

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -159,7 +159,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", [
         if (!appPreview && menuResponse.persistentMenu) {
             FormplayerFrontend.regions.getRegion('persistentMenu').show(
                 views.PersistentMenuView({
-                    collection: _toMenuCommands(menuResponse.persistentMenu, []),
+                    collection: _toMenuCommands(menuResponse.persistentMenu, [], menuResponse.selections),
                 }).render());
         } else {
             FormplayerFrontend.regions.getRegion('persistentMenu').empty();
@@ -170,7 +170,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", [
         }
     };
 
-    var _toMenuCommands = function (menuCommands, priorSelections) {
+    var _toMenuCommands = function (menuCommands, priorSelections, activeSelection) {
         return new Backbone.Collection(_.map(menuCommands, function (menuCommand) {
             const command = _.pick(menuCommand, [
                 'index',
@@ -181,7 +181,10 @@ hqDefine("cloudcare/js/formplayer/menus/controller", [
             ]);
             // Store an array of the commands needed to navigate to each nested menu item
             command.selections = priorSelections.concat([command.index]);
-            command.commands = _toMenuCommands(command.commands, command.selections);
+            if (JSON.stringify(command.selections) === JSON.stringify(activeSelection)) {
+                command.isActiveSelection = true;
+            }
+            command.commands = _toMenuCommands(command.commands, command.selections, activeSelection);
             return new Backbone.Model(command);
         }));
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1499,10 +1499,11 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
         templateContext: function () {
             const appId = formplayerUtils.currentUrlToObject().appId,
                 imageUri = this.model.get('imageUri'),
-                  icons = {JUMP: 'fa-pencil', NEXT: 'fa-regular fa-folder', ENTITY_SELECT: 'fa-list-ul'};
+                icons = {JUMP: 'fa-pencil', NEXT: 'fa-regular fa-folder', ENTITY_SELECT: 'fa-list-ul'};
             return {
                 imageUri: imageUri ? FormplayerFrontend.getChannel().request('resourceMap', imageUri, appId) : "",
                 iconClass: icons[this.model.get('navigationState')] || 'fa-arrow-up-right-from-square',
+                isActive: this.model.get('isActiveSelection'),
             };
         },
         onRender: function () {

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/persistent_menu.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/persistent_menu.html
@@ -41,7 +41,7 @@
     <% } else { %>
       <i class="fa <%- iconClass %> persistent-menu-image" aria-hidden="true"></i>
     <% } %>
-    <a class="align-middle stretched-link text-reset" href="#"
+    <a class="align-middle stretched-link text-reset <%= isActive ? 'fw-bold' : '' %>" href="#"
        data-bs-toggle="offcanvas" data-bs-target="#persistent-menu-container">
       <%- displayText %>
     </a>


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
For persistent menu navigation, the PR will bold the persistent menu text for the current screen the user is on.

![Screen Shot 2024-08-29 at 4 51 42 PM](https://github.com/user-attachments/assets/c0e4e50d-c8a4-4f48-88cb-38f7b0835958)

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[USH-4866](https://dimagi.atlassian.net/browse/USH-4866)
The `selections` defines the path to the current screen so it traces that with the persistent menu indexes to find the related persistent menu 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
not feature flag but it is behind `cc-peristent-menu` app setting

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Change is limited to persistent menu. Locally tested

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4866]: https://dimagi.atlassian.net/browse/USH-4866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ