### PR TITLE
Include deleted repeaters in SQL dump to satisfy foreign key constraints

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -196,7 +196,8 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('case_importer.CaseUploadFileMeta', SimpleFilter('caseuploadrecord__domain')),
     FilteredModelIteratorBuilder('case_importer.CaseUploadFormRecord', SimpleFilter('case_upload_record__domain')),
     FilteredModelIteratorBuilder('case_importer.CaseUploadRecord', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('repeaters.Repeater', SimpleFilter('domain')),
+    # Repeat Records might foreign key to deleted repeaters, override default manager to include deleted repeaters
+    FilteredModelIteratorBuilder('repeaters.Repeater', SimpleFilter('domain'), use_all_objects=True),
     FilteredModelIteratorBuilder('motech.ConnectionSettings', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('motech.RequestLog', SimpleFilter('domain')),
     # NH (2021-01-08): Including RepeatRecord because we dump (Couch)

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -144,9 +144,10 @@ class MultimediaBlobMetaFilter(IDFilter):
 
 
 class UnfilteredModelIteratorBuilder(object):
-    def __init__(self, model_label):
+    def __init__(self, model_label, use_all_objects=False):
         self.model_label = model_label
         self.domain = self.model_class = self.db_alias = None
+        self.use_all_objects = use_all_objects
 
     def prepare(self, domain, model_class, db_alias):
         self.domain = domain
@@ -156,7 +157,9 @@ class UnfilteredModelIteratorBuilder(object):
 
     def _base_queryset(self):
         assert self.domain and self.model_class and self.db_alias, "Unprepared IteratorBuilder"
-        objects = self.model_class._default_manager
+        objects = (
+            self.model_class.all_objects if self.use_all_objects else self.model_class._default_manager
+        )
         return objects.using(self.db_alias)
 
     def querysets(self):
@@ -170,16 +173,18 @@ class UnfilteredModelIteratorBuilder(object):
             yield queryset_to_iterator(queryset, self.model_class, ignore_ordering=True)
 
     def build(self, domain, model_class, db_alias):
-        return self.__class__(self.model_label).prepare(domain, model_class, db_alias)
+        return self.__class__(self.model_label, self.use_all_objects).prepare(domain, model_class, db_alias)
 
 
 class FilteredModelIteratorBuilder(UnfilteredModelIteratorBuilder):
-    def __init__(self, model_label, filter):
-        super(FilteredModelIteratorBuilder, self).__init__(model_label)
+    def __init__(self, model_label, filter, use_all_objects=False):
+        super(FilteredModelIteratorBuilder, self).__init__(model_label, use_all_objects)
         self.filter = filter
 
     def build(self, domain, model_class, db_alias):
-        return self.__class__(self.model_label, self.filter).prepare(domain, model_class, db_alias)
+        return self.__class__(self.model_label, self.filter, self.use_all_objects).prepare(
+            domain, model_class, db_alias
+        )
 
     def count(self):
         count = self.filter.count(self.domain)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15774

When repeaters were migrated to SQL, foreign key relationships then existed between repeat records and repeaters. It isn't hard to get into a state where repeat records foreign key to a deleted repeater. In the case of dump and restore, we currently dump repeat records and repeaters, but only repeaters that are not deleted. This means that when attempting to load a migration file that has repeat records that foreign key to a deleted repeater, it fails.

One possible solution is to remove repeat records from the dump/restore entirely, but given that things like RequestLogs are also dumped, I felt that that decision was outside of the scope of this. So instead, I added support in the FilterBuilderThing to reference the `all_objects` object manager if specified. This is a bit hacky, but I couldn't figure out to do this in a more generic way (referencing the default `models.Manager()` manager).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
In addition to automated test coverage, I am going to do a manual test for this entire process in the near future, which is part of the motivation for this change.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests in test_sql_filters.py for this behavior.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
