### PR TITLE
Suppress verbose make requirements output

### DIFF
--- a/requirements/Makefile
+++ b/requirements/Makefile
@@ -2,29 +2,29 @@
 
 requirements: export CUSTOM_COMPILE_COMMAND=`make requirements` or `make upgrade-requirements`
 requirements:
-	pip-compile -o requirements.txt requirements.in --allow-unsafe
-	pip-compile -o prod-requirements.txt prod-requirements.in --allow-unsafe
-	pip-compile -o test-requirements.txt test-requirements.in --allow-unsafe
-	pip-compile -o dev-requirements.txt dev-requirements.in --allow-unsafe
-	pip-compile -o docs-requirements.txt docs-requirements.in --allow-unsafe
+	pip-compile -qo requirements.txt requirements.in --allow-unsafe
+	pip-compile -qo prod-requirements.txt prod-requirements.in --allow-unsafe
+	pip-compile -qo test-requirements.txt test-requirements.in --allow-unsafe
+	pip-compile -qo dev-requirements.txt dev-requirements.in --allow-unsafe
+	pip-compile -qo docs-requirements.txt docs-requirements.in --allow-unsafe
 	python ../scripts/purge-platform-pkgs.py ./*requirements.txt
 
 upgrade-requirements: export CUSTOM_COMPILE_COMMAND=`make requirements` or `make upgrade-requirements`
 upgrade-requirements:
-	pip-compile --upgrade -o requirements.txt requirements.in --allow-unsafe
-	pip-compile --upgrade -o prod-requirements.txt prod-requirements.in --allow-unsafe
-	pip-compile --upgrade -o test-requirements.txt test-requirements.in --allow-unsafe
-	pip-compile --upgrade -o dev-requirements.txt dev-requirements.in --allow-unsafe
-	pip-compile --upgrade -o docs-requirements.txt docs-requirements.in --allow-unsafe
+	pip-compile --upgrade -qo requirements.txt requirements.in --allow-unsafe
+	pip-compile --upgrade -qo prod-requirements.txt prod-requirements.in --allow-unsafe
+	pip-compile --upgrade -qo test-requirements.txt test-requirements.in --allow-unsafe
+	pip-compile --upgrade -qo dev-requirements.txt dev-requirements.in --allow-unsafe
+	pip-compile --upgrade -qo docs-requirements.txt docs-requirements.in --allow-unsafe
 	python ../scripts/purge-platform-pkgs.py ./*requirements.txt
 
 # To upgrade a specific package to latest version use this command
 # make upgrade-package package={package_name}
 upgrade-package: export CUSTOM_COMPILE_COMMAND=`make requirements` or `make upgrade-requirements`
 upgrade-package:
-	pip-compile --upgrade-package $(package) -o requirements.txt requirements.in --allow-unsafe
-	pip-compile --upgrade-package $(package) -o prod-requirements.txt prod-requirements.in --allow-unsafe
-	pip-compile --upgrade-package $(package) -o test-requirements.txt test-requirements.in --allow-unsafe
-	pip-compile --upgrade-package $(package) -o dev-requirements.txt dev-requirements.in --allow-unsafe
-	pip-compile --upgrade-package $(package) -o docs-requirements.txt docs-requirements.in --allow-unsafe
+	pip-compile --upgrade-package $(package) -qo requirements.txt requirements.in --allow-unsafe
+	pip-compile --upgrade-package $(package) -qo prod-requirements.txt prod-requirements.in --allow-unsafe
+	pip-compile --upgrade-package $(package) -qo test-requirements.txt test-requirements.in --allow-unsafe
+	pip-compile --upgrade-package $(package) -qo dev-requirements.txt dev-requirements.in --allow-unsafe
+	pip-compile --upgrade-package $(package) -qo docs-requirements.txt docs-requirements.in --allow-unsafe
 	python ../scripts/purge-platform-pkgs.py ./*requirements.txt


### PR DESCRIPTION
Suppresses full requirements.txt output printed in console.

**Before:**
```
$ make requirements
cd requirements && make requirements
make[1]: Entering directory '/home/dimagi/code/commcare-hq/requirements'
pip-compile -o requirements.txt requirements.in --allow-unsafe
WARNING: --strip-extras is becoming the default in version 8.0.0. To silence this warning, either use --strip-extras to opt into the new default or use --no-strip-extras to retain the existing behavior.
#
# This file is autogenerated by pip-compile with Python 3.9
# by the following command:
#
#    `make requirements` or `make upgrade-requirements`
#
alembic==1.7.7
    # via -r base-requirements.in
amqp==5.1.1
    # via kombu
architect==0.6.0
    # via -r base-requirements.in
asgiref==3.7.2
    # via django
asttokens==2.4.1
    # via transifex-python
async-timeout==4.0.2
    # via redis
attrs==23.1.0
    # via
    #   -r base-requirements.in
    #   cattrs
    #   ddtrace
    #   jsonschema
beaker==1.11.0
...
```
Many many lines of requirements for each `pip-compile` command.

**After:**
```
cd requirements && make requirements
make[1]: Entering directory '/home/dimagi/code/commcare-hq/requirements'
pip-compile -qo requirements.txt requirements.in --allow-unsafe
WARNING: --strip-extras is becoming the default in version 8.0.0. To silence this warning, either use --strip-extras to opt into the new default or use --no-strip-extras to retain the existing behavior.
pip-compile -qo prod-requirements.txt prod-requirements.in --allow-unsafe
WARNING: --strip-extras is becoming the default in version 8.0.0. To silence this warning, either use --strip-extras to opt into the new default or use --no-strip-extras to retain the existing behavior.
pip-compile -qo test-requirements.txt test-requirements.in --allow-unsafe
...
```

One line (and one warning that we should address) for each `pip-compile` command.

## Safety Assurance

### Safety story

Changes a requirements build script, does not affect production code.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations