### PR TITLE
Filename broadcast bug fix 2

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -940,7 +940,7 @@ hqDefine("cloudcare/js/form_entry/entries", [
     FileEntry.prototype.constructor = EntrySingleAnswer;
     FileEntry.prototype.onPreProcess = function (newValue) {
         var self = this;
-        if (newValue === "" && self.question.filename()) {
+        if (newValue === "" && self.question.filename) {
             self.question.hasAnswered = true;
             self.fileNameDisplay(self.question.filename());
         } else if (newValue !== constants.NO_ANSWER && newValue !== "") {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -694,11 +694,17 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                 const inputControl = [constants.CONTROL_IMAGE_CHOOSE, constants.CONTROL_LABEL,
                     constants.CONTROL_AUDIO_CAPTURE, constants.CONTROL_VIDEO_CAPTURE];
 
+                var isBroadcast = false
+                if (element.style.raw) {
+                    isBroadcast = element.style.raw().includes('broadcast');
+                }
+
                 let findChildAndSetFilename = function (children) {
                     for (let child of children) {
                         if (child.children && child.children.length > 0) {
                             findChildAndSetFilename(child.children);
-                        } else if (inputControl.includes(child.control)) {
+                        } else if (inputControl.includes(child.control) && child.style &&
+                            child.style.raw.includes('broadcast') === isBroadcast) {
                             child.filename = element.answer();
                             return;
                         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -694,17 +694,12 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                 const inputControl = [constants.CONTROL_IMAGE_CHOOSE, constants.CONTROL_LABEL,
                     constants.CONTROL_AUDIO_CAPTURE, constants.CONTROL_VIDEO_CAPTURE];
 
-                var isBroadcast = false;
-                if (element.style.raw) {
-                    isBroadcast = element.style.raw().includes('broadcast');
-                }
-
                 let findChildAndSetFilename = function (children) {
                     for (let child of children) {
                         if (child.children && child.children.length > 0) {
                             findChildAndSetFilename(child.children);
-                        } else if (inputControl.includes(child.control) && child.style &&
-                            child.style.raw.includes('broadcast') === isBroadcast) {
+                        } else if (inputControl.includes(child.control) && element.binding() === child.binding &&
+                            element.ix() === child.ix && element.answer()) {
                             child.filename = element.answer();
                             return;
                         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -694,7 +694,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                 const inputControl = [constants.CONTROL_IMAGE_CHOOSE, constants.CONTROL_LABEL,
                     constants.CONTROL_AUDIO_CAPTURE, constants.CONTROL_VIDEO_CAPTURE];
 
-                var isBroadcast = false
+                var isBroadcast = false;
                 if (element.style.raw) {
                     isBroadcast = element.style.raw().includes('broadcast');
                 }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -691,14 +691,16 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                     element.serverError(null);
                 }
 
+                const inputControl = [constants.CONTROL_IMAGE_CHOOSE, constants.CONTROL_LABEL,
+                    constants.CONTROL_AUDIO_CAPTURE, constants.CONTROL_VIDEO_CAPTURE];
+
                 let findChildAndSetFilename = function (children) {
-                    for (var i = 0; i < children.length; i++) {
-                        var child = children[i];
+                    for (let child of children) {
                         if (child.children && child.children.length > 0) {
                             findChildAndSetFilename(child.children);
-                        } else if (child.control >= constants.CONTROL_IMAGE_CHOOSE) {
+                        } else if (inputControl.includes(child.control)) {
                             child.filename = element.answer();
-                            break;
+                            return;
                         }
                     }
                 };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -691,13 +691,19 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                     element.serverError(null);
                 }
 
-                if (allChildren) {
-                    for (let i = 0; i < allChildren.length; i++) {
-                        if (allChildren[i].control >= constants.CONTROL_IMAGE_CHOOSE) {
-                            allChildren[i].filename = element.answer();
+                var findChildAndSetFilename = function (children) {
+                    for (const [_, child] of Object.entries(children)) {
+                        if (child.children && child.children.length > 0) {
+                            findChildAndSetFilename(child.children)
+                        } else if (child.control >= constants.CONTROL_IMAGE_CHOOSE) {
+                            child.filename = element.answer();
                         }
                     }
                 }
+                if (allChildren && allChildren.length > 0) {
+                    findChildAndSetFilename(allChildren)
+                }
+
                 response.children = allChildren;
                 self.fromJS(response);
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -691,7 +691,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                     element.serverError(null);
                 }
 
-                var findChildAndSetFilename = function (children) {
+                let findChildAndSetFilename = function (children) {
                     for (var i = 0; i < children.length; i++) {
                         var child = children[i];
                         if (child.children && child.children.length > 0) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -692,16 +692,18 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                 }
 
                 var findChildAndSetFilename = function (children) {
-                    for (const [_, child] of Object.entries(children)) {
+                    for (var i = 0; i < children.length; i++) {
+                        var child = children[i];
                         if (child.children && child.children.length > 0) {
-                            findChildAndSetFilename(child.children)
+                            findChildAndSetFilename(child.children);
                         } else if (child.control >= constants.CONTROL_IMAGE_CHOOSE) {
                             child.filename = element.answer();
+                            break;
                         }
                     }
-                }
+                };
                 if (allChildren && allChildren.length > 0) {
-                    findChildAndSetFilename(allChildren)
+                    findChildAndSetFilename(allChildren);
                 }
 
                 response.children = allChildren;


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Continuation of [this PR](https://github.com/dimagi/commcare-hq/pull/35041) that addressed the initial problem of filename not being propagated to hidden text questions within the same question tile.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4690)

I hadn't realized the extent to which a single question can be buried under parent questions / nested under additional question tiles so all this adds is a recursion logic that searches for any questions of file type input (`control >= 10`) throughout the form question tree and sets the correct filename based on the `ix` and `binding` properties.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[WEB_APPS_UPLOAD_QUESTIONS](https://www.commcarehq.org/hq/flags/edit/web_apps_upload_questions/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

 Tested on staging - QA will test again on prod. Does the same thing as before but checks children questions to ensure the right question gets the right filename. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

QA will test again on prod. ([previous QA ticket](https://dimagi.atlassian.net/browse/QA-7039))

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
