### PR TITLE
Get rid of extraneous white space from persistent menu navigation

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/persistent_menu.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/persistent_menu.html
@@ -11,7 +11,7 @@
      class="position-fixed top-50 start-0 rounded-end persistent-menu-toggle">
     <i class="fa fa-chevron-right"></i>
   </a>
-  <div id="persistent-menu-container" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="persistent-menu-label">
+  <div id="persistent-menu-container" class="offcanvas offcanvas-start w-auto" tabindex="-1" aria-labelledby="persistent-menu-label">
     <div class="offcanvas-header">
       <h5 class="offcanvas-title position-relative" id="persistent-menu-label">
         <% if (imageUri) { %>
@@ -25,7 +25,7 @@
           <%- appName %>
         </a>
       </h5>
-      <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+      <button type="button" class="btn-close text-reset p-3" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <div class="offcanvas-body">
       <div id="persistent-menu-content" class="persistent-menu"></div>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/persistent_menu.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/persistent_menu.html
@@ -12,39 +12,41 @@
     <i class="fa fa-chevron-right"></i>
   </a>
   <div id="persistent-menu-container" class="offcanvas offcanvas-start w-auto" tabindex="-1" aria-labelledby="persistent-menu-label">
-    <div class="offcanvas-header">
-      <h5 class="offcanvas-title position-relative" id="persistent-menu-label">
-        <% if (imageUri) { %>
-          <i class="fcc persistent-menu-image" aria-hidden="true"
-             style="background-image: url('<%- imageUri %>');"></i>
-        <% } else { %>
-          <i class="fcc fcc-flower persistent-menu-image" aria-hidden="true"></i>
-        <% } %>
-        <a id="app-main" class="align-middle stretched-link text-reset" href="#"
+    <div class="offcanvas-header persistent-menu-max-width d-flex align-items-center justify-content-between">
+      <% if (imageUri) { %>
+        <i class="fcc persistent-menu-image align-self-start flex-shrink-0" aria-hidden="true"
+           style="background-image: url('<%- imageUri %>');"></i>
+      <% } else { %>
+        <i class="fcc fcc-flower persistent-menu-image align-self-start flex-shrink-0" aria-hidden="true"></i>
+      <% } %>
+      <h5 class="offcanvas-title position-relative mx-2 flex-grow-1" id="persistent-menu-label">
+        <a id="app-main" class="stretched-link text-reset d-block" href="#"
            data-bs-toggle="offcanvas" data-bs-target="#persistent-menu-container">
           <%- appName %>
         </a>
       </h5>
       <button type="button" class="btn-close text-reset p-3" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
-    <div class="offcanvas-body">
+    <div class="offcanvas-body persistent-menu-max-width">
       <div id="persistent-menu-content" class="persistent-menu"></div>
     </div>
   </div>
 </script>
 
 <script type="text/template" id="persistent-menu-item">
-  <div class="position-relative persistent-menu-item rounded">
+  <div class="position-relative persistent-menu-item rounded d-flex align-items-center">
     <% if (imageUri) { %>
-      <i class="fcc persistent-menu-image" aria-hidden="true"
+      <i class="fcc persistent-menu-image align-self-start flex-shrink-0" aria-hidden="true"
          style="background-image: url('<%- imageUri %>');"></i>
     <% } else { %>
-      <i class="fa <%- iconClass %> persistent-menu-image" aria-hidden="true"></i>
+      <i class="fa <%- iconClass %> persistent-menu-image align-self-start flex-shrink-0" aria-hidden="true"></i>
     <% } %>
-    <a class="align-middle stretched-link text-reset <%= isActive ? 'fw-bold' : '' %>" href="#"
-       data-bs-toggle="offcanvas" data-bs-target="#persistent-menu-container">
-      <%- displayText %>
-    </a>
+    <div class="mx-3 flex-grow-1">
+      <a class="d-block stretched-link text-reset <%= isActive ? 'fw-bold' : '' %>" href="#"
+         data-bs-toggle="offcanvas" data-bs-target="#persistent-menu-container">
+        <%- displayText %>
+      </a>
+    </div>
   </div>
   <ul></ul>
 </script>

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/menu.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/menu.scss
@@ -51,3 +51,7 @@ $persistent-menu-image-size: 2rem;
     background-color: darken($cc-bg, 5);
   }
 }
+
+.persistent-menu-max-width {
+    max-width: 400px;
+}


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Removes extra white space in the menu by making the width auto flexible (and tiny bit of padding around the exit button to make it not so squished)

Before:
![image](https://github.com/user-attachments/assets/02a7f722-ff32-4b9a-9fec-aa0e32905588)

After:
![image](https://github.com/user-attachments/assets/997e6116-019d-4824-9e8f-1e2ab9424e8f)

Update:
I decided to implement the maximum width sizing (and also proper text wrapping) at Martin's suggestion. Now when either the app name or a menu/form name is too long it'll wrap around like this.

<img width="481" alt="Screen Shot 2024-09-13 at 6 32 36 PM" src="https://github.com/user-attachments/assets/b28cae62-7113-40da-a4f4-644ba78aad8e">


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4935)

From the ticket: "The framing for this specific ticket is a short-term fix for BHA." This PR is exactly that - a quick and easy fix to unblock users before we start to consider more nuanced design choices found in future planned work like how it'll live alongside form content instead of just being overlaid. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[Persistent Menu Navigation](https://staging.commcarehq.org/hq/flags/edit/persistent_menu_setting/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Only UI changes

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
