### PR TITLE
Disable CodeQL on PR merges

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,8 +12,8 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ master ]
+#  push:
+#    branches: [ master ]
 #  pull_request:
 #    # The branches below must be a subset of the branches above
 #    branches: [ master ]


### PR DESCRIPTION
## Product Description


## Technical Summary
Following up from https://github.com/dimagi/commcare-hq/commit/c640813c40132d4c28056a099778b2c7c309b2ac
This switches the CodeQL workflow to run only once a week, not also on PR merge.

## Feature Flag


## Safety Assurance
Only affects CodeQL workflow

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change