### PR TITLE
Removed TestBootstrap5DomainView

### DIFF
--- a/corehq/apps/domain/templates/domain/test_bootstrap5.html
+++ b/corehq/apps/domain/templates/domain/test_bootstrap5.html
@@ -1,8 +1,0 @@
-{% extends "hqwebapp/bootstrap5/base_section.html" %}
-{% load hq_shared_tags %}
-{% load crispy_forms_tags %}
-{% load i18n %}
-
-{% block page_content %}
-{{ use_bootstrap5 }}
-{% endblock %}

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -49,7 +49,6 @@ from corehq.apps.domain.views.internal import (
     FlagsAndPrivilegesView,
     ProjectLimitsView,
     TransferDomainView,
-    TestBootstrap5DomainView,
     calculated_properties,
     toggle_diff,
 )
@@ -193,7 +192,6 @@ domain_settings = [
     url(r'^location_settings/$', LocationFixtureConfigView.as_view(), name=LocationFixtureConfigView.urlname),
     url(r'^commtrack/settings/$', RedirectView.as_view(url='commtrack_settings', permanent=True)),
     url(r'^internal/info/$', EditInternalDomainInfoView.as_view(), name=EditInternalDomainInfoView.urlname),
-    url(r'^internal/bootstrap5/$', TestBootstrap5DomainView.as_view(), name=TestBootstrap5DomainView.urlname),
     url(r'^internal/calculations/$', EditInternalCalculationsView.as_view(),
         name=EditInternalCalculationsView.urlname),
     url(r'^internal/calculated_properties/$', calculated_properties, name='calculated_properties'),

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -41,7 +41,7 @@ from corehq.apps.domain.views.settings import (
     BaseAdminProjectSettingsView,
     BaseProjectSettingsView,
 )
-from corehq.apps.hqwebapp.decorators import use_jquery_ui, use_multiselect, use_bootstrap5
+from corehq.apps.hqwebapp.decorators import use_jquery_ui, use_multiselect
 from corehq.apps.hqwebapp.tasks import send_html_email_async, send_mail_async
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.receiverwrapper.rate_limiter import domain_case_rate_limiter, submission_rate_limiter
@@ -70,13 +70,6 @@ class BaseInternalDomainSettingsView(BaseProjectSettingsView):
     @property
     def page_name(self):
         return format_html("{} <small>Internal</small>", self.page_title)
-
-
-@method_decorator(use_bootstrap5, name='dispatch')
-class TestBootstrap5DomainView(BaseInternalDomainSettingsView):
-    urlname = 'test_bootstrap5_domain_view'
-    page_title = gettext_lazy("Test Bootstrap 5 Changes")
-    template_name = 'domain/test_bootstrap5.html'
 
 
 class EditInternalDomainInfoView(BaseInternalDomainSettingsView):


### PR DESCRIPTION
## Technical Summary
I ran across this while scoping out migrating the `domain` app. I think this view has served its purpose.

About half(!) of HQ's django apps are on B5 at this point, we have lots of places to test B5.

## Safety Assurance

### Safety story
Code removal. This was an admin-only page that wasn't linked from anywhere.

### Automated test coverage

no

### QA Plan

no


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
