### PR TITLE
Pass "required_for" property when creating Field for linked domains

### DIFF
--- a/corehq/apps/linked_domain/tests/test_update_custom_data_fields.py
+++ b/corehq/apps/linked_domain/tests/test_update_custom_data_fields.py
@@ -103,14 +103,17 @@ class TestUpdateCustomDataFields(BaseLinkedDomainTest):
 
 class TestUpdateFields(TestCase):
     def test_can_update_user_fields(self):
-        self._set_fields([Field(slug='a', label='label1', upstream_id='1')], UserFieldsView.field_type)
+        self._set_fields([
+            Field(slug='a', label='label1', upstream_id='1', is_required=True, required_for=['mobile_user'])
+        ], UserFieldsView.field_type)
 
-        updated_field = Field(id='1', slug='a', label='label2')
+        updated_field = Field(id='1', slug='a', label='label2', is_required=False, required_for=['web_user'])
         update_definition = self._generate_update_definition_for_fields([updated_field], UserFieldsView.field_type)
         update_custom_data_models_impl(update_definition, self.domain)
 
         fields = self._get_fields(UserFieldsView.field_type)
-        expected_field = Field(slug='a', label='label2', upstream_id='1')
+        expected_field = Field(slug='a', label='label2', upstream_id='1',
+                               is_required=False, required_for=['web_user'])
         self.assertEqual(len(fields), 1)
         self.assertEqual(fields[0].to_dict(), expected_field.to_dict())
 
@@ -394,6 +397,7 @@ def field_to_json(field):
         'id': field.id,
         'slug': field.slug,
         'is_required': field.is_required,
+        'required_for': field.required_for,
         'label': field.label,
         'choices': field.choices,
         'regex': field.regex,

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -311,6 +311,7 @@ def create_local_field(upstream_field_definition):
     return Field(
         slug=upstream_field_definition['slug'],
         is_required=upstream_field_definition['is_required'],
+        required_for=upstream_field_definition['required_for'],
         label=upstream_field_definition['label'],
         choices=upstream_field_definition['choices'],
         regex=upstream_field_definition['regex'],


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This transfers the "required_for" Field data when creating a linked app. This is related to https://github.com/dimagi/commcare-hq/pull/35218.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests exist that user data is initialized and updated correctly for linked apps. I added a test that checks for `is_required` and `required_for`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
