### PR TITLE
Update migration tool to not require confirmation before displaying s…

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
+++ b/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
@@ -247,7 +247,7 @@ class Command(BaseCommand):
         ])
 
     def optional_display_list(self, confirmation_message, list_to_display):
-        confirm = get_confirmation(confirmation_message)
+        confirm = get_confirmation(confirmation_message) if len(list_to_display) > 5 else True
         if confirm:
             self.stdout.write("\n\n")
             self.stdout.write("\n".join(list_to_display))


### PR DESCRIPTION
…hort lists

## Technical Summary
Teeny. I was running this script a bunch of times and got tired of getting prompted before displaying a single file. But for long lists it's nice to not consume the whole screen with output.

## Safety Assurance

### Safety story
Tiny change to engineering tool.

### Automated test coverage

For the tool, yes, not for this particular functionality change.

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
