### PR TITLE
Self-start subscription alert for ops

### DIFF
--- a/corehq/apps/accounting/emails.py
+++ b/corehq/apps/accounting/emails.py
@@ -6,8 +6,14 @@ from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.util.global_request import get_request
 
 
-def send_subscription_change_alert(domain, new_subscription, old_subscription, internal_change,
-                                   change_type='Change'):
+class SubjectTemplate:
+    CHANGE = "{env}Subscription Change Alert: {domain} from {old_plan} to {new_plan}"
+    RENEW = "{env}Subscription Renewal Alert: {domain} from {old_plan} to {new_plan}"
+    SELF_START = "{env}New Self-Start Subscription Alert: {domain} to {new_plan}"
+
+
+def send_subscription_change_alert(domain, new_subscription, old_subscription, internal_change=False,
+                                   subject=SubjectTemplate.CHANGE):
 
     billing_account = (
         new_subscription.account if new_subscription else
@@ -27,10 +33,9 @@ def send_subscription_change_alert(domain, new_subscription, old_subscription, i
         'username': request.couch_user.username if getattr(request, 'couch_user', None) else None,
         'referer': request.META.get('HTTP_REFERER') if request else None,
     }
-    email_subject = "{env}Subscription {change_type} Alert: {domain} from {old_plan} to {new_plan}".format(
+    email_subject = subject.format(
         env=("[{}] ".format(settings.SERVER_ENVIRONMENT.upper())
              if settings.SERVER_ENVIRONMENT == "staging" else ""),
-        change_type=change_type,
         domain=email_context['domain'],
         old_plan=email_context['old_plan'],
         new_plan=email_context['new_plan'],
@@ -48,4 +53,9 @@ def send_subscription_change_alert(domain, new_subscription, old_subscription, i
 
 
 def send_subscription_renewal_alert(domain, new_subscription, old_subscription):
-    send_subscription_change_alert(domain, new_subscription, old_subscription, False, change_type='Renewal')
+    send_subscription_change_alert(domain, new_subscription, old_subscription, subject=SubjectTemplate.RENEW)
+
+
+def send_self_start_subscription_alert(domain, new_subscription, old_subscription):
+    send_subscription_change_alert(domain, new_subscription, old_subscription,
+                                   subject=SubjectTemplate.SELF_START)

--- a/corehq/apps/accounting/emails.py
+++ b/corehq/apps/accounting/emails.py
@@ -13,7 +13,7 @@ class SubjectTemplate:
 
 
 def send_subscription_change_alert(domain, new_subscription, old_subscription, internal_change=False,
-                                   subject=SubjectTemplate.CHANGE):
+                                   subject_template=SubjectTemplate.CHANGE):
 
     billing_account = (
         new_subscription.account if new_subscription else
@@ -33,7 +33,7 @@ def send_subscription_change_alert(domain, new_subscription, old_subscription, i
         'username': request.couch_user.username if getattr(request, 'couch_user', None) else None,
         'referer': request.META.get('HTTP_REFERER') if request else None,
     }
-    email_subject = subject.format(
+    email_subject = subject_template.format(
         env=("[{}] ".format(settings.SERVER_ENVIRONMENT.upper())
              if settings.SERVER_ENVIRONMENT == "staging" else ""),
         domain=email_context['domain'],
@@ -53,9 +53,10 @@ def send_subscription_change_alert(domain, new_subscription, old_subscription, i
 
 
 def send_subscription_renewal_alert(domain, new_subscription, old_subscription):
-    send_subscription_change_alert(domain, new_subscription, old_subscription, subject=SubjectTemplate.RENEW)
+    send_subscription_change_alert(domain, new_subscription, old_subscription,
+                                   subject_template=SubjectTemplate.RENEW)
 
 
 def send_self_start_subscription_alert(domain, new_subscription, old_subscription):
     send_subscription_change_alert(domain, new_subscription, old_subscription,
-                                   subject=SubjectTemplate.SELF_START)
+                                   subject_template=SubjectTemplate.SELF_START)

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -66,11 +66,11 @@ from corehq.apps.accounting.utils import (
     log_accounting_error,
     log_accounting_info,
     quantize_accounting_decimal,
+    self_signup_workflow_in_progress,
 )
 from corehq.apps.domain import UNKNOWN_DOMAIN
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.tasks import send_html_email_async
-from corehq.apps.registration.models import SelfSignupWorkflow
 from corehq.apps.users.models import WebUser
 from corehq.apps.users.util import is_dimagi_email
 from corehq.blobs.mixin import CODES, BlobMixin
@@ -1133,7 +1133,7 @@ class Subscriber(models.Model):
             Subscriber._process_upgrade(self.domain, upgraded_privileges, new_plan_version)
 
         if Subscriber.should_send_subscription_notification(old_subscription, new_subscription):
-            if SelfSignupWorkflow.get_in_progress_for_domain(self.domain):
+            if self_signup_workflow_in_progress(self.domain):
                 send_self_start_subscription_alert(self.domain, new_subscription, old_subscription)
             else:
                 send_subscription_change_alert(self.domain, new_subscription, old_subscription, internal_change)

--- a/corehq/apps/accounting/utils/__init__.py
+++ b/corehq/apps/accounting/utils/__init__.py
@@ -506,3 +506,8 @@ def count_form_submitting_mobile_workers(domain, start, end):
         .aggregations.user.normalized_buckets
     )
     return len(form_counts_by_worker)
+
+
+def self_signup_workflow_in_progress(domain):
+    from corehq.apps.registration.models import SelfSignupWorkflow
+    return SelfSignupWorkflow.get_in_progress_for_domain(domain)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
Updates the accounting email "subscription change alert" subject to use a `SubjectTemplate` class to be more flexible in structure. Adds a check for whether a self-signup workflow is in progress when sending a new subscription alert to ops -- and if so, sends the "self-start" alert instead of the plain "subscription change" alert.

## Safety Assurance

### Safety story
Pretty minor changes to emails that are only sent to ops.

### Automated test coverage
I don't believe there are any for this in particular.

### QA Plan
QA holistically with [SAAS-16034](https://dimagi.atlassian.net/browse/SAAS-16034)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16034]: https://dimagi.atlassian.net/browse/SAAS-16034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ