### PR TITLE
Command to disable toggles in deleted domains

### DIFF
--- a/corehq/apps/domain/management/commands/disable_toggles_for_deleted_domains.py
+++ b/corehq/apps/domain/management/commands/disable_toggles_for_deleted_domains.py
@@ -1,0 +1,28 @@
+from django.core.management.base import BaseCommand
+
+from corehq.apps.domain.models import Domain
+from corehq.toggles import NAMESPACE_DOMAIN, all_toggles_by_name, set_toggle
+
+
+class Command(BaseCommand):
+    help = "Disable toggles for domains that no longer exist"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--save',
+            help="Actually disable toggles",
+            action='store_true',
+        )
+
+    def handle(self, **options):
+        all_toggles = all_toggles_by_name()
+        domain_existence = {}
+        for toggle in all_toggles.values():
+            for domain in toggle.get_enabled_domains():
+                if domain not in domain_existence:
+                    domain_existence[domain] = bool(Domain.get_by_name(domain))
+                if not domain_existence[domain]:
+                    prefix = '[DRY RUN] ' if not options['save'] else ''
+                    print(f"{prefix}Disabling {toggle.slug} for {domain}")
+                    if options['save']:
+                        set_toggle(toggle.slug, domain, False, NAMESPACE_DOMAIN)

--- a/corehq/apps/domain/management/commands/disable_toggles_for_deleted_domains.py
+++ b/corehq/apps/domain/management/commands/disable_toggles_for_deleted_domains.py
@@ -1,7 +1,9 @@
-from django.core.management.base import BaseCommand
+from couchdbkit import ResourceNotFound
+from django.core.management.base import BaseCommand, CommandError
 
 from corehq.apps.domain.models import Domain
-from corehq.toggles import NAMESPACE_DOMAIN, all_toggles_by_name, set_toggle
+from corehq.toggles import NAMESPACE_DOMAIN, all_toggles_by_name, set_toggle, Toggle
+from corehq.toggles.shortcuts import find_domains_with_toggle_enabled
 
 
 class Command(BaseCommand):
@@ -13,12 +15,30 @@ class Command(BaseCommand):
             help="Actually disable toggles",
             action='store_true',
         )
+        parser.add_argument('--domain', help="Only update this domain")
+        parser.add_argument('--slug', help="Only update this toggle")
 
     def handle(self, **options):
-        all_toggles = all_toggles_by_name()
+        if options['slug']:
+            try:
+                toggles = [Toggle.get(options['slug'])]
+            except ResourceNotFound:
+                raise CommandError(f"Slug {options['slug']} not found - are you using the lowercase slug?")
+        else:
+            toggles = all_toggles_by_name().values()
+
+        domain = options['domain']
         domain_existence = {}
-        for toggle in all_toggles.values():
-            for domain in toggle.get_enabled_domains():
+        for toggle in toggles:
+            domains = []
+            if domain:
+                if domain in find_domains_with_toggle_enabled(toggle):
+                    domains = [domain]
+            else:
+                domains = find_domains_with_toggle_enabled(toggle)
+
+            print(f"Toggle {toggle.slug}, {len(domains)} domains")
+            for domain in domains:
                 if domain not in domain_existence:
                     domain_existence[domain] = bool(Domain.get_by_name(domain))
                 if not domain_existence[domain]:


### PR DESCRIPTION
## Technical Summary
As discussed in cross-divisional dev owners the other day.

## Safety Assurance

### Safety story
This is a management command to be run ad hoc.

The command itself can have far-reaching impacts, although anything it does can be undone fairly quickly. Its default mode is to not save anything and just print what *would* be disabled.

### Automated test coverage

no

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
