### PR TITLE
Handle resource url according to new standard

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1396,7 +1396,6 @@ class CommCareAnalyticsUserResource(CouchResourceMixin, HqBaseResource, DomainSp
 
     class Meta(CustomResourceMeta):
         resource_name = 'analytics-roles'
-        list_allowed_methods = []
         detail_allowed_methods = ['get']
 
     def dehydrate(self, bundle):

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -33,7 +33,7 @@ from tastypie import fields, http
 from tastypie.authorization import ReadOnlyAuthorization
 from tastypie.bundle import Bundle
 from tastypie.exceptions import BadRequest, ImmediateHttpResponse, NotFound
-from tastypie.http import HttpForbidden, HttpUnauthorized, HttpNotFound
+from tastypie.http import HttpForbidden, HttpUnauthorized
 from tastypie.resources import ModelResource, Resource
 
 
@@ -131,7 +131,6 @@ from corehq.const import USER_CHANGE_VIA_API
 from corehq.util import get_document_or_404
 from corehq.util.couch import DocumentNotFound
 from corehq.util.timer import TimingContext
-from corehq.apps.users.role_utils import get_commcare_analytics_access_for_user_domain
 
 from ..exceptions import UpdateUserException
 from ..user_updates import update
@@ -1387,41 +1386,3 @@ def get_datasource_data(request, config_id, domain):
     query = cursor_based_query_for_datasource(request_params, datasource_adapter)
     data = response_for_cursor_based_pagination(request, query, request_params, datasource_adapter)
     return JsonResponse(data)
-
-
-class CommCareAnalyticsUserResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMixin):
-
-    roles = fields.ListField()
-    permissions = fields.DictField()
-
-    class Meta(CustomResourceMeta):
-        resource_name = 'analytics-roles'
-        detail_allowed_methods = ['get']
-
-    def dehydrate(self, bundle):
-        cca_access = get_commcare_analytics_access_for_user_domain(bundle.obj, bundle.request.domain)
-
-        bundle.data['roles'] = cca_access['roles']
-        bundle.data['permissions'] = cca_access['permissions']
-
-        return bundle
-
-    def obj_get(self, bundle, **kwargs):
-        domain = kwargs['domain']
-        if not toggles.SUPERSET_ANALYTICS.enabled(domain):
-            raise ImmediateHttpResponse(
-                HttpNotFound()
-            )
-
-        user = CouchUser.get_by_username(bundle.request.user.username)
-
-        if not (user and user.is_member_of(domain) and user.is_active):
-            return None
-        return user
-
-    def prepend_urls(self):
-        # We're overriding the default "list" view to redirect to "detail" view since
-        # we already know the user through OAuth.
-        return [
-            url(r"^$", self.wrap_view('dispatch_detail'), name='api_dispatch_detail'),
-        ]

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1424,5 +1424,5 @@ class CommCareAnalyticsUserResource(CouchResourceMixin, HqBaseResource, DomainSp
         # We're overriding the default "list" view to redirect to "detail" view since
         # we already know the user through OAuth.
         return [
-            url(r"^(?P<resource_name>%s)/$" % self._meta.resource_name, self.wrap_view('dispatch_detail')),
+            url(r"^$", self.wrap_view('dispatch_detail'), name='api_dispatch_detail'),
         ]

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1423,5 +1423,5 @@ class CommCareAnalyticsUserResource(CouchResourceMixin, HqBaseResource, DomainSp
         # We're overriding the default "list" view to redirect to "detail" view since
         # we already know the user through OAuth.
         return [
-            url(r"^(?P<resource_name>%s)/$" % self._meta.resource_name, self.wrap_view('dispatch_detail')),
+            url(r"^$", self.wrap_view('dispatch_detail'), name='api_dispatch_detail'),
         ]

--- a/corehq/apps/api/resources/v1_0.py
+++ b/corehq/apps/api/resources/v1_0.py
@@ -1,0 +1,51 @@
+from django.urls import re_path as url
+from tastypie import fields
+from tastypie.exceptions import ImmediateHttpResponse
+from tastypie.http import HttpNotFound
+from . import (
+    CouchResourceMixin,
+    DomainSpecificResourceMixin,
+    HqBaseResource,
+)
+from corehq.apps.api.resources.meta import CustomResourceMeta
+from corehq.apps.users.role_utils import get_commcare_analytics_access_for_user_domain
+from corehq import toggles
+from corehq.apps.users.models import CouchUser
+
+
+class CommCareAnalyticsUserResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMixin):
+
+    roles = fields.ListField()
+    permissions = fields.DictField()
+
+    class Meta(CustomResourceMeta):
+        resource_name = 'analytics-roles'
+        detail_allowed_methods = ['get']
+
+    def dehydrate(self, bundle):
+        cca_access = get_commcare_analytics_access_for_user_domain(bundle.obj, bundle.request.domain)
+
+        bundle.data['roles'] = cca_access['roles']
+        bundle.data['permissions'] = cca_access['permissions']
+
+        return bundle
+
+    def obj_get(self, bundle, **kwargs):
+        domain = kwargs['domain']
+        if not toggles.SUPERSET_ANALYTICS.enabled(domain):
+            raise ImmediateHttpResponse(
+                HttpNotFound()
+            )
+
+        user = CouchUser.get_by_username(bundle.request.user.username)
+
+        if not (user and user.is_member_of(domain) and user.is_active):
+            return None
+        return user
+
+    def prepend_urls(self):
+        # We're overriding the default "list" view to redirect to "detail" view since
+        # we already know the user through OAuth.
+        return [
+            url(r"^$", self.wrap_view('dispatch_detail'), name='api_dispatch_detail'),
+        ]

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -730,7 +730,7 @@ class TestUserDomainsResource(TestCase):
 
 class TestCommCareAnalyticsUserResource(APIResourceTest):
     resource = v0_5.CommCareAnalyticsUserResource
-    api_name = 'v0.5'
+    api_name = 'v1'
 
     def test_flag_not_enabled(self):
         response = self._assert_auth_get_resource(self.list_endpoint)

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -8,7 +8,7 @@ from django.utils.http import urlencode
 from flaky import flaky
 from tastypie.bundle import Bundle
 
-from corehq.apps.api.resources import v0_5
+from corehq.apps.api.resources import v0_5, v1_0
 from corehq.apps.custom_data_fields.models import (
     PROFILE_SLUG,
     CustomDataFieldsDefinition,
@@ -729,7 +729,7 @@ class TestUserDomainsResource(TestCase):
 
 
 class TestCommCareAnalyticsUserResource(APIResourceTest):
-    resource = v0_5.CommCareAnalyticsUserResource
+    resource = v1_0.CommCareAnalyticsUserResource
     api_name = 'v1'
 
     def test_flag_not_enabled(self):

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -733,14 +733,12 @@ class TestCommCareAnalyticsUserResource(APIResourceTest):
     api_name = 'v0.5'
 
     def test_flag_not_enabled(self):
-        endpoint = self.single_endpoint(self.username)
-        response = self._assert_auth_get_resource(endpoint)
+        response = self._assert_auth_get_resource(self.list_endpoint)
         self.assertEqual(response.status_code, 404)
 
     @flag_enabled('SUPERSET_ANALYTICS')
     def test_user_roles_returned(self):
-        endpoint = self.single_endpoint(self.username)
-        response = self._assert_auth_get_resource(endpoint)
+        response = self._assert_auth_get_resource(self.list_endpoint)
         expected_response_obj = {
             'permissions': {'can_edit': True, 'can_view': True},
             'resource_uri': '',

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -182,6 +182,7 @@ urlpatterns = [
     fixtures.v0_1.LookupTableItemResource.get_urlpattern('v1'),
     fixtures.v0_6.LookupTableItemResource.get_urlpattern('v2'),
     v0_5.NavigationEventAuditResource.get_urlpattern('v1'),
+    v0_5.CommCareAnalyticsUserResource.get_urlpattern('v1'),
 ]
 
 

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -43,7 +43,7 @@ from corehq.apps.api.odata.urls import (
     odata_case_urlpatterns,
     odata_form_urlpatterns,
 )
-from corehq.apps.api.resources import v0_1, v0_3, v0_4, v0_5
+from corehq.apps.api.resources import v0_1, v0_3, v0_4, v0_5, v1_0
 from corehq.apps.api.resources.messaging_event.view import messaging_events
 from corehq.apps.api.resources.v0_5 import (
     DomainCases,
@@ -101,7 +101,6 @@ _OLD_API_LIST = (
         fixtures.v0_1.LookupTableResource,
         fixtures.v0_1.LookupTableItemResource,
         v0_5.NavigationEventAuditResource,
-        v0_5.CommCareAnalyticsUserResource,
     )),
     ((0, 6), (
         locations.v0_6.LocationResource,
@@ -182,7 +181,7 @@ urlpatterns = [
     fixtures.v0_1.LookupTableItemResource.get_urlpattern('v1'),
     fixtures.v0_6.LookupTableItemResource.get_urlpattern('v2'),
     v0_5.NavigationEventAuditResource.get_urlpattern('v1'),
-    v0_5.CommCareAnalyticsUserResource.get_urlpattern('v1'),
+    v1_0.CommCareAnalyticsUserResource.get_urlpattern('v1'),
 ]
 
 


### PR DESCRIPTION
## Technical Summary
With the merge of [this PR](https://github.com/dimagi/commcare-hq/pull/35048) it's necessary to update the resource URL to remove the resource name as it's not necessary to specify the resource name manually anymore (@esoergel can expound in more detail if necessary)

## Feature flag
Although this change is technically global, only users with the SUPERSET_ANALYTICS feature flag will be directly impacted **after** [this PR](https://github.com/dimagi/commcare-analytics/pull/59) has been deployed. 

## Safety Assurance
Tested locally 

### Automated test coverage
No QA. Local testing if fine

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
