### PR TITLE
Replace nose attrs and convert yield tests to use `pytest.mark`

### DIFF
--- a/corehq/apps/app_manager/tests/test_app_strings.py
+++ b/corehq/apps/app_manager/tests/test_app_strings.py
@@ -1,6 +1,7 @@
 import os
 from collections import OrderedDict
 
+import pytest
 from django.test import TestCase
 
 import commcare_translations
@@ -61,28 +62,28 @@ def test_non_empty_only():
     eq(non_empty_things, {"all_of_the_things": [None, 0, "", [], {}]})
 
 
+@pytest.mark.parametrize("input, expected_output", [
+    ('hello', '<value>hello</value>'),
+    ('abc < def > abc', '<value>abc &lt; def &gt; abc</value>'),
+    ("bee's knees", "<value>bee's knees</value>"),
+    ('unfortunate <xml expression', '<value>unfortunate &lt;xml expression</value>'),
+    ('क्लिक', '<value>क्लिक</value>'),
+    ('&#39', '<value>&amp;#39</value>'),
+    ('question1 is <output value="/data/question1" vellum:value="#form/question1"/> !',
+        '<value>question1 is &lt;output value="/data/question1" '
+        'vellum:value="#form/question1"/&gt; !</value>'),
+    ('Here is a ref <output value="/data/no_media"/> with some "trailing" text & that\'s some bad < xml.',
+        '<value>Here is a ref &lt;output value="/data/no_media"/&gt; with some "trailing" text &amp; that\'s'
+        ' some bad &lt; xml.</value>')
+])
+def test_escape_output_value(input, expected_output):
+    escaped_input = BulkAppTranslationFormUpdater.escape_output_value(input)
+    escaped_value = etree.tostring(escaped_input, encoding='utf-8').decode('utf-8')
+    assert escaped_value == expected_output
+
+
 class AppManagerTranslationsTest(TestCase, SuiteMixin):
     root = os.path.dirname(__file__)
-
-    def test_escape_output_value(self):
-        test_cases = [
-            ('hello', '<value>hello</value>'),
-            ('abc < def > abc', '<value>abc &lt; def &gt; abc</value>'),
-            ("bee's knees", "<value>bee's knees</value>"),
-            ('unfortunate <xml expression', '<value>unfortunate &lt;xml expression</value>'),
-            ('क्लिक', '<value>क्लिक</value>'),
-            ('&#39', '<value>&amp;#39</value>'),
-            ('question1 is <output value="/data/question1" vellum:value="#form/question1"/> !',
-             '<value>question1 is &lt;output value="/data/question1" '
-             'vellum:value="#form/question1"/&gt; !</value>'),
-            ('Here is a ref <output value="/data/no_media"/> with some "trailing" text & that\'s some bad < xml.',
-             '<value>Here is a ref &lt;output value="/data/no_media"/&gt; with some "trailing" text &amp; that\'s'
-             ' some bad &lt; xml.</value>')
-
-        ]
-        for input, expected_output in test_cases:
-            escaped_input = BulkAppTranslationFormUpdater.escape_output_value(input)
-            self.assertEqual(expected_output, etree.tostring(escaped_input, encoding='utf-8').decode('utf-8'))
 
     def test_language_names(self):
         factory = AppFactory(build_version='2.40.0')

--- a/corehq/apps/case_search/tests/test_subcase_query_parser.py
+++ b/corehq/apps/case_search/tests/test_subcase_query_parser.py
@@ -1,3 +1,4 @@
+import pytest
 from eulxml.xpath import parse as parse_xpath
 from testil import eq, assert_raises
 
@@ -5,121 +6,97 @@ from corehq.apps.case_search.exceptions import XPathFunctionException
 from corehq.apps.case_search.xpath_functions.subcase_functions import _parse_normalize_subcase_query
 
 
-def test_subcase_query_parsing():
-    def _check(query, expected):
-        node = parse_xpath(query)
-        result = _parse_normalize_subcase_query(node)
-        eq(result.as_tuple(), expected)
-
-    yield from [
-        (
-            _check,
-            "subcase-exists('parent', @case_type='bob')",
-            ("parent", "@case_type='bob'", ">", 0, False)
-        ),
-        (
-            _check,
-            "subcase-exists('p', @case_type='bob' and prop='value')",
-            ("p", "@case_type='bob' and prop='value'", ">", 0, False)
-        ),
-        (
-            _check,
-            "subcase-count('p', prop=1) > 3",
-            ("p", "prop=1", ">", 3, False)
-        ),
-        (
-            _check,
-            "subcase-count('p', prop=1) >= 3",
-            ("p", "prop=1", ">", 2, False)
-        ),
-        (
-            _check,
-            "subcase-count('p', prop=1) < 3",
-            ("p", "prop=1", ">", 2, True)
-        ),
-        (
-            _check,
-            "subcase-count('p', prop=1) <= 3",
-            ("p", "prop=1", ">", 3, True)
-        ),
-        (
-            _check,
-            "subcase-count('p', prop=1) = 3",
-            ("p", "prop=1", "=", 3, False)
-        ),
-        (
-            _check,
-            "subcase-count('p', prop=1) = 0",
-            ("p", "prop=1", ">", 0, True)
-        ),
-        (
-            _check,
-            "subcase-count('p', prop=1) != 2",
-            ("p", "prop=1", "=", 2, True)
-        ),
-        (
-            _check,
-            "subcase-count('p') = 2",
-            ("p", None, "=", 2, False)
-        ),
-        (
-            _check,
-            "subcase-exists('p')",
-            ("p", None, ">", 0, False)
-        ),
-    ]
+@pytest.mark.parametrize("query, expected", [
+    (
+        "subcase-exists('parent', @case_type='bob')",
+        ("parent", "@case_type='bob'", ">", 0, False)
+    ),
+    (
+        "subcase-exists('p', @case_type='bob' and prop='value')",
+        ("p", "@case_type='bob' and prop='value'", ">", 0, False)
+    ),
+    (
+        "subcase-count('p', prop=1) > 3",
+        ("p", "prop=1", ">", 3, False)
+    ),
+    (
+        "subcase-count('p', prop=1) >= 3",
+        ("p", "prop=1", ">", 2, False)
+    ),
+    (
+        "subcase-count('p', prop=1) < 3",
+        ("p", "prop=1", ">", 2, True)
+    ),
+    (
+        "subcase-count('p', prop=1) <= 3",
+        ("p", "prop=1", ">", 3, True)
+    ),
+    (
+        "subcase-count('p', prop=1) = 3",
+        ("p", "prop=1", "=", 3, False)
+    ),
+    (
+        "subcase-count('p', prop=1) = 0",
+        ("p", "prop=1", ">", 0, True)
+    ),
+    (
+        "subcase-count('p', prop=1) != 2",
+        ("p", "prop=1", "=", 2, True)
+    ),
+    (
+        "subcase-count('p') = 2",
+        ("p", None, "=", 2, False)
+    ),
+    (
+        "subcase-exists('p')",
+        ("p", None, ">", 0, False)
+    ),
+])
+def test_subcase_query_parsing(query, expected):
+    node = parse_xpath(query)
+    result = _parse_normalize_subcase_query(node)
+    eq(result.as_tuple(), expected)
 
 
-def test_subcase_query_parsing_validations():
-    def _check(query, msg):
-        node = parse_xpath(query)
-        with assert_raises(XPathFunctionException, msg=msg):
-            _parse_normalize_subcase_query(node)
-
-    yield from [
-        (
-            _check,
-            "subcase-exists()",
-            "'subcase-exists' expects one or two arguments"
-        ),
-        (
-            _check,
-            "subcase-count() > 1",
-            "'subcase-count' expects one or two arguments"
-        ),
-        (
-            _check,
-            "subcase-count()",
-            "XPath incorrectly formatted. Expected 'subcase-exists'"
-        ),
-        (
-            _check,
-            "subcase-count('p', name = 'bob') > -1",
-            "'subcase-count' must be compared to a positive integer"
-        ),
-        (
-            _check,
-            "subcase-count('p', name = 'bob') + 1",
-            "Unsupported operator for use with 'subcase-count': +"
-        ),
-        (
-            _check,
-            "subcase-count('p', name = 'bob') > 'bob'",
-            "'subcase-count' must be compared to a positive integer"
-        ),
-        (
-            _check,
-            "subcase-count('p', name = 'bob') > date('2020-01-01')",
-            "'subcase-count' must be compared to a positive integer"
-        ),
-        (
-            _check,
-            "subcase-count(parent) = 1",
-            "'subcase-count' error. Index identifier must be a string"
-        ),
-        (
-            _check,
-            "subcase-exists(3)",
-            "'subcase-exists' error. Index identifier must be a string"
-        ),
-    ]
+@pytest.mark.parametrize("query, msg", [
+    (
+        "subcase-exists()",
+        "'subcase-exists' expects one or two arguments"
+    ),
+    (
+        "subcase-count() > 1",
+        "'subcase-count' expects one or two arguments"
+    ),
+    (
+        "subcase-count()",
+        "XPath incorrectly formatted. Expected 'subcase-exists'"
+    ),
+    (
+        "subcase-count('p', name = 'bob') > -1",
+        "'subcase-count' must be compared to a positive integer"
+    ),
+    (
+        "subcase-count('p', name = 'bob') + 1",
+        "Unsupported operator for use with 'subcase-count': +"
+    ),
+    (
+        "subcase-count('p', name = 'bob') > 'bob'",
+        "'subcase-count' must be compared to a positive integer"
+    ),
+    (
+        "subcase-count('p', name = 'bob') > date('2020-01-01')",
+        "'subcase-count' must be compared to a positive integer"
+    ),
+    (
+        "subcase-count(parent) = 1",
+        "'subcase-count' error. Index identifier must be a string"
+    ),
+    (
+        "subcase-exists(3)",
+        "'subcase-exists' error. Index identifier must be a string"
+    ),
+])
+def test_subcase_query_parsing_validations(query, msg):
+    node = parse_xpath(query)
+    with assert_raises(XPathFunctionException, msg=msg):
+        _parse_normalize_subcase_query(node)

--- a/corehq/apps/case_search/tests/test_value_functions.py
+++ b/corehq/apps/case_search/tests/test_value_functions.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+import pytest
 from eulxml.xpath import parse as parse_xpath
 from freezegun import freeze_time
 from testil import assert_raises, eq
@@ -63,62 +64,52 @@ class TestDate(TestCase):
         eq(result, '2021-08-02')
 
 
-def test_date_add():
-    def _do_test(expression, expected):
-        node = parse_xpath(expression)
-        result = date_add(node, SearchFilterContext("domain"))
-        eq(result, expected)
-
-    test_cases = [
-        ("date-add('2020-02-29', 'years', 1)", "2021-02-28"),
-        ("date-add('2020-02-29', 'years', 1.0)", "2021-02-28"),
-        ("date-add('2022-01-01', 'months', 1)", "2022-02-01"),
-        ("date-add('2022-01-01', 'months', '3')", "2022-04-01"),
-        ("date-add('2020-04-30', 'months', -2)", "2020-02-29"),
-        ("date-add('2020-03-31', 'weeks', 4)", "2020-04-28"),
-        ("date-add('2020-02-01', 'weeks', 1.5)", "2020-02-11"),
-        ("date-add('2022-01-01', 'days', -1)", "2021-12-31"),
-        ("date-add('2022-01-01', 'days', 1.5)", "2022-01-02"),
-        ("date-add('2022-01-01', 'days', '5')", "2022-01-06"),
-        ("date-add(0, 'days', '5')", "1970-01-06"),
-        ("date-add(365, 'years', '5')", "1976-01-01"),
-        ("date-add(date('2021-01-01'), 'years', '5')", "2026-01-01"),
-        ("date-add(date(5), 'months', '1')", "1970-02-06"),
-    ]
-
-    for expression, expected in test_cases:
-        yield _do_test, expression, expected
+@pytest.mark.parametrize("expression, expected", [
+    ("date-add('2020-02-29', 'years', 1)", "2021-02-28"),
+    ("date-add('2020-02-29', 'years', 1.0)", "2021-02-28"),
+    ("date-add('2022-01-01', 'months', 1)", "2022-02-01"),
+    ("date-add('2022-01-01', 'months', '3')", "2022-04-01"),
+    ("date-add('2020-04-30', 'months', -2)", "2020-02-29"),
+    ("date-add('2020-03-31', 'weeks', 4)", "2020-04-28"),
+    ("date-add('2020-02-01', 'weeks', 1.5)", "2020-02-11"),
+    ("date-add('2022-01-01', 'days', -1)", "2021-12-31"),
+    ("date-add('2022-01-01', 'days', 1.5)", "2022-01-02"),
+    ("date-add('2022-01-01', 'days', '5')", "2022-01-06"),
+    ("date-add(0, 'days', '5')", "1970-01-06"),
+    ("date-add(365, 'years', '5')", "1976-01-01"),
+    ("date-add(date('2021-01-01'), 'years', '5')", "2026-01-01"),
+    ("date-add(date(5), 'months', '1')", "1970-02-06"),
+])
+def test_date_add(expression, expected):
+    node = parse_xpath(expression)
+    result = date_add(node, SearchFilterContext("domain"))
+    eq(result, expected)
 
 
-def test_date_add_errors():
-    def _do_test(expression):
-        node = parse_xpath(expression)
-        with assert_raises(XPathFunctionException):
-            date_add(node, SearchFilterContext("domain"))
+@pytest.mark.parametrize("expression", [
+    # bad date
+    "date-add('2020-02-31', 'years', 1)",
+    "date-add(1.5, 'years', 1)",
 
-    test_cases = [
-        # bad date
-        "date-add('2020-02-31', 'years', 1)",
-        "date-add(1.5, 'years', 1)",
+    # non-integer quantity
+    "date-add('2020-02-01', 'years', 1.5)",
+    "date-add('2020-02-01', 'months', 1.5)",
 
-        # non-integer quantity
-        "date-add('2020-02-01', 'years', 1.5)",
-        "date-add('2020-02-01', 'months', 1.5)",
+    # non-numeric quantity
+    "date-add('2020-02-01', 'months', 'five')",
 
-        # non-numeric quantity
-        "date-add('2020-02-01', 'months', 'five')",
+    # bad interval names
+    "date-add('2020-02-01', 'year', 1)",
+    "date-add('2020-02-01', 'month', 1)",
+    "date-add('2020-02-01', 'week', 1)",
+    "date-add('2020-02-01', 'day', 1)",
 
-        # bad interval names
-        "date-add('2020-02-01', 'year', 1)",
-        "date-add('2020-02-01', 'month', 1)",
-        "date-add('2020-02-01', 'week', 1)",
-        "date-add('2020-02-01', 'day', 1)",
-
-        # missing args
-        "date-add('2020-02-01', 'days')",
-        "date-add('2020-02-01')",
-        "date-add()",
-    ]
-
-    for expression in test_cases:
-        yield _do_test, expression
+    # missing args
+    "date-add('2020-02-01', 'days')",
+    "date-add('2020-02-01')",
+    "date-add()",
+])
+def test_date_add_errors(expression):
+    node = parse_xpath(expression)
+    with assert_raises(XPathFunctionException):
+        date_add(node, SearchFilterContext("domain"))

--- a/corehq/apps/case_search/tests/test_xpath_functions.py
+++ b/corehq/apps/case_search/tests/test_xpath_functions.py
@@ -1,5 +1,8 @@
+import re
+
+import pytest
 from eulxml.xpath import parse as parse_xpath
-from nose.tools import assert_raises_regex
+from nose.tools import assert_raises
 
 from corehq.apps.case_search.exceptions import XPathFunctionException
 from corehq.apps.case_search.filter_dsl import (
@@ -31,11 +34,9 @@ INVALID_TEST_CASES = [(
 )]
 
 
-def test_invalid():
-    def _check(xpath, error_msg):
-        with assert_raises_regex(XPathFunctionException, error_msg):
-            parsed = parse_xpath(xpath)
-            build_filter_from_ast(parsed, SearchFilterContext("mydomain"))
-
-    for xpath, expected in INVALID_TEST_CASES:
-        yield _check, xpath, expected
+@pytest.mark.parametrize("xpath, error_msg", INVALID_TEST_CASES)
+def test_invalid(xpath, error_msg):
+    regex = re.compile(re.escape(error_msg))
+    with assert_raises(XPathFunctionException, msg=regex):
+        parsed = parse_xpath(xpath)
+        build_filter_from_ast(parsed, SearchFilterContext("mydomain"))

--- a/corehq/apps/es/tests/test_utils.py
+++ b/corehq/apps/es/tests/test_utils.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 
+import pytest
 from django.test.testcases import SimpleTestCase
 from pytz import UTC, timezone
 
@@ -15,24 +16,21 @@ ET = timezone('US/Eastern')
 
 
 @es_test
-def test_es_format_datetime():
-    def _assert_returns(date_or_datetime, expected):
-        actual = es_format_datetime(date_or_datetime)
-        assert actual == expected, f"Expected {expected}, got {actual}"
-
-    for date_or_datetime, expected in [
-            ("04/28/21", "04/28/21"),
-            (date(2021, 4, 28), "2021-04-28"),
-            (datetime(2021, 4, 28), "2021-04-28T00:00:00"),
-            (datetime(2021, 4, 28, 11, 47, 22), "2021-04-28T11:47:22"),
-            (datetime(2021, 4, 28, 11, 47, 22, 3), "2021-04-28T11:47:22.000003"),
-            (datetime(2021, 4, 28, 11, 47, 22, 300000), "2021-04-28T11:47:22.300000"),
-            (datetime(2021, 4, 28, 11, tzinfo=UTC), "2021-04-28T11:00:00+00:00"),
-            (ET.localize(datetime(2021, 4, 28, 11)), "2021-04-28T11:00:00-04:00"),
-            # 2021-04-28T11:00:00.000001-04:00 isn't supported in ES, so convert to server time
-            (ET.localize(datetime(2021, 4, 28, 11, microsecond=1)), "2021-04-28T15:00:00.000001"),
-    ]:
-        yield _assert_returns, date_or_datetime, expected
+@pytest.mark.parametrize("date_or_datetime, expected", [
+    ("04/28/21", "04/28/21"),
+    (date(2021, 4, 28), "2021-04-28"),
+    (datetime(2021, 4, 28), "2021-04-28T00:00:00"),
+    (datetime(2021, 4, 28, 11, 47, 22), "2021-04-28T11:47:22"),
+    (datetime(2021, 4, 28, 11, 47, 22, 3), "2021-04-28T11:47:22.000003"),
+    (datetime(2021, 4, 28, 11, 47, 22, 300000), "2021-04-28T11:47:22.300000"),
+    (datetime(2021, 4, 28, 11, tzinfo=UTC), "2021-04-28T11:00:00+00:00"),
+    (ET.localize(datetime(2021, 4, 28, 11)), "2021-04-28T11:00:00-04:00"),
+    # 2021-04-28T11:00:00.000001-04:00 isn't supported in ES, so convert to server time
+    (ET.localize(datetime(2021, 4, 28, 11, microsecond=1)), "2021-04-28T15:00:00.000001"),
+])
+def test_es_format_datetime(date_or_datetime, expected):
+    actual = es_format_datetime(date_or_datetime)
+    assert actual == expected, f"Expected {expected}, got {actual}"
 
 
 @es_test

--- a/corehq/apps/es/tests/utils.py
+++ b/corehq/apps/es/tests/utils.py
@@ -4,14 +4,14 @@ from datetime import datetime
 from functools import wraps
 from inspect import isclass
 
-from nose.plugins.attrib import attr
-from nose.tools import nottest
+import pytest
 
 from pillowtop.es_utils import initialize_index_and_mapping
 from pillowtop.tests.utils import get_pillow_doc_adapter
 
 from corehq.apps.es.client import ElasticMultiplexAdapter
 from corehq.apps.es.migration_operations import CreateIndex
+from corehq.tests.tools import nottest
 from corehq.tests.util.warnings import filter_warnings
 from corehq.util.elastic import ensure_index_deleted
 from corehq.util.es.elasticsearch import NotFoundError
@@ -39,7 +39,7 @@ ignore_index_settings_key_warning = filter_warnings(
     UserWarning,
 )
 
-es_test_attr = attr(es_test=True)
+es_test_attr = pytest.mark.es_test
 
 
 class TEST_ES_INFO:

--- a/corehq/apps/es/transient_util.py
+++ b/corehq/apps/es/transient_util.py
@@ -88,6 +88,7 @@ def populate_doc_adapter_map():
         from pillowtop.tests.utils import TEST_ES_TYPE, TEST_ES_MAPPING, TEST_ES_INDEX
         add_dynamic_adapter("PillowTop", TEST_ES_INDEX, TEST_ES_TYPE, TEST_ES_MAPPING)
 
+        import corehq.tests.pytest_compat  # noqa: F401 - to be removed after switch to pytest
         from corehq.apps.es.tests.utils import TEST_ES_INFO, TEST_ES_MAPPING
         add_dynamic_adapter("UtilES", TEST_ES_INFO.alias, TEST_ES_INFO.type,
                         TEST_ES_MAPPING)

--- a/corehq/apps/export/tests/test_dbaccessors.py
+++ b/corehq/apps/export/tests/test_dbaccessors.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
+
+import pytest
 from django.test import TestCase
-from nose.plugins.attrib import attr
 
 from corehq.apps.export.dbaccessors import (
     get_brief_deid_exports,
@@ -291,7 +292,7 @@ class TestInferredSchemasDBAccessors(TestCase):
         self.assertIsNone(result)
 
 
-@attr('slow')
+@pytest.mark.slow
 class TestODataExportFetcher(TestCase):
     def setUp(self):
         self.fetcher = ODataExportFetcher()

--- a/corehq/apps/export/tests/test_export_models_new.py
+++ b/corehq/apps/export/tests/test_export_models_new.py
@@ -1,6 +1,6 @@
+import pytest
 from django.test import TestCase
 from unittest.mock import patch
-from nose.plugins.attrib import attr
 from corehq.apps.es.tests.utils import es_test
 
 import pytz
@@ -13,7 +13,7 @@ from corehq.util.es.elasticsearch import TransportError
 from corehq.apps.export.models.new import CaseExportInstance, FormExportInstance
 
 
-@attr('slow')
+@pytest.mark.slow
 @es_test
 class FormExportInstanceTests(TestCase):
     def setUp(self):
@@ -61,7 +61,7 @@ class FormExportInstanceTests(TestCase):
         self.assertEqual(export.get_count(), 2)
 
 
-@attr('slow')
+@pytest.mark.slow
 @es_test
 class CaseExportInstanceTests(TestCase):
     def setUp(self):

--- a/corehq/apps/hqadmin/tests/test_corrupt_couch.py
+++ b/corehq/apps/hqadmin/tests/test_corrupt_couch.py
@@ -1,24 +1,25 @@
+import pytest
 from testil import eq
 
 from ..corrupt_couch import find_missing_ids
 
 
-def test_find_missing_ids():
-    def test(result_sets, expected_missing, expected_tries, min_tries=5):
-        def get_ids():
-            while len(results) > 1:
-                return results.pop()
-            return results[0]
+@pytest.mark.parametrize("result_sets, expected_missing, expected_tries, min_tries", [
+    ([{1, 2}], set(), 5, 5),
+    ([{1, 2}], set(), 6, 6),
+    ([{1, 2}], set(), 10, 10),
+    ([{1, 2}, {1, 3}, {2, 3}], {1, 2, 3}, 7, 5),
+    ([{1, 2}, {1, 3}, {1, 3}, {1, 3}, {1, 3}, {2, 3}], {1, 2, 3}, 10, 5),
+    ([{1, 2}] + [{1, 3}] * 5 + [{2, 4}], {2, 3}, 6, 5),
+    ([{1, 2}] + [{1, 3}] * 10 + [{2, 4}], {2, 3}, 11, 10),
+])
+def test_find_missing_ids(result_sets, expected_missing, expected_tries, min_tries):
+    def get_ids():
+        while len(results) > 1:
+            return results.pop()
+        return results[0]
 
-        results = list(reversed(result_sets))
-        missing, tries = find_missing_ids(get_ids, min_tries)
-        eq(missing, expected_missing)
-        eq(tries, expected_tries)
-
-    yield test, [{1, 2}], set(), 5
-    yield test, [{1, 2}], set(), 6, 6
-    yield test, [{1, 2}], set(), 10, 10
-    yield test, [{1, 2}, {1, 3}, {2, 3}], {1, 2, 3}, 7
-    yield test, [{1, 2}, {1, 3}, {1, 3}, {1, 3}, {1, 3}, {2, 3}], {1, 2, 3}, 10
-    yield test, [{1, 2}] + [{1, 3}] * 5 + [{2, 4}], {2, 3}, 6
-    yield test, [{1, 2}] + [{1, 3}] * 10 + [{2, 4}], {2, 3}, 11, 10
+    results = list(reversed(result_sets))
+    missing, tries = find_missing_ids(get_ids, min_tries)
+    eq(missing, expected_missing)
+    eq(tries, expected_tries)

--- a/corehq/apps/hqwebapp/tests/test_compress_command.py
+++ b/corehq/apps/hqwebapp/tests/test_compress_command.py
@@ -1,10 +1,9 @@
 import os
 
+import pytest
 from django.conf import settings
 from django.template.utils import get_app_template_dirs
 from django.test import SimpleTestCase
-
-from nose.plugins.attrib import attr
 
 B3_BASE = 'hqwebapp/bootstrap3/base_navigation.html'
 
@@ -31,7 +30,7 @@ class TestDjangoCompressOffline(SimpleTestCase):
         for tag in DISALLOWED_REGEXES:
             self.assertNotRegex(line.strip(), tag[0], '{}: {}'.format(tag[1], filename))
 
-    @attr("slow")
+    @pytest.mark.slow
     def test_compress_offline(self):
         template_dir_list = []
         for template_dir in get_app_template_dirs('templates'):

--- a/corehq/apps/locations/tests/test_location_safety.py
+++ b/corehq/apps/locations/tests/test_location_safety.py
@@ -1,5 +1,6 @@
 from django.views.generic.base import View
 
+import pytest
 from unittest.mock import MagicMock
 
 from corehq.apps.reports.dispatcher import ReportDispatcher
@@ -35,20 +36,17 @@ class SafeChildofUnsafeClsView(UnsafeClsView):
     """This shouldn't hoist its safety up to the parent class"""
 
 
-def test_django_view_safety():
-    def _assert(view_fn, is_safe):
-        assert is_location_safe(view_fn, MagicMock(), (), {}) == is_safe, \
-            f"{view_fn} {'IS NOT' if is_safe else 'IS'} marked as location-safe"
-
-    for view, is_safe in [
-            (safe_fn_view, True),
-            (unsafe_fn_view, False),
-            (SafeClsView.as_view(), True),
-            (UnsafeClsView.as_view(), False),
-            (ImplicitlySafeChildOfSafeClsView.as_view(), True),
-            (SafeChildofUnsafeClsView.as_view(), True),
-    ]:
-        yield _assert, view, is_safe
+@pytest.mark.parametrize("view_fn, is_safe", [
+    (safe_fn_view, True),
+    (unsafe_fn_view, False),
+    (SafeClsView.as_view(), True),
+    (UnsafeClsView.as_view(), False),
+    (ImplicitlySafeChildOfSafeClsView.as_view(), True),
+    (SafeChildofUnsafeClsView.as_view(), True),
+])
+def test_django_view_safety(view_fn, is_safe):
+    assert is_location_safe(view_fn, MagicMock(), (), {}) == is_safe, \
+        f"{view_fn} {'IS NOT' if is_safe else 'IS'} marked as location-safe"
 
 
 def _sometimes_safe(view_fn, request, *args, **kwargs):
@@ -69,21 +67,18 @@ class ImplicitlySafeChildOfConditionallySafeClsView(ConditionallySafeClsView):
     pass
 
 
-def test_conditionally_safe_django_views():
-    safe_request = MagicMock(this_is_safe=True)
-    unsafe_request = MagicMock(this_is_safe=False)
-
-    def _assert(view_fn, request, is_safe):
-        assert is_location_safe(view_fn, request, (), {}) == is_safe, \
-            f"{view_fn} {'IS NOT' if is_safe else 'IS'} marked as location-safe"
-
-    for view in [
-            conditionally_safe_fn_view,
-            ConditionallySafeClsView.as_view(),
-            ImplicitlySafeChildOfConditionallySafeClsView.as_view(),
-    ]:
-        yield _assert, view, safe_request, True
-        yield _assert, view, unsafe_request, False
+@pytest.mark.parametrize("view_fn, is_safe", [
+    (conditionally_safe_fn_view, True),
+    (ConditionallySafeClsView.as_view(), True),
+    (ImplicitlySafeChildOfConditionallySafeClsView.as_view(), True),
+    (conditionally_safe_fn_view, False),
+    (ConditionallySafeClsView.as_view(), False),
+    (ImplicitlySafeChildOfConditionallySafeClsView.as_view(), False),
+])
+def test_conditionally_safe_django_views(view_fn, is_safe):
+    request = MagicMock(this_is_safe=is_safe)
+    assert is_location_safe(view_fn, request, (), {}) == is_safe, \
+        f"{view_fn} {'IS NOT' if is_safe else 'IS'} marked as location-safe"
 
 
 class ExampleReportDispatcher(ReportDispatcher):
@@ -126,19 +121,16 @@ class ConditionallySafeHQReport(BaseReport):
     slug = 'conditionally_safe_hq_report'
 
 
-def test_hq_report_safety():
-    def _assert(report, request, is_safe):
-        view_fn = report.dispatcher.as_view()
-        view_kwargs = {'domain': 'foo', 'report_slug': report.slug}
-        assert is_location_safe(view_fn, request, (), view_kwargs) == is_safe, \
-            f"{report} {'IS NOT' if is_safe else 'IS'} marked as location-safe"
-
-    for report, request, is_safe in [
-            (SafeHQReport, MagicMock(), True),
-            (UnsafeHQReport, MagicMock(), False),
-            (ImplicitlySafeChildOfSafeHQReport, MagicMock(), True),
-            (SafeChildOfUnsafeHQReport, MagicMock(), True),
-            (ConditionallySafeHQReport, MagicMock(this_is_safe=True), True),
-            (ConditionallySafeHQReport, MagicMock(this_is_safe=False), False),
-    ]:
-        yield _assert, report, request, is_safe
+@pytest.mark.parametrize("report, request_, is_safe", [
+    (SafeHQReport, MagicMock(), True),
+    (UnsafeHQReport, MagicMock(), False),
+    (ImplicitlySafeChildOfSafeHQReport, MagicMock(), True),
+    (SafeChildOfUnsafeHQReport, MagicMock(), True),
+    (ConditionallySafeHQReport, MagicMock(this_is_safe=True), True),
+    (ConditionallySafeHQReport, MagicMock(this_is_safe=False), False),
+])
+def test_hq_report_safety(report, request_, is_safe):
+    view_fn = report.dispatcher.as_view()
+    view_kwargs = {'domain': 'foo', 'report_slug': report.slug}
+    assert is_location_safe(view_fn, request_, (), view_kwargs) == is_safe, \
+        f"{report} {'IS NOT' if is_safe else 'IS'} marked as location-safe"

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+from unittest.mock import patch
+
+import pytest
 from django.test import TestCase
 from faker import Faker
-from unittest.mock import patch
 from testil import assert_raises
 
 from corehq.apps.domain.shortcuts import create_domain
@@ -31,6 +33,7 @@ from corehq.apps.users.models_role import UserRole
 from corehq.apps.custom_data_fields.models import (CustomDataFieldsDefinition,
     CustomDataFieldsProfile)
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
+from corehq.tests.tools import nottest
 from corehq.util.test_utils import flag_enabled
 
 factory = Faker()
@@ -147,61 +150,60 @@ TEST_CASES = [
 ]
 
 
-def test_validators():
-    def _test_spec(validator, specs, errors):
-        for i, spec in enumerate(specs):
-            if i in errors:
-                with assert_raises(UserUploadError, msg=errors[i]):
-                    validator(spec)
-            else:
-                validator(spec)
-
-    for specs, validator, errors in TEST_CASES:
-        yield _test_spec, validator, specs, errors
-
-
-def test_duplicates():
-    specs = [
-        {'name': 1},
-        {'name': 2},
-        {'name': 3},
-        {'name': 2},
-        {'name': 3},
-        {},
-    ]
-    duplicates = (2, 3)
-    yield from _test_duplicates(specs, duplicates)
-
-
-def test_duplicates_with_check():
-    specs = [
-        {'name': 1},
-        {'name': 2},
-        {'name': 2},
-        {'name': 3},
-        {'name': 3},
-        {},
-    ]
-    duplicates = (3,)
-
-    def check(item):
-        return item != 2
-
-    yield from _test_duplicates(specs, duplicates, check)
-
-
-def _test_duplicates(specs, duplicates, check=None):
-    validator = DuplicateValidator('domain', 'name', specs, check_function=check)
-
-    def _test(spec):
-        if spec.get('name') in duplicates:
-            with assert_raises(UserUploadError, msg=validator.error_message):
+@pytest.mark.parametrize("specs, validator, errors", TEST_CASES)
+def test_validators(specs, validator, errors):
+    for i, spec in enumerate(specs):
+        if i in errors:
+            with assert_raises(UserUploadError, msg=errors[i]):
                 validator(spec)
         else:
             validator(spec)
 
+
+@nottest
+def _test_duplicates(specs, duplicates, check=None):
+    validator = DuplicateValidator('domain', 'name', specs, check_function=check)
     for spec in specs:
-        yield _test, spec
+        yield validator, spec, duplicates
+
+
+@pytest.mark.parametrize("validator, spec, duplicates", list(_test_duplicates(
+    [
+        {'name': 1},
+        {'name': 2},
+        {'name': 3},
+        {'name': 2},
+        {'name': 3},
+        {},
+    ],
+    (2, 3),
+)))
+def test_duplicates(validator, spec, duplicates):
+    if spec.get('name') in duplicates:
+        with assert_raises(UserUploadError, msg=validator.error_message):
+            validator(spec)
+    else:
+        validator(spec)
+
+
+@pytest.mark.parametrize("validator, spec, duplicates", list(_test_duplicates(
+    [
+        {'name': 1},
+        {'name': 2},
+        {'name': 2},
+        {'name': 3},
+        {'name': 3},
+        {},
+    ],
+    (3,),
+    check=(lambda item: item != 2)
+)))
+def test_duplicates_with_check(validator, spec, duplicates):
+    if spec.get('name') in duplicates:
+        with assert_raises(UserUploadError, msg=validator.error_message):
+            validator(spec)
+    else:
+        validator(spec)
 
 
 def test_existing_users():

--- a/corehq/apps/userreports/tests/test_utils.py
+++ b/corehq/apps/userreports/tests/test_utils.py
@@ -1,5 +1,6 @@
 from django.test import SimpleTestCase
 
+import pytest
 from testil import eq
 
 from dimagi.utils.couch.undo import remove_deleted_doc_type_suffix
@@ -90,15 +91,13 @@ class UtilitiesTestCase(SimpleTestCase):
         )
 
 
-def test_remove_deleted_doc_type_suffix():
-    def _check(doc_type, expected):
-        eq(expected, remove_deleted_doc_type_suffix(doc_type))
-
-    yield from [
-        (_check, 'DataSource', 'DataSource'),
-        (_check, 'DataSource-Deleted', 'DataSource'),
-        (_check, 'DataSource-Deleted-Deleted', 'DataSource'),
-    ]
+@pytest.mark.parametrize("doc_type, expected", [
+    ('DataSource', 'DataSource'),
+    ('DataSource-Deleted', 'DataSource'),
+    ('DataSource-Deleted-Deleted', 'DataSource'),
+])
+def test_remove_deleted_doc_type_suffix(doc_type, expected):
+    eq(expected, remove_deleted_doc_type_suffix(doc_type))
 
 
 class TestGetDomainForUCRTableName(SimpleTestCase):

--- a/corehq/ex-submodules/couchexport/tests/test_excel_format_value.py
+++ b/corehq/ex-submodules/couchexport/tests/test_excel_format_value.py
@@ -1,6 +1,7 @@
 import datetime
 from decimal import Decimal
 
+import pytest
 from openpyxl.styles import numbers
 from testil import eq
 
@@ -16,130 +17,168 @@ def check(input, output, format, output_type):
     eq(type(value), output_type)
 
 
-def test_integers():
-    yield check, '3423', 3423, numbers.FORMAT_NUMBER, int
-    yield check, '-234', -234, numbers.FORMAT_NUMBER, int
-    yield check, 324, 324, numbers.FORMAT_NUMBER, int
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('3423', 3423, numbers.FORMAT_NUMBER, int),
+    ('-234', -234, numbers.FORMAT_NUMBER, int),
+    (324, 324, numbers.FORMAT_NUMBER, int),
+])
+def test_integers(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
-def test_decimal():
-    yield check, '4.0345', 4.0345, numbers.FORMAT_NUMBER_00, float
-    yield check, '-3.234', -3.234, numbers.FORMAT_NUMBER_00, float
-    yield check, 5.032, 5.032, numbers.FORMAT_NUMBER_00, float
-    yield check, Decimal('3.00'), 3.00, numbers.FORMAT_NUMBER_00, float
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('4.0345', 4.0345, numbers.FORMAT_NUMBER_00, float),
+    ('-3.234', -3.234, numbers.FORMAT_NUMBER_00, float),
+    (5.032, 5.032, numbers.FORMAT_NUMBER_00, float),
+    (Decimal('3.00'), 3.00, numbers.FORMAT_NUMBER_00, float),
+])
+def test_decimal(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
-def test_boolean():
-    yield check, 'TRUE', True, numbers.FORMAT_GENERAL, bool
-    yield check, 'True', True, numbers.FORMAT_GENERAL, bool
-    yield check, 'true', True, numbers.FORMAT_GENERAL, bool
-    yield check, True, True, numbers.FORMAT_GENERAL, bool
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('TRUE', True, numbers.FORMAT_GENERAL, bool),
+    ('True', True, numbers.FORMAT_GENERAL, bool),
+    ('true', True, numbers.FORMAT_GENERAL, bool),
+    (True, True, numbers.FORMAT_GENERAL, bool),
 
-    yield check, 'FALSE', False, numbers.FORMAT_GENERAL, bool
-    yield check, 'False', False, numbers.FORMAT_GENERAL, bool
-    yield check, 'false', False, numbers.FORMAT_GENERAL, bool
-    yield check, False, False, numbers.FORMAT_GENERAL, bool
-
-
-def test_decimal_eur():
-    yield check, '6,9234', 6.9234, numbers.FORMAT_NUMBER_00, float
-    yield check, '-5,342', -5.342, numbers.FORMAT_NUMBER_00, float
+    ('FALSE', False, numbers.FORMAT_GENERAL, bool),
+    ('False', False, numbers.FORMAT_GENERAL, bool),
+    ('false', False, numbers.FORMAT_GENERAL, bool),
+    (False, False, numbers.FORMAT_GENERAL, bool),
+])
+def test_boolean(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
-def test_percentage():
-    yield check, '80%', 0.8, numbers.FORMAT_PERCENTAGE, float
-    yield check, '-50%', -0.5, numbers.FORMAT_PERCENTAGE, float
-    yield check, '3.45%', 0.0345, numbers.FORMAT_PERCENTAGE_00, float
-    yield check, '-4.35%', -0.0435, numbers.FORMAT_PERCENTAGE_00, float
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('6,9234', 6.9234, numbers.FORMAT_NUMBER_00, float),
+    ('-5,342', -5.342, numbers.FORMAT_NUMBER_00, float),
+])
+def test_decimal_eur(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
-def test_comma_separated_us():
-    yield check, '3,000.0234', 3000.0234, numbers.FORMAT_NUMBER_COMMA_SEPARATED1, float
-    yield check, '3,234,000.342', 3234000.342, numbers.FORMAT_NUMBER_COMMA_SEPARATED1, float
-    yield check, '5,000,343', 5000343, numbers.FORMAT_NUMBER_COMMA_SEPARATED1, float
-    yield check, '-5,334.32', -5334.32, numbers.FORMAT_NUMBER_COMMA_SEPARATED1, float
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('80%', 0.8, numbers.FORMAT_PERCENTAGE, float),
+    ('-50%', -0.5, numbers.FORMAT_PERCENTAGE, float),
+    ('3.45%', 0.0345, numbers.FORMAT_PERCENTAGE_00, float),
+    ('-4.35%', -0.0435, numbers.FORMAT_PERCENTAGE_00, float),
+])
+def test_percentage(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
-def test_comma_separated_eur():
-    yield check, '5.600,0322', 5600.0322, numbers.FORMAT_NUMBER_COMMA_SEPARATED2, float
-    yield check, '5.600,0322', 5600.0322, numbers.FORMAT_NUMBER_COMMA_SEPARATED2, float
-    yield check, '8.435.600,0322', 8435600.0322, numbers.FORMAT_NUMBER_COMMA_SEPARATED2, float
-    yield check, '5.555.600', 5555600, numbers.FORMAT_NUMBER_COMMA_SEPARATED2, float
-    yield check, '-2.433,032', -2433.032, numbers.FORMAT_NUMBER_COMMA_SEPARATED2, float
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('3,000.0234', 3000.0234, numbers.FORMAT_NUMBER_COMMA_SEPARATED1, float),
+    ('3,234,000.342', 3234000.342, numbers.FORMAT_NUMBER_COMMA_SEPARATED1, float),
+    ('5,000,343', 5000343, numbers.FORMAT_NUMBER_COMMA_SEPARATED1, float),
+    ('-5,334.32', -5334.32, numbers.FORMAT_NUMBER_COMMA_SEPARATED1, float),
+])
+def test_comma_separated_us(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
-def test_currency_usd():
-    yield check, '$3,534.02', 3534.02, numbers.FORMAT_CURRENCY_USD_SIMPLE, float
-    yield check, '$99', 99, numbers.FORMAT_CURRENCY_USD_SIMPLE, float
-    yield check, '$5,000', 5000, numbers.FORMAT_CURRENCY_USD_SIMPLE, float
-    yield check, '-$234.02', -234.02, numbers.FORMAT_CURRENCY_USD_SIMPLE, float
-    yield check, '$4.4302', 4.4302, numbers.FORMAT_CURRENCY_USD_SIMPLE, float
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('5.600,0322', 5600.0322, numbers.FORMAT_NUMBER_COMMA_SEPARATED2, float),
+    ('5.600,0322', 5600.0322, numbers.FORMAT_NUMBER_COMMA_SEPARATED2, float),
+    ('8.435.600,0322', 8435600.0322, numbers.FORMAT_NUMBER_COMMA_SEPARATED2, float),
+    ('5.555.600', 5555600, numbers.FORMAT_NUMBER_COMMA_SEPARATED2, float),
+    ('-2.433,032', -2433.032, numbers.FORMAT_NUMBER_COMMA_SEPARATED2, float),
+])
+def test_comma_separated_eur(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
-def test_currency_eur():
-    yield check, '€5.323,09', 5323.09, numbers.FORMAT_CURRENCY_EUR_SIMPLE, float
-    yield check, '-€303,03', -303.03, numbers.FORMAT_CURRENCY_EUR_SIMPLE, float
-    yield check, '€22', 22, numbers.FORMAT_CURRENCY_EUR_SIMPLE, float
-    yield check, '€3.303', 3303, numbers.FORMAT_CURRENCY_EUR_SIMPLE, float
-    yield check, '€3,003', 3.003, numbers.FORMAT_CURRENCY_EUR_SIMPLE, float
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('$3,534.02', 3534.02, numbers.FORMAT_CURRENCY_USD_SIMPLE, float),
+    ('$99', 99, numbers.FORMAT_CURRENCY_USD_SIMPLE, float),
+    ('$5,000', 5000, numbers.FORMAT_CURRENCY_USD_SIMPLE, float),
+    ('-$234.02', -234.02, numbers.FORMAT_CURRENCY_USD_SIMPLE, float),
+    ('$4.4302', 4.4302, numbers.FORMAT_CURRENCY_USD_SIMPLE, float),
+])
+def test_currency_usd(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
-def test_date():
-    yield check, '2020-01-20', datetime.datetime(2020, 1, 20, 0, 0), \
-        numbers.FORMAT_DATE_YYYYMMDD2, datetime.datetime
-    yield check, '2020/01/20', datetime.datetime(2020, 1, 20, 0, 0), \
-        numbers.FORMAT_DATE_YYYYMMDD2, datetime.datetime
-    yield check, '2020.01.20', datetime.datetime(2020, 1, 20, 0, 0), \
-        numbers.FORMAT_DATE_YYYYMMDD2, datetime.datetime
-    yield check, datetime.date(2020, 1, 20), datetime.date(2020, 1, 20), \
-        numbers.FORMAT_DATE_YYYYMMDD2, datetime.date
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('$3,534.02', 3534.02, numbers.FORMAT_CURRENCY_USD_SIMPLE, float),
+    ('$99', 99, numbers.FORMAT_CURRENCY_USD_SIMPLE, float),
+    ('$5,000', 5000, numbers.FORMAT_CURRENCY_USD_SIMPLE, float),
+    ('-$234.02', -234.02, numbers.FORMAT_CURRENCY_USD_SIMPLE, float),
+    ('$4.4302', 4.4302, numbers.FORMAT_CURRENCY_USD_SIMPLE, float),
+])
+def test_currency_eur(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
-def test_datetime():
-    yield check, '2020-01-20 12:33', \
-        datetime.datetime(2020, 1, 20, 12, 33), \
-        numbers.FORMAT_DATE_DATETIME, datetime.datetime
-    yield check, '2020-01-20 12:33:22', \
-        datetime.datetime(2020, 1, 20, 12, 33, 22), \
-        numbers.FORMAT_DATE_DATETIME, datetime.datetime
-    yield check, '2020-01-20 1:33:22PM', \
-        datetime.datetime(2020, 1, 20, 13, 33, 22), \
-        numbers.FORMAT_DATE_DATETIME, datetime.datetime
-    yield check, '2020-01-20 09:33:22.890000-6:00', \
-        datetime.datetime(2020, 1, 20, 9, 33, 22, 890000), \
-        numbers.FORMAT_DATE_DATETIME, datetime.datetime
-    yield check, '2020-01-20 09:33:22.890000-6', \
-        datetime.datetime(2020, 1, 20, 9, 33, 22, 890000), \
-        numbers.FORMAT_DATE_DATETIME, datetime.datetime
-    yield check, datetime.datetime(2020, 1, 20, 11, 11), \
-        datetime.datetime(2020, 1, 20, 11, 11), \
-        numbers.FORMAT_DATE_DATETIME, datetime.datetime
-    yield check, '2020-01-17T15:45:37.268000Z', \
-        datetime.datetime(2020, 1, 17, 15, 45, 37, 268000), \
-        numbers.FORMAT_DATE_DATETIME, datetime.datetime
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('2020-01-20', datetime.datetime(2020, 1, 20, 0, 0),
+        numbers.FORMAT_DATE_YYYYMMDD2, datetime.datetime),
+    ('2020/01/20', datetime.datetime(2020, 1, 20, 0, 0),
+        numbers.FORMAT_DATE_YYYYMMDD2, datetime.datetime),
+    ('2020.01.20', datetime.datetime(2020, 1, 20, 0, 0),
+        numbers.FORMAT_DATE_YYYYMMDD2, datetime.datetime),
+    (datetime.date(2020, 1, 20), datetime.date(2020, 1, 20),
+        numbers.FORMAT_DATE_YYYYMMDD2, datetime.date),
+])
+def test_date(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
-def test_time():
-    yield check, '12:33', '12:33', numbers.FORMAT_DATE_TIME4, str
-    yield check, '12:33:66', '12:33:66', numbers.FORMAT_DATE_TIME4, str
-    yield check, '09:33:22.890000-6:00', '09:33:22.890000-6:00', numbers.FORMAT_DATE_TIME4, str
-    yield check, '09:33:22.890000-6', '09:33:22.890000-6', numbers.FORMAT_DATE_TIME4, str
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('2020-01-20 12:33',
+        datetime.datetime(2020, 1, 20, 12, 33),
+        numbers.FORMAT_DATE_DATETIME, datetime.datetime),
+    ('2020-01-20 12:33:22',
+        datetime.datetime(2020, 1, 20, 12, 33, 22),
+        numbers.FORMAT_DATE_DATETIME, datetime.datetime),
+    ('2020-01-20 1:33:22PM',
+        datetime.datetime(2020, 1, 20, 13, 33, 22),
+        numbers.FORMAT_DATE_DATETIME, datetime.datetime),
+    ('2020-01-20 09:33:22.890000-6:00',
+        datetime.datetime(2020, 1, 20, 9, 33, 22, 890000),
+        numbers.FORMAT_DATE_DATETIME, datetime.datetime),
+    ('2020-01-20 09:33:22.890000-6',
+        datetime.datetime(2020, 1, 20, 9, 33, 22, 890000),
+        numbers.FORMAT_DATE_DATETIME, datetime.datetime),
+    (datetime.datetime(2020, 1, 20, 11, 11),
+        datetime.datetime(2020, 1, 20, 11, 11),
+        numbers.FORMAT_DATE_DATETIME, datetime.datetime),
+    ('2020-01-17T15:45:37.268000Z',
+        datetime.datetime(2020, 1, 17, 15, 45, 37, 268000),
+        numbers.FORMAT_DATE_DATETIME, datetime.datetime),
+])
+def test_datetime(input, output, format, output_type):
+    check(input, output, format, output_type)
+
+
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('12:33', '12:33', numbers.FORMAT_DATE_TIME4, str),
+    ('12:33:66', '12:33:66', numbers.FORMAT_DATE_TIME4, str),
+    ('09:33:22.890000-6:00', '09:33:22.890000-6:00', numbers.FORMAT_DATE_TIME4, str),
+    ('09:33:22.890000-6', '09:33:22.890000-6', numbers.FORMAT_DATE_TIME4, str),
+])
+def test_time(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
 def test_missing():
-    yield check, MISSING_VALUE, MISSING_VALUE, numbers.FORMAT_TEXT, str
+    check(MISSING_VALUE, MISSING_VALUE, numbers.FORMAT_TEXT, str)
 
 
 def test_empty():
-    yield check, EMPTY_VALUE, EMPTY_VALUE, numbers.FORMAT_TEXT, str
+    check(EMPTY_VALUE, EMPTY_VALUE, numbers.FORMAT_TEXT, str)
 
 
-def test_text():
-    yield check, 'hi this is text', 'hi this is text', numbers.FORMAT_TEXT, str
-    yield check, '1241234eeeesffsfs', '1241234eeeesffsfs', numbers.FORMAT_TEXT, str
-    yield check, {'en': 'Thanks', 'de': 'Danke'}, "{'en': 'Thanks', 'de': 'Danke'}", \
-          numbers.FORMAT_TEXT, str
+@pytest.mark.parametrize("input, output, format, output_type", [
+    ('hi this is text', 'hi this is text', numbers.FORMAT_TEXT, str),
+    ('1241234eeeesffsfs', '1241234eeeesffsfs', numbers.FORMAT_TEXT, str),
+    ({'en': 'Thanks', 'de': 'Danke'}, "{'en': 'Thanks', 'de': 'Danke'}", numbers.FORMAT_TEXT, str),
+])
+def test_text(input, output, format, output_type):
+    check(input, output, format, output_type)
 
 
 def test_bad_date_string():
-    yield check, '112020-02-2609', '112020-02-2609', numbers.FORMAT_TEXT, str
+    check('112020-02-2609', '112020-02-2609', numbers.FORMAT_TEXT, str)

--- a/corehq/ex-submodules/couchforms/tests/test_geopoint.py
+++ b/corehq/ex-submodules/couchforms/tests/test_geopoint.py
@@ -1,28 +1,26 @@
 from decimal import Decimal
 
+import pytest
 from jsonobject.exceptions import BadValueError
 from nose.tools import assert_equal, assert_raises
 
 from ..geopoint import GeoPoint
 
 
-def test_valid_geopoint_properties():
-    for input_string, output in [
-        ('42.3739063 -71.1109113 0.0 886.0', ('42.3739063', '-71.1109113', '0.0', '886.0')),
-        ('-7.130 -41.563 7.53E-4 8.0', ('-7.130', '-41.563', '0', '8.0')),
-        ('-7.130 -41.563 -2.2709742188453674E-4 8.0', ('-7.130', '-41.563', '0', '8.0')),
-        ('-7.130 -41.563', ('-7.130', '-41.563', 'NaN', 'NaN')),
-        ('-7.130 -41.563 1.2E-3 0', ('-7.130', '-41.563', '0.012', '0')),
-        ('-7.130 -41.563 0.0 1.0', ('-7.130', '-41.563', '0.0', '1.0')),
-    ]:
-        actual = GeoPoint.from_string(input_string, flexible=True)
-        expected = GeoPoint(*(Decimal(x) for x in output))
-    yield _geopoints_equal, actual, expected
+@pytest.mark.parametrize("input_string, output", [
+    ('42.3739063 -71.1109113 0.0 886.0', ('42.3739063', '-71.1109113', '0.0', '886.0')),
+    ('-7.130 -41.563 7.53E-4 8.0', ('-7.130', '-41.563', '0', '8.0')),
+    ('-7.130 -41.563 -2.2709742188453674E-4 8.0', ('-7.130', '-41.563', '0', '8.0')),
+    ('-7.130 -41.563', ('-7.130', '-41.563', 'NaN', 'NaN')),
+    ('-7.130 -41.563 1.2E-3 0', ('-7.130', '-41.563', '0.0012', '0')),
+    ('-7.130 -41.563 0.0 1.0', ('-7.130', '-41.563', '0.0', '1.0')),
+])
+def test_valid_geopoint_properties(input_string, output):
+    actual = GeoPoint.from_string(input_string, flexible=True)
+    expected = GeoPoint(*(Decimal(x) for x in output))
 
-
-def _geopoints_equal(a, b):
     for field in ['latitude', 'longitude', 'altitude', 'accuracy']:
-        assert_equal(str(getattr(a, field)), str(getattr(b, field)))
+        assert_equal(str(getattr(actual, field)), str(getattr(expected, field)))
 
 
 def test_inflexible_is_strict():
@@ -30,19 +28,15 @@ def test_inflexible_is_strict():
         GeoPoint.from_string('-7.130 -41.563', flexible=False)
 
 
-def test_invalid_geopoint_properties():
-    for input_string in [
-            'these are not decimals',
-            '42.3739063 -71.1109113 0.0 whoops',
-            '42.3739063 -71.1109113 0.0',  # only three elements
-            3,  # wrong type
-            '24.85676533097921 240.27256620218806 0.0 0.0',  # out of bounds
-            '-11.683438999546881 -184.6692769950829 0.0 0.0',  # out of bounds
-            'NaN -71.669 0.0 0.0',
-    ]:
-        yield _is_invalid_input, input_string
-
-
-def _is_invalid_input(input_string):
+@pytest.mark.parametrize("input_string", [
+    'these are not decimals',
+    '42.3739063 -71.1109113 0.0 whoops',
+    '42.3739063 -71.1109113 0.0',  # only three elements
+    3,  # wrong type
+    '24.85676533097921 240.27256620218806 0.0 0.0',  # out of bounds
+    '-11.683438999546881 -184.6692769950829 0.0 0.0',  # out of bounds
+    'NaN -71.669 0.0 0.0',
+])
+def test_invalid_geopoint_properties(input_string):
     with assert_raises(BadValueError):
         GeoPoint.from_string(input_string)

--- a/corehq/ex-submodules/dimagi/utils/tests/test_database.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/test_database.py
@@ -1,3 +1,4 @@
+import pytest
 from testil import Config, assert_raises, eq
 
 from requests.exceptions import RequestException
@@ -7,23 +8,22 @@ from .test_retry import make_retry_function, mock_retry_sleep
 from ..couch import database as mod
 
 
-def test_retry_on_couch_error():
-    @timelimit
-    def test(n, error=None):
-        func, calls = make_couch_retry_function(n, error)
-        with mock_retry_sleep() as sleeps:
-            eq(func(n), n * 2)
-        eq(sleeps, ([0.1] + [2 ** i for i in range(n - 1)]) if n else [])
-        eq(len(calls), n + 1)
-
-    yield test, 0
-    yield test, 1
-    yield test, 2
-    yield test, 3
-    yield test, 4
-    yield test, 5
-
-    yield test, 1, mod.BulkFetchException
+@pytest.mark.parametrize("n, error", [
+    (0, None),
+    (1, None),
+    (2, None),
+    (3, None),
+    (4, None),
+    (5, None),
+    (1, mod.BulkFetchException),
+])
+@timelimit
+def test_retry_on_couch_error(n, error):
+    func, calls = make_couch_retry_function(n, error)
+    with mock_retry_sleep() as sleeps:
+        eq(func(n), n * 2)
+    eq(sleeps, ([0.1] + [2 ** i for i in range(n - 1)]) if n else [])
+    eq(len(calls), n + 1)
 
 
 @timelimit

--- a/corehq/ex-submodules/dimagi/utils/tests/test_web.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/test_web.py
@@ -1,26 +1,26 @@
+import pytest
 from testil import eq, assert_raises
 
 from dimagi.utils.web import get_ip, json_request
 
 
-def test_get_ip():
+@pytest.mark.parametrize("request_meta, expected_value", [
     # localhost default
-    yield _test_get_ip, {}, '127.0.0.1'
+    ({}, '127.0.0.1'),
     # garbage default
-    yield _test_get_ip, {'REMOTE_ADDR': 'garbage'}, '10.0.0.1'
+    ({'REMOTE_ADDR': 'garbage'}, '10.0.0.1'),
     # Use x-forwarded-for
-    yield _test_get_ip, {'HTTP_X_FORWARDED_FOR': '54.13.132.27'}, '54.13.132.27'
+    ({'HTTP_X_FORWARDED_FOR': '54.13.132.27'}, '54.13.132.27'),
     # Use remote address
-    yield _test_get_ip, {'REMOTE_ADDR': '44.44.44.44'}, '44.44.44.44'
+    ({'REMOTE_ADDR': '44.44.44.44'}, '44.44.44.44'),
     # Use x-forwarded-for over remote address
-    yield _test_get_ip, {'HTTP_X_FORWARDED_FOR': '54.13.132.27', 'REMOTE_ADDR': '44.44.44.44'}, '54.13.132.27'
+    ({'HTTP_X_FORWARDED_FOR': '54.13.132.27', 'REMOTE_ADDR': '44.44.44.44'}, '54.13.132.27'),
     # Use x-forwarded-for first IP address if many
-    yield _test_get_ip, {'HTTP_X_FORWARDED_FOR': '54.13.132.27, 10.200.40.12'}, '54.13.132.27'
+    ({'HTTP_X_FORWARDED_FOR': '54.13.132.27, 10.200.40.12'}, '54.13.132.27'),
     # Use x-forwarded-for first IP address if many (even if no space)
-    yield _test_get_ip, {'HTTP_X_FORWARDED_FOR': '54.13.132.27,10.200.40.12'}, '54.13.132.27'
-
-
-def _test_get_ip(request_meta, expected_value):
+    ({'HTTP_X_FORWARDED_FOR': '54.13.132.27,10.200.40.12'}, '54.13.132.27'),
+])
+def test_get_ip(request_meta, expected_value):
     class FakeRequest:
         def __init__(self):
             self.META = request_meta
@@ -28,46 +28,25 @@ def _test_get_ip(request_meta, expected_value):
     eq(get_ip(FakeRequest()), expected_value)
 
 
-def test_json_request():
+@pytest.mark.parametrize("params, kwargs, expected_result", [
     # empty
-    yield _test_json_request, {}, {}, {}
+    ({}, {}, {}),
     # quoted string
-    yield _test_json_request, {'hello': '"world"'}, {}, {'hello': 'world'}
+    ({'hello': '"world"'}, {}, {'hello': 'world'}),
     # string of an integer
-    yield _test_json_request, {'hello': '123'}, {}, {'hello': 123}
+    ({'hello': '123'}, {}, {'hello': 123}),
     # string of an object
-    yield (
-        _test_json_request,
-        {'hello': '{"foo": "bar"}'},
-        {},
-        {'hello': {'foo': 'bar'}},
-    )
+    ({'hello': '{"foo": "bar"}'}, {}, {'hello': {'foo': 'bar'}}),
     # boolean
-    yield (
-        _test_json_request,
-        {'hello': 'true'},
-        {},
-        {'hello': True},
-    )
+    ({'hello': 'true'}, {}, {'hello': True}),
     # booleans as strings
-    yield (
-        _test_json_request,
-        {'hello': 'true'},
-        {'booleans_as_strings': True},
-        {'hello': 'true'},
-    )
+    ({'hello': 'true'}, {'booleans_as_strings': True}, {'hello': 'true'}),
     # key is not a string
-    yield _test_json_request, {123: '"world"'}, {}, {'123': 'world'}
+    ({123: '"world"'}, {}, {'123': 'world'}),
     # lenient
-    yield (
-        _test_json_request,
-        {'hello': 'not JSON'},
-        {},  # {'lenient': True}
-        {'hello': 'not JSON'},
-    )
-
-
-def _test_json_request(params, kwargs, expected_result):
+    ({'hello': 'not JSON'}, {}, {'hello': 'not JSON'}),  # {} -> {'lenient': True}
+])
+def test_json_request(params, kwargs, expected_result):
     eq(json_request(params, **kwargs), expected_result)
 
 

--- a/corehq/extensions/tests.py
+++ b/corehq/extensions/tests.py
@@ -1,5 +1,6 @@
 import re
 
+import pytest
 import testil
 
 from corehq.extensions.interface import CommCareExtensions, ExtensionError, ResultFormat
@@ -44,19 +45,15 @@ def demo_extension_3(**kwargs):
     return "p3"
 
 
-def test_commcare_extensions():
-    def check(args, kwargs, expected):
-        results = ext_point_a(*args, **kwargs)
-        testil.eq(results, expected)
-
-    cases = [
-        ([], {"arg1": 1, "domain": "d1"}, ["p2", "p3"]),
-        ([], {"arg1": 2, "domain": "d1"}, ["p3"]),
-        ([1, "d2"], {}, ["p1", "p2"]),
-        ([], {"arg1": 2, "domain": "d2"}, []),
-    ]
-    for args, kwargs, expected in cases:
-        yield check, args, kwargs, expected
+@pytest.mark.parametrize("args, kwargs, expected", [
+    ([], {"arg1": 1, "domain": "d1"}, ["p2", "p3"]),
+    ([], {"arg1": 2, "domain": "d1"}, ["p3"]),
+    ([1, "d2"], {}, ["p1", "p2"]),
+    ([], {"arg1": 2, "domain": "d2"}, []),
+])
+def test_commcare_extensions(args, kwargs, expected):
+    results = ext_point_a(*args, **kwargs)
+    testil.eq(results, expected)
 
 
 def test_validation_not_callable():

--- a/corehq/form_processor/tests/test_sql_update_strategy.py
+++ b/corehq/form_processor/tests/test_sql_update_strategy.py
@@ -1,3 +1,4 @@
+import pytest
 from django.test import TestCase
 from freezegun import freeze_time
 from unittest.mock import patch
@@ -205,19 +206,16 @@ class SqlUpdateStrategyTest(TestCase):
         soft_assert_mock.reset_mock()
 
 
-def test_update_known_properties_with_empty_values():
-    def test(prop):
-        case = SqlCaseUpdateStrategy.case_implementation_class()
-        setattr(case, prop, "value")
-        action = CaseUpdateAction(block=None, **{prop: ""})
+@pytest.mark.parametrize("prop", [p for p, d in KNOWN_PROPERTIES.items() if d is not None])
+def test_update_known_properties_with_empty_values(prop):
+    case = SqlCaseUpdateStrategy.case_implementation_class()
+    setattr(case, prop, "value")
+    action = CaseUpdateAction(block=None, **{prop: ""})
 
-        SqlCaseUpdateStrategy(case)._update_known_properties(action)
+    SqlCaseUpdateStrategy(case)._update_known_properties(action)
 
-        eq(getattr(case, prop), "")
+    eq(getattr(case, prop), "")
 
-    # verify that at least one property will be tested
+
+def test_at_least_one_property_will_be_tested():
     assert any(v is not None for v in KNOWN_PROPERTIES.values()), KNOWN_PROPERTIES
-
-    for prop, default in KNOWN_PROPERTIES.items():
-        if default is not None:
-            yield test, prop

--- a/corehq/form_processor/tests/test_system_action.py
+++ b/corehq/form_processor/tests/test_system_action.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+import pytest
 from django.test import TestCase
 
 from testil import eq
@@ -27,11 +28,11 @@ class TestSystemActions(TestCase):
             XFormInstance.objects.get_form(form_id, domain)
 
 
-def test_system_action_constants():
-    def test(actual, expected):
-        eq(actual, expected,
-            f"Changing the value of this constant will break all "
-            f"'{expected}' system action forms in existence.")
-
-    yield test, ARCHIVE_FORM, "archive_form"
-    yield test, HARD_DELETE_CASE_AND_FORMS, "hard_delete_case_and_forms"
+@pytest.mark.parametrize("actual, expected", [
+    (ARCHIVE_FORM, "archive_form"),
+    (HARD_DELETE_CASE_AND_FORMS, "hard_delete_case_and_forms"),
+])
+def test_system_action_constants(actual, expected):
+    eq(actual, expected,
+        f"Changing the value of this constant will break all "
+        f"'{expected}' system action forms in existence.")

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.test import TestCase, TransactionTestCase
 from django.utils.functional import classproperty
 
-from nose.plugins.attrib import attr
+import pytest
 from nose.tools import nottest
 from unittest import skipIf, skipUnless
 
@@ -112,7 +112,7 @@ def sharded(cls):
 
     Was previously named @use_sql_backend
     """
-    return patch_shard_db_transactions(attr(sharded=True)(cls))
+    return patch_shard_db_transactions(pytest.mark.sharded(cls))
 
 
 def only_run_with_non_partitioned_database(cls):

--- a/corehq/messaging/tests/test_smsbackends.py
+++ b/corehq/messaging/tests/test_smsbackends.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from corehq.apps.hqadmin.management.commands import verify_ssl_connections
 
 
@@ -17,19 +19,20 @@ def test_iter_sms_endpoints():
         assert not list(Command.iter_sms_endpoints(ConsoleChecker))
 
 
-def test_sms_urls():
+@pytest.mark.parametrize(
+    "model_class",
+    [m for _, m in verify_ssl_connections.iter_sms_model_classes()],
+)
+def test_sms_urls(model_class):
     def test_manager(model_class):
         class NoDbManager:
             def filter(**kw):
                 return [model_class()]
         return NoDbManager
 
-    def test(model_class):
-        def log(msg):
-            raise NotImplementedError
-        with patch.object(model_class, "active_objects", test_manager(model_class)):
-            urls = list(verify_ssl_connections.iter_sms_urls(model_class, log))
-            assert urls, f"{model_class} has no URL(s)"
+    def log(msg):
+        raise NotImplementedError
 
-    for name, model_class in verify_ssl_connections.iter_sms_model_classes():
-        yield test, model_class
+    with patch.object(model_class, "active_objects", test_manager(model_class)):
+        urls = list(verify_ssl_connections.iter_sms_urls(model_class, log))
+        assert urls, f"{model_class} has no URL(s)"

--- a/corehq/motech/fhir/tests/test_searchers.py
+++ b/corehq/motech/fhir/tests/test_searchers.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import attr
+import pytest
 from nose.tools import assert_equal, assert_in, assert_true
 
 from corehq.motech.auth import BasicAuthManager
@@ -16,154 +17,154 @@ from ..searchers import (
 )
 
 
-def test_param_helper():
+@pytest.mark.parametrize("resource, expected_valueset", [
+    (
+        {'name': [{'given': ['Jane'], 'family': 'Fonda'}]},
+        'Fonda',
+    ),
+    (
+        {'name': [
+            {'given': ['Jane'], 'family': 'Fonda'},
+            {'given': ['Jane'], 'family': 'Plemiannikov'},
+        ]},
+        {'Fonda', 'Plemiannikov'},
+    ),
+])
+def test_param_helper(resource, expected_valueset):
     search_param = SearchParam('family', '$.name[*].family', ParamHelper)
-    for resource, expected_valueset in [
-        (
-            {'name': [{'given': ['Jane'], 'family': 'Fonda'}]},
-            'Fonda',
-        ),
-        (
-            {'name': [
-                {'given': ['Jane'], 'family': 'Fonda'},
-                {'given': ['Jane'], 'family': 'Plemiannikov'},
-            ]},
-            {'Fonda', 'Plemiannikov'},
-        ),
-    ]:
-        yield check_param_helper, search_param, resource, expected_valueset
+    check_param_helper(search_param, resource, expected_valueset)
 
 
-def test_given_name():
+@pytest.mark.parametrize("resource, expected_valueset", [
+    (
+        {'name': [{'given': ['Jane'], 'family': 'Fonda'}]},
+        'Jane',
+    ),
+    (
+        {'name': [{'given': ['Jane', 'Seymour'], 'family': 'Fonda'}]},
+        'Jane Seymour',
+    ),
+    (
+        {'name': [{'family': 'Fonda'}]},
+        None,
+    ),
+])
+def test_given_name(resource, expected_valueset):
     search_param = SearchParam('given', '$.name[0].given', GivenName)
-    for resource, expected_valueset in [
-        (
-            {'name': [{'given': ['Jane'], 'family': 'Fonda'}]},
-            'Jane',
-        ),
-        (
-            {'name': [{'given': ['Jane', 'Seymour'], 'family': 'Fonda'}]},
-            'Jane Seymour',
-        ),
-        (
-            {'name': [{'family': 'Fonda'}]},
-            None,
-        ),
-    ]:
-        yield check_param_helper, search_param, resource, expected_valueset
+    check_param_helper(search_param, resource, expected_valueset)
 
 
-def test_each_unique_value_given_names():
+@pytest.mark.parametrize("resource, expected_valueset", [
+    (
+        {'name': [{'given': ['Jane'], 'family': 'Fonda'}]},
+        'Jane',
+    ),
+    (
+        {'name': [{'given': ['Jane', 'Seymour'], 'family': 'Fonda'}]},
+        {'Jane', 'Seymour'},
+    ),
+    (
+        {'name': [{'family': 'Fonda'}]},
+        None,
+    ),
+    (
+        {'name': [
+            {'given': ['Jane'], 'family': 'Fonda'},
+            {'given': ['Jane'], 'family': 'Plemiannikov'},
+        ]},
+        'Jane',
+    ),
+    (
+        {'name': [
+            {'given': ['Jane', 'Seymour'], 'family': 'Fonda'},
+            {'given': ['Jane', 'Seymour'], 'family': 'Plemiannikov'},
+        ]},
+        {'Jane', 'Seymour'},
+    ),
+    (
+        {'name': [
+            {'given': ['Jane', 'Seymour'], 'family': 'Fonda'},
+            {'given': ['Jane', 'S.'], 'family': 'Plemiannikov'},
+        ]},
+        {'Jane', 'S.', 'Seymour'},
+    ),
+    (
+        {'name': [
+            {'family': 'Fonda'},
+            {'family': 'Plemiannikov'},
+        ]},
+        None,
+    ),
+])
+def test_each_unique_value_given_names(resource, expected_valueset):
     search_param = SearchParam('given', '$.name[*].given', EachUniqueValue)
-    for resource, expected_valueset in [
-        (
-            {'name': [{'given': ['Jane'], 'family': 'Fonda'}]},
-            'Jane',
-        ),
-        (
-            {'name': [{'given': ['Jane', 'Seymour'], 'family': 'Fonda'}]},
-            {'Jane', 'Seymour'},
-        ),
-        (
-            {'name': [{'family': 'Fonda'}]},
-            None,
-        ),
-        (
-            {'name': [
-                {'given': ['Jane'], 'family': 'Fonda'},
-                {'given': ['Jane'], 'family': 'Plemiannikov'},
-            ]},
-            'Jane',
-        ),
-        (
-            {'name': [
-                {'given': ['Jane', 'Seymour'], 'family': 'Fonda'},
-                {'given': ['Jane', 'Seymour'], 'family': 'Plemiannikov'},
-            ]},
-            {'Jane', 'Seymour'},
-        ),
-        (
-            {'name': [
-                {'given': ['Jane', 'Seymour'], 'family': 'Fonda'},
-                {'given': ['Jane', 'S.'], 'family': 'Plemiannikov'},
-            ]},
-            {'Jane', 'S.', 'Seymour'},
-        ),
-        (
-            {'name': [
-                {'family': 'Fonda'},
-                {'family': 'Plemiannikov'},
-            ]},
-            None,
-        ),
-    ]:
-        yield check_param_helper, search_param, resource, expected_valueset
+    check_param_helper(search_param, resource, expected_valueset)
 
 
-def test_each_unique_value_countries():
+@pytest.mark.parametrize("resource, expected_valueset", [
+    (
+        {'address': [{'country': 'USA'}]},
+        'USA',
+    ),
+    (
+        {'address': [
+            {'country': 'USA'},
+            {'country': 'France'},
+        ]},
+        {'USA', 'France'},
+    ),
+    (
+        {'address': [
+            {'state': 'New York'},
+            {'state': 'Île-de-France'},
+        ]},
+        None,
+    ),
+    (
+        {'address': [
+            {'state': 'New York'},
+            {'country': 'France'},
+        ]},
+        'France',
+    ),
+])
+def test_each_unique_value_countries(resource, expected_valueset):
     search_param = SearchParam('country', '$.address[*].country',
                                EachUniqueValue)
-    for resource, expected_valueset in [
-        (
-            {'address': [{'country': 'USA'}]},
-            'USA',
-        ),
-        (
-            {'address': [
-                {'country': 'USA'},
-                {'country': 'France'},
-            ]},
-            {'USA', 'France'},
-        ),
-        (
-            {'address': [
-                {'state': 'New York'},
-                {'state': 'Île-de-France'},
-            ]},
-            None,
-        ),
-        (
-            {'address': [
-                {'state': 'New York'},
-                {'country': 'France'},
-            ]},
-            'France',
-        ),
-    ]:
-        yield check_param_helper, search_param, resource, expected_valueset
+    check_param_helper(search_param, resource, expected_valueset)
 
 
-def test_each_unique_value_phones():
+@pytest.mark.parametrize("resource, expected_valueset", [
+    (
+        {'telecom': [{'system': 'phone', 'value': '(555) 675 5745'}]},
+        '(555) 675 5745',
+    ),
+    (
+        {'telecom': [
+            {'system': 'phone', 'value': '+1 555 675 5745'},
+            {'system': 'phone', 'value': '(555) 675 5745'},
+        ]},
+        {'+1 555 675 5745', '(555) 675 5745'},
+    ),
+    (
+        {'telecom': [
+            {'system': 'email', 'value': 'user@example.com'},
+            {'system': 'email', 'value': 'admin@example.com'},
+        ]},
+        None,
+    ),
+    (
+        {'telecom': [
+            {'system': 'phone', 'value': '+1 555 675 5745'},
+            {'system': 'email', 'value': 'user@example.com'},
+        ]},
+        '+1 555 675 5745',
+    ),
+])
+def test_each_unique_value_phones(resource, expected_valueset):
     search_param = SearchParam('phone', "$.telecom[?system='phone'].value",
                                EachUniqueValue)
-    for resource, expected_valueset in [
-        (
-            {'telecom': [{'system': 'phone', 'value': '(555) 675 5745'}]},
-            '(555) 675 5745',
-        ),
-        (
-            {'telecom': [
-                {'system': 'phone', 'value': '+1 555 675 5745'},
-                {'system': 'phone', 'value': '(555) 675 5745'},
-            ]},
-            {'+1 555 675 5745', '(555) 675 5745'},
-        ),
-        (
-            {'telecom': [
-                {'system': 'email', 'value': 'user@example.com'},
-                {'system': 'email', 'value': 'admin@example.com'},
-            ]},
-            None,
-        ),
-        (
-            {'telecom': [
-                {'system': 'phone', 'value': '+1 555 675 5745'},
-                {'system': 'email', 'value': 'user@example.com'},
-            ]},
-            '+1 555 675 5745',
-        ),
-    ]:
-        yield check_param_helper, search_param, resource, expected_valueset
+    check_param_helper(search_param, resource, expected_valueset)
 
 
 def check_param_helper(search_param, resource, expected_valueset):

--- a/corehq/motech/openmrs/tests/test_tasks.py
+++ b/corehq/motech/openmrs/tests/test_tasks.py
@@ -2,13 +2,14 @@ import datetime
 import doctest
 import json
 import logging
+import re
 from contextlib import contextmanager
 
 from django.test import SimpleTestCase
 
 import pytz
 from unittest.mock import patch
-from nose.tools import assert_raises_regex
+from nose.tools import assert_raises
 from requests.exceptions import ConnectTimeout, ReadTimeout
 
 from corehq.apps.groups.models import Group
@@ -193,8 +194,7 @@ def test_bad_data_type():
         'property': 'data_proxima_consulta'
     }
     with get_importer(bad_column_mapping) as importer:
-        with assert_raises_regex(
-            ConfigurationError,
+        with assert_raises(ConfigurationError, msg=re.compile(re.escape(
             'Errors importing from <OpenmrsImporter None admin@http://www.example.com/openmrs>:\n'
             'Unable to deserialize value 1551564000000 '
             'in column "data_proxima_consulta" '
@@ -202,7 +202,7 @@ def test_bad_data_type():
             'OpenMRS data type is given as "omrs_datetime". '
             'CommCare data type is given as "cc_date": '
             "argument of type 'int' is not iterable"
-        ):
+        ))):
             get_case_properties(patient, importer)
 
 

--- a/corehq/project_limits/tests/test_rate_definition.py
+++ b/corehq/project_limits/tests/test_rate_definition.py
@@ -1,49 +1,37 @@
 import math
 import random
 
+import pytest
 import testil
 
 from corehq.project_limits.rate_limiter import RateDefinition
 
 
-def test_rate_definition_times():
-    def check(rate_def, factor):
-        testil.eq(
-            rate_def.times(factor),
-            RateDefinition(
-                per_second=times_or_none(rate_def.per_second, factor),
-                per_minute=times_or_none(rate_def.per_minute, factor),
-                per_hour=times_or_none(rate_def.per_hour, factor),
-                per_day=times_or_none(rate_def.per_day, factor),
-                per_week=times_or_none(rate_def.per_week, factor),
-            ),
-        )
-
+@pytest.mark.parametrize("_", range(15))
+def test_rate_definition_times(_):
     def times_or_none(number_or_none, factor):
         if number_or_none is None:
             return None
         else:
             return number_or_none * factor
 
-    for _ in range(15):
-        rate_def = _get_random_rate_def()
-        factor = int(random.expovariate(1 / 10000))
-        yield check, rate_def, factor
+    rate_def = _get_random_rate_def()
+    factor = int(random.expovariate(1 / 10000))
+
+    testil.eq(
+        rate_def.times(factor),
+        RateDefinition(
+            per_second=times_or_none(rate_def.per_second, factor),
+            per_minute=times_or_none(rate_def.per_minute, factor),
+            per_hour=times_or_none(rate_def.per_hour, factor),
+            per_day=times_or_none(rate_def.per_day, factor),
+            per_week=times_or_none(rate_def.per_week, factor),
+        ),
+    )
 
 
-def test_rate_definition_with_minimum():
-
-    def check(base_rate, floor_rate):
-        testil.eq(
-            base_rate.plus(floor_rate),
-            RateDefinition(
-                per_second=asymmetric_sum(base_rate.per_second, floor_rate.per_second),
-                per_minute=asymmetric_sum(base_rate.per_minute, floor_rate.per_minute),
-                per_hour=asymmetric_sum(base_rate.per_hour, floor_rate.per_hour),
-                per_day=asymmetric_sum(base_rate.per_day, floor_rate.per_day),
-                per_week=asymmetric_sum(base_rate.per_week, floor_rate.per_week)
-            )
-        )
+@pytest.mark.parametrize("_", range(15))
+def test_rate_definition_with_minimum(_):
 
     def asymmetric_sum(base_number_or_none, incr_number_or_none):
         """
@@ -64,55 +52,57 @@ def test_rate_definition_with_minimum():
         else:
             return base_number_or_none + incr_number_or_none
 
-    for _ in range(15):
-        base_rate = _get_random_rate_def()
-        incr_rate = _get_random_rate_def()
-        yield check, base_rate, incr_rate
-
-
-def test_rate_definition_map():
-    def check(rate_def, fn):
-        testil.eq(
-            rate_def.map(fn),
-            RateDefinition(
-                per_second=fn(rate_def.per_second),
-                per_minute=fn(rate_def.per_minute),
-                per_hour=fn(rate_def.per_hour),
-                per_day=fn(rate_def.per_day),
-                per_week=fn(rate_def.per_week),
-            ),
+    base_rate = _get_random_rate_def()
+    floor_rate = _get_random_rate_def()
+    testil.eq(
+        base_rate.plus(floor_rate),
+        RateDefinition(
+            per_second=asymmetric_sum(base_rate.per_second, floor_rate.per_second),
+            per_minute=asymmetric_sum(base_rate.per_minute, floor_rate.per_minute),
+            per_hour=asymmetric_sum(base_rate.per_hour, floor_rate.per_hour),
+            per_day=asymmetric_sum(base_rate.per_day, floor_rate.per_day),
+            per_week=asymmetric_sum(base_rate.per_week, floor_rate.per_week)
         )
+    )
 
+
+@pytest.mark.parametrize("_", range(15))
+def test_rate_definition_map(_):
     def preserve_none(fn):
         return lambda x: None if x is None else fn(x)
 
-    for _ in range(15):
-        rate_def = _get_random_rate_def()
-        fn, = random.choices([preserve_none(int),
-                              preserve_none(lambda x: x * x),
-                              preserve_none(math.exp)])
-        yield check, rate_def, fn
+    rate_def = _get_random_rate_def()
+    fn, = random.choices([preserve_none(int),
+                          preserve_none(lambda x: x * x),
+                          preserve_none(math.exp)])
+    testil.eq(
+        rate_def.map(fn),
+        RateDefinition(
+            per_second=fn(rate_def.per_second),
+            per_minute=fn(rate_def.per_minute),
+            per_hour=fn(rate_def.per_hour),
+            per_day=fn(rate_def.per_day),
+            per_week=fn(rate_def.per_week),
+        ),
+    )
 
 
-def test_rate_definition_map_with_other():
-    def check(rate_def, fn, other):
-        testil.eq(
-            rate_def.map(fn, other),
-            RateDefinition(
-                per_second=fn(rate_def.per_second, other.per_second),
-                per_minute=fn(rate_def.per_minute, other.per_minute),
-                per_hour=fn(rate_def.per_hour, other.per_hour),
-                per_day=fn(rate_def.per_day, other.per_day),
-                per_week=fn(rate_def.per_week, other.per_week),
-            ),
-        )
-
-    for _ in range(15):
-        rate_def = _get_random_rate_def()
-        fn, = random.choices([lambda x, y: max(filter(None, [x, y, -1])),
-                              lambda x, y: None if None in (x, y) else (x * y)])
-        other = _get_random_rate_def()
-        yield check, rate_def, fn, other
+@pytest.mark.parametrize("_", range(15))
+def test_rate_definition_map_with_other(_):
+    rate_def = _get_random_rate_def()
+    fn, = random.choices([lambda x, y: max(filter(None, [x, y, -1])),
+                          lambda x, y: None if None in (x, y) else (x * y)])
+    other = _get_random_rate_def()
+    testil.eq(
+        rate_def.map(fn, other),
+        RateDefinition(
+            per_second=fn(rate_def.per_second, other.per_second),
+            per_minute=fn(rate_def.per_minute, other.per_minute),
+            per_hour=fn(rate_def.per_hour, other.per_hour),
+            per_day=fn(rate_def.per_day, other.per_day),
+            per_week=fn(rate_def.per_week, other.per_week),
+        ),
+    )
 
 
 def _get_random_rate_def():
@@ -126,32 +116,22 @@ def _get_random_rate_def():
     )
 
 
-def test_rate_definition_against_fixed_user_table():
-    tab_delimited_table = """
-    # of users  second  minute  hour    day       week
-    1           1       10      33      73        215
-    10          1       10      60      280       1,250
-    100         1       17      330     2,350     11,600
-    1000        6       80      3,030   23,050    115,100
-    10000       51      710     30,030  230,050   1,150,100
-    100000      501     7,010   300,030 2,300,050 11,500,100
-    """
-
-    rows = tab_delimited_table.strip().splitlines()[1:]
-    table = [[int(cell.replace(',', '')) for cell in row.split()] for row in rows]
-
-    def check(n_users, per_second, per_minute, per_hour, per_day, per_week):
-        testil.eq(
-            per_user_rate.times(n_users).plus(floor_rate).map(int),
-            RateDefinition(
-                per_week=per_week,
-                per_day=per_day,
-                per_hour=per_hour,
-                per_minute=per_minute,
-                per_second=per_second,
-            ),
-        )
-
+@pytest.mark.parametrize(
+    "n_users, per_second, per_minute, per_hour, per_day, per_week",
+    [
+        [int(cell.replace(',', '')) for cell in row.split()]
+        for row in """
+        # of users  second  minute  hour     day        week
+        1           1       10      33       73         215
+        10          1       10      60       280        1,250
+        100         1       17      330      2,350      11,600
+        1000        6       80      3,030    23,050     115,100
+        10000       51      710     30,030   230,050    1,150,100
+        100000      501     7,010   300,030  2,300,050  11,500,100
+        """.strip().splitlines()[1:]
+    ],
+)
+def test_rate_definition_against_fixed_user_table(n_users, per_second, per_minute, per_hour, per_day, per_week):
     per_user_rate = RateDefinition(
         per_week=115,
         per_day=23,
@@ -166,5 +146,14 @@ def test_rate_definition_against_fixed_user_table():
         per_minute=10,
         per_second=1,
     )
-    for n_users, per_second, per_minute, per_hour, per_day, per_week in table:
-        yield check, n_users, per_second, per_minute, per_hour, per_day, per_week
+
+    testil.eq(
+        per_user_rate.times(n_users).plus(floor_rate).map(int),
+        RateDefinition(
+            per_week=per_week,
+            per_day=per_day,
+            per_hour=per_hour,
+            per_minute=per_minute,
+            per_second=per_second,
+        ),
+    )

--- a/corehq/sql_db/tests/test_checks.py
+++ b/corehq/sql_db/tests/test_checks.py
@@ -1,3 +1,4 @@
+import pytest
 from django.test import override_settings
 from nose.tools import assert_equal, assert_in
 
@@ -5,65 +6,61 @@ from corehq.sql_db import check_standby_configs
 
 from .utils import ignore_databases_override_warning
 
-
-def test_check_standby_configs():
-    databases = {
-        'default': {},
-        'other': {},
-        's1': {
-            'HQ_ACCEPTABLE_STANDBY_DELAY': 1
-        },
-        's2': {
-            'STANDBY': {
-                'MASTER': 'default'
-            }
-        },
-        's3': {
-            'STANDBY': {
-                'MASTER': 'other'
-            }
+DATABASES = {
+    'default': {},
+    'other': {},
+    's1': {
+        'HQ_ACCEPTABLE_STANDBY_DELAY': 1
+    },
+    's2': {
+        'STANDBY': {
+            'MASTER': 'default'
+        }
+    },
+    's3': {
+        'STANDBY': {
+            'MASTER': 'other'
         }
     }
+}
 
-    @ignore_databases_override_warning
-    def _check_settings(config, is_error):
-        settings = {
-            'DATABASES': databases,
-            'REPORTING_DATABASES': {
-                'db_A': config
-            }
+
+@pytest.mark.parametrize("config, is_error", [
+    ({
+        'WRITE': 'default',
+        'READ': [
+            ('default', 1),
+            ('s1', 1),
+            ('s2', 1)
+        ]
+    }, False),
+    ({
+        'WRITE': 'default',
+        'READ': [
+            ('default', 1),
+            ('s3', 1),
+        ]
+    }, True),
+    ({
+        'WRITE': 'default',
+        'READ': [
+            ('default', 1),
+            ('other', 1),
+        ]
+    }, True),
+])
+@ignore_databases_override_warning
+def test_check_standby_configs(config, is_error):
+    settings = {
+        'DATABASES': DATABASES,
+        'REPORTING_DATABASES': {
+            'db_A': config
         }
-        with override_settings(**settings):
-            errors = check_standby_configs(None)
-            if is_error:
-                assert_equal(1, len(errors))
-                assert_in('settings.REPORTING_DATABASES.db_A', errors[0].msg)
-            else:
-                assert_equal(0, len(errors))
-
-    test_cases = [
-        ({
-            'WRITE': 'default',
-            'READ': [
-                ('default', 1),
-                ('s1', 1),
-                ('s2', 1)
-            ]
-        }, False),
-        ({
-            'WRITE': 'default',
-            'READ': [
-                ('default', 1),
-                ('s3', 1),
-            ]
-        }, True),
-        ({
-            'WRITE': 'default',
-            'READ': [
-                ('default', 1),
-                ('other', 1),
-            ]
-        }, True),
-    ]
-    for config, is_error in test_cases:
-        yield _check_settings, config, is_error
+    }
+    with override_settings(**settings):
+        errors = check_standby_configs(None)
+        if is_error:
+            assert_equal(1, len(errors))
+            assert_in('settings.REPORTING_DATABASES.db_A', errors[0].msg)
+        else:
+            assert_equal(0, len(errors))

--- a/corehq/tests/noseplugins/__init__.py
+++ b/corehq/tests/noseplugins/__init__.py
@@ -1,0 +1,1 @@
+import corehq.tests.pytest_compat  # noqa: F401

--- a/corehq/tests/pytest_compat.py
+++ b/corehq/tests/pytest_compat.py
@@ -1,4 +1,5 @@
 import sys
+from functools import wraps
 
 
 def _install_pytest_compat():
@@ -13,6 +14,26 @@ class Marker:
             setattr(test_obj, name, True)
             return test_obj
         return set_attribute
+
+    def parametrize(self, arg_names, args_tuples):
+        def parametrize(func):
+            @wraps(func)
+            def test():
+                test_tuple = (func,)
+                test = (func,)
+                for args in args_tuples:
+                    if "," not in arg_names and (
+                        not isinstance(args, tuple)
+                        or len(args) != 1
+                    ):
+                        args = (args,)
+                    try:
+                        test_tuple = test + args
+                    except TypeError:
+                        raise TypeError(f"could not construct test tuple for {func} with args {args!r}")
+                    yield test_tuple
+            return test
+        return parametrize
 
 
 mark = Marker()

--- a/corehq/tests/pytest_compat.py
+++ b/corehq/tests/pytest_compat.py
@@ -27,6 +27,8 @@ class Marker:
                         or len(args) != 1
                     ):
                         args = (args,)
+                    elif isinstance(args, list) and len(args) == arg_names.count(",") + 1:
+                        args = tuple(args)
                     try:
                         test_tuple = test + args
                     except TypeError:

--- a/corehq/tests/pytest_compat.py
+++ b/corehq/tests/pytest_compat.py
@@ -1,0 +1,20 @@
+import sys
+
+
+def _install_pytest_compat():
+    assert 'pytest' not in sys.modules, "Already installed or a real pytest is present"
+    sys.modules['pytest'] = sys.modules[__name__]
+
+
+class Marker:
+
+    def __getattr__(self, name):
+        def set_attribute(test_obj):
+            setattr(test_obj, name, True)
+            return test_obj
+        return set_attribute
+
+
+mark = Marker()
+
+_install_pytest_compat()

--- a/corehq/tests/test_pickle.py
+++ b/corehq/tests/test_pickle.py
@@ -1,5 +1,6 @@
 import pickle
 
+import pytest
 from testil import eq
 
 
@@ -17,9 +18,6 @@ def test_pickle_5():
     eq(pickle.loads(b'\x80\x05\x89.'), False)
 
 
-def test_dump_and_load_all_protocols():
-    def test(protocol):
-        eq(pickle.loads(pickle.dumps(False, protocol=protocol)), False)
-
-    for protocol in range(1, pickle.HIGHEST_PROTOCOL + 1):
-        yield test, protocol
+@pytest.mark.parametrize("protocol", range(1, pickle.HIGHEST_PROTOCOL + 1))
+def test_dump_and_load_all_protocols(protocol):
+    eq(pickle.loads(pickle.dumps(False, protocol=protocol)), False)

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -5,7 +5,6 @@ New test utilities should be added to a module in the
 it makes sense to do so. See the docstring on that package for important
 guidelines.
 """
-import functools
 import json
 import logging
 import os
@@ -298,63 +297,6 @@ class mock_out_couch(object):
 
 def NOOP(*args, **kwargs):
     pass
-
-
-class RunConfig(object):
-
-    def __init__(self, settings, pre_run=None, post_run=None):
-        self.settings = settings
-        self.pre_run = pre_run or NOOP
-        self.post_run = post_run or NOOP
-
-
-class RunWithMultipleConfigs(object):
-
-    def __init__(self, fn, run_configs):
-        self.fn = fn
-        self.run_configs = run_configs
-
-    def __call__(self, *args, **kwargs):
-        for run_config in self.run_configs:
-
-            def fn_with_pre_and_post(*args, **kwargs):
-                # make sure the pre and post run also run with the right settings
-                run_config.pre_run(*args, **kwargs)
-                self.fn(*args, **kwargs)
-                run_config.post_run(*args, **kwargs)
-
-            try:
-                call_with_settings(fn_with_pre_and_post, run_config.settings, args, kwargs)
-            except Exception:
-                print(self.fn, 'failed with the following settings:')
-                for key, value in run_config.settings.items():
-                    print('settings.{} = {!r}'.format(key, value))
-                raise
-
-
-def call_with_settings(fn, settings_dict, args, kwargs):
-    original_settings = {key: getattr(settings, key, None) for key in settings_dict}
-    try:
-        # set settings to new values
-        for key, value in settings_dict.items():
-            setattr(settings, key, value)
-        fn(*args, **kwargs)
-    finally:
-        # set settings back to original values
-        for key, value in original_settings.items():
-            setattr(settings, key, value)
-
-
-def run_with_multiple_configs(fn, run_configs, nose_tags=None):
-    from nose.plugins.attrib import attr
-    helper = RunWithMultipleConfigs(fn, run_configs)
-
-    @functools.wraps(fn)
-    @attr(**(nose_tags or {}))
-    def inner(*args, **kwargs):
-        return helper(*args, **kwargs)
-
-    return inner
 
 
 class capture_log_output(ContextDecorator):

--- a/corehq/util/urlvalidate/test/test_urlsanitize.py
+++ b/corehq/util/urlvalidate/test/test_urlsanitize.py
@@ -23,13 +23,10 @@ NO_RAISE = object()
     ('http://Localhost/', PossibleSSRFAttempt('is_loopback')),
     ('http://169.254.169.254/latest/meta-data', PossibleSSRFAttempt('is_link_local')),
     ('http://2852039166/', PossibleSSRFAttempt('is_link_local')),
-    ('http://7147006462/', PossibleSSRFAttempt('is_link_local')),
     ('http://0xA9.0xFE.0xA9.0xFE/', PossibleSSRFAttempt('is_link_local')),
-    ('http://0x41414141A9FEA9FE/', PossibleSSRFAttempt('is_link_local')),
     ('http://0xA9FEA9FE/', PossibleSSRFAttempt('is_link_local')),
     ('http://0251.0376.0251.0376/', PossibleSSRFAttempt('is_link_local')),
     ('http://0251.00376.000251.0000376/', PossibleSSRFAttempt('is_link_local')),
-    ('http://169.254.169.254.xip.io/', PossibleSSRFAttempt('is_link_local')),
     ('http://10.124.10.11', PossibleSSRFAttempt('is_private')),
     ('some-non-url', InvalidURL()),
 ])

--- a/corehq/util/urlvalidate/test/test_urlsanitize.py
+++ b/corehq/util/urlvalidate/test/test_urlsanitize.py
@@ -1,8 +1,6 @@
-import ipaddress
-import socket
-
 from django.test import SimpleTestCase
 
+import pytest
 from testil import assert_raises, eq
 
 from ..ip_resolver import CannotResolveHost
@@ -14,56 +12,38 @@ from ..urlvalidate import (
 from .mockipinfo import hostname_resolving_to_ips
 
 NO_RAISE = object()
-RAISE = object()
 
 
-INDEX_ACTION = 0
-INDEX_REASON = 1
-
-
-GOOGLE_IP = SUITE = None  # set in setup_module
-
-
-def setup_module():
-    global GOOGLE_IP, SUITE
-
-    GOOGLE_IP = ipaddress.ip_address(socket.gethostbyname('google.com'))
-    SUITE = [
-        ('https://google.com/', NO_RAISE),
-        ('http://google.com/', NO_RAISE),
-        ('http://google.com', NO_RAISE),
-        ('http://foo.example.com/', RAISE, CannotResolveHost('foo.example.com')),
-        ('http://localhost/', RAISE, PossibleSSRFAttempt('is_loopback')),
-        ('http://Localhost/', RAISE, PossibleSSRFAttempt('is_loopback')),
-        ('http://169.254.169.254/latest/meta-data', RAISE, PossibleSSRFAttempt('is_link_local')),
-        ('http://2852039166/', RAISE, PossibleSSRFAttempt('is_link_local')),
-        ('http://7147006462/', RAISE, PossibleSSRFAttempt('is_link_local')),
-        ('http://0xA9.0xFE.0xA9.0xFE/', RAISE, PossibleSSRFAttempt('is_link_local')),
-        ('http://0x41414141A9FEA9FE/', RAISE, PossibleSSRFAttempt('is_link_local')),
-        ('http://0xA9FEA9FE/', RAISE, PossibleSSRFAttempt('is_link_local')),
-        ('http://0251.0376.0251.0376/', RAISE, PossibleSSRFAttempt('is_link_local')),
-        ('http://0251.00376.000251.0000376/', RAISE, PossibleSSRFAttempt('is_link_local')),
-        ('http://169.254.169.254.xip.io/', RAISE, PossibleSSRFAttempt('is_link_local')),
-        ('http://10.124.10.11', RAISE, PossibleSSRFAttempt('is_private')),
-        ('some-non-url', RAISE, InvalidURL()),
-    ]
-
-
-def test_example_suite():
-    for input_url, *expected in SUITE:
-        expected_action = expected[INDEX_ACTION]
-        if expected_action is NO_RAISE:
-            validate_user_input_url(input_url)
-        elif expected_action is RAISE:
-            expected_reason = expected[INDEX_REASON]
-            if type(expected_action) == PossibleSSRFAttempt:
-                with assert_raises(PossibleSSRFAttempt, msg=lambda e: eq(e.reason, expected_reason.reason)):
-                    validate_user_input_url(input_url)
-            else:
-                with assert_raises(type(expected_reason), msg=str(expected_reason)):
-                    validate_user_input_url(input_url)
+@pytest.mark.parametrize("input_url, expected", [
+    ('https://google.com/', NO_RAISE),
+    ('http://google.com/', NO_RAISE),
+    ('http://google.com', NO_RAISE),
+    ('http://foo.example.com/', CannotResolveHost('foo.example.com')),
+    ('http://localhost/', PossibleSSRFAttempt('is_loopback')),
+    ('http://Localhost/', PossibleSSRFAttempt('is_loopback')),
+    ('http://169.254.169.254/latest/meta-data', PossibleSSRFAttempt('is_link_local')),
+    ('http://2852039166/', PossibleSSRFAttempt('is_link_local')),
+    ('http://7147006462/', PossibleSSRFAttempt('is_link_local')),
+    ('http://0xA9.0xFE.0xA9.0xFE/', PossibleSSRFAttempt('is_link_local')),
+    ('http://0x41414141A9FEA9FE/', PossibleSSRFAttempt('is_link_local')),
+    ('http://0xA9FEA9FE/', PossibleSSRFAttempt('is_link_local')),
+    ('http://0251.0376.0251.0376/', PossibleSSRFAttempt('is_link_local')),
+    ('http://0251.00376.000251.0000376/', PossibleSSRFAttempt('is_link_local')),
+    ('http://169.254.169.254.xip.io/', PossibleSSRFAttempt('is_link_local')),
+    ('http://10.124.10.11', PossibleSSRFAttempt('is_private')),
+    ('some-non-url', InvalidURL()),
+])
+def test_example_urls(input_url, expected):
+    if expected is NO_RAISE:
+        validate_user_input_url(input_url)
+    else:
+        assert isinstance(expected, Exception), f"expected exception instance, got {expected!r}"
+        if type(expected) is PossibleSSRFAttempt:
+            with assert_raises(PossibleSSRFAttempt, msg=lambda e: eq(e.reason, expected.reason)):
+                validate_user_input_url(input_url)
         else:
-            raise Exception("expected action in suite should be NO_RAISE or RAISE")
+            with assert_raises(type(expected), msg=str(expected)):
+                validate_user_input_url(input_url)
 
 
 def test_rebinding():

--- a/custom/abt/reports/tests/test_flagspecs.py
+++ b/custom/abt/reports/tests/test_flagspecs.py
@@ -1,15 +1,14 @@
-from glob import glob
+from pathlib import Path
 
+import pytest
 from yaml import load, Loader, parser
 
-
-def test_yaml_formatting():
-    for filename in glob('custom/abt/reports/*.yaml'):
-        yield check_yaml_file, filename
+REPORTS_DIR = Path(__file__).parent.parent
 
 
-def check_yaml_file(filename):
-    with open(filename, 'r') as f:
+@pytest.mark.parametrize("filename", [p.name for p in REPORTS_DIR.glob('*.yml')])
+def test_yaml_formatting(filename):
+    with open(REPORTS_DIR / filename, 'r') as f:
         try:
             load(f.read(), Loader=Loader)
         except parser.ParserError:

--- a/testapps/test_gunicorn/tests.py
+++ b/testapps/test_gunicorn/tests.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 from unittest import mock
 from deployment.gunicorn.gunicorn_conf import _child_exit, _on_starting
 from testil import eq
@@ -25,18 +26,9 @@ def setup():
     os.environ.pop('prometheus_multiproc_dir', None)
 
 
-def test_on_starting():
-    paths = [
-        None,
-        '',
-        '/not/a/real/path',
-    ]
-
-    def _test(path):
-        _on_starting(Server(), path=path)
-
-    for path in paths:
-        yield _test, path
+@pytest.mark.parametrize("path", [None, '', '/not/a/real/path'])
+def test_on_starting(path):
+    _on_starting(Server(), path=path)
 
 
 def test_on_starting_error():


### PR DESCRIPTION
- Convert things that use nose `@attr` to `@pytest.mark...`
- Convert `yield` tests to `@pytest.mark.parametrize` since pytest does not support yield tests.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Affects tests only.

### Automated test coverage

Yes.

### Rollback instructions

This tests will cause tests to fail if it is rolled back after the switch to pytest.
