### PR TITLE
Added messaging to PARENT_PATHS in B5 migration tooling

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/paths.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/paths.py
@@ -8,6 +8,7 @@ TRACKED_JS_FOLDERS = ["js", "spec"]
 PARENT_PATHS = {
     "corehq": COREHQ_BASE_DIR,
     "custom": CUSTOM_BASE_DIR,
+    "messaging": COREHQ_BASE_DIR / "messaging",
     "motech": COREHQ_BASE_DIR / "motech",
     "casexml": COREHQ_BASE_DIR / "ex-submodules/casexml/apps",
     "ex-submodules": COREHQ_BASE_DIR / "ex-submodules",


### PR DESCRIPTION
## Technical Summary
Another tiny one. This just updates the `PARENT_PATHS` map so it can find views under `corehq.messaging`, which don't follow the usual `corehq.apps.<app_name>` pattern.

## Safety Assurance

### Safety story
Basically no risk. Change to internal engineering tool.

### Automated test coverage

Tool has coverage.

### QA Plan

no

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
