### PR TITLE
[B5] Updated styling for invalid select2

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
@@ -102,17 +102,33 @@
   }
 }
 
+.select2-container--default .select2-selection--single.select2-selection--clearable {
+
+  .select2-selection__clear {
+    font-size: 1.5em;
+  }
+}
+
 .select2-container--default.is-invalid,
 .select2-container--default.is-valid {
 
   .select2-selection__rendered {
     padding-right: 66px !important;
   }
-  .select2-selection--single .select2-selection__arrow {
+  .select2-selection--single::before {
+    content: ' ';
     background-repeat: no-repeat;
-    background-size: 32%;
+    background-size: 100%;
     background-position: 0 7px;
-    width: 50px !important;
+    width: 16px;
+    position: absolute;
+    display: block;
+    top: 1px;
+    right: 35px;
+    height: 30px;
+  }
+  .select2-selection--single.select2-selection--clearable::before {
+    right: 49px;
   }
 
   &.select2-container--focus {
@@ -128,11 +144,8 @@
   .select2-selection--multiple {
     border-color: $form-feedback-icon-invalid-color !important;
   }
-  .select2-selection--single .select2-selection__arrow {
+  .select2-selection--single::before {
     background-image: escape-svg($form-feedback-icon-invalid);
-  }
-  .select2-selection--single .select2-selection__clear {
-    margin-right: 55px !important;
   }
 }
 
@@ -141,7 +154,7 @@
   .select2-selection--multiple {
     border-color: $form-feedback-icon-valid-color !important;
   }
-  .select2-selection--single .select2-selection__arrow {
+  .select2-selection--single::before {
     background-image: escape-svg($form-feedback-icon-valid);
   }
 }

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
@@ -110,9 +110,9 @@
   }
   .select2-selection--single .select2-selection__arrow {
     background-repeat: no-repeat;
-    background-size: 24%;
-    background-position: 15px 7px;
-    width: 66px !important;
+    background-size: 32%;
+    background-position: 0 7px;
+    width: 50px !important;
   }
 
   &.select2-container--focus {
@@ -130,6 +130,9 @@
   }
   .select2-selection--single .select2-selection__arrow {
     background-image: escape-svg($form-feedback-icon-invalid);
+  }
+  .select2-selection--single .select2-selection__clear {
+    margin-right: 55px !important;
   }
 }
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
@@ -67,7 +67,7 @@
      .select2-search-field {
          width: 100% !important;
      }
-@@ -72,16 +64,114 @@
+@@ -72,16 +64,127 @@
      .select2-input {
          width: 100% !important;
      }
@@ -115,17 +115,33 @@
 +  }
 +}
 +
++.select2-container--default .select2-selection--single.select2-selection--clearable {
++
++  .select2-selection__clear {
++    font-size: 1.5em;
++  }
++}
++
 +.select2-container--default.is-invalid,
 +.select2-container--default.is-valid {
 +
 +  .select2-selection__rendered {
 +    padding-right: 66px !important;
 +  }
-+  .select2-selection--single .select2-selection__arrow {
++  .select2-selection--single::before {
++    content: ' ';
 +    background-repeat: no-repeat;
-+    background-size: 32%;
++    background-size: 100%;
 +    background-position: 0 7px;
-+    width: 50px !important;
++    width: 16px;
++    position: absolute;
++    display: block;
++    top: 1px;
++    right: 35px;
++    height: 30px;
++  }
++  .select2-selection--single.select2-selection--clearable::before {
++    right: 49px;
 +  }
 +
 +  &.select2-container--focus {
@@ -141,11 +157,8 @@
 +  .select2-selection--multiple {
 +    border-color: $form-feedback-icon-invalid-color !important;
 +  }
-+  .select2-selection--single .select2-selection__arrow {
++  .select2-selection--single::before {
 +    background-image: escape-svg($form-feedback-icon-invalid);
-+  }
-+  .select2-selection--single .select2-selection__clear {
-+    margin-right: 55px !important;
 +  }
 +}
 +
@@ -154,7 +167,7 @@
 +  .select2-selection--multiple {
 +    border-color: $form-feedback-icon-valid-color !important;
 +  }
-+  .select2-selection--single .select2-selection__arrow {
++  .select2-selection--single::before {
 +    background-image: escape-svg($form-feedback-icon-valid);
 +  }
 +}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
@@ -67,7 +67,7 @@
      .select2-search-field {
          width: 100% !important;
      }
-@@ -72,16 +64,111 @@
+@@ -72,16 +64,114 @@
      .select2-input {
          width: 100% !important;
      }
@@ -123,9 +123,9 @@
 +  }
 +  .select2-selection--single .select2-selection__arrow {
 +    background-repeat: no-repeat;
-+    background-size: 24%;
-+    background-position: 15px 7px;
-+    width: 66px !important;
++    background-size: 32%;
++    background-position: 0 7px;
++    width: 50px !important;
 +  }
 +
 +  &.select2-container--focus {
@@ -143,6 +143,9 @@
 +  }
 +  .select2-selection--single .select2-selection__arrow {
 +    background-image: escape-svg($form-feedback-icon-invalid);
++  }
++  .select2-selection--single .select2-selection__clear {
++    margin-right: 55px !important;
 +  }
 +}
 +

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/select2_manual_allow_clear.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/select2_manual_allow_clear.html
@@ -1,0 +1,14 @@
+<select id="manual-select2-clear" class="form-select basic">
+  <option value="1">one</option>
+  <option value="2">two</option>
+  <option value="3">three</option>
+</select>
+
+<script>
+  $(function () {
+    $("#manual-select2-clear").select2({
+        allowClear: true,
+        placeholder: "Select an option...",
+    });
+  });
+</script>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/selections.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/selections.html
@@ -150,6 +150,10 @@
     This is the most straightforward way of initializing a <code>select2</code> element.
   </p>
   {% include 'styleguide/bootstrap5/code_example.html' with content=examples.select2_manual %}
+  <p>
+    A clearable version of that <code>select2</code> element:
+  </p>
+  {% include 'styleguide/bootstrap5/code_example.html' with content=examples.select2_manual_allow_clear %}
 
   <h4 id="select2-manual-crispy" class="pt-2">
     Manual Setup with Crispy Forms

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -167,6 +167,9 @@ def styleguide_molecules_selections(request):
                 SelectToggleDemoForm(), get_python_example_context('select_toggle_form.py'),
             ),
             'select2_manual': get_example_context('styleguide/bootstrap5/examples/select2_manual.html'),
+            'select2_manual_allow_clear': get_example_context(
+                'styleguide/bootstrap5/examples/select2_manual_allow_clear.html'
+            ),
             'select2_manual_crispy': CrispyFormsWithJsDemo(
                 form=Select2ManualDemoForm(),
                 code_python=get_python_example_context('select2_manual_form.py'),


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/QA-7209

This came up during QA for locations B5, but I didn't realize until after merging [that PR](https://github.com/dimagi/commcare-hq/pull/35286).

For invalid select2s, the new B5 icon overlaps with the X to clear the selection, which also makes that X not clickable.
![Screenshot 2024-11-05 at 9 01 29 AM](https://github.com/user-attachments/assets/eb696c71-7858-4917-9b64-f900aacd22ef)

After this PR, here are the states of this widget:
### Valid, no selection
<img width="279" alt="Screenshot 2024-11-05 at 4 26 56 PM" src="https://github.com/user-attachments/assets/a33d3a68-6338-4027-b529-5a1106b703f5">


### Valid, option selected
<img width="287" alt="Screenshot 2024-11-05 at 4 26 50 PM" src="https://github.com/user-attachments/assets/9563ed6d-c609-433e-8e3f-f93f293f97a8">


### Invalid, no selection
![Screenshot 2024-11-05 at 8 54 55 AM](https://github.com/user-attachments/assets/a66695fb-9427-47e9-b4cc-5814e6cf8583)

### Invalid, option selected
![Screenshot 2024-11-05 at 8 55 05 AM](https://github.com/user-attachments/assets/355b7420-6e48-4f2f-a054-f99b71ef0fef)

I debated a little what order to put the X and icon, and decided to put the icon in the middle because it separates the two clickable things (X and arrow) more definitively. It's also a simpler approach, since the icon and arrow are already in the same element.

## Safety Assurance

### Safety story
Styling change to some very specific rules. No effect beyond this widget.

### Automated test coverage

no

### QA Plan

QA will verify the fix, although I'm not blocking merge on the verification.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
