### PR TITLE
Translate 'owner_id' to '@owner_id' in dedupe

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_case_deduplication.py
+++ b/corehq/apps/data_interfaces/tests/test_case_deduplication.py
@@ -323,8 +323,14 @@ class EnsureCaseExistsTest(TestCase):
 
         self.assertTrue(case_exists_in_es(self.domain, updated_case, ['case_name']))
 
-    def _create_case(self, name='Anakin Skywalker'):
-        return self.factory.create_case(case_name=name, update={})
+    def test_when_case_metadata_parameters_match_returns_true(self):
+        case = self._create_case(name='Anakin Skywalker', owner_id='abc123')
+        self._prime_es_index([case])
+
+        self.assertTrue(case_exists_in_es(self.domain, case, ['owner_id']))
+
+    def _create_case(self, name='Anakin Skywalker', owner_id=None):
+        return self.factory.create_case(case_name=name, owner_id=owner_id, update={})
 
 
 @es_test(requires=[case_search_adapter])


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-16052

There is a bug in the dedupe code specifically with rules that use the "owner_id" field. This is a metadata field that is stored as "owner_id" in SQL, but "@owner_id" on the ES object. We display the text "owner_id" to the user, and that same value gets saved to the defined rule as a case property to filter on. The problem is that we currently don't identify that "owner_id" is a metadata property that needs to be converted to "@owner_id" for the ES query, so we instead build an ES query that attempts to match on "owner_id".

This query is used to determine if the current case being processed in the case pillow exists in ES and is up to date. If not, we resave the case to have it processed by the case pillow again, allowing time for ES to refresh its index (every 5 seconds). The problem is, because this query will always fail, we continue to retry this case update by resaving it, and we do this for up to an hour after the case was initially updated.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Only impacts the owner_id field, which is currently broken anyway, and this code only impacts deduplication in general.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added a regression test since owner_id is the only metadata field used in dedupe rules that requires being converted (name is the other metadata field that is consistent across frontend and backend code, and therefore doesn't need to be converted).

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
