### PR TITLE
Migration to remove location info in SQLUserData.data

### DIFF
--- a/corehq/apps/users/management/commands/rm_location_from_user_data.py
+++ b/corehq/apps/users/management/commands/rm_location_from_user_data.py
@@ -1,0 +1,33 @@
+# One-off migration, Nov 2024
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from corehq.apps.domain_migration_flags.api import once_off_migration
+from corehq.apps.users.user_data import SQLUserData
+
+from corehq.util.log import with_progress_bar
+
+
+class Command(BaseCommand):
+    help = "Remove now-stale location info from SQLUserData.data field"
+
+    def handle(self, *args, **options):
+        do_migration()
+
+
+@once_off_migration("rm_location_from_user_data")
+def do_migration():
+    rows_need_migration = SQLUserData.objects.filter(Q(data__has_key='commcare_location_id'))
+
+    for user_data in with_progress_bar(rows_need_migration):
+        data = user_data.data
+        keys_to_remove = ['commcare_location_id', 'commcare_location_ids', 'commcare_primary_case_sharing_id']
+
+        modified = False
+        for key in keys_to_remove:
+            if key in data:
+                del data[key]
+                modified = True
+
+        if modified:
+            user_data.save()

--- a/corehq/apps/users/migrations/0073_rm_location_from_user_data.py
+++ b/corehq/apps/users/migrations/0073_rm_location_from_user_data.py
@@ -1,0 +1,20 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def remove_location_from_user_data(apps, schema_editor):
+    call_command('rm_location_from_user_data')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0072_remove_invitation_supply_point'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_location_from_user_data, migrations.RunPython.noop),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -1260,6 +1260,7 @@ users
  0070_alter_invitation_tableau_role
  0071_rm_user_data
  0072_remove_invitation_supply_point
+ 0073_rm_location_from_user_data
 util
  0001_initial
  0002_complaintbouncemeta_permanentbouncemeta_transientbounceemail


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15717

Here is where we stopped writing and reading location info from `SQLUserData.data`: https://github.com/dimagi/commcare-hq/pull/34852

This PR is just a follow up to that PR, because now the location info (`commcare_location_id`, `commcare_location_ids`, `commcare_primary_case_sharing_id`) in `SQLUserData.data` is stale and not used.

This is a rework on https://github.com/dimagi/commcare-hq/pull/34899, because I got suggestions that I should write the migration in a management command, and make it resumable to pick up.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
We used to store location info in two places: on CouchUser model and in SQLUserData. In previous PR, we have stopped writing location info to and reading location info from SQLUserData. This PR is just a follow up step to clean up some data we no longer needed.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations
revert this PR won't do anything, because it is a once-off migration

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
