### PR TITLE
Fixes migration

### DIFF
--- a/corehq/motech/repeaters/migrations/0015_drop_receiverwrapper_couchdb.py
+++ b/corehq/motech/repeaters/migrations/0015_drop_receiverwrapper_couchdb.py
@@ -8,7 +8,7 @@ from couchdbkit.client import Database, ResourceNotFound
 
 
 @skip_on_fresh_install
-def _delete_receiverwrapper_couchdb():
+def _delete_receiverwrapper_couchdb(apps, schema_editor):
     db = Database(f"{settings.COUCH_DATABASE}__receiverwrapper")
     try:
         db.server.delete_db(db.dbname)


### PR DESCRIPTION
## Technical Summary

Fixes the following error when running migrations:

```
Traceback (most recent call last):
  File "corehq/sql_db/management/commands/migrate_multi.py", line 66, in handle
    job.get()
  File "src/gevent/greenlet.py", line 805, in gevent._gevent_cgreenlet.Greenlet.get
  File "src/gevent/greenlet.py", line 373, in gevent._gevent_cgreenlet.Greenlet._raise_exception
  File ".venv/lib/python3.9/site-packages/gevent/_compat.py", line 49, in reraise
    raise value.with_traceback(tb)
  File "src/gevent/greenlet.py", line 908, in gevent._gevent_cgreenlet.Greenlet.run
  File "corehq/sql_db/management/commands/migrate_multi.py", line 43, in migrate_db
    call_command('migrate', *args, **call_options)
  File ".venv/lib/python3.9/site-packages/django/core/management/__init__.py", line 194, in call_command
    return command.execute(*args, **defaults)
  File ".venv/lib/python3.9/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
  File ".venv/lib/python3.9/site-packages/django/core/management/base.py", line 106, in wrapper
    res = handle_func(*args, **kwargs)
  File "corehq/sql_db/management/commands/migrate.py", line 17, in handle
    result = super().handle(*args, **options)
  File ".venv/lib/python3.9/site-packages/django/core/management/base.py", line 106, in wrapper
    res = handle_func(*args, **kwargs)
  File ".venv/lib/python3.9/site-packages/django/core/management/commands/migrate.py", line 356, in handle
    post_migrate_state = executor.migrate(
  File ".venv/lib/python3.9/site-packages/django/db/migrations/executor.py", line 135, in migrate
    state = self._migrate_all_forwards(
  File ".venv/lib/python3.9/site-packages/django/db/migrations/executor.py", line 167, in _migrate_all_forwards
    state = self.apply_migration(
  File ".venv/lib/python3.9/site-packages/django/db/migrations/executor.py", line 252, in apply_migration
    state = migration.apply(state, schema_editor)
  File ".venv/lib/python3.9/site-packages/django/db/migrations/migration.py", line 132, in apply
    operation.database_forwards(
  File ".venv/lib/python3.9/site-packages/django/db/migrations/operations/special.py", line 193, in database_forwards
    self.code(from_state.apps, schema_editor)
  File "corehq/util/django_migrations.py", line 121, in _inner
    return migration_fn(*args, **kwargs)
TypeError: _delete_receiverwrapper_couchdb() takes 0 positional arguments but 2 were given
```

## Safety Assurance

### Safety story

Tested locally

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
