### PR TITLE
Improve Case Selection for Case Management Page

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/case_management.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_management.js
@@ -138,12 +138,17 @@ hqDefine("geospatial/js/case_management", [
                 self.showParams(true);
             };
 
-            let userData = users.map(function (c) {
-                return {
-                    id: c.itemId,
-                    lon: c.itemData.coordinates.lng,
-                    lat: c.itemData.coordinates.lat,
-                };
+            const hasSelectedUsers = mapModel.hasSelectedUsers();
+            let userData = [];
+            users.forEach((userMapItem) => {
+                // Either select all if none selected, or only pick selected users
+                if (!hasSelectedUsers || userMapItem.isSelected()) {
+                    userData.push({
+                        id: userMapItem.itemId,
+                        lon: userMapItem.itemData.coordinates.lng,
+                        lat: userMapItem.itemData.coordinates.lat,
+                    });
+                }
             });
 
             $.ajax({

--- a/corehq/apps/geospatial/static/geospatial/js/case_management.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_management.js
@@ -93,6 +93,7 @@ hqDefine("geospatial/js/case_management", [
         self.clearConnectionLines = function (cases) {
             let mapInstance = mapModel.mapInstance;
             let caseData = [];
+            const hasSelectedCases = mapModel.hasSelectedCases();
             cases.forEach(function (c) {
                 const layerId = mapModel.getLineFeatureId(c.itemId);
                 if (mapInstance.getLayer(layerId)) {
@@ -102,11 +103,14 @@ hqDefine("geospatial/js/case_management", [
                     mapInstance.removeSource(layerId);
                 }
 
-                caseData.push({
-                    id: c.itemId,
-                    lon: c.itemData.coordinates.lng,
-                    lat: c.itemData.coordinates.lat,
-                });
+                // Either select all if none selected, or only pick selected cases
+                if (!hasSelectedCases || c.isSelected()) {
+                    caseData.push({
+                        id: c.itemId,
+                        lon: c.itemData.coordinates.lng,
+                        lat: c.itemData.coordinates.lat,
+                    });
+                }
             });
 
             return caseData;

--- a/corehq/apps/geospatial/static/geospatial/js/case_management.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_management.js
@@ -252,7 +252,9 @@ hqDefine("geospatial/js/case_management", [
         if (polygonFilterModel.activeSavedPolygon()) {
             features = features.concat(polygonFilterModel.activeSavedPolygon().geoJson.features);
         }
-        mapModel.selectAllMapItems(features);
+        if (features.length) {
+            mapModel.selectAllMapItems(features);
+        }
     }
 
     function initPolygonFilters() {
@@ -362,6 +364,7 @@ hqDefine("geospatial/js/case_management", [
 
                     const userMapItems = mapModel.addMarkersToMap(userData, userMarkerColors);
                     mapModel.userMapItems(userMapItems);
+                    selectMapItemsInPolygons();
                 },
                 error: function () {
                     self.hasErrors(true);

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -541,6 +541,11 @@ hqDefine('geospatial/js/models', [
             });
         };
 
+        self.hasSelectedCases = function () {
+            return self.caseMapItems().some((caseMapItem) => {
+                return caseMapItem.isSelected();
+            });
+        };
     };
 
     var PolygonFilter = function (mapObj, shouldUpdateQueryParam, shouldSelectAfterFilter) {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -534,6 +534,13 @@ hqDefine('geospatial/js/models', [
             });
             return layerRemoved;
         };
+
+        self.hasSelectedUsers = function () {
+            return self.userMapItems().some((userMapItem) => {
+                return userMapItem.isSelected();
+            });
+        };
+
     };
 
     var PolygonFilter = function (mapObj, shouldUpdateQueryParam, shouldSelectAfterFilter) {


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Only selected cases and mobile workers will now be considered for disbursement. If no cases are selected, then all cases will be considered. The same is true for mobile workers:
![disburse-selection](https://github.com/user-attachments/assets/0e4e265a-6b3c-4552-9a53-6a5e13cfa326)

If a polygon is added to the map before loading in the mobile workers, these mobile workers will now automatically be selected:
![select-users-when-adding](https://github.com/user-attachments/assets/3de51adb-0d4a-48be-8ae6-e3d576a11314)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3995).

This PR addresses two bugs for the Case Management page. Specifically:
- All cases and mobile workers are considered for disbursement, regardless of what has been selected.
- Loading in mobile workers after applying polygon filtering does not automatically cause the mobile workers to be selected.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

Small front-end only change. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
