### PR TITLE
Fixed outdated tableau.js being served by loading proper template tag libraries

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/tableau_template.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/tableau_template.html.diff.txt
@@ -3,10 +3,10 @@
 @@ -1,4 +1,4 @@
 -{% extends "hqwebapp/bootstrap3/base_section.html" %}
 +{% extends "hqwebapp/bootstrap5/base_section.html" %}
- {% load compress %}
  {% load hq_shared_tags %}
- {% load i18n %}
-@@ -21,7 +21,7 @@
+ 
+ {% block page_content %}
+@@ -18,7 +18,7 @@
          <i class="fa fa-spin fa-spinner"></i>
      </div>
      <div id="vizContainer"></div>

--- a/corehq/apps/integration/templates/integration/base_cloudcare_template.html
+++ b/corehq/apps/integration/templates/integration/base_cloudcare_template.html
@@ -1,6 +1,5 @@
 {% extends "hqwebapp/bootstrap5/base_navigation.html" %}
 {% load i18n %}
-{% load static %}
 {% load hq_shared_tags %}
 {% load compress %}
 

--- a/corehq/apps/integration/templates/integration/web_app_dialer.html
+++ b/corehq/apps/integration/templates/integration/web_app_dialer.html
@@ -1,7 +1,6 @@
 {% extends "integration/base_cloudcare_template.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
-{% load static %}
 {% load compress %}
 {% requirejs_main_b5 "integration/js/dialer/domain_dialer_main" %}
 

--- a/corehq/apps/integration/templates/integration/web_app_gaen_otp.html
+++ b/corehq/apps/integration/templates/integration/web_app_gaen_otp.html
@@ -1,7 +1,6 @@
 {% extends "integration/base_cloudcare_template.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
-{% load static %}
 {% load compress %}
 
 {% block stylesheets %}

--- a/corehq/apps/integration/templates/integration/web_app_integration_err.html
+++ b/corehq/apps/integration/templates/integration/web_app_integration_err.html
@@ -1,7 +1,6 @@
 {% extends "integration/base_cloudcare_template.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
-{% load static %}
 {% load compress %}
 {% requirejs_main_b5 "integration/js/dialer/domain_dialer_main" %}
 

--- a/corehq/apps/reports/templates/reports/bootstrap3/tableau_template.html
+++ b/corehq/apps/reports/templates/reports/bootstrap3/tableau_template.html
@@ -1,8 +1,5 @@
 {% extends "hqwebapp/bootstrap3/base_section.html" %}
-{% load compress %}
 {% load hq_shared_tags %}
-{% load i18n %}
-{% load static %}
 
 {% block page_content %}
 

--- a/corehq/apps/reports/templates/reports/bootstrap5/tableau_template.html
+++ b/corehq/apps/reports/templates/reports/bootstrap5/tableau_template.html
@@ -1,8 +1,5 @@
 {% extends "hqwebapp/bootstrap5/base_section.html" %}
-{% load compress %}
 {% load hq_shared_tags %}
-{% load i18n %}
-{% load static %}
 
 {% block page_content %}
 


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/USH-5051

## Technical Summary
Static files need to be referenced using the `static` tag, defined in [hq_shared_tags](https://github.com/dimagi/commcare-hq/blob/a73e798851fb078f7139024aa4872eb1a7b2da4b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py#L99-L106). This tag creates a URL that references our CDN and includes a `version` URL param for cache busting.

The tableau template was loading django's `static` template tags library, which also defines a tag named `static` https://docs.djangoproject.com/en/5.1/ref/templates/builtins/#static The template also included `hq_shared_tags`, but it was included earlier in the file, so its `static` tag got replaced by the one from the `static` library.

This PR also removes the django `static` library from the small number of other files that were using it.

## Feature Flag
Tableau

## Safety Assurance

### Safety story
I tested on staging that a tableau report still loads, and its script tag now references the CDN and includes a version param in the URL.

I did not test the integrations pages. The change made should be safe, and these pages aren't being used by live projects.

### Automated test coverage

no

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
