### PR TITLE
Fix code scanning alert no. 392: Regular expression injection

### DIFF
--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -751,9 +751,7 @@ def chat_contact_list(request, domain):
     total_records = len(data)
 
     if sSearch:
-        safe_search = re.escape(sSearch)
-        regex = re.compile('^.*%s.*$' % safe_search)
-        data = [row for row in data if regex.match(row[0]) or regex.match(row[2])]
+        data = [row for row in data if sSearch in row[0] or sSearch in row[2]]
     filtered_records = len(data)
 
     data.sort(key=lambda row: row[0])

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -751,7 +751,8 @@ def chat_contact_list(request, domain):
     total_records = len(data)
 
     if sSearch:
-        regex = re.compile('^.*%s.*$' % sSearch)
+        safe_search = re.escape(sSearch)
+        regex = re.compile('^.*%s.*$' % safe_search)
         data = [row for row in data if regex.match(row[0]) or regex.match(row[2])]
     filtered_records = len(data)
 


### PR DESCRIPTION
## Product Description


## Technical Summary

Fixes [https://github.com/dimagi/commcare-hq/security/code-scanning/392](https://github.com/dimagi/commcare-hq/security/code-scanning/392)

We don't really need to use a regular expression here - a simple `contains` is easier and avoids the risk of injection

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
