### PR TITLE
Add GTM IDs

### DIFF
--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -32,7 +32,9 @@
         <div class="btn-group">
           {% if data_source.disable_destructive_rebuild %}
             <div style="margin-right: 15px;">
-              <button class="btn btn-default" disabled>
+              <button id="gtm-rebuild-ds-disabled"
+                      class="btn btn-default"
+                      disabled>
                 {% if use_updated_ucr_naming %}
                   {% trans 'Rebuild Custom Web Report Source'%}
                 {% else %}
@@ -47,7 +49,10 @@
             </div>
           {% else %}
             <div>
-              <a href="#confirm_rebuild" class="btn btn-default" data-toggle="modal">
+              <a id="gtm-rebuild-ds-btn"
+                 class="btn btn-default"
+                 href="#confirm_rebuild"
+                 data-toggle="modal">
                 {% if use_updated_ucr_naming %}
                   {% trans 'Rebuild Custom Web Report Source'%}
                 {% else %}
@@ -85,7 +90,8 @@
               </a>
             </li>
             <li>
-              <a class="submit-dropdown-form"
+              <a id="gtm-rebuild-in-place-btn"
+                 class="submit-dropdown-form"
                  href=""
                  data-action="{% url 'build_in_place' domain data_source.get_id %}">
                 {% trans 'Rebuild Table in Place' %}
@@ -226,7 +232,12 @@
               <button type="button" class="btn btn-default" data-dismiss="modal">
                 {% trans "Cancel" %}
               </button>
-              <button type="submit" value="{% trans 'Confirm'%}" class="disable-on-submit btn btn-danger">{% trans 'Confirm'%}</button>
+              <button id="gtm-rebuild-ds-confirm"
+                      class="disable-on-submit btn btn-danger"
+                      type="submit"
+                      value="{% trans 'Confirm'%}">
+                  {% trans 'Confirm'%}
+              </button>
             </div>
           </form>
         </div>

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -234,8 +234,7 @@
               </button>
               <button id="gtm-rebuild-ds-confirm"
                       class="disable-on-submit btn btn-danger"
-                      type="submit"
-                      value="{% trans 'Confirm'%}">
+                      type="submit">
                   {% trans 'Confirm'%}
               </button>
             </div>

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -231,6 +231,7 @@ class ConfigurableDataSourceEditForm(DocumentFormBase):
                 twbscrispy.StrictButton(
                     _("Save"),
                     type="submit",
+                    css_id="gtm-save-ds-btn",
                     css_class="btn btn-primary",
                 ),
             ),


### PR DESCRIPTION
## Technical Summary

Context:
* [SC-3840](https://dimagi.atlassian.net/browse/SC-3840)
* [Requirements](https://docs.google.com/document/d/1kcr1qlYLI_Onv-DR2hkGkGpmo9A4nM3z2h44277GR6A/edit)

This change adds IDs for Google Tag Manager to track the actions of users related to rebuilding data sources.

(The second commit removes an unused button "value" attribute.)

## Safety Assurance

### Safety story

HTML only. Adds "id" attributes, and drops an unused "value" attribute. Does not change any behavior.

Tested locally to verify that attributes are added/removed and that the "Confirm" button behaves the same.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3840]: https://dimagi.atlassian.net/browse/SC-3840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ