### PR TITLE
Fixed buttons displayed in Solutions Feature Request modal

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/modal_report_issue.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/modal_report_issue.html
@@ -149,7 +149,7 @@
           <div class="modal-footer">
               <button type="button"
                       id="bug-report-cancel"
-                      class="btn btn-default"
+                      class="btn btn-outline-secondary"
                       data-bs-dismiss="modal"
                       data-bind="enable: cancelBtnEnabled">{% trans 'Cancel' %}</button>
               <button type="submit"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/modal_solutions_feature_request.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/modal_solutions_feature_request.html
@@ -111,7 +111,7 @@
           <div class="modal-footer">
               <button type="button"
                       id="request-report-cancel"
-                      class="btn btn-default"
+                      class="btn btn-outline-secondary"
                       data-bs-dismiss="modal"
                       data-bind="enable: cancelBtnEnabled">{% trans 'Cancel' %}</button>
               <button type="submit"

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/modal_report_issue.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/modal_report_issue.html.diff.txt
@@ -297,7 +297,7 @@
 +          <div class="modal-footer">
 +              <button type="button"
 +                      id="bug-report-cancel"
-+                      class="btn btn-default"
++                      class="btn btn-outline-secondary"
 +                      data-bs-dismiss="modal"
 +                      data-bind="enable: cancelBtnEnabled">{% trans 'Cancel' %}</button>
 +              <button type="submit"

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/modal_solutions_feature_request.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/modal_solutions_feature_request.html.diff.txt
@@ -225,7 +225,7 @@
 +          <div class="modal-footer">
 +              <button type="button"
 +                      id="request-report-cancel"
-+                      class="btn btn-default"
++                      class="btn btn-outline-secondary"
 +                      data-bs-dismiss="modal"
 +                      data-bind="enable: cancelBtnEnabled">{% trans 'Cancel' %}</button>
 +              <button type="submit"


### PR DESCRIPTION
## Product Description
Tiny: the "Cancel" button here wasn't displaying a border.

![Screenshot 2024-09-02 at 3 09 09 PM](https://github.com/user-attachments/assets/a3773a8e-d59c-474f-abcd-8e95930d133e)

## Feature Flag
I think this is superuser-only. It ought to be.

## Safety Assurance

### Safety story
Eensy-weensy change.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
