### PR TITLE
Management command to convert UCR references

### DIFF
--- a/corehq/apps/app_manager/management/commands/convert_mobile_ucr_refs.py
+++ b/corehq/apps/app_manager/management/commands/convert_mobile_ucr_refs.py
@@ -1,0 +1,78 @@
+import json
+import re
+import uuid
+from copy import deepcopy
+
+from django.core.management.base import BaseCommand
+
+from corehq.apps.app_manager.dbaccessors import get_app
+from corehq.apps.app_manager.exceptions import AppValidationError
+from corehq.apps.app_manager.tasks import prune_auto_generated_builds
+
+# Mobile UCR report references:
+# V1: `instance('reports')/reports/report[@id='xxxxxxx']`
+# V2: `instance('commcare-reports:xxxxxxx')`
+V1_REPORT_REFS = r"instance\('reports'\)/reports/report\[@id='([^']+)'\]"
+V2_REPORT_REFS = r"instance\('commcare-reports:\1'\)"
+
+# Mobile UCR column references:
+# V1: `column[@id = 'column_id']`
+# V2: `column_id`
+V1_COLUMN_REFS = r"column\[@id.?=.?'([^']+)'\]"
+V2_COLUMN_REFS = r'\1'
+
+
+class Command(BaseCommand):
+    help = 'Convert Mobile UCR references from V1 to V2'
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('app_id')
+
+    def handle(self, domain, app_id, **options):
+        # Based on ApplicationBase.make_build()
+        v1_app = get_app(domain, app_id)
+        assert v1_app.copy_of is None
+
+        app_dict = _copy_app_dict(v1_app.to_json())
+        app_dict = _replace_v1_refs(app_dict)
+        v2_app = v1_app.__class__.wrap(app_dict)
+        v2_app.convert_app_to_build(
+            v1_app._id,
+            user_id=None,
+            comment=self.help,
+        )
+        v2_app.copy_attachments(v1_app)
+        assert not v2_app._id  # _copy_app_dict() dropped _id
+        v2_app._id = uuid.uuid4().hex
+        errors = v2_app.validate_app()
+        if errors:
+            raise AppValidationError(errors)
+        if v2_app.create_build_files_on_build:
+            v2_app.create_build_files()
+        prune_auto_generated_builds.delay(v1_app.domain, v1_app._id)
+        v2_app.save(increment_version=False)
+
+        self.stdout.write(self.style.SUCCESS(
+            'Successfully converted app "%s"' % v1_app.name
+        ))
+
+
+def _copy_app_dict(app_dict):
+    bad_keys = (
+        '_id',
+        '_rev',
+        '_attachments',
+        'external_blobs',
+        'short_odk_url',
+        'short_odk_media_url',
+        'recipients'
+    )
+    return {k: deepcopy(v) for k, v in app_dict.items() if k not in bad_keys}
+
+
+def _replace_v1_refs(app_dict):
+    app_str = json.dumps(app_dict)
+    app_str = re.sub(V1_REPORT_REFS, V2_REPORT_REFS, app_str)
+    app_str = re.sub(V1_COLUMN_REFS, V2_COLUMN_REFS, app_str)
+    return json.loads(app_str)


### PR DESCRIPTION
## Technical Summary

Context: [SC-4004](https://dimagi.atlassian.net/browse/SC-4004)

A self-hosting partner has an app with about 2000 Mobile UCR references that need to be converted from V1 to V2. This management command is intended to help them to do that.

## Safety Assurance

### Safety story

* Tested locally.
* Only applicable to one self-hosting partner.
* If the command fails, the new app will not be saved.

### Automated test coverage

Not covered by tests

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-4004]: https://dimagi.atlassian.net/browse/SC-4004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ