### PR TITLE
Make sure element isn't an empty object

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -705,7 +705,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                         }
                     }
                 };
-                if (allChildren && allChildren.length > 0) {
+                if (!_.isEmpty(element) && allChildren && allChildren.length > 0) {
                     findChildAndSetFilename(allChildren);
                 }
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Fixes a bug for mobile preview when in single question mode, a multimedia question with a display condition will throw an error when it comes after another random question. 

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/SAAS-16065)

Previously, when the `element` in `session.reconcile` was empty, it won't really do anything but I've since added an additional check to reassign multimedia filenames as needed. I've just added a check to make sure `element` isn't empty before starting that process. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

No impact to data. I've tested existing scenarios surrounding multimedia file uploads that I had from previous tickets to make sure everything is still working as intended.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
