### PR TITLE
Add Custom Date Range Support to Enterprise Console Form Submission Report

### DIFF
--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -234,7 +234,7 @@ class EnterpriseFormReport(EnterpriseReport):
             self.subtitle = _("past {} days").format(num_days)
 
         if self.datespan.enddate - self.datespan.startdate > timedelta(days=90):
-            raise ValueError(_('Date ranges with more than 90 days are not supported'))
+            raise TooMuchRequestedDataError(_('Date ranges with more than 90 days are not supported'))
 
         self.include_form_id = include_form_id
 

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -213,6 +213,7 @@ class EnterpriseFormReport(EnterpriseReport):
     title = _('Mobile Form Submissions')
     MAXIMUM_USERS_PER_DOMAIN = getattr(settings, 'ENTERPRISE_REPORT_DOMAIN_USER_LIMIT', 20_000)
     MAXIMUM_ROWS_PER_REQUEST = getattr(settings, 'ENTERPRISE_REPORT_ROW_LIMIT', 1_000_000)
+    MAX_DATE_RANGE_DAYS = 90
 
     def __init__(self, account, couch_user, start_date=None, end_date=None, num_days=30, include_form_id=False):
         super().__init__(account, couch_user)
@@ -233,8 +234,10 @@ class EnterpriseFormReport(EnterpriseReport):
             self.datespan = DateSpan(end_date - timedelta(days=num_days), end_date)
             self.subtitle = _("past {} days").format(num_days)
 
-        if self.datespan.enddate - self.datespan.startdate > timedelta(days=90):
-            raise TooMuchRequestedDataError(_('Date ranges with more than 90 days are not supported'))
+        if self.datespan.enddate - self.datespan.startdate > timedelta(days=self.MAX_DATE_RANGE_DAYS):
+            raise TooMuchRequestedDataError(
+                _('Date ranges with more than {} days are not supported').format(self.MAX_DATE_RANGE_DAYS)
+            )
 
         self.include_form_id = include_form_id
 

--- a/corehq/apps/enterprise/static/enterprise/js/enterprise_dashboard.js
+++ b/corehq/apps/enterprise/static/enterprise/js/enterprise_dashboard.js
@@ -191,9 +191,8 @@ hqDefine("enterprise/js/enterprise_dashboard", [
     }
 
     $(function () {
-        const datePicker = tempusDominus.createDateRangePicker(
+        const datePicker = tempusDominus.createDefaultDateRangePicker(
             document.getElementById("id_date_range"),
-            gettext(" to "),
             moment().subtract(30, "days"),
             moment()
         );

--- a/corehq/apps/enterprise/static/enterprise/js/enterprise_dashboard.js
+++ b/corehq/apps/enterprise/static/enterprise/js/enterprise_dashboard.js
@@ -8,7 +8,7 @@ hqDefine("enterprise/js/enterprise_dashboard", [
     'hqwebapp/js/tempus_dominus',
     'moment',
     'hqwebapp/js/bootstrap5/hq.helpers',
-    'hqwebapp/js/bootstrap5/components.ko',
+    'hqwebapp/js/bootstrap5/components.ko', // used for the date range modal's select-toggle
 ], function (
     $,
     ko,

--- a/corehq/apps/enterprise/static/enterprise/js/enterprise_dashboard.js
+++ b/corehq/apps/enterprise/static/enterprise/js/enterprise_dashboard.js
@@ -1,34 +1,224 @@
 hqDefine("enterprise/js/enterprise_dashboard", [
     'jquery',
+    'knockout',
+    'underscore',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/bootstrap5/alert_user',
     'analytix/js/kissmetrix',
+    'hqwebapp/js/tempus_dominus',
+    'moment',
     'hqwebapp/js/bootstrap5/hq.helpers',
+    'hqwebapp/js/bootstrap5/components.ko',
 ], function (
     $,
+    ko,
+    _,
     initialPageData,
     alertUser,
-    kissmetrics
+    kissmetrics,
+    tempusDominus,
+    moment
 ) {
+    const PRESET_LAST_30 = "last_30";
+    const PRESET_PREV_MONTH = "prev_month";
+    const PRESET_CUSTOM = "custom";
+
+    const dateRangePresetOptions = [
+        {id: PRESET_LAST_30, text: gettext("Last 30 Days")},
+        {id: PRESET_PREV_MONTH, text: gettext("Previous Month")},
+        {id: PRESET_CUSTOM, text: gettext("Custom")},
+    ];
+
+    var MobileFormSubmissionsTile = function (datePicker) {
+        var self = {};
+        self.endDate = ko.observable(moment().utc());
+        self.startDate = ko.observable(self.endDate().clone().subtract(30, "days"));
+        self.presetType = ko.observable(PRESET_LAST_30);
+        self.customDateRangeDisplay = ko.observable(datePicker.optionsStore.input.value);
+
+        self.presetText = ko.pureComputed(function () {
+            if (self.presetType() !== PRESET_CUSTOM) {
+                return dateRangePresetOptions.find(ele => ele.id === self.presetType()).text;
+            } else {
+                return self.customDateRangeDisplay();
+            }
+        });
+
+        self.onApply = function (preset, startDate, endDate) {
+            self.startDate(startDate);
+            self.endDate(endDate);
+            self.presetType(preset);
+            self.customDateRangeDisplay(datePicker.optionsStore.input.value);
+
+            updateDisplayTotal($("#form_submissions"), {
+                "start_date": startDate.toISOString(),
+                "end_date": endDate.toISOString(),
+            });
+        };
+
+        return self;
+    };
+
+    var DateRangeModal = function (datePicker, presetOptions, maxDateRangeDays, tileDisplay) {
+        var self = {};
+        self.presetOptions = presetOptions;
+        self.presetType = ko.observable(PRESET_LAST_30);
+        self.displayCustom = ko.pureComputed(function () {
+            return self.presetType() === PRESET_CUSTOM;
+        });
+
+        self.clarifyingText = ko.pureComputed(function () {
+            const template = _.template('<i class="fa-solid fa-info-circle"></i> ' + gettext("Spans <%- startDate %> to <%- endDate %> (UTC)"));
+            return template({
+                startDate: self.startDate().format("YYYY-MM-DD"),
+                endDate: self.endDate().format("YYYY-MM-DD"),
+            });
+        });
+
+        self.customStartDate = ko.observable(datePicker.dates.picked[0]);
+        self.customEndDate = ko.observable(datePicker.dates.picked[1]);
+
+        const updateWidgetDates = function (startDate, endDate) {
+            datePicker.dates.clear();
+            datePicker.dates.setValue(new tempusDominus.tempusDominus.DateTime(startDate));
+            datePicker.dates.setValue(new tempusDominus.tempusDominus.DateTime(endDate), 1);
+            self.customStartDate(startDate);
+            self.customEndDate(endDate);
+        };
+
+        /*
+        NOTE: The `.local(true)` calls below are due to TempusDominus only supporting local time.
+        These calls change the datetime to the local timezone without adjusting the displayed date,
+        so the displayed UTC datetime will still display as the same string within TempusDominus.
+        */
+        self.onApply = function () {
+            if (self.presetType() !== PRESET_CUSTOM) {
+                // update the custom values to align with the selected preset, for opening the modal in the future
+                updateWidgetDates(self.startDate().clone().local(true), self.endDate().clone().local(true));
+            }
+            tileDisplay.onApply(self.presetType(), self.startDate(), self.endDate());
+        };
+
+        self.onCancel = function () {
+            self.presetType(tileDisplay.presetType());
+            const startDate = tileDisplay.startDate().clone();
+            const endDate = tileDisplay.endDate().clone();
+            if (tileDisplay.presetType() !== PRESET_CUSTOM) {
+                startDate.local(true);
+                endDate.local(true);
+            }
+            updateWidgetDates(startDate, endDate);
+        };
+
+        self.endDate = ko.pureComputed(function () {
+            const presetType = self.presetType();
+            let endDate = null;
+            if (presetType === PRESET_LAST_30) {
+                endDate = moment().utc();
+            } else if (presetType === PRESET_PREV_MONTH) {
+                endDate = moment().utc().subtract(1, "months").endOf("month");
+            } else {
+                endDate = moment(self.customEndDate());
+            }
+
+            // the backend handles inclusive date ranges by adding a full day to the end date,
+            // so we'd like to minimize the results shown from the next day
+            return endDate.startOf('day');
+        });
+
+        self.startDate = ko.pureComputed(function () {
+            const presetType = self.presetType();
+            let startDate = null;
+            if (presetType === PRESET_LAST_30) {
+                startDate = self.endDate().clone().subtract(30, "days");
+            } else if (presetType === PRESET_PREV_MONTH) {
+                startDate = self.endDate().clone().startOf("month");
+            } else {
+                startDate = moment(self.customStartDate());
+            }
+
+            return startDate;
+        });
+
+        datePicker.subscribe("change.td", function () {
+            if (datePicker.dates.picked.length === 1) {
+                const selectedDate = moment(datePicker.dates.picked[0]);
+                datePicker.updateOptions({
+                    restrictions: {
+                        minDate: new tempusDominus.tempusDominus.DateTime(selectedDate.clone().subtract(maxDateRangeDays, 'days')),
+                        maxDate: new tempusDominus.tempusDominus.DateTime(selectedDate.clone().add(maxDateRangeDays, 'days')),
+                    },
+                });
+            } else {
+                datePicker.updateOptions({
+                    restrictions: {
+                        minDate: undefined,
+                        maxDate: undefined,
+                    },
+                });
+            }
+            self.customStartDate(datePicker.dates.picked[0]);
+            if (datePicker.dates.picked.length > 1) {
+                self.customEndDate(datePicker.dates.picked[1]);
+            } else {
+                self.customEndDate(datePicker.dates.picked[0]);
+            }
+        });
+
+        return self;
+    };
+
+    function updateDisplayTotal($element, kwargs) {
+        const $display = $element.find(".total");
+        const slug = $element.data("slug");
+        const requestParams = {
+            url: initialPageData.reverse("enterprise_dashboard_total", slug),
+            success: function (data) {
+                $display.html(Number(data.total).toLocaleString());
+            },
+            error: function (request) {
+                if (request.responseJSON) {
+                    alertUser.alert_user(request.responseJSON["message"], "danger");
+                } else {
+                    alertUser.alert_user(gettext("Error updating display total, please try again or report an issue if this persists."), "danger");
+                }
+                $display.html(gettext("??"));
+            },
+            data: kwargs,
+        };
+        $display.html('<i class="fa fa-spin fa-spinner"></i>');
+        $.ajax(requestParams);
+    }
+
     $(function () {
+        const datePicker = tempusDominus.createDateRangePicker(
+            document.getElementById("id_date_range"),
+            gettext(" to "),
+            moment().subtract(30, "days"),
+            moment()
+        );
+
+        const formSubmissionsDisplay = MobileFormSubmissionsTile(datePicker);
+        const maxDateRangeDays = initialPageData.get("max_date_range_days");
+        const dateRangeModal = DateRangeModal(datePicker, dateRangePresetOptions, maxDateRangeDays, formSubmissionsDisplay);
+
+        $("#dateRangeDisplay").koApplyBindings(formSubmissionsDisplay);
+        $("#enterpriseFormsDaterange").koApplyBindings(
+            dateRangeModal
+        );
+
         kissmetrics.track.event("[Enterprise Dashboard] Visited page");
         $(".report-panel").each(function () {
             var $element = $(this),
                 slug = $element.data("slug");
 
-            // Load total
-            $.ajax({
-                url: initialPageData.reverse("enterprise_dashboard_total", slug),
-                success: function (data) {
-                    $element.find(".total").html(Number(data.total).toLocaleString());
-                },
-            });
+            updateDisplayTotal($element);
 
             $element.find(".btn-primary").click(function () {
                 kissmetrics.track.event("[Enterprise Dashboard] Clicked Email Report for " + slug);
                 var $button = $(this);
                 $button.disableButton();
-                $.ajax({
+                const requestParams = {
                     url: initialPageData.reverse("enterprise_dashboard_email", slug),
                     success: function (data) {
                         alertUser.alert_user(data.message, "success");
@@ -42,7 +232,14 @@ hqDefine("enterprise/js/enterprise_dashboard", [
                         }
                         $button.enableButton();
                     },
-                });
+                };
+                if (slug === "form_submissions") {
+                    requestParams["data"] = {
+                        "start_date": dateRangeModal.startDate().toISOString(),
+                        "end_date": dateRangeModal.endDate().toISOString(),
+                    };
+                }
+                $.ajax(requestParams);
             });
         });
     });

--- a/corehq/apps/enterprise/static/enterprise/js/enterprise_dashboard.js
+++ b/corehq/apps/enterprise/static/enterprise/js/enterprise_dashboard.js
@@ -34,8 +34,12 @@ hqDefine("enterprise/js/enterprise_dashboard", [
                         alertUser.alert_user(data.message, "success");
                         $button.enableButton();
                     },
-                    error: function () {
-                        alertUser.alert_user(gettext("Error sending email, please try again or report an issue if this persists."), "danger");
+                    error: function (request) {
+                        if (request.responseJSON) {
+                            alertUser.alert_user(request.responseJSON["message"], "danger");
+                        } else {
+                            alertUser.alert_user(gettext("Error sending email, please try again or report an issue if this persists."), "danger");
+                        }
                         $button.enableButton();
                     },
                 });

--- a/corehq/apps/enterprise/templates/enterprise/enterprise_dashboard.html
+++ b/corehq/apps/enterprise/templates/enterprise/enterprise_dashboard.html
@@ -10,6 +10,8 @@
   {% registerurl "enterprise_dashboard_email" domain "---" %}
   {% registerurl "enterprise_dashboard_total" domain "---" %}
 
+  {% initial_page_data 'max_date_range_days' max_date_range_days %}
+
   <div class="row">
     {% for report in reports %}
       <div class="col-md-6 col-lg-6 col-xl-3">

--- a/corehq/apps/enterprise/templates/enterprise/enterprise_dashboard.html
+++ b/corehq/apps/enterprise/templates/enterprise/enterprise_dashboard.html
@@ -15,10 +15,14 @@
   <div class="row">
     {% for report in reports %}
       <div class="col-md-6 col-lg-6 col-xl-3">
-        <div class="card text-center report-panel mb-3" data-slug="{{ report.slug }}">
+        <div class="card text-center report-panel mb-3" data-slug="{{ report.slug }}" id="{{ report.slug }}">
           <div class="card-header">
             <div class="fs-4">{{ report.title }}</div>
-            <div class="fs-6">{{ report.subtitle|default:"&nbsp;" }}</div>
+            {% if report.title == "Mobile Form Submissions" %}
+              <button id="dateRangeDisplay" type="button" data-bind="text: presetText" data-bs-toggle="modal" data-bs-target="#enterpriseFormsDaterange" class="btn btn-link fs-6">&nbsp;</button>
+            {% else %}
+               <div class="form-control-plaintext fs-6">{{ report.subtitle|default:"&nbsp;" }}</div>
+            {% endif %}
           </div>
           <div class="card-body">
             <h1 class="card-text total">
@@ -34,4 +38,6 @@
       </div>
     {% endfor %}
   </div>
+
+  {% include 'enterprise/partials/date_range_modal.html' %}
 {% endblock %}

--- a/corehq/apps/enterprise/templates/enterprise/partials/date_range_modal.html
+++ b/corehq/apps/enterprise/templates/enterprise/partials/date_range_modal.html
@@ -1,0 +1,25 @@
+{% load i18n %}
+
+<div class="modal" role="dialog" tabindex="-1" id="enterpriseFormsDaterange">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{% trans 'Customize Mobile Form Submissions Date Range' %}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <select-toggle name="range_type" data-apply-bindings="false" params="value: presetType, options: presetOptions"></select-toggle>
+                <div class="row">
+                    <div class="col-xs-6 pt-1">
+                        <input type="text" name="date_range" class="form-control" id="id_date_range" data-bind="visible: displayCustom">
+                        <div id="clarifyingText" class="form-control-plaintext" data-bind="html: clarifyingText, visible: !displayCustom()"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-primary" data-bind="click: onCancel" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
+                <button type="button" class="btn btn-primary" data-bind="click: onApply" data-bs-dismiss="modal">{% trans 'Apply' %}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/corehq/apps/enterprise/templates/enterprise/partials/date_range_modal.html
+++ b/corehq/apps/enterprise/templates/enterprise/partials/date_range_modal.html
@@ -1,3 +1,4 @@
+{% load hq_shared_tags %}
 {% load i18n %}
 
 <div class="modal" role="dialog" tabindex="-1" id="enterpriseFormsDaterange">
@@ -5,7 +6,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">{% trans 'Customize Mobile Form Submissions Date Range' %}</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans_html_attr 'Close' %}"></button>
             </div>
             <div class="modal-body">
                 <select-toggle name="range_type" data-apply-bindings="false" params="value: presetType, options: presetOptions"></select-toggle>

--- a/corehq/apps/enterprise/tests/test_enterprise.py
+++ b/corehq/apps/enterprise/tests/test_enterprise.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from freezegun import freeze_time
 from unittest.mock import patch, MagicMock
 
+from corehq.apps.enterprise.exceptions import TooMuchRequestedDataError
 from corehq.apps.export.models.new import FormExportInstance
 from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.domain.models import Domain
@@ -172,7 +173,7 @@ class EnterpriseFormReportTests(SimpleTestCase):
 
     def test_specifying_timespan_greater_than_90_days_throws_error(self):
         end_date = datetime(month=10, day=1, year=2020)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TooMuchRequestedDataError):
             EnterpriseFormReport(self.billing_account, None, end_date=end_date, num_days=91)
 
     def test_specifying_timespans_up_to_90_days_works(self):

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -54,13 +54,14 @@ from corehq.apps.enterprise.tasks import email_enterprise_report
 
 from corehq.apps.export.utils import get_default_export_settings_if_available
 
-from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_tempusdominus
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.users.decorators import require_can_edit_or_view_web_users
 
 from corehq.const import USER_DATE_FORMAT
 
 
+@use_tempusdominus
 @use_bootstrap5
 @always_allow_project_access
 @require_enterprise_admin

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -47,7 +47,7 @@ from corehq.apps.domain.views import DomainAccountingSettings, BaseDomainView
 from corehq.apps.domain.views.accounting import PAYMENT_ERROR_MESSAGES, InvoiceStripePaymentView, \
     BulkStripePaymentView, WireInvoiceView, BillingStatementPdfView
 
-from corehq.apps.enterprise.enterprise import EnterpriseReport
+from corehq.apps.enterprise.enterprise import EnterpriseReport, EnterpriseFormReport
 
 from corehq.apps.enterprise.forms import EnterpriseSettingsForm
 from corehq.apps.enterprise.tasks import email_enterprise_report
@@ -72,6 +72,7 @@ def enterprise_dashboard(request, domain):
     context = {
         'account': request.account,
         'domain': domain,
+        'max_date_range_days': EnterpriseFormReport.MAX_DATE_RANGE_DAYS,
         'reports': [EnterpriseReport.create(slug, request.account.id, request.couch_user) for slug in (
             EnterpriseReport.DOMAINS,
             EnterpriseReport.WEB_USERS,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
@@ -50,8 +50,8 @@ hqDefine("hqwebapp/js/tempus_dominus", [
     };
 
     // This replaces createBootstrap3DefaultDateRangePicker in hqwebapp/js/daterangepicker.config
-    let createDefaultDateRangePicker = function (el) {
-        return createDateRangePicker(el, getDateRangeSeparator());
+    let createDefaultDateRangePicker = function (el, start, end) {
+        return createDateRangePicker(el, getDateRangeSeparator(), start, end);
     };
 
     // This replaces createDateRangePicker in hqwebapp/js/daterangepicker.config
@@ -144,7 +144,7 @@ hqDefine("hqwebapp/js/tempus_dominus", [
     };
 
     let getDateRangeSeparator = function () {
-        return ' to ';
+        return gettext(' to ');
     };
 
     const defaultTranslations = {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
@@ -55,7 +55,7 @@ hqDefine("hqwebapp/js/tempus_dominus", [
     };
 
     // This replaces createDateRangePicker in hqwebapp/js/daterangepicker.config
-    let createDateRangePicker = function (el, separator) {
+    let createDateRangePicker = function (el, separator, start, end) {
         let picker = new tempusDominus.TempusDominus(
             el, {
                 dateRange: true,
@@ -76,6 +76,12 @@ hqDefine("hqwebapp/js/tempus_dominus", [
                 }),
             }
         );
+
+        if (start && end) {
+            picker.dates.setValue(new tempusDominus.DateTime(start), 0);
+            picker.dates.setValue(new tempusDominus.DateTime(end), 1);
+        }
+
 
         // Handle single-date ranges
         picker.subscribe("hide.td", function () {


### PR DESCRIPTION
## Product Description
Previously, Enterprise Console users were restricted to generating the Mobile Form Submissions report for the last 30 days. This PR introduces a new modal dialog that allows users to change the range to the last 30 days (default), previous month, or a custom date range.

Initial Page Display:
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/db656256-80dc-4e38-b1a7-cde827ad7fe4">

Modal with Last 30 days:
<img width="519" alt="image" src="https://github.com/user-attachments/assets/828d8a9d-84e1-4237-a8a6-aa01ea992edc">

Modal with Previous Month:
<img width="519" alt="image" src="https://github.com/user-attachments/assets/4311fc06-cc0e-4a9e-b045-5c475c358031">

Modal with Custom Range:
<img width="522" alt="image" src="https://github.com/user-attachments/assets/b33c30ae-5590-45f1-8fce-fcf35a8b2d9c">

Tile with Custom Range:
<img width="288" alt="image" src="https://github.com/user-attachments/assets/0d48491d-f9da-4f05-b8c9-76a2fe0a693a">


## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15883

## Safety Assurance

### Safety story
Because the bulk of this is Javascript, there is a lack of automated testing. However, I have run through all the scenarios locally.

### Automated test coverage

No new tests.

### QA Plan

Not opening this for QA at the moment, but am open to sending it to QA if requested.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
