### PR TITLE
Add `domain` arg in `send_device_log_to_sumologic`

### DIFF
--- a/corehq/ex-submodules/phonelog/tasks.py
+++ b/corehq/ex-submodules/phonelog/tasks.py
@@ -28,7 +28,7 @@ def purge_old_device_report_entries():
 
 @no_result_task(queue='sumologic_logs_queue', default_retry_delay=10 * 60, max_retries=3, bind=True)
 def send_device_log_to_sumologic(self, url, data, headers, domain):
-    # `domain` is added inorder to be able to filter out this task by domain in datadog
+    # `domain` is added in order to be able to filter out this task by domain in datadog
     # `corehq.celery_monitoring.signals.get_domain_from_task` will use this argument to get the domain
     # and pass it to datadog post celery task run
     encoded_headers = {key.encode('utf-8'): header.encode('utf-8') for key, header in headers.items()}

--- a/corehq/ex-submodules/phonelog/tasks.py
+++ b/corehq/ex-submodules/phonelog/tasks.py
@@ -27,7 +27,10 @@ def purge_old_device_report_entries():
 
 
 @no_result_task(queue='sumologic_logs_queue', default_retry_delay=10 * 60, max_retries=3, bind=True)
-def send_device_log_to_sumologic(self, url, data, headers):
+def send_device_log_to_sumologic(self, url, data, headers, domain):
+    # `domain` is added inorder to be able to filter out this task by domain in datadog
+    # `corehq.celery_monitoring.signals.get_domain_from_task` will use this argument to get the domain
+    # and pass it to datadog post celery task run
     encoded_headers = {key.encode('utf-8'): header.encode('utf-8') for key, header in headers.items()}
     with Session() as s:
         s.mount(url, HTTPAdapter(max_retries=5))

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -294,6 +294,7 @@ class SumoLogicLog(object):
 
         return data
 
+
 def clear_device_log_request(domain, xform):
     from corehq.apps.ota.models import DeviceLogRequest
     user_subreport = _get_logs(xform.form_data, 'user_subreport', 'user')

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -191,9 +191,15 @@ class SumoLogicLog(object):
         self.xform = xform
 
     def send_data(self, url):
-        send_device_log_to_sumologic.delay(url, self.log_subreport(), self._get_header('log'))
-        send_device_log_to_sumologic.delay(url, self.user_error_subreport(), self._get_header('user_error'))
-        send_device_log_to_sumologic.delay(url, self.force_close_subreport(), self._get_header('force_close'))
+        send_device_log_to_sumologic.delay(
+            url, self.log_subreport(), self._get_header('log'), self.domain
+        )
+        send_device_log_to_sumologic.delay(
+            url, self.user_error_subreport(), self._get_header('user_error'), self.domain
+        )
+        send_device_log_to_sumologic.delay(
+            url, self.force_close_subreport(), self._get_header('force_close'), self.domain
+        )
 
     def _get_header(self, fmt):
         """


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
While looking into the Sumologic tasks volume today we were not able to figure out how the load is distributed between the domains. My understanding is `domain` is populated in post task run action in https://github.com/dimagi/commcare-hq/blob/03376c7728b81156a4ca1c76c33d2b2732199cad/corehq/celery_monitoring/signals.py#L57 
After this change we should be able to see the distribution for `sumologic_queue` based on domains.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA
## Safety Assurance
I have not tested this change, I will put it on staging to see if it breaks anything but its a small change so should be fine. 
### Safety story

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
