### PR TITLE
Error Handling When Reverting/Releasing App Version with V1 Mobile UCR References

### DIFF
--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -97,3 +97,8 @@ DEFAULT_PAGE_LIMIT = 10
 CALCULATED_SORT_FIELD_RX = r'^_cc_calculated_(\d+)$'
 
 CASE_LIST_FILTER_LOCATIONS_FIXTURE = 'Locations Fixture'
+
+MOBILE_UCR_V1_FIXTURE_IDENTIFIER = 'src="jr://fixture/commcare:reports'
+MOBILE_UCR_V1_FIXTURE_PATTERN = r'<.*src="jr://fixture/commcare:reports.*>'
+MOBILE_UCR_V1_REFERENCES_PATTERN = r"<.*instance\('reports'\)/reports/.*>"
+MOBILE_UCR_V1_ALL_REFERENCES = f"{MOBILE_UCR_V1_FIXTURE_PATTERN}|{MOBILE_UCR_V1_REFERENCES_PATTERN}"

--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -102,3 +102,4 @@ MOBILE_UCR_V1_FIXTURE_IDENTIFIER = 'src="jr://fixture/commcare:reports'
 MOBILE_UCR_V1_FIXTURE_PATTERN = r'<.*src="jr://fixture/commcare:reports.*>'
 MOBILE_UCR_V1_REFERENCES_PATTERN = r"<.*instance\('reports'\)/reports/.*>"
 MOBILE_UCR_V1_ALL_REFERENCES = f"{MOBILE_UCR_V1_FIXTURE_PATTERN}|{MOBILE_UCR_V1_REFERENCES_PATTERN}"
+MOBILE_UCR_V1_CASE_LIST_REFERENCES_PATTERN = r"instance\('commcare:reports'\)/reports/report\[@id='.*'\]/rows/row"

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
@@ -5,9 +5,8 @@
   <div class="alert alert-warning alert-build">
     <h4 class="alert-heading">
       <i class="fa fa-exclamation-circle"></i>
-      {% trans "Cannot make new version" %}</h4>
+      {% trans "Warning while making new version" %}</h4>
         <span>
           {{ warning_message }}
         </span>
   </div>
-{% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+{% load xforms_extras %}
+
+  <div class="alert alert-warning alert-build">
+    <h4 class="alert-heading">
+      <i class="fa fa-exclamation-circle"></i>
+      {% trans "Cannot make new version" %}</h4>
+        <span>
+          {{ warning_message }}
+        </span>
+  </div>
+{% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
@@ -5,7 +5,7 @@
   <div class="alert alert-warning alert-build">
     <h4 class="alert-heading">
       <i class="fa fa-exclamation-circle"></i>
-      {% trans "Warning while making new version" %}</h4>
+      {% trans "Warning" %}</h4>
         <span>
           {{ warning_message }}
         </span>

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -7,7 +7,6 @@ from corehq.apps.app_manager.models import (
     BuildProfile,
     GlobalAppConfig,
     LatestEnabledBuildProfiles,
-    Module,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -218,7 +218,7 @@ class TestSplitPath(SimpleTestCase):
         self.assertEqual(name, '')
 
 
-class TestDoesAppHaveMobileUCRV1Refs(SimpleTestCase, SuiteMixin):
+class TestDoesAppHaveMobileUCRV1Refs(TestCase, SuiteMixin):
     file_path = ('data', 'suite')
 
     def _create_app_with_form(self, xml_source_name):

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -10,8 +10,12 @@ from corehq.apps.app_manager.models import (
     Module,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
-from corehq.apps.app_manager.tests.util import get_simple_form, patch_validate_xform
-from corehq.apps.app_manager.util import split_path
+from corehq.apps.app_manager.tests.util import (
+    get_simple_form,
+    patch_validate_xform,
+    SuiteMixin,
+)
+from corehq.apps.app_manager.util import split_path, does_app_have_mobile_ucr_v1_refs
 from corehq.apps.app_manager.views.utils import get_default_followup_form_xml
 from corehq.apps.domain.models import Domain
 
@@ -213,3 +217,24 @@ class TestSplitPath(SimpleTestCase):
         path, name = split_path('')
         self.assertEqual(path, '')
         self.assertEqual(name, '')
+
+
+class TestDoesAppHaveMobileUCRV1Refs(SimpleTestCase, SuiteMixin):
+    file_path = ('data', 'suite')
+
+    def _create_app_with_form(self, xml_source_name):
+        app = Application.new_app('domain', "Untitled Application")
+        app.add_module(AdvancedModule.new_module('module', None))
+        app.new_form(
+            module_id=0,
+            name="My Form",
+            lang=None,
+            attachment=self.get_xml(xml_source_name).decode('utf-8')
+        )
+        return app
+
+    def test_does_app_have_mobile_ucr_v1_refs(self):
+        app_with_refs = self._create_app_with_form('reports_module_data_entry')
+        self.assertTrue(does_app_have_mobile_ucr_v1_refs(app_with_refs))
+        app_without_refs = self._create_app_with_form('normal-suite')
+        self.assertFalse(does_app_have_mobile_ucr_v1_refs(app_without_refs))

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -315,9 +315,9 @@ def languages_mapping():
     if not mapping:
         with open('submodules/langcodes/langs.json', encoding='utf-8') as langs_file:
             lang_data = json.load(langs_file)
-            mapping = dict([(l["two"], l["names"]) for l in lang_data])
+            mapping = dict([(lang["two"], lang["names"]) for lang in lang_data])
         mapping["default"] = ["Default Language"]
-        cache.set('__languages_mapping', mapping, 12*60*60)
+        cache.set('__languages_mapping', mapping, 12 * 60 * 60)
     return mapping
 
 
@@ -363,8 +363,8 @@ def get_commcare_builds(request_user):
 
 
 def actions_use_usercase(actions):
-    return (('usercase_update' in actions and actions['usercase_update'].update) or
-            ('usercase_preload' in actions and actions['usercase_preload'].preload))
+    return (('usercase_update' in actions and actions['usercase_update'].update)
+            or ('usercase_preload' in actions and actions['usercase_preload'].preload))
 
 
 def advanced_actions_use_usercase(actions):
@@ -412,8 +412,8 @@ def module_offers_search(module):
     from corehq.apps.app_manager.models import AdvancedModule, Module, ShadowModule
 
     return (
-        isinstance(module, (Module, AdvancedModule, ShadowModule)) and
-        module.search_config
+        isinstance(module, (Module, AdvancedModule, ShadowModule))
+        and module.search_config
         and (module.search_config.properties
         or module.search_config.default_properties)
     )
@@ -594,7 +594,9 @@ def get_sort_and_sort_only_columns(detail_columns, sort_elements):
             except IndexError:
                 raise AppManagerException(f"Sort column references an unknown column at index: {column_index}")
             if not column.useXpathExpression:
-                raise AppManagerException(f"Calculation sort column references an incorrect column: {column.field}")
+                raise AppManagerException(
+                    f"Calculation sort column references an incorrect column: {column.field}"
+                )
             sort_columns[column.field] = (element, element_order)
 
     sort_only_elements = [

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -27,6 +27,8 @@ from corehq.apps.app_manager.const import (
     USERCASE_ID,
     USERCASE_PREFIX,
     USERCASE_TYPE,
+    MOBILE_UCR_V1_FIXTURE_IDENTIFIER,
+    MOBILE_UCR_V1_ALL_REFERENCES,
 )
 from corehq.apps.app_manager.dbaccessors import get_app, get_apps_in_domain
 from corehq.apps.app_manager.exceptions import (
@@ -752,3 +754,16 @@ def extract_instance_id_from_nodeset_ref(nodeset):
     if nodeset:
         matches = re.findall(r"instance\('(.*?)'\)", nodeset)
         return matches[0] if matches else None
+
+
+def does_app_have_mobile_ucr_v1_refs(app):
+    re_mobile_ucr_v1_all_refs = re.compile(MOBILE_UCR_V1_ALL_REFERENCES)
+    for form in app.get_forms():
+        # The second condition should always be False if the first one is
+        # but just as a precaution we'll check for it
+        if (
+            MOBILE_UCR_V1_FIXTURE_IDENTIFIER in form.source
+            or re_mobile_ucr_v1_all_refs.search(form.source)
+        ):
+            return True
+    return False

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -29,6 +29,7 @@ from corehq.apps.app_manager.const import (
     USERCASE_TYPE,
     MOBILE_UCR_V1_FIXTURE_IDENTIFIER,
     MOBILE_UCR_V1_ALL_REFERENCES,
+    MOBILE_UCR_V1_CASE_LIST_REFERENCES_PATTERN,
 )
 from corehq.apps.app_manager.dbaccessors import get_app, get_apps_in_domain
 from corehq.apps.app_manager.exceptions import (
@@ -759,6 +760,11 @@ def extract_instance_id_from_nodeset_ref(nodeset):
 
 
 def does_app_have_mobile_ucr_v1_refs(app):
+    suite = app.create_suite()
+    re_mobile_ucr_v1_case_list_references_pattern = re.compile(MOBILE_UCR_V1_CASE_LIST_REFERENCES_PATTERN)
+    if re.search(re_mobile_ucr_v1_case_list_references_pattern, suite.decode()):
+        return True
+
     re_mobile_ucr_v1_all_refs = re.compile(MOBILE_UCR_V1_ALL_REFERENCES)
     for form in app.get_forms():
         # The second condition should always be False if the first one is

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -276,6 +276,10 @@ def release_build(request, domain, app_id, saved_app_id):
     saved_app = get_app(domain, saved_app_id)
     if saved_app.copy_of != app_id:
         raise Http404
+    if is_released:
+        error_message = _check_app_for_mobile_ucr_v1_refs(domain, saved_app)
+        if error_message:
+            return json_response({'error': error_message})
     saved_app.is_released = is_released
     saved_app.last_released = datetime.datetime.utcnow() if is_released else None
     saved_app.is_auto_generated = False

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -416,6 +416,9 @@ def revert_to_copy(request, domain, app_id):
     copy = get_app(domain, request.POST['build_id'])
     if copy.get_doc_type() == 'LinkedApplication' and app.get_doc_type() == 'Application':
         copy = copy.convert_to_application()
+    warning_message = _check_app_for_mobile_ucr_v1_refs(domain, app=copy)
+    if warning_message:
+        messages.warning(request, warning_message)
     app = app.make_reversion_to_copy(copy)
     app.save()
     messages.success(

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -68,7 +68,10 @@ from corehq.apps.app_manager.models import (
 from corehq.apps.app_manager.tasks import (
     create_build_files_for_all_app_profiles,
 )
-from corehq.apps.app_manager.util import get_and_assert_practice_user_in_domain
+from corehq.apps.app_manager.util import (
+    get_and_assert_practice_user_in_domain,
+    does_app_have_mobile_ucr_v1_refs,
+)
 from corehq.apps.app_manager.views.download import source_files
 from corehq.apps.app_manager.views.settings import PromptSettingsUpdateView
 from corehq.apps.app_manager.views.utils import (
@@ -386,6 +389,19 @@ def _track_build_for_app_preview(domain, couch_user, app_id, message):
         'is_dimagi': couch_user.is_dimagi,
         'preview_app_enabled': True,
     })
+
+
+def _check_app_for_mobile_ucr_v1_refs(domain, app):
+    if not toggles.MOBILE_UCR.enabled(domain):
+        return
+    if app.mobile_ucr_restore_version != '2.0':
+        return _("The mobile UCR restore version for v%(app_version)s needs to be updated to V2.0") % {
+            'app_version': app.version,
+        }
+    if does_app_have_mobile_ucr_v1_refs(app):
+        return _("One or more forms for v%(app_version)s contain V1 Mobile UCR references.") % {
+            'app_version': app.version,
+        }
 
 
 @no_conflict_require_POST

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -365,10 +365,17 @@ def save_copy(request, domain, app_id):
     case_types = get_case_types_for_app_build(domain, app_id)
     deprecated_case_types = get_data_dict_deprecated_case_types(domain)
     used_deprecated_case_types = case_types.intersection(deprecated_case_types)
+    error_html = ''
+    warning_message = _check_app_for_mobile_ucr_v1_refs(domain, app)
+    if warning_message:
+        error_html = render_to_string("app_manager/partials/mobile_ucr_v1_warning.html", {
+            'warning_message': warning_message,
+        })
+
     return JsonResponse({
         "saved_app": copy_json,
         "deprecated_case_types": list(used_deprecated_case_types),
-        "error_html": "",
+        "error_html": error_html,
     })
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
One of two alert messages can be shown to the user depending on whether the app version still has V1 set as the mobile UCR restore version or if the app version contains any V1 fixture references:
![v1-restore-version-warning](https://github.com/user-attachments/assets/3f9a3917-f1cf-498b-858b-f52c16ff5c36)

![v1-refs-warning](https://github.com/user-attachments/assets/39a917ea-6013-4115-a099-c6d2b234d719)

The following conditions will cause one of the new alert messages to be shown:
- If a user reverts an app to an earlier version containing V1 refs then a non-blocking warning message will be shown.
- If a user builds a new version of an app containing V1 refs then a non-blocking warning message will be shown.
- If a user releases an app version containing V1 refs then a blocking error message will be shown.

The blocking error looks as follows:
![Screenshot from 2024-10-21 10-02-40](https://github.com/user-attachments/assets/b1723c0b-01b2-4487-9814-bbef1241fb8a)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3915).

This PR introduces some guard rails to ensure that users are not able to release app versions which contain any mobile UCR V1 references. The feature is currently undergoing a process of migrating to V2, and so these extra checks are being put in place to ensure that V1 of the feature is able to be deprecated.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`MOBILE_UCR`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- QA completed

The checks implemented in this PR will only apply to domains that have the `MOBILE_UCR` feature flag enabled.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests have been created for the new helper function to ensure that it correctly identifies when one or more forms in an app are using mobile UCR V1 fixtures.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA has been completed. Ticket is available [here](https://dimagi.atlassian.net/browse/QA-7130).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
