### PR TITLE
Removed help text related to java phones

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
@@ -51,16 +51,6 @@
         <i class="fa fa-cog"></i>
         {% trans 'Set Path' %}
       </button>
-      {% if type == "audio" %}
-        <p data-bind="visible: isMediaMatched"
-           class="help-block">
-          <i class="fa fa-info-circle"></i>
-          {% blocktrans %}
-            To hear audio on Java Phones, you must be in CommCare Sense
-            mode or Numeric Selection Mode. (On Android it will always work.)
-          {% endblocktrans %}
-        </p>
-      {% endif %}
       {% if app.langs|length > 1%}
         <div data-bind="visible: isDefaultLanguage">
           <label>


### PR DESCRIPTION
## Product Description
Removed this warning

![Screenshot 2024-10-17 at 12 51 59 PM](https://github.com/user-attachments/assets/73f7ecb0-8abf-4e47-82dc-6f42c7e60c99)

J2ME has been deprecated for a while: https://github.com/dimagi/commcare-hq/pull/31494

## Safety Assurance

### Safety story
Tiny UI change.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
