### PR TITLE
Self-signup for paid software plans

### DIFF
--- a/corehq/apps/hqwebapp/static/registration/less/registration-main.less
+++ b/corehq/apps/hqwebapp/static/registration/less/registration-main.less
@@ -258,7 +258,7 @@ p.sso-message-block {
 .plan-container {
   background-color: @well-bg;
   border-radius: 5px;
-  padding-bottom: 35px;
+  padding-bottom: 7px;
 
   p {
     margin: 10px 15px 0;

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -73,6 +73,7 @@ class RegisterWebUserForm(forms.Form):
             """)))
     atypical_user = forms.BooleanField(required=False, widget=forms.HiddenInput())
     is_mobile = forms.BooleanField(required=False, widget=forms.HiddenInput())
+    is_self_signup = forms.BooleanField(required=False, widget=forms.HiddenInput())
 
     def __init__(self, *args, **kwargs):
         self.is_sso = kwargs.pop('is_sso', False)
@@ -215,6 +216,7 @@ class RegisterWebUserForm(forms.Form):
                                   "disable: disableNextStepTwo"
                     )
                 ),
+                hqcrispy.InlineField('is_self_signup'),
                 css_class="form-bubble form-step step-2",
                 style="display: none;"
             ),

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -225,6 +225,9 @@ hqDefine('registration/js/new_user.ko', [
                    && (!self.isPersonaChoiceOther() || self.isPersonaChoiceOtherPresent());
         });
 
+        // Self-signup for paid software plan
+        self.isSelfSignup = ko.observable(false);
+
         // ---------------------------------------------------------------------
         // Form Functionality
         // ---------------------------------------------------------------------
@@ -247,6 +250,7 @@ hqDefine('registration/js/new_user.ko', [
                 eula_confirmed: self.eulaConfirmed(),
                 phone_number: module.getPhoneNumberFn() || self.phoneNumber(),
                 atypical_user: defaults.atypical_user,
+                is_self_signup: self.isSelfSignup(),
             };
             if (self.hasPersonaFields) {
                 _.extend(data, {

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -26,11 +26,11 @@ hqDefine('registration/js/new_user.ko', [
     module.csrf = null;
     module.showPasswordFeedback = false;
     module.rmi = function () {
-        throw "Please call initRMI first.";
+        throw new Error("Please call initRMI first.");
     };
     module.resetEmailFeedback = function (isValidating) {
-        throw "please call setResetEmailFeedbackFn. " +
-              "Expects boolean isValidating. " + isValidating;
+        throw new Error("please call setResetEmailFeedbackFn. " +
+            "Expects boolean isValidating. " + isValidating);
     };
     module.submitAttemptAnalytics = function (data) {  // eslint-disable-line no-unused-vars
         kissmetrics.track.event("Clicked Create Account");

--- a/corehq/apps/registration/static/registration/js/register_new_user.js
+++ b/corehq/apps/registration/static/registration/js/register_new_user.js
@@ -17,12 +17,21 @@ hqDefine('registration/js/register_new_user', [
     'use strict';
 
     $('#js-create-account').click(function (e) {
+        startCreateAccount(e);
+    });
+
+    $('#js-self-signup').click(function (e) {
+        regForm.isSelfSignup(true);
+        startCreateAccount(e);
+    });
+
+    var startCreateAccount = function (e) {
         e.preventDefault();
         $('#registration-choose-plan-container').hide();
         $('#registration-form-container').fadeIn();
 
         $('#back-to-start-btn').removeClass('hide');
-    });
+    };
 
     $('#back-to-start-btn').click(function () {
         $('#registration-form-container').hide();

--- a/corehq/apps/registration/templates/registration/partials/choose_your_plan.html
+++ b/corehq/apps/registration/templates/registration/partials/choose_your_plan.html
@@ -15,7 +15,7 @@
         </div>
         <p class="lead">
           {% blocktrans %}
-            For organizations exploring CommCare.
+            For organizations managing projects.
           {% endblocktrans %}
         </p>
         {% include 'registration/partials/feature_list.html' with features=professional_features %}
@@ -30,7 +30,7 @@
              data-toggle="modal"
              class="btn btn-primary">
             {% blocktrans %}
-              Request Custom Trial
+              Request a Trial
             {% endblocktrans %}
           </a>
           <script src="//fast.wistia.com/embed/medias/jzm3ggrinr.jsonp" async></script>
@@ -55,6 +55,14 @@
               {% endblocktrans %}
             </a>
           </span>
+          <p>
+            <small>
+              {% trans "Know what you need?" %}
+              <a href="#" id="js-self-signup">
+                {% trans "Get started here!" %}
+              </a>
+            </small>
+          </p>
         </div>
       </div>
     </div>

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -181,7 +181,7 @@ class ProcessRegistrationView(JSONResponseMixin, View):
                     self.request,
                     reg_form.cleaned_data['project_name'],
                     is_new_user=True,
-                    is_self_signup=False  # TODO: connect this to RegisterWebUserForm
+                    is_self_signup=reg_form.cleaned_data['is_self_signup']
                 )
             except NameUnavailableException:
                 # technically, the form should never reach this as names are

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -300,7 +300,7 @@ class UserRegistrationView(BasePageView):
                 _("Custom mobile app builder"),
                 _("Powerful case management"),
                 _("Field staff reports"),
-                _("Unlimited mobile users"),
+                _("125+ mobile users"),
                 _("Full suite of data tools"),
                 _("3rd party integrations"),
                 _("2-way SMS workflows"),


### PR DESCRIPTION
## Product Description
Adds text and a link at the bottom of SaaS-environment signup page "Know what you need? Get started here!"
Updates a couple pieces of text on signup page as described in spec. 
Old:
![Screenshot 2024-10-31 at 2 15 03 PM](https://github.com/user-attachments/assets/9e3e29f5-94ac-4c0c-89d6-0244e9c10000)

New:
![image](https://github.com/user-attachments/assets/a46e8721-4ee1-440f-98da-12b152106723)

## Technical Summary
[SAAS-16033](https://dimagi.atlassian.net/browse/SAAS-16033)
Adds an `is_self_signup` hidden input to the `RegisterWebUserForm` to initiate a self-signup workflow when the user clicks the particular "Get started here!" link to start the account creation process.

This is final core component of the "self-signup for paid software plans" workflow and the one that will make it usable, following #35177, #35246, and #35281


## Safety Assurance

### Safety story
This change in and of itself is pretty small. Tested the entire workflow locally and on staging (and ensuring that the non "self-signup" account creation still works). Will get QA for the feature before release.

### Automated test coverage
None on this change.

### QA Plan
[SAAS-16034](https://dimagi.atlassian.net/browse/SAAS-16034)
QA holistically for the self-signup for paid software plans workflow including the 3 related PRs mentioned above.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16033]: https://dimagi.atlassian.net/browse/SAAS-16033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-16034]: https://dimagi.atlassian.net/browse/SAAS-16034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ