### PR TITLE
Move feedback component out of components.ko.js

### DIFF
--- a/corehq/apps/export/static/export/js/bootstrap3/export_list.js
+++ b/corehq/apps/export/static/export/js/bootstrap3/export_list.js
@@ -21,7 +21,8 @@ hqDefine("export/js/bootstrap3/export_list", [
     'analytix/js/kissmetrix',
     'export/js/utils',
     'hqwebapp/js/bootstrap3/validators.ko',        // needed for validation of startDate and endDate
-    'hqwebapp/js/bootstrap3/components.ko',        // pagination & feedback widget
+    'hqwebapp/js/bootstrap3/components.ko',        // pagination widget
+    'hqwebapp/js/components/bootstrap3/feedback',
     'select2/dist/js/select2.full.min',
 ], function (
     $,

--- a/corehq/apps/export/static/export/js/bootstrap5/export_list.js
+++ b/corehq/apps/export/static/export/js/bootstrap5/export_list.js
@@ -21,7 +21,8 @@ hqDefine("export/js/bootstrap5/export_list", [
     'analytix/js/kissmetrix',
     'export/js/utils',
     'hqwebapp/js/bootstrap5/validators.ko',        // needed for validation of startDate and endDate
-    'hqwebapp/js/bootstrap5/components.ko',        // pagination & feedback widget
+    'hqwebapp/js/bootstrap5/components.ko',        // pagination widget
+    'hqwebapp/js/components/bootstrap5/feedback',
     'select2/dist/js/select2.full.min',
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/components.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/components.ko.js
@@ -6,7 +6,6 @@ hqDefine("hqwebapp/js/bootstrap3/components.ko", [
     'hqwebapp/js/components/pagination',
     'hqwebapp/js/components/search_box',
     'hqwebapp/js/components/select_toggle',
-    'hqwebapp/js/components/bootstrap3/feedback',
 ], function (
     $,
     ko,
@@ -14,15 +13,13 @@ hqDefine("hqwebapp/js/bootstrap3/components.ko", [
     inlineEdit,
     pagination,
     searchBox,
-    selectToggle,
-    feedback
+    selectToggle
 ) {
     var components = {
         'inline-edit': inlineEdit,
         'pagination': pagination,
         'search-box': searchBox,
         'select-toggle': selectToggle,
-        'feedback': feedback,
     };
 
     _.each(components, function (moduleName, elementName) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/components.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/components.ko.js
@@ -6,7 +6,6 @@ hqDefine("hqwebapp/js/bootstrap5/components.ko", [
     'hqwebapp/js/components/pagination',
     'hqwebapp/js/components/search_box',
     'hqwebapp/js/components/select_toggle',
-    'hqwebapp/js/components/bootstrap5/feedback',
 ], function (
     $,
     ko,
@@ -14,15 +13,13 @@ hqDefine("hqwebapp/js/bootstrap5/components.ko", [
     inlineEdit,
     pagination,
     searchBox,
-    selectToggle,
-    feedback
+    selectToggle
 ) {
     var components = {
         'inline-edit': inlineEdit,
         'pagination': pagination,
         'search-box': searchBox,
         'select-toggle': selectToggle,
-        'feedback': feedback,
     };
 
     _.each(components, function (moduleName, elementName) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/bootstrap3/feedback.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/bootstrap3/feedback.js
@@ -82,7 +82,7 @@ hqDefine('hqwebapp/js/components/bootstrap3/feedback', [
     $(function () {
         _.each($('feedback'), function (el) {
             var $el = $(el);
-            if (!($el.data('apply-bindings') === false)) {
+            if ($el.data('apply-bindings') !== false) {
                 $(el).koApplyBindings();
             }
         });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/bootstrap3/feedback.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/bootstrap3/feedback.js
@@ -16,13 +16,15 @@
 hqDefine('hqwebapp/js/components/bootstrap3/feedback', [
     'knockout',
     'jquery',
+    'underscore',
     'hqwebapp/js/initial_page_data',
 ], function (
     ko,
     $,
+    _,
     initialPageData
 ) {
-    return {
+    const component = {
         viewModel: function (params) {
             var self = {};
 
@@ -74,4 +76,17 @@ hqDefine('hqwebapp/js/components/bootstrap3/feedback', [
         },
         template: '<div data-bind="template: { name: \'ko-feedback-template\' }"></div>',
     };
+
+    ko.components.register('feedback', component);
+
+    $(function () {
+        _.each($('feedback'), function (el) {
+            var $el = $(el);
+            if (!($el.data('apply-bindings') === false)) {
+                $(el).koApplyBindings();
+            }
+        });
+    });
+
+    return component;
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/bootstrap5/feedback.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/bootstrap5/feedback.js
@@ -16,13 +16,15 @@
 hqDefine('hqwebapp/js/components/bootstrap5/feedback', [
     'knockout',
     'jquery',
+    'underscore',
     'hqwebapp/js/initial_page_data',
 ], function (
     ko,
     $,
+    _,
     initialPageData
 ) {
-    return {
+    const component = {
         viewModel: function (params) {
             let self = {};
 
@@ -69,4 +71,17 @@ hqDefine('hqwebapp/js/components/bootstrap5/feedback', [
         },
         template: '<div data-bind="template: { name: \'ko-feedback-template\' }"></div>',
     };
+
+    ko.components.register('feedback', component);
+
+    $(function () {
+        _.each($('feedback'), function (el) {
+            var $el = $(el);
+            if (!($el.data('apply-bindings') === false)) {
+                $(el).koApplyBindings();
+            }
+        });
+    });
+
+    return component;
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/bootstrap5/feedback.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/bootstrap5/feedback.js
@@ -77,7 +77,7 @@ hqDefine('hqwebapp/js/components/bootstrap5/feedback', [
     $(function () {
         _.each($('feedback'), function (el) {
             var $el = $(el);
-            if (!($el.data('apply-bindings') === false)) {
+            if ($el.data('apply-bindings') !== false) {
                 $(el).koApplyBindings();
             }
         });

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/export/js/export_list.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/export/js/export_list.js.diff.txt
@@ -9,18 +9,20 @@
      'jquery',
      'knockout',
      'underscore',
-@@ -20,8 +20,8 @@
+@@ -20,9 +20,9 @@
      'analytix/js/google',
      'analytix/js/kissmetrix',
      'export/js/utils',
 -    'hqwebapp/js/bootstrap3/validators.ko',        // needed for validation of startDate and endDate
--    'hqwebapp/js/bootstrap3/components.ko',        // pagination & feedback widget
+-    'hqwebapp/js/bootstrap3/components.ko',        // pagination widget
+-    'hqwebapp/js/components/bootstrap3/feedback',
 +    'hqwebapp/js/bootstrap5/validators.ko',        // needed for validation of startDate and endDate
-+    'hqwebapp/js/bootstrap5/components.ko',        // pagination & feedback widget
++    'hqwebapp/js/bootstrap5/components.ko',        // pagination widget
++    'hqwebapp/js/components/bootstrap5/feedback',
      'select2/dist/js/select2.full.min',
  ], function (
      $,
-@@ -181,7 +181,7 @@
+@@ -182,7 +182,7 @@
                          self.isAutoRebuildEnabled(data.isAutoRebuildEnabled);
                      }
                      $button.enableButton();
@@ -29,7 +31,7 @@
                  },
              });
          };
-@@ -261,7 +261,7 @@
+@@ -262,7 +262,7 @@
          };
  
          self.updateData = function () {
@@ -38,7 +40,7 @@
              self.updatingData(true);
              $.ajax({
                  method: 'POST',
-@@ -472,11 +472,11 @@
+@@ -473,11 +473,11 @@
          $(function () {
              $('[data-toggle="tooltip-bulkExport"]').attr('title',
                  gettext("All of the selected exports will be collected for download to a " +
@@ -52,7 +54,7 @@
          });
  
          self.isMultiple = ko.computed(function () {
-@@ -680,7 +680,7 @@
+@@ -681,7 +681,7 @@
                          if (export_.hasEmailedExport) {
                              export_.emailedExport.pollProgressBar();
                          }

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/components.ko.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/components.ko.js.diff.txt
@@ -6,12 +6,3 @@
      'jquery',
      'knockout',
      'underscore',
-@@ -6,7 +6,7 @@
-     'hqwebapp/js/components/pagination',
-     'hqwebapp/js/components/search_box',
-     'hqwebapp/js/components/select_toggle',
--    'hqwebapp/js/components/bootstrap3/feedback',
-+    'hqwebapp/js/components/bootstrap5/feedback',
- ], function (
-     $,
-     ko,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/components/feedback.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/components/feedback.js.diff.txt
@@ -8,17 +8,17 @@
 +hqDefine('hqwebapp/js/components/bootstrap5/feedback', [
      'knockout',
      'jquery',
-     'hqwebapp/js/initial_page_data',
-@@ -24,7 +24,7 @@
+     'underscore',
+@@ -26,7 +26,7 @@
  ) {
-     return {
+     const component = {
          viewModel: function (params) {
 -            var self = {};
 +            let self = {};
  
              if (!params.featureName) {
                  throw new Error("Please specify a featureName in params.");
-@@ -62,11 +62,6 @@
+@@ -64,11 +64,6 @@
                          if (data.success) {
                              self.showSuccess(true);
                          }

--- a/corehq/apps/reports/static/reports/v2/js/views/bootstrap3/explore_case_data.js
+++ b/corehq/apps/reports/static/reports/v2/js/views/bootstrap3/explore_case_data.js
@@ -4,6 +4,7 @@ hqDefine('reports/v2/js/views/bootstrap3/explore_case_data', [
     'underscore',
     'reports/v2/js/context',
     'reports/v2/js/bootstrap3/datagrid',
+    'hqwebapp/js/components/bootstrap3/feedback',
 ], function (
     $,
     ko,

--- a/corehq/apps/reports/static/reports/v2/js/views/bootstrap5/explore_case_data.js
+++ b/corehq/apps/reports/static/reports/v2/js/views/bootstrap5/explore_case_data.js
@@ -4,6 +4,7 @@ hqDefine('reports/v2/js/views/bootstrap5/explore_case_data', [
     'underscore',
     'reports/v2/js/context',
     'reports/v2/js/bootstrap5/datagrid',
+    'hqwebapp/js/components/bootstrap5/feedback',
 ], function (
     $,
     ko,


### PR DESCRIPTION
## Technical Summary
As discussed here: https://github.com/dimagi/commcare-hq/pull/35166#discussion_r1786427040

This PR just updates the feedback component, which is the least-frequently-used one. Since comments are indeed unreliable, I grepped for `<feedback` to find  the two places it's used (OData feeds and the Explore Case Data report), updated those, and tested that the widget still works.

Bonus, this PR makes it so that `components.ko.js` no longer needs to be split into a B3 and B5 version, which will reduce the number of split js files at least a little bit. I'll follow up on that in a different PR.

## Safety Assurance

### Safety story
Smoke tested locally.

### Automated test coverage

unlikely

### QA Plan

not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
