### PR TITLE
Set appropriate content-type on responses when known

### DIFF
--- a/corehq/apps/accounting/decorators.py
+++ b/corehq/apps/accounting/decorators.py
@@ -1,7 +1,6 @@
-import json
 from functools import wraps
 
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 
 from django_prbac.decorators import requires_privilege
 from django_prbac.exceptions import PermissionDenied
@@ -114,8 +113,7 @@ def requires_privilege_json_response(slug, http_status_code=None,
             except PermissionDenied:
                 error_message = "You have lost access to this feature."
                 response = get_response(error_message, http_status_code)
-                return HttpResponse(json.dumps(response),
-                                    content_type="application/json", status=401)
+                return JsonResponse(response, status=401)
         return wrapped
     return decorate
 

--- a/corehq/apps/accounting/decorators.py
+++ b/corehq/apps/accounting/decorators.py
@@ -65,7 +65,7 @@ def requires_privilege_plaintext_response(slug,
     """
     A version of the requires_privilege decorator which returns an
     HttpResponse object with HTTP Status Code of 412 by default and
-    content_type of tex/plain if the privilege is not found.
+    content_type of text/plain if the privilege is not found.
     """
     def decorate(fn):
         @wraps(fn)

--- a/corehq/apps/api/object_fetch_api.py
+++ b/corehq/apps/api/object_fetch_api.py
@@ -122,7 +122,7 @@ class CaseAttachmentAPI(View):
         if attachment_meta is not None:
             mime_type = attachment_meta['content_type']
         else:
-            mime_type = "plain/text"
+            mime_type = "text/plain"
 
         return StreamingHttpResponse(streaming_content=FileWrapper(attachment_stream),
                                      content_type=mime_type)

--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -189,7 +189,7 @@ class ODataAuthentication(LoginAndDomainAuthentication):
 class DomainAdminAuthentication(LoginAndDomainAuthentication):
 
     def is_authenticated(self, request, **kwargs):
-        permission_check = lambda couch_user, domain: couch_user.is_domain_admin(domain)
+        permission_check = lambda couch_user, domain: couch_user.is_domain_admin(domain)  # noqa: E731
         wrappers = [
             require_permission_raw(permission_check, login_decorator=self._get_auth_decorator(request)),
             wrap_4xx_errors_for_apis,

--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -1,8 +1,7 @@
-import json
 from functools import wraps
 
 from django.core.exceptions import PermissionDenied
-from django.http import Http404, HttpResponse, HttpResponseForbidden
+from django.http import Http404, HttpResponseForbidden, JsonResponse
 
 from attrs import define, field
 from tastypie.authentication import Authentication
@@ -28,11 +27,9 @@ def wrap_4xx_errors_for_apis(view_func):
             return view_func(req, *args, **kwargs)
         except Http404 as e:
             if str(e):
-                return HttpResponse(json.dumps({"error": str(e)}),
-                                content_type="application/json",
-                                status=404)
-            return HttpResponse(json.dumps({"error": "not authorized"}),
-                                content_type="application/json",
+                return JsonResponse({"error": str(e)},
+                                    status=404)
+            return JsonResponse({"error": "not authorized"},
                                 status=401)
     return _inner
 

--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -114,7 +114,8 @@ def safe_cached_download(f):
             if not username:
                 content_response = dict(error="app.update.not.allowed.user.logged_out",
                                         default_response=_("Please log in to the app to check for an update."))
-                return HttpResponse(status=406, content=json.dumps(content_response))
+                return HttpResponse(status=406, content=json.dumps(content_response),
+                                    content_type='application/json')
         if latest and not target:
             latest_enabled_build = _get_latest_enabled_build(domain, username, app_id, request.GET.get('profile'),
                                                              location_flag_enabled)

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -947,7 +947,7 @@ def edit_app_attr(request, domain, app_id, attr):
     if should_edit("custom_suite"):
         app.set_custom_suite(hq_settings['custom_suite'])
 
-    return HttpResponse(json.dumps(resp), content_type='application/json')
+    return JsonResponse(resp)
 
 
 @no_conflict_require_POST
@@ -959,7 +959,7 @@ def edit_add_ons(request, domain, app_id):
         if slug in current:
             app.add_ons[slug] = value == 'on'
     app.save()
-    return HttpResponse(json.dumps({'success': True}), content_type='application/json')
+    return JsonResponse({'success': True})
 
 
 @no_conflict_require_POST
@@ -1003,7 +1003,7 @@ def rearrange(request, domain, app_id, key):
         return back_to_main(request, domain, app_id=app_id, module_id=module_id)
     app.save(resp)
     if ajax:
-        return HttpResponse(json.dumps(resp), content_type='application/json')
+        return JsonResponse(resp)
     else:
         return back_to_main(request, domain, app_id=app_id, module_id=module_id)
 

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -947,7 +947,7 @@ def edit_app_attr(request, domain, app_id, attr):
     if should_edit("custom_suite"):
         app.set_custom_suite(hq_settings['custom_suite'])
 
-    return HttpResponse(json.dumps(resp))
+    return HttpResponse(json.dumps(resp), content_type='application/json')
 
 
 @no_conflict_require_POST
@@ -959,7 +959,7 @@ def edit_add_ons(request, domain, app_id):
         if slug in current:
             app.add_ons[slug] = value == 'on'
     app.save()
-    return HttpResponse(json.dumps({'success': True}))
+    return HttpResponse(json.dumps({'success': True}), content_type='application/json')
 
 
 @no_conflict_require_POST
@@ -1003,7 +1003,7 @@ def rearrange(request, domain, app_id, key):
         return back_to_main(request, domain, app_id=app_id, module_id=module_id)
     app.save(resp)
     if ajax:
-        return HttpResponse(json.dumps(resp))
+        return HttpResponse(json.dumps(resp), content_type='application/json')
     else:
         return back_to_main(request, domain, app_id=app_id, module_id=module_id)
 

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -205,7 +205,7 @@ def get_form_data_schema(request, domain, app_id, form_unique_id):
     kw = {}
     if "pretty" in request.GET:
         kw["indent"] = 2
-    return HttpResponse(json.dumps(data, **kw))
+    return HttpResponse(json.dumps(data, **kw), content_type='application/json')
 
 
 @require_GET

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -470,7 +470,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
     app.save(resp)
     notify_form_changed(domain, request.couch_user, app_id, form_unique_id)
     if ajax:
-        return HttpResponse(json.dumps(resp), content_type='application/json')
+        return JsonResponse(resp)
     else:
         return back_to_main(request, domain, app_id=app_id, form_unique_id=form_unique_id)
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -588,8 +588,7 @@ def get_xform_source(request, domain, app_id, form_unique_id):
 
     lang = request.COOKIES.get('lang', app.langs[0])
     source = form.source
-    response = HttpResponse(source)
-    response['Content-Type'] = "application/xml"
+    response = HttpResponse(source, content_type='application/xml')
     filename = form.default_name()
     for lc in [lang] + app.langs:
         if lc in form.name:

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -470,7 +470,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
     app.save(resp)
     notify_form_changed(domain, request.couch_user, app_id, form_unique_id)
     if ajax:
-        return HttpResponse(json.dumps(resp))
+        return HttpResponse(json.dumps(resp), content_type='application/json')
     else:
         return back_to_main(request, domain, app_id=app_id, form_unique_id=form_unique_id)
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -857,7 +857,7 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
 
     app.save(resp)
     resp['case_list-show'] = module.requires_case_details()
-    return HttpResponse(json.dumps(resp), content_type='application/json')
+    return JsonResponse(resp)
 
 
 def _new_advanced_module(request, domain, app, name, lang):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -857,7 +857,7 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
 
     app.save(resp)
     resp['case_list-show'] = module.requires_case_details()
-    return HttpResponse(json.dumps(resp))
+    return HttpResponse(json.dumps(resp), content_type='application/json')
 
 
 def _new_advanced_module(request, domain, app, name, lang):

--- a/corehq/apps/app_manager/views/settings.py
+++ b/corehq/apps/app_manager/views/settings.py
@@ -3,9 +3,9 @@ from collections import defaultdict
 
 from django.contrib import messages
 from django.http import (
-    HttpResponse,
     HttpResponseBadRequest,
     HttpResponseRedirect,
+    JsonResponse,
 )
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -30,7 +30,7 @@ from corehq.apps.domain.decorators import login_and_domain_required
 @login_and_domain_required
 def commcare_profile(request, domain, app_id):
     app = get_app(domain, app_id)
-    return HttpResponse(json.dumps(app.profile), content_type='application/json')
+    return JsonResponse(app.profile, safe=False)
 
 
 @no_conflict_require_POST

--- a/corehq/apps/app_manager/views/settings.py
+++ b/corehq/apps/app_manager/views/settings.py
@@ -30,7 +30,7 @@ from corehq.apps.domain.decorators import login_and_domain_required
 @login_and_domain_required
 def commcare_profile(request, domain, app_id):
     app = get_app(domain, app_id)
-    return HttpResponse(json.dumps(app.profile))
+    return HttpResponse(json.dumps(app.profile), content_type='application/json')
 
 
 @no_conflict_require_POST

--- a/corehq/apps/auditcare/views.py
+++ b/corehq/apps/auditcare/views.py
@@ -22,7 +22,7 @@ def export_all(request):
         else:
             return HttpResponseBadRequest(f'[start] {e}')
 
-    response = HttpResponse()
+    response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename="AuditAll.csv"'
     write_export_from_all_log_events(response, start=start, end=end)
     return response

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -829,10 +829,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
         if not self.has_custom_logo:
             return None
 
-        return (
-            self.fetch_attachment(LOGO_ATTACHMENT),
-            self.blobs[LOGO_ATTACHMENT].content_type
-        )
+        return self.fetch_attachment(LOGO_ATTACHMENT)
 
     def get_odata_feed_limit(self):
         return self.odata_feed_limit or settings.DEFAULT_ODATA_FEED_LIMIT

--- a/corehq/apps/domain/views/feedback.py
+++ b/corehq/apps/domain/views/feedback.py
@@ -1,7 +1,5 @@
-import json
-
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import JsonResponse
 from django.views.decorators.http import require_POST
 
 from corehq.apps.domain.decorators import login_and_domain_required
@@ -37,6 +35,4 @@ def submit_feedback(request, domain):
         message,
         [settings.FEEDBACK_EMAIL],
     )
-    return HttpResponse(json.dumps({
-        'success': True,
-    }), content_type="application/json")
+    return JsonResponse({'success': True})

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -275,7 +275,7 @@ def logo(request, domain):
     if logo is None:
         raise Http404()
 
-    return HttpResponse(logo[0], content_type=logo[1])
+    return HttpResponse(logo, content_type='image/png')
 
 
 class EditPrivacySecurityView(BaseAdminProjectSettingsView):

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -666,7 +666,7 @@ hqDefine('geospatial/js/models', [
 
         self.exportSelectedPolygonGeoJson = function (data, event) {
             if (self.activeSavedPolygon()) {
-                const convertedData = 'text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(self.activeSavedPolygon().geoJson));
+                const convertedData = 'application/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(self.activeSavedPolygon().geoJson));
                 $(event.target).attr('href', 'data:' + convertedData);
                 $(event.target).attr('download',self.activeSavedPolygon().text + '.geojson');
                 return true;

--- a/corehq/apps/hqadmin/views/data.py
+++ b/corehq/apps/hqadmin/views/data.py
@@ -1,6 +1,6 @@
 import json
 
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.utils.translation import gettext as _
 
@@ -66,8 +66,8 @@ def raw_doc(request):
         if 'doc' in context:
             return HttpResponse(context['doc'], content_type="application/json")
         else:
-            return HttpResponse(json.dumps({"status": "missing"}),
-                                content_type="application/json", status=404)
+            return JsonResponse({"status": "missing"},
+                                status=404)
 
     context['all_databases'] = [db for db in get_databases()]
     return render(request, "hqadmin/raw_doc.html", context)

--- a/corehq/apps/hqadmin/views/system.py
+++ b/corehq/apps/hqadmin/views/system.py
@@ -1,4 +1,3 @@
-import json
 import socket
 from collections import defaultdict, namedtuple
 
@@ -146,8 +145,8 @@ def system_ajax(request):
                     traw['name'] = None
                 ret.append(traw)
             ret = sorted(ret, key=lambda x: x['succeeded'], reverse=True)
-            return HttpResponse(json.dumps(ret), content_type='application/json')
-    return HttpResponse('{}', content_type='application/json')
+            return JsonResponse(ret, safe=False)
+    return JsonResponse({})
 
 
 @require_superuser_or_contractor

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -948,7 +948,7 @@ class MultimediaUploadStatusView(View):
             response = fake_status.get_response()
         else:
             response = status.get_response()
-        return HttpResponse(json.dumps(response), content_type='application/json')
+        return JsonResponse(response)
 
 
 class ViewMultimediaFile(View):

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -948,7 +948,7 @@ class MultimediaUploadStatusView(View):
             response = fake_status.get_response()
         else:
             response = status.get_response()
-        return HttpResponse(json.dumps(response))
+        return HttpResponse(json.dumps(response), content_type='application/json')
 
 
 class ViewMultimediaFile(View):

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -1111,7 +1111,7 @@ class CRUDPaginatedViewMixin(object):
         Return this in the post method of your view class.
         """
         response = getattr(self, '%s_response' % self.action)
-        return HttpResponse(json.dumps(response, cls=LazyEncoder))
+        return HttpResponse(json.dumps(response, cls=LazyEncoder), content_type='application/json')
 
     @property
     def create_response(self):

--- a/corehq/apps/products/views.py
+++ b/corehq/apps/products/views.py
@@ -2,7 +2,12 @@ import json
 from io import BytesIO
 
 from django.contrib import messages
-from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.http import (
+    Http404,
+    HttpResponse,
+    HttpResponseRedirect,
+    JsonResponse,
+)
 from django.http.response import HttpResponseServerError
 from django.shortcuts import render
 from django.urls import reverse
@@ -207,11 +212,11 @@ class FetchProductListView(ProductListView):
             }
 
     def get(self, request, *args, **kwargs):
-        return HttpResponse(json.dumps({
+        return JsonResponse({
             'success': True,
             'current_page': int(self.page),
             'data_list': self.product_data,
-        }), content_type='application/json')
+        })
 
 
 @method_decorator(use_bootstrap5, name='dispatch')

--- a/corehq/apps/products/views.py
+++ b/corehq/apps/products/views.py
@@ -211,7 +211,7 @@ class FetchProductListView(ProductListView):
             'success': True,
             'current_page': int(self.page),
             'data_list': self.product_data,
-        }), 'text/json')
+        }), content_type='application/json')
 
 
 @method_decorator(use_bootstrap5, name='dispatch')

--- a/corehq/apps/programs/views.py
+++ b/corehq/apps/programs/views.py
@@ -1,7 +1,9 @@
-import json
-
 from django.contrib import messages
-from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.http import (
+    Http404,
+    HttpResponseRedirect,
+    JsonResponse,
+)
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
@@ -68,10 +70,10 @@ class FetchProgramListView(ProgramListView):
         return data
 
     def get(self, request, *args, **kwargs):
-        return HttpResponse(json.dumps({
+        return JsonResponse({
             'success': True,
             'data_list': self.program_data,
-        }), content_type='application/json')
+        })
 
 
 @method_decorator(use_bootstrap5, name='dispatch')
@@ -186,8 +188,8 @@ class FetchProductForProgramListView(EditProgramView):
             }
 
     def get(self, request, *args, **kwargs):
-        return HttpResponse(json.dumps({
+        return JsonResponse({
             'success': True,
             'current_page': self.page,
             'data_list': list(self.get_product_data()),
-        }), content_type='application/json')
+        })

--- a/corehq/apps/programs/views.py
+++ b/corehq/apps/programs/views.py
@@ -71,7 +71,7 @@ class FetchProgramListView(ProgramListView):
         return HttpResponse(json.dumps({
             'success': True,
             'data_list': self.program_data,
-        }), 'text/json')
+        }), content_type='application/json')
 
 
 @method_decorator(use_bootstrap5, name='dispatch')
@@ -190,4 +190,4 @@ class FetchProductForProgramListView(EditProgramView):
             'success': True,
             'current_page': self.page,
             'data_list': list(self.get_product_data()),
-        }), 'text/json')
+        }), content_type='application/json')

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -1,6 +1,5 @@
 import datetime
 import io
-import json
 import re
 from itertools import chain
 
@@ -658,11 +657,11 @@ class GenericReportView(object):
         rendered_filters = render_to_string(
             self.template_filters, self.context, request=self.request
         )
-        return HttpResponse(json.dumps(dict(
+        return JsonResponse(dict(
             filters=rendered_filters,
             slug=self.slug,
             url_root=self.url_root
-        )), content_type='application/json')
+        ))
 
     @property
     @request_cache()

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -662,7 +662,7 @@ class GenericReportView(object):
             filters=rendered_filters,
             slug=self.slug,
             url_root=self.url_root
-        )))
+        )), content_type='application/json')
 
     @property
     @request_cache()

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -955,7 +955,7 @@ class ChatMessageHistory(View, DomainViewMixin):
 
     def get(self, request, *args, **kwargs):
         if not self.contact:
-            return HttpResponse('[]')
+            return JsonResponse([], safe=False)
 
         data, last_sms = self.get_response_data(request.couch_user.get_id)
         if last_sms:

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -14,6 +14,7 @@ from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
     HttpResponseRedirect,
+    JsonResponse,
 )
 from django.shortcuts import render
 from django.urls import reverse
@@ -765,7 +766,7 @@ def chat_contact_list(request, domain):
         'iTotalDisplayRecords': filtered_records,
     }
 
-    return HttpResponse(json.dumps(result), content_type='application/json')
+    return JsonResponse(result)
 
 
 def get_contact_name_for_chat(contact, domain_obj):
@@ -963,7 +964,7 @@ class ChatMessageHistory(View, DomainViewMixin):
             except Exception:
                 notify_exception(request, "Error updating last read message for %s" % last_sms.pk)
 
-        return HttpResponse(json.dumps(data), content_type='application/json')
+        return JsonResponse(data, safe=False)
 
 
 class ChatLastReadMessage(View, DomainViewMixin):
@@ -989,9 +990,9 @@ class ChatLastReadMessage(View, DomainViewMixin):
 
             if lrm:
                 lrm_timestamp = json_format_datetime(lrm.message_timestamp)
-        return HttpResponse(json.dumps({
+        return JsonResponse({
             'message_timestamp': lrm_timestamp,
-        }), content_type='application/json')
+        })
 
 
 class DomainSmsGatewayListView(CRUDPaginatedViewMixin, BaseMessagingSectionView):

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -765,7 +765,7 @@ def chat_contact_list(request, domain):
         'iTotalDisplayRecords': filtered_records,
     }
 
-    return HttpResponse(json.dumps(result))
+    return HttpResponse(json.dumps(result), content_type='application/json')
 
 
 def get_contact_name_for_chat(contact, domain_obj):
@@ -963,7 +963,7 @@ class ChatMessageHistory(View, DomainViewMixin):
             except Exception:
                 notify_exception(request, "Error updating last read message for %s" % last_sms.pk)
 
-        return HttpResponse(json.dumps(data))
+        return HttpResponse(json.dumps(data), content_type='application/json')
 
 
 class ChatLastReadMessage(View, DomainViewMixin):
@@ -991,7 +991,7 @@ class ChatLastReadMessage(View, DomainViewMixin):
                 lrm_timestamp = json_format_datetime(lrm.message_timestamp)
         return HttpResponse(json.dumps({
             'message_timestamp': lrm_timestamp,
-        }))
+        }), content_type='application/json')
 
 
 class DomainSmsGatewayListView(CRUDPaginatedViewMixin, BaseMessagingSectionView):

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -5,7 +5,7 @@ from collections import Counter, defaultdict
 from django.conf import settings
 from django.contrib import messages
 from django.http import JsonResponse
-from django.http.response import Http404, HttpResponse
+from django.http.response import Http404
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.views.decorators.http import require_POST
@@ -212,7 +212,7 @@ class ToggleEditView(BasePageView):
         if self.usage_info:
             data['last_used'] = _get_usage_info(toggle)
             data['service_type'], data['by_service'] = _get_service_type(toggle)
-        return HttpResponse(json.dumps(data), content_type="application/json")
+        return JsonResponse(data)
 
     def _save_randomness(self, toggle, randomness):
         if 0 <= randomness <= 1:
@@ -387,7 +387,7 @@ def set_toggle(request, toggle_slug):
     namespace = request.POST['namespace']
     _set_toggle(request.user.username, static_toggle, item, namespace, enabled)
 
-    return HttpResponse(json.dumps({'success': True}), content_type="application/json")
+    return JsonResponse({'success': True})
 
 
 @require_superuser_or_contractor

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -1,4 +1,3 @@
-import json
 from contextlib import closing, contextmanager
 from io import BytesIO
 
@@ -6,9 +5,9 @@ from django.conf import settings
 from django.contrib import messages
 from django.http import (
     Http404,
-    HttpResponse,
     HttpResponseBadRequest,
     HttpResponseRedirect,
+    JsonResponse,
 )
 from django.http.response import HttpResponseServerError
 from django.shortcuts import redirect, render
@@ -556,9 +555,9 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
                 self.report_export.create_export(temp, Format.HTML)
             except UserReportsError as e:
                 return self.render_json_response({'error': str(e)})
-            return HttpResponse(json.dumps({
+            return JsonResponse({
                 'report': temp.getvalue().decode('utf-8'),
-            }), content_type='application/json')
+            })
 
     @property
     @memoized

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1546,7 +1546,7 @@ def change_password(request, domain, login_id):
     else:
         form = SetUserPasswordForm(request.project, login_id, user=django_user)
     json_dump['formHTML'] = render_crispy_form(form)
-    return HttpResponse(json.dumps(json_dump), content_type='application/json')
+    return JsonResponse(json_dump)
 
 
 @httpdigest

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1546,7 +1546,7 @@ def change_password(request, domain, login_id):
     else:
         form = SetUserPasswordForm(request.project, login_id, user=django_user)
     json_dump['formHTML'] = render_crispy_form(form)
-    return HttpResponse(json.dumps(json_dump))
+    return HttpResponse(json.dumps(json_dump), content_type='application/json')
 
 
 @httpdigest

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -1,4 +1,3 @@
-import json
 import os
 import re
 import stat
@@ -9,7 +8,7 @@ from wsgiref.util import FileWrapper
 from django.conf import settings
 from django.core import cache
 from django.core.cache import DEFAULT_CACHE_ALIAS
-from django.http import HttpResponse, StreamingHttpResponse
+from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.urls import reverse
 
 from django_transfer import TransferHttpResponse
@@ -125,11 +124,11 @@ class DownloadBase(object):
         return response
 
     def get_start_response(self):
-        return HttpResponse(json.dumps({
+        return JsonResponse({
             'download_id': self.download_id,
             'download_url': reverse('ajax_job_poll', kwargs={'download_id': self.download_id}),
             'message': self.message
-        }), content_type='application/json')
+        })
 
     def __str__(self):
         return "content-type: %s, disposition: %s" % (self.content_type, self.content_disposition)

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -9,13 +9,18 @@ from wsgiref.util import FileWrapper
 from django.conf import settings
 from django.core import cache
 from django.core.cache import DEFAULT_CACHE_ALIAS
-from django.urls import reverse
 from django.http import HttpResponse, StreamingHttpResponse
+from django.urls import reverse
 
 from django_transfer import TransferHttpResponse
-from soil.progress import get_task_progress, get_multiple_task_progress, set_task_progress
-from corehq.blobs import get_blob_db, CODES
 
+from soil.progress import (
+    get_multiple_task_progress,
+    get_task_progress,
+    set_task_progress,
+)
+
+from corehq.blobs import CODES, get_blob_db
 from corehq.const import ONE_DAY
 
 GLOBAL_RW = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH
@@ -70,7 +75,7 @@ class DownloadBase(object):
         return cache.caches[self.cache_backend]
 
     def get_content(self):
-        raise NotImplemented("Use CachedDownload or FileDownload!")
+        raise NotImplementedError("Use CachedDownload or FileDownload!")
 
     def get_filename(self):
         """
@@ -237,8 +242,8 @@ class FileDownload(DownloadBase):
                  transfer_encoding=None, extras=None, download_id=None, cache_backend=SOIL_DEFAULT_CACHE,
                  use_transfer=False, content_type=None, owner_ids=None):
         super(FileDownload, self).__init__(
-                content_type if content_type else mimetype, content_disposition,
-                transfer_encoding, extras, download_id, cache_backend, owner_ids=owner_ids)
+            content_type if content_type else mimetype, content_disposition,
+            transfer_encoding, extras, download_id, cache_backend, owner_ids=owner_ids)
         self.filename = filename
         self.use_transfer = use_transfer
 

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -124,7 +124,7 @@ class DownloadBase(object):
             'download_id': self.download_id,
             'download_url': reverse('ajax_job_poll', kwargs={'download_id': self.download_id}),
             'message': self.message
-        }))
+        }), content_type='application/json')
 
     def __str__(self):
         return "content-type: %s, disposition: %s" % (self.content_type, self.content_disposition)

--- a/corehq/messaging/smsbackends/tropo/views.py
+++ b/corehq/messaging/smsbackends/tropo/views.py
@@ -1,13 +1,14 @@
 import json
-from corehq.apps.sms.api import incoming as incoming_sms
+from datetime import datetime
+
 from django.http import HttpResponse, HttpResponseBadRequest
-from django.views.decorators.csrf import csrf_exempt
+
 from corehq.apps.ivr.models import Call
+from corehq.apps.sms.api import incoming as incoming_sms
 from corehq.apps.sms.models import INCOMING, PhoneNumber
+from corehq.apps.sms.util import strip_plus
 from corehq.apps.sms.views import IncomingBackendView
 from corehq.messaging.smsbackends.tropo.models import SQLTropoBackend
-from datetime import datetime
-from corehq.apps.sms.util import strip_plus
 
 
 def sms_in(request, backend_id=None):
@@ -25,7 +26,7 @@ def sms_in(request, backend_id=None):
                 numberToDial = params["numberToDial"]
                 msg = params["msg"]
                 t = Tropo()
-                t.call(to = numberToDial, network = "SMS")
+                t.call(to=numberToDial, network="SMS")
                 t.say(msg)
                 return HttpResponse(t.RenderJson(), content_type='application/json')
         # Handle incoming SMS

--- a/corehq/messaging/smsbackends/tropo/views.py
+++ b/corehq/messaging/smsbackends/tropo/views.py
@@ -27,7 +27,7 @@ def sms_in(request, backend_id=None):
                 t = Tropo()
                 t.call(to = numberToDial, network = "SMS")
                 t.say(msg)
-                return HttpResponse(t.RenderJson())
+                return HttpResponse(t.RenderJson(), content_type='application/json')
         # Handle incoming SMS
         phone_number = None
         text = None
@@ -41,7 +41,7 @@ def sms_in(request, backend_id=None):
         incoming_sms(phone_number, text, SQLTropoBackend.get_api_id(), backend_id=backend_id)
         t = Tropo()
         t.hangup()
-        return HttpResponse(t.RenderJson())
+        return HttpResponse(t.RenderJson(), content_type='application/json')
     else:
         return HttpResponseBadRequest("Bad Request")
 
@@ -76,7 +76,7 @@ def ivr_in(request):
 
         t = Tropo()
         t.reject()
-        return HttpResponse(t.RenderJson())
+        return HttpResponse(t.RenderJson(), content_type='application/json')
     else:
         return HttpResponseBadRequest("Bad Request")
 

--- a/corehq/messaging/smsbackends/twilio/views.py
+++ b/corehq/messaging/smsbackends/twilio/views.py
@@ -34,7 +34,7 @@ class TwilioIncomingSMSView(IncomingBackendView):
             domain_scope=self.domain,
             backend_id=self.backend_couch_id
         )
-        return HttpResponse(EMPTY_RESPONSE)
+        return HttpResponse(EMPTY_RESPONSE, content_type='application/xml')
 
 
 class TwilioIncomingIVRView(IncomingBackendView):
@@ -48,4 +48,4 @@ class TwilioIncomingIVRView(IncomingBackendView):
         from_number = request.POST.get('From')
         call_sid = request.POST.get('CallSid')
         log_call(from_number, '%s-%s' % (SQLTwilioBackend.get_api_id(), call_sid))
-        return HttpResponse(IVR_RESPONSE)
+        return HttpResponse(IVR_RESPONSE, content_type='application/xml')

--- a/corehq/util/jqueryrmi.py
+++ b/corehq/util/jqueryrmi.py
@@ -85,6 +85,6 @@ class JSONResponseMixin:
 
     def json_response(self, response_data, status=200, **kwargs):
         out_data = json.dumps(response_data, cls=self.json_encoder, **kwargs)
-        response = HttpResponse(out_data, self.json_content_type, status=status)
+        response = HttpResponse(out_data, content_type=self.json_content_type, status=status)
         response['Cache-Control'] = 'no-cache'
         return response

--- a/custom/abt/reports/views.py
+++ b/custom/abt/reports/views.py
@@ -1,7 +1,6 @@
 import io
-import json
 
-from django.http import HttpResponse
+from django.http import JsonResponse
 from memoized import memoized
 
 import openpyxl
@@ -112,9 +111,9 @@ class FormattedSupervisoryReport(CustomConfigurableReport):
 
     @property
     def email_response(self):
-        return HttpResponse(json.dumps({
+        return JsonResponse({
             'report': '',
-        }), content_type='application/json')
+        })
 
 
 class UniqueSOPSumDataSource(SqlData):

--- a/custom/abt/reports/views.py
+++ b/custom/abt/reports/views.py
@@ -114,7 +114,7 @@ class FormattedSupervisoryReport(CustomConfigurableReport):
     def email_response(self):
         return HttpResponse(json.dumps({
             'report': '',
-        }))
+        }), content_type='application/json')
 
 
 class UniqueSOPSumDataSource(SqlData):


### PR DESCRIPTION
## Technical Summary
[SAAS-15890](https://dimagi.atlassian.net/browse/SAAS-15890)
Combed through all the uses of `HttpResponse` I could find in HQ to see that we're correctly setting content type.
Specifically, this: 
- replaces `HttpResponse` with a json body with `JsonResponse` where possible
- adds `image/png` to the project custom logo response because the image is always saved as PNG
- adds `application/xml` in a couple of places
- changes several `text/html` to more explicit types based on file type
- fixes a few smaller things like `plain/text` and `text/json` which are not generally accepted content-types


## Safety Assurance

### Safety story
Theoretically, this change should have no visible or practical effect at all. All this does is change `content-type` markers to the type of content that was already being returned, or set json responses to explicitly use `JsonResponse`.

### Automated test coverage
I don't think we have automated tests for this in particular. This change cuts across many code areas though, so any significant issues would likely be captured there.

### QA Plan
This definitely wants QA. I don't think it's reasonable to ask to just "try all the things", but I can provide a list of URLs that were known previously to have the wrong content-type present, and/or the list of places responses were changed, where it is clear. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-15890]: https://dimagi.atlassian.net/browse/SAAS-15890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ