### PR TITLE
Add MVP "case search count" endpoint

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -535,3 +535,7 @@ def _get_case_search_cases(helper, case_ids):
 # Warning: '_tag_is_related_case' may cause the relevant user-defined properties to be overwritten.
 def _tag_is_related_case(case):
     case.case_json[IS_RELATED_CASE] = "true"
+
+
+def get_case_search_count(domain, xpath_query):
+    return CaseSearchES().domain(domain).xpath_query(domain, xpath_query).count()

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -313,3 +313,10 @@ class CaseClaimEndpointTests(TestCase):
             response = self.client.post(self.url, {'case_id': self.case_id},
                                         HTTP_X_COMMCAREHQ_LASTSYNCTOKEN=self.synclog.synclog_id)
             self.assertEqual(response.status_code, 201)
+
+    def test_case_search_count(self):
+        url = reverse('case_search_count', kwargs={'domain': DOMAIN})
+        response = self.client.post(url, {'xpath': f'opened_by = "{OWNER_ID}"'})
+        self.assertEqual(response.content, b'2')
+        response = self.client.post(url, {'xpath': f'case_name = "{CASE_NAME}"'})
+        self.assertEqual(response.content, b'1')

--- a/corehq/apps/ota/urls.py
+++ b/corehq/apps/ota/urls.py
@@ -3,14 +3,15 @@ from django.urls import re_path as url
 from corehq.apps.hqadmin.views.users import DomainAdminRestoreView
 from corehq.apps.ota.views import (
     app_aware_search,
+    case_fixture,
+    case_restore,
+    case_search_count,
     claim,
     get_next_id,
     heartbeat,
     recovery_measures,
     restore,
     search,
-    case_fixture,
-    case_restore,
 )
 
 urlpatterns = [
@@ -20,6 +21,7 @@ urlpatterns = [
     url(r'^restore/(?P<app_id>[\w-]+)/$', restore, name='app_aware_restore'),
     url(r'^search/$', search, name='remote_search'),
     url(r'^search/(?P<app_id>[\w-]+)/$', app_aware_search, name='app_aware_remote_search'),
+    url(r'^case_search_count/$', case_search_count, name='case_search_count'),
     url(r'^claim-case/$', claim, name='claim_case'),
     url(r'^heartbeat/(?P<app_build_id>[\w-]+)/$', heartbeat, name='phone_heartbeat'),
     url(r'^get_next_id/$', get_next_id, name='get_next_id'),


### PR DESCRIPTION
## Product Description


## Technical Summary

[[CEP] Real-Time Data Access in WebApps](https://docs.google.com/document/d/1ndrAT0OEsw8rJeKvMwdMfXR7hmmUN2P77RNH2lMUOUY/edit)
[[Tech Spec] Menu badges
](https://docs.google.com/document/d/1NpBZjexp4FLnrCH8fqkuXSTdooYHS6ag0TGtt2IouqU/edit)

As-yet-unused API endpoint to support module badges showing a count from case search.  It accepts only a string representing a CSQL query and returns a single number.  Depending on what's useful on mobile, we could also wrap the number in a bit of XML.

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change