### PR TITLE
Custom User Data Field Minor UI Change

### DIFF
--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/partials/fields_tab.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/partials/fields_tab.html
@@ -109,7 +109,7 @@
                                                       optionsText: 'text',
                                                       optionsValue: 'value',
                                                       value: required_for,
-                                                      attr: { disabled: !isEditable() }">
+                                                      attr: { disabled: !isEditable() || !is_required() }">
           </select>
     </td>
     <!-- /ko -->

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/partials/fields_tab.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/partials/fields_tab.html
@@ -46,6 +46,17 @@
                           {% endblocktrans %}">
       </span>
     </th>
+    <!-- ko if: requiredForOptions.length > 0 -->
+    <th class="col-md-1">
+      {% trans "Required for" %}
+      <span class="hq-help-template"
+            data-title="{% trans "Required for" %}"
+            data-content="{% blocktrans with entity_string=view.entity_string|lower %}
+                          Specify which {{ entity_string }} type this field is required for.
+                          {% endblocktrans %}">
+      </span>
+    </th>
+    <!-- /ko -->
     <th class="col-md-3">
       {% if request|request_has_privilege:"REGEX_FIELD_VALIDATION" or couch_user.is_superuser %}
         {% trans "Validation" %}
@@ -88,18 +99,20 @@
       <input class="form-control" type="text" data-bind="value: label, attr: { 'readonly': !isEditable() }"/>
     </td>
     <td>
-      <div class="form-check mt-2 d-flex align-items-center">
+      <div class="form-check mt-2">
         <input class="form-check-input" type="checkbox" data-bind="checked: is_required, attr: { 'disabled': !isEditable() }"/>
-        <!-- ko if: is_required() && $root.requiredForOptions.length > 0 -->
-          <select class="form-select ms-2" data-bind="options: $root.requiredForOptions,
+      </div>
+    </td>
+    <!-- ko if: $root.requiredForOptions.length > 0 -->
+    <td>
+          <select class="form-select" data-bind="options: $root.requiredForOptions,
                                                       optionsText: 'text',
                                                       optionsValue: 'value',
                                                       value: required_for,
                                                       attr: { disabled: !isEditable() }">
           </select>
-        <!-- /ko -->
-      </div>
     </td>
+    <!-- /ko -->
     <td>
 
       {% if request|request_has_privilege:"REGEX_FIELD_VALIDATION" or couch_user.is_superuser %}


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This change splits the "required for" dropdown to its own column. If the field is not "required", the dropdown is disabled.

![Screen Shot 2024-10-25 at 2 17 27 PM](https://github.com/user-attachments/assets/ded2db11-1d15-4f40-ac97-95b71a3d776a)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Change was a result of [this feedback](https://docs.google.com/document/d/1dsHnvS1xFeVRoBruWOFgcxyMaCi6H15aiMmSaicg_Gk/edit?disco=AAABXtehgTA) and is a follow up to this [PR](https://github.com/dimagi/commcare-hq/pull/35218).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no feature Flag

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is solely a UI change and was tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated test exists for UI.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
