### PR TITLE
Tag test-looking things that are not tests

### DIFF
--- a/corehq/apps/cleanup/tests/test_populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/tests/test_populate_sql_model_from_couch_model.py
@@ -187,6 +187,8 @@ class Command(PopulateSQLCommand):
 
 
 class TestDoc(SyncCouchToSQLMixin, Document):
+    __test__ = False
+
     class Meta:
         app_label = "couch"
 

--- a/corehq/apps/domain/tests/test_utils.py
+++ b/corehq/apps/domain/tests/test_utils.py
@@ -18,6 +18,7 @@ from corehq.apps.domain.utils import (
 )
 from corehq.apps.users.models import CommCareUser
 from corehq.motech.utils import b64_aes_decrypt
+from corehq.tests.tools import nottest
 from corehq.util.test_utils import generate_cases, unit_testing_only
 
 
@@ -126,6 +127,7 @@ class TestGetSerializableWireInvoiceItem(SimpleTestCase):
         self.assertTrue(serialized_items)
 
 
+@nottest
 @contextmanager
 def test_domain(name="domain", skip_full_delete=False):
     """Context manager for use in tests"""

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
@@ -91,7 +91,7 @@ def assert_each_test_is_unique(tests_to_run):
         seen[sig] = test["name"]
 
 
-class TestSequenceMeta(type):
+class SequenceTestMeta(type):
 
     def __new__(mcs, name, bases, dict):
         tests_to_run = get_test_file_json('case_relationship_tests')
@@ -110,7 +110,7 @@ class TestSequenceMeta(type):
 
 
 @sharded
-class IndexTreeTest(BaseSyncTest, metaclass=TestSequenceMeta):
+class IndexTreeTest(BaseSyncTest, metaclass=SequenceTestMeta):
     """Fetch all testcases from data/case_relationship_tests.json and run them
 
     Each testcase is structured as follows:

--- a/corehq/ex-submodules/dimagi/utils/tests/test_undo.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/test_undo.py
@@ -9,7 +9,7 @@ from corehq.apps.groups.models import DeleteGroupRecord
 
 
 class TestDocument(Document):
-    pass
+    __test__ = False
 
 
 class TestSubDocument(TestDocument):

--- a/corehq/ex-submodules/pillow_retry/tests/test_retry.py
+++ b/corehq/ex-submodules/pillow_retry/tests/test_retry.py
@@ -20,7 +20,7 @@ from testapps.test_pillowtop.utils import process_pillow_changes
 
 
 class TestException(Exception):
-    pass
+    __test__ = False
 
 
 class TestMixin(object):

--- a/corehq/ex-submodules/pillowtop/processors/sample.py
+++ b/corehq/ex-submodules/pillowtop/processors/sample.py
@@ -39,6 +39,7 @@ class TestProcessor(PillowProcessor):
     """
     Processor that just keeps the change in an in-memory list for testing
     """
+    __test__ = False
 
     def __init__(self):
         self.changes_seen = []

--- a/corehq/ex-submodules/pillowtop/tests/test_dao.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_dao.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
 from django.test import SimpleTestCase
+from django.utils.functional import classproperty
 from fakecouch import FakeCouchDb
 from pillowtop.dao.couch import CouchDocumentStore
 from pillowtop.dao.exceptions import DocumentNotFoundError
@@ -7,6 +8,10 @@ from pillowtop.dao.mock import MockDocumentStore
 
 
 class _AbstractDocumentStoreTestCase(SimpleTestCase):
+
+    @classproperty
+    def __test__(cls):
+        return not getattr(cls.dao.fget, "__isabstractmethod__", False)
 
     @property
     @abstractmethod

--- a/corehq/form_processor/utils/xform.py
+++ b/corehq/form_processor/utils/xform.py
@@ -67,6 +67,7 @@ class TestFormMetadata(jsonobject.JsonObject):
     time_start = jsonobject.DateTimeProperty(default=datetime(2013, 4, 19, 16, 53, 2))
     # Set this property to fake the submission time
     received_on = jsonobject.DateTimeProperty(default=datetime.utcnow)
+    __test__ = False
 
 
 class FormSubmissionBuilder(object):

--- a/corehq/messaging/scheduling/scheduling_partitioned/tests/test_dbaccessors_partitioned.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/tests/test_dbaccessors_partitioned.py
@@ -24,10 +24,15 @@ from corehq.sql_db.config import plproxy_config
 from corehq.sql_db.tests.utils import DefaultShardingTestConfigMixIn
 from datetime import datetime, date
 from django.test import TestCase
+from django.utils.functional import classproperty
 
 
 @only_run_with_partitioned_database
 class BaseSchedulingPartitionedDBAccessorsTest(DefaultShardingTestConfigMixIn, TestCase):
+
+    @classproperty
+    def __test__(cls):
+        return cls is not BaseSchedulingPartitionedDBAccessorsTest
 
     @classmethod
     def setUpClass(cls):

--- a/corehq/tests/locks.py
+++ b/corehq/tests/locks.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 import attr
 
+from corehq.tests.tools import nottest
+
 log = logging.getLogger(__name__)
 _LOCK = Lock()
 
@@ -69,6 +71,7 @@ def real_redis_client():
 _mock_redis_client = True
 
 
+@nottest
 @attr.s
 class TestRedisClient:
     lock = attr.ib()

--- a/corehq/tests/test_middleware.py
+++ b/corehq/tests/test_middleware.py
@@ -38,6 +38,7 @@ def slow_function_view(request):
 class TestReportDispatcher(ReportDispatcher):
     map_name = "REPORTS"
     prefix = "test"
+    __test__ = False
 
     @classmethod
     def get_reports(cls, domain):
@@ -50,6 +51,7 @@ class TestReportDispatcher(ReportDispatcher):
 class TestNoDomainReportDispatcher(ReportDispatcher):
     map_name = "REPORTS"
     prefix = "test_no_domain"
+    __test__ = False
 
     @classmethod
     def get_reports(cls, domain):
@@ -61,6 +63,7 @@ class TestNoDomainReportDispatcher(ReportDispatcher):
 class TestCustomReportDispatcher(TestNoDomainReportDispatcher):
     map_name = "REPORTS"
     prefix = "test_custom"
+    __test__ = False
 
     def dispatch(self, request, *args, **kwargs):
         return CustomReport(request).view_response

--- a/corehq/tests/tools.py
+++ b/corehq/tests/tools.py
@@ -1,0 +1,4 @@
+
+def nottest(fn):
+    fn.__test__ = False
+    return fn

--- a/corehq/tests/util/tests/test_warnings.py
+++ b/corehq/tests/util/tests/test_warnings.py
@@ -1,7 +1,7 @@
 import warnings
 from difflib import unified_diff
 from functools import wraps
-from unittest import TestCase, TestResult, TestSuite
+from unittest import TestCase, TestResult as Result, TestSuite as Suite
 from unittest.mock import patch
 
 from testil import Regex, assert_raises, eq
@@ -110,7 +110,7 @@ def test_class_decorator():
             log.append("test")
 
     log = []
-    TestSuite([Test()]).debug()
+    Suite([Test()]).debug()
     eq(log, ["setup", "test", "teardown"])
 
 
@@ -133,8 +133,8 @@ def test_class_decorator_should_not_catch_unfiltered_setup_warning():
             log.append("test")
 
     log = []
-    result = TestResult()
-    TestSuite([Test()]).run(result)
+    result = Result()
+    Suite([Test()]).run(result)
     eq(str(result.errors), Regex(r" in setUpClass\\n .*Warning: fail"), result)
     eq(log, ["setup"])
 
@@ -158,8 +158,8 @@ def test_class_decorator_should_not_catch_unfiltered_test_warning():
             log.append("test")  # should not get here
 
     log = []
-    result = TestResult()
-    TestSuite([Test()]).run(result)
+    result = Result()
+    Suite([Test()]).run(result)
     eq(str(result.errors), Regex(r" in runTest\\n .*Warning: fail"), result)
     eq(log, ["setup", "teardown"])
 
@@ -182,7 +182,7 @@ def test_class_decorator_should_not_catch_unfiltered_teardown_warning():
             log.append("test")  # should not get here
 
     log = []
-    result = TestResult()
-    TestSuite([Test()]).run(result)
+    result = Result()
+    Suite([Test()]).run(result)
     eq(str(result.errors), Regex(r" in tearDownClass\\n .*Warning: fail"), result)
     eq(log, ["setup", "test"])

--- a/corehq/util/metrics/tests/test_metrics.py
+++ b/corehq/util/metrics/tests/test_metrics.py
@@ -1,6 +1,7 @@
 from typing import Dict, Tuple
 
 from django.test import SimpleTestCase
+from django.utils.functional import classproperty
 
 from corehq.util.metrics.datadog import DatadogMetrics
 from corehq.util.metrics.prometheus import PrometheusMetrics
@@ -11,6 +12,10 @@ from prometheus_client.utils import INF
 
 class _TestMetrics(SimpleTestCase):
     provider_class = None
+
+    @classproperty
+    def __test__(cls):
+        return cls.provider_class is not None
 
     @classmethod
     def setUpClass(cls):

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -86,6 +86,7 @@ class GetDocMockTestCase(SimpleTestCase):
 
 
 class TestLoggingDB(object):
+    __test__ = False
 
     def __init__(self):
         self.docs_saved = []


### PR DESCRIPTION
Prep for switching from `nose` to `pytest`. These test-looking classes and functions are not tests, but would cause `pytest` to fail when it treats them as tests.

## Safety Assurance

### Safety story

Most of the changes in this PR affect test files, a few add a `__test__ = False` attribute to non-test classes or functions that are not in test modules.

### Automated test coverage

Yes, in most cases.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations. However, it may cause tests to fail if we have switched to pytest by that time.