### PR TITLE
Clear cache for toggle states

### DIFF
--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -469,6 +469,12 @@ class TestViews(ViewsBase):
         copied_app = other_domain.full_applications()[0]
         self.assertEqual(copied_app.name, 'Copy App')
         self.assertEqual(copied_app.doc_type, 'Application')
+
+        copied_module = copied_app.modules[0]
+        copied_form = list(copied_module.get_forms())[0]
+        self.assertEqual(copied_module.name['en'], "Module0")
+        self.assertEqual(copied_form.name['en'], "Form0")
+
         copied_app.delete()
 
     def test_copy_linked_app_to_different_domain(self, _):
@@ -496,6 +502,12 @@ class TestViews(ViewsBase):
         linked_app = other_domain.full_applications()[0]
         self.assertEqual(linked_app.name, 'Linked App')
         self.assertEqual(linked_app.doc_type, 'LinkedApplication')
+
+        linked_module = linked_app.modules[0]
+        linked_form = list(linked_module.get_forms())[0]
+        self.assertEqual(linked_module.name['en'], "Module0")
+        self.assertEqual(linked_form.name['en'], "Form0")
+
         linked_app.delete()
 
     def test_cannot_copy_linked_app_to_same_domain(self, _):

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -560,7 +560,7 @@ class TestViews(ViewsBase):
             'toggles': 'test_toggle',
         }
         with patch('corehq.toggles.all_toggles_by_name', return_value={'test_toggle': TEST_TOGGLE}), \
-             mock.patch('corehq.apps.toggle_ui.views.clear_cache_for_toggle') as mock_clear_cache:
+             mock.patch('corehq.apps.toggle_ui.views.clear_toggle_cache_by_namespace') as mock_clear_cache:
             self.client.post(reverse('copy_app', args=[self.domain]), copy_data)
             mock_clear_cache.assert_called_once_with(NAMESPACE_DOMAIN, other_domain.name)
         self.assertTrue(TEST_TOGGLE.enabled(other_domain.name))

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -545,7 +545,8 @@ class TestViews(ViewsBase):
             'toggles': 'test_toggle',
         }
         with patch('corehq.toggles.all_toggles_by_name', return_value={'test_toggle': TEST_TOGGLE}), \
-             mock.patch('corehq.apps.app_manager.views.apps.clear_cache_for_toggle') as mock_clear_cache:
+             patch('corehq.toggles.shortcuts.set_toggle', return_value=True), \
+             mock.patch('corehq.apps.toggle_ui.views.clear_cache_for_toggle') as mock_clear_cache:
             self.client.post(reverse('copy_app', args=[self.domain]), copy_data)
             mock_clear_cache.assert_called_once_with(NAMESPACE_DOMAIN, other_domain.name)
 

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -98,6 +98,7 @@ from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.linked_domain.applications import create_linked_app
 from corehq.apps.linked_domain.exceptions import RemoteRequestError
+from corehq.apps.toggle_ui.views import clear_cache_for_toggle
 from corehq.apps.translations.models import Translation
 from corehq.apps.users.dbaccessors import (
     get_practice_mode_mobile_workers,
@@ -454,6 +455,7 @@ def copy_app(request, domain):
         if data['toggles']:
             for slug in data['toggles'].split(","):
                 set_toggle(slug, to_domain, True, namespace=toggles.NAMESPACE_DOMAIN)
+            clear_cache_for_toggle(toggles.NAMESPACE_DOMAIN, to_domain)
 
         linked = data.get('linked')
         if linked:

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -98,14 +98,13 @@ from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.linked_domain.applications import create_linked_app
 from corehq.apps.linked_domain.exceptions import RemoteRequestError
-from corehq.apps.toggle_ui.views import clear_cache_for_toggle
 from corehq.apps.translations.models import Translation
 from corehq.apps.users.dbaccessors import (
     get_practice_mode_mobile_workers,
 )
 from corehq.elastic import ESError
 from corehq.tabs.tabclasses import ApplicationsTab
-from corehq.toggles.shortcuts import set_toggle
+from corehq.toggles.shortcuts import set_toggles
 from corehq.util.dates import iso_string_to_datetime
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import reverse as reverse_util
@@ -453,9 +452,8 @@ def copy_app(request, domain):
         clear_app_cache(request, to_domain)
 
         if data['toggles']:
-            for slug in data['toggles'].split(","):
-                set_toggle(slug, to_domain, True, namespace=toggles.NAMESPACE_DOMAIN)
-            clear_cache_for_toggle(toggles.NAMESPACE_DOMAIN, to_domain)
+            toggle_slugs = data['toggles'].split(",")
+            set_toggles(toggle_slugs, to_domain, True, namespace=toggles.NAMESPACE_DOMAIN)
 
         linked = data.get('linked')
         if linked:

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -88,7 +88,7 @@ class TestDomainGlobalSettingsForm(TestCase):
         self.assertTrue('confirmation_link_expiry' not in form.fields)
 
     def test_confirmation_link_expiry_default_present_when_flag_set(self):
-        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain_obj, True, namespace=NAMESPACE_DOMAIN)
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain, True, namespace=NAMESPACE_DOMAIN)
         form = self.create_form(
             confirmation_link_expiry=self.account_confirmation_settings.confirmation_link_expiry_time,
             confirmation_sms_project_name=self.account_confirmation_settings.project_name)
@@ -98,7 +98,7 @@ class TestDomainGlobalSettingsForm(TestCase):
         self.assertEqual(14, self.account_confirmation_settings.confirmation_link_expiry_time)
 
     def test_confirmation_link_expiry_custom_present_when_flag_set(self):
-        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain_obj, True, namespace=NAMESPACE_DOMAIN)
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain, True, namespace=NAMESPACE_DOMAIN)
         form = self.create_form(
             confirmation_link_expiry=25,
             confirmation_sms_project_name=self.account_confirmation_settings.project_name)
@@ -110,7 +110,7 @@ class TestDomainGlobalSettingsForm(TestCase):
 
     def test_confirmation_link_expiry_error_when_invalid_value(self):
         OperatorCallLimitSettings.objects.all().delete()
-        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain_obj, True, namespace=NAMESPACE_DOMAIN)
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain, True, namespace=NAMESPACE_DOMAIN)
         form = self.create_form(
             confirmation_link_expiry='abc',
             confirmation_sms_project_name=self.account_confirmation_settings.project_name)
@@ -120,7 +120,7 @@ class TestDomainGlobalSettingsForm(TestCase):
 
     def test_confirmation_link_expiry_error_when_value_less_than_lower_limit(self):
         OperatorCallLimitSettings.objects.all().delete()
-        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain_obj, True, namespace=NAMESPACE_DOMAIN)
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain, True, namespace=NAMESPACE_DOMAIN)
         form = self.create_form(
             confirmation_link_expiry='-1',
             confirmation_sms_project_name=self.account_confirmation_settings.project_name)
@@ -131,7 +131,7 @@ class TestDomainGlobalSettingsForm(TestCase):
 
     def test_confirmation_link_expiry_error_when_value_more_than_upper_limit(self):
         OperatorCallLimitSettings.objects.all().delete()
-        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain_obj, True, namespace=NAMESPACE_DOMAIN)
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain, True, namespace=NAMESPACE_DOMAIN)
         form = self.create_form(
             confirmation_link_expiry='31',
             confirmation_sms_project_name=self.account_confirmation_settings.project_name)
@@ -203,7 +203,7 @@ class TestDomainGlobalSettingsForm(TestCase):
         return DomainGlobalSettingsForm(data, domain=domain)
 
     def tearDown(self):
-        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain_obj, False, namespace=NAMESPACE_DOMAIN)
+        set_toggle(TWO_STAGE_USER_PROVISIONING_BY_SMS.slug, self.domain, False, namespace=NAMESPACE_DOMAIN)
         self.domain_obj.delete()
         OperatorCallLimitSettings.objects.all().delete()
         SMSAccountConfirmationSettings.objects.all().delete()

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -112,7 +112,7 @@ from corehq.apps.users.models import UserRole, HqPermissions
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.toggles import NAMESPACE_DOMAIN, EMBEDDED_TABLEAU
 from corehq.apps.users.views.mobile.custom_data_fields import CUSTOM_USER_DATA_FIELD_TYPE
-from corehq.toggles.shortcuts import set_toggle
+from corehq.toggles.shortcuts import set_toggles
 
 from corehq.apps.users.role_utils import UserRolePresets
 
@@ -158,8 +158,7 @@ def update_toggles(domain_link, is_pull=False, overwrite=False):
     downstream_toggles = set(local_enabled_toggles(domain_link.linked_domain))
 
     def _set_toggles(collection, enabled):
-        for slug in collection:
-            set_toggle(slug, domain_link.linked_domain, enabled, NAMESPACE_DOMAIN)
+        set_toggles(collection, domain_link.linked_domain, enabled, NAMESPACE_DOMAIN)
 
     # enable downstream toggles that are enabled upstream
     _set_toggles(upstream_toggles - downstream_toggles, True)
@@ -175,8 +174,7 @@ def update_previews(domain_link, is_pull=False, overwrite=False):
     downstream_previews = set(local_enabled_previews(domain_link.linked_domain))
 
     def _set_toggles(collection, enabled):
-        for slug in collection:
-            set_toggle(slug, domain_link.linked_domain, enabled, NAMESPACE_DOMAIN)
+        set_toggles(collection, domain_link.linked_domain, enabled, NAMESPACE_DOMAIN)
 
     # enable downstream previews that are enabled upstream
     _set_toggles(upstream_previews - downstream_previews, True)

--- a/corehq/apps/toggle_ui/tests.py
+++ b/corehq/apps/toggle_ui/tests.py
@@ -7,7 +7,7 @@ from django.test import TestCase, SimpleTestCase
 from couchdbkit import ResourceNotFound
 
 from corehq.apps.toggle_ui.models import ToggleAudit
-from corehq.apps.toggle_ui.views import _clear_cache_for_toggle
+from corehq.apps.toggle_ui.views import clear_cache_for_toggle
 from corehq.toggles import NAMESPACE_USER, NAMESPACE_DOMAIN, NAMESPACE_OTHER, NAMESPACE_EMAIL_DOMAIN
 from corehq.toggles.models import Toggle
 
@@ -96,7 +96,7 @@ class TestClearCacheForToggle(SimpleTestCase):
         with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock,\
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
-            _clear_cache_for_toggle(NAMESPACE_DOMAIN, 'test-domain')
+            clear_cache_for_toggle(NAMESPACE_DOMAIN, 'test-domain')
             self.assertEqual(1, domain_mock.call_count)
             self.assertEqual(0, user_mock.call_count)
             self.assertEqual(0, email_domain_mock.call_count)
@@ -105,7 +105,7 @@ class TestClearCacheForToggle(SimpleTestCase):
         with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock,\
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
-            _clear_cache_for_toggle(NAMESPACE_USER, 'testuser')
+            clear_cache_for_toggle(NAMESPACE_USER, 'testuser')
             self.assertEqual(0, domain_mock.call_count)
             self.assertEqual(1, user_mock.call_count)
             self.assertEqual(0, email_domain_mock.call_count)
@@ -114,7 +114,7 @@ class TestClearCacheForToggle(SimpleTestCase):
         with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock,\
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
-            _clear_cache_for_toggle(NAMESPACE_OTHER, 'testother')
+            clear_cache_for_toggle(NAMESPACE_OTHER, 'testother')
             self.assertEqual(0, domain_mock.call_count)
             self.assertEqual(1, user_mock.call_count)
             self.assertEqual(0, email_domain_mock.call_count)
@@ -123,11 +123,11 @@ class TestClearCacheForToggle(SimpleTestCase):
         with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock,\
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
-            _clear_cache_for_toggle(NAMESPACE_EMAIL_DOMAIN, 'testemaildomain')
+            clear_cache_for_toggle(NAMESPACE_EMAIL_DOMAIN, 'testemaildomain')
             self.assertEqual(0, domain_mock.call_count)
             self.assertEqual(0, user_mock.call_count)
             self.assertEqual(1, email_domain_mock.call_count)
 
     def test_clear_cache_raises_exception_for_colon_in_non_domain_namespaces(self):
         with self.assertRaises(AssertionError):
-            _clear_cache_for_toggle(NAMESPACE_USER, 'testuser:test')
+            clear_cache_for_toggle(NAMESPACE_USER, 'testuser:test')

--- a/corehq/apps/toggle_ui/tests.py
+++ b/corehq/apps/toggle_ui/tests.py
@@ -7,7 +7,7 @@ from django.test import TestCase, SimpleTestCase
 from couchdbkit import ResourceNotFound
 
 from corehq.apps.toggle_ui.models import ToggleAudit
-from corehq.apps.toggle_ui.views import clear_cache_for_toggle
+from corehq.apps.toggle_ui.views import clear_toggle_cache_by_namespace
 from corehq.toggles import NAMESPACE_USER, NAMESPACE_DOMAIN, NAMESPACE_OTHER, NAMESPACE_EMAIL_DOMAIN
 from corehq.toggles.models import Toggle
 
@@ -96,7 +96,7 @@ class TestClearCacheForToggle(SimpleTestCase):
         with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
-            clear_cache_for_toggle(NAMESPACE_DOMAIN, 'test-domain')
+            clear_toggle_cache_by_namespace(NAMESPACE_DOMAIN, 'test-domain')
             self.assertEqual(1, domain_mock.call_count)
             self.assertEqual(0, user_mock.call_count)
             self.assertEqual(0, email_domain_mock.call_count)
@@ -105,7 +105,7 @@ class TestClearCacheForToggle(SimpleTestCase):
         with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
-            clear_cache_for_toggle(NAMESPACE_USER, 'testuser')
+            clear_toggle_cache_by_namespace(NAMESPACE_USER, 'testuser')
             self.assertEqual(0, domain_mock.call_count)
             self.assertEqual(1, user_mock.call_count)
             self.assertEqual(0, email_domain_mock.call_count)
@@ -114,7 +114,7 @@ class TestClearCacheForToggle(SimpleTestCase):
         with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
-            clear_cache_for_toggle(NAMESPACE_OTHER, 'testother')
+            clear_toggle_cache_by_namespace(NAMESPACE_OTHER, 'testother')
             self.assertEqual(0, domain_mock.call_count)
             self.assertEqual(1, user_mock.call_count)
             self.assertEqual(0, email_domain_mock.call_count)
@@ -123,11 +123,11 @@ class TestClearCacheForToggle(SimpleTestCase):
         with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
-            clear_cache_for_toggle(NAMESPACE_EMAIL_DOMAIN, 'testemaildomain')
+            clear_toggle_cache_by_namespace(NAMESPACE_EMAIL_DOMAIN, 'testemaildomain')
             self.assertEqual(0, domain_mock.call_count)
             self.assertEqual(0, user_mock.call_count)
             self.assertEqual(1, email_domain_mock.call_count)
 
     def test_clear_cache_raises_exception_for_colon_in_non_domain_namespaces(self):
         with self.assertRaises(AssertionError):
-            clear_cache_for_toggle(NAMESPACE_USER, 'testuser:test')
+            clear_toggle_cache_by_namespace(NAMESPACE_USER, 'testuser:test')

--- a/corehq/apps/toggle_ui/tests.py
+++ b/corehq/apps/toggle_ui/tests.py
@@ -93,8 +93,8 @@ class TestToggleAudit(TestCase):
 class TestClearCacheForToggle(SimpleTestCase):
 
     def test_clear_cache_for_domain_namespace(self):
-        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
-             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock,\
+        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock, \
+             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
             clear_cache_for_toggle(NAMESPACE_DOMAIN, 'test-domain')
             self.assertEqual(1, domain_mock.call_count)
@@ -102,8 +102,8 @@ class TestClearCacheForToggle(SimpleTestCase):
             self.assertEqual(0, email_domain_mock.call_count)
 
     def test_clear_cache_for_user_namespace(self):
-        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
-             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock,\
+        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock, \
+             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
             clear_cache_for_toggle(NAMESPACE_USER, 'testuser')
             self.assertEqual(0, domain_mock.call_count)
@@ -111,8 +111,8 @@ class TestClearCacheForToggle(SimpleTestCase):
             self.assertEqual(0, email_domain_mock.call_count)
 
     def test_clear_cache_for_other_namespace(self):
-        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
-             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock,\
+        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock, \
+             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
             clear_cache_for_toggle(NAMESPACE_OTHER, 'testother')
             self.assertEqual(0, domain_mock.call_count)
@@ -120,8 +120,8 @@ class TestClearCacheForToggle(SimpleTestCase):
             self.assertEqual(0, email_domain_mock.call_count)
 
     def test_clear_cache_for_email_namespace(self):
-        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock,\
-             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock,\
+        with patch('corehq.apps.toggle_ui.views.toggles_enabled_for_domain.clear') as domain_mock, \
+             patch('corehq.apps.toggle_ui.views.toggles_enabled_for_user.clear') as user_mock, \
              patch('corehq.apps.toggle_ui.views.toggles_enabled_for_email_domain.clear') as email_domain_mock:
             clear_cache_for_toggle(NAMESPACE_EMAIL_DOMAIN, 'testemaildomain')
             self.assertEqual(0, domain_mock.call_count)

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -251,7 +251,7 @@ def _call_save_fn_and_clear_cache_and_enable_dependencies(request_username, stat
         enabled = entry in currently_enabled
         namespace, entry = parse_toggle(entry)
         _call_save_fn_for_toggle(static_toggle, namespace, entry, enabled)
-        _clear_cache_for_toggle(namespace, entry)
+        clear_cache_for_toggle(namespace, entry)
         _enable_dependencies(request_username, static_toggle, entry, namespace, enabled)
 
 
@@ -271,7 +271,7 @@ def _set_toggle(request_username, static_toggle, item, namespace, is_enabled):
         if is_enabled:
             _notify_on_change(static_toggle, [item], request_username)
 
-        _clear_cache_for_toggle(namespace, item)
+        clear_cache_for_toggle(namespace, item)
         _enable_dependencies(request_username, static_toggle, item, namespace, is_enabled)
 
 
@@ -282,7 +282,7 @@ def _call_save_fn_for_toggle(static_toggle, namespace, entry, enabled):
             static_toggle.save_fn(domain, enabled)
 
 
-def _clear_cache_for_toggle(namespace, entry):
+def clear_cache_for_toggle(namespace, entry):
     if namespace == NAMESPACE_DOMAIN:
         domain = entry
         toggles_enabled_for_domain.clear(domain)

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -271,7 +271,6 @@ def _set_toggle(request_username, static_toggle, item, namespace, is_enabled):
         if is_enabled:
             _notify_on_change(static_toggle, [item], request_username)
 
-        clear_cache_for_toggle(namespace, item)
         _enable_dependencies(request_username, static_toggle, item, namespace, is_enabled)
 
 

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -251,7 +251,7 @@ def _call_save_fn_and_clear_cache_and_enable_dependencies(request_username, stat
         enabled = entry in currently_enabled
         namespace, entry = parse_toggle(entry)
         _call_save_fn_for_toggle(static_toggle, namespace, entry, enabled)
-        clear_cache_for_toggle(namespace, entry)
+        clear_toggle_cache_by_namespace(namespace, entry)
         _enable_dependencies(request_username, static_toggle, entry, namespace, enabled)
 
 
@@ -281,7 +281,7 @@ def _call_save_fn_for_toggle(static_toggle, namespace, entry, enabled):
             static_toggle.save_fn(domain, enabled)
 
 
-def clear_cache_for_toggle(namespace, entry):
+def clear_toggle_cache_by_namespace(namespace, entry):
     if namespace == NAMESPACE_DOMAIN:
         domain = entry
         toggles_enabled_for_domain.clear(domain)

--- a/corehq/toggles/shortcuts.py
+++ b/corehq/toggles/shortcuts.py
@@ -20,8 +20,8 @@ def toggle_enabled(slug, item, namespace=None):
 
 def set_toggle(slug, item, enabled, namespace=None):
     if _set_toggle_without_clear_cache(slug, item, enabled, namespace=namespace):
-        from corehq.apps.toggle_ui.views import clear_cache_for_toggle
-        clear_cache_for_toggle(namespace, item)
+        from corehq.apps.toggle_ui.views import clear_toggle_cache_by_namespace
+        clear_toggle_cache_by_namespace(namespace, item)
         return True
 
 
@@ -31,8 +31,8 @@ def set_toggles(slugs, item, enabled, namespace=None):
         if _set_toggle_without_clear_cache(slug, item, enabled, namespace):
             toggle_changed = True
     if toggle_changed:
-        from corehq.apps.toggle_ui.views import clear_cache_for_toggle
-        clear_cache_for_toggle(namespace, item)
+        from corehq.apps.toggle_ui.views import clear_toggle_cache_by_namespace
+        clear_toggle_cache_by_namespace(namespace, item)
 
 
 def _set_toggle_without_clear_cache(slug, item, enabled, namespace=None):

--- a/corehq/toggles/shortcuts.py
+++ b/corehq/toggles/shortcuts.py
@@ -19,9 +19,6 @@ def toggle_enabled(slug, item, namespace=None):
 
 
 def set_toggle(slug, item, enabled, namespace=None):
-    """
-    Sets a toggle value explicitly. Should only save anything if the value needed to be changed.
-    """
     if _set_toggle_without_clear_cache(slug, item, enabled, namespace=namespace):
         from corehq.apps.toggle_ui.views import clear_cache_for_toggle
         clear_cache_for_toggle(namespace, item)
@@ -39,6 +36,9 @@ def set_toggles(slugs, item, enabled, namespace=None):
 
 
 def _set_toggle_without_clear_cache(slug, item, enabled, namespace=None):
+    """
+    Sets a toggle value explicitly. Should only save anything if the value needed to be changed.
+    """
     if toggle_enabled(slug, item, namespace=namespace) == enabled:
         return False
 

--- a/corehq/toggles/shortcuts.py
+++ b/corehq/toggles/shortcuts.py
@@ -22,7 +22,7 @@ def set_toggle(slug, item, enabled, namespace=None):
     """
     Sets a toggle value explicitly. Should only save anything if the value needed to be changed.
     """
-    if _set_toggle_without_clear_cache(slug, item, enabled, namespace=namespace) != enabled:
+    if _set_toggle_without_clear_cache(slug, item, enabled, namespace=namespace):
         from corehq.apps.toggle_ui.views import clear_cache_for_toggle
         clear_cache_for_toggle(namespace, item)
         return True

--- a/corehq/toggles/shortcuts.py
+++ b/corehq/toggles/shortcuts.py
@@ -42,6 +42,16 @@ def set_toggle(slug, item, enabled, namespace=None):
         return True
 
 
+def set_toggles(slugs, item, enabled, namespace=None):
+    toggle_changed = False
+    for slug in slugs:
+        if set_toggle(slug, item, enabled, namespace):
+            toggle_changed = True
+    if toggle_changed:
+        from corehq.apps.toggle_ui.views import clear_cache_for_toggle
+        clear_cache_for_toggle(namespace, item)
+
+
 def namespaced_item(item, namespace):
     return '{namespace}:{item}'.format(
         namespace=namespace, item=item

--- a/corehq/toggles/shortcuts.py
+++ b/corehq/toggles/shortcuts.py
@@ -39,6 +39,8 @@ def set_toggle(slug, item, enabled, namespace=None):
             static_toggle = static_toggles_by_slug[slug]
             if static_toggle.save_fn:
                 static_toggle.save_fn(item, enabled)
+        from corehq.apps.toggle_ui.views import clear_cache_for_toggle
+        clear_cache_for_toggle(namespace, item)
         return True
 
 

--- a/corehq/toggles/shortcuts.py
+++ b/corehq/toggles/shortcuts.py
@@ -39,24 +39,26 @@ def set_toggles(slugs, item, enabled, namespace=None):
 
 
 def _set_toggle_without_clear_cache(slug, item, enabled, namespace=None):
-    if toggle_enabled(slug, item, namespace=namespace) != enabled:
-        ns_item = namespaced_item(item, namespace)
-        try:
-            toggle_doc = Toggle.get(slug)
-        except ResourceNotFound:
-            toggle_doc = Toggle(slug=slug, enabled_users=[])
-        if enabled:
-            toggle_doc.add(ns_item)
-        else:
-            toggle_doc.remove(ns_item)
-        from corehq.feature_previews import all_previews
-        from corehq.toggles import all_toggles, NAMESPACE_DOMAIN
-        static_toggles_by_slug = {t.slug: t for t in all_toggles() + all_previews()}
-        if namespace == NAMESPACE_DOMAIN and slug in static_toggles_by_slug:
-            static_toggle = static_toggles_by_slug[slug]
-            if static_toggle.save_fn:
-                static_toggle.save_fn(item, enabled)
-        return True
+    if toggle_enabled(slug, item, namespace=namespace) == enabled:
+        return False
+
+    ns_item = namespaced_item(item, namespace)
+    try:
+        toggle_doc = Toggle.get(slug)
+    except ResourceNotFound:
+        toggle_doc = Toggle(slug=slug, enabled_users=[])
+    if enabled:
+        toggle_doc.add(ns_item)
+    else:
+        toggle_doc.remove(ns_item)
+    from corehq.feature_previews import all_previews
+    from corehq.toggles import all_toggles, NAMESPACE_DOMAIN
+    static_toggles_by_slug = {t.slug: t for t in all_toggles() + all_previews()}
+    if namespace == NAMESPACE_DOMAIN and slug in static_toggles_by_slug:
+        static_toggle = static_toggles_by_slug[slug]
+        if static_toggle.save_fn:
+            static_toggle.save_fn(item, enabled)
+    return True
 
 
 def namespaced_item(item, namespace):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Currently, when copying an app to another domain, users have the option to enable toggles on the target domain. However, a bug prevents these toggles from being reflected in Web Apps, even though they are enabled on the new domain. This PR resolves that issue.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-4261](https://dimagi.atlassian.net/browse/USH-4261)
In this PR, I address an issue with toggle state caching when verifying toggle status through JavaScript. Currently, the toggle status is checked against `toggle_dict` populated [here](https://github.com/dimagi/commcare-hq/blob/304feb1b4c238d175f7b12aea47c8b7ca0ea59fd/corehq/toggles/__init__.py#L581-L584), which is passed to the [page context](https://github.com/dimagi/commcare-hq/blob/64f7a498c20fa3475cd9592f50fe3071c5160757/corehq/util/context_processors.py#L140). `toggle_dict` itself is populated by `toggle_values_by_name`, which relies on `toggles_enabled_for_domain` and `toggles_enabled_for_user`.

The issue arises because `toggles_enabled_for_domain`, `toggles_enabled_for_email_domain`, and `toggles_enabled_for_user` are cached. Although this cache is cleared when toggles are modified directly via the UI, it remains stale in workflows that involve copying an app and enabling feature flags within that process.

This PR includes updates to clear the cache in these workflows to prevent stale toggle states. Additionally, cache-clearing logic is incorporated directly into `set_toggle`, ensuring that cache invalidation is not overlooked. To optimize performance, I introduced a new function, `set_toggles`, which allows setting multiple toggles at once while clearing the cache only once afterward.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No specific FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests for copying an app and copying as a linked app. Also added a test that would have caught this bug - that enabling toggles on the receiving domain will clear the toggle cache.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change

[USH-4261]: https://dimagi.atlassian.net/browse/USH-4261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ