### PR TITLE
Remove CCA gamma role for selection

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -785,10 +785,6 @@ class ListRolesView(BaseRoleAccessView):
 def _commcare_analytics_roles_options():
     return [
         {
-            'slug': 'gamma',
-            'name': 'Gamma'
-        },
-        {
             'slug': 'sql_lab',
             'name': 'SQL Lab'
         },


### PR DESCRIPTION
## Product Description
Removing the `Gamma` CommCare Analytics role from HQ.

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-3964?focusedCommentId=351902)

Simply removing a role.

## Feature Flag
CommCare Analytics

## Safety Assurance

### Safety story
Local testing. Testing on staging will also be done as part of the larger test effort for the CCA role changes.

### Automated test coverage

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
