### PR TITLE
Serialize list before passing them to renderer

### DIFF
--- a/corehq/apps/case_search/fixtures.py
+++ b/corehq/apps/case_search/fixtures.py
@@ -20,7 +20,7 @@ def _get_user_template_info(restore_user):
         "username": restore_user.username,
         "uuid": restore_user.user_id,
         "user_data": restore_user.user_session_data,
-        "location_ids": restore_user.get_location_ids(restore_user.domain),
+        "location_ids": " ".join(restore_user.get_location_ids(restore_user.domain)),
     }
 
 

--- a/custom/bha/commcare_extensions.py
+++ b/custom/bha/commcare_extensions.py
@@ -12,6 +12,6 @@ BHA_DOMAINS = settings.CUSTOM_DOMAINS_BY_MODULE['custom.bha']
 def bha_csql_fixture_context(domain, restore_user):
     facility_ids = get_user_facility_ids(domain, restore_user)
     return ('bha', SimpleDictTemplateParam({
-        'facility_ids': facility_ids,
+        'facility_ids': ' '.join(facility_ids),
         'user_clinic_ids': get_user_clinic_ids(domain, restore_user, facility_ids),
     }))


### PR DESCRIPTION
## Product Description

The CSQL fixtures provide a context with a couple of variables. Two of them are arrays. Since CSQL does not have a join function, we need to join them before we set them in the context. That way they can just be used with the selected function.


## Technical Summary

None

## Feature Flag

- USH: Show case counts from CSQL queries as badges on modules

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
