### PR TITLE
Catch JSONReaderError if it occurs before validating an upload

### DIFF
--- a/corehq/apps/fixtures/upload/workbook.py
+++ b/corehq/apps/fixtures/upload/workbook.py
@@ -10,7 +10,10 @@ from corehq.util.workbook_json.excel import (
     WorkbookJSONError,
     WorksheetNotFound,
 )
-from corehq.util.workbook_json.excel import get_workbook as excel_get_workbook
+from corehq.util.workbook_json.excel import (
+    JSONReaderError,
+    get_workbook as excel_get_workbook
+)
 
 from ..models import (
     Field,
@@ -45,6 +48,9 @@ class _FixtureWorkbook(object):
             return self.get_data_sheet("types")
         except WorksheetNotFound:
             raise FixtureUploadError([FAILURE_MESSAGES['no_types_sheet']])
+        except JSONReaderError as e:
+            raise FixtureUploadError(e.args)
+
 
     def get_data_sheet(self, tag):
         # Cache all rows in memory in order to traverse them more than

--- a/corehq/apps/fixtures/upload/workbook.py
+++ b/corehq/apps/fixtures/upload/workbook.py
@@ -51,7 +51,6 @@ class _FixtureWorkbook(object):
         except JSONReaderError as e:
             raise FixtureUploadError(e.args)
 
-
     def get_data_sheet(self, tag):
         # Cache all rows in memory in order to traverse them more than
         # once because IteratorJSONReader only allows a single iteration


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-16112

https://dimagi.sentry.io/issues/6018930150/?project=136860&referrer=issue-stream&sort=date&statsPeriod=24h&stream_index=1

This is the absolute minimum amount of changes I could make to prevent [this error](https://dimagi.sentry.io/issues/6018930150/?project=136860&referrer=issue-stream&sort=date&statsPeriod=24h&stream_index=1) from resulting in a 500.

This validation code seems pretty complex, so I wouldn't want to try to do something more elegant without spending the time understanding what is going on here first.

Also noting that this error message is not translated, but that is also true in [this scenario](https://github.com/dimagi/commcare-hq/blob/1a6cbecf4937a9f9028f315cbbd0b3cdf7cfc803/corehq/apps/fixtures/upload/validation.py#L17-L17).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This has a very low blast radius as it just changes the exception that is raised from JSONReaderError to FixtureUploadError, which is more likely to be caught by calling functions, so the "worst case" change is that what was once a 500 error now fails silently, but it seems unlikely that we would swallow a FixtureUploadError.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
