### PR TITLE
Remove Refresh Request Alert For Case Management Page

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -548,7 +548,7 @@ hqDefine("geospatial/js/case_grouping_map",[
                 initMap();
                 $("#clusterStats").koApplyBindings(clusterStatsInstance);
                 mapModel.mapInstance.on('load', () => {
-                    polygonFilterInstance = new models.PolygonFilter(mapModel, true, false);
+                    polygonFilterInstance = new models.PolygonFilter(mapModel, true, false, true);
                     polygonFilterInstance.loadPolygons(initialPageData.get('saved_polygons'));
                     $("#polygon-filters").koApplyBindings(polygonFilterInstance);
                 });

--- a/corehq/apps/geospatial/static/geospatial/js/case_management.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_management.js
@@ -260,7 +260,7 @@ hqDefine("geospatial/js/case_management", [
     function initPolygonFilters() {
         // Assumes `map` var is initialized
         const $mapControlDiv = $("#polygon-filters");
-        polygonFilterModel = new models.PolygonFilter(mapModel, false, true);
+        polygonFilterModel = new models.PolygonFilter(mapModel, false, true, false);
         polygonFilterModel.loadPolygons(initialPageData.get('saved_polygons'));
         if ($mapControlDiv.length) {
             ko.cleanNode($mapControlDiv[0]);

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -809,7 +809,7 @@ hqDefine('geospatial/js/models', [
                         );
                         // redraw using mapControlsModelInstance
                         self.selectedSavedPolygonId(ret.id);
-                        self.shouldRefreshPage(self.requiresPageRefresh());
+                        self.shouldRefreshPage(true);
                     },
                     error: function (response) {
                         const responseText = response.responseText;

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -548,7 +548,7 @@ hqDefine('geospatial/js/models', [
         };
     };
 
-    var PolygonFilter = function (mapObj, shouldUpdateQueryParam, shouldSelectAfterFilter) {
+    var PolygonFilter = function (mapObj, shouldUpdateQueryParam, shouldSelectAfterFilter, requiresPageRefresh) {
         var self = this;
 
         self.mapObj = mapObj;
@@ -565,6 +565,7 @@ hqDefine('geospatial/js/models', [
 
         self.polygons = {};
         self.shouldRefreshPage = ko.observable(false);
+        self.requiresPageRefresh = ko.observable(requiresPageRefresh);  // If true then actions such as adding or moving a polygon requires a page refresh
         self.hasUrlError = ko.observable(false);
 
         self.savedPolygons = ko.observableArray([]);
@@ -600,7 +601,7 @@ hqDefine('geospatial/js/models', [
             } else {
                 success = utils.clearQueryParam(FEATURE_QUERY_PARAM);
             }
-            self.shouldRefreshPage(success);
+            self.shouldRefreshPage(success && self.requiresPageRefresh());
             self.hasUrlError(!success);
         }
 
@@ -618,7 +619,7 @@ hqDefine('geospatial/js/models', [
             } else {
                 success = utils.clearQueryParam(SELECTED_FEATURE_ID_QUERY_PARAM);
             }
-            self.shouldRefreshPage(success);
+            self.shouldRefreshPage(success && self.requiresPageRefresh());
             self.hasUrlError(!success);
         }
 
@@ -808,7 +809,7 @@ hqDefine('geospatial/js/models', [
                         );
                         // redraw using mapControlsModelInstance
                         self.selectedSavedPolygonId(ret.id);
-                        self.shouldRefreshPage(true);
+                        self.shouldRefreshPage(self.requiresPageRefresh());
                     },
                     error: function (response) {
                         const responseText = response.responseText;


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The following alert is currently being shown on both the Case Management and Case Grouping pages when any polygon filtering changes are made (e.g. new polygon added to map):
![Screenshot from 2024-10-30 11-10-58](https://github.com/user-attachments/assets/61caf6fa-580e-4b2d-bffe-a8d84b606a0c)

This alert has now been removed from the Case Management page, and so should now only appear for the Case Grouping page.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-3996).

The refresh request alert has been removed from the Case Management page since it is not needed there. Specifically, the alert is required on the Case Grouping page since cases are filtered on the back-end using the polygons specified by the user, hence requiring a page refresh. The same is not true for the Case Management page, and so the alert can safely be removed from this page.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`GEOSPATIAL`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

Very small UI change. Additionally, it has been tested locally to ensure that the alert is still correctly showing for the Case Grouping page.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
