### PR TITLE
Management Command to Update Geopoint Data in ES

### DIFF
--- a/corehq/apps/geospatial/management/commands/index_geolocation_case_properties.py
+++ b/corehq/apps/geospatial/management/commands/index_geolocation_case_properties.py
@@ -41,7 +41,9 @@ def index_case_docs(domain, query_limit=DEFAULT_QUERY_LIMIT, chunk_size=DEFAULT_
     query = _es_case_query(domain, geo_case_property, case_type)
     count = query.count()
     print(f'{count} case(s) to process')
-    batch_count = math.ceil(count / query_limit)
+    batch_count = 1
+    if query_limit:
+        batch_count = math.ceil(count / query_limit)
     print(f"Cases will be processed in {batch_count} batches")
     for i in range(batch_count):
         print(f'Processing {i+1}/{batch_count}')

--- a/corehq/apps/geospatial/management/commands/index_geolocation_case_properties.py
+++ b/corehq/apps/geospatial/management/commands/index_geolocation_case_properties.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
         case_type = options.get('case_type')
         query_limit = options.get('query_limit')
         chunk_size = options.get('chunk_size')
-        self.index_case_docs(domain, query_limit, chunk_size, case_type)
+        index_case_docs(domain, query_limit, chunk_size, case_type)
 
 
 def index_case_docs(domain, query_limit=DEFAULT_QUERY_LIMIT, chunk_size=DEFAULT_CHUNK_SIZE, case_type=None):

--- a/corehq/apps/geospatial/management/commands/index_geolocation_case_properties.py
+++ b/corehq/apps/geospatial/management/commands/index_geolocation_case_properties.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = 'Index geopoint data in ES'
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('--case_type', required=False)
+        parser.add_argument('--query_limit', required=False)
+        parser.add_argument('--chunk_size', required=False)
+
+    def handle(self, *args, **options):
+        domain = options['domain']
+        case_type = options.get('case_type')
+        query_limit = options.get('query_limit')
+        chunk_size = options.get('chunk_size')

--- a/corehq/apps/geospatial/management/commands/index_geolocation_case_properties.py
+++ b/corehq/apps/geospatial/management/commands/index_geolocation_case_properties.py
@@ -38,14 +38,14 @@ class Command(BaseCommand):
 
 def index_case_docs(domain, query_limit=DEFAULT_QUERY_LIMIT, chunk_size=DEFAULT_CHUNK_SIZE, case_type=None):
     geo_case_property = get_geo_case_property(domain)
-    query = _case_query(domain, geo_case_property, case_type)
+    query = _es_case_query(domain, geo_case_property, case_type)
     count = query.count()
     print(f'{count} case(s) to process')
     batch_count = math.ceil(count / query_limit)
     print(f"Cases will be processed in {batch_count} batches")
-    for i in range(0, batch_count):
+    for i in range(batch_count):
         print(f'Processing {i+1}/{batch_count}')
-        query = _case_query(domain, geo_case_property, case_type, size=query_limit)
+        query = _es_case_query(domain, geo_case_property, case_type, size=query_limit)
         case_ids = query.get_ids()
         _index_case_ids(domain, case_ids, chunk_size)
 
@@ -57,7 +57,7 @@ def _index_case_ids(domain, case_ids, chunk_size):
     manager.index_refresh(case_search_adapter.index_name)
 
 
-def _case_query(domain, geo_case_property, case_type=None, size=None):
+def _es_case_query(domain, geo_case_property, case_type=None, size=None):
     query = (
         CaseSearchES()
         .domain(domain)

--- a/corehq/apps/geospatial/management/commands/index_geolocation_case_properties.py
+++ b/corehq/apps/geospatial/management/commands/index_geolocation_case_properties.py
@@ -1,4 +1,10 @@
 from django.core.management.base import BaseCommand
+from corehq.apps.es import CaseSearchES, filters, queries
+from corehq.apps.es.case_search import (
+    CASE_PROPERTIES_PATH,
+    PROPERTY_GEOPOINT_VALUE,
+    PROPERTY_KEY,
+)
 
 
 class Command(BaseCommand):
@@ -15,3 +21,32 @@ class Command(BaseCommand):
         case_type = options.get('case_type')
         query_limit = options.get('query_limit')
         chunk_size = options.get('chunk_size')
+
+
+def _case_query(domain, geo_case_property, case_type=None, size=None):
+    query = (
+        CaseSearchES()
+        .domain(domain)
+        .filter(_geopoint_value_missing_for_property(geo_case_property))
+    )
+    if case_type:
+        query = query.case_type(case_type)
+    if size:
+        query = query.size(size)
+    return query
+
+
+def _geopoint_value_missing_for_property(geo_case_property_name):
+    """
+    Query to find docs with missing 'geopoint_value' for the given case property.
+    """
+    return queries.nested(
+        CASE_PROPERTIES_PATH,
+        queries.filtered(
+            queries.match_all(),
+            filters.AND(
+                filters.term(PROPERTY_KEY, geo_case_property_name),
+                filters.missing(PROPERTY_GEOPOINT_VALUE)
+            )
+        )
+    )

--- a/corehq/apps/geospatial/tests/test_index_geolocation_case_properties.py
+++ b/corehq/apps/geospatial/tests/test_index_geolocation_case_properties.py
@@ -38,7 +38,11 @@ class TestGetFormCases(TestCase):
             case_type=cls.secondary_case_type,
             update={cls.gps_prop_name: '5.5 6.6'},
         )
-        case_search_adapter.bulk_index([case1, case2, case3], refresh=True)
+        case4 = factory.create_case(
+            case_name='no_props',
+            case_type=cls.primary_case_type,
+        )
+        case_search_adapter.bulk_index([case1, case2, case3, case4], refresh=True)
         cls.geo_config = GeoConfig.objects.create(
             domain=cls.domain,
             case_location_property_name=cls.gps_prop_name

--- a/corehq/apps/geospatial/tests/test_index_geolocation_case_properties.py
+++ b/corehq/apps/geospatial/tests/test_index_geolocation_case_properties.py
@@ -1,0 +1,76 @@
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseFactory
+
+from corehq.apps.es import CaseSearchES
+from corehq.apps.es.case_search import case_search_adapter
+from corehq.apps.es.tests.utils import es_test
+from corehq.apps.geospatial.management.commands.index_geolocation_case_properties import (
+    _case_query,
+    index_case_docs,
+)
+from corehq.apps.geospatial.models import GeoConfig
+
+
+@es_test(requires=[case_search_adapter], setup_class=True)
+class TestGetFormCases(TestCase):
+    domain = 'foobar'
+    primary_case_type = 'primary'
+    secondary_case_type = 'secondary'
+    gps_prop_name = 'gps_coordinates'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        factory = CaseFactory(cls.domain)
+        case1 = factory.create_case(
+            case_name='foo',
+            case_type=cls.primary_case_type,
+            update={cls.gps_prop_name: '1.1 2.2'},
+        )
+        case2 = factory.create_case(
+            case_name='bar',
+            case_type=cls.primary_case_type,
+            update={cls.gps_prop_name: '3.3 4.4'},
+        )
+        case3 = factory.create_case(
+            case_name='other',
+            case_type=cls.secondary_case_type,
+            update={cls.gps_prop_name: '5.5 6.6'},
+        )
+        case_search_adapter.bulk_index([case1, case2, case3], refresh=True)
+        cls.geo_config = GeoConfig.objects.create(
+            domain=cls.domain,
+            case_location_property_name=cls.gps_prop_name
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.geo_config.delete()
+        super().tearDownClass()
+
+    def test_has_cases_to_index(self):
+        query = _case_query(self.domain, self.gps_prop_name, self.primary_case_type)
+        case_count = query.count()
+        self.assertEqual(case_count, 2)
+
+    def test_cases_correctly_indexed(self):
+        index_case_docs(self.domain, case_type=self.secondary_case_type)
+        query = _case_query(self.domain, self.gps_prop_name, self.secondary_case_type)
+        case_count = query.count()
+        self.assertEqual(case_count, 0)
+        doc = (
+            CaseSearchES()
+            .domain(self.domain)
+            .case_type(self.secondary_case_type)
+        ).run().hits[0]
+        case_props = doc['case_properties']
+        expected_geopoint_val = {
+            'key': self.gps_prop_name,
+            'value': '5.5 6.6',
+            'geopoint_value': {
+                'lat': 5.5,
+                'lon': 6.6
+            }
+        }
+        self.assertTrue(expected_geopoint_val in case_props)

--- a/corehq/apps/geospatial/tests/test_index_geolocation_case_properties.py
+++ b/corehq/apps/geospatial/tests/test_index_geolocation_case_properties.py
@@ -47,6 +47,7 @@ class TestGetFormCases(TestCase):
             domain=cls.domain,
             case_location_property_name=cls.gps_prop_name
         )
+        cls.addClassCleanup(cls.geo_config.delete)
 
     def test_has_cases_to_index(self):
         query = _es_case_query(self.domain, self.gps_prop_name, self.primary_case_type)

--- a/corehq/apps/geospatial/tests/test_index_geolocation_case_properties.py
+++ b/corehq/apps/geospatial/tests/test_index_geolocation_case_properties.py
@@ -6,7 +6,7 @@ from corehq.apps.es import CaseSearchES
 from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.geospatial.management.commands.index_geolocation_case_properties import (
-    _case_query,
+    _es_case_query,
     index_case_docs,
 )
 from corehq.apps.geospatial.models import GeoConfig
@@ -48,19 +48,14 @@ class TestGetFormCases(TestCase):
             case_location_property_name=cls.gps_prop_name
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.geo_config.delete()
-        super().tearDownClass()
-
     def test_has_cases_to_index(self):
-        query = _case_query(self.domain, self.gps_prop_name, self.primary_case_type)
+        query = _es_case_query(self.domain, self.gps_prop_name, self.primary_case_type)
         case_count = query.count()
         self.assertEqual(case_count, 2)
 
     def test_cases_correctly_indexed(self):
         index_case_docs(self.domain, case_type=self.secondary_case_type)
-        query = _case_query(self.domain, self.gps_prop_name, self.secondary_case_type)
+        query = _es_case_query(self.domain, self.gps_prop_name, self.secondary_case_type)
         case_count = query.count()
         self.assertEqual(case_count, 0)
         doc = (


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3863).
Link to tech spec [here](https://docs.google.com/document/d/1bLg-pTzLrd62ExNAb9Fdh6zCJzJ11gWUZTtlz1L7HY8/edit#heading=h.pqej54ii9qji).

A new `index_geolocation_case_properties` management command exists to add `geopoint_value` data to relevant case search documents in ES based on the filters given in the command. This command will be run for domains that have the Geospatial feature flag enabled but has pre-existing case data that needs to be reindexed so that they can be used by the feature.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

The code from this PR resides behind a management command, and so is safe considering that general users will not be able to access it.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests exist to ensure that functions from the new management command properly fetch relevant ES docs and indexes them correctly.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
