### PR TITLE
Hide 0-quantity features from software plan details

### DIFF
--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -26,7 +26,7 @@
     <div class="plan-included well well-sm">
       <dl class="dl-horizontal">
         {% for rate in plan.rates %}
-          {% if rate.included > 0 %}
+          {% if rate.included != 0 %}
             <dt>{{ rate.name }}</dt>
             <dd>{{ rate.included }}</dd>
           {% endif %}

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -26,8 +26,10 @@
     <div class="plan-included well well-sm">
       <dl class="dl-horizontal">
         {% for rate in plan.rates %}
-          <dt>{{ rate.name }}</dt>
-          <dd>{{ rate.included }}</dd>
+          {% if rate.included > 0 %}
+            <dt>{{ rate.name }}</dt>
+            <dd>{{ rate.included }}</dd>
+          {% endif %}
         {% endfor %}
       </dl>
     </div>

--- a/corehq/apps/accounting/templates/accounting/partials/renew_plan_selection.html
+++ b/corehq/apps/accounting/templates/accounting/partials/renew_plan_selection.html
@@ -32,7 +32,7 @@
       </h4>
       <div class="plan-included well well-sm">
         <dl class="dl-horizontal" data-bind="foreach: {data: selectedPlan().rates, as: 'rate'}">
-          <!-- ko if: rate.included > 0 -->
+          <!-- ko if: rate.included !== 0 -->
             <dt data-bind="text: rate.name"></dt>
             <dd data-bind="text: rate.included"></dd>
           <!-- /ko -->

--- a/corehq/apps/accounting/templates/accounting/partials/renew_plan_selection.html
+++ b/corehq/apps/accounting/templates/accounting/partials/renew_plan_selection.html
@@ -31,9 +31,11 @@
         {% trans 'Included each month' %}
       </h4>
       <div class="plan-included well well-sm">
-        <dl class="dl-horizontal" data-bind="foreach: selectedPlan().rates">
-          <dt data-bind="text: name"></dt>
-          <dd data-bind="text: included"></dd>
+        <dl class="dl-horizontal" data-bind="foreach: {data: selectedPlan().rates, as: 'rate'}">
+          <!-- ko if: rate.included > 0 -->
+            <dt data-bind="text: rate.name"></dt>
+            <dd data-bind="text: rate.included"></dd>
+          <!-- /ko -->
         </dl>
       </div>
 


### PR DESCRIPTION
## Product Description
Hides software plan features from the plan details card if 0 quantity is included.
Before:
![image](https://github.com/user-attachments/assets/19b033c5-bcf7-405d-a2c4-dd6a8b2d438a)
After:
![image](https://github.com/user-attachments/assets/bc1f30c5-ec76-4f83-8ed4-225a912a1491)

## Technical Summary
[SAAS-16141](https://dimagi.atlassian.net/browse/SAAS-16141)
It's a convenience that this display loops through all feature rates that a plan has set. These are _major_ features of which we only have 4 right now: Mobile Worker, Web User, Form-submitting Mobile Worker, and SMS.

However:
1. there is a requirement that every software plan has an "SMS" feature rate included
2. every public software plan currently includes 0 SMS messages

So to hide the "SMS: 0" I've opted for a simple conditional to suppress features with '0' values from the display.

## Safety Assurance

### Safety story
This is a really minor change to UI only, limited to a couple of pages. Tested locally with various software plan configs on renewal and confirm plan pages.

### Automated test coverage
We don't usually test HTML templates.

### QA Plan
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16141]: https://dimagi.atlassian.net/browse/SAAS-16141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ