### PR TITLE
Custom User Data Property String Bug

### DIFF
--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -143,8 +143,8 @@ class CustomDataEditor(object):
                 data_bind_field_name = (
                     without_prefix(field_name, self.prefix) if field_name_includes_prefix else field_name)
                 data_binds = [
-                    f"value: {self.ko_model}.{data_bind_field_name}.value",
-                    f"disable: {self.ko_model}.{data_bind_field_name}.disable",
+                    f"value: {self.ko_model}['{data_bind_field_name}'].value",
+                    f"disable: {self.ko_model}['{data_bind_field_name}'].disable",
                 ]
                 if hasattr(field, 'choices') or without_prefix(field_name, self.prefix) == PROFILE_SLUG:
                     data_binds.append("select2: " + json.dumps([


### PR DESCRIPTION

## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
None

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
If a custom user data property string contains a hyphen, the knock-out binding will error.
https://stackoverflow.com/questions/17122018/knockout-js-dash-in-binding-name

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Blast radius limited to custom user data. Also tested locally and on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA briefly tested with this [ticket](https://dimagi.atlassian.net/browse/QA-7182)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
