### PR TITLE
Removed jquery-timeago

### DIFF
--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -75,20 +75,6 @@ def use_nvd3_v3(view_func):
     return set_request_flag(view_func, 'use_nvd3_v3')
 
 
-def use_timeago(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to enable the inclusion of the timeago library at the base template
-    level.
-
-    Example:
-
-    @use_timeago
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-    return set_request_flag(view_func, 'use_timeago')
-
-
 def use_datatables(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable the inclusion of the datatables library at the base template

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js
@@ -35,11 +35,6 @@ hqDefine("hqwebapp/js/bootstrap3/hq.helpers", [
         $(this).parents('.alert').hide(150);
     });
 
-    if ($.timeago) {
-        $.timeago.settings.allowFuture = true;
-        $(".timeago").timeago();
-    }
-
     window.onerror = function (message, file, line, col, error) {
         var stack = error ? error.stack : null;
         if (!stack && (

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
@@ -37,11 +37,6 @@ hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
         $(this).parents('.alert').hide(150);
     });
 
-    if ($.timeago) {
-        $.timeago.settings.allowFuture = true;
-        $(".timeago").timeago();
-    }
-
     window.onerror = function (message, file, line, col, error) {
         var stack = error ? error.stack : null;
         if (!stack && (

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -428,10 +428,6 @@
       {% endcompress %}
     {% endif %}
 
-    {% if request.use_timeago and not use_js_bundler %}
-      <script src="{% static 'jquery-timeago/jquery.timeago.js' %}"></script>
-    {% endif %}
-
     {% if request.use_multiselect and not use_js_bundler %}
       {% compress js %}
         <script src="{% static 'multiselect/js/jquery.multi-select.js' %}"></script>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
@@ -18,7 +18,7 @@
  ) {
      // disable-on-submit is a class for form submit buttons so they're automatically disabled when the form is submitted
      $(document).on('submit', 'form', function (ev) {
-@@ -59,19 +61,6 @@
+@@ -54,19 +56,6 @@
          return false; // let default handler run
      };
  
@@ -38,7 +38,7 @@
      $.fn.hqHelp = function (opts) {
          var self = this;
          self.each(function (i) {
-@@ -88,22 +77,19 @@
+@@ -83,22 +72,19 @@
              if (opts) {
                  options = _.extend(options, opts);
              }

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/reports.async.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/reports.async.js.diff.txt
@@ -33,7 +33,7 @@
                      }
                      self.hqLoading = $(self.loaderClass);
                      self.reportContent.html(data.report);
-@@ -174,7 +174,7 @@
+@@ -171,7 +171,7 @@
  
                      if (!initialLoad || !self.standardReport.needsFilters) {
                          self.standardReport.filterSubmitButton
@@ -42,7 +42,7 @@
                          setTimeout(function () {
                              // Bootstrap clears all btn styles except btn on reset
                              // This gets around it by waiting 10ms.
-@@ -186,7 +186,7 @@
+@@ -183,7 +183,7 @@
                          }, 10);
                      } else {
                          self.standardReport.filterSubmitButton
@@ -51,7 +51,7 @@
                              .addClass('btn-primary')
                              .removeClass('disabled')
                              .prop('disabled', false);
-@@ -205,10 +205,10 @@
+@@ -202,10 +202,10 @@
                          self.loadingIssueModal.find('.report-error-status').html('<strong>' + data.status + '</strong> ' +
                              ((humanReadable) ? humanReadable : ""));
                          if (self.issueAttempts > 0) {
@@ -64,7 +64,7 @@
                      } else {
                          self.hqLoading = $(self.loaderClass);
                          self.hqLoading.find('h4').text(gettext("Loading Stopped"));
-@@ -216,7 +216,7 @@
+@@ -213,7 +213,7 @@
                      }
                  },
                  beforeSend: function () {
@@ -73,7 +73,7 @@
                      $('.loading-backdrop').fadeIn();
                      if (self.hqLoading) {
                          self.hqLoading.attr('style', 'position: absolute; top: 30px; left: 40%;');
-@@ -228,7 +228,7 @@
+@@ -225,7 +225,7 @@
          };
  
          $(document).on('click', '.try-again', function () {

--- a/corehq/apps/hqwebapp/tests/test_proptable_tags.py
+++ b/corehq/apps/hqwebapp/tests/test_proptable_tags.py
@@ -38,8 +38,9 @@ class CaseDisplayDataTest(SimpleTestCase):
         })
 
     def test_get_display_data_function(self):
-        get_color = lambda x: x['color']
-        column = DisplayConfig(name='favorite color', expr=get_color)
+        def _get_color(x):
+            return x['color']
+        column = DisplayConfig(name='favorite color', expr=_get_color)
         data = {
             'color': 'red'
         }
@@ -108,22 +109,6 @@ class CaseDisplayDataTest(SimpleTestCase):
         data = {'date': "2021-03-16T14:37:22Z"}
         expected_value = (
             "<time title='2021-03-16T14:37:22+00:00' datetime='2021-03-16T14:37:22+00:00'>"
-            "Mar 16, 2021 14:37 UTC"
-            "</time>"
-        )
-        self.assertEqual(get_display_data(data, column), {
-            'expr': 'date',
-            'name': 'date',
-            'description': None,
-            'value': expected_value,
-            'has_history': False,
-        })
-
-    def test_get_display_process_timeago(self):
-        column = DisplayConfig(expr='date', process="date", timeago=True)
-        data = {'date': "2021-03-16T14:37:22Z"}
-        expected_value = (
-            "<time class='timeago' title='2021-03-16T14:37:22+00:00' datetime='2021-03-16T14:37:22+00:00'>"
             "Mar 16, 2021 14:37 UTC"
             "</time>"
         )

--- a/corehq/apps/reports/static/reports/js/bootstrap3/reports.async.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/reports.async.js
@@ -165,9 +165,6 @@ hqDefine("reports/js/bootstrap3/reports.async", function () {
 
                     // Assorted UI cleanup/initialization
                     $('.hq-report-time-notice').removeClass('hide');
-                    if ($.timeago) {
-                        $(".timeago").timeago();
-                    }
 
                     $('.loading-backdrop').fadeOut();
                     self.hqLoading.fadeOut();

--- a/corehq/apps/reports/static/reports/js/bootstrap5/reports.async.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/reports.async.js
@@ -165,9 +165,6 @@ hqDefine("reports/js/bootstrap5/reports.async", function () {
 
                     // Assorted UI cleanup/initialization
                     $('.hq-report-time-notice').removeClass('hide');
-                    if ($.timeago) {
-                        $(".timeago").timeago();
-                    }
 
                     $('.loading-backdrop').fadeOut();
                     self.hqLoading.fadeOut();

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
         "jquery-form": "4.2.2",
         "jquery-memoized-ajax": "0.5.0",
         "jquery-textchange": "jmalonzo/bower-jquery-textchange#0.2.3",
-        "jquery-timeago": "rmm5t/jquery-timeago#1.2.0",
         "jquery-tiny-pubsub": "cowboy/jquery-tiny-pubsub#~0.7.0",
         "jquery-treetable": "ludo/jquery-treetable#3.2.0",
         "jquery-ui": "1.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3679,10 +3679,6 @@ jquery-textchange@jmalonzo/bower-jquery-textchange#0.2.3:
   version "0.0.0"
   resolved "https://codeload.github.com/jmalonzo/bower-jquery-textchange/tar.gz/fd7d7c0ac5116861759cd467135307dc9aab7cdc"
 
-jquery-timeago@rmm5t/jquery-timeago#1.2.0:
-  version "0.0.0"
-  resolved "https://codeload.github.com/rmm5t/jquery-timeago/tar.gz/f2afbeaf787a93f01822d062fc80a571f4ebda48"
-
 jquery-tiny-pubsub@cowboy/jquery-tiny-pubsub#~0.7.0:
   version "0.0.0-ignored"
   resolved "https://codeload.github.com/cowboy/jquery-tiny-pubsub/tar.gz/d9b4a093221f43d1119aac088258c8d0ea2b183b"


### PR DESCRIPTION
## Technical Summary
This was used in the careplan report template (see https://github.com/dimagi/commcare-hq/commit/438cb6327cb914c7530b1a0d0168f9b680b0a2a6) which has since been removed (see https://github.com/dimagi/commcare-hq/pull/31096). The proptable template tags also supported a `timeago` flag, which does not appear to be in use - none of the code that instantiates a `DisplayConfig` sets that flag.

@esoergel including you because I think you touched the proptable code in the past few months.

## Safety Assurance

### Safety story
I'm confident this code is unused. Locally, I loaded the "Form Completion vs. Submission Trends" report (to test datetime columns) and a case data page (to test the proptable tags).

### Automated test coverage

This PR deletes the (limited) relevant tests.

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
