### PR TITLE
Allow domain scoped keys to access domain agnostic urls

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -285,12 +285,13 @@ class HQApiKeyAuthentication(ApiKeyAuthentication):
             return False
 
         # ensure API Key exists
-        domain_accessible = Q(domain='')
+        query = Q(key=api_key)
         domain = getattr(request, 'domain', '')
         if domain:
-            domain_accessible = domain_accessible | Q(domain=domain)
+            domain_accessible = Q(domain='') | Q(domain=domain)
+            query = domain_accessible & query
         try:
-            key = user.api_keys.get(domain_accessible, key=api_key)
+            key = user.api_keys.get(query)
         except HQApiKey.DoesNotExist:
             return self._unauthorized()
 

--- a/corehq/apps/domain/tests/test_auth.py
+++ b/corehq/apps/domain/tests/test_auth.py
@@ -303,6 +303,15 @@ class HQApiKeyAuthenticationTests(TestCase):
             response = auth.is_authenticated(request)
             self.assertEqual(response.status_code, 401)
 
+    def test_user_can_authenticate_to_urls_lacking_domain_with_domain_scoped_keys(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', domain='test-domain')
+        request = self._create_request(username='test@dimagi.com', api_key='1234', for_domain='')
+
+        auth = HQApiKeyAuthentication()
+
+        self.assertIs(auth.is_authenticated(request), True)
+
     @classmethod
     def _create_user(cls, username):
         return User.objects.create_user(username=username, password='password')
@@ -339,3 +348,12 @@ class HQApiKeyAuthenticationTests(TestCase):
             request.META['HTTP_X_FORWARDED_FOR'] = ip
 
         return request
+
+    def test_domain_scoped_api_key_allows_authentication_to_domain_agnostic_urls(self):
+        user = self._create_user('test@dimagi.com')
+        self._create_api_key_for_user(user, key='1234', domain='test-domain')
+        request = self._create_request(username='test@dimagi.com', api_key='1234', for_domain='')
+
+        auth = HQApiKeyAuthentication()
+
+        self.assertIs(auth.is_authenticated(request), True)


### PR DESCRIPTION
We recently updated the authentication behaviour in https://github.com/dimagi/commcare-hq/pull/34901 where we started to factor in the domain present in url.

It broke some of the /admin/* apis which did not have a domain in their url.

For example if we use `user_domains` api with a domain scoped api key, we would get a 401.

```
# On master it fails with 401
(hqa)  amitphulera@work  ~/Development/dimagi/commcare-hq  ↰ master  curl -H "Authorization: ApiKey aphulera@dimagi.com:95d6fedad62068fcbd5a808d1b1c82f68e16cc09" 'http://localhost:8000/hq/admin/api/global/user_domains/'
Username or API Key is incorrect, expired or deactivated% 

# Switch to this branch                                                                                        
(hqa)  amitphulera@work  ~/Development/dimagi/commcare-hq  ↰ master  gco ap/allow-domainless-api-keys      
Switched to branch 'ap/allow-domainless-api-keys'

# API works fine
(hqa)  amitphulera@work  ~/Development/dimagi/commcare-hq   ap/allow-domainless-api-keys  curl -H "Authorization: ApiKey aphulera@dimagi.com:95d6fedad62068fcbd5a808d1b1c82f68e16cc09" 'http://localhost:8000/hq/admin/api/global/user_domains/'
{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null, "total_count": 4}, "objects": [{"domain_name": "new-project", "project_name": "New Project"}, {"domain_name": "icds-cas", "project_name": "icds-cas"}, {"domain_name": "intrahealth", "project_name": "intrahealth"}, {"domain_name": "billing-domain-1", "project_name": "billing-domain-1"}]}%   
```

This was noticed during upgrading Zapier version where we use `user_domains` API to test the authentication with the provided API key. 

@mjriley and I pair coded on this fix.
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
I don't think there is a ticket yet. I will create it and update it here.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested it locally and have good test coverage.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
