### PR TITLE
Add assertion to rule out bad test cleanup

### DIFF
--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -141,6 +141,10 @@ class CouchDumpLoadTest(TestCase):
             image_data = f.read()
 
         image = CommCareImage.get_by_data(image_data)
+        assert not image.blobs, (
+            f"Expected empty blobs, got {image.blobs!r}. Failure indicates"
+            "incomplete cleanup by a test that ran before this one."
+        )
         image.attach_data(image_data, original_filename='logo.png')
         image.add_domain(self.domain_name)
         self.assertEqual(image_data, image.get_display_file(False))


### PR DESCRIPTION
This assertion was useful to track down tests that were not cleaning up after themselves. It was an issue in the switch from nose to pytest, where the tests running on each github actions job were shuffled around due to a new implementation of the --divided-we-run plugin.

## Safety Assurance

### Safety story

Affects tests only.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations