### PR TITLE
Filename Broadcast in Repeat Group Bug

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -4,6 +4,7 @@ hqDefine("cloudcare/js/form_entry/const", [], function () {
         GROUP_TYPE: 'sub-group',
         QUESTION_TYPE: 'question',
         GROUPED_ELEMENT_TILE_ROW_TYPE: 'grouped-element-tile-row',
+        BROADCAST_FIELD_FILENAME: 'filename',
 
         // Entry types
         STRING: 'str',

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -198,8 +198,7 @@ hqDefine("cloudcare/js/form_entry/entries", [
                 var receiveTopic = match[1];
                 var receiveTopicField = match[2];
                 if (receiveTopicField === constants.RECEIVER_FIELD_INDEXED) {
-                    var ixMatch = question.ix().match(/_(\d+)/g);
-                    receiveTopicField = ixMatch ? ixMatch.pop().replace('_', '') : '0';
+                    receiveTopicField = constants.BROADCAST_FIELD_FILENAME;
                 }
                 question.broadcastPubSub.subscribe(function (message) {
                     if (message === constants.NO_ANSWER) {
@@ -993,8 +992,8 @@ hqDefine("cloudcare/js/form_entry/entries", [
             self.question.onchange();
 
             if (self.broadcastTopics.length) {
-                // allow support for broadcasting multiple filenames
-                var broadcastObj = Object.fromEntries([self.file()].map((file, i) => [i, file.name]));
+                var broadcastObj = {};
+                broadcastObj[constants.BROADCAST_FIELD_FILENAME] = self.file().name;
                 self.question.formplayerMediaRequest.then(function () {
                     self.broadcastMessages(self.question, broadcastObj);
                 });


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
There was a bug where the filename broadcast did not work for repeat groups unless they were the first group.

Demo of the fix with this PR:

https://github.com/user-attachments/assets/fc17f687-1f42-45ac-93df-9c41da257d46



## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-5064](https://dimagi.atlassian.net/browse/USH-5064)
[Related Appearance Attribute](https://dimagi.atlassian.net/wiki/spaces/USH/pages/2234548257/Filename+Broadcast+from+Multimedia+Questions)

During the [initial implementation](https://github.com/dimagi/commcare-hq/pull/34137) of filename broadcasting, the code was designed with future support for multiple file uploads in mind. However, this functionality was never completed, and the related [ticket](https://dimagi.atlassian.net/browse/USH-4399) remains in the backlog. As a result, multiple file uploads are currently unsupported.

The unused code intended for multiple file uploads was causing a bug, so I chose to remove it given that the feature isn’t yet in use.

Summary of issue:

For the first item of the repeat group:

The message published is `{"0": "filename.png"}`. The receiveTopicField (resulting from `ixMatch` is 0 since question.ix is 1_0,1). So `message[field]` [here](https://github.com/dimagi/commcare-hq/blob/1ebd4c38879c1291581681f647d283724ef6c5d3/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js#L217-L220) accesses the correct key and string.

For the second item of the repeat group:

The message published is the same `{"0": "filename.png"}` The receiveTopicField (resulting from `ixMatch` is 1 since question.ix is 1_1,1). So `message[field]` [here](https://github.com/dimagi/commcare-hq/blob/1ebd4c38879c1291581681f647d283724ef6c5d3/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js#L217-L220) is undefined, resulting it setting the receiver to an empty string

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No feature flag

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and blast radius is limited to filename broadcasting.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no existing test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-5064]: https://dimagi.atlassian.net/browse/USH-5064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ