### PR TITLE
FHIR Importer docs and UI changes (minor)

### DIFF
--- a/corehq/motech/admin.py
+++ b/corehq/motech/admin.py
@@ -1,0 +1,32 @@
+from django.contrib import admin
+from django.utils.html import escape
+from .models import ConnectionSettings
+
+
+class ConnectionSettingsAdmin(admin.ModelAdmin):
+    model = ConnectionSettings
+    fieldsets = [(None, {
+        'description': escape('To edit, go to /a/<domain>/motech/conn/'),
+        'fields': [
+            'domain',
+            'name',
+            'notify_addresses_str',
+            'url',
+            'auth_type',
+            'skip_cert_verify',
+            'is_deleted',
+        ],
+    })]
+    search_fields = ('name', 'domain',)
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+admin.site.register(ConnectionSettings, ConnectionSettingsAdmin)

--- a/corehq/motech/fhir/admin.py
+++ b/corehq/motech/fhir/admin.py
@@ -69,6 +69,7 @@ class FHIRImportConfigAdmin(admin.ModelAdmin):
     )
     list_filter = ('domain',)
     list_select_related = ('connection_settings',)
+    autocomplete_fields = ('connection_settings',)
 
 
 class FHIRImportResourcePropertyInline(admin.TabularInline):

--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -117,7 +117,7 @@ class ConnectionSettings(models.Model):
     encrypted_fields = {"password": PASSWORD_PLACEHOLDER, "client_secret": PASSWORD_PLACEHOLDER}
 
     def __str__(self):
-        return self.name
+        return f"{self.name} [{self.domain}]"
 
     @property
     def repeaters(self):

--- a/docs/fhir/fhir_import_config.rst
+++ b/docs/fhir/fhir_import_config.rst
@@ -65,7 +65,7 @@ and select the case type.
     to send the same resources back to FHIR when they are modified in
     CommCare, then you will either need to stick to the Data Dictionary
     FHIR resource types limitation, or add the resource type you want to
-    the list in `corehq/motech/fhir/const.py`_.)
+    the ``FHIR_DATA_TYPES`` const in ``corehq/motech/fhir/const.py``
 
 The "Import related only" checkbox controls that third import strategy
 mentioned earlier.
@@ -119,8 +119,6 @@ some of the imported values before overwriting existing values on the
 case. It is wise to confirm with the delivery team how to treat case
 properties that can be edited.
 
-
-.. _corehq/motech/fhir/const.py: https://github.com/dimagi/commcare-hq/blob/master/corehq/motech/fhir/const.py#L35
 .. _Patient search parameters: https://www.hl7.org/fhir/patient.html#search
 
 

--- a/docs/fhir/fhir_import_config.rst
+++ b/docs/fhir/fhir_import_config.rst
@@ -43,10 +43,9 @@ cases will be assigned to this ID.
 Mapping imported FHIR resource properties
 -----------------------------------------
 
-Resource properties are mapped via the Admin interface using
-ValueSource definitions, similar to :ref:`admin-interface-mapping` for
-data forwarding and the FHIR API. But there are a few important
-differences:
+Resource properties are mapped via the Admin interface using ValueSource
+definitions, similar to :ref:`admin-interface-mapping` for data
+forwarding and the FHIR API. But there are a few important differences:
 
 The first difference is that FHIRRepeater and the FHIR API use
 FHIRResourceType instances (rendered as "FHIR Resource Types" in Django
@@ -89,14 +88,14 @@ Patient's phone number. They might look like this:
 .. code:: javascript
 
     {
-      "jsonpath":"$.telecom[0].system",
+      "jsonpath": "$.telecom[0].system",
       "value": "phone"
     }
 
 .. code:: javascript
 
     {
-      "jsonpath":"$.telecom[0].value",
+      "jsonpath": "$.telecom[0].value",
       "case_property": "phone_number"
     }
 
@@ -108,7 +107,7 @@ item whose "system" is set to "phone". That is defined like this:
 .. code:: javascript
 
     {
-      "jsonpath":"$.telecom[?system='phone'].value",
+      "jsonpath": "$.telecom[?system='phone'].value",
       "case_property": "phone_number"
     }
 

--- a/docs/fhir/fhir_import_config.rst
+++ b/docs/fhir/fhir_import_config.rst
@@ -128,26 +128,40 @@ Configuring related resources
 If a FHIR Import resource type has "Import related only" checked, we
 need to configure how the resource type is related.
 
-Navigate to FHIR > JSON Path to resource types, and click "Add JSON Path
-to resource type".
+For example, Patient resources may have associated ServiceRequests, which you
+may want to import. To achieve this, you'd set up a FHIRImportResourceType for
+ServiceRequests, with "import related only" checked, so only those associated
+with patients in the import are fetched.
 
-A ServiceRequest.subject is a reference to the Patient it is referring.
+Navigate to FHIR > "Resource type relationships", and click "Add
+resource type relationship".
 
-Set "Resource type" to "ServiceRequest".
+Relationships are configured on the child resource type, with a
+reference to their parent, just like a typical foreign key relationship.
+Options available in this config are:
 
-Set "JSONPath" to "$.subject.reference".
+* Resource type - the type of the child or descendant resource.
+* Jsonpath - the path used to identify the parent or ancestor resource.
+* Related resource type - the type of the parent or ancestor resource.
+* Related resource is parent - checkbox indicating whether CommCare
+  should set up a parent/child index between the two cases.
 
-Set "Related resource type" to "Patient".
+.. admonition:: Example: Adding a patient service request
 
-If the "Related resource is parent" checkbox is not checked, then
-CommCare will just create a case for the Patient. If it is checked, then
-CommCare will also create an index on the case for the ServiceRequest as
-a child case, and link it to the case for the Patient as its parent
-case.
+    First set up a ServiceRequest resource type as described in the previous
+    section. Check "import related only" to only fetch those linked to patients
+    in the import. Then navigate to the "Add resource type relationship" page.
 
-The child-to-parent relationship will follow the direction of the
-reference. So if a Foo resource has a reference to a Bar resource,
-then in CommCare the "foo" case will be the child of the "bar" case.
+    ``ServiceRequest.subject`` references the Patient it is referring.
+    To set up this relationship:
+
+    * Set "Resource type" to "ServiceRequest".
+    * Set "Jsonpath" to ``$.subject.reference``.
+    * Set "Related resource type" to "Patient".
+
+    If the "Related resource is parent" checkbox is checked, then CommCare will
+    create an index on the ServiceRequest case, making the Patient case its
+    parent.
 
 
 Testing FHIRImportConfig configuration

--- a/docs/fhir/fhir_import_config.rst
+++ b/docs/fhir/fhir_import_config.rst
@@ -53,8 +53,8 @@ FHIRResourceType instances (rendered as "FHIR Resource Types" in Django
 Admin) to configure mapping; FHIRImportConfig uses
 FHIRImportResourceType instances ("FHIR Import Resource Types").
 
-To see what this looks like, navigate to FHIR > FHIR Importer Resource
-Types, and click "Add FHIR Importer Resource Type".
+To see what this looks like, navigate to FHIR > FHIR Import Resource
+Types, and click "Add FHIR Import Resource Type".
 
 Select the FHIR Import Config, set the name of the FHIR resource type,
 and select the case type.
@@ -127,7 +127,7 @@ properties that can be edited.
 Configuring related resources
 -----------------------------
 
-If a FHIR Importer resource type has "Import related only" checked, we
+If a FHIR Import resource type has "Import related only" checked, we
 need to configure how the resource type is related.
 
 Navigate to FHIR > JSON Path to resource types, and click "Add JSON Path

--- a/docs/fhir/fhir_import_config.rst
+++ b/docs/fhir/fhir_import_config.rst
@@ -35,17 +35,9 @@ In Django Admin, navigate to FHIR > FHIR Import Configs. If you have any
 FHIRImportConfig instances, they will be listed there, and you can
 filter by domain. To add a new one, click "Add FHIR Import Config +".
 
-The form is quite straight forward. You will need to provide the ID of a
-mobile worker in the "Owner ID" field. All cases that are imported will
-be assigned to this user.
-
-This workflow will not scale for large projects. When such a project
-comes up, we have planned for two approaches, and will implement one or
-both based on the project's requirements:
-
-1. Set the owner to a user, group or location.
-2. Assign a FHIRImportConfig to a CommCare location, and set ownership
-   to the mobile worker at that location.
+The form is quite straightforward. You will need to provide the ID of a
+mobile worker, location, or group in the "Owner ID" field. All imported
+cases will be assigned to this ID.
 
 
 Mapping imported FHIR resource properties

--- a/docs/fhir/fhir_import_config.rst
+++ b/docs/fhir/fhir_import_config.rst
@@ -58,14 +58,6 @@ Types, and click "Add FHIR Import Resource Type".
 Select the FHIR Import Config, set the name of the FHIR resource type,
 and select the case type.
 
-.. note::
-    The resource types you can import are not limited to the resource
-    types that can be managed using the Data Dictionary. But if you want
-    to send the same resources back to FHIR when they are modified in
-    CommCare, then you will either need to stick to the Data Dictionary
-    FHIR resource types limitation, or add the resource type you want to
-    the ``FHIR_DATA_TYPES`` const in ``corehq/motech/fhir/const.py``
-
 The "Import related only" checkbox controls that third import strategy
 mentioned earlier.
 

--- a/docs/fhir/fhir_import_config.rst
+++ b/docs/fhir/fhir_import_config.rst
@@ -31,14 +31,6 @@ Configuring a FHIRImportConfig
 Currently, all configuration is managed via Django Admin (except for
 adding Connection Settings).
 
-.. warning::
-    Django Admin cannot filter select box values by domain. Name your
-    Connection Setting with the name of your domain so that typing the
-    domain name in the select box will find it fast.
-
-    .. TODO: Is this definitely true? Is there no way to filter select
-             box values by domain?
-
 In Django Admin, navigate to FHIR > FHIR Import Configs. If you have any
 FHIRImportConfig instances, they will be listed there, and you can
 filter by domain. To add a new one, click "Add FHIR Import Config +".


### PR DESCRIPTION
## Product Description

I was recently reviewing some of our FHIR documentation and familiarizing myself with the importer tool.  Made some minor improvements to the process and particularly the docs.  See commit messages for explanations.

The non-documentation changes are to the admin interface - I added `ConnectionSettings` as a non-editable model and configured it so the `FHIRImportConfigAdmin` can do a fancier select2 autocomplete against both name and domain.  Here's what that looks like now:

![image](https://github.com/user-attachments/assets/ab3ed6a2-2858-41e3-b935-dc414383f756)

And if you click on the :eye: , it takes you to this page:

![image](https://github.com/user-attachments/assets/a779187a-cf3d-4e45-ad31-c531b24e029d)

Aside: if you don't disable the add/change/delete permissions, you get :heavy_plus_sign: ,  :pencil2: , and :wastebasket: actions available in line too - very fancy!

## Technical Summary


## Feature Flag


## Safety Assurance


### Safety story

Admin-only pages - should only affect creation and editing of these settings, not their actual usage.  Local testing seems sufficient.

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change