### PR TITLE
Make sure element has both binding and ix attributes

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -705,8 +705,8 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                         }
                     }
                 };
-                if (element.hasOwnProperty('binding') && element.hasOwnProperty('ix') && allChildren &&
-                    allChildren.length > 0) {
+                if (Object.prototype.hasOwnProperty.call(element, 'binding') &&
+                    Object.prototype.hasOwnProperty.call(element, 'ix') && allChildren && allChildren.length > 0) {
                     findChildAndSetFilename(allChildren);
                 }
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -705,8 +705,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                         }
                     }
                 };
-                if (Object.prototype.hasOwnProperty.call(element, 'binding') &&
-                    Object.prototype.hasOwnProperty.call(element, 'ix') && allChildren && allChildren.length > 0) {
+                if (_.has(element, 'binding') && _.has(element, 'ix') && !_.isEmpty(allChildren)) {
                     findChildAndSetFilename(allChildren);
                 }
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -705,7 +705,8 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
                         }
                     }
                 };
-                if (!_.isEmpty(element) && allChildren && allChildren.length > 0) {
+                if (element.hasOwnProperty('binding') && element.hasOwnProperty('ix') && allChildren &&
+                    allChildren.length > 0) {
                     findChildAndSetFilename(allChildren);
                 }
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

This fixes another edge case where if a user tries to change the language in a form that has a multimedia question in it, it'll complain about `element.binding` not existing. 

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/SAAS-16079)

Previously, I changed the conditional to only move into the filename assignment logic if the returned `element` object wasn't empty but there was another edge case where the returned element could sometimes be a string (language slug). This PR makes is more explicit that it needs both the `binding` and `ix` attributes before entering that block. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[Multimedia in Web Apps FF](https://www.commcarehq.org/hq/flags/edit/web_apps_upload_questions/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and on staging.
No data impact.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Re-testing with QA because there's been an uptick in bugs around this area recently. 
[QA Ticket](https://dimagi.atlassian.net/browse/QA-7186)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
