### PR TITLE
Catch ArcGIS error with no messageCode

### DIFF
--- a/corehq/motech/repeaters/expression/repeaters.py
+++ b/corehq/motech/repeaters/expression/repeaters.py
@@ -236,29 +236,24 @@ class ArcGISFormExpressionRepeater(FormExpressionRepeater):
 
         >>> response_json = {
         ...     "error": {
-        ...         "code": 403,
-        ...         "details": [
-        ...             "You do not have permissions to access this "
-        ...             "resource or perform this operation."
-        ...         ],
-        ...         "message": "You do not have permissions to access "
-        ...                    "this resource or perform this operation.",
-        ...         "messageCode": "GWM_0003"
+        ...         "code": 503,
+        ...         "details": [],
+        ...         "message": "An error occurred."
         ...     }
         ... }
         >>> resp = ArcGISFormExpressionRepeater._error_response(response_json)
         >>> resp.status_code
-        403
+        503
         >>> resp.reason
-        'You do not have permissions to access this resource or perform this operation. (GWM_0003)'
-        >>> resp.text
-        'You do not have permissions to access this resource or perform this operation.'
+        'An error occurred.'
 
         """
+        reason = response_json['error']['message']
+        if 'messageCode' in response_json['error']:
+            reason += f' ({response_json["error"]["messageCode"]})'
         return RepeaterResponse(
             status_code=response_json['error']['code'],
-            reason=f'{response_json["error"]["message"]} '
-                   f'({response_json["error"]["messageCode"]})',
+            reason=reason,
             text='\n'.join(response_json['error']['details']),
         )
 


### PR DESCRIPTION
## Technical Summary

Catches ArcGIS errors that are missing a "messageCode" property.

Context: [Sentry](https://dimagi.sentry.io/issues/5969162994/?environment=production&project=136860&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20repeater&referrer=issue-stream&sort=date&statsPeriod=24h&stream_index=1)

Some ArcGIS errors look like this:
```javascript
{
  "error": {
    "code": 403,
    "details": [
      "You do not have permissions to access this resource or perform this operation."
    ],
    "message": "You do not have permissions to access this resource or perform this operation.",
    "messageCode": "GWM_0003",
  }
}
```

But it turns out that some look like this:
```javascript
{
  "error": {
    "code": 503,
    "details": [],
    "message": "An error occurred."
  }
}
```

## Feature Flag

`ARCGIS_INTEGRATION`

## Safety Assurance

### Safety story

Ran tests locally

### Automated test coverage

The change is covered by the method's doctest. The previously expected error format is covered by `ArcGISExpressionRepeaterTest`

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
