### PR TITLE
Let user know they put a invalid tenant id instead of saying unknown issue happen

### DIFF
--- a/corehq/apps/sso/tasks.py
+++ b/corehq/apps/sso/tasks.py
@@ -132,8 +132,8 @@ def auto_deactivate_removed_sso_users():
         except EntraVerificationFailed as e:
             notify_exception(None, f"Failed to get members of the IdP. {str(e)}")
             send_deactivation_skipped_email(idp=idp, failure_code=MSGraphIssue.VERIFICATION_ERROR,
-                                            error=EntraVerificationFailed.error,
-                                            error_description=EntraVerificationFailed.message)
+                                            error=e.error,
+                                            error_description=e.message)
             continue
         except requests.exceptions.HTTPError as e:
             notify_exception(None, f"Failed to get members of the IdP. {str(e)}")

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -1,6 +1,8 @@
 import json
 import requests
 
+from django.utils.translation import gettext_lazy as _
+
 from corehq.apps.sso.exceptions import EntraVerificationFailed, EntraUnsupportedType
 
 
@@ -34,7 +36,7 @@ def get_all_usernames_of_the_idp_from_entra(idp):
     except ValueError as e:
         if "check your tenant name" in str(e):
             raise EntraVerificationFailed(error="invalid_tenant",
-                                          message="Please double check your tenant id is correct")
+                                          message=_("Please double check your tenant id is correct"))
         else:
             raise e
 
@@ -117,7 +119,7 @@ def _get_access_token(app, config):
         result = app.acquire_token_for_client(scopes=config["scope"])
     if "access_token" not in result:
         raise EntraVerificationFailed(result.get('error', {}),
-                                      result.get('error_description', 'No error description provided'))
+                                      result.get('error_description', _('No error description provided')))
     return result.get("access_token")
 
 
@@ -142,8 +144,8 @@ def _get_all_user_ids_in_app(token, app_id):
         elif assignment["principalType"] == "Group":
             group_queue.append(assignment["principalId"])
         else:
-            raise EntraUnsupportedType("Nested applications (ServicePrincipal members) are not supported. "
-                                       "Please include only Users or Groups as members of this SSO application")
+            raise EntraUnsupportedType(_("Nested applications (ServicePrincipal members) are not supported. "
+                                       "Please include only Users or Groups as members of this SSO application"))
 
     for group_id in group_queue:
         members_data = _get_group_members(group_id, token)

--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -26,10 +26,17 @@ def get_all_usernames_of_the_idp_from_entra(idp):
     config = _configure_idp(idp)
 
     # Create a preferably long-lived app instance which maintains a token cache.
-    app = msal.ConfidentialClientApplication(
-        config["client_id"], authority=config["authority"],
-        client_credential=config["secret"],
-    )
+    try:
+        app = msal.ConfidentialClientApplication(
+            config["client_id"], authority=config["authority"],
+            client_credential=config["secret"],
+        )
+    except ValueError as e:
+        if "check your tenant name" in str(e):
+            raise EntraVerificationFailed(error="invalid_tenant",
+                                          message="Please double check your tenant id is correct")
+        else:
+            raise e
 
     token = _get_access_token(app, config)
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Example Sentry issue: https://dimagi.sentry.io/issues/5991125083/

From the stack trace, we can see it is because user put a wrong tenant id.

We didn't catch it, so we send a message saying we encountered an unknown issue, which is incorrect and misleading.
![image](https://github.com/user-attachments/assets/976fe7b4-847d-45c3-a6b1-384573cb6d11)


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

Ticket: https://dimagi.atlassian.net/browse/SAAS-16123

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe as we just add a try catch to catch errors.
I will also request QA on it.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

No

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA Ticket: https://dimagi.atlassian.net/browse/QA-7193
QA should change the configuration, to make the tenant id incorrect, and see if receive the "Auto deactivation skipped" email. The email context should explicitly say what's the issue, instead of saying unknown issue.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
