### PR TITLE
Remove dependency on jquery-form

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -63,7 +63,11 @@ hqDefine('accounting/js/payment_method_handler', [
         self.paymentMethod = ko.observable();
 
         self.submitForm = function () {
-            $('#' + self.formId).ajaxSubmit({
+            const $form = $('#' + self.formId);
+            $.ajax({
+                url: $form.attr("action"),
+                data: Object.fromEntries(new FormData($form.get(0))),
+                method: 'POST',
                 success: self.handleSuccess,
                 error: self.handleGeneralError,
             });
@@ -200,10 +204,13 @@ hqDefine('accounting/js/payment_method_handler', [
         self.removeSavedCard = function () {
             self.isRemovingCard(true);
             self.showConfirmRemoveCard(false);
-            $('#' + self.formId).ajaxSubmit({
-                data: {
-                    removeCard: true,
-                },
+            const $form = $('#' + self.formId);
+            let formData = new FormData($form.get(0));
+            formData.set("removeCard", true);
+            $.ajax({
+                url: $form.attr("action"),
+                method: "POST",
+                data: Object.fromEntries(formData),
                 success: function (response) {
                     self.handleProcessingErrors(response);
                     for (var i = 0; i < self.handlers.length; i++) {

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -109,7 +109,10 @@ hqDefine("groups/js/group_members", [
                     };
                 _showMembershipUpdating();
                 $(this).find(':button').prop('disabled', true);
-                $(this).ajaxSubmit({
+                $.ajax({
+                    url: $(this).attr("action"),
+                    method: "POST",
+                    data: Object.fromEntries(new FormData(this)),
                     success: outcome(true, "Group membership", "#edit_membership", "Edit Group Membership", _hideMembershipUpdating),
                     error: outcome(false, "Group membership", "#edit_membership", _hideMembershipUpdating),
                 });
@@ -117,7 +120,10 @@ hqDefine("groups/js/group_members", [
             });
             $('#edit-group-settings').submit(function () {
                 $(this).find('.modal-footer :button').disableButton();
-                $(this).ajaxSubmit({
+                $.ajax({
+                    url: $(this).attr("action"),
+                    method: "POST",
+                    data: Object.fromEntries(new FormData(this)),
                     success: outcome(true, "Group settings", "#edit-group-settings", "Edit Settings"),
                     error: outcome(false, "Group settings", "#edit-group-settings"),
                 });
@@ -132,7 +138,10 @@ hqDefine("groups/js/group_members", [
             });
             $('#group-data-form').submit(function () {
                 $(this).find(':button').prop('disabled', true);
-                $(this).ajaxSubmit({
+                $.ajax({
+                    url: $(this).attr("action"),
+                    method: "POST",
+                    data: Object.fromEntries(new FormData(this)),
                     success: outcome(true, "Group data", "#group-data-form", "Edit Group Data"),
                     error: outcome(false, "Group data", "#group-data-form"),
                 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/crud_paginated_list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/crud_paginated_list.js
@@ -143,16 +143,15 @@ hqDefine("hqwebapp/js/bootstrap3/crud_paginated_list", [
         };
 
         self.initCreateForm = function () {
-            var $createForm = $("#create-item-form");
+            const $createForm = $("#create-item-form");
             $createForm.submit(function (e) {
                 e.preventDefault();
-                $createForm.ajaxSubmit({
-                    url: "",
-                    type: 'post',
+                let formData = new FormData($createForm.get(0));
+                formData.set("action", "create");
+                $.ajax({
+                    method: 'POST',
                     dataType: 'json',
-                    data: {
-                        'action': 'create',
-                    },
+                    data: Object.fromEntries(formData),
                     statusCode: self.handleStatusCode,
                     success: function (data) {
                         $createForm[0].reset();
@@ -296,14 +295,12 @@ hqDefine("hqwebapp/js/bootstrap3/crud_paginated_list", [
             var $updateForm = $(elems).find('.update-item-form');
             if ($updateForm) {
                 $updateForm.submit(function (e) {
+                    let formData = new FormData($updateForm.get(0));
+                    formData.set("action", "update");
                     e.preventDefault();
-                    $updateForm.ajaxSubmit({
-                        url: "",
-                        type: 'post',
-                        dataType: 'json',
-                        data: {
-                            action: 'update',
-                        },
+                    $.ajax({
+                        method: 'POST',
+                        data: Object.fromEntries(formData),
                         success: function (data) {
                             if (data.updatedItem) {
                                 self.dismissModals();

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/crud_paginated_list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/crud_paginated_list.js
@@ -57,7 +57,7 @@ hqDefine("hqwebapp/js/bootstrap3/crud_paginated_list", [
         });
 
         self.isPaginatedListEmpty = ko.computed(function () {
-            return self.paginatedList().length == 0;
+            return self.paginatedList().length === 0;
         });
 
         self.isNewListVisible = ko.computed(function () {
@@ -88,12 +88,14 @@ hqDefine("hqwebapp/js/bootstrap3/crud_paginated_list", [
         });
 
         self.allPages = ko.computed(function () {
-            var last_ind = self.maxPage() + 1;
-            if (self.maxPage() <= 5 || self.currentPage() <= 3)
-                return _.range(1, Math.min(last_ind, 6));
-            if (self.currentPage() >= self.maxPage() - 2)
-                return _.range(self.maxPage() - 4, last_ind);
-            return _.range(self.currentPage() - 2, Math.min(last_ind, self.currentPage() + 3));
+            var lastIndex = self.maxPage() + 1;
+            if (self.maxPage() <= 5 || self.currentPage() <= 3) {
+                return _.range(1, Math.min(lastIndex, 6));
+            }
+            if (self.currentPage() >= self.maxPage() - 2) {
+                return _.range(self.maxPage() - 4, lastIndex);
+            }
+            return _.range(self.currentPage() - 2, Math.min(lastIndex, self.currentPage() + 3));
         });
 
         self.utils = {
@@ -196,7 +198,7 @@ hqDefine("hqwebapp/js/bootstrap3/crud_paginated_list", [
             self.changePage(1);
         };
 
-        self.deleteItem = function (paginatedItem, event) {
+        self.deleteItem = function (paginatedItem) {
             var pList = self.paginatedList();
             paginatedItem.dismissModals();
             self.paginatedList(_(pList).without(paginatedItem));
@@ -245,9 +247,10 @@ hqDefine("hqwebapp/js/bootstrap3/crud_paginated_list", [
             return null;
         };
 
-        self.initRow = function (rowElems, paginatedItem) {
+        self.initRow = function () {
             // Intended to be overridden with additional initialization for
             // each row in the paginated list.
+            // Arguments: rowElems, paginatedItem
         };
 
         return self;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/email-request.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/email-request.js
@@ -1,7 +1,6 @@
 hqDefine('hqwebapp/js/bootstrap3/email-request', [
     "jquery",
     "knockout",
-    "jquery-form/dist/jquery.form.min",
     "hqwebapp/js/bootstrap3/hq.helpers",
 ], function ($, ko) {
 
@@ -66,11 +65,15 @@ hqDefine('hqwebapp/js/bootstrap3/email-request', [
             } else if (!self.isRequestReportSubmitting) {
                 self.$submitBtn.button('loading');
                 self.cancelBtnEnabled(false);
-                self.$formElement.ajaxSubmit({
-                    type: "POST",
+                self.reportUrl(location.href);
+                self.isRequestReportSubmitting = true;
+                $.ajax({
+                    method: "POST",
                     url: self.$formElement.attr('action'),
-                    beforeSerialize: hqwebappRequestReportBeforeSerialize,
-                    beforeSubmit: hqwebappRequestReportBeforeSubmit,
+                    data: new FormData(self.$formElement.get(0)),
+                    contentType: false,
+                    processData: false,
+                    enctype: 'multipart/form-data',
                     success: hqwebappRequestReportSucccess,
                     error: hqwebappRequestReportError,
                 });
@@ -84,7 +87,7 @@ hqDefine('hqwebapp/js/bootstrap3/email-request', [
 
         self.resetForm = function () {
             self.$formElement.find("button[type='submit']").button('reset');
-            self.$formElement.resetForm();
+            self.$formElement.get(0).reset();
             self.cancelBtnEnabled(true);
             self.$submitBtn.button('reset');
             resetErrors();
@@ -104,14 +107,6 @@ hqDefine('hqwebapp/js/bootstrap3/email-request', [
             self.hasSubjectError(false);
             self.hasEmailInputError(false);
             self.recipientsErrorMessage(null);
-        }
-
-        function hqwebappRequestReportBeforeSerialize() {
-            self.reportUrl(location.href);
-        }
-
-        function hqwebappRequestReportBeforeSubmit() {
-            self.isRequestReportSubmitting = true;
         }
 
         function hqwebappRequestReportSucccess() {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list.js
@@ -59,7 +59,7 @@ hqDefine("hqwebapp/js/bootstrap5/crud_paginated_list", [
         });
 
         self.isPaginatedListEmpty = ko.computed(function () {
-            return self.paginatedList().length == 0;
+            return self.paginatedList().length === 0;
         });
 
         self.isNewListVisible = ko.computed(function () {
@@ -90,12 +90,14 @@ hqDefine("hqwebapp/js/bootstrap5/crud_paginated_list", [
         });
 
         self.allPages = ko.computed(function () {
-            var last_ind = self.maxPage() + 1;
-            if (self.maxPage() <= 5 || self.currentPage() <= 3)
-                return _.range(1, Math.min(last_ind, 6));
-            if (self.currentPage() >= self.maxPage() - 2)
-                return _.range(self.maxPage() - 4, last_ind);
-            return _.range(self.currentPage() - 2, Math.min(last_ind, self.currentPage() + 3));
+            var lastIndex = self.maxPage() + 1;
+            if (self.maxPage() <= 5 || self.currentPage() <= 3) {
+                return _.range(1, Math.min(lastIndex, 6));
+            }
+            if (self.currentPage() >= self.maxPage() - 2) {
+                return _.range(self.maxPage() - 4, lastIndex);
+            }
+            return _.range(self.currentPage() - 2, Math.min(lastIndex, self.currentPage() + 3));
         });
 
         self.utils = {
@@ -249,9 +251,10 @@ hqDefine("hqwebapp/js/bootstrap5/crud_paginated_list", [
             return null;
         };
 
-        self.initRow = function (rowElems, paginatedItem) {
+        self.initRow = function () {
             // Intended to be overridden with additional initialization for
             // each row in the paginated list.
+            // Arguments: rowElems, paginatedItem
         };
 
         return self;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list.js
@@ -145,16 +145,15 @@ hqDefine("hqwebapp/js/bootstrap5/crud_paginated_list", [
         };
 
         self.initCreateForm = function () {
-            var $createForm = $("#create-item-form");
+            const $createForm = $("#create-item-form");
             $createForm.submit(function (e) {
                 e.preventDefault();
-                $createForm.ajaxSubmit({
-                    url: "",
-                    type: 'post',
+                let formData = new FormData($createForm.get(0));
+                formData.set("action", "create");
+                $.ajax({
+                    method: 'POST',
                     dataType: 'json',
-                    data: {
-                        'action': 'create',
-                    },
+                    data: Object.fromEntries(formData),
                     statusCode: self.handleStatusCode,
                     success: function (data) {
                         $createForm[0].reset();
@@ -294,14 +293,12 @@ hqDefine("hqwebapp/js/bootstrap5/crud_paginated_list", [
             var $updateForm = $(elems).find('.update-item-form');
             if ($updateForm) {
                 $updateForm.submit(function (e) {
+                    let formData = new FormData($updateForm.get(0));
+                    formData.set("action", "update");
                     e.preventDefault();
-                    $updateForm.ajaxSubmit({
-                        url: "",
-                        type: 'post',
-                        dataType: 'json',
-                        data: {
-                            action: 'update',
-                        },
+                    $.ajax({
+                        method: 'POST',
+                        data: Object.fromEntries(formData),
                         success: function (data) {
                             if (data.updatedItem) {
                                 self.dismissModals();

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
@@ -2,7 +2,6 @@ hqDefine('hqwebapp/js/bootstrap5/email-request', [
     "jquery",
     "knockout",
     "es6!hqwebapp/js/bootstrap5_loader",
-    "jquery-form/dist/jquery.form.min",
     "hqwebapp/js/bootstrap5/hq.helpers",
 ], function ($, ko, bootstrap) {
     'use strict';
@@ -69,11 +68,15 @@ hqDefine('hqwebapp/js/bootstrap5/email-request', [
             } else if (!self.isRequestReportSubmitting) {
                 self.$submitBtn.changeButtonState('loading');
                 self.cancelBtnEnabled(false);
-                self.$formElement.ajaxSubmit({
-                    type: "POST",
+                self.reportUrl(location.href);
+                self.isRequestReportSubmitting = true;
+                $.ajax({
+                    method: "POST",
                     url: self.$formElement.attr('action'),
-                    beforeSerialize: hqwebappRequestReportBeforeSerialize,
-                    beforeSubmit: hqwebappRequestReportBeforeSubmit,
+                    data: new FormData(self.$formElement.get(0)),
+                    contentType: false,
+                    processData: false,
+                    enctype: 'multipart/form-data',
                     success: hqwebappRequestReportSucccess,
                     error: hqwebappRequestReportError,
                 });
@@ -87,7 +90,7 @@ hqDefine('hqwebapp/js/bootstrap5/email-request', [
 
         self.resetForm = function () {
             self.$formElement.find("button[type='submit']").changeButtonState('reset');
-            self.$formElement.resetForm();
+            self.$formElement.get(0).reset();
             self.cancelBtnEnabled(true);
             self.$submitBtn.changeButtonState('reset');
             resetErrors();
@@ -107,14 +110,6 @@ hqDefine('hqwebapp/js/bootstrap5/email-request', [
             self.hasSubjectError(false);
             self.hasEmailInputError(false);
             self.recipientsErrorMessage(null);
-        }
-
-        function hqwebappRequestReportBeforeSerialize() {
-            self.reportUrl(location.href);
-        }
-
-        function hqwebappRequestReportBeforeSubmit() {
-            self.isRequestReportSubmitting = true;
         }
 
         function hqwebappRequestReportSucccess() {

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/core_libraries.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/core_libraries.html
@@ -20,7 +20,6 @@
 
 <script src="{% static 'jquery/dist/jquery.min.js' %}"></script>
 {% compress js %}
-    <script src="{% static 'jquery-form/dist/jquery.form.min.js' %}"></script>
     <script src="{% static 'jquery.cookie/jquery.cookie.js' %}"></script>
     <script src="{% static 'jquery.rmi/jquery.rmi.js' %}"></script>
 {% endcompress %}

--- a/corehq/apps/hqwebapp/templatetags/tests/rendered/javascript_libraries_hq.html
+++ b/corehq/apps/hqwebapp/templatetags/tests/rendered/javascript_libraries_hq.html
@@ -5,7 +5,6 @@
 <script src="{% static 'hqwebapp/js/lib/modernizr.js' %}"></script>
 
 <script src="{% static 'jquery/dist/jquery.min.js' %}"></script>
-<script src="{% static 'jquery-form/dist/jquery.form.min.js' %}"></script>
 <script src="{% static 'jquery.cookie/jquery.cookie.js' %}"></script>
 <script src="{% static 'jquery.rmi/jquery.rmi.js' %}"></script>
 <script src="{% static 'bootstrap/dist/js/bootstrap.min.js' %}"></script>

--- a/corehq/apps/hqwebapp/templatetags/tests/rendered/javascript_libraries_hq_bootstrap5.html
+++ b/corehq/apps/hqwebapp/templatetags/tests/rendered/javascript_libraries_hq_bootstrap5.html
@@ -5,7 +5,6 @@
 <script src="{% static 'hqwebapp/js/lib/modernizr.js' %}"></script>
 
 <script src="{% static 'jquery/dist/jquery.min.js' %}"></script>
-<script src="{% static 'jquery-form/dist/jquery.form.min.js' %}"></script>
 <script src="{% static 'jquery.cookie/jquery.cookie.js' %}"></script>
 <script src="{% static 'jquery.rmi/jquery.rmi.js' %}"></script>
 <script src="{% static 'bootstrap5/dist/js/bootstrap.bundle.min.js' %}"></script>

--- a/corehq/apps/hqwebapp/templatetags/tests/rendered/javascript_libraries_jquery_only.html
+++ b/corehq/apps/hqwebapp/templatetags/tests/rendered/javascript_libraries_jquery_only.html
@@ -1,6 +1,5 @@
 {% load hq_shared_tags %}
 <script src="{% static 'jquery/dist/jquery.min.js' %}"></script>
-<script src="{% static 'jquery-form/dist/jquery.form.min.js' %}"></script>
 <script src="{% static 'jquery.cookie/jquery.cookie.js' %}"></script>
 <script src="{% static 'jquery.rmi/jquery.rmi.js' %}"></script>
 <script src="{% static 'bootstrap/dist/js/bootstrap.min.js' %}"></script>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list.js.diff.txt
@@ -17,7 +17,7 @@
  ) {
      var CRUDPaginatedListModel = function (
          total,
-@@ -197,8 +199,9 @@
+@@ -196,8 +198,9 @@
              self.changePage(1);
          };
  
@@ -28,7 +28,7 @@
              paginatedItem.dismissModals();
              self.paginatedList(_(pList).without(paginatedItem));
              self.deletedList.push(paginatedItem);
-@@ -222,7 +225,7 @@
+@@ -221,7 +224,7 @@
              });
          };
  
@@ -37,7 +37,7 @@
              $.ajax({
                  url: '',
                  type: 'post',
-@@ -238,6 +241,7 @@
+@@ -237,6 +240,7 @@
                  statusCode: self.handleStatusCode,
                  success: function (data) {
                      self.utils.reloadList(data);
@@ -45,7 +45,7 @@
                  },
              });
          };
-@@ -268,15 +272,9 @@
+@@ -267,15 +271,9 @@
          };
  
          self.dismissModals = function () {
@@ -64,7 +64,7 @@
              }
          };
  
-@@ -321,15 +319,15 @@
+@@ -318,15 +316,15 @@
              var $deleteButton = $(elems).find('.delete-item-confirm');
              if ($deleteButton) {
                  $deleteButton.click(function () {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list.js.diff.txt
@@ -17,18 +17,18 @@
  ) {
      var CRUDPaginatedListModel = function (
          total,
-@@ -196,8 +198,9 @@
+@@ -198,8 +200,9 @@
              self.changePage(1);
          };
  
--        self.deleteItem = function (paginatedItem, event) {
+-        self.deleteItem = function (paginatedItem) {
 +        self.deleteItem = function (paginatedItem, event, button) {
              var pList = self.paginatedList();
 +            $(button).enableButton();
              paginatedItem.dismissModals();
              self.paginatedList(_(pList).without(paginatedItem));
              self.deletedList.push(paginatedItem);
-@@ -221,7 +224,7 @@
+@@ -223,7 +226,7 @@
              });
          };
  
@@ -37,7 +37,7 @@
              $.ajax({
                  url: '',
                  type: 'post',
-@@ -237,6 +240,7 @@
+@@ -239,6 +242,7 @@
                  statusCode: self.handleStatusCode,
                  success: function (data) {
                      self.utils.reloadList(data);
@@ -45,7 +45,7 @@
                  },
              });
          };
-@@ -267,15 +271,9 @@
+@@ -270,15 +274,9 @@
          };
  
          self.dismissModals = function () {
@@ -64,7 +64,7 @@
              }
          };
  
-@@ -318,15 +316,15 @@
+@@ -321,15 +319,15 @@
              var $deleteButton = $(elems).find('.delete-item-confirm');
              if ($deleteButton) {
                  $deleteButton.click(function () {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/email-request.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/email-request.js.diff.txt
@@ -1,14 +1,13 @@
 --- 
 +++ 
-@@ -1,14 +1,17 @@
+@@ -1,13 +1,16 @@
 -hqDefine('hqwebapp/js/bootstrap3/email-request', [
 +hqDefine('hqwebapp/js/bootstrap5/email-request', [
      "jquery",
      "knockout",
-+    "es6!hqwebapp/js/bootstrap5_loader",
-     "jquery-form/dist/jquery.form.min",
 -    "hqwebapp/js/bootstrap3/hq.helpers",
 -], function ($, ko) {
++    "es6!hqwebapp/js/bootstrap5_loader",
 +    "hqwebapp/js/bootstrap5/hq.helpers",
 +], function ($, ko, bootstrap) {
 +    'use strict';
@@ -21,7 +20,7 @@
          self.$formElement = $(`#${formId}`);
          self.$submitBtn = self.$formElement.find("button[type='submit']");
  
-@@ -62,9 +65,9 @@
+@@ -61,9 +64,9 @@
  
              if (!self.isRequestReportSubmitting && self.isReportSent) {
                  self.isReportSent = false;
@@ -31,22 +30,22 @@
 -                self.$submitBtn.button('loading');
 +                self.$submitBtn.changeButtonState('loading');
                  self.cancelBtnEnabled(false);
-                 self.$formElement.ajaxSubmit({
-                     type: "POST",
-@@ -83,10 +86,10 @@
+                 self.reportUrl(location.href);
+                 self.isRequestReportSubmitting = true;
+@@ -86,10 +89,10 @@
          };
  
          self.resetForm = function () {
 -            self.$formElement.find("button[type='submit']").button('reset');
 +            self.$formElement.find("button[type='submit']").changeButtonState('reset');
-             self.$formElement.resetForm();
+             self.$formElement.get(0).reset();
              self.cancelBtnEnabled(true);
 -            self.$submitBtn.button('reset');
 +            self.$submitBtn.changeButtonState('reset');
              resetErrors();
          };
  
-@@ -117,12 +120,12 @@
+@@ -112,12 +115,12 @@
          function hqwebappRequestReportSucccess() {
              self.isRequestReportSubmitting = false;
              self.isReportSent = true;

--- a/corehq/apps/userreports/static/userreports/js/ucr_expression.js
+++ b/corehq/apps/userreports/static/userreports/js/ucr_expression.js
@@ -43,7 +43,9 @@ hqDefine("userreports/js/ucr_expression", [
         };
 
         self.saveExpression = function (form) {
-            $(form).ajaxSubmit({
+            $.ajax({
+                method: 'POST',
+                data: Object.fromEntries(new FormData(form)),
                 dataType: 'json',
                 success: function (response) {
                     alertUser.alert_user(gettext("Expression saved"), 'success');

--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -37,11 +37,12 @@ hqDefine('users/js/edit_commcare_user', [
         return false;
     });
 
-    $('#reset-password-form').submit(function () {
-        $(this).ajaxSubmit({
+    $('#reset-password-form').submit(function (e) {
+        $.ajax({
             url: $(this).attr('action'),
-            type: 'POST',
+            method: $(this).attr('method'),
             dataType: 'json',
+            data: Object.fromEntries(new FormData(this)),
             success: function (response) {
                 if (response.status === "OK") {
                     alertUser.alert_user(gettext("Password changed successfully."), 'success');

--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -37,7 +37,7 @@ hqDefine('users/js/edit_commcare_user', [
         return false;
     });
 
-    $('#reset-password-form').submit(function (e) {
+    $('#reset-password-form').submit(function () {
         $.ajax({
             url: $(this).attr('action'),
             method: $(this).attr('method'),

--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -83,11 +83,8 @@
     <div class="tab-pane" id="user-password">
       <div class="panel-body">
         {% if not request.is_view_only %}
-          <form id="reset-password-form" class="form-horizontal" action="{% url "change_password" domain couch_user.user_id %}" method="post">
-            {% csrf_token %}
-            <div id="reset-password-form-container">
-              {% crispy reset_password_form %}
-            </div>
+          <form id="reset-password-form" class="form-horizontal" action="{% url "change_password" domain couch_user.user_id %}" method="POST">
+            {% crispy reset_password_form %}
           </form>
         {% endif %}
       </div>

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
         "htmx.org": "2.0.3",
         "intl-tel-input": "9.0.7",
         "jquery": "3.5.1",
-        "jquery-form": "4.2.2",
         "jquery-memoized-ajax": "0.5.0",
         "jquery-textchange": "jmalonzo/bower-jquery-textchange#0.2.3",
         "jquery-tiny-pubsub": "cowboy/jquery-tiny-pubsub#~0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3682,13 +3682,6 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jquery-form@4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/jquery-form/-/jquery-form-4.2.2.tgz#9f96fb141ec9cbe0cdaf58b4d3f1dcbb009cdd52"
-  integrity sha512-HJTef7DRBSg8ge/RNUw8rUTTtB3l8ozO0OhD16AzDl+eIXp4skgCqRTd9fYPsOzL+pN6+1B9wvbTLGjgikz8Tg==
-  dependencies:
-    jquery ">=1.7.2"
-
 jquery-memoized-ajax@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jquery-memoized-ajax/-/jquery-memoized-ajax-0.5.0.tgz#5331f2fa5838569bd564e4760d4520570a732817"
@@ -3731,7 +3724,7 @@ jquery@3.5.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
-"jquery@>= 1.7.1", jquery@>=1.10, jquery@>=1.7, jquery@>=1.7.2, jquery@>=1.8, "jquery@>=1.8.0 <4.0.0", jquery@^3.5.1:
+"jquery@>= 1.7.1", jquery@>=1.10, jquery@>=1.7, jquery@>=1.8, "jquery@>=1.8.0 <4.0.0", jquery@^3.5.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==


### PR DESCRIPTION
## Technical Summary
This dependency isn't really pulling its weight. I've thought about removing it before, and this morning @gherceg and I ran into an issue integrating it with webpack, so now seemed like a good time to kill it.

The API is pretty small: https://github.com/jquery-form/form

We primarily use `ajaxSubmit`, and also use `resetForm` in a couple of places. I imagine this library was more useful when we started using it, but now we can use native js functionality that's approximately as concise.

https://dimagi.atlassian.net/browse/SAAS-16090

## Safety Assurance

### Safety story
These are fairly minor changes on ~5 areas in HQ (although the CRUD view is used in a couple of places). I tested each of them locally.

### Automated test coverage

Unlikely

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
