### PR TITLE
Log out a user when user is not active

### DIFF
--- a/corehq/apps/users/middleware.py
+++ b/corehq/apps/users/middleware.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import logout
 from django.utils.deprecation import MiddlewareMixin
 
 from corehq.apps.users.models import CouchUser, InvalidUser
@@ -15,6 +16,9 @@ class UsersMiddleware(MiddlewareMixin):
         if 'org' in view_kwargs:
             request.org = view_kwargs['org']
         if request.user and request.user.is_authenticated:
+            if not request.user.is_active:
+                logout(request)
+                return self.get_response(request)
             user_id = username_to_user_id(request.user.username)
             couch_user = CouchUser.get_by_user_id(user_id)
             if not couch_user:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

When a user signed in, even if the user get deactivated, as long as the user is still in his session, he can still use commcarehq, which sounds unsafe.

This PR will make sure, after the user is deactivated, the next request he sent, will log him out.

I know it is not user friendly enough, so I created a follow up ticket: https://dimagi.atlassian.net/browse/SAAS-16009. We want to roll this out sooner to solve the issue for CRS.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15996

I modified the UsersMiddleWare that checks if a user is active during each request

logout function is used in Django documentation: https://docs.djangoproject.com/en/4.2/topics/auth/default/#how-to-log-a-user-out
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

This ticket improved safety as we only allow activated user access hq.
Tested locally and on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
