### PR TITLE
Webpack: Add Documentation Updates to the JavaScript Guide (RTD)

### DIFF
--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -41,7 +41,7 @@ It happens, try restarting.
 > I'm getting TemplateSyntaxErrors related to Webpack.
 
 Please run `yarn dev`. If this build is failing, and you didn't make any changes to JavaScript files on your branch,
-please raise this as an issue on `#gtd-web-team`.
+please raise this as an issue.
 
 ## Generating Sample Data
 

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -38,6 +38,11 @@ Formplayer isn't running properly. See [Formplayer](https://github.com/dimagi/co
 
 It happens, try restarting.
 
+> I'm getting TemplateSyntaxErrors related to Webpack.
+
+Please run `yarn dev`. If this build is failing, and you didn't make any changes to JavaScript files on your branch,
+please raise this as an issue on `#gtd-web-team`.
+
 ## Generating Sample Data
 
 ### SMS

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -762,7 +762,23 @@ This can also be used to promote a user created by signing up to a superuser.
 Note that promoting a user to superuser status using this command will also give them the
 ability to assign other users as superuser in the in-app Superuser Management page.
 
-### Step 11: Running CommCare HQ
+### Step 11: Running `yarn dev`
+
+In order to build JavaScript bundles with Webpack, you will need to have `yarn dev`
+running in the background. It will watch any existing Webpack Entry Point, aka modules
+included on a page using the `webpack_main` template tag.
+
+When you add a new entry point (`webpack_main` tag), please remember to restart `yarn dev` so
+that it can identify the new entry point it needs to watch.
+
+To build Webpack bundles like it's done in production environments, pleas use `yarn build`.
+This command does not have a watch functionality, so it needs to be re-run every time you make
+changes to javascript files bundled by Webpack.
+
+For more information about JavaScript and Static Files, please see the
+[Dimagi JavaScript Guide](https://commcare-hq.readthedocs.io/js-guide/README.html) on Read the Docs.
+
+### Step 12: Running CommCare HQ
 
 Make sure the required services are running (PostgreSQL, Redis, CouchDB, Kafka,
 Elasticsearch).
@@ -793,6 +809,9 @@ yarn install --frozen-lockfile
 ./manage.py compilejsi18n
 ./manage.py fix_less_imports_collectstatic
 ```
+
+See the [Dimagi JavaScript Guide](https://commcare-hq.readthedocs.io/js-guide/README.html) for additional
+useful background and tips.
 
 ## Running Formplayer and submitting data with Web Apps
 

--- a/docs/js-guide/README.rst
+++ b/docs/js-guide/README.rst
@@ -15,6 +15,7 @@ Table of contents
     :maxdepth: 1
 
     code-organization
+    static-files
 
 .. toctree::
     :caption: Dependencies
@@ -22,9 +23,16 @@ Table of contents
 
     dependencies
     module-history
-    migrating
     libraries
     external-packages
+
+.. toctree::
+    :caption: Migrations
+    :maxdepth: 1
+
+    migrating
+    requirejs-to-webpack
+    amd-to-esm
 
 .. toctree::
     :caption: Best practices
@@ -32,7 +40,6 @@ Table of contents
 
     integration-patterns
     security
-    static-files
     inheritance
     code-review
 

--- a/docs/js-guide/amd-to-esm.rst
+++ b/docs/js-guide/amd-to-esm.rst
@@ -1,0 +1,206 @@
+Updating Module Syntax from AMD to ESM
+======================================
+
+Most entry points for legacy modules that have recently been migrated from RequireJS to
+Webpack as part of the `RequireJS to Webpack Migration
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/requirejs-to-webpack.rst>`__
+are eligible for this update.
+
+See the `Historical Background on Module Patterns
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/module-history.rst>`__
+for a more detailed discussion of module types. As a quick refresher, here are some definitions:
+
+AMD (Asynchronous Module Definition)
+    The legacy module type used for older JavaScript modules on HQ.
+    This was the only module type compatible with RequireJS, our first JavaScript bundler.
+    It is still needed as a format for modules required by No-Bundler pages.
+
+ESM (ES Modules)
+    The newest module type with updated powerful import and export syntax. This is the module
+    format that you will see referenced by documentation in modern javascript frameworks.
+
+The different types of modules you will encounter are:
+
+Entry Point Modules
+    Modules that are included directly on a page using a bundler template tag, like
+    ``webpack_main``. These are the modules that the bundler (Webpack) uses to build
+    a dependency graph so that it knows what bundle of javascript dependencies and
+    page-specific code is needed to render that page / entry point.
+
+Dependency Modules
+    These are modules that are never referenced in a bundler template tag and are only
+    in the list of dependencies for other modules. Often these modules are used as utility modules
+    or a way to organize JavaScript for a page that is very front-end heavy.
+
+
+Step 1: Determine if the Module is Eligible for a Syntax Update
+---------------------------------------------------------------
+
+The HQ AMD-style module will look something like:
+
+::
+
+    hqDefine('hqwebapp/js/my_module', [
+        'jquery',
+        'knockout',
+        'underscore',
+        'hqwebapp/js/initial_page_data',
+        'hqwebapp/js/assert_properties',
+        'hqwebapp/js/bootstrap5/knockout_bindings.ko',
+        'commcarehq',
+    ], function (
+        $,
+        ko,
+        _,
+        initialPageData,
+        assertProperties
+    ) {
+        ...
+    });
+
+
+Entry Points
+~~~~~~~~~~~~
+
+If this module is a webpack entry point, then it is eligible for an update. In the example above, you would find
+``hqwebapp/js/my_module`` used on a page with the following:
+
+::
+
+    {% webpack_main "hqwebapp/js/my_module %}
+
+The entry point can also be specified with ``webpack_main_b3`` if the module is part of the Bootstrap 3 build
+of Webpack.
+
+If this module is inside a ``requirejs_main`` or ``requirejs_main_b5`` tag, then it is NOT eligible for an update.
+Instead, please first
+`migrate this module from RequireJS to Webpack <https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/requirejs-to-webpack.rst>`__
+
+Dependency Modules
+~~~~~~~~~~~~~~~~~~
+
+If this module is a dependency of any modules that are ``requirejs_main`` entry points, then this module is not
+eligible for migration. If a module's syntax is updated when it's still required by RequireJS modules, then
+it will result in a RequireJS build failure on deploy.
+
+If this module is referenced by any ``hqImport`` calls (for instance ``hqImport('hqwebapp/js/my_module')``),
+then this module is NOT yet eligible, and must continue using the older AMD-style syntax until
+the ``hqImport`` statements are no longer needed. See the
+`JS Bundler Migration Guide <https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/migrating.rst>`__ for
+how to proceed in this case.
+
+Slightly Different Syntax
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the AMD-style module looks a bit different than the syntax above--for instance, the list of dependencies are missing or
+``hqImport`` and/or global variables can be found in the main body of the module--then this module must be
+`migrated to use a JS Bundler <https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/migrating.rst>`__.
+
+
+Step 2: Update Surrounding Module Structure
+-------------------------------------------
+
+ESM no longer needs to define the module name within the module itself. Instead, Webpack (our bundler) is configured
+to know how to reference this module by its filename and relative path within an application.
+
+You can start this by changing:
+
+::
+
+    hqDefine('hqwebapp/js/my_module', [
+        'jquery',
+        'knockout',
+        'underscore',
+        'hqwebapp/js/initial_page_data',
+        'hqwebapp/js/assert_properties',
+        'hqwebapp/js/bootstrap5/knockout_bindings.ko',
+        'commcarehq',
+    ], function (
+        $,
+        ko,
+        _,
+        initialPageData,
+        assertProperties
+    ) {
+        ...
+    });
+
+to
+
+::
+
+    [
+        'jquery',
+        'knockout',
+        'underscore',
+        'hqwebapp/js/initial_page_data',
+        'hqwebapp/js/assert_properties',
+        'hqwebapp/js/bootstrap5/knockout_bindings.ko',
+        'commcarehq',
+    ] (
+        $,
+        ko,
+        _,
+        initialPageData,
+        assertProperties
+    )
+    // additionally, the indentation for the module-specific code can be updated
+    ...
+
+Step 3: Update Dependency Imports
+---------------------------------
+
+Common ``yarn`` dependencies can now be referenced by their NPM name (or the alias defined in
+``webpack/webpack.common.js``.
+
+The same can be done with named internal dependencies, or referenced internal dependencies.
+
+The final module dependency structure will look something like:
+
+::
+
+    import "commcarehq";  // Note: moved to top
+
+    // named yarn/npm dependencies
+    import $ from "jquery";
+    import ko from "knockout";
+    import _ from "underscore";
+
+    // named internal dependencies:
+    import initialPageData from "hqwebapp/js/initial_page_data";
+    import assertProperties from "hqwebapp/js/assert_properties";
+
+    // referenced internal dependencies:
+    import "hqwebapp/js/bootstrap3/knockout_bindings.ko";
+
+    // module specific code...
+    ...
+
+Note that ``import "commcarehq";`` has been moved to the top of the file. The ordering is
+for consistency purposes, but it's important that either ``import "commcarehq";`` or
+``import "commcarehq_b3";`` (for Bootstrap 3 / ``webpack_main_b3``) is present in the list
+of imports for Webpack Entry Point modules.
+
+Remember, an Entry Point is any module that is included directly on a page using the
+``webpack_main`` or ``webpack_main_b3`` template tags.
+
+Modules that are not entry points are not required to have this import. If you are updating the
+syntax of a dependency (non-entry point) module, do not worry about including this import if
+it is not already present.
+
+
+Step 4: Other Code Updates
+--------------------------
+
+If this module is an entry point, then the rest of the module-specific code can remain as is,
+with the indentation level updated. However, some entry points are also dependencies of other
+entry points. If that's the case, proceed to the next part.
+
+If this module is a dependency module, meaning it is referenced by other modules,
+then the ``return`` line at the end of the module should follow the appropriate ``export`` syntax
+needed by the modules that depend on this module.
+
+The most likely change is to replace ``return`` with ``export`` and leave everything else as is.
+Otherwise, see the
+`export documentation <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export>`__
+for details and inspiration in case you want to do some additional refactoring.

--- a/docs/js-guide/code-organization.rst
+++ b/docs/js-guide/code-organization.rst
@@ -1,8 +1,9 @@
 Static Files Organization
 -------------------------
 
-All\* JavaScript code should be in a .js file and encapsulated as a
-module using ``hqDefine``.
+All JavaScript code should be in a .js file and encapsulated as a
+module either using the ES Module syntax or modified-AMD syntax in
+legacy code using using ``hqDefine``.
 
 JavaScript files belong in the ``static`` directory of a Django app,
 which we structure as follows:
@@ -15,15 +16,15 @@ which we structure as follows:
        font/
        images/
        js/       <= JavaScript
-       less/
+       scss/
        lib/      <= Third-party code: This should be rare, since most third-party code should be coming from yarn
        spec/     <= JavaScript tests
        ...       <= May contain other directories for data files, i.e., `json/`
      templates/myapp/
        mytemplate.html
 
-\* There are a few places we do intentionally use script blocks, such as
-configuring less.js in CommCare HQ’s main template,
-``hqwebapp/base.html``. These are places where there are just a few
-lines of code that are truly independent of the rest of the site’s
-JavaScript. They are rare.
+To develop with javascript locally, make sure you run ``yarn dev`` and
+restart ``yarn dev`` whenever you add a new Webpack Entry Point.
+
+Please review the next section for a more detailed discussion of Static Files
+and the use of JavaScript bundlers, like Webpack.

--- a/docs/js-guide/code-organization.rst
+++ b/docs/js-guide/code-organization.rst
@@ -1,7 +1,7 @@
 Static Files Organization
 -------------------------
 
-All JavaScript code should be in a .js file and encapsulated as a
+All\* JavaScript code should be in a .js file and encapsulated as a
 module either using the ES Module syntax or modified-AMD syntax in
 legacy code using using ``hqDefine``.
 
@@ -25,3 +25,8 @@ which we structure as follows:
 
 To develop with javascript locally, make sure you run ``yarn dev`` and
 restart ``yarn dev`` whenever you add a new Webpack Entry Point.
+
+\* There are a few places we do intentionally use script blocks.
+These are places where there are just a few lines of code that are
+truly independent of the rest of the site's JavaScript. They are rare.
+For instance, third-party analytics script blocks are an example.

--- a/docs/js-guide/code-organization.rst
+++ b/docs/js-guide/code-organization.rst
@@ -25,6 +25,3 @@ which we structure as follows:
 
 To develop with javascript locally, make sure you run ``yarn dev`` and
 restart ``yarn dev`` whenever you add a new Webpack Entry Point.
-
-Please review the next section for a more detailed discussion of Static Files
-and the use of JavaScript bundlers, like Webpack.

--- a/docs/js-guide/dependencies.rst
+++ b/docs/js-guide/dependencies.rst
@@ -5,11 +5,19 @@ Front-end dependencies are managed using ``yarn`` and are defined in ``package.j
 root of the ``commcare-hq`` repository.
 
 Most JavaScript on HQ is included on a page via a JavaScript bundle.
-These bundles are created by a JavaScript bundler. The bundler is given a
-list of "entry points" (or pages), builds a dependency graph of modules to determine what
-code is needed for a page, and combines related code into bundles.
+These bundles are created by Webpack. Webpack is given a list of "entry points"
+(or pages) and builds a dependency graph of modules to determine what
+code is needed for a page, combining related code into bundles.
 These bundles are split along ``vendor`` (npm modules),
 ``common`` (all of hq), and application (like ``hqwebapp`` or ``domain``).
+
+For legacy code, RequireJS creates bundles around Django applications.
+These bundles are created during deploy with the ``build_requirejs`` management
+command, and are typically not created during development. Here
+are the production bundles split along Bootstrap versions for RequireJS:
+
+- `Bootstrap 3 <https://www.commcarehq.org/static/build.b3.txt>`__
+- `Bootstrap 5 <https://www.commcarehq.org/static/build.b5.txt>`__
 
 By bundling code, we can make fewer round-trip requests to fetch all of a page's JavaScript.
 Additionally, the bundler minifies each bundle to reduce its overall size. You can learn
@@ -104,8 +112,9 @@ Then in your HTML page:
    {% webpack_main 'prototype/js/combined_example' %}
 
 The exception to the above is if your page inherits from a legacy page that
-doesn't use a JavaScript bundler. This is rare, but one example would be adding a
-new page to app manager that inherits from ``managed_app.html``.
+doesn't use a JavaScript bundler, like reports and app manager. This is rare,
+but one example would be adding a new page to app manager that inherits
+from ``managed_app.html``.
 
 
 Why is old code formatted differently?
@@ -120,7 +129,7 @@ once these entry points `are migrated to Webpack
 
 However, be careful when migrating modified AMD modules that aren't entry points, as some of these modules,
 like ``hqwebapp/js/initial_page_data``, are still being referenced by pages not using a JavaScript bundler.
-These pages still require this modified AMD approach until they transition to using a bundler.
+These pages still require this modified AMD approach until they transition to using Webpack.
 
 We will cover what common modified AMD modules look like in this section, but you can read more
 about this choice of module format in the `Historical Background on Module Patterns
@@ -167,12 +176,11 @@ instead relying on globals like ``ko`` (for Knockout.js) in the example below.
    });
 
 
-How do I know whether or not I’m working with Webpack or RequireJS?
--------------------------------------------------------------------
+How do I know whether I’m working with Webpack or RequireJS?
+------------------------------------------------------------
 
 You are likely working with either Webpack or RequireJS, as most of HQ has been migrated to use a bundler.
-However, several major areas have **not** been migrated: app manager,
-reports, and web apps.
+However, two major areas have **not** been migrated: app manager and reports.
 
 The easiest way to determine if a page is using either Webpack or RequireJS is to
 open the JavaScript console on that page and type ``window.USE_WEBPACK``, which will return
@@ -198,7 +206,8 @@ ESM can quickly be identified by scanning the file for ``import`` statements lik
 How do I add a new internal module or external dependency to an existing page?
 ------------------------------------------------------------------------------
 
-Webpack supports multiple module formats, with ES Modules (ESM) being the preferred format. New modules should be written in the ESM format.
+Webpack supports multiple module formats, with ES Modules (ESM) being the preferred format.
+New modules should be written in the ESM format.
 
 That being said, a lot of legacy code on HQ is written in a modified AMD format.
 If you are adding a lot of new code to such a module, it is recommended that you
@@ -238,7 +247,7 @@ Modified AMD (previously "RequireJS")
     RequireJS is being replaced by Webpack. You should NOT create NEW modules with this style.
 
 To use your new module/dependency, add it your module’s ``hqDefine`` list of dependencies.
-If the new dependency will be directly referenced in the body of the odule, also add a
+If the new dependency will be directly referenced in the body of the module, also add a
 parameter to the ``hqDefine`` callback:
 
 ::

--- a/docs/js-guide/dependencies.rst
+++ b/docs/js-guide/dependencies.rst
@@ -203,7 +203,7 @@ Webpack supports multiple module formats, with ES Modules (ESM) being the prefer
 That being said, a lot of legacy code on HQ is written in a modified AMD format.
 If you are adding a lot of new code to such a module, it is recommended that you
 `migrate this module to ESM format
-<<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/amd-to-esm.rst>`__.
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/amd-to-esm.rst>`__.
 However, not every modified AMD module is ready to be migrated to ESM immediately,
 so it's worth familiarizing yourself with working in that format.
 

--- a/docs/js-guide/dependencies.rst
+++ b/docs/js-guide/dependencies.rst
@@ -1,72 +1,145 @@
 Managing Dependencies
 =====================
 
-HQ’s JavaScript is being gradually migrated from a legacy, unstructured
-coding style the relies on the ordering of script tags to instead use
-RequireJS for dependency management. This means that dependencies are
-managed differently depending on which area of the code you’re working
-in. This page is a developer’s guide to understanding which area you’re
-working in and what that means for your code.
+Front-end dependencies are managed using ``yarn`` and are defined in ``package.json`` at the
+root of the ``commcare-hq`` repository.
 
-My python tests are failing because of javascript
--------------------------------------------------
-`TestRequireJS
-<https://github.com/dimagi/commcare-hq/blob/0acf35279639c695b943784704a9f74ce6a86465/corehq/apps/hqwebapp/tests/test_requirejs.py#L10>`__
-reads all of our javascript files, checking for common errors.
+Most JavaScript on HQ is included on a page via a JavaScript bundle.
+These bundles are created by a JavaScript bundler. The bundler is given a
+list of "entry points" (or pages), builds a dependency graph of modules to determine what
+code is needed for a page, and combines related code into bundles.
+These bundles are split along ``vendor`` (npm modules),
+``common`` (all of hq), and application (like ``hqwebapp`` or ``domain``).
 
-These tests are naive. They don't parse JavaScript, they just run regexes based on expected coding patterns.
-They use `this method <#how-do-i-know-whether-or-not-im-working-with-requirejs>`__ to determine if a file is
-using RequireJS. This is one reason not to add dependency lists in areas of HQ that don't yet use RequireJS.
+By bundling code, we can make fewer round-trip requests to fetch all of a page's JavaScript.
+Additionally, the bundler minifies each bundle to reduce its overall size. You can learn
+more about bundlers in `the Static Files Overview
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/static-files.rst#why-use-a-javascript-bundler>`__
 
-**test_requirejs_disallows_hqimport**
+HQ is transitioning from RequireJS (our original JavaScript bundler, which is no longer maintained)
+to Webpack. Portions of this documentation that reference RequireJS will remain until RequireJS
+has been fully removed from the codebase. See the `RequireJS to Webpack Migration Guide
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/requirejs-to-webpack.rst>`__
+for more information about this migration.
 
-``hqImport`` only works in non-RequireJS contexts. In RequireJS files, dependencies should be included in the
-module's ``hqDefine`` call, as described `here <#how-do-i-know-whether-or-not-im-working-with-requirejs>`__.
+A few areas of our codebase are also undergoing a migration toward using a bundler.
+You can read more about this migration in the `JS Bundler Migration Guide
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/migration.rst>`__
 
-Occasionally, this does not work due to a circular dependency. This will manifest as the module being undefined.
-`hqRequire <https://github.com/dimagi/commcare-hq/commit/15b436f77875f57d1e3d8d6db9b990720fa5dd6f#diff-73c73327e873d0e5f5f4e17c3251a1ceR100>`__
-exists for this purpose, to require the necessary module at the point where it’s used. ``hqRequire`` defines
-a new module, which can be fragile, so limit the code using it. As in python, best practice is to include
-dependencies at the module level, at the top of the file.
+Before adopting a bundler, HQ's javascript followed a more legacy, unstructured coding style
+that relied on ordering script tags on a page. This approach required more individual
+requests to fetch each dependency separately. "Bundles" were created manually by grouping
+script tags inside the ``compress`` template tag managed by Django Compressor.
+
+If you are modifying code inside a section that still follows this structure, the way you
+import external modules/dependencies for use in that page's code will differ from the module
+approach on pages using either Webpack or RequireJS. We will address this legacy approach
+at the end of this chapter.
 
 
-**test_files_match_modules**
+How do I create a new page with JavaScript?
+-------------------------------------------
 
-RequireJS requires that a module's name is the same as the file containing it. Rename your module.
+New code should be written using the ES Module (ESM) format and bundled using Webpack. This approach
+is oriented around a single "entry point" per page (with some pages sharing the same entry point).
+This entry point contains the page-level logic needed for that page and imports other modules for shared logic.
 
-My deploy is failing because of javascript
-------------------------------------------
+A typical new module structure will look something like:
 
-This manifests as an error during static files handling, referencing
-optimization, minification, or parsing.
-Sometimes this is due to strictness in the requirejs parsing.
-Most often this is a trailing comma in a list of function parameters.
+::
 
-Errors also pop up due to certain syntax, including
-`spread syntax <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax>`__ and
-`optional chaining <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining>`__.
-This is the result of requirejs depending on a version of uglify that depends on an old version of
-esprima. See `here <https://github.com/requirejs/r.js/issues/971>`__.
-In third party libraries that are already minified, we can work around this by using ``empty:`` to
-skip optimization (docs). This is done for Sentry `here <https://github.com/dimagi/commcare-hq/blob/0d3badffdfe65bdbab554a1e1aed518398fcb53e/corehq/apps/hqwebapp/static/hqwebapp/yaml/bootstrap3/requirejs.yml#L12-L14>`__.
-For our own code, we have a `babel plugin for requirejs <https://www.npmjs.com/package/requirejs-babel7>`__.
-See `here <https://github.com/dimagi/commcare-hq/pull/33083>`__.
+    import "commcarehq";  // REQUIRED at the top of every "entry point"
+                          // This loads site-wide dependencies needed to run global navigation, modals, notifications, etc.
 
-How do I know whether or not I’m working with RequireJS?
---------------------------------------------------------
+    // Common third-party dependencies
+    import $ from "jquery";                     // Ideally, new pages should move away from jQuery and use native
+                                                // javascript. But this is here as an example.
+    import ko from "knockout";
+    import "hqwebapp/js/knockout_bindings.ko";  // This one doesn't need a named parameter because it only adds
+                                                // knockout bindings and is not referenced in this file
+    import _ from "underscore";
 
-You are likely working with RequireJS, as most of HQ has been migrated.
-However, several major areas have **not** been migrated: app manager,
-reports, and web apps. Test code also does not currently use RequireJS;
-see
-`Testing <https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/testing.rst>`__
-for working with tests.
+    // A commonly used internal module for passing server-side data to the front end
+    import initialPageData from "hqwebapp/js/initial_page_data";
 
-To tell for sure, look at your module’s ``hqDefine`` call, at the top of
-the file.
+    /* page-level entry point logic begins here */
 
-RequireJS modules look like this, with all dependencies loaded as part
-of ``hqDefine``:
+
+
+To register your module as a Webpack entry point, add the ``webpack_main`` template tag to your HTML template,
+near the top and outside of any other block:
+
+::
+
+   {% webpack_main 'prototype/js/example' %}
+
+Some pages don't have any unique logic but do rely on other modules.
+These are usually pages that use some common widgets but don't have custom UI interactions.
+
+If your page only relies on a single JavaScript module, you can use that as that
+page's entry point:
+
+::
+
+   {% webpack_main 'locations/js/widgets' %}
+
+If your page relies on multiple modules, it still needs one entry point.
+You can handle this by making a module that only imports other modules.
+For instance an entry point located at ``prototype/js/combined_example.js``
+might look like:
+
+::
+
+    import "commcarehq";  // always at the top
+
+    import "hqwebapp/js/crud_paginated_list_init";
+    import "hqwebapp/js/bootstrap5/widgets";
+
+    // No page-specific logic, just need to collect the dependencies above
+
+Then in your HTML page:
+
+::
+
+   {% webpack_main 'prototype/js/combined_example' %}
+
+The exception to the above is if your page inherits from a legacy page that
+doesn't use a JavaScript bundler. This is rare, but one example would be adding a
+new page to app manager that inherits from ``managed_app.html``.
+
+
+Why is old code formatted differently?
+--------------------------------------
+
+You may notice that older JavaScript code on HQ is written in a modified AMD
+(Asynchronous Module Definition) format. AMD was the only module format compatible
+with our previous bundler, RequireJS. Most older entry points are written in this
+modified AMD style and should eventually be migrated to an ESM format
+once these entry points `are migrated to Webpack
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/requirejs-to-webpack.rst>`__.
+
+However, be careful when migrating modified AMD modules that aren't entry points, as some of these modules,
+like ``hqwebapp/js/initial_page_data``, are still being referenced by pages not using a JavaScript bundler.
+These pages still require this modified AMD approach until they transition to using a bundler.
+
+We will cover what common modified AMD modules look like in this section, but you can read more
+about this choice of module format in the `Historical Background on Module Patterns
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/module-history.rst>`__
+
+The process of migrating a module from AMD to ESM is very straightforward. To learn more,
+please see `Migrating Modules from AMD to ESM
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/amd-to-esm.rst>`__
+
+
+Modified AMD Legacy Modules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Modified AMD-style modules are used both on bundler pages and no-bundler pages.
+
+To differentiate between the two, look at the module's ``hqDefine`` call at the top of the file.
+
+Modules in this format used with Webpack (or RequireJS) will look like the following,
+with all dependencies loaded as part of ``hqDefine``:
 
 ::
 
@@ -81,10 +154,10 @@ of ``hqDefine``:
        ...
    });
 
-Non-RequireJS modules look like this, with no list and no function
-parameters. HQ modules are loaded using ``hqImport`` in the body, and
-third party libraries aren’t declared at all, instead relying on
-globals:
+In no-bundler areas of the codebase, "transition" AMD modules look like the following,
+having no dependency list and no function parameters.
+Additionally, HQ modules are loaded using ``hqImport`` in the body, and third-party libraries aren't declared at all,
+instead relying on globals like ``ko`` (for Knockout.js) in the example below.
 
 ::
 
@@ -93,102 +166,80 @@ globals:
        ...
    });
 
-How do I write a new page?
---------------------------
 
-New code should be written in RequireJS, which is oriented around a
-single “entry point” into the page.
+How do I know whether or not I’m working with Webpack or RequireJS?
+-------------------------------------------------------------------
 
-Most pages have some amount of logic only relevant to that page, so they
-have a file that includes that logic and then depends on other modules
-for shared logic.
+You are likely working with either Webpack or RequireJS, as most of HQ has been migrated to use a bundler.
+However, several major areas have **not** been migrated: app manager,
+reports, and web apps.
 
-`data_dictionary.js <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js>`__
-fits this common pattern:
+The easiest way to determine if a page is using either Webpack or RequireJS is to
+open the JavaScript console on that page and type ``window.USE_WEBPACK``, which will return
+``true`` if the page is using Webpack, or ``window.USE_REQUIREJS``, which will return
+``true`` if the page is using RequireJS. If neither are ``true``, then the page is
+a no-bundler page.
 
-::
+ES Modules (ESM)
+~~~~~~~~~~~~~~~~
 
-   hqDefine("data_dictionary/js/data_dictionary", [    // Module name must match filename
-       "jquery",                                       // Common third-party dependencies
-       "knockout",
-       "underscore",
-       "hqwebapp/js/initial_page_data",                // Dependencies on HQ files always match the file's path
-       "hqwebapp/js/main",
-       "analytix/js/google",
-       "hqwebapp/js/knockout_bindings.ko",             // This one doesn't need a named parameter because it only adds
-                                                       // knockout bindings and is not referenced in this file
-   ], function (
-       $,                                              // These common dependencies use these names for compatibility
-       ko,                                             // with non-requirejs pages, which rely on globals
-       _,
-       initialPageData,                                // Any dependency that will be referenced in this file needs a name.
-       hqMain,
-       googleAnalytics
-   ) {
-       /* Function definitions, knockout model definitions, etc. */
+If your page is using ESM, it is using Webpack, as RequireJS and no-bundler pages do
+not use this module format.
 
-       var dataUrl = initialPageData.reverse('data_dictionary_json');  // Refer to dependencies by their named parameter
-       ...
-
-       $(function () {
-           /* Logic to run on documentready */
-       });
-
-       // Other code isn't going to depend on this module, so it doesn't return anything or returns 1
-   });
-
-To register your module as the RequireJS entry point, add the
-``requirejs_main`` template tag to your HTML page, near the top but
-outside of any other block:
+ESM can quickly be identified by scanning the file for ``import`` statements like this:
 
 ::
 
-   {% requirejs_main 'data_dictionary/js/data_dictionary' %}
+    import myDependency from "hqwebapp/js/my_dependency";
 
-Some pages don’t have any unique logic but do rely on other modules.
-These are usually pages that use some common widgets but don’t have
-custom UI interactions.
+    import { Modal } from "bootstrap5";
 
-If your page only relies on a single js module, you can use that as the
-module’s entry point:
 
-::
+How do I add a new internal module or external dependency to an existing page?
+------------------------------------------------------------------------------
 
-   {% requirejs_main 'locations/js/widgets' %}
+Webpack supports multiple module formats, with ES Modules (ESM) being the preferred format. New modules should be written in the ESM format.
 
-If your page relies on multiple modules, it still needs one entry point.
-You can handle this by making a module that has no body, just a set of
-dependencies, like in
-`gateway_list.js <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/sms/static/sms/js/gateway_list.js>`__:
+That being said, a lot of legacy code on HQ is written in a modified AMD format.
+If you are adding a lot of new code to such a module, it is recommended that you
+`migrate this module to ESM format
+<<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/amd-to-esm.rst>`__.
+However, not every modified AMD module is ready to be migrated to ESM immediately,
+so it's worth familiarizing yourself with working in that format.
 
-::
+The format of the module you add a dependency to will determine how you include that dependency.
 
-   hqDefine("sms/js/gateway_list", [
-       "hqwebapp/js/crud_paginated_list_init",
-       "hqwebapp/js/bootstrap3/widgets",
-   ], function () {
-       // No page-specific logic, just need to collect the dependencies above
-   });
+ESM Module
+~~~~~~~~~~
 
-Then in your HTML page:
+ESM modules provide an extensive and flexible away of managing and naming imports from dependencies.
 
 ::
 
-   {% requirejs_main 'sms/js/gateway_list' %}
+    import myDependency from "hqwebapp/js/my_new_dependency";
+    myDependency.myFunction();
 
-The exception to the above is if your page inherits from a page that
-doesn’t use RequireJS. This is rare, but one example would be adding a
-new page to app manager that inherits from ``managed_app.html``.
+    // using only portions of an dependency
+    import { Modal } from "bootstrap5";
+    const myModal = new Modal(document.getElementById('#myModal'));
 
-How do I add a new dependency to an existing page?
---------------------------------------------------
+    // this also works
+    import bootstrap from "bootstrap5";
+    const myOtherModal = new bootstrap.Modal(document.getElementById('#myOtherModal'));
 
-RequireJS
-~~~~~~~~~
+    // you can also alias imports
+    import * as myAliasedDep from "hqwebapp/js/my_other_dependency";
 
-Add the new module to your module’s ``hqDefine`` list of dependencies.
-If the new dependency will be directly referenced in the body of the
-module, also add a parameter to the ``hqDefine`` callback:
+
+Modified AMD (previously "RequireJS")
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+    RequireJS is being replaced by Webpack. You should NOT create NEW modules with this style.
+
+To use your new module/dependency, add it your module’s ``hqDefine`` list of dependencies.
+If the new dependency will be directly referenced in the body of the odule, also add a
+parameter to the ``hqDefine`` callback:
 
 ::
 
@@ -203,8 +254,21 @@ module, also add a parameter to the ``hqDefine`` callback:
        myDependency.myFunction();
    });
 
-Non-RequireJS
-~~~~~~~~~~~~~
+
+No-Bundler Pages
+~~~~~~~~~~~~~~~~
+
+.. note::
+
+    No-Bundler pages are pages that do not have a Webpack (or RequireJS) entry point.
+    New pages should never be created without a ``webpack_main`` entry point.
+
+    Eventually, the remaining pages in this category will be modularized properly to integrate with Webpack
+    as part of the `JS Bundler Migration
+    <https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/migrating.rst>`__.
+
+    Also note that these pages are **only** compatible with legacy modified AMD modules. ESM modules
+    do not work here.
 
 In your HTML template, add a script tag to your new dependency. Your
 template likely already has scripts included in a ``js`` block:
@@ -227,12 +291,93 @@ dependency:
        myDependency.myFunction();
    });
 
-Do **not** add the RequireJS-style dependency list and parameters. It’s
+Do **not** add the dependency list and parameters from the modified AMD style or
+use `hqImport` on ESM formatted modules. It's
 easy to introduce bugs that won’t be visible until the module is
 actually migrated, and migrations are harder when they have pre-existing
-bugs. See the `troubleshooting section of the RequireJS Migration
+bugs. See the `troubleshooting section of the JS Bundler Migration
 Guide <https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/migrating.rst#troubleshooting>`__
 if you’re curious about the kinds of issues that crop up.
+
+
+My python tests are failing because of javascript
+-------------------------------------------------
+
+Failures after "Building Webpack"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The JavaScript tests run in Github Actions ``yarn build`` to check that ``webpack`` is building
+without errors. You can run ``yarn build`` locally to simulate any errors encountered by these tests.
+
+Since you are likely developing using ``yarn dev``, you should have already encountered the
+build errors during development. However, if the development build of Webpack is running
+without failures, please check the ``webpack/webpack.prod.js`` configuration for possible
+issues if the error messages don't yield anything useful.
+
+
+RequireJS Test Failures
+~~~~~~~~~~~~~~~~~~~~~~~
+
+`TestRequireJS
+<https://github.com/dimagi/commcare-hq/blob/0acf35279639c695b943784704a9f74ce6a86465/corehq/apps/hqwebapp/tests/test_requirejs.py#L10>`__
+reads all of our javascript files, checking for common errors.
+
+These tests are naive. They don't parse JavaScript, they just run regexes based on expected coding patterns.
+They use `this method <#amd-style-legacy-modules>`__ to determine if a file is using an AMD module compatible
+with a bundler (originally, RequireJS). This is one reason not to add dependency lists in areas of HQ
+that don't yet use a bundler.
+
+**test_requirejs_disallows_hqimport**
+
+``hqImport`` only works in non-bundled contexts. In modules (Webpack or RequireJS), dependencies should be
+included using ESM ``imports`` or listed module's ``hqDefine`` call, as described `here <#amd-style-legacy-modules>`__.
+
+Occasionally, this does not work due to a circular dependency. This will manifest as the module being undefined.
+`hqRequire <https://github.com/dimagi/commcare-hq/commit/15b436f77875f57d1e3d8d6db9b990720fa5dd6f#diff-73c73327e873d0e5f5f4e17c3251a1ceR100>`__
+exists for this purpose, to require the necessary module at the point where it’s used. ``hqRequire`` defines
+a new module, which can be fragile, so limit the code using it. As in python, best practice is to include
+dependencies at the module level, at the top of the file.
+
+
+**test_files_match_modules**
+
+RequireJS requires that a module's name is the same as the file containing it. Rename your module.
+
+
+My deploy is failing because of javascript
+------------------------------------------
+
+Webpack Failures
+~~~~~~~~~~~~~~~~
+
+Webpack failures during deploy should be rare if you were able to run ``yarn dev`` successfully
+locally during development. However, if these failures do occur, it is likely due to
+issues with supporting deployment infrastructure.
+
+Is the version of ``npm`` and ``yarn`` up-to-date on the deploy machines? Are the supporting scripts
+outlined in the staticfiles_collect tasks for `Webpack
+<https://github.com/dimagi/commcare-cloud/blob/master/src/commcare_cloud/ansible/roles/deploy_hq/tasks/staticfiles_collect.yml>`__
+configured properly?
+
+
+RequireJS Failures
+~~~~~~~~~~~~~~~~~~
+
+This manifests as an error during static files handling, referencing
+optimization, minification, or parsing.
+Sometimes this is due to strictness in the requirejs parsing.
+Most often this is a trailing comma in a list of function parameters.
+
+Errors also pop up due to certain syntax, including
+`spread syntax <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax>`__ and
+`optional chaining <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining>`__.
+This is the result of requirejs depending on a version of uglify that depends on an old version of
+esprima. See `here <https://github.com/requirejs/r.js/issues/971>`__.
+In third party libraries that are already minified, we can work around this by using ``empty:`` to
+skip optimization (docs). This is done for Sentry `here <https://github.com/dimagi/commcare-hq/blob/0d3badffdfe65bdbab554a1e1aed518398fcb53e/corehq/apps/hqwebapp/static/hqwebapp/yaml/bootstrap3/requirejs.yml#L12-L14>`__.
+For our own code, we have a `babel plugin for requirejs <https://www.npmjs.com/package/requirejs-babel7>`__.
+See `here <https://github.com/dimagi/commcare-hq/pull/33083>`__.
+
 
 How close are we to a world where we’ll just have one set of conventions?
 -------------------------------------------------------------------------
@@ -242,24 +387,14 @@ significant complexity.
 
 `hqDefine.sh <https://github.com/dimagi/commcare-hq/blob/master/scripts/codechecks/hqDefine.sh>`__
 generates metrics for the current status of the migration and locates
-umigrated files. At the time of writing:
+un-migrated files. At the time of writing:
 
 ::
 
-   $ ./scripts/codechecks/hqDefine.sh
+    $ ./scripts/codechecks/hqDefine.sh
 
-   97%     (1040/1081) of HTML files are free of inline scripts
-   93%     (501/539) of JS files use hqDefine
-   64%     (342/539) of JS files specify their dependencies
-   93%     (995/1080) of HTML files are free of script tags
-
-Why aren’t we using something more fully-featured, more modern, or cooler than RequireJS?
------------------------------------------------------------------------------------------
-
-RequireJS is now `deprecated <https://github.com/requirejs/requirejs/issues/1817>`__.
-
-This migration began quite a while ago. At the time, the team discussed
-options and selected RequireJS. The majority of the work done to move to
-RequireJS has been around reorganizing code into modules and explicitly
-declaring dependencies, which is necessary for any kind of modern
-dependency management.
+    97%	(1209/1254) of HTML files are free of inline scripts
+    94%	(553/594) of non-ESM JS files use hqDefine
+    75%	(443/594) of non-ESM JS files specify their dependencies
+    93%	(1162/1254) of HTML files are free of script tags
+    1%	(3/597) of JS files use ESM format

--- a/docs/js-guide/migrating.rst
+++ b/docs/js-guide/migrating.rst
@@ -1,8 +1,11 @@
+JS Bundler Migration Guide
+===========================
 
-RequireJS Migration Guide
-=========================
+This page is a guide to upgrading legacy code in HQ to use Webpack, a modern JavaScript bundler.
+Previously, we were migrating legacy code to RequireJS, an older JavaScript bundler which has since been
+deprecated. If you wish to migrate a RequireJS page to Webpack, please see the `RequireJS to Webpack Migration Guide
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/requirejs-to-webpack.rst>`__
 
-This page is a guide to upgrading legacy code in HQ to use RequireJS.
 For information on how to work within existing code, see `Managing
 Dependencies <https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/dependencies.rst>`__.
 Both that page and `Historical Background on Module
@@ -16,20 +19,22 @@ are useful background for this guide.
 Background: modules and pages
 -----------------------------
 
-The RequireJS migration deals with both **pages** (HTML) and **modules**
+The JS Bundler migration deals with both **pages** (HTML) and **modules**
 (JavaScript). Any individual page is either migrated or not. Individual
 modules are also migrated or not, but a “migrated” module may be used on
-both RequireJS and non-RequireJS pages.
+both bundled (Webpack and RequireJS) and non-bundled pages.
 
-Logic in ``hqModules.js`` determines whether or not we’re in a RequireJS
-environment and changes the behavior of ``hqDefine`` accordingly. In a
-RequireJS environment, ``hqDefine`` just passes through to RequireJS’s
-``define``. Once all pages have been migrated, we’ll be able to delete
+Logic in ``hqModules.js`` determines whether or not we’re in a bundler
+environment (Webpack or RequireJS) and changes the behavior of
+``hqDefine`` accordingly. In a bundler environment, ``hqDefine`` just passes
+through to the standard AMD Module ``define``, which is understood by
+both Webpack and RequireJS as a module and bundled accordingly.
+Once all pages have been migrated, we’ll be able to delete
 ``hqModules.js`` altogether and switch all of the ``hqDefine`` calls to
-``define``.
+``define``--or better, switch to using ES Modules (ESM).
 
 These docs walk through the process of migrating a single page to
-RequireJS.
+from not using a JavaScript bundler to using Webpack.
 
 Basic Migration Process
 -----------------------
@@ -41,66 +46,77 @@ in HQ. Pages that are not descendants of
 `hqwebapp/base.html <https://github.com/dimagi/commcare-hq/tree/master/corehq/apps/hqwebapp/templates/hqwebapp/base.html>`__,
 which are rare, cannot yet be migrated.
 
-Once these conditions are met, migrating to RequireJS is essentially the
+Once these conditions are met, migrating to Webpack is essentially the
 process of explicitly adding each module’s dependencies to the module’s
 definition, and also updating each HTML page to reference a single
 “main” module rather than including a bunch of ``<script>`` tags: 1. Add
-``requirejs_main`` tag and remove ``<script>`` tags 1. Add dependencies
+``webpack_main`` tag and remove ``<script>`` tags 1. Add dependencies
 1. Test
 
-Sample PRs: - `RequireJS migration:
+.. note::
+    The sample PRs below were created when we were still using RequireJS.
+    You can read the sample PRs and substitute ``webpack_main`` where you see
+    ``requirejs_main``. Additionally, you should be sure to include the ``commcarehq``
+    module in the list of dependencies of the final ``hqDefine`` entry point.
+
+    See the `RequireJS to Webpack Migration Guide
+    <https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/requirejs-to-webpack.rst>`__
+    for additional guidance.
+
+
+Sample PRs: - `Bundler migration (RequireJS):
 dashboard <https://github.com/dimagi/commcare-hq/pull/19182/>`__ is an
 example of an easy migration, where all dependencies are already
-migrated - `RequireJS proof of
-concept <https://github.com/dimagi/commcare-hq/pull/18116>`__ migrates a
+migrated - `Bundler proof of
+concept (with RequireJS) <https://github.com/dimagi/commcare-hq/pull/18116>`__ migrates a
 few pages (lookup tables, data dictionary) and many of our commonly-used
 modules (analytics, ``hq.helpers.js``, etc.). This also contains the
 changes to ``hqModules.js`` that make ``hqDefine`` support both migrated
 and unmigrated pages.
 
-Add ``requirejs_main`` tag and remove ``<script>`` tags
+Add ``webpack_main`` tag and remove ``<script>`` tags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``requirejs_main`` tag is what indicates that a page should use
-RequireJS. The page should have one “main” module. Most of our pages are
-already set up like this: they might include a bunch of scripts, but
-there’s one in particular that handles the event handlers, bindings,
-etc. that are specific to that page.
+The ``webpack_main`` tag is what indicates that a page should use
+Webpack. The page should have one "main" module, referred to as an Entry Point.
+Most of our pages are already set up like this: they might include a bunch of scripts, but
+there's one in particular that handles the event handlers, bindings,
+etc. that are specific to that page. That script is the Entry Point.
 
-Considerations when choosing or creating a main module
+Considerations when choosing or creating an Entry Point
 
-- Most often, there’s already a single script that’s only included on the page you’re
-  migrating, which you can use as the main module.
-- It’s fine for multiple pages to use the same main module
+- Most often, there's already a single script that's only included on the page you're
+  migrating, which you can use as the entry point.
+- It's fine for multiple pages to use the same entry point
   - this may make sense for closely related pages.
 - Sometimes a page will have some dependencies
-  but no page-specific logic, so you can make a main module with an empty body, as in
+  but no page-specific logic, so you can make an entry point with an empty body, as in
   `invoice_main.js <https://github.com/dimagi/commcare-hq/commit/d14ba14f13d7d44e3a96940d2c72d2a1b918534d#diff-b81a32d5fee6a9c8af07b189c6a5693e>`__.
 - Sometimes you can add a dependency or two to an existing module and
-  then use it as your main module. This can work fine, but be cautious of
+  then use it as your entry point. This can work fine, but be cautious of
   adding bloat or creating dependencies between django apps. There’s a
   loose hierarchy:
 
   - Major third-party libraries: jQuery, knockout, underscore
   - hqwebapp
   - analytics
-  - app-specific reusable modules like `accounting/js/widgets <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/accounting/static/accounting/js/widgets.js>`__, which are also sometimes used as main modules
+  - app-specific reusable modules like `accounting/js/widgets <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/accounting/static/accounting/js/widgets.js>`__, which are also sometimes used as entry points
   - page-specific modules like `accounting/js/subscriptions_main <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/accounting/static/accounting/js/subscriptions_main.js>`__
-- There’s a growing convention of using the suffix ``_main`` for main modules - more specifically, for any module that runs logic in a document ready handler.
-- HTML files that are only used as the base for other templates don’t need to have a main module or a ``requirejs_main`` tag.
+- There's a growing convention of using the suffix ``_main`` for entry points - more specifically, for any module that runs logic in a document ready handler.
+- HTML files that are only used as the base for other templates don't need to have a entry point or a ``webpack_main`` tag.
 
-Add ``{% requirejs_main 'myApp/js/myModule' %}`` near the top of the
+Add ``{% webpack_main "myApp/js/my_module" %}`` near the top of the
 template: it can go after ``load`` and ``extends`` but should appear
 before content blocks. Note that it’s a module name, not a file name, so
 it doesn’t include ``.js``.
 
 Remove other ``<script>`` tags from the file. You’ll be adding these as
-dependencies to the main module.
+dependencies to the entry point.
 
 Add dependencies
 ~~~~~~~~~~~~~~~~
 
-In your main module, add any dependent modules. Pre-RequireJS, a module
+In your entry point, add any dependent modules. Pre-bundler, a module
 definition looks like this:
 
 ::
@@ -119,7 +135,9 @@ module’s encompassing function:
 
    hqDefine("app/js/utils", [
       "jquery",
-      "otherApp/js/utils"
+      "otherApp/js/utils",
+      "commcarehq"  // REQUIRED: always list this module that imports all site-level dependencies
+                    // This can be at the end of the list. Use ``commcarehq_b3`` for Bootstrap 3 pages.
    ], function(
       $,
       otherUtils
@@ -137,16 +155,16 @@ To declare dependencies:
 - If you removed any ``<script>`` tags from the template
   and haven’t yet added them to the dependency list, do that.
 - Check the template’s parent template
-    - If the parent has a ``requirejs_main`` module, the template you’re migrating should include a dependency on that module.
+    - If the parent has a ``webpack_main`` module, the template you’re migrating should include a dependency on that module.
        - If the parent still has ``<script>`` tags, the template
          you’re migrating should include those as dependencies. It’s usually
          convenient to migrate the parent and any “sibling” templates at the same
          time so you can remove the ``<script>`` tags altogether. If that isn’t
          possible, make the parent check before including script tags:
-         ``{% if requirejs_main %}<script ...></script>{% endif %}``
+         ``{% if webpack_main %}<script ...></script>{% endif %}``
        - Also check the parent’s parent template, etc. Stop once you get to
-         ``hqwebapp/base.html``, ``hqwebapp/bootstrap3/two_column.html``, or
-         ``hqwebapp/bootstrap3/base_section.html``, which already support requirejs.
+         ``hqwebapp/base.html``, ``hqwebapp/bootstrap5/two_column.html``, or
+         ``hqwebapp/bootstrap5/base_section.html``, which already support a bundler.
 -  Check the view for any `hqwebapp
    decorators <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/decorators.py>`__
    like ``use_jquery_ui`` which are used to include many common yet not
@@ -158,7 +176,7 @@ To declare dependencies:
    a dependency and also add the global to ``thirdPartyGlobals`` in
    `hqModules.js <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js>`__
    which prevents errors on pages that use your module but are not yet
-   migrated to requirejs.
+   migrated to Webpack.
 
 Dependencies that aren’t directly referenced as modules **don’t** need
 to be added as function parameters, but they **do** need to be in the
@@ -178,9 +196,9 @@ based on the changes you made:
 - If you replaced any ``hqImport`` calls
   that were inside of event handlers or other callbacks, verify that those
   areas still work correctly. When a migrated module is used on an
-  unmigrated page, its dependencies need to be available at the time the
+  un-migrated page, its dependencies need to be available at the time the
   module is defined. This is a change from previous behavior, where the
-  dependencies didn’t need to be defined until ``hqImport`` first called
+  dependencies didn't need to be defined until ``hqImport`` first called
   them. We do not currently have a construct to require dependencies after
   a module is defined.
 - The most likely missing dependencies are the
@@ -188,8 +206,9 @@ based on the changes you made:
   often don’t error but will look substantially different on the page if
   they haven’t been initialized.
 - If your page depends on any third-party
-  modules that might not yet be used on any RequireJS pages, test them.
-  Third-party modules sometimes need to be upgraded to be compatible with RequireJS.
+  modules that might not yet be used on any Webpack pages, test them.
+  Third-party modules sometimes need to be upgraded to be compatible with Webpack
+  or "shimmed" using Webpack's ``exports-loader``.
 - If your page touched any javascript modules that are used
   by pages that haven’t yet been migrated, test at least one of those
   non-migrated pages.
@@ -201,11 +220,13 @@ Troubleshooting
 Troubleshooting migration issues
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When debugging RequireJS issues, the first question is whether or not
+When debugging Webpack issues, the first question is whether or not
 the page you’re on has been migrated. You can find out by checking the
-value of ``window.USE_REQUIREJS`` in the browser console.
+value of ``window.USE_WEBPACK`` in the browser console or ``window.USE_REQUIREJS``
+if the page is still using RequireJS. If neither values return ``true``, then
+the page has not been migrated yet.
 
-Common issues on RequireJS pages:
+Common issues on Webpack pages:
 
 - JS error like
   ``$(...).something is not a function``: this indicates there’s a missing
@@ -215,34 +236,30 @@ Common issues on RequireJS pages:
 - Missing functionality, but no error: this
   usually indicates a missing knockout binding. To fix, add the file
   containing the binding to the module that applies that binding, which
-  usually means adding ``hqwebapp/js/knockout_bindings.ko`` to the page’s main module.
+  usually means adding ``hqwebapp/js/knockout_bindings.ko`` to the page’s entry point.
 - JS error like ``something is not defined`` where
   ``something`` is one of the parameters in the module’s main function:
   this can indicate a circular dependency. This is rare in HQ. Track down
   the circular dependency and see if it makes sense to eliminate it by
-  reorganizing code. If it doesn’t, you can use
+  reorganizing code. If it doesn’t work, you can use
   `hqRequire <https://github.com/dimagi/commcare-hq/commit/15b436f77875f57d1e3d8d6db9b990720fa5dd6f#diff-73c73327e873d0e5f5f4e17c3251a1ceR100>`__
   to require the necessary module at the point where it’s used rather than
   at the top of the module using it.
 - JS error like ``x is not defined``
   where ``x`` is a third-party module, which is the dependency of another
-  third party module ``y`` and both of them are non RequireJs modules. You
+  third party module ``y`` and both of them are not modules. You
   may get this intermittent error when you want to use ``y`` in the
-  migrated module and ``x`` and ``y`` does not support
-  `AMD <https://requirejs.org/docs/whyamd.html>`__. You can fix this using
-  `shim <https://www.devbridge.com/articles/understanding-amd-requirejs#To-shim-or-not-to-shim>`__
-  or
-  `hqRequire <https://github.com/dimagi/commcare-hq/commit/15b436f77875f57d1e3d8d6db9b990720fa5dd6f#diff-73c73327e873d0e5f5f4e17c3251a1ceR100>`__.
-  `Example <https://github.com/dimagi/commcare-hq/pull/21604/files#diff-cf0be09b7db821551ac73dc3a9829e5eR24>`__
-  of this could be ``d3`` and ``nvd3``
+  migrated module and ``x`` and ``y`` is not formatted as a recognizable JavaScript module that
+  Webpack recognizes (AMD, ESM, CommonJS are supported formats). You can fix this by adding
+  an ``exports-loader`` ``rule`` `like this example <https://github.com/dimagi/commcare-hq/blob/e0b722c61e63b5878759d545282178ae374695e9/webpack/webpack.common.js#L70-L80>`__.
 
-Common issues on non-RequireJS pages:
+Common issues on non-Bundled pages:
 
 - JS error like
   ``something is not defined`` where ``something`` is a third-party
-  module: this can happen if a non-RequireJS page uses a RequireJS module
+  module: this can happen if a non-Bundled page uses a Bundled module
   which uses a third party module based on a global variable. There’s some
-  code that mimicks RequireJS in this situation, but it needs to know
+  code that mimics AMD modules in this situation, but it needs to know
   about all of the third party libraries. To fix, add the third party
   module’s global to `thirdPartyMap in
   hqModules.js <https://github.com/dimagi/commcare-hq/commit/85286460a8b08812f82d6709c161b259e77165c4#diff-73c73327e873d0e5f5f4e17c3251a1ceR57>`__.
@@ -251,7 +268,7 @@ Common issues on non-RequireJS pages:
   appears before one of its dependencies. This can happen to migrated
   modules because one of the effects of the migration is to typically
   import all of a module’s dependencies at the time the module is defined,
-  which in a non-RequireJS context means all of the dependencies’ script
+  which in a non-bundled context means all of the dependencies’ script
   tags must appear before the script tags that depend on them. Previously,
   dependencies were not imported until ``hqImport`` was called, which
   could be later on, possibly in an event handler or some other code that
@@ -261,6 +278,10 @@ Common issues on non-RequireJS pages:
 
 Troubleshooting the RequireJS build process
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+    This is here for informational purposes only and will be removed once
+    all of the RequireJS code is moved to Webpack.
 
 Tactics that can help track down problems with the RequireJS build
 process, which usually manifest as errors that happen on staging but not

--- a/docs/js-guide/module-history.rst
+++ b/docs/js-guide/module-history.rst
@@ -7,29 +7,43 @@ Dependencies <https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/de
 
 We talk about JavaScript modules, but (at least pre-ES6) JavaScript has
 no built in support for modules. It’s easy to say that, but think about
-how crazy that is. If this were Python, it would mean your program’s
+how crazy that is. If this were Python, it would mean your program's
 main file has to directly list all of the files that will be needed, in
 the correct order, and then the files share state through global
-variables. That’s insane.
+variables. That's insane.
 
-And it’s also JavaScript. Fortunately, there are things you can do to
+And it's also JavaScript. Fortunately, there are things you can do to
 enforce and respect the boundaries that keep us sane by following one of
 a number of patterns.
 
-We’re in the process of migrating to
-`RequireJS <https://requirejs.org/>`__. Part of this process has
-included developing a lighter-weight alternative module system called
-``hqDefine``.
+We're in the process of migrating to
+`Webpack <https://webpack.js.org/>`__. Prior to the migration to Webpack,
+we were migrating No-Bundler pages to RequireJS, which has since become deprecated.
+Part of this ongoing process has included developing a lighter-weight
+alternative module system called ``hqDefine``, that is based on the AMD (Asynchronous
+Module Definition) format. This ``hqDefine`` variant of AMD is relevant even for
+Webpack bundles, as it serves as the "transition" module format between pages using
+a bundler and pages not using a bundler (Legacy Pages).
 
 ``hqDefine`` serves as a stepping stone between legacy code and
-requirejs modules: it adds encapsulation but not full-blown dependency
-management. New code is written in RequireJS, but ``hqDefine`` exists to
-support legacy code that does not yet use RequireJS.
+bundled code: it adds encapsulation but not full-blown dependency
+management. New code is written in Webpack, but ``hqDefine`` exists to
+support legacy code that does not yet use Webpack.
 
 Before diving into ``hqDefine``, I want to talk first about the status
-quo convention for sanity with no module system. As we’ll describe, it’s
+quo convention for sanity with no module system. As we'll describe, it's
 a step down from our current preferred choice, but it’s still miles
 ahead of having no convention at all.
+
+Creating a Brand New Page?
+--------------------------
+
+If you are creating new pages with Webpack, then you can skip this
+discussion for now. All **new** Webpack entry points should be written using
+the new ES Module (ESM) format. This is the modern module format you will
+see referenced in most modern JavaScript library documentation. ``hqDefine``
+(aka Modified AMD) should eventually only be used for transition points
+between legacy code and bundled code.
 
 The Crockford Pattern
 ---------------------
@@ -127,7 +141,7 @@ hqDefine
 
 There are many great module systems out there, so why did we write our
 own? The answer’s pretty simple: while it’s great to start with
-require.js or system.js, with a code base HQ’s size, getting from here
+Webpack, with a code base HQ’s size, getting from here
 to there is nearly impossible without an intermediate step.
 
 Using the above example again, using ``hqDefine``, you’d write your file
@@ -164,8 +178,9 @@ function itself is exactly the same. It’s just being passed to
 ``hqDefine`` instead of being called directly.
 
 ``hqDefine`` is an intermediate step on the way to full support for AMD
-modules, which in HQ is implemented using RequireJS. ``hqDefine`` checks
-whether or not it is on a page that uses AMD modules and then behaves in
+modules, which is supported by Webpack as well as our previous bundler RequireJS.
+
+``hqDefine`` checks whether or not it is on a page that uses AMD modules and then behaves in
 one of two ways: \* If the page has been migrated, meaning it uses AMD
 modules, ``hqDefine`` just delegates to ``define``. \* If the page has
 not been migrated, ``hqDefine`` acts as a thin wrapper around the
@@ -173,7 +188,7 @@ Crockford module pattern. ``hqDefine`` takes a function, calls it
 immediately, and puts it in a namespaced global; ``hqImport`` then looks
 up the module in that global.
 
-In the first case, by handing control over to RequireJS,
+In the first case, by handing control over to Webpack,
 ``hqDefine``/``hqImport`` also act as a module *loader*. But in the
 second case, they work only as a module *dereferencer*, so in order to
 use a module, it still needs to be included as a ``<script>`` on your
@@ -186,11 +201,12 @@ html page:
 Note that in the example above, the module name matches the end of the
 filename, the same name used to identify the file when using the
 ``static`` tag, but without the ``js`` extension. This is necessary for
-RequireJS to work properly. For consistency, all modules, regardless of
-whether or not they are yet compatible with RequireJS, should be named
+Webpack to work properly. For consistency, all modules, regardless of
+whether or not they are yet compatible with Webpack, should be named
 to match their filename.
 
 ``hqDefine`` and ``hqImport`` provide a consistent interface for both
 migrated and unmigrated pages, and that interface is also consistent
-with RequireJS, making it easy to eventually “flip the switch” and
-remove them altogether once all code is compatible with RequireJS.
+with AMD Modules (supported by Webpack, and previously RequireJS),
+making it easy to eventually  “flip the switch” and remove them altogether
+once all code is compatible with Webpack.

--- a/docs/js-guide/requirejs-to-webpack.rst
+++ b/docs/js-guide/requirejs-to-webpack.rst
@@ -5,29 +5,11 @@ RequireJS `reached its end of life <https://github.com/requirejs/requirejs/issue
 in September of 2020. Since then, it has been increasingly difficult to work with as more modern libraries
 no longer provide AMD modules (the preferred module format of RequireJS), and use modern JavaScript
 syntax that is no longer compatible with RequireJS's build process. We decided to use Webpack as our
-replacement for RequireJS in September of 2024. We expect the migration to be brief and straightforward
-with the following challenges to highlight:
-
-1. The use of ``stripe`` will need to be updated to use the module from ``npm``, and we will need update
-    our front-end to use Stripe's credit card widgets library.
-2. Shimmed dependencies in requirejs that do no yet have an analogous ``exports-loader`` statement in
-    ``webpack.common.js`` will need a statement added and usage tested. This should be straightforward, but
-    there might be a couple challenging shims in this process.
-3. Tests will also need to be moved to using Webpack instead of RequireJS. The difference with webpack is that
-    the ``commcarehq`` or ``commcarehq_b3`` common module is always imported in the entry point. In RequireJS
-    this main module was included in ``hqwebapp/partials/requirejs.html``. However, Webpack can't reliably build
-    bundles with this global bundle separated from the entry point. This shouldn't cause issues for tests, but it might.
+replacement for RequireJS in September of 2024. We expect the migration to be brief and straightforward.
 
 
 Overview of the Process
 -----------------------
-
-Migrations should happen in pull-request "chunks", meaning that pull requests should contain migrations for
-all (or most) entry points within a single application or a set of closely related applications. Additionally,
-commits should be made separately for each entry point migration.
-
-If new ``exports-loader`` statements are added, it is recommended to test the changes on staging to ensure
-the functionality is maintained between production and staging.
 
 The following steps outline the migration process on a per entry point basis.
 
@@ -42,61 +24,21 @@ that it knows what bundle of javascript dependencies and page-specific code is n
 See `the Static Files Overview <https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/static-files.rst>`__
 for a more detailed explanation.
 
-Step 1: Identify the Entry Point and Details
---------------------------------------------
+.. note::
 
-First, identify the entry point you would like to migrate. Additionally, we need to determine if the entry
-point is split along the Bootstrap 3 or Bootstrap 5 RequireJS build.
-
-Bootstrap 5 Entry Points
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-As an example, let's migrate ``case_importer/js/main``.
-
-We should find a ``requirejs_main_b5`` template tag referencing this entry point inside a template.
-
-The following template tag is present in ``case_importer/excel_config.html``:
-
-::
-
-    {% requirejs_main_b5 "case_importer/js/main" %}
-
-Since the ``requirejs_main_b5`` template tag is being used, we know this entry point is part of the Bootstrap 5
-build. We also do not need to be concerned that this file might be undergoing a Bootstrap 5 migration.
-
-We can now proceed to Step 2.
-
-Bootstrap 3 Entry Points
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-As an example, let's migrate ``domain/js/my_project_settings``.
-
-We should find a ``requirejs_main`` template tag referencing this entry point inside a template.
-
-The following template tag is preset in ``domain/admin/my_project_settings.html``:
-
-::
-
-    {% requirejs_main "domain/js/my_project_settings" %}
-
-Since the ``requirejs_main`` template tag is being used, we know this entry point has not been migrated
-from Bootstrap 3 to 5. Since we are currently undergoing a migration from Bootstrap 3 to 5, it is important
-to establish that this page is not actively undergoing a migration.
-
-Please see the `Bootstrap Migration Status List
-<https://docs.google.com/spreadsheets/d/1tkSXR643Da-fp6a-uYPa5dYs5if4W2LqtvUJs3IfUKs/edit?gid=0#gid=0>`__
-to see if the application housing that entry point is undergoing a migration. If unsure, please
-raise a question to ``#gtd-dev``.
-
-If you are able to determine that this entry point is NOT actively undergoing a Bootstrap 3 to 5 migration,
-then please proceed to Step 2.
+    If new ``exports-loader`` statements are added, it is recommended to test the changes on staging to ensure
+    the functionality is maintained between production and staging.
 
 
-Step 2: Update the Template Tag and Add Global ``commcarehq`` Dependency
+Step 1: Update the Template Tag and Add Global ``commcarehq`` Dependency
 ------------------------------------------------------------------------
+
+First, find either the ``requirejs_main`` tag (Bootstrap 3 pages) or the ``requirejs_main_b5`` tag
+(Bootstrap 5 pages) that references the entry point you want to migrate.
 
 The migration of an entry point from RequireJS to Webpack will involve updating the template tag
 used to define the entry point and then adding the ``commcarehq`` global dependency to the list of dependencies.
+Two examples are below.
 
 Bootstrap 5 Entry Points
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -157,7 +99,7 @@ Then, in the file itself, we add the ``commcarehq_b3`` dependency to the list of
         ...
 
 
-Step 3: Verify Webpack Build
+Step 2: Verify Webpack Build
 ----------------------------
 
 The next step is to ensure that the Webpack build succeeds with the newly-added
@@ -181,15 +123,10 @@ please see the troubleshooting guide below. If there is no help there, please re
 the lead developers in charge of this migration for assistance. Please add troubleshooting
 guidance afterward.
 
-Once the build succeeds, please commit all tho changes for that entry point, with
-a commit message that might look like the following
-
-::
-
-    migrated case_importer/js/main to webpack
+Once the build succeeds, please commit all the changes for that entry point.
 
 
-Step 4: Verify Page Loads Without JavaScript Errors
+Step 3: Verify Page Loads Without JavaScript Errors
 ---------------------------------------------------
 
 The final step is to ensure that the page with the Entry Point loads without
@@ -206,9 +143,3 @@ existing patterns of ``exports-loader`` statements for dependencies that were sh
 in ``requirejs_config`` similarly to the dependency you are having issues with now.
 
 Please add any additional guidance here as the migration continues.
-
-
-Troubleshooting Guide
----------------------
-
-TBD -- Please add any additional guidance here as the migration continues.

--- a/docs/js-guide/requirejs-to-webpack.rst
+++ b/docs/js-guide/requirejs-to-webpack.rst
@@ -130,9 +130,8 @@ Step 3: Verify Page Loads Without JavaScript Errors
 ---------------------------------------------------
 
 The final step is to ensure that the page with the Entry Point loads without
-JavaScript errors. It is recommended to do this on staging if any additional
-complex local setup is required. Most of the time, entry points should load
-without errors if the build succeeds.
+JavaScript errors. Most of the time, entry points should load without errors if
+the build succeeds.
 
 If there are JavaScript errors, the mostly likely issue is due to ``undefined`` errors
 when referencing a module/dependency. The most likely cause of this is a missing

--- a/docs/js-guide/requirejs-to-webpack.rst
+++ b/docs/js-guide/requirejs-to-webpack.rst
@@ -1,0 +1,214 @@
+Migrating RequireJS to Webpack
+==============================
+
+RequireJS `reached its end of life <https://github.com/requirejs/requirejs/issues/1816#issuecomment-707503323>`__
+in September of 2020. Since then, it has been increasingly difficult to work with as more modern libraries
+no longer provide AMD modules (the preferred module format of RequireJS), and use modern JavaScript
+syntax that is no longer compatible with RequireJS's build process. We decided to use Webpack as our
+replacement for RequireJS in September of 2024. We expect the migration to be brief and straightforward
+with the following challenges to highlight:
+
+1. The use of ``stripe`` will need to be updated to use the module from ``npm``, and we will need update
+    our front-end to use Stripe's credit card widgets library.
+2. Shimmed dependencies in requirejs that do no yet have an analogous ``exports-loader`` statement in
+    ``webpack.common.js`` will need a statement added and usage tested. This should be straightforward, but
+    there might be a couple challenging shims in this process.
+3. Tests will also need to be moved to using Webpack instead of RequireJS. The difference with webpack is that
+    the ``commcarehq`` or ``commcarehq_b3`` common module is always imported in the entry point. In RequireJS
+    this main module was included in ``hqwebapp/partials/requirejs.html``. However, Webpack can't reliably build
+    bundles with this global bundle separated from the entry point. This shouldn't cause issues for tests, but it might.
+
+
+Overview of the Process
+-----------------------
+
+Migrations should happen in pull-request "chunks", meaning that pull requests should contain migrations for
+all (or most) entry points within a single application or a set of closely related applications. Additionally,
+commits should be made separately for each entry point migration.
+
+If new ``exports-loader`` statements are added, it is recommended to test the changes on staging to ensure
+the functionality is maintained between production and staging.
+
+The following steps outline the migration process on a per entry point basis.
+
+As a reminder, Entry Points are modules that are included directly on a page using a bundler template tag,
+like the ones listed below. We want to migrate the RequireJS entry points to Webpack entry points:
+
+ - ``requirejs_main_b5`` to ``webpack_main``
+ - ``requirejs_main`` to ``webpack_main_b3``
+
+Entry points are the modules that the bundler (RequireJS or Webpack) uses to build a dependency graph so
+that it knows what bundle of javascript dependencies and page-specific code is needed to render that page.
+See `the Static Files Overview <https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/static-files.rst>`__
+for a more detailed explanation.
+
+Step 1: Identify the Entry Point and Details
+--------------------------------------------
+
+First, identify the entry point you would like to migrate. Additionally, we need to determine if the entry
+point is split along the Bootstrap 3 or Bootstrap 5 RequireJS build.
+
+Bootstrap 5 Entry Points
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+As an example, let's migrate ``case_importer/js/main``.
+
+We should find a ``requirejs_main_b5`` template tag referencing this entry point inside a template.
+
+The following template tag is present in ``case_importer/excel_config.html``:
+
+::
+
+    {% requirejs_main_b5 "case_importer/js/main" %}
+
+Since the ``requirejs_main_b5`` template tag is being used, we know this entry point is part of the Bootstrap 5
+build. We also do not need to be concerned that this file might be undergoing a Bootstrap 5 migration.
+
+We can now proceed to Step 2.
+
+Bootstrap 3 Entry Points
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+As an example, let's migrate ``domain/js/my_project_settings``.
+
+We should find a ``requirejs_main`` template tag referencing this entry point inside a template.
+
+The following template tag is preset in ``domain/admin/my_project_settings.html``:
+
+::
+
+    {% requirejs_main "domain/js/my_project_settings" %}
+
+Since the ``requirejs_main`` template tag is being used, we know this entry point has not been migrated
+from Bootstrap 3 to 5. Since we are currently undergoing a migration from Bootstrap 3 to 5, it is important
+to establish that this page is not actively undergoing a migration.
+
+Please see the `Bootstrap Migration Status List
+<https://docs.google.com/spreadsheets/d/1tkSXR643Da-fp6a-uYPa5dYs5if4W2LqtvUJs3IfUKs/edit?gid=0#gid=0>`__
+to see if the application housing that entry point is undergoing a migration. If unsure, please
+raise a question to ``#gtd-dev``.
+
+If you are able to determine that this entry point is NOT actively undergoing a Bootstrap 3 to 5 migration,
+then please proceed to Step 2.
+
+
+Step 2: Update the Template Tag and Add Global ``commcarehq`` Dependency
+------------------------------------------------------------------------
+
+The migration of an entry point from RequireJS to Webpack will involve updating the template tag
+used to define the entry point and then adding the ``commcarehq`` global dependency to the list of dependencies.
+
+Bootstrap 5 Entry Points
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the ``case_importer/js/main`` example from Step 1, we can update the ``requirejs_main_b5`` template tag
+to ``webpack_main``, so that the final usage looks like:
+
+::
+
+    {% webpack_main "case_importer/js/main" %}
+
+Then, in the file itself, we add the ``commcarehq`` dependency to the list of dependencies:
+
+::
+
+    hqDefine("case_importer/js/main", [
+        'jquery',
+        'underscore',
+        'hqwebapp/js/initial_page_data',
+        'case_importer/js/import_history',
+        'case_importer/js/excel_fields',
+        'hqwebapp/js/bootstrap5/widgets',
+        'commcarehq',  // <--- dependency added for webpack
+    ], function (
+        $,
+        _,
+        initialPageData,
+        importHistory,
+        excelFieldsModule
+    ) {
+        ...
+
+
+Bootstrap 3 Entry Points
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the ``domain/js/my_project_settings`` example from Step 1, we can update the ``requirejs_main``
+tag to ``webpack_main_b3``, so that the final usage looks like:
+
+::
+
+    {% webpack_main_b3 "domain/js/my_project_settings" %}
+
+Then, in the file itself, we add the ``commcarehq_b3`` dependency to the list of dependencies:
+
+::
+
+    hqDefine("domain/js/my_project_settings", [
+        'jquery',
+        'knockout',
+        'hqwebapp/js/initial_page_data',
+        'commcarehq_b3',  // <--- dependency added for webpack
+    ], function (
+        $,
+        ko,
+        initialPageData
+    ) {
+        ...
+
+
+Step 3: Verify Webpack Build
+----------------------------
+
+The next step is to ensure that the Webpack build succeeds with the newly-added
+entry point. To do this, restart or run ``yarn dev`` locally. If the build fails,
+it is likely due to a missing alias or application folder path.
+
+If it is a missing alias for a ``yarn`` dependency, first check to if the
+dependency being referenced is using the ``npm`` package name (or ``npm_modules`` filepath)
+or if it referring to an alias previously specified in the ``requirejs_config`` files.
+Ideally, try to use the ``npm`` package/path and update the references for the dependency (if possible).
+If not, you can add the alias in ``webpack/webpack.common.js``.
+
+If an application path is missing, for instance it can't find a path to a dependency
+that is under ``<app_name>/js/<path>``, then it might be that there are no entry points
+in that app yet. If this is the case, add the ``<app_name>`` to the
+``alwaysIncludeApps`` list in ``webpack/generateDetails.js``. Eventually, this list
+won't be necessary once everything is migrated, but for now that's the best workaround.
+
+Once these points are updated, please restart ``yarn dev``. If more build errors persist,
+please see the troubleshooting guide below. If there is no help there, please reach out
+the lead developers in charge of this migration for assistance. Please add troubleshooting
+guidance afterward.
+
+Once the build succeeds, please commit all tho changes for that entry point, with
+a commit message that might look like the following
+
+::
+
+    migrated case_importer/js/main to webpack
+
+
+Step 4: Verify Page Loads Without JavaScript Errors
+---------------------------------------------------
+
+The final step is to ensure that the page with the Entry Point loads without
+JavaScript errors. It is recommended to do this on staging if any additional
+complex local setup is required. Most of the time, entry points should load
+without errors if the build succeeds.
+
+If there are JavaScript errors, the mostly likely issue is due to ``undefined`` errors
+when referencing a module/dependency. The most likely cause of this is a missing
+``exports-loader`` statement for a dependency that was previously shimmed in the
+``requirejs_config`` files. See the `documentation for exports-loader
+<https://webpack.js.org/loaders/exports-loader/>`__ on how to do this, or follow
+existing patterns of ``exports-loader`` statements for dependencies that were shimmed
+in ``requirejs_config`` similarly to the dependency you are having issues with now.
+
+Please add any additional guidance here as the migration continues.
+
+
+Troubleshooting Guide
+---------------------
+
+TBD -- Please add any additional guidance here as the migration continues.

--- a/docs/js-guide/static-files.rst
+++ b/docs/js-guide/static-files.rst
@@ -20,9 +20,6 @@ to using Webpack as part of the `JS Bundler Migration
 Image files generally stay as-is. The only "dynamic" images
 come from file attachments in our database.
 
-As of this writing, we don't compile our JavaScript from a higher level scripting
-language, although Webpack offers ways to do this easily.
-
 Due to their static natures, the primary objective when working with static files is
 to make as few requests as possible to them during page load. We aim to combine
 static files into one larger, minified file whenever possible.
@@ -34,7 +31,8 @@ Why use a javascript bundler?
 -----------------------------
 
 We use a bundler for our javascript files to reduce the amount of separate
-javascript ``script`` tags needed for any page load. A bundler, like Webpack, not only combines the necessary javascript, it minifies the javascript to reduce
+network requests tags needed for any page load. A bundler, like Webpack,
+not only combines the necessary javascript, it minifies the javascript to reduce
 its overall size. Additionally, Webpack employs code splitting to split commonly referenced
 "chunks" of code into separate collective bundles:
 
@@ -83,7 +81,8 @@ Developing on No-Bundle pages
 
 There are still some very old sections of the codebase that are not under the jurisdiction of a JavaScript bundler.
 These pages can be developed without needing ``yarn dev`` to run in the background. However, you should pay special
-attention to your ``localsettings`` setup for Django Compressor, which is explained in the Compression
+attention to your ``localsettings`` setup for Django Compressor, which is explained in the `Compression
+<#compression>`__
 section below.
 
 Developing with RequireJS page

--- a/docs/js-guide/static-files.rst
+++ b/docs/js-guide/static-files.rst
@@ -1,19 +1,104 @@
-Static Files
-============
+Overview of Static Files and JavaScript Bundlers
+================================================
+
+What are Static Files?
+----------------------
 
 Static files include any ``css``, ``js``, and image files that are not
 dynamically generated during runtime. ``css`` is typically compiled from
-``less`` and minified prior to server runtime. ``js`` files are
-collected, combined, and minified prior to server runtime. As of this
-writing we don’t compile our JavaScript from a higher level scripting
-language. Image files generally stay as-is. The only ‘dynamic’ images
+``scss`` (or ``less`` on Bootstrap 3 pages) and minified before server
+runtime.
+
+``js`` files are collected, combined, and minified using Webpack
+or RequireJS, called JavaScript bundlers. We are currently
+transitioning from RequireJS (deprecated) to Webpack. Some pages do
+not use a bundler or any structured JavaScript module format,
+referred to as No-Bundler Pages. No-Bundler Pages are rare and are being transitioned
+to using Webpack as part of the `JS Bundler Migration
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/migrating.rst>`__.`
+
+Image files generally stay as-is. The only "dynamic" images
 come from file attachments in our database.
 
-Due to their static natures, the primary objective for static files is
-to make as few requests to them during page load, meaning that our goal
-is to combine static files into one larger, minified file when possible.
-An additional goal is to ensure that the browser caches the static files
-it is served to make subsequent page loads faster.
+As of this writing, we don't compile our JavaScript from a higher level scripting
+language, although Webpack offers ways to do this easily.
+
+Due to their static natures, the primary objective when working with static files is
+to make as few requests as possible to them during page load. We aim to combine
+static files into one larger, minified file whenever possible.
+Another goal is to ensure that the browser caches the static files when possible
+to make subsequent page loads faster.
+
+
+Why use a javascript bundler?
+-----------------------------
+
+We use a bundler for our javascript files to reduce the amount of separate
+javascript ``script`` tags needed for any page load. A bundler, like Webpack, not only combines the necessary javascript, it minifies the javascript to reduce
+its overall size. Additionally, Webpack employs code splitting to split commonly referenced
+"chunks" of code into separate collective bundles:
+
+    - ``vendor``: common code that comes ``yarn`` dependencies
+    - ``common``: native HQ javascript that is referenced across the whole site
+    - "app" bundles: shared code across entry points inside a specific app, e.g. ``hqwebapp``, ``domain``, etc.
+
+This code splitting allows chunks of code shared across entry points to be cached in the browser
+once, making subsequent page loads much faster.
+
+What is an entry point?
+~~~~~~~~~~~~~~~~~~~~~~~
+
+An "entry point" is the starting point or root file for a given page that Webpack (or RequireJS) uses to
+build the dependency graph and generate the output bundle(s).
+
+There is only **one** entry point per page. Multiple pages may share the same entry points; however, there
+should never be more than one entry point on a single page.
+
+
+How do I develop with a JavaScript bundler?
+-------------------------------------------
+
+To build Webpack locally for continuous development, run the ``yarn dev`` command.
+
+This command first runs
+``webpack/generateDetails.js`` to scan all template files for ``webpack_main`` template tags,
+identifying Webpack entry points. It then builds Webpack bundles based on the ``webpack/webpack.dev.js``
+configuration.
+
+``yarn dev`` can be left running, as it will watch existing entry points for any changes and rebuild
+Webpack bundles as needed.
+
+When adding new entry points, please remember to restart ``yarn dev``.
+
+When deploying CommCare HQ, ``yarn build`` is used instead of ``yarn dev``. The primary differences are:
+
+- minification of bundles
+- a different algorithm for source maps that is better with minified files but takes longer to generate
+- appending filenames with content hashes of files for cache busting purposes
+
+To troubleshoot production-related Webpack issues, you can run ``yarn build`` locally.
+
+Developing on No-Bundle pages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are still some very old sections of the codebase that are not under the jurisdiction of a JavaScript bundler.
+These pages can be developed without needing ``yarn dev`` to run in the background. However, you should pay special
+attention to your ``localsettings`` setup for Django Compressor, which is explained in the Compression
+section below.
+
+Developing with RequireJS page
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are developing a RequireJS page, consider `migrating it to Webpack first
+<https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/requirejs-to-webpack.rst>`__.
+The majority of migrations are relatively quick and straightforward.
+
+Otherwise, these pages can be developed without running ``yarn dev`` in the background.
+
+When a production deploy happens, RequireJS production bundles are built using the ``build_requirejs`` management
+command. This build step is often the point where people see build failures due to using unsupported es6 syntax in
+RequireJS bundles. If you see that, consider it a sign that the module throwing that error should be moved to Webpack.
+
 
 Collectstatic
 -------------
@@ -49,13 +134,14 @@ static files. First run:
    manage.py fix_less_imports_collectstatic
    manage.py compilejsi18n
 
+
 Compression
 -----------
 
 `Django
 Compressor <https://django-compressor.readthedocs.org/en/latest/>`__ is
-the library we use to handle compilation of ``less`` files and the
-minification of ``js`` and compiled ``css`` files.
+the library we use to handle compilation of ``scss`` (and ``less``) files and the
+minification of no-bundler ``js`` and compiled ``css`` files.
 
 Compressor blocks are defined inside the
 ``{% compress css %}{% endcompress %}`` or
@@ -69,7 +155,7 @@ requests made per page.
 
 There are three ways of utilizing Django Compressor’s features:
 
-1. Dev Setup: Server-side on the fly ``less`` compilation
+1. Dev Setup: Server-side on the fly ``scss`` compilation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This does not combine any files in compress blocks, and as no effect on
@@ -182,3 +268,14 @@ Note that this cache busting is irrelevant to files that are contained
 within a ``compress`` block. Each compressed block generated a file that
 contains a hash in the filename, so there’s no need for the URL
 parameter.
+
+A Note on Webpack and Cache Busting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Webpack has its own built-in Cache Busting capabilities which are activated
+with the ``webapck/webpack.prod.js`` configuration. This is run during
+``yarn build``. Bundles generated by Webpack are then appended with that file's
+content cache in order to bust the cache.
+
+In order to run build Webpack locally in the same way as you would in a production
+environment, you can run ``yarn build`` instead of ``yarn dev``.

--- a/docs/js-guide/testing.rst
+++ b/docs/js-guide/testing.rst
@@ -57,12 +57,6 @@ tests will be in
 defined in ``Gruntfile.js`` as ``<app_name>/<config_name>``, e.g.,
 ``cloudcare/form_entry``.
 
-Dependency Management
----------------------
-
-Tests are one of the few areas of HQ’s JavaScript that do not use
-a bundler. Instead, dependencies are included in the relevant HTML
-template as script tags.
 
 Running tests from the command line
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/js-guide/testing.rst
+++ b/docs/js-guide/testing.rst
@@ -61,7 +61,7 @@ Dependency Management
 ---------------------
 
 Tests are one of the few areas of HQ’s JavaScript that do not use
-RequireJS. Instead, dependencies are included in the relevant HTML
+a bundler. Instead, dependencies are included in the relevant HTML
 template as script tags.
 
 Running tests from the command line

--- a/docs/translations.rst
+++ b/docs/translations.rst
@@ -266,9 +266,9 @@ JavaScript has a ``gettext`` function that works exactly the same as in python:
     gettext("Welcome to CommCare HQ")
 
 ``gettext`` is available globally in HQ, coming from `django.js <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/django.js>`__
-which is available via the `base RequireJS setup
-<https://github.com/dimagi/commcare-hq/blob/f922211689b39240fcf16efe36d9dc13382977b8/corehq/apps/hqwebapp/templates/hqwebapp/partials/requirejs.html#L28>`__,
-so it doesn't need to be added as a dependency to modules that use it.
+which is part of the imports within the `commcarehq module
+<https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/commcarehq.js>`__,
+that is included within any ``webpack_main`` entry point.
 
 For translations with interpolated variables, use Underscore's `_.template <https://underscorejs.org/#template>`__
 function similarly to python's string formatting, calling ``gettext`` on the template and __then__ interpolating

--- a/scripts/codechecks/hqDefine.sh
+++ b/scripts/codechecks/hqDefine.sh
@@ -8,6 +8,14 @@ function list-js() {
   find corehq custom -name '*.js' | grep -v '/_design/' | grep -v 'couchapps' | grep -v '/js/vellum/'
 }
 
+function list-no-esm-js() {
+  list-js | xargs grep -L '^import.*;'
+}
+
+function list-esm-js() {
+  list-js | xargs grep -l '^import.*;'
+}
+
 function list-html() {
   find corehq custom -name '*.html' | grep -v 'vellum'
 }
@@ -19,13 +27,13 @@ function list-html-with-inline-scripts() {
 }
 
 function list-js-without-hqDefine() {
-  list-js | xargs grep -L 'hqDefine'
+  list-no-esm-js | xargs grep -L 'hqDefine'
 }
 
 # Partial indicator of RequireJS work left: how many js files don't yet use
 # the variation of hqDefine that specifies dependencies?
 function list-js-without-requirejs() {
-  list-js | xargs grep -L 'hqDefine.*\['
+  list-no-esm-js | xargs grep -L 'hqDefine.*\['
 }
 
 # The other indicator of RequireJS work left: how many HTML files still have script tags?
@@ -43,9 +51,10 @@ function percent() {
 ## Main script
 
 command=${1:-""}
-help="Pass list-script, list-hqdefine, list-requirejs, or list-requirejs-html to list the files that have yet to be migrated"
+help="Pass list-script, list-hqdefine, list-requirejs, or list-requirejs-html to list the files that have yet to be migrated. list-esm to list ESM formatted files"
 
 jsTotalCount=$(echo $(list-js | wc -l))
+noEsmJsTotalCount=$(echo $(list-no-esm-js | wc -l))
 htmlTotalCount=$(echo $(list-html | wc -l))
 
 case $command in
@@ -53,6 +62,11 @@ case $command in
   "list-script" )
     echo "The following templates still have inline script tags:"
     list-html-with-inline-scripts | sed 's/^/  /'
+    ;;
+
+  "list-esm" )
+    echo "These files use ESM syntax:"
+    list-esm-js | sed 's/^/  /'
     ;;
 
   "list-hqdefine" )
@@ -74,7 +88,7 @@ case $command in
   "static-analysis" )
     withoutHqDefineCount=$(echo $(list-js-without-hqDefine | wc -l))
     withoutRequireJsCount=$(echo $(list-js-without-requirejs | wc -l))
-    echo "$withoutHqDefineCount $(($withoutRequireJsCount - $withoutHqDefineCount)) $(($jsTotalCount - $withoutRequireJsCount))"
+    echo "$withoutHqDefineCount $(($withoutRequireJsCount - $withoutHqDefineCount)) $(($noEsmJsTotalCount - $withoutRequireJsCount))"
     ;;
 
   "")
@@ -86,13 +100,16 @@ case $command in
     echo "$(percent $unmigratedCount $htmlTotalCount) of HTML files are free of inline scripts"
 
     unmigratedCount=$(echo $(list-js-without-hqDefine | wc -l))
-    echo "$(percent $unmigratedCount $jsTotalCount) of JS files use hqDefine"
+    echo "$(percent $unmigratedCount $noEsmJsTotalCount) of non-ESM JS files use hqDefine"
 
     unmigratedCount=$(echo $(list-js-without-requirejs | wc -l))
-    echo "$(percent $unmigratedCount $jsTotalCount) of JS files specify their dependencies"
+    echo "$(percent $unmigratedCount $noEsmJsTotalCount) of non-ESM JS files specify their dependencies"
 
     unmigratedCount=$(echo $(list-html-with-external-scripts | wc -l))
     echo "$(percent $unmigratedCount $htmlTotalCount) of HTML files are free of script tags"
+
+    unmigratedCount=$(echo $(list-no-esm-js | wc -l))
+    echo "$(percent $unmigratedCount $jsTotalCount) of JS files use ESM format"
 
     echo
     echo $help


### PR DESCRIPTION
## Technical Summary
This updates the JavaScript Guide to:
- rename the "RequireJS migration" to the "JS Bundler Migration"
- add documentation for migrating RequireJS entry points to Webpack
- add documentation for updating AMD / `hqDefine` module syntax to ESM (and how to determine when it is safe to do so)
- update references to "Require JS" and replace with "Webpack", where appropriate, or indicate that a technology transition is happening
- improve wording and organization
- update `hqDefine` code check to ignore `ESM` JS files when calculating metrics. Add new metric for seeing ESM-format percentage of all JS files
- update `DEV_SETUP.md` and `DEV_FAQ.md` with Webpack related steps and information.

## Safety Assurance

### Safety story
Documentation change only. tests catch documentation errors

### Automated test coverage
Yes

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
