### PR TITLE
Add metric for no matching case in dedupe

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -72,7 +72,6 @@ from corehq.sql_db.util import (
 )
 from corehq import toggles
 from corehq.util.log import with_progress_bar
-from corehq.util.metrics import metrics_counter
 from corehq.util.metrics.load_counters import dedupe_load_counter
 from corehq.util.quickcache import quickcache
 from corehq.util.test_utils import unit_testing_only
@@ -1164,8 +1163,6 @@ class CaseDeduplicationActionDefinition(BaseUpdateCaseDefinition):
         if is_copied_case(case):
             return CaseRuleActionResult()
 
-        dedupe_load_counter('unknown', case.domain)()
-
         if not case_matching_rule_criteria_exists_in_es(case, rule):
             ALLOWED_ES_DELAY = timedelta(hours=1)
             if datetime.utcnow() - case.server_modified_on > ALLOWED_ES_DELAY:
@@ -1179,7 +1176,7 @@ class CaseDeduplicationActionDefinition(BaseUpdateCaseDefinition):
                 # but disabling this to avoid further quota issues.
                 # raise ValueError(f'Unable to find current ElasticSearch data for: {case.case_id}')
                 # Ignore this result for now
-                metrics_counter('commcare.dedupe.no_matching_case', tags={'domain': case.domain})
+                dedupe_load_counter('unknown', case.domain, {'result': 'errored'})()
                 return CaseRuleActionResult(num_errors=1)
             else:
                 # Normal processing can involve latency between when a case is written to the database and when
@@ -1191,8 +1188,11 @@ class CaseDeduplicationActionDefinition(BaseUpdateCaseDefinition):
                 # inserts into ElasticSearch are asychronous, we can receive cases here that will not yet be
                 # present in ElasticSearch but will never be processed later. In the short-term, we're avoiding
                 # this by resaving the case, with the intention to use a more stable approach in the future
+                dedupe_load_counter('unknown', case.domain, {'result': 'retried'})()
                 resave_case(rule.domain, case, send_post_save_signal=False)
                 return CaseRuleActionResult(num_updates=0)
+
+        dedupe_load_counter('unknown', case.domain, {'result': 'processed'})()
 
         try:
             existing_duplicate = CaseDuplicateNew.objects.get(case_id=case.case_id, action=self)

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -72,6 +72,7 @@ from corehq.sql_db.util import (
 )
 from corehq import toggles
 from corehq.util.log import with_progress_bar
+from corehq.util.metrics import metrics_counter
 from corehq.util.metrics.load_counters import dedupe_load_counter
 from corehq.util.quickcache import quickcache
 from corehq.util.test_utils import unit_testing_only
@@ -1178,6 +1179,7 @@ class CaseDeduplicationActionDefinition(BaseUpdateCaseDefinition):
                 # but disabling this to avoid further quota issues.
                 # raise ValueError(f'Unable to find current ElasticSearch data for: {case.case_id}')
                 # Ignore this result for now
+                metrics_counter('commcare.dedupe.no_matching_case', tags={'domain': case.domain})
                 return CaseRuleActionResult(num_errors=1)
             else:
                 # Normal processing can involve latency between when a case is written to the database and when


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
~If we want it, can be useful to do a before/after when decreasing the allowed lag in ES for dedupe. Related to https://github.com/dimagi/commcare-hq/pull/35154~

This is a good chance to make as it will give us insight into the breakdown of dedupe load (how much of that load is from retries).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
