### PR TITLE
Retry 400 "Bad Request" responses

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -462,6 +462,7 @@ class Repeater(RepeaterSuperProxy):
         result may be either a response object or an exception
         """
         _4XX_retry_codes = (
+            HTTPStatus.BAD_REQUEST,
             HTTPStatus.REQUEST_TIMEOUT,
             HTTPStatus.CONFLICT,
             HTTPStatus.PRECONDITION_FAILED,

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -1,6 +1,7 @@
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+from http import HTTPStatus
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
@@ -14,6 +15,7 @@ from freezegun import freeze_time
 from nose.tools import assert_in, assert_raises
 
 from corehq.motech.models import ConnectionSettings
+from corehq.motech.repeater_helpers import RepeaterResponse
 from corehq.util.test_utils import _create_case
 
 from ..const import (
@@ -27,6 +29,7 @@ from ..const import (
     State,
 )
 from ..models import (
+    HTTP_STATUS_4XX_RETRY,
     FormRepeater,
     Repeater,
     RepeatRecord,
@@ -390,6 +393,75 @@ class AttemptsTests(RepeaterTestCase):
             self.assertEqual(len(self.repeat_record.attempts), 2)
         with self.assertNumQueries(0):
             self.assertEqual(len(self.repeat_record.attempts), 2)
+
+
+class TestRepeaterHandleResponse(RepeaterTestCase):
+
+    @contextmanager
+    def repeat_record(self):
+        repeat_record = self.repeater.repeat_records.create(
+            domain=DOMAIN,
+            payload_id='eggs',
+            registered_at=timezone.now(),
+        )
+        try:
+            yield repeat_record
+        finally:
+            repeat_record.delete()
+
+    def test_handle_response_success(self):
+        resp = RepeaterResponse(
+            status_code=200,
+            reason='OK',
+            text='<h1>Hello World</h1>',
+        )
+        with self.repeat_record() as repeat_record:
+            self.repeater.handle_response(resp, repeat_record)
+            self.assertEqual(repeat_record.state, RECORD_SUCCESS_STATE)
+
+    def test_handle_response_server_failure(self):
+        resp = RepeaterResponse(
+            status_code=504,
+            reason='Gateway Timeout',
+        )
+        with self.repeat_record() as repeat_record:
+            self.repeater.handle_response(resp, repeat_record)
+            self.assertEqual(repeat_record.state, RECORD_FAILURE_STATE)
+
+    def test_handle_4XX_retry_codes(self):
+        for status_code in HTTP_STATUS_4XX_RETRY:
+            resp = RepeaterResponse(
+                status_code=status_code,
+                reason='Retry',
+            )
+            with self.repeat_record() as repeat_record:
+                self.repeater.handle_response(resp, repeat_record)
+                self.assertEqual(repeat_record.state, RECORD_FAILURE_STATE)
+
+    def test_handle_4XX_invalid_payload(self):
+        for http_status in HTTPStatus:
+            if (
+                400 <= http_status.value < 500
+                and http_status not in HTTP_STATUS_4XX_RETRY
+            ):
+                resp = RepeaterResponse(
+                    status_code=http_status.value,
+                    reason='Invalid Payload',
+                )
+                with self.repeat_record() as repeat_record:
+                    self.repeater.handle_response(resp, repeat_record)
+                    self.assertEqual(repeat_record.state, RECORD_INVALIDPAYLOAD_STATE)
+
+    def test_handle_5XX_retry(self):
+        for http_status in HTTPStatus:
+            if 500 <= http_status.value < 600:
+                resp = RepeaterResponse(
+                    status_code=http_status.value,
+                    reason='Invalid Payload',
+                )
+                with self.repeat_record() as repeat_record:
+                    self.repeater.handle_response(resp, repeat_record)
+                    self.assertEqual(repeat_record.state, RECORD_FAILURE_STATE)
 
 
 class TestConnectionSettingsUsedBy(TestCase):

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -240,10 +240,18 @@ class RepeaterTest(BaseRepeaterTest):
         )
         self.assertEqual(len(repeat_records), 2)
 
-    def test_repeater_payload_failed_cancels(self):
-        """
-        This tests records with bad payloads are cancelled
-        """
+    def test_bad_payload_invalid(self):
+        with patch(
+            'corehq.motech.repeaters.models.simple_request',
+            return_value=MockResponse(status_code=401, reason='Unauthorized')
+        ):
+            for repeat_record in self.repeat_records():
+                repeat_record.fire()
+
+        for repeat_record in self.repeat_records():
+            self.assertEqual(repeat_record.state, State.InvalidPayload)
+
+    def test_bad_request_fail(self):
         with patch(
             'corehq.motech.repeaters.models.simple_request',
             return_value=MockResponse(status_code=400, reason='Bad Request')
@@ -252,7 +260,7 @@ class RepeaterTest(BaseRepeaterTest):
                 repeat_record.fire()
 
         for repeat_record in self.repeat_records():
-            self.assertEqual(repeat_record.state, State.Cancelled)
+            self.assertEqual(repeat_record.state, State.Fail)
 
     def test_update_failure_next_check(self):
         now = datetime.utcnow()


### PR DESCRIPTION
## Technical Summary

Context: [SAAS-15905 discussion](https://dimagi.atlassian.net/browse/SAAS-15905?focusedCommentId=348881)

Currently when Data Forwarding gets a 400 "Bad Request" response, it handles the repeat record as an invalid payload.

However, when Data Forwarding forwards a case update for a case that has not yet been created, CommCare's Configurable API returns a 400 "Bad Request" response, and we want that repeat record to be retried, so that the next attempt might be after the case has been created.

This change is to retry 400 "Bad Request" responses. It feels arguably justifiable that the 400 error code is broad enough to include situations where one might want to retry the request.

## Safety Assurance

### Safety story

* Small change (adds one HTTP status code to a list)
* Tested locally

### Automated test coverage

Includes tests

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-15905]: https://dimagi.atlassian.net/browse/SAAS-15905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ