### PR TITLE
Adds India to the Analytics Environment

### DIFF
--- a/corehq/apps/analytics/templates/analytics/initial/global.html
+++ b/corehq/apps/analytics/templates/analytics/initial/global.html
@@ -1,5 +1,5 @@
 {% load hq_shared_tags %}
-{% if is_saas_environment or ANALYTICS_CONFIG.DEBUG %}
+{% if IS_ANALYTICS_ENVIRONMENT or ANALYTICS_CONFIG.DEBUG%}
   {% initial_analytics_data 'global.isEnabled' True %}
 {% else %}
   {% initial_analytics_data 'global.isEnabled' False %}

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -573,6 +573,7 @@ class TestViewGeneric(ViewsBase):
         'login_template', 'enterprise_mode', 'mobile_ux_cookie_name', 'commcare_hq_names', 'langs',
         'title_context_block', 'timezone', 'helpers', 'has_mobile_workers', 'multimedia_state',
         'bulk_app_translation_upload', 'show_training_modules', 'forloop', 'secure_cookies',
+        'IS_ANALYTICS_ENVIRONMENT',
     }
 
     expected_keys_module = {
@@ -599,7 +600,7 @@ class TestViewGeneric(ViewsBase):
         'custom_assertions', 'analytics', 'form_endpoint_options', 'title_context_block', 'secure_cookies',
         'langs', 'details', 'None', 'CUSTOM_LOGO_URL', 'hq', 'selected_form', 'slug', 'env', 'False', 'id',
         'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'EULA_COMPLIANCE', 'sentry',
-        'case_list_form_not_allowed_reasons', 'child_module_enabled', 'block',
+        'case_list_form_not_allowed_reasons', 'child_module_enabled', 'block', 'IS_ANALYTICS_ENVIRONMENT',
     }
 
     expected_keys_form = {
@@ -628,7 +629,7 @@ class TestViewGeneric(ViewsBase):
         'secure_cookies', 'langs', 'None', 'CUSTOM_LOGO_URL', 'hq', 'allow_form_copy', 'selected_form', 'slug',
         'env', 'False', 'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'is_usercase_in_use',
         'module_loads_registry_case', 'EULA_COMPLIANCE', 'sentry', 'show_shadow_modules', 'show_custom_ref',
-        'block',
+        'block', 'IS_ANALYTICS_ENVIRONMENT',
     }
 
 

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -105,6 +105,7 @@ def js_api_keys(request):
         'ANALYTICS_IDS': settings.ANALYTICS_IDS.copy(),
         'ANALYTICS_CONFIG': settings.ANALYTICS_CONFIG.copy(),
         'MAPBOX_ACCESS_TOKEN': settings.MAPBOX_ACCESS_TOKEN,
+        'IS_ANALYTICS_ENVIRONMENT': settings.SERVER_ENVIRONMENT in ('production', 'staging', 'india'),
     }
     if (
         getattr(request, 'project', None)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This PR makes changes to enable google tag manager for the India environment to use Google Analytics (GTD). (No user facing changes).
There was an [existing PR](https://github.com/dimagi/commcare-hq/pull/35238) for this however it has been aborted in favour of this approach.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Ticket](https://dimagi.atlassian.net/browse/SC-3867?focusedCommentId=352517)
We did not just update the `is_saas_environment` variable because it is used at a lot of other places. 

The change in this PR enables analytics globally on the India environment.  As a result, any tools that have their API ID set will be enabled as well. After discussion with SAAS, we do NOT want to enable any other tools for user interactions except Kissmetrics and Hubspot because we use them today to send information through background tasks. 

Notes:
>  Hence before deployong this PR, the API ID on India environment for AppCues, Google Analytics-Marketing should be removed first. No changes expected as a result of this. 

>  After the merge, we can expect Kissmetrics in addition to Tag Manager to send data for the configured user interactions. A quick search revealed there aren't any events sent to Hubspot so we do not expect any change here.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing done. Sanity testing to be done on staging before merge.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
