### PR TITLE
fix toggle issue on case importer page

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
@@ -60,14 +60,14 @@
                 class="btn btn-outline-primary btn-sm"
                 data-bs-toggle="collapse"
                 data-bind="attr: {
-                  'data-bs-target': '#rowDetailsCollapse-' + $index(),
-                  'aria-controls': 'rowDetailsCollapse-' + $index()
+                  'data-bs-target': '#rowDetailsCollapse-' + $parentContext.$index(),
+                  'aria-controls': 'rowDetailsCollapse-' + $parentContext.$index()
                 }"
                 aria-expanded="false">
           {% trans "Toggle Affected Row(s)" %}
         </button>
         <div class="collapse"
-             data-bind="attr: { id: 'rowDetailsCollapse-' + $index() }">
+             data-bind="attr: { id: 'rowDetailsCollapse-' + $parentContext.$index() }">
           <div class="card card-body mt-3"
                data-bind="text: rows.join(', ')"></div>
         </div>


### PR DESCRIPTION
## Technical Summary
Followup on https://dimagi.atlassian.net/browse/QA-7064 which reported a bug that clicking on the toggle button to view the list of affected rows inside the error messages shows all of the affected rows collapsables on all of the error messages on that page.

This was due to the fact that the knockout context where `index()` was being referenced was nested under a parent context which is directly under the ko for loop. In order to reference the proper index and have each collapsable have a unique ID, we need to use use `$parentContenxt.index()`.

## Safety Assurance

### Safety story
very safe fix. tested locally and on staging.

### Automated test coverage

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
