### PR TITLE
Limit max row count on reports

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -37,6 +37,7 @@ from corehq.apps.hqwebapp.decorators import (
 )
 from corehq.apps.reports.cache import request_cache
 from corehq.apps.reports.datatables import DataTablesHeader
+from corehq.apps.reports.exceptions import BadRequestError
 from corehq.apps.reports.filters.dates import DatespanFilter
 from corehq.apps.reports.tasks import export_all_rows_task
 from corehq.apps.reports.util import DatatablesParams
@@ -830,6 +831,7 @@ class GenericTabularReport(GenericReportView):
     statistics_rows = None
     force_page_size = False  # force page size to be as the default rows
     default_rows = 10
+    max_rows = 1000
     start_at_row = 0
     show_all_rows = False
     fix_left_col = False
@@ -922,6 +924,8 @@ class GenericTabularReport(GenericReportView):
             self._pagination = DatatablesParams.from_request_dict(
                 self.request.POST if self.request.method == 'POST' else self.request.GET
             )
+            if self._pagination.count > self.max_rows:
+                raise BadRequestError(gettext("Row count is too large"))
         return self._pagination
 
     @property


### PR DESCRIPTION
The default is 1000 rows, but can be customized by setting `max_rows` on a `GenericTabularReport` subclass.

https://dimagi.atlassian.net/browse/SAAS-15978

## Safety Assurance

### Safety story

Tiny change to improve validation on the maximum number of rows that can be retrieved in one page.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations