### PR TITLE
Check domain when getting lookup tables for view or download

### DIFF
--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -68,23 +68,7 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
     # Please remove this flag when this method no longer triggers an 'E' or 'F'
     # classification from the radon code static analysis
 
-    if table_ids and table_ids[0]:
-        try:
-            data_types_view = [LookupTable.objects.get(id=id, domain=domain) for id in table_ids]
-        except LookupTable.DoesNotExist:
-            if html_response:
-                raise FixtureDownloadError(
-                    _("Sorry, we couldn't find that table. If you think this "
-                      "is a mistake please report an issue."))
-            data_types_view = LookupTable.objects.by_domain(domain)
-    else:
-        data_types_view = LookupTable.objects.by_domain(domain)
-
-    if html_response:
-        data_types_view = list(data_types_view)[0:1]
-    else:
-        data_types_view = list(data_types_view)
-
+    data_types_view = _generate_data_types_view(table_ids, domain, html_response)
     total_tables = len(data_types_view)
     # when total_tables < 4 the final percentage can be >= 100%, but for
     # a small number of tables it renders more accurate progress
@@ -318,6 +302,25 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
         excel_sheets[data_type.tag] = item_sheet
 
     return data_types_book, excel_sheets
+
+
+def _generate_data_types_view(table_ids, domain, html_response):
+    if table_ids and table_ids[0]:
+        try:
+            data_types_view = [LookupTable.objects.get(id=id, domain=domain) for id in table_ids]
+        except LookupTable.DoesNotExist:
+            if html_response:
+                raise FixtureDownloadError(
+                    _("Sorry, we couldn't find that table. If you think this "
+                      "is a mistake please report an issue."))
+            data_types_view = LookupTable.objects.by_domain(domain)
+    else:
+        data_types_view = LookupTable.objects.by_domain(domain)
+
+    if html_response:
+        return list(data_types_view)[0:1]
+    else:
+        return list(data_types_view)
 
 
 class OwnerNames:

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -70,7 +70,7 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
 
     if table_ids and table_ids[0]:
         try:
-            data_types_view = [LookupTable.objects.get(id=id) for id in table_ids]
+            data_types_view = [LookupTable.objects.get(id=id, domain=domain) for id in table_ids]
         except LookupTable.DoesNotExist:
             if html_response:
                 raise FixtureDownloadError(


### PR DESCRIPTION
## Technical Summary
[SAAS-15893](https://dimagi.atlassian.net/browse/SAAS-15893)
Fixes an issue where a user with access to lookup tables can view base information about _any_ lookup table if its id is known. Also makes a _really_ small move toward refactoring the "HELPME" flagged `_prepare_fixtures` method.

## Safety Assurance

### Safety story
Given that we already use `LookupTable.objects.by_domain(domain)` as an alternative to getting specific tables by id, it seems that we should always have a valid `domain` to use here and that we can assert the table(s) should always belong to that domain. The refactor here is fairly trivial and just pulls some conditional logic into a helper function.

Tested locally and on staging to see that this does actually limit access based on the domain used in the request. We also get the helpful message: ![image](https://github.com/user-attachments/assets/724f3e4b-9bc4-46b1-9025-116f641d5c9a)


### Automated test coverage
It looks like `_prepare_fixture` is used in tests so would throw any obvious failures there, but not itself explicitly tested.

### QA Plan
Not planning QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-15893]: https://dimagi.atlassian.net/browse/SAAS-15893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ