### PR TITLE
Update the Django user

### DIFF
--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -84,6 +84,7 @@ class SsoBackend(ModelBackend):
         if not is_new_user and not web_user.is_active:
             web_user.is_active = True
             web_user.save()
+            user.refresh_from_db()
             request.sso_new_user_messages['success'].append(
                 _("User account for {} has been re-activated.").format(web_user.username)
             )


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This PR is to solve issues for SSO user reactivation. Current situation is, after a SSO user login, Django User will be reactivated, but `WebUser` is still inactive. This PR solves it.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-16095
After we [toggle `WebUser` to active and save `WebUser` in reactivation](https://github.com/dimagi/commcare-hq/blob/0a7341ea2a5db082df7f72fd42ed551222fd8590/corehq/apps/sso/backends.py#L85-L86), we also saved DjangoUser.
But when we're returning a DjangoUser in this `authenticate` method, we're still returning the old Django User instance, which have `is_active = False`.
Then we're using this returned User to do [login](https://github.com/dimagi/commcare-hq/blob/0a7341ea2a5db082df7f72fd42ed551222fd8590/corehq/apps/sso/views/saml.py#L97), in this login method, django will send `user_logged_in` signal, this signal will then trigger [update_last_login](https://github.com/django/django/blob/438fc42ac667653488200578a47e59f6608f2b0b/django/contrib/auth/models.py#L18-L24), which will save the staled django user. This save will then trigger [django_user_post_save_signal](https://github.com/dimagi/commcare-hq/blob/7e0fc233fef08d0967023d89cf3e4eb0e940b8bc/corehq/apps/users/models.py#L1576-L1594), which will sync the staled django user status to couch user.

All I did is to refetch from the database. Pass a fresh Django User to the login method.

Though this PR fixed the issue, we still don't know who set Django User to active, after we saved the staled Django User instance. 
Here is a document that I write my findings: https://docs.google.com/document/d/159VuEatGqJQMAdxupJ5QyOXC6bdsOMPvI6_bHb9saHM/edit?tab=t.0#heading=h.f3pp936bwmh0
Here is the branch I put on staging to investigate: jc/resolve-resource-conflict-for-couchuser

An unresolved question is: how we should ultimately put this change deeper in the Django user save signal logic to prevent syncing a stale Django user to couch.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The change will be limited to sso user reactivation, it's just doing a refresh after the save.
I've tested on staging multiple times and it works everytime.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
