### PR TITLE
Disable `custom.onse`

### DIFF
--- a/custom/onse/README.rst
+++ b/custom/onse/README.rst
@@ -1,3 +1,30 @@
+How to enable this module
+=========================
+
+The ``custom.onse`` module is a custom Django app for the self-hosted
+ONSE ISS project.
+
+Follow these steps to enable this module for the ONSE ISS project:
+
+1. In CommCare Cloud, edit the **public.yml** file for your environment.
+   You will find an entry named "localsettings" in the file. Inside the
+   "localsettings" entry, add a key named "LOCAL_APPS" and set its value
+   as follows:
+
+   .. code-block:: yaml
+
+      localsettings:
+        LOCAL_APPS:
+          - host: "all"
+            name: "custom.onse"
+
+2. Deploy the updated configuration to your environment:
+
+   .. code-block:: bash
+
+      $ commcare-cloud <env> update-config
+
+
 Importing aggregated data from DHIS2
 ====================================
 

--- a/settings.py
+++ b/settings.py
@@ -399,7 +399,6 @@ HQ_APPS = (
     'custom.champ',
     'custom.covid',
     'custom.inddex',
-    'custom.onse',
     'custom.nutrition_project',
     'custom.cowin.COWINAppConfig',
     'custom.hmhb',
@@ -1965,7 +1964,7 @@ DOMAIN_MODULE_MAP = {
     'india-nutrition-project': 'custom.nutrition_project',
 
     'champ-cameroon': 'custom.champ',
-    'onse-iss': 'custom.onse',
+    'onse-iss': 'custom.onse',  # Required by self-hosted ONSE-ISS project
 
     # vectorlink domains
     'abtmali': 'custom.abt',


### PR DESCRIPTION
## Technical Summary

1. Disables the `custom.onse` module, but leaves the code in the codebase for the ONSE-ISS team.

2. Adds instructions for the ONSE-ISS team on how to enable the module in their own self-hosted environment.

More context: [SC-3796](https://dimagi.atlassian.net/browse/SC-3796)

## Safety Assurance

### Safety story

Disables project-specific custom code for a project that is no longer hosted on a Dimagi environment. No other changes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3796]: https://dimagi.atlassian.net/browse/SC-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ