### PR TITLE
EscapeHTML instead of escapeJS strings

### DIFF
--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -212,7 +212,6 @@ def _get_dynamic_input_trans_options(name, escape_method: EscapeMethod, langs=No
 
 
 def _escape_options(options, escape_method: EscapeMethod):
-    escaped_options = {}
     if escape_method == EscapeMethod.HTML:
         escape_func = html.escape
     elif escape_method == EscapeMethod.JS:

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -5,6 +5,7 @@ from django.utils.translation import (
     gettext as _,
     gettext_lazy
 )
+from enum import Enum
 
 register = template.Library()
 
@@ -117,10 +118,15 @@ def html_name(name):
     return html.strip_tags(name) or EMPTY_LABEL
 
 
+class EscapeMethod(Enum):
+    HTML = 'html'
+    JS = 'js'
+
+
 @register.simple_tag
 def input_trans(name, langs=None, input_name='name', input_id=None, data_bind=None, element_type='input_text'):
     if element_type == 'input_text':
-        options = _get_dynamic_input_trans_options(name, langs=langs)
+        options = _get_dynamic_input_trans_options(name, EscapeMethod.HTML, langs=langs)
         template = '''
             <input type="text"
                    name="{input_name}" {input_id_attribute} {data_bind_attribute}
@@ -129,7 +135,7 @@ def input_trans(name, langs=None, input_name='name', input_id=None, data_bind=No
                    placeholder="{placeholder}" />
         '''
     elif element_type == 'textarea':
-        options = _get_dynamic_input_trans_options(name, langs=langs, is_textarea=True)
+        options = _get_dynamic_input_trans_options(name, EscapeMethod.HTML, langs=langs)
         template = '''
             <textarea name="{input_name}" {input_id_attribute} {data_bind_attribute}
                       class="form-control vertical-resize"
@@ -151,7 +157,7 @@ def input_trans(name, langs=None, input_name='name', input_id=None, data_bind=No
 @register.simple_tag
 def inline_edit_trans(name, langs=None, url='', saveValueName='', postSave='',
         containerClass='', iconClass='', readOnlyClass='', disallow_edit='false'):
-    options = _get_dynamic_input_trans_options(name, langs=langs, allow_blank=False)
+    options = _get_dynamic_input_trans_options(name, EscapeMethod.JS, langs=langs, allow_blank=False)
     options.update({
         'url': url,
         'saveValueName': saveValueName,
@@ -181,7 +187,7 @@ def inline_edit_trans(name, langs=None, url='', saveValueName='', postSave='',
     return format_html(template, **options)
 
 
-def _get_dynamic_input_trans_options(name, langs=None, allow_blank=True, is_textarea=False):
+def _get_dynamic_input_trans_options(name, escape_method: EscapeMethod, langs=None, allow_blank=True):
     if langs is None:
         langs = ["default"]
     placeholder = _("Untitled")
@@ -201,18 +207,17 @@ def _get_dynamic_input_trans_options(name, langs=None, allow_blank=True, is_text
                 options['placeholder'] = name[lang] if (allow_blank or name[lang] != '') else placeholder
                 options['lang'] = lang
             break
-    if is_textarea:
-        options = _escape_options(options, keys_to_html_escape=['value'])
-    else:
-        options = _escape_options(options)
+    options = _escape_options(options, escape_method=escape_method)
     return options
 
 
-def _escape_options(options, keys_to_html_escape: list[str] = []):
+def _escape_options(options, escape_method: EscapeMethod):
     escaped_options = {}
-    for (key, value) in options.items():
-        if key in keys_to_html_escape:
-            escaped_options[key] = html.escape(value)
-        else:
-            escaped_options[key] = html.escapejs(value)
+    if escape_method == EscapeMethod.HTML:
+        escape_func = html.escape
+    elif escape_method == EscapeMethod.JS:
+        escape_func = html.escapejs
+
+    for key, value in options.items():
+        escaped_options[key] = escape_func(value)
     return escaped_options

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -217,7 +217,6 @@ def _escape_options(options, escape_method: EscapeMethod):
         escape_func = html.escape
     elif escape_method == EscapeMethod.JS:
         escape_func = html.escapejs
-
-    for key, value in options.items():
-        escaped_options[key] = escape_func(value)
+    
+    escaped_options = {key: escape_func(value) for key, value in options.items()}
     return escaped_options

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -216,6 +216,6 @@ def _escape_options(options, escape_method: EscapeMethod):
         escape_func = html.escape
     elif escape_method == EscapeMethod.JS:
         escape_func = html.escapejs
-    
+
     escaped_options = {key: escape_func(value) for key, value in options.items()}
     return escaped_options

--- a/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
+++ b/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
@@ -288,18 +288,18 @@ class TestInputTransFilter(SimpleTestCase):
             data_bind=data_bind,
             element_type=element_type)
 
-        return fragment_fromstring(markup)
+        return markup, fragment_fromstring(markup)
 
     def test_creates_input_tag(self):
-        fragment = self.generate_markup_fragment()
+        markup, fragment = self.generate_markup_fragment()
         self.assertEqual(fragment.tag, 'input')
 
     def test_creates_textarea_tag(self):
-        fragment = self.generate_markup_fragment(element_type='textarea')
+        markup, fragment = self.generate_markup_fragment(element_type='textarea')
         self.assertEqual(fragment.tag, 'textarea')
 
     def test_fills_all_attributes(self):
-        fragment = self.generate_markup_fragment(
+        markup, fragment = self.generate_markup_fragment(
             name_dict={'en': 'English Output'},
             langs=['en'],
             input_name='name',
@@ -316,7 +316,7 @@ class TestInputTransFilter(SimpleTestCase):
         self.assertEqual(fragment.attrib['placeholder'], '')
 
     def test_primary_language_populates_value(self):
-        fragment = self.generate_markup_fragment(
+        markup, fragment = self.generate_markup_fragment(
             name_dict={'en': 'English Output'},
             langs=['en']
         )
@@ -325,7 +325,7 @@ class TestInputTransFilter(SimpleTestCase):
         self.assertEqual(fragment.attrib['placeholder'], '')
 
     def test_secondary_language_ignores_value_and_populates_placeholder(self):
-        fragment = self.generate_markup_fragment(
+        markup, fragment = self.generate_markup_fragment(
             name_dict={'por': 'Portuguese Output'},
             langs=['en', 'por']
         )
@@ -334,30 +334,29 @@ class TestInputTransFilter(SimpleTestCase):
         self.assertEqual(fragment.attrib['placeholder'], 'Portuguese Output')
 
     def test_no_id_contains_no_id_attribute(self):
-        fragment = self.generate_markup_fragment(input_name=None)
+        markup, fragment = self.generate_markup_fragment(input_name=None)
 
         self.assertFalse('input_id' in fragment.attrib)
 
     def test_no_data_binding_contains_no_data_binding(self):
-        fragment = self.generate_markup_fragment(data_bind=None)
+        markup, fragment = self.generate_markup_fragment(data_bind=None)
 
         self.assertFalse('data-bind' in fragment.attrib)
 
-    # NOTE: documenting existing behavior -- I think this was a side effect
-    # of the parsing logic also being used elsewhere, and I doubt 'value' is meant to have javascript-escaping
-    def test_escapes_value_using_javascript_notation(self):
-        fragment = self.generate_markup_fragment(
-            name_dict={'en': 'English; Output'},
+    def test_escapes_value_using_html_escape(self):
+        markup, fragment = self.generate_markup_fragment(
+            name_dict={'en': 'English <div>Output</div>'},
             langs=['en']
         )
 
-        self.assertEqual(fragment.attrib['value'], 'English\\u003B Output')
+        self.assertIn('value="English &lt;div&gt;Output&lt;/div&gt;"', markup)
+        self.assertEqual(fragment.attrib['value'], 'English <div>Output</div>')
 
-    # NOTE: documenting existing behavior -- it is unlikely this needs to be javascript-escaped
-    def test_escapes_placeholder_using_javascript_notation(self):
-        fragment = self.generate_markup_fragment(
-            name_dict={'por': 'Portuguese; Output'},
+    def test_escapes_placeholder_using_html_escape(self):
+        markup, fragment = self.generate_markup_fragment(
+            name_dict={'por': 'Portuguese <div>Output</div>'},
             langs=['en', 'por']
         )
 
-        self.assertEqual(fragment.attrib['placeholder'], 'Portuguese\\u003B Output')
+        self.assertIn('placeholder="Portuguese &lt;div&gt;Output&lt;/div&gt;"', markup)
+        self.assertEqual(fragment.attrib['placeholder'], 'Portuguese <div>Output</div>')


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
There was a bug where inputs were incorrectly javascript escaped and displayed as such.

![image](https://github.com/user-attachments/assets/d418606d-9123-4817-9653-b26fa67bb768)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This PR was a result of [this](https://dimagi.slack.com/archives/C02A78X98AK/p1728490455609239) bug report.

The strings involved in `input_trans` are not used as string literals within javascript in any context so there is no need for it to be javascript escaped. inline-edit is an[ HQ component ](https://www.commcarehq.org/styleguide/b5/molecules/inline_editing/)so the value string would be involved as a javascript literal so those strings continue to be javascript escaped.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No Feature Flag

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Locally tested. The change is limited to how special characters for text is displayed.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Test exists that checks the markup output is as expected.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
