### PR TITLE
Mobile UCR Version Migration Link

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -243,6 +243,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         self.buildState = ko.observable('');
         self.buildErrorCode = ko.observable('');
         self.errorMessage = ko.observable(self.genericErrorMessage);
+        self.releaseErrorMessage = ko.observable();
         self.onlyShowReleased = ko.observable(false);
         self.fetchState = ko.observable('');
         self.fetchLimit = ko.observable();
@@ -387,6 +388,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         };
 
         self.toggleRelease = function (savedApp, event) {
+            self.releaseErrorMessage(null);
             $(event.currentTarget).parent().prev('.js-release-waiting').removeClass('hide');
             var isReleased = savedApp.is_released();
             var savedAppId = savedApp.id();
@@ -404,7 +406,7 @@ hqDefine('app_manager/js/releases/releases', function () {
                     },
                     success: function (data) {
                         if (data.error) {
-                            alert(data.error);
+                            self.releaseErrorMessage(data.error);
                             $(event.currentTarget).parent().prev('.js-release-waiting').addClass('hide');
                             savedApp.is_released(isReleased);
                         } else {
@@ -492,6 +494,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         self.actuallyMakeBuild = function () {
             self.buildState('pending');
             self.errorMessage(self.genericErrorMessage);
+            self.releaseErrorMessage(null);
             $.post({
                 url: self.reverse('save_copy'),
                 success: function (data) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -97,6 +97,8 @@
     <span data-bind="visible: buildErrorCode() !== 403, text: errorMessage">
     </span>
   </div>
+  <div class="alert alert-danger" data-bind="html: releaseErrorMessage, visible: releaseErrorMessage">
+  </div>
 
   <h4 id="loading" class="hide"
       data-bind="visible: showLoadingSpinner(), css: {hide: false}">

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -405,14 +405,24 @@ def _track_build_for_app_preview(domain, couch_user, app_id, message):
 def _check_app_for_mobile_ucr_v1_refs(domain, app):
     if not toggles.MOBILE_UCR.enabled(domain):
         return
+
+    mobile_ucr_doc_url = 'https://commcare-hq.readthedocs.io/ucr/mobile_ucr_v2_migration_guide.html'
     if app.mobile_ucr_restore_version != '2.0':
-        return _("The mobile UCR restore version for v%(app_version)s needs to be updated to V2.0") % {
-            'app_version': app.version,
-        }
+        return mark_safe(_(
+            "The mobile UCR restore version for v%(app_version)s needs to be updated to V2.0. "
+            "Please refer to the <a href='%(url)s'>migration documentation</a> for more details."
+        ) % {
+            "app_version": app.version,
+            "url": mobile_ucr_doc_url,
+        })
     if does_app_have_mobile_ucr_v1_refs(app):
-        return _("One or more forms for v%(app_version)s contain V1 Mobile UCR references.") % {
-            'app_version': app.version,
-        }
+        return mark_safe(_(
+            "One or more forms for v%(app_version)s contain V1 Mobile UCR references."
+            "Please refer to the <a href='%(url)s'>migration documentation</a> for more details."
+        ) % {
+            "app_version": app.version,
+            "url": mobile_ucr_doc_url,
+        })
 
 
 @no_conflict_require_POST


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The alert that gets shown when there is an error releasing an app version has been changed to use an alert banner instead of an alert popup.
**Old:**
![Screenshot from 2024-10-31 16-32-31](https://github.com/user-attachments/assets/6fe63cde-304b-444d-ac73-b2dd454d4a83)

**New:**
![Screenshot from 2024-10-31 16-31-53](https://github.com/user-attachments/assets/97114683-3e7b-4217-a019-dbfc82cbf133)

Additionally, the alerts shown when trying to make a new version, revert to a previous version, or release a version of an app have been updated to include a link to the Mobile UCR migration documentation which can be found on CommCare HQ's ReadTheDocs. This documentation can be found [here](https://commcare-hq.readthedocs.io/ucr/mobile_ucr_v2_migration_guide.html).

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-4003).

This is a small PR which makes a simple text update, as well as changes the format in which app release error alerts are presented to the user. Initially, I attempted to keep with the same formatting, however it proved to be challenging when trying to present a URL within an anchor tag to the user. Using a simple JS `alert()` does not allow for HTML formatting, and so I converted this to a banner alert instead so that the anchor tag can be properly rendered in the UI.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`MOBILE_UCR`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Small UI change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
