### PR TITLE
Fix Failing Mobile UCR v1 Test

### DIFF
--- a/corehq/apps/app_manager/tests/data/suite/reports_module_data_entry_mobile_ucr_v1.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_data_entry_mobile_ucr_v1.xml
@@ -1,0 +1,19 @@
+<partial>
+  <entry>
+    <command id="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i">
+      <text>
+        <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.name"/>
+      </text>
+    </command>
+    <instance id="reports" src="jr://fixture/commcare:reports"/>
+    <session>
+      <datum
+        id="report_id_ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i"
+        nodeset="instance('reports')/reports/report[@id='ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i']"
+        value="./@id"
+        detail-select="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.select"
+        detail-confirm="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.summary"
+        autoselect="true"/>
+    </session>
+  </entry>
+</partial>

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -233,7 +233,7 @@ class TestDoesAppHaveMobileUCRV1Refs(TestCase, SuiteMixin):
         return app
 
     def test_does_app_have_mobile_ucr_v1_refs(self):
-        app_with_refs = self._create_app_with_form('reports_module_data_entry')
+        app_with_refs = self._create_app_with_form('reports_module_data_entry_mobile_ucr_v1')
         self.assertTrue(does_app_have_mobile_ucr_v1_refs(app_with_refs))
         app_without_refs = self._create_app_with_form('normal-suite')
         self.assertFalse(does_app_have_mobile_ucr_v1_refs(app_without_refs))


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
As part of the effort to deprecate Mobile UCR v1/1.5 the following three PRs were merged in together:
- [Error Handling When Reverting/Releasing App Version with V1 Mobile UCR References](https://github.com/dimagi/commcare-hq/pull/35168)
- [Gracefully removes mobile ucr version drop down from app advanced settings](https://github.com/dimagi/commcare-hq/pull/35046)
- [New app should default to mobile ucr version v2](https://github.com/dimagi/commcare-hq/pull/35179)

The third PR changed a test form XML file which was required in a test by the first PR. Specifically, the XML was changed to use Mobile UCR v2 references, which ultimately have caused the `test_does_app_have_mobile_ucr_v1_refs` test from the first PR to fail as it relied on the file having v1 references.

This PR addresses the above by creating a new XML file containing v1 references for use by the `test_does_app_have_mobile_ucr_v1_refs`  test.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`MOBILE_UCR`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

Small change that only affects a single unit test.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
This PR is to address a fix for the `TestDoesAppHaveMobileUCRV1Refs` test class which tests that the `does_app_have_mobile_ucr_v1_refs` util function correctly picks up whether a form's XML contains Mobile UCR v1 references.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
