### PR TITLE
Check can_edit_or_view_location on location_lineage

### DIFF
--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -720,6 +720,7 @@ def delete_location(request, domain, loc_id):
     })
 
 
+@can_edit_or_view_location
 @location_safe
 def location_lineage(request, domain, loc_id):
     lineage = SQLLocation.objects.get_locations([loc_id])[0].lineage


### PR DESCRIPTION
## Technical Summary
[SAAS-15892](https://dimagi.atlassian.net/browse/SAAS-15892)
Adds a decorator to `location_lineage` to ensure a user can at edit or at least view the specific location they are getting the lineage for. Currently a user can potentially view location lineages they should not be able to, including those in other project spaces.

## Safety Assurance

### Safety story
This is a really small change to add on a security check. The decorator itself is already used pretty widely through locations views, there is decent test coverage of the locations app, and I believe the risk is quite low. Tested locally to ensure this does the right thing - limits access to `location_lineage` to only those users who have access to edit or view the particular location.

### Automated test coverage
There are existing automated tests for some of the views in the locations app. I think a test of this particular change wouldn't necessarily add anything, since it'd effectively be testing the decorator itself.

### QA Plan
Not planning QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-15892]: https://dimagi.atlassian.net/browse/SAAS-15892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ