### PR TITLE
Disabling invite a deactivated user

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -23,7 +23,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.programs.models import Program
 from corehq.apps.users.forms import SelectUserLocationForm, BaseTableauUserForm
-from corehq.apps.users.models import CouchUser
+from corehq.apps.users.models import CouchUser, WebUser
 
 
 class RegisterWebUserForm(forms.Form):
@@ -592,6 +592,10 @@ class AdminInvitesUserForm(SelectUserLocationForm):
         if email.lower() in self.excluded_emails:
             raise forms.ValidationError(_("A user with this email address is already in "
                                           "this project or has a pending invitation."))
+        web_user = WebUser.get_by_username(email)
+        if web_user and not web_user.is_active:
+            raise forms.ValidationError(_("A user with this email address is deactivated. "
+                                          "Please reactivate this user first."))
         return email
 
     def clean(self):

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -594,8 +594,7 @@ class AdminInvitesUserForm(SelectUserLocationForm):
                                           "this project or has a pending invitation."))
         web_user = WebUser.get_by_username(email)
         if web_user and not web_user.is_active:
-            raise forms.ValidationError(_("A user with this email address is deactivated. "
-                                          "Please reactivate this user first."))
+            raise forms.ValidationError(_("A user with this email address is deactivated. "))
         return email
 
     def clean(self):

--- a/corehq/apps/registration/tests/test_forms.py
+++ b/corehq/apps/registration/tests/test_forms.py
@@ -14,14 +14,16 @@ patch_query = patch.object(
 
 
 @patch_query
-def test_minimal_valid_form():
+@patch("corehq.apps.users.models.WebUser.get_by_username", return_value=None)
+def test_minimal_valid_form(mock_web_user):
     form = create_form()
 
     assert form.is_valid(), form.errors
 
 
 @patch_query
-def test_form_is_invalid_when_invite_existing_email_with_case_mismatch():
+@patch("corehq.apps.users.models.WebUser.get_by_username", return_value=None)
+def test_form_is_invalid_when_invite_existing_email_with_case_mismatch(mock_web_user):
     form = create_form(
         {"email": "test@TEST.com"},
         excluded_emails=["TEST@test.com"],


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
![image](https://github.com/user-attachments/assets/a144deb2-a915-47d8-a031-1d59fd7940ff)

One of our customer thought, by invite an deactivated user who is already a member of the domain with a new role, the new role will overwrite the old role, which is not the case. Theoretically you should not invite someone who is already a member again. 
So I decide to disable invitation for deactivated user. This is discussed and approved in product meeting.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15997



## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. The change is very straightforward.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
