### PR TITLE
Fix bug with emailing custom enterprise report date range

### DIFF
--- a/corehq/apps/enterprise/tasks.py
+++ b/corehq/apps/enterprise/tasks.py
@@ -25,9 +25,9 @@ from corehq.util.view_utils import absolute_reverse
 
 
 @task(serializer='pickle', queue="email_queue")
-def email_enterprise_report(domain: str, slug, couch_user):
+def email_enterprise_report(domain: str, slug, couch_user, **kwargs):
     account = BillingAccount.get_account_by_domain(domain)
-    report = EnterpriseReport.create(slug, account.id, couch_user)
+    report = EnterpriseReport.create(slug, account.id, couch_user, **kwargs)
 
     # Generate file
     csv_file = io.StringIO()

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -150,7 +150,7 @@ def enterprise_dashboard_email(request, domain, slug):
         response.status_code = 400
         return response
 
-    email_enterprise_report.delay(domain, slug, request.couch_user)
+    email_enterprise_report.delay(domain, slug, request.couch_user, **kwargs)
     message = _("Generating {title} report, will email to {email} when complete.").format(**{
         'title': report.title,
         'email': request.couch_user.username,


### PR DESCRIPTION
## Technical Summary
Bug was included in https://github.com/dimagi/commcare-hq/pull/35166, where any customized data range was ignored for actually generating the CSV download. This fix passes the custom date parameters on to the download generation task.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Verified the fix locally and on staging.

### Automated test coverage

No tests.

### QA Plan

No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
