### PR TITLE
Improve test cleanup to avoid interdependent tests

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -829,7 +829,7 @@ class SoftwarePlan(models.Model):
     class Meta(object):
         app_label = 'accounting'
 
-    @quickcache(vary_on=['self.pk'], timeout=10)
+    @quickcache(vary_on=['self.pk'], timeout=10, skip_arg=lambda *a, **k: settings.UNIT_TESTING)
     def get_version(self):
         try:
             return self.softwareplanversion_set.filter(is_active=True).latest('date_created')

--- a/corehq/apps/api/tests/test_ucr_resources.py
+++ b/corehq/apps/api/tests/test_ucr_resources.py
@@ -27,6 +27,7 @@ from corehq.apps.userreports.models import (
     ReportConfiguration,
 )
 from corehq.apps.userreports.tasks import rebuild_indicators
+from corehq.apps.userreports.tests.utils import cleanup_ucr
 from corehq.apps.users.models import Document, WebUser
 from corehq.form_processor.models import CommCareCase
 from corehq.util.test_utils import flag_enabled
@@ -439,8 +440,8 @@ class TestUCRPaginated(TestCase):
             table_id=uuid.uuid4().hex,
         )
         cls.data_source.save()
-        cls.addClassCleanup(cls.data_source.delete)
         rebuild_indicators(cls.data_source._id)
+        cls.addClassCleanup(cleanup_ucr, cls.data_source)
         cls.client = Client()
 
     def test_forbidden_when_feature_flag_not_enabled(self):

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -47,6 +47,7 @@ from corehq.apps.linked_domain.util import (
     convert_app_for_remote_linking,
 )
 from corehq.apps.userreports.tests.utils import (
+    cleanup_ucr,
     get_sample_data_source,
     get_sample_report_config,
 )
@@ -159,6 +160,7 @@ class TestLinkedApps(BaseLinkedAppsTest):
 
         # link report on master app to linked domain
         link_info = create_linked_ucr(self.domain_link, master_report.get_id)
+        self.addCleanup(cleanup_ucr, link_info.datasource)
 
         updated_app = update_linked_app(self.linked_app, self.master1, 'a-user-id')
 
@@ -169,6 +171,7 @@ class TestLinkedApps(BaseLinkedAppsTest):
         master_data_source = get_sample_data_source()
         master_data_source.domain = self.domain
         master_data_source.save()
+        self.addCleanup(cleanup_ucr, master_data_source)
 
         master_report = get_sample_report_config()
         master_report.config_id = master_data_source.get_id
@@ -199,6 +202,7 @@ class TestLinkedApps(BaseLinkedAppsTest):
             "datasource": master_data_source,
         }
         link_info = create_linked_ucr(self.domain_link, master_report.get_id)
+        self.addCleanup(cleanup_ucr, link_info.datasource)
         updated_app = update_linked_app(self.linked_app, self.master1, 'a-user-id')
 
         # report config added with the linked report id updated in report config

--- a/corehq/apps/locations/tests/test_views.py
+++ b/corehq/apps/locations/tests/test_views.py
@@ -200,8 +200,8 @@ class LocationsSearchViewTest(TestCase):
         response = self.send_request(url, data)
         self.assertEqual(response.status_code, 200)
         results = json.loads(response.content)['results']
-        self.assertEqual(results[0]['id'], self.loc1.location_id)
-        self.assertEqual(results[1]['id'], self.loc2.location_id)
+        expected = {self.loc1.location_id, self.loc2.location_id}
+        self.assertEqual({r['id'] for r in results}, expected)
 
     @flag_enabled('USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION')
     def test_search_view_has_users_only(self):
@@ -219,9 +219,8 @@ class LocationsSearchViewTest(TestCase):
         response = self.send_request(url, data)
         self.assertEqual(response.status_code, 200)
         results = json.loads(response.content)['results']
-        self.assertEqual(len(results), 2)
-        self.assertEqual(results[0]['id'], self.loc1.location_id)
-        self.assertEqual(results[1]['id'], self.loc2.location_id)
+        expected = {self.loc1.location_id, self.loc2.location_id}
+        self.assertEqual({r['id'] for r in results}, expected)
 
 
 class BulkLocationUploadAPITest(TestCase):

--- a/corehq/apps/userreports/tests/test_data_source_repeats.py
+++ b/corehq/apps/userreports/tests/test_data_source_repeats.py
@@ -1,11 +1,8 @@
 import datetime
-import json
-import os
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase, TestCase
 
-from corehq.apps.userreports.models import DataSourceConfiguration
 from corehq.apps.userreports.tests.utils import get_data_source_with_repeat
 from corehq.apps.userreports.util import get_indicator_adapter
 
@@ -19,7 +16,8 @@ class RepeatDataSourceTestMixin(object):
         self.config = get_data_source_with_repeat()
 
 
-@patch('corehq.apps.userreports.models.AllowedUCRExpressionSettings.disallowed_ucr_expressions', MagicMock(return_value=[]))
+@patch('corehq.apps.userreports.models.AllowedUCRExpressionSettings.disallowed_ucr_expressions',
+       MagicMock(return_value=[]))
 class RepeatDataSourceConfigurationTest(RepeatDataSourceTestMixin, SimpleTestCase):
 
     def test_test_doc_matches(self):
@@ -76,6 +74,7 @@ class RepeatDataSourceBuildTest(RepeatDataSourceTestMixin, TestCase):
 
     def test_table_population(self):
         adapter = get_indicator_adapter(self.config)
+        self.addCleanup(adapter.drop_table)
         # Delete and create table
         adapter.rebuild_table()
 

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -19,6 +19,7 @@ from corehq.apps.userreports.models import (
     DataSourceConfiguration,
     ReportConfiguration, RegistryDataSourceConfiguration,
 )
+from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.sql_db.connections import connection_manager
 
 
@@ -34,6 +35,13 @@ def get_sample_data_source():
 
 def get_sample_registry_data_source(**kwargs):
     return _get_sample_doc('sample_registry_data_source.json', RegistryDataSourceConfiguration, **kwargs)
+
+
+def cleanup_ucr(data_source):
+    try:
+        get_indicator_adapter(data_source).drop_table()
+    finally:
+        data_source.delete()
 
 
 def get_data_source_with_related_doc_type():

--- a/corehq/apps/users/tests/test_tasks.py
+++ b/corehq/apps/users/tests/test_tasks.py
@@ -38,7 +38,9 @@ class TasksTest(TestCase):
 
         # Set up domains
         cls.domain = create_domain('test')
+        cls.addClassCleanup(cls.domain.delete)
         cls.mirror_domain = create_domain('mirror')
+        cls.addClassCleanup(cls.mirror_domain.delete)
         create_enterprise_permissions('web@web.com', 'test', ['mirror'])
 
         # Set up user
@@ -49,16 +51,10 @@ class TasksTest(TestCase):
             created_by=None,
             created_via=None,
         )
+        cls.addClassCleanup(cls.web_user.delete, None, None)
 
         cls.today = datetime.today().date()
         cls.last_week = cls.today - timedelta(days=7)
-
-    @classmethod
-    def tearDownClass(cls):
-        delete_all_users()
-        cls.domain.delete()
-        cls.mirror_domain.delete()
-        super().tearDownClass()
 
     def _last_accessed(self, user, domain):
         domain_membership = user.get_domain_membership(domain, allow_enterprise=False)

--- a/corehq/messaging/smsbackends/telerivet/tests/test_log_call.py
+++ b/corehq/messaging/smsbackends/telerivet/tests/test_log_call.py
@@ -16,9 +16,8 @@ class TelerivetLogCallTestCase(util.LogCallTestCase):
         self.backend.set_extra_fields(webhook_secret='abc')
         self.backend.save()
 
-    def tearDown(self):
-        self.backend.delete()
-        super(TelerivetLogCallTestCase, self).tearDown()
+        clear_cache = SQLTelerivetBackend.by_webhook_secret.clear
+        self.addCleanup(clear_cache, SQLTelerivetBackend, 'abc')
 
     def simulate_inbound_call(self, phone_number):
         return Client().post('/telerivet/in/', {

--- a/corehq/messaging/smsbackends/telerivet/tests/test_webhook_lookup.py
+++ b/corehq/messaging/smsbackends/telerivet/tests/test_webhook_lookup.py
@@ -25,9 +25,10 @@ class TelerivetWebhookLookupTestCase(TestCase):
         )
         self.backend2.save()
 
-    def tearDown(self):
-        self.backend1.delete()
-        self.backend2.delete()
+        clear_cache = SQLTelerivetBackend.by_webhook_secret.clear
+        self.addCleanup(clear_cache, SQLTelerivetBackend, 'abc')
+        self.addCleanup(clear_cache, SQLTelerivetBackend, 'def')
+        self.addCleanup(clear_cache, SQLTelerivetBackend, 'ghi')
 
     def test_webhook_lookup(self):
         self.assertEqual(

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1262,6 +1262,7 @@ class DataSourceRepeaterTest(BaseRepeaterTest):
         super().setUp()
         self.config = get_sample_data_source()
         self.config.save()
+        self.addCleanup(self.config.delete)
         self.adapter = get_indicator_adapter(self.config)
         self.adapter.build_table()
         self.addCleanup(self.adapter.drop_table)

--- a/custom/champ/tests/test_enhanced_peer_mobilization.py
+++ b/custom/champ/tests/test_enhanced_peer_mobilization.py
@@ -41,6 +41,7 @@ class TestEnhancedPeerMobilization(TestDataSourceExpressions):
 
         user = {
             'id': 'user_id',
+            'doc_type': 'CommCareUser',
             'domain': 'champ_cameroon',
             'location_id': 'test_location_id'
         }


### PR DESCRIPTION
These changes are necessary when swiching from nose to pytest because tests are allocated slightly differently with the `--divided-we-run` plugin on pytest.

## Safety Assurance

### Safety story

Affects tests only.

### Automated test coverage

Yes.

### Rollback instructions

May cause tests to fail if rolled back after switching to pytest.