### PR TITLE
Update entry point for HTMX and Alpine

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_and_alpine.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_and_alpine.js
@@ -2,6 +2,9 @@
  * Include this module as the entry point to use HTMX and Alpine.js on a page without
  * any additional configuration.
  *
+ * NOTE: This entry point only supports Bootstrap 5 pages!
+ * You can make your view support Bootstrap 5 by using the `@use_bootstrap5` decorator.
+ *
  * e.g.:
  *
  *      {% js_entry "hqwebapp/js/htmx_and_alpine" %}
@@ -11,6 +14,7 @@
  * - To show errors encountered by HTMX requests, include the `hqwebapp/htmx/error_modal.html` template
  *   in the `modals` block of the page, or `include` a template that extends it.
  */
+import 'commcarehq';
 import 'hqwebapp/js/htmx_base';
 
 import Alpine from 'alpinejs';


### PR DESCRIPTION
## Technical Summary
It was an oversight to not `import 'commcarehq`;` in the `htmx_and_alpine` entry point.
Due to modal support already being in bootstrap 5, and the fact we do not want to encourage new pages being written in bootstrap 3, I added a message at the top of the module that it can only support bootstrap 5 pages.

## Safety Assurance

### Safety story
Safe change. We don't have any released features using HTMX and Alpine yet.

### Automated test coverage
No

### QA Plan
N/A


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
