### PR TITLE
Set `secure` and `httponly` on `formplayer_session` cookie

### DIFF
--- a/corehq/apps/cloudcare/middleware.py
+++ b/corehq/apps/cloudcare/middleware.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
 FORMPLAYER_SESSION_COOKIE_NAME = 'formplayer_session'
-FORMPLAYER_SESSION_COOKIE_HTTPONLY = settings.SESSION_COOKIE_HTTPONLY
 
 
 class CloudcareMiddleware(MiddlewareMixin):
@@ -29,4 +28,4 @@ class CloudcareMiddleware(MiddlewareMixin):
         if couch_user:
             if request.COOKIES.get(FORMPLAYER_SESSION_COOKIE_NAME) != couch_user.user_id:
                 response.set_cookie(FORMPLAYER_SESSION_COOKIE_NAME, couch_user.user_id,
-                                    httponly=FORMPLAYER_SESSION_COOKIE_HTTPONLY)
+                                    httponly=settings.SESSION_COOKIE_HTTPONLY)

--- a/corehq/apps/cloudcare/middleware.py
+++ b/corehq/apps/cloudcare/middleware.py
@@ -1,7 +1,8 @@
+from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
-
 FORMPLAYER_SESSION_COOKIE_NAME = 'formplayer_session'
+FORMPLAYER_SESSION_COOKIE_HTTPONLY = settings.SESSION_COOKIE_HTTPONLY
 
 
 class CloudcareMiddleware(MiddlewareMixin):
@@ -27,4 +28,5 @@ class CloudcareMiddleware(MiddlewareMixin):
         couch_user = getattr(request, 'couch_user', None)
         if couch_user:
             if request.COOKIES.get(FORMPLAYER_SESSION_COOKIE_NAME) != couch_user.user_id:
-                response.set_cookie(FORMPLAYER_SESSION_COOKIE_NAME, couch_user.user_id)
+                response.set_cookie(FORMPLAYER_SESSION_COOKIE_NAME, couch_user.user_id,
+                                    httponly=FORMPLAYER_SESSION_COOKIE_HTTPONLY)

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -340,6 +340,10 @@ def get_view_func(view_fn, view_kwargs):
 
 
 class SecureCookiesMiddleware(MiddlewareMixin):
+    """Sets `secure` flag for cookies on the response object.
+    Must be come before middleware that adds cookies, because of order and layering.
+    https://docs.djangoproject.com/en/4.2/topics/http/middleware/#middleware-order-and-layering
+    """
 
     def process_response(self, request, response):
         if hasattr(response, 'cookies') and response.cookies:

--- a/settings.py
+++ b/settings.py
@@ -146,6 +146,7 @@ SECRET_KEY = 'you should really change this'
 
 MIDDLEWARE = [
     'corehq.middleware.NoCacheMiddleware',
+    'corehq.middleware.SecureCookiesMiddleware',
     'corehq.middleware.SelectiveSessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -171,8 +172,6 @@ MIDDLEWARE = [
     'no_exceptions.middleware.NoExceptionsMiddleware',
     'corehq.apps.locations.middleware.LocationAccessMiddleware',
     'corehq.apps.cloudcare.middleware.CloudcareMiddleware',
-    # middleware that adds cookies must come before SecureCookiesMiddleware
-    'corehq.middleware.SecureCookiesMiddleware',
     'field_audit.middleware.FieldAuditMiddleware',
 ]
 


### PR DESCRIPTION
## Technical Summary
[SAAS-15897](https://dimagi.atlassian.net/browse/SAAS-15897)
The `secure` flag was found not to be set on the `formplayer_session` cookie - this was traced to an issue of middleware order and layering (see [Django docs](https://docs.djangoproject.com/en/4.2/topics/http/middleware/#middleware-order-and-layering)). Since the `SecureCookiesMiddleware` modifies cookies the response object, it should be listed _above_ middleware that adds cookies. This is because middleware is processed as a stack, top -> bottom for the request, then bottom -> top for the response.

Here I've moved the `SecureCookiesMiddleware` above every middleware that seems to add cookies, though that may not be strictly necessary since `SelectiveSessionMiddleware` and `CsrfViewMiddleware` also set `secure` based on their own settings.

I've also set the `httponly` flag on the `formplayer_session` cookie as recommended in the ticket.

## Safety Assurance

### Safety story
Tested locally and on staging to see that `secure` is now set on the `formplayer_session` cookie according to `SecureCookiesMiddleware`, and additionally that it now affects the `sessionid` and `csrftoken` cookies.

Also confirmed that `httponly` is now set for the `formplayer_session` cookie, which is appropriate here because we don't ever access it in javascript.

### Automated test coverage
There are existing automated tests for `SecureCookiesMiddleware` though I haven't actually changed anything in that class.

### QA Plan
Not planning QA. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-15897]: https://dimagi.atlassian.net/browse/SAAS-15897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ