### PR TITLE
Bug Fix - now() time showing PM when it should be AM

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -835,7 +835,7 @@ hqDefine("cloudcare/js/form_entry/entries", [
         this.templateType = 'time';
         if (question.style) {
             if (question.stylesContains(constants.TIME_12_HOUR)) {
-                this.clientFormat = 'h:mm T';
+                this.clientFormat = 'h:mm A';
             }
         }
         DateTimeEntryBase.call(this, question, options);

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -346,7 +346,7 @@ hqDefine('cloudcare/js/utils', [
     // TD does have a plugin to integrate with moment, but since other usages of TD in HQ
     // don't need it, instead of enabling that, hack around this.
     const _momentFormatToTempusFormat = function (momentFormat) {
-        return momentFormat.replaceAll("D", "d").replaceAll("Y", "y");
+        return momentFormat.replaceAll("D", "d").replaceAll("Y", "y").replaceAll("A", "T");
     };
 
     /** Coerce an input date string to a moment object */
@@ -393,6 +393,7 @@ hqDefine('cloudcare/js/utils', [
         }
 
         let date = moment(selectedTime, timeFormat);
+        const tempusTimeFormat = _momentFormatToTempusFormat(timeFormat);
         let options = {
             display: {
                 buttons: {
@@ -401,8 +402,8 @@ hqDefine('cloudcare/js/utils', [
                 },
             },
             localization: {
-                format: timeFormat,
-                hourCycle: timeFormat.indexOf('T') === -1 ? 'h23' : 'h12',
+                format: tempusTimeFormat,
+                hourCycle: tempusTimeFormat.indexOf('T') === -1 ? 'h23' : 'h12',
             },
             useCurrent: true,
         };


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
There was a bug where when a `12-hour` appearance attribute is used for a "time" question, the ui would display the `now()` time as AM when it should be PM.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-4920
](https://dimagi.atlassian.net/browse/USH-4920)

The cause of the bug is that the format `h:mm T` was used to convert the `moment` from server to client format. However, the `T` is not a supported moment format. Meaning that the string "17:00" would be incorrectly formatted to "5:00 T" as opposed to "5:00 PM". Later, when the moment is initiated using "5:00 T", it gets created as 5:00 (aka 5AM).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested, affects only UI and is limited to appearance attribute `12-hour`
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
