### PR TITLE
Add text-wrap class to entire case list html block

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/tile_grouped_item.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/tile_grouped_item.html
@@ -5,7 +5,7 @@
     </div>
   <% } %>
 
-  <div class="group-data collapsible-tile-content">
+  <div class="group-data collapsible-tile-content text-break">
     <div class="<%- prefix %>-cell-grid-style">
       <% for (let [index, datum] of Object.entries(indexedHeaderData)) { %>
         <% if (styles[index].displayFormat === 'ClickableIcon') { %>


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Some sections within a case tile wasn't wrapping properly for long, unbroken strings and was bleeding into other sections. This resolves that

From this:
<img width="409" alt="Screen Shot 2024-10-14 at 11 44 59 AM" src="https://github.com/user-attachments/assets/7c58463c-26bd-4350-a088-a8df2a04bf7a">

To this:
<img width="390" alt="Screen Shot 2024-10-14 at 11 46 12 AM" src="https://github.com/user-attachments/assets/4021e575-f4fa-4426-aa53-fd26e6f7145a">


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

The title says it all. This also resolves the same issue that was happening in other sections so now everything is neatly contained within the case tile / their own sections. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[Case tile feature flags](https://dimagi.atlassian.net/wiki/spaces/GS/pages/2146602199/Allow+Configuration+of+Case+List+Tiles#AllowConfigurationofCaseListTiles-EnableFeatureflags)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Just a tiny UI change 
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
