### PR TITLE
Fix case grouping page

### DIFF
--- a/corehq/apps/geospatial/templates/geospatial/case_grouping_map_base.html
+++ b/corehq/apps/geospatial/templates/geospatial/case_grouping_map_base.html
@@ -18,4 +18,5 @@
     {% initial_page_data "saved_polygons" saved_polygons %}
     {% registerurl 'geo_polygons' domain %}
     {% registerurl 'geo_polygon' domain '---' %}
+    {% registerurl 'reassign_cases' domain %}
 {% endblock %}


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
A [change](https://github.com/dimagi/commcare-hq/pull/34993/files#diff-f7678da076b04a23a985a832225e6710338270977cf3f107bd1c46bc93eaae14R23) in a PR related to geospatial added a dependency that broke case grouping page. The case grouping page would not load correctly, due to JS error.
This PR adds that dependency.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Adding a URL to the javascript file, needs the URL to be registered in the template. A URL was added to the JS file which was included in 2 places and hence broke the other place that was not a part of the feature change being done.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
GEOSPATIAL

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally that page loads okay now.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
