### PR TITLE
B5 migration tool: Updated regex for make_data_attribute_renames

### DIFF
--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -79,6 +79,15 @@ def test_make_data_attribute_renames_bootstrap5():
     eq(renames, ['renamed data-toggle to data-bs-toggle'])
 
 
+def test_ko_make_data_attribute_renames_bootstrap5():
+    line = """        data-bind="attr: {'data-target': '#modalGroup-' + id()}"\n"""
+    final_line, renames = make_data_attribute_renames(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    eq(final_line, """        data-bind="attr: {'data-bs-target': '#modalGroup-' + id()}"\n""")
+    eq(renames, ['renamed data-target to data-bs-target'])
+
+
 def test_make_javascript_dependency_renames():
     line = """        "hqwebapp/js/bootstrap3/widgets",\n"""
     final_line, renames = make_javascript_dependency_renames(

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -127,7 +127,7 @@ def make_data_attribute_renames(line, spec):
     return _do_rename(
         line,
         spec['data_attribute_renames'],
-        lambda x: r"([\n }])(" + x + r")(=[\"\'])",
+        lambda x: r"([\n }\"\'])(" + x + r")([\"\']?[=:]\s*[\"\'])",
         lambda x: r"\1" + spec['data_attribute_renames'][x] + r"\3"
     )
 


### PR DESCRIPTION
## Technical Summary
Ran into this while migrating exports.

Updates the regex that renames data attributes to also capture attributes that are set via a knockout `attr` binding.

For example, the tool would now rename [this attribute](https://github.com/dimagi/commcare-hq/blob/2a6e9c79051993e20e44a8ec189d4139edd26c88/corehq/apps/export/templates/export/partials/bootstrap5/table.html#L278) to `data-bs-target`.

## Safety Assurance

### Safety story
internal tool

### Automated test coverage

yes, in PR

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
