### PR TITLE
Remove Enterprise edition from select plan workflow

### DIFF
--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -999,14 +999,6 @@ class PlanViewBase(DomainAccountingSettings):
                   "workflows, and advanced security needs. Also for M&E teams "
                   "integrating data with 3rd party analytics."),
             ),
-            PlanOption(
-                SoftwarePlanEdition.ENTERPRISE,
-                _("Contact Us"),
-                _("Contact Us"),
-                _("For organizations that need a sustainable path to scale "
-                  "mobile data collection and service delivery across multiple "
-                  "teams, programs, or countries."),
-            )
         ]
 
     @property
@@ -1083,7 +1075,6 @@ class PlanViewBase(DomainAccountingSettings):
                     SoftwarePlanEdition.STANDARD,
                     SoftwarePlanEdition.PRO,
                     SoftwarePlanEdition.ADVANCED,
-                    SoftwarePlanEdition.ENTERPRISE,
                 ]
             ],
             'plan_options': [p._asdict() for p in self.plan_options],
@@ -1342,8 +1333,6 @@ class ConfirmSelectedPlanView(PlanViewBase):
     def post(self, request, *args, **kwargs):
         if not self.can_domain_unpause:
             return HttpResponseRedirect(reverse(SelectPlanView.urlname, args=[self.domain]))
-        if self.edition == SoftwarePlanEdition.ENTERPRISE:
-            return HttpResponseRedirect(reverse(SelectedEnterprisePlanView.urlname, args=[self.domain]))
         return super(ConfirmSelectedPlanView, self).get(request, *args, **kwargs)
 
 


### PR DESCRIPTION
## Product Description
Removes the choice of "Enterprise" from the select plan page.
Before:
![image](https://github.com/user-attachments/assets/c46b7045-a8c7-42b2-a91d-5bb1c869ae94)


After:
![image](https://github.com/user-attachments/assets/fd25c647-f2a8-4f07-8a16-ecf28d574192)


## Technical Summary
[SAAS-15941](https://dimagi.atlassian.net/browse/SAAS-15941)
Removes Enterprise from the list of options used by the `SelectPlanView`. Also removes a redirect to the Enterprise Plan contact form from that view since it is no longer applicable.

## Safety Assurance

### Safety story
Small code removal only, tested locally and on staging, including entering the Select Plan page from an existing Enterprise plan (previously the Enterprise card would be highlighted, now there is simply none highlighted).

### Automated test coverage
No automated test coverage here.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-15941]: https://dimagi.atlassian.net/browse/SAAS-15941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ