### PR TITLE
Fix "next error" button scrolling bug - web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -67,6 +67,7 @@ hqDefine("cloudcare/js/form_entry/const", [], function () {
         QUESTIONS_FOR_INDEX: 'questions_for_index',
         NEXT_QUESTION: 'next_index',
         PREV_QUESTION: 'prev_index',
+        SCROLLABLE_CONTENT_CONTAINER: '#content-plus-version-info-container',
 
         // XForm Actions
         NEW_FORM: 'new-form',
@@ -112,7 +113,7 @@ hqDefine("cloudcare/js/form_entry/const", [], function () {
         FLOAT_VALUE_LIMIT: +("9".repeat(14)),
         FILE_PREFIX: "C:\\fakepath\\",
 
-        // Boostrap
+        // Bootstrap
         GRID_COLUMNS: 12,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -301,6 +301,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
                 }
             });
             self.smallScreenEnabled = cloudcareUtils.smallScreenIsEnabled();
+            self.scrollContainer = $(constants.SCROLLABLE_CONTENT_CONTAINER);
         },
 
         className: "formplayer-request case-row",
@@ -447,10 +448,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
                 arrow.removeClass("fa-angle-double-up");
                 arrow.addClass("fa-angle-double-down");
                 tileContent.addClass("collapsed-tile-content");
-                const scrollContainer = $(constants.SCROLLABLE_CONTENT_CONTAINER);
                 const offset = getScrollTopOffset(this.smallScreenEnabled);
-                $(scrollContainer).animate({
-                    scrollTop: scrollContainer.scrollTop() + $(e.currentTarget).parent().offset().top - offset
+                $(this.scrollContainer).animate({
+                    scrollTop: this.scrollContainer.scrollTop() + $(e.currentTarget).parent().offset().top - offset
                 });
             }
 
@@ -700,6 +700,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
                 self.handleSmallScreenChange(smallScreenEnabled);
             });
             self.smallScreenListener.listen();
+            self.scrollContainer = $(constants.SCROLLABLE_CONTENT_CONTAINER);
         },
 
         ui: CaseListViewUI(),
@@ -754,7 +755,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
         },
 
         scrollToBottom: function () {
-            this.scrollContainer().animate({
+            const self = this;
+            self.scrollContainer.animate({
                 scrollTop: $('.container.pagination-container').offset().top,
             }, 500);
         },
@@ -979,9 +981,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
                                     marker.setIcon(selectedLocationIcon);
 
                                     const offset = getScrollTopOffset(this.smallScreenEnabled, addressMap.isFullscreen());
-                                    const scrollContainer = this.scrollContainer();
-                                    scrollContainer.animate({
-                                        scrollTop: scrollContainer.scrollTop() + $(`#${rowId}`).offset().top - offset,
+                                    this.scrollContainer.animate({
+                                        scrollTop: this.scrollContainer.scrollTop() + $(`#${rowId}`).offset().top - offset,
                                     }, 500);
 
                                     addressMap.panTo(markerCoordinates);
@@ -1004,10 +1005,6 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             }
         },
 
-        scrollContainer: function () {
-            return $(constants.SCROLLABLE_CONTENT_CONTAINER);
-        },
-
         handleScroll: function () {
             const self = this;
             if (self.smallScreenEnabled) {
@@ -1021,10 +1018,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
         },
 
         shouldShowScrollButton: function () {
+            const self = this;
             const $pagination = $('.container.pagination-container');
-            const scrollContainer = this.scrollContainer();
             const paginationOffscreen = $pagination[0]
-                ? $pagination.offset().top - scrollContainer.scrollTop() > scrollContainer.innerHeight() : false;
+                ? $pagination.offset().top - self.scrollContainer.scrollTop() > self.scrollContainer.innerHeight() : false;
             return paginationOffscreen;
         },
 
@@ -1035,7 +1032,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             }
             self.handleSmallScreenChange(self.smallScreenEnabled);
             self.boundHandleScroll = self.handleScroll.bind(self);
-            self.scrollContainer().on('scroll', self.boundHandleScroll);
+            self.scrollContainer.on('scroll', self.boundHandleScroll);
             if (self.shouldShowScrollButton()) {
                 $('#scroll-to-bottom').removeClass("d-none");
             }
@@ -1044,7 +1041,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
         onBeforeDetach: function () {
             const self = this;
             self.smallScreenListener.stopListening();
-            self.scrollContainer().off('scroll', self.boundHandleScroll);
+            self.scrollContainer.off('scroll', self.boundHandleScroll);
         },
 
         templateContext: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -755,8 +755,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
         },
 
         scrollToBottom: function () {
-            const self = this;
-            self.scrollContainer.animate({
+            this.scrollContainer.animate({
                 scrollTop: $('.container.pagination-container').offset().top,
             }, 500);
         },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1035,7 +1035,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             }
             self.handleSmallScreenChange(self.smallScreenEnabled);
             self.boundHandleScroll = self.handleScroll.bind(self);
-            this.scrollContainer().on('scroll', self.boundHandleScroll);
+            self.scrollContainer().on('scroll', self.boundHandleScroll);
             if (self.shouldShowScrollButton()) {
                 $('#scroll-to-bottom').removeClass("d-none");
             }
@@ -1044,7 +1044,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
         onBeforeDetach: function () {
             const self = this;
             self.smallScreenListener.stopListening();
-            this.scrollContainer().off('scroll', self.boundHandleScroll);
+            self.scrollContainer().off('scroll', self.boundHandleScroll);
         },
 
         templateContext: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -449,7 +449,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
                 arrow.addClass("fa-angle-double-down");
                 tileContent.addClass("collapsed-tile-content");
                 const offset = getScrollTopOffset(this.smallScreenEnabled);
-                $(this.scrollContainer).animate({
+                this.scrollContainer.animate({
                     scrollTop: this.scrollContainer.scrollTop() + $(e.currentTarget).parent().offset().top - offset
                 });
             }


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Fixes https://dimagi.atlassian.net/browse/USH-5099, a bug with the automatic scrolling that happens when you click the "next error" button on a form.

The bug was introduced in [this PR](https://github.com/dimagi/commcare-hq/pull/35324) from the ad-hoc deploy earlier this week.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

- Simple mistake: the `constants` variable used in `form_ui.js` is different from the one used in `views.js`
- Also added some cleanup. Tested all 4 scrolling features with the current code locally to make sure things look OK

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- Tested all scrolling features locally

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Don't think I'll ask for QA. I think local testing should be sufficient.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
