### PR TITLE
Case-insensitive DD_TRACE_ENABLED comparison

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -152,7 +152,7 @@ def patch_jsonfield():
 
 def unpatch_sys_modules():
     # until https://github.com/DataDog/dd-trace-py/issues/9143 is implemented
-    if os.environ.get("DD_TRACE_ENABLED") == "false":
+    if os.environ.get("DD_TRACE_ENABLED", "").lower() == "false":
         from ddtrace import ModuleWatchdog
         if isinstance(sys.modules, ModuleWatchdog):
             sys.modules.uninstall()


### PR DESCRIPTION
https://github.com/dimagi/commcare-cloud/pull/6404#issuecomment-2423302476

## Safety Assurance

### Safety story

Tiny change, only affects environments where `DD_TRACE_ENABLED` is set (which is none of our production environments).

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations