### PR TITLE
BLOCK_SUMOLOGIC_LOGS operates on domain namespace

### DIFF
--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -398,7 +398,7 @@ class SubmissionPost(object):
     def _conditionally_send_device_logs_to_sumologic(self, instance):
         url = getattr(settings, 'SUMOLOGIC_URL', None)
         if (url and SUMOLOGIC_LOGS.enabled(instance.form_data.get('device_id'), NAMESPACE_OTHER)
-                and not BLOCK_SUMOLOGIC_LOGS.enabled(instance.form_data.get('device_id'), self.domain)):
+                and not BLOCK_SUMOLOGIC_LOGS.enabled(self.domain)):
             SumoLogicLog(self.domain, instance).send_data(url)
 
     def _invalidate_caches(self, xform):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Followup to https://github.com/dimagi/commcare-hq/pull/34876

In its current form, we are passing the device_id in at the "item" and the domain as the "namespace" for the `enabled` method on the toggle. However the BLOCK_SUMOLOGIC_LOGS is setup to namespace by domain:

```
BLOCK_SUMOLOGIC_LOGS = StaticToggle(
    'block_sumologic_logs',
    'Block sending logs to sumologic per domain',
    TAG_INTERNAL,
    namespaces=[NAMESPACE_DOMAIN],
)
```
And therefore, we should only pass in the domain when checking if the toggle is enabled.

![Screenshot 2024-10-14 at 7 03 55 PM](https://github.com/user-attachments/assets/ad0781f3-626f-40ba-9aa5-9d69378420a2)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`BLOCK_SUMOLOGIC_LOGS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This feature flag doesn't work in its current form, and the syntax used in the change has been tested in a shell.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
