### PR TITLE
Bump xmlsec to 1.3.14

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -841,7 +841,7 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.12
+xmlsec==1.3.14
     # via python3-saml
 xmltodict==0.13.0
     # via ddtrace

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -695,7 +695,7 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.12
+xmlsec==1.3.14
     # via python3-saml
 xmltodict==0.13.0
     # via ddtrace

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -646,7 +646,7 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.12
+xmlsec==1.3.14
     # via python3-saml
 xmltodict==0.13.0
     # via ddtrace

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -704,7 +704,7 @@ xlrd==2.0.1
     # via -r base-requirements.in
 xlwt==1.3.0
     # via -r base-requirements.in
-xmlsec==1.3.12
+xmlsec==1.3.14
     # via python3-saml
 xmltodict==0.13.0
     # via ddtrace


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
@jingcheng16 dug into this to understand how upgrading xmlsec will help with compatibility issues with lxml>=5. This is only a patch version update (1.3.12 -> 1.3.14). No breaking changes are mentioned in the changelog.

[Changelog](https://github.com/xmlsec/python-xmlsec/releases)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
