### PR TITLE
CommCareAnalyticsUserResource doesn't support list

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1396,6 +1396,7 @@ class CommCareAnalyticsUserResource(CouchResourceMixin, HqBaseResource, DomainSp
 
     class Meta(CustomResourceMeta):
         resource_name = 'analytics-roles'
+        list_allowed_methods = []
         detail_allowed_methods = ['get']
 
     def dehydrate(self, bundle):

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -733,12 +733,14 @@ class TestCommCareAnalyticsUserResource(APIResourceTest):
     api_name = 'v0.5'
 
     def test_flag_not_enabled(self):
-        response = self._assert_auth_get_resource(self.list_endpoint)
+        endpoint = self.single_endpoint(self.username)
+        response = self._assert_auth_get_resource(endpoint)
         self.assertEqual(response.status_code, 404)
 
     @flag_enabled('SUPERSET_ANALYTICS')
     def test_user_roles_returned(self):
-        response = self._assert_auth_get_resource(self.list_endpoint)
+        endpoint = self.single_endpoint(self.username)
+        response = self._assert_auth_get_resource(endpoint)
         expected_response_obj = {
             'permissions': {'can_edit': True, 'can_view': True},
             'resource_uri': '',


### PR DESCRIPTION
## Technical Summary

Fixes failing test.

I'm guessing this test wasn't being run in PR https://github.com/dimagi/commcare-hq/pull/34987

## Feature Flag

`SUPERSET_ANALYTICS`

## Safety Assurance

### Safety story

Fixes a failing test

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
