### PR TITLE
Treat web user location fields the same

### DIFF
--- a/corehq/apps/callcenter/sync_usercase.py
+++ b/corehq/apps/callcenter/sync_usercase.py
@@ -136,11 +136,6 @@ def _get_user_case_fields(user, case_type, owner_id, domain):
     fields = {k: v for k, v in user.get_user_data(domain).items() if
               valid_element_name(k)}
 
-    if user.is_web_user():
-        fields['commcare_location_id'] = user.get_location_id(domain)
-        fields['commcare_location_ids'] = user_location_data(user.get_location_ids(domain))
-        fields['commcare_primary_case_sharing_id'] = user.get_location_id(domain)
-
     # language or phone_number can be null and will break
     # case submission
     fields.update({

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2641,14 +2641,6 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     def get_usercase_by_domain(self, domain):
         return CommCareCase.objects.get_case_by_external_id(domain, self._id, USERCASE_TYPE)
 
-    def get_user_session_data(self, domain):
-        # TODO can we do this for both types of users and remove the fields from user data?
-        session_data = super(WebUser, self).get_user_session_data(domain)
-        session_data['commcare_location_id'] = self.get_location_id(domain)
-        session_data['commcare_location_ids'] = user_location_data(self.get_location_ids(domain))
-        session_data['commcare_primary_case_sharing_id'] = self.get_location_id(domain)
-        return session_data
-
 
 class FakeUser(WebUser):
     """


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
https://dimagi.atlassian.net/browse/USH-4428
For more context, see https://github.com/dimagi/commcare-hq/pull/34401/ I still prefer the way I had it with web users, where it's injected in the usercase and restore code at the last minute, but I think consistency between the two models is more important still.

The big difference here is that the way I did it for WebUsers made those fields always present, but sometimes empty.  I do think this is a better way of doing things, but "missing" and "null" are treated differently on mobile, so it's conceivable that doing that change for mobile workers would break someone's app.  I think this is the easiest way to ensure web and mobile workers behave the same without breaking existing apps


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
