### PR TITLE
More fixes and tweaks for expression repeaters

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/repeaters/partials/attempt_history.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/repeaters/partials/attempt_history.html.diff.txt
@@ -15,7 +15,7 @@
                              {% if attempt.message %}
 -                                <div class="well record-attempt" style="font-family: monospace;">
 +                                <div class="card record-attempt" style="font-family: monospace;">  {# todo B5: css:well, inline style #}
-                                     {{ attempt.message }}
+                                     {{ attempt.message|escape|linebreaksbr }}
                                  </div>
                              {% endif %}
 @@ -53,7 +53,7 @@

--- a/corehq/motech/repeaters/expression/repeater_generators.py
+++ b/corehq/motech/repeaters/expression/repeater_generators.py
@@ -16,12 +16,8 @@ class ExpressionPayloadGenerator(BasePayloadGenerator):
         return 'application/json'
 
     def get_payload(self, repeat_record, payload_doc, parsed_expression):
-        result = self._parse_payload(payload_doc, parsed_expression)
+        result = _generate_payload(payload_doc, parsed_expression)
         return json.dumps(result, cls=DjangoJSONEncoder)
-
-    def _parse_payload(self, payload_doc, parsed_expression):
-        payload_doc_json = payload_doc.to_json()
-        return parsed_expression(payload_doc_json, EvaluationContext(payload_doc_json))
 
     def get_url(self, repeat_record, url_template, payload_doc):
         if not toggles.UCR_EXPRESSION_REGISTRY.enabled(repeat_record.domain):
@@ -58,7 +54,7 @@ class ArcGISFormExpressionPayloadGenerator(ExpressionPayloadGenerator):
         return 'application/x-www-form-urlencoded'
 
     def get_payload(self, repeat_record, payload_doc, parsed_expression):
-        payload = self._parse_payload(payload_doc, parsed_expression)
+        payload = _generate_payload(payload_doc, parsed_expression)
         conn_settings = repeat_record.repeater.connection_settings
         api_token = conn_settings.plaintext_password
         formatted_payload = {
@@ -67,3 +63,8 @@ class ArcGISFormExpressionPayloadGenerator(ExpressionPayloadGenerator):
             'token': api_token,
         }
         return formatted_payload
+
+
+def _generate_payload(payload_doc, parsed_expression):
+    payload_doc_json = payload_doc.to_json()
+    return parsed_expression(payload_doc_json, EvaluationContext(payload_doc_json))

--- a/corehq/motech/repeaters/expression/repeater_generators.py
+++ b/corehq/motech/repeaters/expression/repeater_generators.py
@@ -49,11 +49,9 @@ class ExpressionPayloadGenerator(BasePayloadGenerator):
 class ArcGISFormExpressionPayloadGenerator(ExpressionPayloadGenerator):
 
     def get_url(self, repeat_record, url_template, payload_doc):
-        if not (
-            toggles.UCR_EXPRESSION_REGISTRY.enabled(repeat_record.domain)
-            and toggles.ARCGIS_INTEGRATION.enabled(repeat_record.domain)
-        ):
+        if not toggles.ARCGIS_INTEGRATION.enabled(repeat_record.domain):
             return ""
+        return super().get_url(repeat_record, url_template, payload_doc)
 
     @property
     def content_type(self):

--- a/corehq/motech/repeaters/expression/repeaters.py
+++ b/corehq/motech/repeaters/expression/repeaters.py
@@ -22,7 +22,6 @@ from corehq.motech.repeater_helpers import RepeaterResponse
 from corehq.motech.repeaters.expression.repeater_generators import (
     ArcGISFormExpressionPayloadGenerator,
     ExpressionPayloadGenerator,
-    FormExpressionPayloadGenerator,
 )
 from corehq.motech.repeaters.models import (
     OptionValue,
@@ -156,7 +155,7 @@ class CaseExpressionRepeater(BaseExpressionRepeater):
 
     @memoized
     def payload_doc(self, repeat_record):
-        return CommCareCase.objects.get_case(repeat_record.payload_id, repeat_record.domain).to_json()
+        return CommCareCase.objects.get_case(repeat_record.payload_id, repeat_record.domain)
 
     def allowed_to_forward(self, payload):
         allowed = super().allowed_to_forward(payload)
@@ -183,7 +182,6 @@ class CaseExpressionRepeater(BaseExpressionRepeater):
 class FormExpressionRepeater(BaseExpressionRepeater):
 
     friendly_name = _("Configurable Form Repeater")
-    payload_generator_classes = (FormExpressionPayloadGenerator,)
 
     class Meta:
         app_label = 'repeaters'
@@ -282,7 +280,7 @@ def get_evaluation_context(domain, repeat_record, payload_doc, response):
         'success': is_success_response(response),
         'payload': {
             'id': repeat_record.payload_id,
-            'doc': payload_doc,
+            'doc': payload_doc.to_json(),
         },
         'response': {
             'status_code': response.status_code,

--- a/corehq/motech/repeaters/expression/tests.py
+++ b/corehq/motech/repeaters/expression/tests.py
@@ -221,7 +221,7 @@ class CaseExpressionRepeaterTest(BaseExpressionRepeaterTest):
 
         response = MockResponse(201)
         message = self.repeater._process_response_as_case_update(response, repeat_record)
-        self.assertEqual(message, "Response generated form: fake_form_id")
+        self.assertEqual(message, "Response generated a form: fake_form_id")
         self.repeater._perform_case_update.assert_called()
 
     def test_process_response(self):

--- a/corehq/motech/repeaters/expression/tests.py
+++ b/corehq/motech/repeaters/expression/tests.py
@@ -213,13 +213,15 @@ class CaseExpressionRepeaterTest(BaseExpressionRepeaterTest):
             "operator": "eq",
             "property_value": 201,
         }
-        self.repeater._perform_case_update = Mock()
+        self.repeater._perform_case_update = Mock(return_value="fake_form_id")
         response = MockResponse(200)
-        self.assertFalse(self.repeater._process_response_as_case_update(response, repeat_record))
+        message = self.repeater._process_response_as_case_update(response, repeat_record)
+        self.assertEqual(message, "Response did not match filter")
         self.repeater._perform_case_update.assert_not_called()
 
         response = MockResponse(201)
-        self.assertTrue(self.repeater._process_response_as_case_update(response, repeat_record))
+        message = self.repeater._process_response_as_case_update(response, repeat_record)
+        self.assertEqual(message, "Response generated form: fake_form_id")
         self.repeater._perform_case_update.assert_called()
 
     def test_process_response(self):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -477,19 +477,19 @@ class Repeater(RepeaterSuperProxy):
         result may be either a response object or an exception
         """
         if isinstance(result, RequestConnectionError):
-            repeat_record.handle_timeout(result)
+            return repeat_record.handle_timeout(result)
         elif isinstance(result, Exception):
-            repeat_record.handle_exception(result)
+            return repeat_record.handle_exception(result)
         elif is_success_response(result):
-            repeat_record.handle_success(result)
+            return repeat_record.handle_success(result)
         elif not is_response(result) or (
             500 <= result.status_code < 600
             or result.status_code in HTTP_STATUS_4XX_RETRY
         ):
-            repeat_record.handle_failure(result)
+            return repeat_record.handle_failure(result)
         else:
             message = format_response(result)
-            repeat_record.handle_payload_error(message)
+            return repeat_record.handle_payload_error(message)
 
     def get_headers(self, repeat_record):
         # to be overridden
@@ -1049,10 +1049,11 @@ class RepeatRecord(models.Model):
         # although the Couch RepeatRecord did the same.
         code = getattr(response, "status_code", None)
         state = State.Empty if code == 204 else State.Success
-        self.attempt_set.create(state=state, message=format_response(response) or '')
+        attempt = self.attempt_set.create(state=state, message=format_response(response) or '')
         self.state = state
         self.next_check = None
         self.save()
+        return attempt
 
     def add_client_failure_attempt(self, message, retry=True):
         """
@@ -1060,7 +1061,7 @@ class RepeatRecord(models.Model):
         service is assumed to be in a good state, so do not back off, so
         that this repeat record does not hold up the rest.
         """
-        self._add_failure_attempt(message, MAX_ATTEMPTS, retry)
+        return self._add_failure_attempt(message, MAX_ATTEMPTS, retry)
 
     def add_server_failure_attempt(self, message):
         """
@@ -1073,7 +1074,7 @@ class RepeatRecord(models.Model):
            days and will hold up all other payloads.
 
         """
-        self._add_failure_attempt(message, MAX_BACKOFF_ATTEMPTS)
+        return self._add_failure_attempt(message, MAX_BACKOFF_ATTEMPTS)
 
     def _add_failure_attempt(self, message, max_attempts, retry=True):
         if retry and self.num_attempts < max_attempts:
@@ -1085,9 +1086,10 @@ class RepeatRecord(models.Model):
         self.state = state
         self.next_check = (attempt.created_at + wait) if state == State.Fail else None
         self.save()
+        return attempt
 
     def add_payload_error_attempt(self, message, traceback_str):
-        self.attempt_set.create(
+        attempt = self.attempt_set.create(
             state=State.InvalidPayload,
             message=message,
             traceback=traceback_str,
@@ -1095,6 +1097,7 @@ class RepeatRecord(models.Model):
         self.state = State.InvalidPayload
         self.next_check = None
         self.save()
+        return attempt
 
     @property
     def attempts(self):
@@ -1224,23 +1227,23 @@ class RepeatRecord(models.Model):
                 response.status_code,
                 self.repeater_type
             )
-        self.add_success_attempt(response)
+        return self.add_success_attempt(response)
 
     def handle_failure(self, response):
         log_repeater_error_in_datadog(self.domain, response.status_code, self.repeater_type)
-        self.add_server_failure_attempt(format_response(response))
+        return self.add_server_failure_attempt(format_response(response))
 
     def handle_exception(self, exception):
         log_repeater_error_in_datadog(self.domain, None, self.repeater_type)
-        self.add_client_failure_attempt(str(exception))
+        return self.add_client_failure_attempt(str(exception))
 
     def handle_timeout(self, exception):
         log_repeater_timeout_in_datadog(self.domain)
-        self.add_server_failure_attempt(str(exception))
+        return self.add_server_failure_attempt(str(exception))
 
     def handle_payload_error(self, message, traceback_str=''):
         log_repeater_error_in_datadog(self.domain, status_code=None, repeater_type=self.repeater_type)
-        self.add_payload_error_attempt(message, traceback_str)
+        return self.add_payload_error_attempt(message, traceback_str)
 
     def cancel(self):
         self.state = State.Cancelled

--- a/corehq/motech/repeaters/templates/repeaters/partials/bootstrap3/attempt_history.html
+++ b/corehq/motech/repeaters/templates/repeaters/partials/bootstrap3/attempt_history.html
@@ -30,7 +30,7 @@
                             {% endif %}
                             {% if attempt.message %}
                                 <div class="well record-attempt" style="font-family: monospace;">
-                                    {{ attempt.message }}
+                                    {{ attempt.message|escape|linebreaksbr }}
                                 </div>
                             {% endif %}
                         </div>

--- a/corehq/motech/repeaters/templates/repeaters/partials/bootstrap5/attempt_history.html
+++ b/corehq/motech/repeaters/templates/repeaters/partials/bootstrap5/attempt_history.html
@@ -30,7 +30,7 @@
                             {% endif %}
                             {% if attempt.message %}
                                 <div class="card record-attempt" style="font-family: monospace;">  {# todo B5: css:well, inline style #}
-                                    {{ attempt.message }}
+                                    {{ attempt.message|escape|linebreaksbr }}
                                 </div>
                             {% endif %}
                         </div>


### PR DESCRIPTION
## Product Description
This fixes a bug with Configurable Form Repeaters and the ARC GIS Repeater. There are also minor updates to the display of the repeater attempts as shown in the screenshot below:

* Line breaks in the message are preserved in the display
* If a Configurable Repeater submits a form during response handling then the form ID will be added to the attempt message.

![image](https://github.com/user-attachments/assets/d5fa7d8b-8258-4e59-8f5e-c219bf37917c)


## Technical Summary
The primary change here is to standardise the return value of `Repeater.payload_doc`. The 'CaseExpressionRepeater` class was returning the serialized case while other repeaters return the Django data model. The `CaseExpressionRepeater` was updated to return the `CommCareCase` object instead of the result of calling `case.to_json()`.

Because of this discrepancy, the response processing code (`get_evaluation_context`) was expecting a dict but was getting an `XFormInstance` object. This method has now been updated to convert to the DB object to a dict.

To improve visibility into the processing, the attempt message is updated when the repeater is configured to submit a form based on the response.

## Feature Flag
Mostly the expression_repeater feature flag but some of the changes affect core repeater code (refactoring + attempt message formatting).

## Safety Assurance

### Safety story
As a worst case scenario this could prevent all repeaters from working due to a bug in the refactoring however local testing and unit tests make that very unlikely. 

The changes that affect all repeaters are very minor and easily verifiable via code review.

The changes to configurable repeaters have been tested locally as well as updates to the unit tests.

### Automated test coverage
Unit tests for the Form and Case expression repeaters have been updated. An additional bug was found with the `ArcGISFormExpressionRepeater.get_url` method which has also been tested and fixed.

### QA Plan
This code is fairly well covered by unit tests and I have tested this locally so I'm not recommending any additional QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
