### PR TITLE
Add message about automatic build/rebuild

### DIFF
--- a/corehq/apps/userreports/pillow_utils.py
+++ b/corehq/apps/userreports/pillow_utils.py
@@ -24,6 +24,11 @@ def _is_datasource_active(adapter):
 
 
 def rebuild_sql_tables(adapters):
+
+    def _notify_rebuild(msg, obj):
+        assert_ = soft_assert(notify_admins=True)
+        assert_(False, msg, obj)
+
     tables_by_engine = defaultdict(dict)
     all_adapters = []
     for adapter in adapters:
@@ -41,10 +46,6 @@ def rebuild_sql_tables(adapters):
                 Domain {adapter.config.domain}.
                 Skipping."""
             )
-
-    _assert = soft_assert(notify_admins=True)
-    _notify_rebuild = lambda msg, obj: _assert(False, msg, obj)
-
     for engine_id, table_map in tables_by_engine.items():
         table_names = list(table_map)
         engine = connection_manager.get_engine(engine_id)

--- a/corehq/apps/userreports/pillow_utils.py
+++ b/corehq/apps/userreports/pillow_utils.py
@@ -102,5 +102,10 @@ def rebuild_table(adapter, diffs=None):
         adapter.log_table_rebuild_skipped(source='pillowtop', diffs=diff_dicts)
         return
 
-    rebuild_indicators.delay(adapter.config.get_id, source='pillowtop', engine_id=adapter.engine_id,
-                             diffs=diff_dicts, domain=config.domain)
+    rebuild_indicators.delay(
+        adapter.config.get_id,
+        source='pillowtop',
+        engine_id=adapter.engine_id,
+        diffs=diff_dicts,
+        domain=config.domain,
+    )

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -514,7 +514,11 @@ class ManagedReportBuilderDataSourceHelper(ReportBuilderDataSourceInterface):
         raise NotImplementedError
 
     def construct_data_source(self, table_id, **kwargs):
-        return DataSourceConfiguration(domain=self.domain, table_id=table_id, **kwargs)
+        return DataSourceConfiguration(
+            domain=self.domain,
+            table_id=table_id,
+            **kwargs,
+        )
 
     def _ds_config_kwargs(self, indicators, is_multiselect_chart_report=False, multiselect_field=None):
         if is_multiselect_chart_report:
@@ -1197,10 +1201,12 @@ class ConfigureNewReportBase(forms.Form):
     def _get_data_source_configuration_kwargs(self):
         filters = self.cleaned_data['user_filters'] + self.cleaned_data['default_filters']
         ms_field = self._report_aggregation_cols[0] if self._is_multiselect_chart_report else None
-        return self.ds_builder.get_datasource_constructor_kwargs(self._configured_columns,
-                                                                 filters,
-                                                                 self._is_multiselect_chart_report,
-                                                                 ms_field)
+        return self.ds_builder.get_datasource_constructor_kwargs(
+            self._configured_columns,
+            filters,
+            self._is_multiselect_chart_report,
+            ms_field,
+        )
 
     def _build_data_source(self):
         data_source_config = self.ds_builder.construct_data_source(
@@ -1210,8 +1216,11 @@ class ConfigureNewReportBase(forms.Form):
         )
         data_source_config.validate()
         data_source_config.save()
-        tasks.rebuild_indicators.delay(data_source_config._id, source="report_builder",
-                                       domain=data_source_config.domain)
+        tasks.rebuild_indicators.delay(
+            data_source_config._id,
+            source="report_builder",
+            domain=data_source_config.domain,
+        )
         return data_source_config._id
 
     def update_report(self):
@@ -1249,8 +1258,10 @@ class ConfigureNewReportBase(forms.Form):
                     data_source.save()
                     now = datetime.datetime.utcnow()
                     tasks.rebuild_indicators.delay(
-                        data_source._id, source='report_builder_update',
-                        trigger_time=now, domain=data_source.domain
+                        data_source._id,
+                        source='report_builder_update',
+                        trigger_time=now,
+                        domain=data_source.domain
                     )
 
     def create_report(self):
@@ -1341,9 +1352,11 @@ class ConfigureNewReportBase(forms.Form):
         )
         settings.CELERY_TASK_ALWAYS_EAGER = always_eager
 
-        tasks.rebuild_indicators(data_source_config._id,
-                                 username,
-                                 limit=SAMPLE_DATA_MAX_ROWS)  # Do synchronously
+        tasks.rebuild_indicators(  # Do synchronously
+            data_source_config._id,
+            username,
+            limit=SAMPLE_DATA_MAX_ROWS
+        )
         self._filter_data_source_changes(data_source_config._id)
         return data_source_config._id
 
@@ -1388,9 +1401,11 @@ class ConfigureNewReportBase(forms.Form):
             data_source_config.base_item_expression = temp_config["base_item_expression"]
             data_source_config.validate()
             data_source_config.save()
-            tasks.rebuild_indicators(data_source_config._id,
-                                     username,
-                                     limit=SAMPLE_DATA_MAX_ROWS)  # Do synchronously
+            tasks.rebuild_indicators(  # Do synchronously
+                data_source_config._id,
+                username,
+                limit=SAMPLE_DATA_MAX_ROWS
+            )
             self._filter_data_source_changes(data_source_config._id)
 
     @property

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -80,8 +80,16 @@ def _build_indicators(config, document_store, relevant_ids):
 
 @serial_task('{indicator_config_id}', default_retry_delay=60 * 10, timeout=3 * 60 * 60, max_retries=20,
              queue=UCR_CELERY_QUEUE, ignore_result=True, serializer='pickle')
-def rebuild_indicators(indicator_config_id, initiated_by=None, limit=-1, source=None,
-                       engine_id=None, diffs=None, trigger_time=None, domain=None):
+def rebuild_indicators(
+    indicator_config_id,
+    initiated_by=None,
+    limit=-1,
+    source=None,
+    engine_id=None,
+    diffs=None,
+    trigger_time=None,
+    domain=None,
+):
     config = get_ucr_datasource_config_by_id(indicator_config_id)
     if trigger_time is not None and trigger_time < config.last_modified:
         return
@@ -254,7 +262,9 @@ def queue_async_indicators():
     cutoff = start + ASYNC_INDICATOR_QUEUE_TIME - timedelta(seconds=30)
     retry_threshold = start - timedelta(hours=4)
     # don't requeue anything that has been retried more than ASYNC_INDICATOR_MAX_RETRIES times
-    indicators = AsyncIndicator.objects.filter(unsuccessful_attempts__lt=ASYNC_INDICATOR_MAX_RETRIES)[:settings.ASYNC_INDICATORS_TO_QUEUE]
+    indicators = AsyncIndicator.objects.filter(
+        unsuccessful_attempts__lt=ASYNC_INDICATOR_MAX_RETRIES
+    )[:settings.ASYNC_INDICATORS_TO_QUEUE]
 
     indicators_by_domain_doc_type = defaultdict(list)
     # page so that envs can have arbitarily large settings.ASYNC_INDICATORS_TO_QUEUE

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1436,9 +1436,12 @@ def build_data_source_in_place(request, domain, config_id):
             config.display_name
         )
     )
-    rebuild_indicators_in_place.delay(config_id, request.user.username,
-                                      source='edit_data_source_build_in_place',
-                                      domain=config.domain)
+    rebuild_indicators_in_place.delay(
+        config_id,
+        request.user.username,
+        source='edit_data_source_build_in_place',
+        domain=config.domain,
+    )
     return HttpResponseRedirect(reverse(
         EditDataSourceView.urlname, args=[domain, config._id]
     ))

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1208,6 +1208,10 @@ class BaseEditDataSourceView(BaseUserConfigReportsView):
                 messages.success(request, _('Data source "{}" saved!').format(
                     config.display_name
                 ))
+                messages.success(request, _(
+                    'This data source will be built/rebuilt automatically the '
+                    'next time a row is added.'
+                ))
                 if self.config_id is None:
                     return HttpResponseRedirect(reverse(
                         EditDataSourceView.urlname, args=[self.domain, config._id])

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -68,11 +68,19 @@ def get_case_to_elasticsearch_pillow(pillow_id='CaseToElasticsearchPillow', num_
 
 
 def get_case_pillow(
-        pillow_id='case-pillow', ucr_division=None,
-        include_ucrs=None, exclude_ucrs=None,
-        num_processes=1, process_num=0, ucr_configs=None, skip_ucr=False,
-        processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, topics=None,
-        dedicated_migration_process=False, **kwargs):
+    pillow_id='case-pillow',
+    ucr_division=None,
+    include_ucrs=None,
+    exclude_ucrs=None,
+    num_processes=1,
+    process_num=0,
+    ucr_configs=None,
+    skip_ucr=False,
+    processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE,
+    topics=None,
+    dedicated_migration_process=False,
+    **kwargs,
+):
     """Return a pillow that processes cases. The processors include, UCR and elastic processors
 
     Processors:

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -1,8 +1,6 @@
-import copy
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, KafkaCheckpointEventHandler
 from corehq.apps.change_feed import topics
 from corehq.apps.es.users import user_adapter
-from corehq.apps.groups.dbaccessors import get_group_id_name_map_by_user
 from corehq.apps.users.models import CommCareUser, CouchUser, WebUser
 from corehq.apps.users.util import WEIRD_USER_IDS
 from corehq.apps.userreports.data_source_providers import DynamicDataSourceProvider, StaticDataSourceProvider

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -106,8 +106,15 @@ def get_user_pillow_old(pillow_id='UserPillow', num_processes=1, process_num=0, 
     )
 
 
-def get_user_pillow(pillow_id='user-pillow', num_processes=1, dedicated_migration_process=False, process_num=0,
-        skip_ucr=False, processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, **kwargs):
+def get_user_pillow(
+    pillow_id='user-pillow',
+    num_processes=1,
+    dedicated_migration_process=False,
+    process_num=0,
+    skip_ucr=False,
+    processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE,
+    **kwargs,
+):
     """Processes users and sends them to ES and UCRs.
 
     Processors:

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -84,11 +84,20 @@ def get_xform_to_elasticsearch_pillow(pillow_id='XFormToElasticsearchPillow', nu
     )
 
 
-def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
-                     include_ucrs=None, exclude_ucrs=None,
-                     num_processes=1, process_num=0, ucr_configs=None, skip_ucr=False,
-                     processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE,
-                     topics=None, dedicated_migration_process=False, **kwargs):
+def get_xform_pillow(
+        pillow_id='xform-pillow',
+        ucr_division=None,
+        include_ucrs=None,
+        exclude_ucrs=None,
+        num_processes=1,
+        process_num=0,
+        ucr_configs=None,
+        skip_ucr=False,
+        processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE,
+        topics=None,
+        dedicated_migration_process=False,
+        **kwargs,
+):
     """Generic XForm change processor
 
     Processors:


### PR DESCRIPTION
## Product Description

This change adds a message to inform a user when their UCR data source will be built or rebuilt automatically.

![image](https://github.com/user-attachments/assets/cea5a928-3a86-434b-9080-15969a39cef9)

This is intended to set expectations, and change user behavior regarding rebuilding data sources.

## Technical Summary

Context: [SC-3956](https://dimagi.atlassian.net/browse/SC-3956)

## Safety Assurance

### Safety story

* Tiny change
* Tested locally

### Automated test coverage

This UI change is not covered by tests

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3956]: https://dimagi.atlassian.net/browse/SC-3956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ