### PR TITLE
Allow manual workflow trigger

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     # see corehq/apps/hqadmin/management/commands/static_analysis.py
     - cron: '47 12 * * *'
+  workflow_dispatch:
 jobs:
   tests:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
To manually trigger a workflow on github.com, navigate to
Actions > commcare-hq tests (in sidebar) > Run workflow...
Then choose a branch and run the workflow.

## Safety Assurance

### Safety story

Only affects Actions (tests) functionality on Github.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations