### PR TITLE
Error handling for ArcGIS responses

### DIFF
--- a/corehq/motech/repeaters/expression/repeaters.py
+++ b/corehq/motech/repeaters/expression/repeaters.py
@@ -220,9 +220,7 @@ class ArcGISFormExpressionRepeater(FormExpressionRepeater):
 
     def send_request(self, repeat_record, payload):
         response = super().send_request(repeat_record, payload)
-        if not is_success_response(response):
-            return response
-        if 'error' in response.json():
+        if is_success_response(response) and 'error' in response.json():
             # It _looks_ like a success response, but it's an error. :/
             return self._error_response(response.json())
         return response

--- a/corehq/motech/repeaters/expression/repeaters.py
+++ b/corehq/motech/repeaters/expression/repeaters.py
@@ -2,7 +2,10 @@ import logging
 from json import JSONDecodeError
 
 from django.utils.translation import gettext_lazy as _
+
 from memoized import memoized
+
+from dimagi.utils.logging import notify_exception
 
 from corehq.apps.hqcase.api.updates import handle_case_update
 from corehq.apps.hqcase.case_helper import UserDuck
@@ -10,18 +13,24 @@ from corehq.apps.hqcase.utils import REPEATER_RESPONSE_XMLNS
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.filters.factory import FilterFactory
 from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
-from corehq.form_processor.models import CaseTransaction, CommCareCase, XFormInstance
+from corehq.form_processor.models import (
+    CaseTransaction,
+    CommCareCase,
+    XFormInstance,
+)
+from corehq.motech.repeater_helpers import RepeaterResponse
 from corehq.motech.repeaters.expression.repeater_generators import (
     ArcGISFormExpressionPayloadGenerator,
+    ExpressionPayloadGenerator,
     FormExpressionPayloadGenerator,
 )
-from corehq.motech.repeaters.expression.repeater_generators import (
-    ExpressionPayloadGenerator,
+from corehq.motech.repeaters.models import (
+    OptionValue,
+    Repeater,
+    is_response,
+    is_success_response,
 )
-from corehq.motech.repeaters.models import OptionValue, Repeater
-from corehq.motech.repeaters.models import is_response, is_success_response
 from corehq.toggles import ARCGIS_INTEGRATION, EXPRESSION_REPEATER
-from dimagi.utils.logging import notify_exception
 
 # max number of repeater updates in a chain before we stop forwarding
 MAX_REPEATER_CHAIN_LENGTH = 5
@@ -207,6 +216,52 @@ class ArcGISFormExpressionRepeater(FormExpressionRepeater):
         return (
             super(ArcGISFormExpressionRepeater, cls).available_for_domain(domain)
             and ARCGIS_INTEGRATION.enabled(domain)
+        )
+
+    def send_request(self, repeat_record, payload):
+        response = super().send_request(repeat_record, payload)
+        if not is_success_response(response):
+            return response
+        if 'error' in response.json():
+            # It _looks_ like a success response, but it's an error. :/
+            return self._error_response(response.json())
+        return response
+
+    @staticmethod
+    def _error_response(response_json):
+        """
+        The ArcGIS API returns error responses with status code 200.
+
+        This method extracts the details from the response JSON, and
+        returns a RepeaterResponse with the error details so that the
+        response will be handled correctly.
+
+        >>> response_json = {
+        ...     "error": {
+        ...         "code": 403,
+        ...         "details": [
+        ...             "You do not have permissions to access this "
+        ...             "resource or perform this operation."
+        ...         ],
+        ...         "message": "You do not have permissions to access "
+        ...                    "this resource or perform this operation.",
+        ...         "messageCode": "GWM_0003"
+        ...     }
+        ... }
+        >>> resp = ArcGISFormExpressionRepeater._error_response(response_json)
+        >>> resp.status_code
+        403
+        >>> resp.reason
+        'You do not have permissions to access this resource or perform this operation. (GWM_0003)'
+        >>> resp.text
+        'You do not have permissions to access this resource or perform this operation.'
+
+        """
+        return RepeaterResponse(
+            status_code=response_json['error']['code'],
+            reason=f'{response_json["error"]["message"]} '
+                   f'({response_json["error"]["messageCode"]})',
+            text='\n'.join(response_json['error']['details']),
         )
 
 

--- a/corehq/motech/repeaters/expression/tests.py
+++ b/corehq/motech/repeaters/expression/tests.py
@@ -1,4 +1,5 @@
 import dataclasses
+import doctest
 import json
 import uuid
 from datetime import datetime, timedelta
@@ -6,8 +7,8 @@ from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
-from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.mock import CaseFactory
+from casexml.apps.case.mock import CaseBlock, CaseFactory
+
 from corehq.apps.accounting.models import SoftwarePlanEdition
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.accounting.utils import clear_plan_version_cache
@@ -19,9 +20,10 @@ from corehq.form_processor.models import CaseTransaction, CommCareCase
 from corehq.form_processor.models.cases import FormSubmissionDetail
 from corehq.motech.models import ConnectionSettings
 from corehq.motech.repeaters.expression.repeaters import (
-    CaseExpressionRepeater,
+    MAX_REPEATER_CHAIN_LENGTH,
     ArcGISFormExpressionRepeater,
-    FormExpressionRepeater, MAX_REPEATER_CHAIN_LENGTH,
+    CaseExpressionRepeater,
+    FormExpressionRepeater,
 )
 from corehq.motech.repeaters.models import RepeatRecord
 from corehq.util.test_utils import flag_enabled, generate_cases
@@ -464,3 +466,10 @@ class ArcGISExpressionRepeaterTest(FormExpressionRepeaterTest):
             'f': 'json',
             'token': ''
         }
+
+
+def test_doctests():
+    import corehq.motech.repeaters.expression.repeaters as module
+
+    results = doctest.testmod(module)
+    assert results.failed == 0


### PR DESCRIPTION
## Technical Summary

The ArcGIS API returns error responses with status code 200, and the actual error code inside a JSON document.

This change parses the JSON response body, and returns an object that looks like a proper error response, so that it is handled correctly.

Jira: [SC-3938](https://dimagi.atlassian.net/browse/SC-3938)

## Feature Flag

arcgis_integration

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Includes test coverage

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3938]: https://dimagi.atlassian.net/browse/SC-3938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ