### PR TITLE
put location assignment work behind feature flag

### DIFF
--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -16,7 +16,12 @@ hqDefine("locations/js/widgets", [
         _.each($source.select2('data'), function (result) {
             const fullLengthName = result.text || result.name;
             const truncatedName = truncateLocationName(fullLengthName, $select);
-            var $option = new Option(truncatedName, result.id);
+            let $option;
+            if (toggles.toggleEnabled('LOCATION_FIELD_USER_PROVISIONING')) {
+                $option = new Option(truncatedName, result.id);
+            } else {
+                $option = new Option(fullLengthName, result.id);
+            }
             $option.setAttribute('title', result.title);
             $select.append($option);
         });
@@ -116,7 +121,11 @@ hqDefine("locations/js/widgets", [
             templateSelection: function (result) {
                 const fullLengthName = result.text || result.name;
                 const truncatedName = truncateLocationName(fullLengthName, $select);
-                return truncatedName;
+                if (toggles.toggleEnabled('LOCATION_FIELD_USER_PROVISIONING')) {
+                    return truncatedName;
+                } else {
+                    return fullLengthName;
+                }
             },
         });
 

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -120,8 +120,8 @@ hqDefine("locations/js/widgets", [
             },
             templateSelection: function (result) {
                 const fullLengthName = result.text || result.name;
-                const truncatedName = truncateLocationName(fullLengthName, $select);
                 if (toggles.toggleEnabled('LOCATION_FIELD_USER_PROVISIONING')) {
+                    const truncatedName = truncateLocationName(fullLengthName, $select);
                     return truncatedName;
                 } else {
                     return fullLengthName;

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -15,9 +15,9 @@ hqDefine("locations/js/widgets", [
         $select.find("option").remove();
         _.each($source.select2('data'), function (result) {
             const fullLengthName = result.text || result.name;
-            const truncatedName = truncateLocationName(fullLengthName, $select);
             let $option;
             if (toggles.toggleEnabled('LOCATION_FIELD_USER_PROVISIONING')) {
+                const truncatedName = truncateLocationName(fullLengthName, $select);
                 $option = new Option(truncatedName, result.id);
             } else {
                 $option = new Option(fullLengthName, result.id);

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -15,7 +15,7 @@ from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
 
-from corehq import privileges
+from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.domain.forms import NoAutocompleteMixin, clean_password
@@ -536,7 +536,8 @@ class AdminInvitesUserForm(SelectUserLocationForm):
                 'profile' if ('profile' in self.fields and len(self.fields['profile'].choices) > 0) else None,
             )
         ]
-        if should_show_location:
+        loc_flag_enabled = toggles.LOCATION_FIELD_USER_PROVISIONING.enabled(domain, toggles.NAMESPACE_DOMAIN)
+        if should_show_location and loc_flag_enabled:
             fields.append(
                 crispy.Fieldset(
                     gettext("Location Settings"),

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -15,7 +15,7 @@ from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
 
-from corehq import privileges, toggles
+from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.domain.forms import NoAutocompleteMixin, clean_password
@@ -536,8 +536,7 @@ class AdminInvitesUserForm(SelectUserLocationForm):
                 'profile' if ('profile' in self.fields and len(self.fields['profile'].choices) > 0) else None,
             )
         ]
-        loc_flag_enabled = toggles.LOCATION_FIELD_USER_PROVISIONING.enabled(domain, toggles.NAMESPACE_DOMAIN)
-        if should_show_location and loc_flag_enabled:
+        if should_show_location:
             fields.append(
                 crispy.Fieldset(
                     gettext("Location Settings"),


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->
This puts recently deployed location assignment work behind a FF.
Everything in [this body of work ](https://dimagi.atlassian.net/browse/USH-4678) will now be behind a flag.

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
[Jira ticket](https://dimagi.atlassian.net/browse/USH-4918)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

location_field_user_provisioning
--

[LOCATION_FIELD_USER_PROVISIONING](https://www.commcarehq.org/hq/flags/edit/location_field_user_provisioning/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
tested locally and on staging

### Automated test coverage
not cover by automated tests

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
no QA planned
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
