### PR TITLE
Case Management Page: Fixes minor issues with saved polygon filters and disbursement

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/case_management.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_management.js
@@ -48,7 +48,6 @@ hqDefine("geospatial/js/case_management", [
         var self = {};
 
         self.isBusy = ko.observable(false);
-        self.showParams = ko.observable(false);
         self.parameters = ko.observableArray([]);
 
         self.disbursementErrorMessage = ko.observable('');
@@ -135,7 +134,7 @@ hqDefine("geospatial/js/case_management", [
                 }
 
                 self.parameters(parametersList);
-                self.showParams(true);
+                $('#disbursement-params').show();
             };
 
             let userData = users.map(function (c) {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -680,6 +680,7 @@ hqDefine('geospatial/js/models', [
                 if (confirmForClearingDisbursement()) {
                     self.mapObj.removeDisbursementLayers();
                     $('#disbursement-clear-message').show();
+                    $('#disbursement-params').hide();
                     proceedFurther = true;
                 } else {
                     proceedFurther = false;

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -663,19 +663,28 @@ hqDefine('geospatial/js/models', [
         };
 
         self.clearSelectedPolygonFilter = function () {
-            if (self.mapObj.hasDisbursementLayers()) {
-                if (confirmForClearingDisbursement()) {
-                    self.mapObj.removeDisbursementLayers();
-                    $('#disbursement-clear-message').show();
-                } else {
-                    return;
-                }
+            if (!clearDisbursementBeforeProceeding()) {
+                return;
             }
 
             self.selectedSavedPolygonId('');
             self.clearActivePolygon();
             updateSelectedSavedPolygonParam();
         };
+
+        function clearDisbursementBeforeProceeding() {
+            let proceedFurther = true;
+            if (self.mapObj.hasDisbursementLayers()) {
+                if (confirmForClearingDisbursement()) {
+                    self.mapObj.removeDisbursementLayers();
+                    $('#disbursement-clear-message').show();
+                    proceedFurther = true;
+                } else {
+                    proceedFurther = false;
+                }
+            }
+            return proceedFurther;
+        }
 
         function confirmForClearingDisbursement() {
             return confirm(
@@ -695,13 +704,8 @@ hqDefine('geospatial/js/models', [
         };
 
         self.deleteSelectedPolygonFilter = function () {
-            if (self.mapObj.hasDisbursementLayers()) {
-                if (confirmForClearingDisbursement()) {
-                    self.mapObj.removeDisbursementLayers();
-                    $('#disbursement-clear-message').show();
-                } else {
-                    return;
-                }
+            if (!clearDisbursementBeforeProceeding()) {
+                return;
             }
 
             const deleteGeoJSONUrl = initialPageData.reverse('geo_polygon', self.selectedSavedPolygonId());
@@ -747,18 +751,13 @@ hqDefine('geospatial/js/models', [
 
             // hide it by default and show it only if necessary
             $('#disbursement-clear-message').hide();
-            if (mapObj.hasDisbursementLayers()) {
-                if (confirmForClearingDisbursement()) {
-                    if (mapObj.removeDisbursementLayers()) {
-                        $('#disbursement-clear-message').show();
-                    }
-                } else {
-                    // set flag
-                    self.resettingSavedPolygon = true;
-                    self.selectedSavedPolygonId(self.oldSelectedSavedPolygonId());
-                    return;
-                }
+            if (!clearDisbursementBeforeProceeding()) {
+                // set flag
+                self.resettingSavedPolygon = true;
+                self.selectedSavedPolygonId(self.oldSelectedSavedPolygonId());
+                return;
             }
+
             self.clearActivePolygon();
 
             createActivePolygonLayer(polygonObj);
@@ -797,13 +796,8 @@ hqDefine('geospatial/js/models', [
                     return;
                 }
 
-                if (self.mapObj.hasDisbursementLayers()) {
-                    if (confirmForClearingDisbursement()) {
-                        self.mapObj.removeDisbursementLayers();
-                        $('#disbursement-clear-message').show();
-                    } else {
-                        return;
-                    }
+                if (!clearDisbursementBeforeProceeding()) {
+                    return;
                 }
 
                 data['name'] = name;

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -675,6 +675,8 @@ hqDefine('geospatial/js/models', [
         function clearDisbursementBeforeProceeding() {
             let proceedFurther = true;
             if (self.mapObj.hasDisbursementLayers()) {
+                // hide it by default and show it only if necessary
+                $('#disbursement-clear-message').hide();
                 if (confirmForClearingDisbursement()) {
                     self.mapObj.removeDisbursementLayers();
                     $('#disbursement-clear-message').show();
@@ -749,8 +751,6 @@ hqDefine('geospatial/js/models', [
                 return;
             }
 
-            // hide it by default and show it only if necessary
-            $('#disbursement-clear-message').hide();
             if (!clearDisbursementBeforeProceeding()) {
                 // set flag
                 self.resettingSavedPolygon = true;

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -681,7 +681,6 @@ hqDefine('geospatial/js/models', [
                     self.mapObj.removeDisbursementLayers();
                     $('#disbursement-clear-message').show();
                     $('#disbursement-params').hide();
-                    proceedFurther = true;
                 } else {
                     proceedFurther = false;
                 }

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -796,6 +796,16 @@ hqDefine('geospatial/js/models', [
                 if (!validateSavedPolygonName(name)) {
                     return;
                 }
+
+                if (self.mapObj.hasDisbursementLayers()) {
+                    if (confirmForClearingDisbursement()) {
+                        self.mapObj.removeDisbursementLayers();
+                        $('#disbursement-clear-message').show();
+                    } else {
+                        return;
+                    }
+                }
+
                 data['name'] = name;
                 $.ajax({
                     type: 'post',

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -695,6 +695,15 @@ hqDefine('geospatial/js/models', [
         };
 
         self.deleteSelectedPolygonFilter = function () {
+            if (self.mapObj.hasDisbursementLayers()) {
+                if (confirmForClearingDisbursement()) {
+                    self.mapObj.removeDisbursementLayers();
+                    $('#disbursement-clear-message').show();
+                } else {
+                    return;
+                }
+            }
+
             const deleteGeoJSONUrl = initialPageData.reverse('geo_polygon', self.selectedSavedPolygonId());
             $.ajax({
                 type: 'DELETE',

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -662,7 +662,7 @@ hqDefine('geospatial/js/models', [
             }
         };
 
-        self.clearSelectedPolygonFilter = function clearSelectedPolygonFilter() {
+        self.clearSelectedPolygonFilter = function () {
             self.selectedSavedPolygonId('');
             self.clearActivePolygon();
             updateSelectedSavedPolygonParam();

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -668,6 +668,13 @@ hqDefine('geospatial/js/models', [
             updateSelectedSavedPolygonParam();
         };
 
+        function confirmForClearingDisbursement() {
+            return confirm(
+                gettext("Warning! This action will clear the current disbursement. " +
+                        "Please confirm if you want to proceed.")
+            );
+        }
+
         self.exportSelectedPolygonGeoJson = function (data, event) {
             if (self.activeSavedPolygon()) {
                 const convertedData = 'application/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(self.activeSavedPolygon().geoJson));
@@ -723,11 +730,7 @@ hqDefine('geospatial/js/models', [
             // hide it by default and show it only if necessary
             $('#disbursement-clear-message').hide();
             if (mapObj.hasDisbursementLayers()) {
-                let confirmation = confirm(
-                    gettext("Warning! This action will clear the current disbursement. " +
-                            "Please confirm if you want to proceed.")
-                );
-                if (confirmation) {
+                if (confirmForClearingDisbursement()) {
                     if (mapObj.removeDisbursementLayers()) {
                         $('#disbursement-clear-message').show();
                     }

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -663,6 +663,15 @@ hqDefine('geospatial/js/models', [
         };
 
         self.clearSelectedPolygonFilter = function () {
+            if (self.mapObj.hasDisbursementLayers()) {
+                if (confirmForClearingDisbursement()) {
+                    self.mapObj.removeDisbursementLayers();
+                    $('#disbursement-clear-message').show();
+                } else {
+                    return;
+                }
+            }
+
             self.selectedSavedPolygonId('');
             self.clearActivePolygon();
             updateSelectedSavedPolygonParam();

--- a/corehq/apps/geospatial/templates/case_management.html
+++ b/corehq/apps/geospatial/templates/case_management.html
@@ -95,7 +95,7 @@
         Previous disbursement was cleared.
     {% endblocktrans %}
 </div>
-<div id="disbursement-params" class="alert alert-info" data-bind="visible: showParams()">
+<div id="disbursement-params" class="alert alert-info" style="display: none">
   <h4>{% trans 'Disbursement parameters' %}</h4>
   <!-- ko foreach: parameters -->
   <span style="padding-right: 1em">


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

A confirm alert is displayed regarding clearing disbursement results before doing any of the below operations.

![image](https://github.com/user-attachments/assets/0d0e7715-76d4-462e-b821-ba6af365d1c7)

- Clear Polygon Filter
- Delete Saved Polygon
- Save new polygon

Also removes below disbursement params info when there is no disbursement results on the map,
![image](https://github.com/user-attachments/assets/145ec0c7-6e69-4994-a0ae-0321a3556235)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket
](https://dimagi.atlassian.net/browse/SC-3933)
(FYI - The above approach for clearing disbursement results were discussed with an AE.)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[geospatial](https://staging.commcarehq.org/hq/flags/edit/geospatial/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Minor changes. Local Testing done. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA request submitted as this was reported during QA testing.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
