### PR TITLE
Upgrade DOMpurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@popperjs/core": "npm:@popperjs/core#2.11.6",
         "At.js": "millerdev/At.js#master",
         "Caret.js": "INTELOGIE/Caret.js#0.3.1",
-        "DOMPurify": "npm:dompurify#2.3.6",
+        "DOMPurify": "npm:dompurify#2.5.0",
         "ace-builds": "1.5.0",
         "babel-loader": "9.1.3",
         "babel-plugin-transform-modules-requirejs-babel": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@popperjs/core": "npm:@popperjs/core#2.11.6",
         "At.js": "millerdev/At.js#master",
         "Caret.js": "INTELOGIE/Caret.js#0.3.1",
-        "DOMPurify": "npm:dompurify#2.5.0",
+        "DOMPurify": "npm:dompurify#3.1.7",
         "ace-builds": "1.5.0",
         "babel-loader": "9.1.3",
         "babel-plugin-transform-modules-requirejs-babel": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,10 +1216,10 @@ Caret.js@INTELOGIE/Caret.js#0.3.1:
   dependencies:
     grunt "~0.4.1"
 
-"DOMPurify@npm:dompurify#2.3.6":
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.6.tgz#2e019d7d7617aacac07cbbe3d88ae3ad354cf875"
-  integrity sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg==
+"DOMPurify@npm:dompurify#2.5.0":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.7.tgz#711a8c96479fb6ced93453732c160c3c72418a6a"
+  integrity sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==
 
 abbrev@1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,7 +1216,7 @@ Caret.js@INTELOGIE/Caret.js#0.3.1:
   dependencies:
     grunt "~0.4.1"
 
-"DOMPurify@npm:dompurify#2.5.0":
+"DOMPurify@npm:dompurify#3.1.7":
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.7.tgz#711a8c96479fb6ced93453732c160c3c72418a6a"
   integrity sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Updates DOMPurify to the latest version. In HQ we only use `DOMPurify.sanitize`. I have looked over the changelog and did not see any noticeable changes that affects us. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA

## Safety Assurance
I think this should be safe as- 
- Tests are passing
- It has been on staging for a while and no issues related to it popped up.
- `sanitize` API has not changes


### Automated test coverage
NA
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
