### PR TITLE
Add Custom Data to Web User Invite

### DIFF
--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -197,7 +197,7 @@ class CustomDataEditor(object):
         else:
             field_names = list(fields)
 
-        CustomDataForm = type('CustomDataForm', (forms.Form,), fields)
+        CustomDataForm = type('CustomDataForm', (forms.Form,), fields.copy())
         if self.ko_model:
             CustomDataForm.helper = HQModalFormHelper()
         else:

--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -33,6 +33,11 @@ def with_prefix(string, prefix):
     return "{}-{}".format(prefix, string)
 
 
+def without_prefix(string, prefix):
+    prefix_len = len(prefix) + 1
+    return string[prefix_len:] if string.startswith(prefix) else string
+
+
 def add_prefix(field_dict, prefix):
     """
     Prefix all keys in the dict.
@@ -136,8 +141,8 @@ class CustomDataEditor(object):
             field_names = []
             for field_name, field in form_fields.items():
                 data_binds = [
-                    f"value: {self.ko_model}.{field_name}.value",
-                    f"disable: {self.ko_model}.{field_name}.disable",
+                    f"value: {self.ko_model}.{without_prefix(field_name,self.prefix)}.value",
+                    f"disable: {self.ko_model}.{without_prefix(field_name, self.prefix)}.disable",
                 ]
                 if hasattr(field, 'choices') or field_name == PROFILE_SLUG:
                     data_binds.append("select2: " + json.dumps([

--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -144,7 +144,7 @@ class CustomDataEditor(object):
                     f"value: {self.ko_model}.{without_prefix(field_name,self.prefix)}.value",
                     f"disable: {self.ko_model}.{without_prefix(field_name, self.prefix)}.disable",
                 ]
-                if hasattr(field, 'choices') or field_name == PROFILE_SLUG:
+                if hasattr(field, 'choices') or without_prefix(field_name, self.prefix) == PROFILE_SLUG:
                     data_binds.append("select2: " + json.dumps([
                         {"id": id, "text": text} for id, text in field.widget.choices
                     ]))

--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -136,13 +136,15 @@ class CustomDataEditor(object):
         else:
             return forms.CharField(label=safe_label, required=field.is_required)
 
-    def make_fieldsets(self, form_fields, is_post):
+    def make_fieldsets(self, form_fields, is_post, field_name_includes_prefix=False):
         if self.ko_model:
             field_names = []
             for field_name, field in form_fields.items():
+                data_bind_field_name = (
+                    without_prefix(field_name, self.prefix) if field_name_includes_prefix else field_name)
                 data_binds = [
-                    f"value: {self.ko_model}.{without_prefix(field_name,self.prefix)}.value",
-                    f"disable: {self.ko_model}.{without_prefix(field_name, self.prefix)}.disable",
+                    f"value: {self.ko_model}.{data_bind_field_name}.value",
+                    f"disable: {self.ko_model}.{data_bind_field_name}.disable",
                 ]
                 if hasattr(field, 'choices') or without_prefix(field_name, self.prefix) == PROFILE_SLUG:
                     data_binds.append("select2: " + json.dumps([

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -505,8 +505,6 @@ class AdminInvitesUserForm(SelectUserLocationForm):
         if domain_obj:
             if self.custom_data:
                 prefixed_fields = []
-                if PROFILE_SLUG in self.custom_data.form.fields:
-                    self.custom_data.form.fields[PROFILE_SLUG].widget.choices.insert(0, ('', ''))
                 prefixed_fields = add_prefix(self.custom_data.form.fields, self.custom_data.prefix)
                 self.fields.update(prefixed_fields)
             if domain_obj.commtrack_enabled:

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -22,6 +22,7 @@ from corehq.apps.domain.forms import NoAutocompleteMixin, clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.programs.models import Program
+from corehq.toggles import WEB_USER_INVITE_ADDITIONAL_FIELDS
 from corehq.apps.users.forms import SelectUserLocationForm, BaseTableauUserForm
 from corehq.apps.users.models import CouchUser
 
@@ -491,7 +492,7 @@ class AdminInvitesUserForm(SelectUserLocationForm):
     def __init__(self, data=None, excluded_emails=None, is_add_user=None,
                  role_choices=(), should_show_location=False, can_edit_tableau_config=False,
                  custom_data=None, *, domain, **kwargs):
-        self.custom_data = custom_data
+        self.custom_data = custom_data if WEB_USER_INVITE_ADDITIONAL_FIELDS.enabled(domain) else None
         if data and self.custom_data:
             data = data.copy()
             custom_data_post_dict = self.custom_data.form.data

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -584,13 +584,12 @@ class AdminInvitesUserForm(SelectUserLocationForm):
             ),
         )
 
-    def clean_profile(self):
-        profile_id = self.cleaned_data['profile']
-        if profile_id and profile_id not in {str(p.id) for p in self.valid_profiles}:
+    def _validate_profile(self, profile_id):
+        valid_profile_ids = {choice[0] for choice in self.custom_data.form.fields[PROFILE_SLUG].widget.choices}
+        if profile_id not in valid_profile_ids:
             raise forms.ValidationError(
                 _('Invalid profile selected. Please select a valid profile.'),
             )
-        return profile_id
 
     def clean_email(self):
         email = self.cleaned_data['email'].strip()
@@ -623,7 +622,9 @@ class AdminInvitesUserForm(SelectUserLocationForm):
             custom_user_data = {key: cleaned_data.pop(key) for key in prefixed_field_names if key in cleaned_data}
 
             if prefixed_profile_key in custom_user_data:
-                cleaned_data['profile'] = custom_user_data.pop(prefixed_profile_key)
+                profile_id = custom_user_data.pop(prefixed_profile_key)
+                self._validate_profile(profile_id)
+                cleaned_data['profile'] = profile_id
             cleaned_data['custom_user_data'] = get_prefixed(custom_user_data, self.custom_data.prefix)
 
         return cleaned_data

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -18,6 +18,7 @@ from crispy_forms.helper import FormHelper
 from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
+from corehq.apps.custom_data_fields.models import PROFILE_SLUG
 from corehq.apps.custom_data_fields.edit_entity import add_prefix
 from corehq.apps.domain.forms import NoAutocompleteMixin, clean_password
 from corehq.apps.domain.models import Domain
@@ -509,6 +510,9 @@ class AdminInvitesUserForm(SelectUserLocationForm):
                     self.fields['profile'].choices = [('', '')] + [
                         (profile.id, profile.name) for profile in self.valid_profiles
                     ]
+
+                if PROFILE_SLUG in custom_data.form.fields:
+                    custom_data.form.fields[PROFILE_SLUG].widget.choices.insert(0, ('', ''))
                 prefixed_fields = add_prefix(custom_data.form.fields, custom_data.prefix)
                 self.fields.update(prefixed_fields)
             if domain_obj.commtrack_enabled:

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -537,7 +537,8 @@ class AdminInvitesUserForm(SelectUserLocationForm):
             )
         ]
         if self.custom_data:
-            custom_data_fieldset = self.custom_data.make_fieldsets(prefixed_fields, data is not None)
+            custom_data_fieldset = self.custom_data.make_fieldsets(prefixed_fields, data is not None,
+                                                                   field_name_includes_prefix=True)
             fields.extend(custom_data_fieldset)
         if should_show_location:
             fields.append(

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -491,6 +491,10 @@ class AdminInvitesUserForm(SelectUserLocationForm):
     def __init__(self, data=None, excluded_emails=None, is_add_user=None,
                  role_choices=(), should_show_location=False, can_edit_tableau_config=False,
                  custom_data=None, *, domain, **kwargs):
+        if data:
+            data = data.copy()
+            custom_data_post_dict = custom_data.form.data
+            data.update({k: v for k, v in custom_data_post_dict.items() if k not in data})
         self.request = kwargs.get('request')
         super(AdminInvitesUserForm, self).__init__(domain=domain, data=data, **kwargs)
         self.can_edit_tableau_config = can_edit_tableau_config

--- a/corehq/apps/users/management/commands/accept_invite.py
+++ b/corehq/apps/users/management/commands/accept_invite.py
@@ -30,6 +30,7 @@ class Command(BaseCommand):
                                 invitation.assigned_locations.all().values_list('location_id', flat=True)),
                             program_id=invitation.program,
                             profile=invitation.profile,
+                            custom_user_data=invitation.custom_user_data,
                             tableau_role=invitation.tableau_role,
                             tableau_group_ids=invitation.tableau_group_ids)
         invitation.is_accepted = True

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -552,9 +552,11 @@ class _AuthorizableMixin(IsMemberOfMixin):
 
     def add_as_web_user(self, domain, role, primary_location_id=None,
                         assigned_location_ids=None, program_id=None, profile=None,
-                        tableau_role=None, tableau_group_ids=None):
+                        tableau_role=None, tableau_group_ids=None, custom_user_data=None):
         if assigned_location_ids is None:
             assigned_location_ids = []
+        if custom_user_data is None:
+            custom_user_data = {}
         domain_obj = Domain.get_by_name(domain)
         self.add_domain_membership(domain=domain)
         self.set_role(domain, role)
@@ -564,9 +566,11 @@ class _AuthorizableMixin(IsMemberOfMixin):
             if primary_location_id:
                 self.set_location(domain, primary_location_id, commit=False)
             self.reset_locations(domain, assigned_location_ids, commit=False)
+        user_data = self.get_user_data(domain_obj.name)
         if domain_has_privilege(domain_obj.name, privileges.APP_USER_PROFILES) and profile:
-            user_data = self.get_user_data(domain_obj.name)
             user_data.update({}, profile_id=profile.id)
+        if custom_user_data:
+            user_data.update(custom_user_data)
         if TABLEAU_USER_SYNCING.enabled(domain) and (tableau_role or tableau_group_ids):
             if tableau_group_ids is None:
                 tableau_group_ids = []
@@ -2853,6 +2857,7 @@ class Invitation(models.Model):
             assigned_location_ids=list(self.assigned_locations.all().values_list('location_id', flat=True)),
             program_id=self.program,
             profile=self.profile,
+            custom_user_data=self.custom_user_data,
             tableau_role=self.tableau_role,
             tableau_group_ids=self.tableau_group_ids
         )

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -555,8 +555,6 @@ class _AuthorizableMixin(IsMemberOfMixin):
                         tableau_role=None, tableau_group_ids=None, custom_user_data=None):
         if assigned_location_ids is None:
             assigned_location_ids = []
-        if custom_user_data is None:
-            custom_user_data = {}
         domain_obj = Domain.get_by_name(domain)
         self.add_domain_membership(domain=domain)
         self.set_role(domain, role)

--- a/corehq/apps/users/static/users/js/invite_web_user.js
+++ b/corehq/apps/users/static/users/js/invite_web_user.js
@@ -3,13 +3,15 @@ hqDefine('users/js/invite_web_user',[
     'knockout',
     'hqwebapp/js/initial_page_data',
     'users/js/custom_data_fields',
+    'hqwebapp/js/toggles',
     'hqwebapp/js/bootstrap3/validators.ko',
     'locations/js/widgets',
 ], function (
     $,
     ko,
     initialPageData,
-    customDataFields
+    customDataFields,
+    toggles
 ) {
     'use strict';
 
@@ -70,15 +72,16 @@ hqDefine('users/js/invite_web_user',[
                 && self.emailDelayed.isValid()
                 && !self.emailDelayed.isValidating();
         });
-
-        var $customDataFieldsForm = $(".custom-data-fieldset");
-        if ($customDataFieldsForm.length) {
-            self.custom_fields = customDataFields.customDataFieldsEditor({
-                profiles: initialPageData.get('custom_fields_profiles'),
-                profile_slug: initialPageData.get('custom_fields_profile_slug'),
-                slugs: initialPageData.get('custom_fields_slugs'),
-                can_edit_original_profile: true,
-            });
+        if (toggles.toggleEnabled('WEB_USER_INVITE_ADDITIONAL_FIELDS')) {
+            var $customDataFieldsForm = $(".custom-data-fieldset");
+            if ($customDataFieldsForm.length) {
+                self.custom_fields = customDataFields.customDataFieldsEditor({
+                    profiles: initialPageData.get('custom_fields_profiles'),
+                    profile_slug: initialPageData.get('custom_fields_profile_slug'),
+                    slugs: initialPageData.get('custom_fields_slugs'),
+                    can_edit_original_profile: true,
+                });
+            }
         }
 
         return self;

--- a/corehq/apps/users/static/users/js/invite_web_user.js
+++ b/corehq/apps/users/static/users/js/invite_web_user.js
@@ -2,12 +2,14 @@ hqDefine('users/js/invite_web_user',[
     'jquery',
     'knockout',
     'hqwebapp/js/initial_page_data',
+    'users/js/custom_data_fields',
     'hqwebapp/js/bootstrap3/validators.ko',
     'locations/js/widgets',
 ], function (
     $,
     ko,
-    initialPageData
+    initialPageData,
+    customDataFields
 ) {
     'use strict';
 
@@ -68,6 +70,16 @@ hqDefine('users/js/invite_web_user',[
                 && self.emailDelayed.isValid()
                 && !self.emailDelayed.isValidating();
         });
+
+        var $customDataFieldsForm = $(".custom-data-fieldset");
+        if ($customDataFieldsForm.length) {
+            self.custom_fields = customDataFields.customDataFieldsEditor({
+                profiles: initialPageData.get('custom_fields_profiles'),
+                profile_slug: initialPageData.get('custom_fields_profile_slug'),
+                slugs: initialPageData.get('custom_fields_slugs'),
+                can_edit_original_profile: true,
+            });
+        }
 
         return self;
     };

--- a/corehq/apps/users/templates/users/invite_web_user.html
+++ b/corehq/apps/users/templates/users/invite_web_user.html
@@ -6,9 +6,11 @@
 {% requirejs_main 'users/js/invite_web_user' %}
 
 {% block page_content %}
-  {% initial_page_data 'custom_fields_slugs' custom_fields_slugs %}
-  {% initial_page_data 'custom_fields_profiles' custom_fields_profiles %}
-  {% initial_page_data 'custom_fields_profile_slug' custom_fields_profile_slug %}
+  {% if request|toggle_enabled:"WEB_USER_INVITE_ADDITIONAL_FIELDS" %}
+    {% initial_page_data 'custom_fields_slugs' custom_fields_slugs %}
+    {% initial_page_data 'custom_fields_profiles' custom_fields_profiles %}
+    {% initial_page_data 'custom_fields_profile_slug' custom_fields_profile_slug %}
+  {% endif %}
   {% registerurl "check_sso_trust" domain %}
 
   <div id="invite-web-user-form"

--- a/corehq/apps/users/templates/users/invite_web_user.html
+++ b/corehq/apps/users/templates/users/invite_web_user.html
@@ -6,6 +6,9 @@
 {% requirejs_main 'users/js/invite_web_user' %}
 
 {% block page_content %}
+  {% initial_page_data 'custom_fields_slugs' custom_fields_slugs %}
+  {% initial_page_data 'custom_fields_profiles' custom_fields_profiles %}
+  {% initial_page_data 'custom_fields_profile_slug' custom_fields_profile_slug %}
   {% registerurl "check_sso_trust" domain %}
 
   <div id="invite-web-user-form"

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1184,8 +1184,12 @@ class InviteWebUserView(BaseManageWebUserView):
 
     @property
     def page_context(self):
+        field_view_context = self.custom_data.field_view.get_field_page_context(
+            self.domain, self.request.couch_user, self.custom_data, None
+        )
         return {
             'registration_form': self.invite_web_user_form,
+            **field_view_context
         }
 
     def _assert_user_has_permission_to_access_locations(self, assigned_location_ids):

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1220,6 +1220,7 @@ class InviteWebUserView(BaseManageWebUserView):
                                          program_id=data.get("program", None),
                                          assigned_location_ids=data.get("assigned_locations", None),
                                          profile=profile,
+                                         custom_user_data=data.get("custom_user_data"),
                                          tableau_role=data.get("tableau_role", None),
                                          tableau_group_ids=data.get("tableau_group_ids", None)
                                          )

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2530,7 +2530,7 @@ RESTRICT_USER_PROFILE_ASSIGNMENT = StaticToggle(
 
 WEB_USER_INVITE_ADDITIONAL_FIELDS = StaticToggle(
     'web_user_invite_additional_fields',
-    'Enable additional fields in web user invite form for enhanced user details',
+    'USH: Enable additional fields in web user invite form for enhanced user details',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
 )

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2528,6 +2528,13 @@ RESTRICT_USER_PROFILE_ASSIGNMENT = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN]
 )
 
+WEB_USER_INVITE_ADDITIONAL_FIELDS = StaticToggle(
+    'web_user_invite_additional_fields',
+    'Enable additional fields in web user invite form for enhanced user details',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 
 def _handle_attendance_tracking_role(domain, is_enabled):
     from corehq.apps.accounting.utils import domain_has_privilege


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Allows the user to define "user data" when creating a web user invite.

<img width="1157" alt="Screen Shot 2024-09-13 at 3 10 12 PM" src="https://github.com/user-attachments/assets/893120d6-a327-4306-8c03-63f66d39f7ba">


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-4895](https://dimagi.atlassian.net/browse/USH-4895)
Editing custom user data uses the `CustomDataEditor` class which generates the profile and user data fields for `CustomDataForm`. The need here is very similar from the form UI side. However, it does not require populating existing user data. 

In order to reuse the `CustomDataForm`, I initialized an instance of `CustomDataEditor` which initializes the form. Then this instance of `CustomDataEditor` is injected into `AdminInvitesUserForm`. The fields and fieldsets created as part of `CustomDataForm ` is then pulled out to create the field and fieldsets for `AdminInvitesUserForm`. One issue faced is that `CustomDataForm` applies a form level defined prefix for each field but this prefix is applied only upon rendering the form. But since we are not using that form directly and are only extracting the fields, adding the prefix needs to be manually handled in `AdminInvitesUserForm`.

Additionally, when a user data field is defined and populated by the profile, the field is disabled. Because of this, posted data will not include data for this field. `CustomDataForm` already handles that and adds profile related fields to the post data. `AdminInvitesUserForm` takes advantage of that by accessing post data via `self.custom_data.form.data`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
New feature flag: `WEB_USER_INVITE_ADDITIONAL_FIELDS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Locally tested and both backend and frontend changes are gated behind a FF which limits the blast radius.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[QA-7109
](https://dimagi.atlassian.net/browse/QA-7109)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4895]: https://dimagi.atlassian.net/browse/USH-4895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ