### PR TITLE
Restored OK button in web apps unsupported questions popup

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_unsupported.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_unsupported.html
@@ -20,6 +20,9 @@
           <br><br>
           <input type="text" class="form-control" data-bind="value: $data.answer" />
         </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">{% trans "OK" %}</button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SAAS-16065

I removed this button in https://github.com/dimagi/commcare-hq/pull/34682/ because all it does is close the popup. Ticket discusses how having an OK button is also useful, since users do sometimes enter input here, and they expect some kind of positive/submit/ok button.

<img width="522" alt="Screenshot 2024-10-21 at 4 55 06 PM" src="https://github.com/user-attachments/assets/ea6d5d49-7886-4132-98f4-cc830ba49e10">


## Safety Assurance

### Safety story
Tested locally, which is appropriate for this scale change.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
