### PR TITLE
Fix Empty Payload View for ArcGIS Repeat Records

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/repeaters/js/repeat_record_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/repeaters/js/repeat_record_report.js.diff.txt
@@ -8,6 +8,15 @@
      const initialPageData = hqImport("hqwebapp/js/initial_page_data"),
          selectAll = document.getElementById('select-all'),
          selectPending = document.getElementById('select-pending'),
+@@ -78,7 +78,7 @@
+                     }
+                     if (contentType === 'text/xml') {
+                         editor.session.setMode('ace/mode/xml');
+-                    } else if (['application/json', 'application/x-www-form-urlencoded'].includes(contentType)) {
++                    } else if (contentType === 'application/json') {
+                         editor.session.setMode('ace/mode/json');
+                     }
+                     editor.session.setValue(data.payload);
 @@ -142,7 +142,7 @@
                  action = getAction();
              let $btn;

--- a/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
+++ b/corehq/motech/repeaters/static/repeaters/js/bootstrap3/repeat_record_report.js
@@ -78,7 +78,7 @@ hqDefine('repeaters/js/bootstrap3/repeat_record_report', function () {
                     }
                     if (contentType === 'text/xml') {
                         editor.session.setMode('ace/mode/xml');
-                    } else if (contentType === 'application/json') {
+                    } else if (['application/json', 'application/x-www-form-urlencoded'].includes(contentType)) {
                         editor.session.setMode('ace/mode/json');
                     }
                     editor.session.setValue(data.payload);

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -292,7 +292,7 @@ class RepeatRecordView(View):
 
         if content_type == 'text/xml':
             payload = indent_xml(payload)
-        elif content_type == 'application/json':
+        elif content_type in ['application/json', 'application/x-www-form-urlencoded']:
             payload = pformat_json(payload)
 
         dhis2_errors = []


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
When viewing the payload for ArcGIS repeat records the user should now be able to see the payload correctly (before was simply blank):
![Screenshot from 2024-10-04 12-44-03](https://github.com/user-attachments/assets/24c0f2da-db11-4b2f-802c-90200c106c3e)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3936).

The ArcGIS repeater introduced a new `application/x-www-form-urlencoded` content type which is not being used by any other repeaters. Given this new content type, the code does not have any support for handling rendering it on the front-end which ultimately causes a blank payload to be shown for the ArcGIS repeat records.

This PR resolves the above issue by accommodating the new `application/x-www-form-urlencoded` content type and having it be rendered as JSON on the front-end.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`ARCGIS_INTEGRATION`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

This is a very small change that should only affect viewing payloads for ArcGIS repeat records. All other repeat record types should remain unaffected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
