### PR TITLE
Simplify blob export code

### DIFF
--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -103,7 +103,6 @@ class UserIDFilter(IDFilter):
 class MultimediaBlobMetaFilter(IDFilter):
     """
     BlobMeta for multimedia references the "<shared>" domain which is not the domain being dumped.
-    This borrows from the same logic used in ``run_blob_export`` by the ``ExportMultimedia`` exporter.
     """
     def __init__(self):
         # 'id' is used in query (e.g., ...filter(id__in=blobmeta_ids))

--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -1,7 +1,9 @@
 import os
-from abc import ABC, abstractmethod
 
-from dimagi.utils.couch.database import iter_docs
+from corehq.apps.dump_reload.sql.dump import (
+    APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP,
+    get_all_model_iterators_builders_for_domain,
+)
 
 from . import NotFound, get_blob_db, CODES
 from .migrate import PROCESSING_COMPLETE_MESSAGE
@@ -41,17 +43,12 @@ class BlobDbBackendExporter(object):
                 self.db.copy_blob(content, key=meta.key)
 
 
-class BlobExporter(ABC):
+class BlobExporter:
+
     def __init__(self, domain):
         self.domain = domain
 
-    @property
-    @abstractmethod
-    def slug(self):
-        raise NotImplementedError
-
-    def migrate(self, filename, chunk_size=100, limit_to_db=None,
-                already_exported=None, force=False):
+    def migrate(self, filename, chunk_size=100, limit_to_db=None, already_exported=None, force=False):
         if not self.domain:
             raise ExportError("Must specify domain")
 
@@ -63,58 +60,20 @@ class BlobExporter(ABC):
 
         migrator = BlobDbBackendExporter(filename, already_exported)
         with migrator:
-            self._migrate(migrator, chunk_size, limit_to_db)
-        print("Processed {} {} objects".format(migrator.total_blobs, self.slug))
+            iterator_builders = APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP['blobs.BlobMeta']
+            builders = get_all_model_iterators_builders_for_domain(
+                BlobMeta, self.domain, iterator_builders, limit_to_db
+            )
+            for model_class, builder in builders:
+                for iterator in builder.iterators():
+                    for obj in iterator:
+                        migrator.process_object(obj)
+                        if migrator.total_blobs % chunk_size == 0:
+                            print("Processed {} objects".format(migrator.total_blobs))
+
+        print("Processed {} total objects".format(migrator.total_blobs))
         return migrator.total_blobs, 0
-
-    @abstractmethod
-    def _migrate(self, migrator, chunk_size, limit_to_db):
-        raise NotImplementedError
-
-
-class ExportByDomain(BlobExporter):
-    slug = 'all_blobs'
-
-    def _migrate(self, migrator, chunk_size, limit_to_db):
-        from corehq.apps.dump_reload.sql.dump import get_all_model_iterators_builders_for_domain
-        from corehq.apps.dump_reload.sql.dump import APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP
-
-        iterator_builders = APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP['blobs.BlobMeta']
-        builders = get_all_model_iterators_builders_for_domain(
-            BlobMeta, self.domain, iterator_builders, limit_to_db)
-        for model_class, builder in builders:
-            for iterator in builder.iterators():
-                for obj in iterator:
-                    migrator.process_object(obj)
-                    if migrator.total_blobs % chunk_size == 0:
-                        print("Processed {} {} objects".format(migrator.total_blobs, self.slug))
-
-
-class ExportMultimedia(BlobExporter):
-    slug = 'multimedia'
-
-    def _migrate(self, migrator, chunk_size, limit_to_db):
-        from corehq.apps.dump_reload.couch.dump import DOC_PROVIDERS_BY_DOC_TYPE
-
-        db = get_blob_db()
-
-        provider = DOC_PROVIDERS_BY_DOC_TYPE['CommCareMultimedia']
-        for doc_class, doc_ids in provider.get_doc_ids(self.domain):
-            couch_db = doc_class.get_db()
-            for doc in iter_docs(couch_db, doc_ids, chunksize=chunk_size):
-                obj = doc_class.get_doc_class(doc['doc_type']).wrap(doc)
-                for name, blob_meta in obj.blobs.items():
-                    meta = db.metadb.get(parent_id=obj._id, key=blob_meta.key)
-                    migrator.process_object(meta)
-                    if migrator.total_blobs % chunk_size == 0:
-                        print("Processed {} {} objects".format(migrator.total_blobs, self.slug))
 
 
 class ExportError(Exception):
     pass
-
-
-EXPORTERS = {m.slug: m for m in [
-    ExportByDomain,
-    ExportMultimedia,
-]}

--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -8,13 +8,7 @@ from django.core.management import BaseCommand, CommandError
 from corehq.blobs.export import EXPORTERS
 from corehq.util.decorators import change_log_level
 
-USAGE = """Usage: ./manage.py run_blob_export [options] <slug> <domain>
-
-Slugs:
-
-{}
-
-""".format('\n'.join(sorted(EXPORTERS)))
+USAGE = "Usage: ./manage.py run_blob_export [options] <domain>"
 
 
 class Command(BaseCommand):
@@ -22,9 +16,9 @@ class Command(BaseCommand):
     Example: ./manage.py run_blob_export [options] domain
 
     Dump XForms in parallel:
-        ./manage.py run_blob_export -e sql_xforms --limit-to-db p0 domain
+        ./manage.py run_blob_export --limit-to-db p0 domain
          ...
-        ./manage.py run_blob_export -e sql_xforms --limit-to-db pN domain
+        ./manage.py run_blob_export --limit-to-db pN domain
 
     To top-up an older blob dump, first extract a list of names from the archive:
         $ tar --list -f blob_export.tar.gz > blob_export.list
@@ -35,11 +29,6 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('domain')
-        parser.add_argument('-e', '--exporter', dest='exporters', action='append', default=[],
-                            help='Exporter slug to run '
-                                 '(use multiple --slug to run multiple exporters or --all to run them all).')
-        parser.add_argument('--all', action='store_true', default=False,
-                            help='Run all exporters')
         parser.add_argument('--chunk-size', type=int, default=100,
                             help='Maximum number of records to read from couch at once.')
         parser.add_argument('--limit-to-db', dest='limit_to_db',
@@ -51,16 +40,13 @@ class Command(BaseCommand):
     @change_log_level('boto3', logging.WARNING)
     @change_log_level('botocore', logging.WARNING)
     def handle(self, domain=None, reset=False,
-               chunk_size=100, all=None, limit_to_db=None, **options):
-        exporters = options.get('exporters')
+               chunk_size=100, limit_to_db=None, **options):
+        exporters = ['all_blobs']  # hard code exporters, will change in next commit
         already_exported = get_lines_from_file(options['already_exported'])
         print("Found {} existing blobs, these will be skipped".format(len(already_exported)))
 
         if not domain:
             raise CommandError(USAGE)
-
-        if all:
-            exporters = list(EXPORTERS)
 
         for exporter_slug in exporters:
             try:

--- a/corehq/blobs/tests/fixtures.py
+++ b/corehq/blobs/tests/fixtures.py
@@ -1,0 +1,11 @@
+from unmagic import fixture
+
+from corehq.blobs import get_blob_db
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
+
+
+@fixture(scope='function')
+def blob_db():
+    with TemporaryFilesystemBlobDB() as blob_db:
+        assert get_blob_db() is blob_db, (get_blob_db(), blob_db)
+        yield blob_db

--- a/corehq/blobs/tests/fixtures.py
+++ b/corehq/blobs/tests/fixtures.py
@@ -4,7 +4,7 @@ from corehq.blobs import get_blob_db
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
 
 
-@fixture(scope='function')
+@fixture
 def blob_db():
     with TemporaryFilesystemBlobDB() as blob_db:
         assert get_blob_db() is blob_db, (get_blob_db(), blob_db)

--- a/corehq/blobs/tests/test_export.py
+++ b/corehq/blobs/tests/test_export.py
@@ -46,7 +46,7 @@ class TestBlobExporter(TestCase):
         with NamedTemporaryFile() as out:
             self.exporter.migrate(out.name, force=True)
             with tarfile.open(out.name, 'r:gz') as tgzfile:
-                self.assertCountEqual({form.key, multimedia.key}, tgzfile.getnames())
+                self.assertEqual({form.key, multimedia.key}, set(tgzfile.getnames()))
 
     def test_blob_meta_referencing_missing_blob_is_not_exported(self):
         expected_meta = self.db.put(

--- a/corehq/blobs/tests/test_export.py
+++ b/corehq/blobs/tests/test_export.py
@@ -1,108 +1,75 @@
 import doctest
-import os
 import tarfile
-import uuid
 from io import BytesIO, RawIOBase
 from tempfile import NamedTemporaryFile
 
 from django.test import SimpleTestCase, TestCase
 
-from corehq.apps.hqmedia.models import (
-    CommCareAudio,
-    CommCareImage,
-    CommCareVideo,
-)
 from corehq.blobs import CODES, get_blob_db
-from corehq.blobs.export import EXPORTERS
+from corehq.blobs.export import BlobExporter
+from corehq.blobs.management.commands.run_blob_import import Command as ImportCommand
+from corehq.blobs.tests.fixtures import blob_db
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB, new_meta
 
 
-class TestBlobExport(TestCase):
+class TestBlobExporter(TestCase):
+
+    def test_only_blob_in_targeted_domain_is_exported(self):
+        # create blob that should be ignored
+        self.db.put(BytesIO(self.blob_data), meta=new_meta(domain='random', type_code=CODES.form_xml))
+        expected_meta = self.db.put(
+            BytesIO(self.blob_data), meta=new_meta(domain=self.domain, type_code=CODES.form_xml)
+        )
+
+        with NamedTemporaryFile() as out:
+            self.exporter.migrate(out.name, force=True)
+            with tarfile.open(out.name, 'r:gz') as tgzfile:
+                self.assertCountEqual({expected_meta.key}, tgzfile.getnames())
+
+    def test_different_blob_types_are_exported(self):
+        form = self.db.put(BytesIO(self.blob_data), meta=new_meta(domain=self.domain, type_code=CODES.form_xml))
+        multimedia = self.db.put(
+            BytesIO(self.blob_data), meta=new_meta(domain=self.domain, type_code=CODES.multimedia)
+        )
+
+        with NamedTemporaryFile() as out:
+            self.exporter.migrate(out.name, force=True)
+            with tarfile.open(out.name, 'r:gz') as tgzfile:
+                self.assertCountEqual({form.key, multimedia.key}, tgzfile.getnames())
+
+    def test_orphaned_blob_meta_is_not_exported(self):
+        expected_meta = self.db.put(
+            BytesIO(self.blob_data), meta=new_meta(domain=self.domain, type_code=CODES.form_xml)
+        )
+        self.addCleanup(self.db.delete, expected_meta.key)
+        orphaned_meta = new_meta(domain=self.domain, type_code=CODES.form_xml, content_length=42)
+        orphaned_meta.save()
+
+        with NamedTemporaryFile() as out:
+            self.exporter.migrate(out.name, force=True)
+            with tarfile.open(out.name, 'r:gz') as tgzfile:
+                self.assertCountEqual({expected_meta.key}, tgzfile.getnames())
+
+    def test_exported_blobs_can_be_imported_successfully(self):
+        form = self.db.put(BytesIO(self.blob_data), meta=new_meta(domain=self.domain, type_code=CODES.form_xml))
+        with NamedTemporaryFile() as out:
+            self.exporter.migrate(out.name, force=True)
+            with TemporaryFilesystemBlobDB() as dest_db:
+                assert get_blob_db() is dest_db, (get_blob_db(), dest_db)
+                ImportCommand.handle(None, out.name)
+                with dest_db.get(meta=form) as fh:
+                    self.assertEqual(fh.read(), self.blob_data)
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.domain = 'exporter-test'
+        cls.blob_data = b'binary data not valid utf-8 \xe4\x94'
+        cls.exporter = BlobExporter(cls.domain)
 
-        cls.db = TemporaryFilesystemBlobDB()
-        assert get_blob_db() is cls.db, (get_blob_db(), cls.db)
-        cls.data = data = b'binary data not valid utf-8 \xe4\x94'
-        cls.blob_metas = []
-        cls.not_found = set()
-
-        cls.domain_name = str(uuid.uuid4)
-
-        for type_code in [CODES.form_xml, CODES.multimedia, CODES.data_export]:
-            for domain in (cls.domain_name, str(uuid.uuid4())):
-                meta = cls.db.put(BytesIO(data), meta=new_meta(domain=domain, type_code=type_code))
-                lost = new_meta(domain=domain, type_code=type_code, content_length=42)
-                cls.blob_metas.append(meta)
-                cls.blob_metas.append(lost)
-                lost.save()
-                cls.not_found.add(lost.key)
-
-    @classmethod
-    def tearDownClass(cls):
-        for blob in cls.blob_metas:
-            blob.delete()
-        cls.db.close()
-        super().tearDownClass()
-
-    def test_migrate_all(self):
-        expected = {
-            m.key for m in self.blob_metas
-            if m.domain == self.domain_name and m.key not in self.not_found
-        }
-        with NamedTemporaryFile() as out:
-            exporter = EXPORTERS['all_blobs'](self.domain_name)
-            exporter.migrate(out.name, force=True)
-            with tarfile.open(out.name, 'r:gz') as tgzfile:
-                self.assertEqual(expected, set(tgzfile.getnames()))
-
-    def test_migrate_multimedia(self):
-        image_path = os.path.join('corehq', 'apps', 'hqwebapp', 'static', 'hqwebapp', 'images',
-                                  'commcare-hq-logo.png')
-        with open(image_path, 'rb') as f:
-            image_data = f.read()
-
-        files = (
-            (CommCareImage, self.domain_name, image_data),
-            (CommCareAudio, self.domain_name, b'fake audio'),
-            (CommCareVideo, self.domain_name, b'fake video'),
-            (CommCareAudio, 'other_domain', b'fake audio 1'),
-        )
-
-        blob_keys = []
-        for doc_class, domain, data in files:
-            obj = doc_class.get_by_data(data)
-            obj.attach_data(data)
-            obj.add_domain(domain)
-            self.addCleanup(obj.delete)
-            self.assertEqual(data, obj.get_display_file(False))
-            blob_keys.append(obj.blobs[obj.attachment_id].key)
-
-        expected = set(blob_keys[:-1])
-        with NamedTemporaryFile() as out:
-            exporter = EXPORTERS['multimedia'](self.domain_name)
-            exporter.migrate(out.name, force=True)
-            with tarfile.open(out.name, 'r:gz') as tgzfile:
-                self.assertEqual(expected, set(tgzfile.getnames()))
-
-    def test_export_and_import_compressed_blobs(self):
-        with NamedTemporaryFile() as out:
-            exporter = EXPORTERS['all_blobs'](self.domain_name)
-            exporter.migrate(out.name, force=True)
-            self.import_and_verify(out.name)
-
-    def import_and_verify(self, filename):
-        from ..management.commands.run_blob_import import Command as ImportCommand
-        expected_metas = {m for m in self.blob_metas
-            if m.key not in self.not_found and m.domain == self.domain_name}
-        self.assertTrue(any(m.is_compressed for m in expected_metas))
-        with TemporaryFilesystemBlobDB() as dest_db:
-            assert get_blob_db() is dest_db, (get_blob_db(), dest_db)
-            ImportCommand.handle(None, filename)
-            for meta in expected_metas:
-                with dest_db.get(meta=meta) as fh:
-                    self.assertEqual(fh.read(), self.data, meta.type_code)
+    def setUp(self):
+        super().setUp()
+        self.db = blob_db()
 
 
 class TestExtendingExport(TestCase):
@@ -110,14 +77,14 @@ class TestExtendingExport(TestCase):
     domain_name = 'extending-export-test-domain'
 
     def setUp(self):
-        self.db = TemporaryFilesystemBlobDB()
-        assert get_blob_db() is self.db, (get_blob_db(), self.db)
+        super().setUp()
+        self.db = blob_db()
         self.blob_metas = []
 
     def tearDown(self):
         for meta in self.blob_metas:
             meta.delete()
-        self.db.close()
+        super().tearDown()
 
     def test_extends(self):
 
@@ -130,7 +97,7 @@ class TestExtendingExport(TestCase):
             meta = self.db.put(BytesIO(blob), meta=meta_meta)  # Naming ftw
             self.blob_metas.append(meta)
         with NamedTemporaryFile() as file_one:
-            exporter = EXPORTERS['all_blobs'](self.domain_name)
+            exporter = BlobExporter(self.domain_name)
             exporter.migrate(file_one.name, force=True)
             with tarfile.open(file_one.name, 'r:gz') as tgzfile:
                 keys_in_file_one = set(m.key for m in self.blob_metas[-3:])
@@ -145,7 +112,7 @@ class TestExtendingExport(TestCase):
                 meta = self.db.put(BytesIO(blob), meta=meta_meta)
                 self.blob_metas.append(meta)
             with NamedTemporaryFile() as file_two:
-                exporter = EXPORTERS['all_blobs'](self.domain_name)
+                exporter = BlobExporter(self.domain_name)
                 exporter.migrate(
                     file_two.name,
                     already_exported=keys_in_file_one, force=True,
@@ -163,7 +130,7 @@ class TestExtendingExport(TestCase):
                     meta = self.db.put(BytesIO(blob), meta=meta_meta)
                     self.blob_metas.append(meta)
                 with NamedTemporaryFile() as file_three:
-                    exporter = EXPORTERS['all_blobs'](self.domain_name)
+                    exporter = BlobExporter(self.domain_name)
                     exporter.migrate(
                         file_three.name,
                         already_exported=keys_in_file_one | keys_in_file_two, force=True,


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15775

Since adding BlobMeta for multimedia in [APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP](https://github.com/dimagi/commcare-hq/pull/34111), we no longer need to rely on a separate exporter for retrieving multimedia blobs. This PR consolidates the two exporter blobs into one `BlobExporter` concrete class.

This also changes the command so that only one blob export file is created instead of two as was previously the case.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The blob import code doesn't care about blob types so this shouldn't impact that command at all.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests that I'm aware of.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
