### PR TITLE
Use refresh_from_db instead of object manager

### DIFF
--- a/corehq/apps/sso/tests/test_tasks.py
+++ b/corehq/apps/sso/tests/test_tasks.py
@@ -253,8 +253,8 @@ class EnforceKeyExpirationTaskTests(TestCase):
         with freeze_time(current_time):
             num_updates = enforce_key_expiration_for_idp(idp)
 
-        updated_key = HQApiKey.objects.get(id=key.id)
-        self.assertEqual(updated_key.expiration_date, current_time + datetime.timedelta(days=30))
+        key.refresh_from_db()
+        self.assertEqual(key.expiration_date, current_time + datetime.timedelta(days=30))
         self.assertEqual(num_updates, 1)
 
     def test_exits_when_no_maximum_date_exists(self):
@@ -288,8 +288,8 @@ class EnforceKeyExpirationTaskTests(TestCase):
         with freeze_time(current_time):
             update_sso_user_api_key_expiration_dates(idp.id)
 
-        updated_key = HQApiKey.objects.get(id=key.id)
-        self.assertEqual(updated_key.expiration_date, current_time + datetime.timedelta(days=30))
+        key.refresh_from_db()
+        self.assertEqual(key.expiration_date, current_time + datetime.timedelta(days=30))
 
     def _create_idp_for_domains(self, domains, max_days_until_user_api_key_expiration=30):
         idp = generator.create_idp('test-idp', account=self.account)


### PR DESCRIPTION
## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Technical Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The HQApiKey has a [custom default manager](https://github.com/dimagi/commcare-hq/blob/c50212b21f8d0a6888809ff10f79da5aaa89eae0/corehq/apps/users/models.py#L3092-L3092) that [excludes expired keys](https://github.com/dimagi/commcare-hq/blob/d94b02efea223e23fbaaa2a061645c26052b9eeb/corehq/apps/users/models.py#L3075-L3075). We were using this object manager to attempt to refetch the API key created in tests in `corehq.apps.sso.tests.test_tasks.EnforceKeyExpirationTaskTests`. The issue was that we were testing a method `_enforce_key_expiration_for_idp` that sets the expiration date to now + 30 days, making the expiration date always August 31st, 2024. Since the object manager's method didn't take the frozen time into consideration, it wasn't including the created key as it's expiration date was now earlier than datetime.utcnow().

So tests are now failing when attempting to refetch the object from the database. Rather than using the `all_objects` manager, we can just use `refresh_from_db()` to get an up to date db object.

![image](https://github.com/user-attachments/assets/9314a6b0-6a52-453c-8593-58c0b0db0822)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
