### PR TITLE
Fix case tile shading blocking tile contents

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/cell_layout_style.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/cell_layout_style.html
@@ -24,7 +24,6 @@
           <% } %>
           <% if (model.showShading) { %>
             background-color: white;
-            z-index: -1;
           <% } %>
         <% } else { %>
           margin: 7px;


### PR DESCRIPTION
## Product Description


## Technical Summary
Remove negative z-index from shaded elements

This seems to be the cause of
https://dimagi.atlassian.net/browse/USH-5012
See ticket for screenshots

It was originally added here:
https://github.com/dimagi/commcare-hq/pull/33908/files#diff-9ba2478f84098bf46ce7d7af2e93881d529b6e0cc6e425d7857a17f0ac992438R264 I asked Robert why it was done that way, and he says "If I remember right, it's -1 because the shading was covering the text otherwise."

Removing it doesn't appear to cover up the text, so maybe that issue has been resolved anyways.  Still not sure how/why this only just started becoming a problem.  My suspicion is that a recent Chrome update might've caused the behavior change.

## Feature Flag
USH: Configure custom case tile for case list and case detail

## Safety Assurance
This is on staging now, where we'll be doing some more testing

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
