### PR TITLE
Disable right click on control for options

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/reportdata/view_form_attachment.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/reportdata/view_form_attachment.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -3,11 +3,11 @@
+@@ -3,7 +3,7 @@
    <head>
      <meta name="viewport" content="width=device-width">
    </head>
@@ -9,8 +9,12 @@
      {% if is_image %}
        <img src="{{ download_url }}">
      {% else %}
--      <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
-+      <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">  {# todo B5: inline style #}
-         <source src="{{ download_url }}">
-       </video>
-     {% endif %}
+@@ -12,7 +12,7 @@
+           <source src="{{ download_url }}">
+         </audio>
+       {% else %}
+-        <video controls autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
++        <video controls autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">  {# todo B5: inline style #}
+           <source src="{{ download_url }}">
+         </video>
+       {% endif %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/reportdata/view_form_attachment.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/reportdata/view_form_attachment.html.diff.txt
@@ -9,8 +9,8 @@
      {% if is_image %}
        <img src="{{ download_url }}">
      {% else %}
--      <video controls {% if disable_download %} controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
-+      <video controls {% if disable_download %} controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">  {# todo B5: inline style #}
+-      <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
++      <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">  {# todo B5: inline style #}
          <source src="{{ download_url }}">
        </video>
      {% endif %}

--- a/corehq/apps/reports/templates/reports/reportdata/bootstrap3/view_form_attachment.html
+++ b/corehq/apps/reports/templates/reports/reportdata/bootstrap3/view_form_attachment.html
@@ -12,7 +12,7 @@
           <source src="{{ download_url }}">
         </audio>
       {% else %}
-        <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
+        <video controls autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
           <source src="{{ download_url }}">
         </video>
       {% endif %}

--- a/corehq/apps/reports/templates/reports/reportdata/bootstrap3/view_form_attachment.html
+++ b/corehq/apps/reports/templates/reports/reportdata/bootstrap3/view_form_attachment.html
@@ -7,7 +7,7 @@
     {% if is_image %}
       <img src="{{ download_url }}">
     {% else %}
-      <video controls {% if disable_download %} controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
+      <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
         <source src="{{ download_url }}">
       </video>
     {% endif %}

--- a/corehq/apps/reports/templates/reports/reportdata/bootstrap3/view_form_attachment.html
+++ b/corehq/apps/reports/templates/reports/reportdata/bootstrap3/view_form_attachment.html
@@ -7,9 +7,15 @@
     {% if is_image %}
       <img src="{{ download_url }}">
     {% else %}
-      <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
-        <source src="{{ download_url }}">
-      </video>
+      {% if disable_download %}
+        <audio controls oncontextmenu="return false;" controlsList="nodownload" autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
+          <source src="{{ download_url }}">
+        </audio>
+      {% else %}
+        <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
+          <source src="{{ download_url }}">
+        </video>
+      {% endif %}
     {% endif %}
   </body>
 </html>

--- a/corehq/apps/reports/templates/reports/reportdata/bootstrap5/view_form_attachment.html
+++ b/corehq/apps/reports/templates/reports/reportdata/bootstrap5/view_form_attachment.html
@@ -7,7 +7,7 @@
     {% if is_image %}
       <img src="{{ download_url }}">
     {% else %}
-      <video controls {% if disable_download %} controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">  {# todo B5: inline style #}
+      <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">  {# todo B5: inline style #}
         <source src="{{ download_url }}">
       </video>
     {% endif %}

--- a/corehq/apps/reports/templates/reports/reportdata/bootstrap5/view_form_attachment.html
+++ b/corehq/apps/reports/templates/reports/reportdata/bootstrap5/view_form_attachment.html
@@ -12,7 +12,7 @@
           <source src="{{ download_url }}">
         </audio>
       {% else %}
-        <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">  {# todo B5: inline style #}
+        <video controls autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">  {# todo B5: inline style #}
           <source src="{{ download_url }}">
         </video>
       {% endif %}

--- a/corehq/apps/reports/templates/reports/reportdata/bootstrap5/view_form_attachment.html
+++ b/corehq/apps/reports/templates/reports/reportdata/bootstrap5/view_form_attachment.html
@@ -7,9 +7,15 @@
     {% if is_image %}
       <img src="{{ download_url }}">
     {% else %}
-      <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">  {# todo B5: inline style #}
-        <source src="{{ download_url }}">
-      </video>
+      {% if disable_download %}
+        <audio controls oncontextmenu="return false;" controlsList="nodownload" autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">
+          <source src="{{ download_url }}">
+        </audio>
+      {% else %}
+        <video controls {% if disable_download %} oncontextmenu="return false;" controlsList="nodownload" {% endif %} autoplay name="{{ content_name }}" style="top: 10%; left: 10%; position: absolute;">  {# todo B5: inline style #}
+          <source src="{{ download_url }}">
+        </video>
+      {% endif %}
     {% endif %}
   </body>
 </html>


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Simply disables options available on right clicking on a media player when viewing form attachment.

![image](https://github.com/user-attachments/assets/a04455f0-315e-4944-a5c6-d52d37ffb0eb)

A follow up to https://github.com/dimagi/commcare-hq/pull/32490 to not provide users the option to download/save the media files.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-3952

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`DISABLE_FORM_ATTACHMENT_DOWNLOAD_IN_BROWSER`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested by making the change in the browser that the controls are not visible anymore. Its a HTML only change, behind a feature flag that should not impact anything outside the feature flag.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
