### PR TITLE
Skip django migration that was used for couch-to-sql migration on fresh installs

### DIFF
--- a/corehq/motech/repeaters/migrations/0002_repeaters_db.py
+++ b/corehq/motech/repeaters/migrations/0002_repeaters_db.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.db import connections, migrations
 from django.db.utils import DEFAULT_DB_ALIAS
 
+from corehq.util.django_migrations import skip_on_fresh_install
+
 # Use a separate user for the fdw connection because postgres_fdw
 # changes session settings like search_path that interfere with other
 # clients because of pg_bouncer connection pooling.
@@ -120,12 +122,14 @@ REPEATERS_APP_LABEL = "repeaters"
 
 class RepeatersMigration(migrations.RunSQL):
 
+    @skip_on_fresh_install
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         if self.should_apply(schema_editor):
             assert count_records(schema_editor.connection, "repeatrecord") == 0
             assert count_records(schema_editor.connection, "repeatrecordattempt") == 0
             self._run_sql(schema_editor, self.sql.format(**self.context))
 
+    @skip_on_fresh_install
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         if self.should_apply(schema_editor):
             assert count_records(connections["repeaters"], "repeatrecord") == 0


### PR DESCRIPTION
On fresh install we were getting error that django.utils.connection.ConnectionDoesNotExist: The connection 'commcarehq_repeaters' doesn't exist. It makes sense, the things that migration was doing were related to repeat records couch to sql migration. And we don't need to run it on fresh installs

## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Should not affect any env except the ones which are newly installing commcare.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
