### PR TITLE
Allow specifying user ID on case property for conditional alert recipients

### DIFF
--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -2929,7 +2929,8 @@ class ConditionalAlertScheduleForm(ScheduleForm):
         ScheduleInstance.RECIPIENT_TYPE_USER_GROUP,
         CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER,
         CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER,
-        CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER,
+        CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME,
+        CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER_ID,
         CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
     ]
 
@@ -2992,6 +2993,10 @@ class ConditionalAlertScheduleForm(ScheduleForm):
     )
 
     username_case_property = CharField(
+        required=False,
+    )
+
+    user_id_case_property = CharField(
         required=False,
     )
 
@@ -3170,7 +3175,10 @@ class ConditionalAlertScheduleForm(ScheduleForm):
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER, _("The Case's Last Submitting User")),
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE, _("The Case's Parent Case")),
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_ALL_CHILD_CASES, _("The Case's Child Cases")),
-            (CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER, _("User Specified via Case Property")),
+            (CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME,
+                _("Username Specified via Case Property")),
+            (CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER_ID,
+                _("User ID Specified via Case Property")),
             (CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL, _("Email Specified via Case Property")),
         ]
         new_choices.extend(self.fields['recipient_types'].choices)
@@ -3210,8 +3218,10 @@ class ConditionalAlertScheduleForm(ScheduleForm):
         for recipient_type, recipient_id in recipients:
             if recipient_type == CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM:
                 initial['custom_recipient'] = recipient_id
-            if recipient_type == CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER:
+            if recipient_type == CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME:
                 initial['username_case_property'] = recipient_id
+            if recipient_type == CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER_ID:
+                initial['user_id_case_property'] = recipient_id
             if recipient_type == CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL:
                 initial['email_case_property'] = recipient_id
 
@@ -3377,7 +3387,13 @@ class ConditionalAlertScheduleForm(ScheduleForm):
                 _("Username Case Property"),
                 twbscrispy.InlineField('username_case_property'),
                 data_bind="visible: recipientTypeSelected('%s')" %
-                          CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER,
+                          CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME,
+            ),
+            hqcrispy.B3MultiField(
+                _("User ID Case Property"),
+                twbscrispy.InlineField('user_id_case_property'),
+                data_bind="visible: recipientTypeSelected('%s')" %
+                          CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER_ID,
             ),
             hqcrispy.B3MultiField(
                 _("Email Case Property"),
@@ -3776,9 +3792,13 @@ class ConditionalAlertScheduleForm(ScheduleForm):
             custom_recipient_id = self.cleaned_data['custom_recipient']
             result.append((CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM, custom_recipient_id))
 
-        if CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER in recipient_types:
+        if CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME in recipient_types:
             username_case_property = self.cleaned_data['username_case_property']
-            result.append((CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER, username_case_property))
+            result.append((CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME,
+                           username_case_property))
+        if CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER_ID in recipient_types:
+            user_id_case_property = self.cleaned_data['user_id_case_property']
+            result.append((CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER_ID, user_id_case_property))
         if CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL in recipient_types:
             email_case_property = self.cleaned_data['email_case_property']
             result.append((CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL, email_case_property))

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -635,9 +635,14 @@ class CaseScheduleInstanceMixin(object):
             )
             return custom_function(self)
         elif self.recipient_type == self.RECIPIENT_TYPE_CASE_PROPERTY_USER:
-            username = self.case.get_case_property(self.recipient_id)
-            full_username = format_username(username, self.domain)
-            return CommCareUser.get_by_username(full_username)
+            username_or_id = self.case.get_case_property(self.recipient_id)
+            if username_or_id:
+                try_full_username = format_username(username_or_id, self.domain)
+                try_cc_user = CommCareUser.get_by_username(try_full_username)
+                if try_cc_user:
+                    return try_cc_user
+                else:
+                    return WebUser.get_by_user_id(username_or_id) or CommCareUser.get_by_user_id(username_or_id)
         elif self.recipient_type == self.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL:
             return EmailAddressRecipient(self.case, self.recipient_id)
         else:

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -558,7 +558,8 @@ class CaseScheduleInstanceMixin(object):
     RECIPIENT_TYPE_PARENT_CASE = 'ParentCase'
     RECIPIENT_TYPE_ALL_CHILD_CASES = 'AllChildCases'
     RECIPIENT_TYPE_CUSTOM = 'CustomRecipient'
-    RECIPIENT_TYPE_CASE_PROPERTY_USER = 'CasePropertyUser'
+    RECIPIENT_TYPE_CASE_PROPERTY_USERNAME = 'CasePropertyUser'
+    RECIPIENT_TYPE_CASE_PROPERTY_USER_ID = 'CasePropertyUserId'
     RECIPIENT_TYPE_CASE_PROPERTY_EMAIL = 'CasePropertyEmail'
 
     @property
@@ -634,15 +635,14 @@ class CaseScheduleInstanceMixin(object):
                 settings.AVAILABLE_CUSTOM_SCHEDULING_RECIPIENTS[self.recipient_id][0]
             )
             return custom_function(self)
-        elif self.recipient_type == self.RECIPIENT_TYPE_CASE_PROPERTY_USER:
-            username_or_id = self.case.get_case_property(self.recipient_id)
-            if username_or_id:
-                try_full_username = format_username(username_or_id, self.domain)
-                try_cc_user = CommCareUser.get_by_username(try_full_username)
-                if try_cc_user:
-                    return try_cc_user
-                else:
-                    return WebUser.get_by_user_id(username_or_id) or CommCareUser.get_by_user_id(username_or_id)
+        elif self.recipient_type == self.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME:
+            username = self.case.get_case_property(self.recipient_id)
+            if username:
+                return CouchUser.get_by_username(format_username(username, self.domain))
+        elif self.recipient_type == self.RECIPIENT_TYPE_CASE_PROPERTY_USER_ID:
+            user_id = self.case.get_case_property(self.recipient_id)
+            if user_id:
+                return CouchUser.get_by_user_id(user_id)
         elif self.recipient_type == self.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL:
             return EmailAddressRecipient(self.case, self.recipient_id)
         else:

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -655,6 +655,37 @@ class SchedulingRecipientTest(TestCase):
             )
             self.assertIsNone(instance.recipient)
 
+    def test_user_id_case_property_recipient(self):
+        # test valid ID
+        with create_case(
+                self.domain,
+                'person',
+                owner_id=self.city_location.location_id,
+                update={'hq_user_id': self.web_user.get_id}
+        ) as case:
+            instance = CaseTimedScheduleInstance(
+                domain=self.domain,
+                case_id=case.case_id,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER,
+                recipient_id='hq_user_id'
+            )
+            self.assertEqual(instance.recipient.get_id, self.web_user.get_id)
+
+        # test invalid ID
+        with create_case(
+                self.domain,
+                'person',
+                owner_id=self.city_location.location_id,
+                update={'hq_user_id': '1234abcd'}
+        ) as case:
+            instance = CaseTimedScheduleInstance(
+                domain=self.domain,
+                case_id=case.case_id,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER,
+                recipient_id='hq_user_id'
+            )
+            self.assertEqual(instance.recipient, None)
+
     def test_email_case_property_recipient(self):
         with create_case(
                 self.domain,

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -621,7 +621,7 @@ class SchedulingRecipientTest(TestCase):
             instance = CaseTimedScheduleInstance(
                 domain=self.domain,
                 case_id=case.case_id,
-                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME,
                 recipient_id='recipient'
             )
             self.assertEqual(instance.recipient.get_id, self.full_mobile_user.get_id)
@@ -636,7 +636,7 @@ class SchedulingRecipientTest(TestCase):
             instance = CaseTimedScheduleInstance(
                 domain=self.domain,
                 case_id=case.case_id,
-                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME,
                 recipient_id='recipient'
             )
             self.assertIsNone(instance.recipient)
@@ -650,7 +650,7 @@ class SchedulingRecipientTest(TestCase):
             instance = CaseTimedScheduleInstance(
                 domain=self.domain,
                 case_id=case.case_id,
-                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME,
                 recipient_id='recipient'
             )
             self.assertIsNone(instance.recipient)
@@ -666,7 +666,7 @@ class SchedulingRecipientTest(TestCase):
             instance = CaseTimedScheduleInstance(
                 domain=self.domain,
                 case_id=case.case_id,
-                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER_ID,
                 recipient_id='hq_user_id'
             )
             self.assertEqual(instance.recipient.get_id, self.web_user.get_id)
@@ -681,7 +681,7 @@ class SchedulingRecipientTest(TestCase):
             instance = CaseTimedScheduleInstance(
                 domain=self.domain,
                 case_id=case.case_id,
-                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER,
+                recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER_ID,
                 recipient_id='hq_user_id'
             )
             self.assertEqual(instance.recipient, None)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Jira: https://dimagi.atlassian.net/browse/USH-4811

For the "user specified via case property" recipient option for conditional alerts, this PR enables specifying a user ID (which can be for a web or mobile user) on a case property instead of just a mobile worker username.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

Small change.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Logic of change is well covered by automated tests
- Small change, confident in the safety of the logic
- Works on staging!

### Automated test coverage

corehq.messaging.scheduling.tests.test_recipients:SchedulingRecipientTest.test_user_id_case_property_recipient

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
