### PR TITLE
add links to example commits of webpack migrations

### DIFF
--- a/docs/js-guide/requirejs-to-webpack.rst
+++ b/docs/js-guide/requirejs-to-webpack.rst
@@ -80,6 +80,9 @@ Then, in the file itself, we add the ``commcarehq`` dependency to the list of de
     ) {
         ...
 
+`Here is an example commit of a migrated Bootstrap 5 entry point
+<https://github.com/dimagi/commcare-hq/pull/35186/commits/029854e14ef08ef29d87293da5970bf35fb5ffca>`__.
+
 
 Bootstrap 3 Entry Points
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -106,6 +109,9 @@ Then, in the file itself, we add the ``commcarehq_b3`` dependency to the list of
         initialPageData
     ) {
         ...
+
+`Here is an example commit of a migrated Bootstrap 3 entry point
+<https://github.com/dimagi/commcare-hq/pull/35186/commits/9153f3cedc550b518f537bc6783d06754fd35577>`__.
 
 
 Step 2: Verify Webpack Build


### PR DESCRIPTION
## Technical Summary
This just adds links to example commits of webpack migrations for bootstrap 3 and 5 entry points.

## Safety Assurance

### Safety story
Just a documentation update

### Automated test coverage
Yes

### QA Plan
N/A


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
