### PR TITLE
Webpack Migration Examples

### DIFF
--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -7,6 +7,7 @@ hqDefine('domain/js/toggles', [
     'hqwebapp/js/assert_properties',
     'hqwebapp/js/bootstrap3/knockout_bindings.ko',  // for slideVisible
     'hqwebapp/js/bootstrap3/main',
+    'commcarehq_b3',
 ], function (
     $,
     ko,

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'domain/js/toggles' %}
+{% js_entry_b3 'domain/js/toggles' %}
 
 {% block page_content %}
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/500.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/500.js
@@ -1,6 +1,7 @@
 hqDefine("hqwebapp/js/500",[
     'jquery',
     'es6!hqwebapp/js/bootstrap5_loader',
+    'commcarehq',
 ], function ($, bootstrap) {
     $(function () {
         new bootstrap.Popover('#sad-danny', {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js
@@ -3,6 +3,7 @@ hqDefine("hqwebapp/js/bootstrap3/hq.helpers", [
     'knockout',
     'underscore',
     'analytix/js/google',
+    'bootstrap',  // for popover constructor override
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/templates/500.html
+++ b/corehq/apps/hqwebapp/templates/500.html
@@ -5,7 +5,7 @@
   {% trans "500 Error" %}
 {% endblock %}
 
-{% requirejs_main_b5 'hqwebapp/js/500' %}
+{% js_entry 'hqwebapp/js/500' %}
 
 {% block page_name %}{% trans "Oh no, something unexpected just happened!" %}{% endblock %}
 {% block page_content %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
@@ -1,12 +1,13 @@
 --- 
 +++ 
-@@ -1,13 +1,15 @@
+@@ -1,14 +1,15 @@
 -hqDefine("hqwebapp/js/bootstrap3/hq.helpers", [
 +hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
      'jquery',
      'knockout',
      'underscore',
      'analytix/js/google',
+-    'bootstrap',  // for popover constructor override
 +    'es6!hqwebapp/js/bootstrap5_loader',
  ], function (
      $,
@@ -18,7 +19,7 @@
  ) {
      // disable-on-submit is a class for form submit buttons so they're automatically disabled when the form is submitted
      $(document).on('submit', 'form', function (ev) {
-@@ -54,19 +56,6 @@
+@@ -55,19 +56,6 @@
          return false; // let default handler run
      };
  
@@ -38,7 +39,7 @@
      $.fn.hqHelp = function (opts) {
          var self = this;
          self.each(function (i) {
-@@ -83,22 +72,19 @@
+@@ -84,22 +72,19 @@
              if (opts) {
                  options = _.extend(options, opts);
              }


### PR DESCRIPTION
## Technical Summary
Two example (simple) webpack migrations. One for the 500 page and one for the domain feature flags and privileges page
Additionally, fixes a `TypeError` issue raised when including `hqwebapp/bootstrap3/hq.helpers`. It seems Webpack is more particular about ensuring that imports required by a bundle are always specified rather than requirejs approach that "it was already imported elsewhere"


## Safety Assurance

### Safety story
safe changes made on relatively simple pages. tested locally.

### Automated test coverage
No

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
