### PR TITLE
Fix bug with the location search on conditional alerts screen

### DIFF
--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -264,10 +264,9 @@ class FilteredLocationDownload(BaseLocationView):
 
 class LocationOptionsController(EmwfOptionsController):
     namespace_locations = False
-    case_sharing_only = False
 
-    def __init__(self, *args, include_locations_with_no_users=True):
-        super().__init__(*args)
+    def __init__(self, *args, include_locations_with_no_users=True, **kwargs):
+        super().__init__(*args, **kwargs)
         self.include_locations_with_no_users = include_locations_with_no_users
 
     @property


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

When selecting an organization as a recipient for a conditional alert, the search/dropdown to select a location does not work:

![Screenshot 2024-09-30 at 4 21 36 PM](https://github.com/user-attachments/assets/5ac62ba7-5cb8-4c9b-bd7a-ab51e0aaad0c)

The dropdown is broken, so you can't select a new location recipeint for new/existing alerts, though existing alerts and their already-chosen recipients should be fine.

Introduced in https://github.com/dimagi/commcare-hq/pull/34912.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

The error message returned by the request to get the locations for the dropdown is:

```
__init__() got an unexpected keyword argument 'case_sharing_only'
```

This is because the recent changes introduced an init method `LocationOptionsController.__init__` which does not allow for other kwargs, like `case_sharing_only`. This PR allows for other kwargs to be passed to `__init__`.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- `LocationOptionsController` is only used in two places, and you can see how its initiated
- The fix works locally, and I confirmed the user location selection widget looks OK locally
- There are some automated tests for `LocationsSearchViewTest`

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

corehq.apps.locations.tests.test_views:LocationSearchViewTest

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

None planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

(original bug would be re-introduced)

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
