### PR TITLE
Simplify function that extracts form ID from URL

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/case_details.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/case_details.js.diff.txt
@@ -21,7 +21,7 @@
      'bootstrap',    // needed for $.tab
      'jquery-memoized-ajax/jquery.memoized.ajax.min',
  ], function (
-@@ -99,7 +99,7 @@
+@@ -92,7 +92,7 @@
                      // form data panel uses sticky tabs when it's its own page
                      // but that behavior would be disruptive here
                      $panel.find(".sticky-tabs").removeClass("sticky-tabs");
@@ -30,7 +30,7 @@
  
                      singleForm.initSingleForm({
                          instance_id: data.xform_id,
-@@ -282,7 +282,7 @@
+@@ -275,7 +275,7 @@
          $propertiesModal.koApplyBindings(modalData);
          $casePropertyNames.click(function () {
              modalData.init($(this).data('property-name'));

--- a/corehq/apps/reports/static/reports/js/bootstrap3/case_details.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/case_details.js
@@ -72,20 +72,13 @@ hqDefine("reports/js/bootstrap3/case_details", [
 
         self.data_loading = ko.observable(false);
 
-        self.getParameterByName = function (name, url) {
-            if (!url) {
-                url = window.location.href;
+        self.getFormIdFromUrl = function () {
+            var regex = new RegExp("[?&]form_id(=([^&#]*)|&|#|$)"),
+                results = regex.exec(window.location.hash);
+            if (results && results[2]) {
+                return decodeURIComponent(results[2]);
             }
-            name = name.replace(/[[\]]/g, "\\$&");
-            var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
-                results = regex.exec(url);
-            if (!results) {
-                return null;
-            }
-            if (!results[2]) {
-                return '';
-            }
-            return decodeURIComponent(results[2].replace(/\+/g, " "));
+            return null;
         };
 
         self.get_xform_data = function (xformId) {
@@ -124,7 +117,7 @@ hqDefine("reports/js/bootstrap3/case_details", [
         var loadForm = function () {
             var hash = window.location.hash.split('?');
             if (hash[0] === '#history') {
-                var formId = self.getParameterByName('form_id', window.location.hash);
+                var formId = self.getFormIdFromUrl();
                 if (formId) {
                     self.get_xform_data(formId);
                     self.selected_xform_doc_id(formId);

--- a/corehq/apps/reports/static/reports/js/bootstrap5/case_details.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/case_details.js
@@ -72,20 +72,13 @@ hqDefine("reports/js/bootstrap5/case_details", [
 
         self.data_loading = ko.observable(false);
 
-        self.getParameterByName = function (name, url) {
-            if (!url) {
-                url = window.location.href;
+        self.getFormIdFromUrl = function () {
+            var regex = new RegExp("[?&]form_id(=([^&#]*)|&|#|$)"),
+                results = regex.exec(window.location.hash);
+            if (results && results[2]) {
+                return decodeURIComponent(results[2]);
             }
-            name = name.replace(/[[\]]/g, "\\$&");
-            var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
-                results = regex.exec(url);
-            if (!results) {
-                return null;
-            }
-            if (!results[2]) {
-                return '';
-            }
-            return decodeURIComponent(results[2].replace(/\+/g, " "));
+            return null;
         };
 
         self.get_xform_data = function (xformId) {
@@ -124,7 +117,7 @@ hqDefine("reports/js/bootstrap5/case_details", [
         var loadForm = function () {
             var hash = window.location.hash.split('?');
             if (hash[0] === '#history') {
-                var formId = self.getParameterByName('form_id', window.location.hash);
+                var formId = self.getFormIdFromUrl();
                 if (formId) {
                     self.get_xform_data(formId);
                     self.selected_xform_doc_id(formId);


### PR DESCRIPTION
## Product Description


## Technical Summary

Discovered in https://github.com/dimagi/commcare-hq/security/code-scanning/402 (though the actual concern there is unfounded)

This was introduced in https://github.com/dimagi/commcare-hq/commit/73beec69d6ba90c3952275927f957e06599d89b4
I suspect it was copy/pasted from somewhere, because it is far more generic than it needs to be.  Could probably simplify the remaining regex (or better yet, there must be a library for this), but I didn't want to grow the scope too much.

## Feature Flag


## Safety Assurance


### Safety story

I tested locally, and the changes are pretty straightforward

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
