### PR TITLE
Added check for region before showing it

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -100,8 +100,10 @@ hqDefine("cloudcare/js/formplayer/app", [
         hqRequire(["cloudcare/js/formplayer/users/views"], function (UsersViews) {
             FormplayerFrontend.regions.getRegion('restoreAsBanner').show(
                 UsersViews.RestoreAsBanner({model: user, smallScreen: false}));
-            FormplayerFrontend.regions.getRegion('mobileRestoreAsBanner').show(
-                UsersViews.RestoreAsBanner({model: user, smallScreen: true}));
+            const mobileRegion = FormplayerFrontend.regions.getRegion('mobileRestoreAsBanner');
+            if (mobileRegion.$el.length) {      // This region doesn't exist in app preview
+                mobileRegion.show(UsersViews.RestoreAsBanner({model: user, smallScreen: true}));
+            }
         });
     };
 


### PR DESCRIPTION
## Technical Summary
Little followup for https://github.com/dimagi/commcare-hq/pull/34985

The new region is present only in web apps, not app preview, resulting in an error in app manager:
![Screenshot 2024-09-03 at 9 15 04 PM](https://github.com/user-attachments/assets/f4f8ced6-2378-4cd4-b4bb-076943067469)

## Safety Assurance

### Safety story
Quite minor. Code review is a sufficient safety check. I smoke tested loading app preview and web apps and verifying the Login As banner still shows (on both small and large screens for web apps).

### Automated test coverage

Doubt it

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
