### PR TITLE
Move location fields out of user data

### DIFF
--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -17,6 +17,7 @@ from corehq.apps.es import FormES
 from corehq.apps.groups.models import Group
 from corehq.apps.user_importer.helpers import UserChangeLogger
 from corehq.apps.users.models import CommCareUser, HqPermissions, WebUser
+from corehq.apps.users.util import user_location_data
 from corehq.const import USER_CHANGE_VIA_API
 
 
@@ -105,6 +106,13 @@ class CommCareUserResource(UserResource):
 
     def dehydrate_user_data(self, bundle):
         user_data = bundle.obj.get_user_data(bundle.obj.domain).to_dict()
+        if location_id := bundle.obj.get_location_id(bundle.obj.domain):
+            # This is all available in the top level, but add in here for backwards-compatibility
+            user_data['commcare_location_id'] = location_id
+            user_data['commcare_location_ids'] = user_location_data(
+                bundle.obj.get_location_ids(bundle.obj.domain))
+            user_data['commcare_primary_case_sharing_id'] = location_id
+
         if self.determine_format(bundle.request) == 'application/xml':
             # attribute names can't start with digits in xml
             user_data = {k: v for k, v in user_data.items() if not k[0].isdigit()}

--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -113,6 +113,7 @@ class CommCareUserResource(UserResource):
                 bundle.obj.get_location_ids(bundle.obj.domain))
             user_data['commcare_primary_case_sharing_id'] = location_id
 
+        user_data['commcare_project'] = bundle.obj.domain
         if self.determine_format(bundle.request) == 'application/xml':
             # attribute names can't start with digits in xml
             user_data = {k: v for k, v in user_data.items() if not k[0].isdigit()}

--- a/corehq/apps/callcenter/sync_usercase.py
+++ b/corehq/apps/callcenter/sync_usercase.py
@@ -136,10 +136,10 @@ def _get_user_case_fields(user, case_type, owner_id, domain):
     fields = {k: v for k, v in user.get_user_data(domain).items() if
               valid_element_name(k)}
 
-    if user.is_web_user():
-        fields['commcare_location_id'] = user.get_location_id(domain)
+    if location_id := user.get_location_id(domain):
+        fields['commcare_location_id'] = location_id
         fields['commcare_location_ids'] = user_location_data(user.get_location_ids(domain))
-        fields['commcare_primary_case_sharing_id'] = user.get_location_id(domain)
+        fields['commcare_primary_case_sharing_id'] = location_id
 
     # language or phone_number can be null and will break
     # case submission

--- a/corehq/apps/callcenter/sync_usercase.py
+++ b/corehq/apps/callcenter/sync_usercase.py
@@ -155,6 +155,7 @@ def _get_user_case_fields(user, case_type, owner_id, domain):
         'hq_user_id': user.get_id,
         'first_name': user.first_name or '',
         'last_name': user.last_name or '',
+        'commcare_project': domain,
     })
 
     return fields

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -1025,7 +1025,6 @@ class TestUserESAccessors(TestCase):
         self.assertEqual(len(results), 1)
         metadata = results[0].pop('user_data_es')
         self.assertEqual({
-            'commcare_project': 'user-esaccessors-test',
             PROFILE_SLUG: self.profile.id,
             'job': 'reporter',
             'office': 'phone_booth',

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -131,8 +131,7 @@ class TestUserDataMixin:
             self.upload_record.pk,
             is_web_upload
         )
-        self.assert_user_data_equals({
-            'commcare_project': self.domain.name, 'key': 'F#', 'commcare_profile': '', 'mode': ''})
+        self.assert_user_data_equals({'key': 'F#', 'commcare_profile': '', 'mode': ''})
 
         # Update user_data
         import_users_and_groups(
@@ -143,8 +142,7 @@ class TestUserDataMixin:
             self.upload_record.pk,
             is_web_upload
         )
-        self.assert_user_data_equals({
-            'commcare_project': self.domain.name, 'key': 'Bb', 'commcare_profile': '', 'mode': ''})
+        self.assert_user_data_equals({'key': 'Bb', 'commcare_profile': '', 'mode': ''})
 
         # set user data to blank
         import_users_and_groups(
@@ -178,12 +176,7 @@ class TestUserDataMixin:
             is_web_upload
         )
 
-        self.assert_user_data_equals({
-            'commcare_project': self.domain.name,
-            'key': 'F#',
-            'mode': 'minor',
-            PROFILE_SLUG: self.profile.id,
-        })
+        self.assert_user_data_equals({'key': 'F#', 'mode': 'minor', PROFILE_SLUG: self.profile.id})
         user_history = UserHistory.objects.get(
             user_id=self.user.get_id,
             changed_by=self.uploading_user.get_id,

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -452,7 +452,6 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin, TestUserDataMi
             False
         )
         self.assertEqual(self.user.location_id, self.loc1._id)
-        self.assert_user_data_item('commcare_location_id', self.user.location_id)
         # multiple locations
         self.assertListEqual([self.loc1._id], self.user.assigned_location_ids)
 
@@ -495,12 +494,8 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin, TestUserDataMi
         )
         # first location should be primary location
         self.assertEqual(self.user.location_id, self.loc1._id)
-        self.assert_user_data_item('commcare_location_id', self.user.location_id)
-        self.assert_user_data_item('commcare_primary_case_sharing_id', self.user.location_id)
         # multiple locations
         self.assertListEqual([loc._id for loc in [self.loc1, self.loc2]], self.user.assigned_location_ids)
-        # non-primary location
-        self.assert_user_data_item('commcare_location_ids', " ".join([self.loc1._id, self.loc2._id]))
 
         user_history = UserHistory.objects.get(action=UserModelAction.CREATE.value,
                                                user_id=self.user.get_id,
@@ -551,7 +546,6 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin, TestUserDataMi
 
         # user should have no locations
         self.assertEqual(self.user.location_id, None)
-        self.assert_user_data_item('commcare_location_id', None)
         self.assertListEqual(self.user.assigned_location_ids, [])
 
         user_history = UserHistory.objects.get(action=UserModelAction.UPDATE.value,
@@ -578,8 +572,6 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin, TestUserDataMi
 
         # user's primary location should be loc1
         self.assertEqual(self.user.location_id, self.loc1._id)
-        self.assert_user_data_item('commcare_location_id', self.loc1._id)
-        self.assert_user_data_item('commcare_location_ids', " ".join([self.loc1._id, self.loc2._id]))
         self.assertListEqual(self.user.assigned_location_ids, [self.loc1._id, self.loc2._id])
 
         user_history = UserHistory.objects.get(action=UserModelAction.CREATE.value,
@@ -604,8 +596,6 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin, TestUserDataMi
 
         # user's location should now be loc2
         self.assertEqual(self.user.location_id, self.loc2._id)
-        self.assert_user_data_item('commcare_location_ids', self.loc2._id)
-        self.assert_user_data_item('commcare_location_id', self.loc2._id)
         self.assertListEqual(self.user.assigned_location_ids, [self.loc2._id])
 
         user_history = UserHistory.objects.get(action=UserModelAction.UPDATE.value,
@@ -653,7 +643,6 @@ class TestMobileUserBulkUpload(TestCase, DomainSubscriptionMixin, TestUserDataMi
 
         # user's location should now be loc2
         self.assertEqual(self.user.location_id, self.loc2._id)
-        self.assert_user_data_item('commcare_location_id', self.loc2._id)
         self.assertListEqual(self.user.assigned_location_ids, [self.loc2._id])
 
         user_history = UserHistory.objects.get(action=UserModelAction.UPDATE.value,

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -708,6 +708,8 @@ def _get_user(domain, doc_id):
         else:
             doc[key] = getattr(user, key)
     doc['user_data'] = user.get_user_data(domain).to_dict()
+    # add location ID in here to not break existing reports - they _should_ just use user.location_id
+    doc['user_data']['commcare_location_id'] = user.get_location_id(domain)
     return doc
 
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1166,6 +1166,12 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             f'{SYSTEM_PREFIX}_phone_number': self.phone_number,
             f'{SYSTEM_PREFIX}_user_type': self._get_user_type(),
         })
+
+        if location_id := self.get_location_id(domain):
+            session_data['commcare_location_id'] = location_id
+            session_data['commcare_location_ids'] = user_location_data(self.get_location_ids(domain))
+            session_data['commcare_primary_case_sharing_id'] = location_id
+
         return session_data
 
     def get_owner_ids(self, domain):
@@ -2645,14 +2651,6 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
 
     def get_usercase_by_domain(self, domain):
         return CommCareCase.objects.get_case_by_external_id(domain, self._id, USERCASE_TYPE)
-
-    def get_user_session_data(self, domain):
-        # TODO can we do this for both types of users and remove the fields from user data?
-        session_data = super(WebUser, self).get_user_session_data(domain)
-        session_data['commcare_location_id'] = self.get_location_id(domain)
-        session_data['commcare_location_ids'] = user_location_data(self.get_location_ids(domain))
-        session_data['commcare_primary_case_sharing_id'] = self.get_location_id(domain)
-        return session_data
 
 
 class FakeUser(WebUser):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1161,6 +1161,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             session_data[COMMCARE_USER_TYPE_KEY] = COMMCARE_USER_TYPE_DEMO
 
         session_data.update({
+            f'{SYSTEM_PREFIX}_project': domain,
             f'{SYSTEM_PREFIX}_first_name': self.first_name,
             f'{SYSTEM_PREFIX}_last_name': self.last_name,
             f'{SYSTEM_PREFIX}_phone_number': self.phone_number,

--- a/corehq/apps/users/tests/test_location_assignment.py
+++ b/corehq/apps/users/tests/test_location_assignment.py
@@ -129,20 +129,15 @@ class CCUserLocationAssignmentTest(TestCase):
 
     def assertPrimaryLocation(self, expected):
         self.assertEqual(self.user.location_id, expected)
-        self.assertEqual(self.user.get_user_data(self.domain).get('commcare_location_id'), expected)
         self.assertTrue(expected in self.user.assigned_location_ids)
 
     def assertAssignedLocations(self, expected_location_ids):
         user = CommCareUser.get(self.user._id)
         self.assertListEqual(user.assigned_location_ids, expected_location_ids)
-        actual_ids = user.get_user_data(self.domain).get('commcare_location_ids', '')
-        actual_ids = actual_ids.split(' ') if actual_ids else []
-        self.assertListEqual(actual_ids, expected_location_ids)
 
     def assertNonPrimaryLocation(self, expected):
         self.assertNotEqual(self.user.location_id, expected)
         self.assertTrue(expected in self.user.assigned_location_ids)
-        self.assertTrue(expected in self.user.get_user_data(self.domain).get('commcare_location_ids'))
 
 
 class WebUserLocationAssignmentTest(TestCase):

--- a/corehq/apps/users/tests/test_user_data.py
+++ b/corehq/apps/users/tests/test_user_data.py
@@ -38,7 +38,6 @@ class TestUserData(TestCase):
     def test_user_data_accessor(self):
         user = self.make_commcare_user()
         user_data = user.get_user_data(self.domain)
-        self.assertEqual(user_data['commcare_project'], self.domain)
         user_data.update({
             'cruise': 'control',
             'this': 'road',
@@ -61,12 +60,10 @@ class TestUserData(TestCase):
 
         # Each domain has a separate user_data object
         self.assertEqual(web_user.get_user_data(self.domain).to_dict(), {
-            'commcare_project': self.domain,
             'commcare_profile': '',
             'what_domain_is_it': 'domain 1',
         })
         self.assertEqual(web_user.get_user_data('another_domain').to_dict(), {
-            'commcare_project': 'another_domain',
             'commcare_profile': '',
             'what_domain_is_it': 'domain 2',
         })
@@ -198,14 +195,12 @@ class TestUserDataModel(TestCase):
         # Custom user data profiles get their data added to metadata automatically for mobile users
         user_data = self.init_user_data({'yearbook_quote': 'Not all who wander are lost.'})
         self.assertEqual(user_data.to_dict(), {
-            'commcare_project': self.domain,
             'commcare_profile': '',
             'yearbook_quote': 'Not all who wander are lost.',
         })
 
         user_data.profile_id = 'blues'
         self.assertEqual(user_data.to_dict(), {
-            'commcare_project': self.domain,
             'commcare_profile': 'blues',
             'favorite_color': 'blue',  # provided by the profile
             'yearbook_quote': 'Not all who wander are lost.',
@@ -214,7 +209,6 @@ class TestUserDataModel(TestCase):
         # Remove profile should remove it and related fields
         user_data.profile_id = None
         self.assertEqual(user_data.to_dict(), {
-            'commcare_project': self.domain,
             'commcare_profile': '',
             'yearbook_quote': 'Not all who wander are lost.',
         })
@@ -317,12 +311,5 @@ class TestUserDataModel(TestCase):
         user_data = self.user.get_user_data(self.domain)
 
         self.assertEqual(user_data.to_dict(), {
-            'commcare_project': self.domain,
             'commcare_profile': '',
         })
-
-    def test_change_data_provided_by_system_will_raise_user_data_error(self):
-        user_data = self.user.get_user_data(self.domain)
-
-        with self.assertRaisesMessage(UserDataError, "'commcare_project' cannot be set directly"):
-            user_data['commcare_project'] = 'blahblah'

--- a/corehq/apps/users/tests/test_user_data.py
+++ b/corehq/apps/users/tests/test_user_data.py
@@ -324,5 +324,5 @@ class TestUserDataModel(TestCase):
     def test_change_data_provided_by_system_will_raise_user_data_error(self):
         user_data = self.user.get_user_data(self.domain)
 
-        with self.assertRaisesMessage(UserDataError, "'commcare_location_id' cannot be set directly"):
-            user_data['commcare_location_id'] = self.loc1.location_id
+        with self.assertRaisesMessage(UserDataError, "'commcare_project' cannot be set directly"):
+            user_data['commcare_project'] = 'blahblah'

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -1,24 +1,17 @@
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models, transaction
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
-from corehq.apps.users.util import user_location_data
 
 from dimagi.utils.chunked import chunked
 
 from corehq.apps.custom_data_fields.models import (
-    COMMCARE_LOCATION_ID,
-    COMMCARE_LOCATION_IDS,
-    COMMCARE_PRIMARY_CASE_SHARING_ID,
     COMMCARE_PROJECT,
     PROFILE_SLUG,
     CustomDataFieldsProfile,
     CustomDataFieldsDefinition,
     is_system_key,
 )
-
-LOCATION_KEYS = {COMMCARE_LOCATION_ID, COMMCARE_LOCATION_IDS, COMMCARE_PRIMARY_CASE_SHARING_ID}
 
 
 class UserDataError(Exception):
@@ -67,36 +60,16 @@ class UserData:
 
     @property
     def _provided_by_system(self):
-        provided_data = {
+        return {
             **(self.profile.fields if self.profile else {}),
             PROFILE_SLUG: self.profile_id or '',
             COMMCARE_PROJECT: self.domain,
         }
 
-        def _add_location_data():
-            if self._couch_user.get_location_id(self.domain):
-                provided_data[COMMCARE_LOCATION_ID] = self._couch_user.get_location_id(self.domain)
-                provided_data[COMMCARE_PRIMARY_CASE_SHARING_ID] = self._couch_user.get_location_id(self.domain)
-
-            if self._couch_user.get_location_ids(self.domain):
-                provided_data[COMMCARE_LOCATION_IDS] = user_location_data(
-                    self._couch_user.get_location_ids(self.domain))
-
-        # Some test don't have an actual user existed
-        # Web User don't store location fields in user data
-        if (self._couch_user or not settings.UNIT_TESTING) and self._couch_user.is_commcare_user():
-            _add_location_data()
-
-        return provided_data
-
-    @property
-    def _system_keys(self):
-        return set(self._provided_by_system.keys()) | LOCATION_KEYS
-
     def to_dict(self):
         return {
             **self._schema_defaults,
-            **{k: v for k, v in self._local_to_user.items() if k not in self._system_keys},
+            **{k: v for k, v in self._local_to_user.items() if k not in self._provided_by_system},
             **self._provided_by_system,
         }
 
@@ -189,7 +162,7 @@ class UserData:
         return self.to_dict().get(key, default)
 
     def __setitem__(self, key, value):
-        if key in self._system_keys:
+        if key in self._provided_by_system:
             if value == self._provided_by_system.get(key, object()):
                 return
             raise UserDataError(_("'{}' cannot be set directly").format(key))
@@ -209,17 +182,17 @@ class UserData:
             self.profile_id = profile_id
         for k, v in data.items():
             if k != PROFILE_SLUG:
-                if v or k not in self._system_keys:
+                if v or k not in self._provided_by_system:
                     self[k] = v
         return original != self.to_dict() or original_profile != self.profile_id
 
     def __delitem__(self, key):
-        if key in self._system_keys:
+        if key in self._provided_by_system:
             raise UserDataError(_("{} cannot be deleted").format(key))
         del self._local_to_user[key]
 
     def pop(self, key, default=...):
-        if key in self._system_keys:
+        if key in self._provided_by_system:
             raise UserDataError(_("{} cannot be deleted").format(key))
         try:
             ret = self._local_to_user[key]

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -6,7 +6,6 @@ from django.utils.translation import gettext as _
 from dimagi.utils.chunked import chunked
 
 from corehq.apps.custom_data_fields.models import (
-    COMMCARE_PROJECT,
     PROFILE_SLUG,
     CustomDataFieldsProfile,
     CustomDataFieldsDefinition,
@@ -63,7 +62,6 @@ class UserData:
         return {
             **(self.profile.fields if self.profile else {}),
             PROFILE_SLUG: self.profile_id or '',
-            COMMCARE_PROJECT: self.domain,
         }
 
     def to_dict(self):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
@@ -7,12 +7,6 @@ DUMMY_USERNAME = "mclovin"
 DUMMY_PASSWORD = "changeme"
 DUMMY_PROJECT = "domain"
 
-LOCATION_IDS_DATA_FIELDS = """
-                              <data key="commcare_location_id"/>
-                              <data key="commcare_location_ids"/>"""
-COMMCARE_PRIMARY_CASE_SHARING_ID = """
-                                      <data key="commcare_primary_case_sharing_id"/>"""
-
 
 def dummy_user_xml(user=None):
     username = user.username if user else DUMMY_USERNAME
@@ -30,8 +24,8 @@ def dummy_user_xml(user=None):
         <date>{}</date>
         <user_data>
             <data key="commcare_first_name"/>
-            <data key="commcare_last_name"/>{}
-            <data key="commcare_phone_number"/>{}
+            <data key="commcare_last_name"/>
+            <data key="commcare_phone_number"/>
             <data key="commcare_profile"/>
             <data key="commcare_project">{}</data>
             <data key="commcare_user_type">{}</data>
@@ -42,8 +36,6 @@ def dummy_user_xml(user=None):
         password,
         user_id,
         date_to_xml_string(date_joined),
-        LOCATION_IDS_DATA_FIELDS if user_type == 'web' else '',
-        COMMCARE_PRIMARY_CASE_SHARING_ID if user_type == 'web' else '',
         project,
         user_type,
     )

--- a/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
@@ -16,48 +16,33 @@ def dummy_user_xml(user=None):
     project = user.domain if user else DUMMY_PROJECT
     user_type = 'web' if isinstance(user, OTARestoreWebUser) else 'commcare'
 
-    return """
+    return f"""
     <Registration xmlns="http://openrosa.org/user/registration">
-        <username>{}</username>
-        <password>{}</password>
-        <uuid>{}</uuid>
-        <date>{}</date>
+        <username>{username}</username>
+        <password>{password}</password>
+        <uuid>{user_id}</uuid>
+        <date>{date_to_xml_string(date_joined)}</date>
         <user_data>
             <data key="commcare_first_name"/>
             <data key="commcare_last_name"/>
             <data key="commcare_phone_number"/>
             <data key="commcare_profile"/>
-            <data key="commcare_project">{}</data>
-            <data key="commcare_user_type">{}</data>
+            <data key="commcare_project">{project}</data>
+            <data key="commcare_user_type">{user_type}</data>
             <data key="something">arbitrary</data>
         </user_data>
-    </Registration>""".format(
-        username,
-        password,
-        user_id,
-        date_to_xml_string(date_joined),
-        project,
-        user_type,
-    )
-
-
-DUMMY_RESTORE_XML_TEMPLATE = ("""
-<OpenRosaResponse xmlns="http://openrosa.org/http/response"%(items_xml)s>
-    <message nature="ota_restore_success">%(message)s</message>
-    <Sync xmlns="http://commcarehq.org/sync">
-        <restore_id>%(restore_id)s</restore_id>
-    </Sync>
-    %(user_xml)s
-    %(case_xml)s
-</OpenRosaResponse>
-""")
+    </Registration>"""
 
 
 def dummy_restore_xml(restore_id, case_xml="", items=None, user=None):
-    return DUMMY_RESTORE_XML_TEMPLATE % {
-        "restore_id": restore_id,
-        "items_xml": '' if items is None else (' items="%s"' % items),
-        "user_xml": dummy_user_xml(user),
-        "case_xml": case_xml,
-        "message": "Successfully restored account mclovin!"
-    }
+    items_xml = '' if items is None else f' items="{items}"'
+    return f"""
+    <OpenRosaResponse xmlns="http://openrosa.org/http/response"{items_xml}>
+        <message nature="ota_restore_success">Successfully restored account mclovin!</message>
+        <Sync xmlns="http://commcarehq.org/sync">
+            <restore_id>{restore_id}</restore_id>
+        </Sync>
+        {dummy_user_xml(user)}
+        {case_xml}
+    </OpenRosaResponse>
+    """

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_restore_user.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_restore_user.py
@@ -30,6 +30,8 @@ def test_get_commtrack_location_id():
     (WebUser(), 'web'),
     (CommCareUser(domain=DOMAIN), 'commcare'),
 ])
+@patch('corehq.apps.users.models._AuthorizableMixin.get_domain_membership',
+       Mock(return_value=DomainMembership(domain=DOMAIN)))
 @use("db")
 def test_user_types(user, expected_type):
     with patch_user_data_db_layer():


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
https://dimagi.atlassian.net/browse/USH-4428
This is an alternative approach to https://github.com/dimagi/commcare-hq/pull/35292 I move location data out of user data entirely, injecting it at the last minute.  We already did this for web users as of https://github.com/dimagi/commcare-hq/pull/34401, but there, the fields were _always_ present, whereas for mobile workers, they're only present if not null.  This commit brings web users in line with the behavior for mobile workers, for better parity

-----

Custom user data is an unschema'd key/value mapping where projects can throw whatever information they want to associate with their users.  This is made available in the restore file so it can be referenced in apps.  At some point in Dimagi's history, we wanted to make the user's assigned location also available for reference in the restore file.  This should have been implemented by adding it (along with other system fields) to the session data at the last minute.  Instead, we wrote handlers for setting, unsetting, and appending the user's locations, and made those mutate the user_data whenever the main location fields were modified, duplicating the information there.

This was tedious to deal with, but it also had the consequence of making these fields available anywhere user data is available, unless someone specifically exempted them.  User data is referenced in a number of places:

* `get_user_session_data` - this is pulled into the registration element in the restore.  That's the main reason we have this data - so it can be referenced in commcare apps.  Other system fields are pulled in here as well - first and last name, phone number, and user_type.
* Edit user UI - "system" fields are hidden
* User import/export - "system" fields are hidden
* API - this gets a pretty raw view of the user doc, including all user data, though system fields don't really belong here, since they are all more readily available in other parts of the doc.  If I weren't concerned about changing user-facing behavior, I'd remove these location fields entirely.  We had a bug report somewhat recently from someone trying to set user locations by modifying these fields in the API, but that's not at all how these work.
* UCR - these fields are likewise available for reference in UCRs, though they are better referenced directly from the top level, and doing so will let location filters work properly, and allow these reports to be made available to location-restricted users.
* `_get_user_case_fields` - this makes data available on the usercase.  If it wouldn't break existing apps, here I'd drop `commcare_primary_case_sharing_id` and make the other two in-line with the other system fields being added just below there (make the fields always present, even when null, and drop the `commcare_` prefix)

Making changes to user-facing behavior in any of these places has the potential to disrupt existing workflows.  In this PR I've gone the route of decoupling and localizing the implementations, since there is no real conceptual linkage between them, besides an accident of history.  My hope is that we stop perpetuating the problem (that changing one changes all of them), and make it easier to correct specific implementations as they go through future changes.  For example, maybe the next version of the API drops them entirely, or we audit usercase usage before GA and decide to bring the fields in line with the other system fields.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
