### PR TITLE
Fix code scanning alert no. 353: Incomplete regular expression for hostnames

### DIFF
--- a/corehq/apps/sso/forms.py
+++ b/corehq/apps/sso/forms.py
@@ -66,7 +66,7 @@ def _check_required_when_active(is_active, value):
 
 def _ensure_entity_id_matches_expected_provider(entity_id, identity_provider):
     if (identity_provider.idp_type == IdentityProviderType.ONE_LOGIN
-            and not re.match(r'^https:\/\/[A-za-z\d-]*.onelogin.com\/', entity_id)):
+            and not re.match(r'^https:\/\/[A-za-z\d-]*\.onelogin\.com\/', entity_id)):
         raise forms.ValidationError(
             _("This is not a valid One Login URL.")
         )


### PR DESCRIPTION
From https://github.com/dimagi/commcare-hq/pull/31633/files#diff-3a0e18ec3001b34cabd014702d1a3b2e835c4c1cf4062a356d33ba798f69d448R65

The regex has unescaped `.` characters, meaning they'd match any character, rather than just a literal `.`

Fixes [https://github.com/dimagi/commcare-hq/security/code-scanning/353](https://github.com/dimagi/commcare-hq/security/code-scanning/353)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
