### PR TITLE
Removed initial field argument to crispy.Div objects that don't have …

### DIFF
--- a/corehq/apps/styleguide/examples/bootstrap5/crispy_forms_knockout.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/crispy_forms_knockout.py
@@ -58,7 +58,6 @@ class KnockoutCrispyExampleForm(forms.Form):
                     # instead of crispy.Div, but make sure any HTMl
                     # inserted here is safe
                     crispy.Div(
-                        '',
                         css_class="alert alert-info",
                         # data-bind to display alertText
                         data_bind="text: alertText",

--- a/corehq/apps/styleguide/examples/bootstrap5/crispy_forms_knockout_validation.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/crispy_forms_knockout_validation.py
@@ -41,7 +41,6 @@ class KnockoutValidationCrispyExampleForm(forms.Form):
                 _("Create New User"),
                 crispy.Div(
                     crispy.Div(
-                        '',
                         css_class="alert alert-info",
                         data_bind="text: alertText",
                     ),


### PR DESCRIPTION
…a field

## Product Description
Curiously, this has making the styleguide 500 in local environments, due to not having a field with a blank name. Yet it's fine on staging and prod. I didn't dig deeply into why beyond checking that it doesn't seem related to settings.DEBUG or python version.

The code's intent is "create a div that isn't associated with a field". Here's the `Div` constructor source: https://github.com/django-crispy-forms/django-crispy-forms/blob/e07622dc68c7199f36677f819d8dcf68125ad596/crispy_forms/layout.py#L735

## Safety Assurance

### Safety story
This page is public yet is largely an internal tool. Tested on staging.

### Automated test coverage

I don't think so.

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
