### PR TITLE
Decrease allowed elasticsearch delay to refresh interval in dedupe rule run

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1166,7 +1166,8 @@ class CaseDeduplicationActionDefinition(BaseUpdateCaseDefinition):
         dedupe_load_counter('unknown', case.domain)()
 
         if not case_matching_rule_criteria_exists_in_es(case, rule):
-            ALLOWED_ES_DELAY = timedelta(hours=1)
+            # refresh interval + avg time to refresh + extra buffer = 1 minute
+            ALLOWED_ES_DELAY = timedelta(minutes=1)
             if datetime.utcnow() - case.server_modified_on > ALLOWED_ES_DELAY:
                 # If old data was found that is not present in ElasticSearch, the data is unreliable.
                 # We've decided skipping this record and recording an error is likely the safest way to handle this


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
The current allowed delay of 1 hour is too lenient and leading to performance issues on elasticsearch.

Our current configuration is set to refresh an index every 5 seconds. As far as I know, there isn't a reported bug in Elasticsearch v5.6 around the refresh interval. It is the case that it takes time to refresh the index, which appears to be roughly ~10 seconds, so refreshes are occurring every 15 seconds in steady state. As documented by Elasticsearch, it is also the case that:
> By default, Elasticsearch periodically refreshes indices every second, but only on indices that have received one search request or more in the last 30 seconds

So my math is 5s refresh interval + 10s avg refresh time + 30s grace period = 45 seconds, and rounding up to a minute seems fine. This should ensure that if the case update is not reflected in ES when the dedupe processor runs, it will _definitely_ trigger a refresh for the index since it performed a search request, and be requeued/resaved to try again. Once it is retried, if it is still not showing up in elasticsearch, I'm inclined to say the reason is unrelated to a stale index in elasticsearch until we have proof otherwise.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change only impacts the deduplication feature. In the worst case, it will lead to fewer duplicates being flagged, but my understanding is that it is already the case that we were still reaching this code path very frequently even with the 1 hour grace period set. If we want to be sure that this change does not have a drastic impact, perhaps the best way is to add a metric in this code path that reports the count for how often a matching case is not found in ES _and_ the grace period has been exceeded, and see how much this change impacts that metric. @mjriley would that make you feel better about this change? PR [here](https://github.com/dimagi/commcare-hq/pull/35155)

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
