### PR TITLE
Reduce tag variance for odata_feed.test_v3 metric

### DIFF
--- a/corehq/apps/api/odata/utils.py
+++ b/corehq/apps/api/odata/utils.py
@@ -56,7 +56,6 @@ def _get_odata_fields_from_columns(export_config, special_types, table_id):
 
 def record_feed_access_in_datadog(request, config_id, duration, response):
     config = ExportInstance.get(config_id)
-    username = request.couch_user.username
     json_response = json.loads(response.content.decode('utf-8'))
     rows = json_response['value']
     row_count = len(rows)
@@ -69,9 +68,7 @@ def record_feed_access_in_datadog(request, config_id, duration, response):
         bucket_tag='duration_bucket', buckets=(1, 5, 20, 60, 120, 300, 600), bucket_unit='s',
         tags={
             'domain': request.domain,
-            'feed_id': config_id,
             'feed_type': config.type,
-            'username': username,
             'row_count': bucket_value(row_count, [100, 1000, 10000, 1000000]),
             'column_count': bucket_value(column_count, [10, 50, 100, 500, 1000]),
             'size': bucket_value(len(response.content) / (1024 ** 2), [1, 10, 100, 1000])  # in MB

--- a/corehq/apps/api/odata/utils.py
+++ b/corehq/apps/api/odata/utils.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 from corehq.apps.export.models import ExportInstance
 from corehq.util.metrics import metrics_histogram
+from corehq.util.metrics.utils import bucket_value
 
 FieldMetadata = namedtuple('FieldMetadata', ['name', 'odata_type'])
 
@@ -71,9 +72,9 @@ def record_feed_access_in_datadog(request, config_id, duration, response):
             'feed_id': config_id,
             'feed_type': config.type,
             'username': username,
-            'row_count': row_count,
-            'column_count': column_count,
-            'size': len(response.content)
+            'row_count': bucket_value(row_count, [100, 1000, 10000, 1000000]),
+            'column_count': bucket_value(column_count, [10, 50, 100, 500, 1000]),
+            'size': bucket_value(len(response.content) / (1024 ** 2), [1, 10, 100, 1000])  # in MB
         }
     )
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This metric accounts for a lot of our custom metric usage in datadog. To reduce the number of custom metrics, I've removed some uniquely identifying tags (like config id and username), and created buckets for tag values that have high variance, like row count, column count, and size.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This only impacts metrics.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
