### PR TITLE
Add a column to the Data Forwarding page for invalid payloads

### DIFF
--- a/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
+++ b/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
@@ -17,8 +17,13 @@
         </a>
     </td>
     <td>
+        <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=INVALIDPAYLOAD">
+            {{ repeater.count_State.InvalidPayload }}
+        </a>
+    </td>
+    <td>
         <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=CANCELLED">
-            {{ repeater.count_State.InvalidOrCancelled }}
+            {{ repeater.count_State.Cancelled }}
         </a>
     </td>
     <td>

--- a/corehq/motech/repeaters/templates/repeaters/repeaters.html
+++ b/corehq/motech/repeaters/templates/repeaters/repeaters.html
@@ -14,7 +14,7 @@
             <table class="table table-striped table-bordered">
             <thead>
                 <tr>
-                    <th class="col-md-4">
+                    <th class="col-md-3">
                         {% trans 'Name' %}
                     </th>
                     <th class="col-md-1">
@@ -22,6 +22,9 @@
                     </th>
                     <th class="col-md-1">
                         {% trans 'Failure' %}
+                    </th>
+                    <th class="col-md-1">
+                        {% trans 'Invalid' %}
                     </th>
                     <th class="col-md-1">
                         {% trans 'Cancelled' %}

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -57,10 +57,6 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
                     repeater.count_State[State.Empty.name]
                     + repeater.count_State[State.Success.name]
                 )
-                repeater.count_State['InvalidOrCancelled'] = (
-                    repeater.count_State[State.InvalidPayload.name]
-                    + repeater.count_State[State.Cancelled.name]
-                )
             return repeaters
 
         return [

--- a/corehq/motech/repeaters/views/tests/test_repeat_records.py
+++ b/corehq/motech/repeaters/views/tests/test_repeat_records.py
@@ -76,7 +76,6 @@ class TestDomainForwardingOptionsView(TestCase):
             'Empty': 0,
             'EmptyOrSuccess': 0,
             'Fail': 0,
-            'InvalidOrCancelled': 0,
             'InvalidPayload': 0,
             'Pending': 1,
             'Success': 0


### PR DESCRIPTION
## Technical Summary

Context:
* [SC-3934](https://dimagi.atlassian.net/browse/SC-3934)
* [SAAS-15903](https://dimagi.atlassian.net/browse/SAAS-15903?focusedCommentId=345550)

This change adds a column to the Data Forwarding page for invalid payloads. Currently the totals for invalid payloads and cancelled payloads are combined in the "Cancelled" column, but this has proven to be confusing, and it has not been obvious to users how to show only invalid payloads in the repeat records report.

![image](https://github.com/user-attachments/assets/81b98885-1706-443d-802f-5df469bcb543)

The link on the total for "Invalid" goes to the repeat records report with "Record Status: Invalid Payload" selected.

![image](https://github.com/user-attachments/assets/78385126-1bac-4d92-89fe-dd44ac9ee232)


## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Includes updated test

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3934]: https://dimagi.atlassian.net/browse/SC-3934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-15903]: https://dimagi.atlassian.net/browse/SAAS-15903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ