### PR TITLE
Remove redundant metrics for restores

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -809,10 +809,6 @@ class RestoreConfig(object):
                     bucket_tag='duration', buckets=timer_buckets, bucket_unit='s',
                     tags={**tags, **extra_tags}
                 )
-                metrics_counter(
-                    'commcare.restores.{}'.format(segment),
-                    tags={**tags, **extra_tags},
-                )
 
         tags['type'] = 'sync' if self.params.sync_log_id else 'restore'
 
@@ -823,7 +819,6 @@ class RestoreConfig(object):
             else:
                 tags['app'] = ''
 
-        metrics_counter('commcare.restores.count', tags=tags)
         metrics_histogram(
             'commcare.restores.duration.seconds', timing.duration,
             bucket_tag='duration', buckets=timer_buckets, bucket_unit='s',


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This [graph](https://app.datadoghq.com/dashboard/u6g-tuv-sau?fromUser=false&fullscreen_end_ts=1730825956587&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1730811556587&fullscreen_widget=308592527&refresh_mode=sliding&from_ts=1730811185422&to_ts=1730825585422&live=true) shows the restore fixtures metrics side by side. The [datadog implementation](https://github.com/dimagi/commcare-hq/blob/1a68b3093415f8123f8fe1894d972776dd6dba80/corehq/util/metrics/datadog.py#L64-L91) of histogram is effectively a counter, so we really don't need to also collect metrics twice. It is the same metric, just the duration has an additional duration metric.
N/A
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Only impacts metric reporting. [See comment below] This could impact self hosters using prometheus if reliant on the count metric, since it does appear that the [prometheus implementation](https://github.com/dimagi/commcare-hq/blob/1a68b3093415f8123f8fe1894d972776dd6dba80/corehq/util/metrics/prometheus.py#L73-L102) actually uses their histogram feature. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
