### PR TITLE
Update FF to deprecated status

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1398,7 +1398,7 @@ def _commtrackify(domain_name, toggle_is_enabled):
 COMMTRACK = StaticToggle(
     'commtrack',
     "CommCare Supply",
-    TAG_SOLUTIONS_LIMITED,
+    TAG_DEPRECATED,
     description=(
         '<a href="https://help.commcarehq.org/display/commtrack/CommCare+Supply+Home">CommCare Supply</a> '
         "is a logistics and supply chain management module. It is designed "


### PR DESCRIPTION
## Product Description
The CommCare Supply FF category is updated to "deprecated".

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3886)

## Feature Flag
CommCare Supply

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
### QA Plan
No QA planned

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
