### PR TITLE
Updated location_types.js to not use $.enable

### DIFF
--- a/corehq/apps/locations/static/locations/js/location_types.js
+++ b/corehq/apps/locations/static/locations/js/location_types.js
@@ -398,12 +398,12 @@ hqDefine('locations/js/location_types', [
         }
 
         $("form#settings").on("change input", function () {
-            $(this).find(":submit").addClass("btn-primary").enable();
+            $(this).find(":submit").addClass("btn-primary").enableButton();
             window.onbeforeunload = warnBeforeUnload;
         });
 
         $("form#settings button").on("click", function () {
-            $("form#settings").find(":submit").enable();
+            $("form#settings").find(":submit").enableButton();
             window.onbeforeunload = warnBeforeUnload;
         });
 


### PR DESCRIPTION
## Product Description
Fixes js error when editing organization levels. The error is present on staging but not yet on any of the production servers.

## Technical Summary
This was caused by https://github.com/dimagi/commcare-hq/pull/35258

`enable` isn't listed in jquery-form's [public API](https://github.com/jquery-form/form?tab=readme-ov-file#api), but it's [in the code](https://github.com/jquery-form/form/blob/421b0aed6ff6ba8615151e1a10d9ffef3fb58923/src/jquery.form.js#L1484-L1492).

I grepped js files for `\.enable\b` and didn't find any other occurrences. I also grepped for the other `$.fn.foo` functions defined in `jquery.form.js` and am pretty confident we're not using them (searching for `selected` was a bit challenging, but I'm fairly certain all of our usages of it refer to locally-defined `selected` functions).

HQ has its own enable button function [here](https://github.com/dimagi/commcare-hq/blob/d4fe27b4c4837e7a6ce213b96c44853ab68cd494/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js#L129-L133), so this is an easy fix.

## Safety Assurance

### Safety story
Tested locally. Review is sufficient safety check.

### Automated test coverage

Yes, QA's selenium tests flagged this.

### QA Plan
not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
