### PR TITLE
Replaced webpack's "commcarehq_b3" dependency with just "commcarehq"

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/widgets.js
+++ b/corehq/apps/accounting/static/accounting/js/widgets.js
@@ -5,7 +5,7 @@ hqDefine('accounting/js/widgets', [
     'underscore',
     'hqwebapp/js/utils/email',
     'select2/dist/js/select2.full.min',
-    'commcarehq_b3',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/auto_update_rules.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/auto_update_rules.js
@@ -6,7 +6,7 @@ hqDefine("data_interfaces/js/auto_update_rules", [
     'analytix/js/google',
     'hqwebapp/js/components/pagination',
     'hqwebapp/js/components/search_box',
-    'commcarehq_b3',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_dedupe_main.js
@@ -6,7 +6,7 @@ hqDefine("data_interfaces/js/case_dedupe_main", [
     'data_interfaces/js/case_property_input',
     'data_interfaces/js/case_rule_criteria',
     'hqwebapp/js/bootstrap3/widgets',
-    'commcarehq_b3',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/case_rule_main.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/case_rule_main.js
@@ -5,7 +5,7 @@ hqDefine("data_interfaces/js/case_rule_main", [
     'data_interfaces/js/case_rule_criteria',
     'data_interfaces/js/case_rule_actions',
     'data_interfaces/js/make_read_only',
-    'commcarehq_b3',
+    'commcarehq',
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/deduplication_rules.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/deduplication_rules.js
@@ -5,7 +5,7 @@ hqDefine("data_interfaces/js/deduplication_rules", [
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/bootstrap3/crud_paginated_list',
     'analytix/js/google',
-    'commcarehq_b3',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/find_by_id.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/find_by_id.js
@@ -5,7 +5,7 @@ hqDefine("data_interfaces/js/find_by_id", [
     'hqwebapp/js/assert_properties',
     'hqwebapp/js/initial_page_data',
     'analytix/js/kissmetrix',
-    'commcarehq_b3',
+    'commcarehq',
 ], function (
     $,
     _,

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/manage_case_groups.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/manage_case_groups.js
@@ -3,7 +3,7 @@ hqDefine("data_interfaces/js/manage_case_groups", [
     'underscore',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/bootstrap3/crud_paginated_list_init',
-    'commcarehq_b3',
+    'commcarehq',
 ], function (
     $,
     _,

--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -7,7 +7,7 @@ hqDefine('domain/js/toggles', [
     'hqwebapp/js/assert_properties',
     'hqwebapp/js/bootstrap3/knockout_bindings.ko',  // for slideVisible
     'hqwebapp/js/bootstrap3/main',
-    'commcarehq_bx',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -7,7 +7,7 @@ hqDefine('domain/js/toggles', [
     'hqwebapp/js/assert_properties',
     'hqwebapp/js/bootstrap3/knockout_bindings.ko',  // for slideVisible
     'hqwebapp/js/bootstrap3/main',
-    'commcarehq_b3',
+    'commcarehq_bx',
 ], function (
     $,
     ko,

--- a/corehq/apps/hqadmin/static/hqadmin/js/admin_restore.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/admin_restore.js
@@ -2,7 +2,7 @@ hqDefine('hqadmin/js/admin_restore',[
     "jquery",
     "hqwebapp/js/base_ace",
     "jquery-treetable/jquery.treetable",
-    "commcarehq_b3",
+    "commcarehq",
 ],function ($, baseAce) {
     $(function () {
         $("#timingTable").treetable();

--- a/corehq/apps/hqadmin/static/hqadmin/js/app_build_timings.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/app_build_timings.js
@@ -1,7 +1,7 @@
 hqDefine('hqadmin/js/app_build_timings', [
     "jquery",
     "jquery-treetable/jquery.treetable",
-    "commcarehq_b3",
+    "commcarehq",
 ], function ($) {
     $(function () {
         $("#timingTable").treetable({

--- a/corehq/apps/hqadmin/static/hqadmin/js/raw_doc.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/raw_doc.js
@@ -3,7 +3,7 @@ hqDefine('hqadmin/js/raw_doc', [
     'underscore',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/base_ace',
-    'commcarehq_b3',
+    'commcarehq',
 ], function ($, _, intialPageData, baseAce) {
     $(function () {
         var allDatabase = intialPageData.get('all_databases').map(function (database) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/crud_paginated_list_init.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/crud_paginated_list_init.js
@@ -3,7 +3,7 @@ hqDefine("hqwebapp/js/bootstrap3/crud_paginated_list_init", [
     "knockout",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap3/crud_paginated_list",
-    "commcarehq_b3",
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/requirejs_config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/requirejs_config.js
@@ -16,7 +16,7 @@ requirejs.config({
         "sentry_captureconsole": "sentry/js/sentry.captureconsole.7.28.0.min",
         "underscore": "underscore/underscore",
         "stripe": "https://js.stripe.com/v2/?noext",
-        "commcarehq_b3": "hqwebapp/js/requirejs_webpack_fake",
+        "commcarehq": "hqwebapp/js/requirejs_webpack_fake",
     },
     shim: {
         "stripe": { exports: 'Stripe' },

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list_init.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list_init.js.diff.txt
@@ -7,7 +7,7 @@
      "knockout",
      "hqwebapp/js/initial_page_data",
 -    "hqwebapp/js/bootstrap3/crud_paginated_list",
--    "commcarehq_b3",
+-    "commcarehq",
 +    "hqwebapp/js/bootstrap5/crud_paginated_list",
  ], function (
      $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -2,21 +2,29 @@
+@@ -2,19 +2,27 @@
  requirejs.config({
      baseUrl: '/static/',
      paths: {
@@ -28,11 +28,8 @@
          "underscore": "underscore/underscore",
 +        "nvd3/nv.d3.latest.min": "nvd3-1.8.6/build/nv.d3.min",
          "stripe": "https://js.stripe.com/v2/?noext",
--        "commcarehq_b3": "hqwebapp/js/requirejs_webpack_fake",
-+        "commcarehq": "hqwebapp/js/requirejs_webpack_fake",
+         "commcarehq": "hqwebapp/js/requirejs_webpack_fake",
      },
-     shim: {
-         "stripe": { exports: 'Stripe' },
 @@ -26,7 +34,6 @@
          "ace-builds/src-min-noconflict/ext-searchbox": { deps: ["ace-builds/src-min-noconflict/ace"] },
          "At.js/dist/js/jquery.atwho": { deps: ['jquery', 'Caret.js/dist/jquery.caret'] },

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/v2/js/views/explore_case_data.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/v2/js/views/explore_case_data.js.diff.txt
@@ -9,7 +9,7 @@
      'reports/v2/js/context',
 -    'reports/v2/js/bootstrap3/datagrid',
 -    'hqwebapp/js/components/bootstrap3/feedback',
--    'commcarehq_b3',
+-    'commcarehq',
 +    'reports/v2/js/bootstrap5/datagrid',
 +    'hqwebapp/js/components/bootstrap5/feedback',
  ], function (

--- a/corehq/apps/prototype/static/prototype/js/webpack/bootstrap3_amd.js
+++ b/corehq/apps/prototype/static/prototype/js/webpack/bootstrap3_amd.js
@@ -5,7 +5,7 @@ hqDefine("prototype/js/webpack/bootstrap3_amd",[
     'knockout',
     'underscore',
     'hqwebapp/js/initial_page_data',
-    "commcarehq_b3",  // IMPORTANT :: this has to be included with any Bootstrap 3 entry point
+    "commcarehq",  // IMPORTANT :: this has to be included with any Bootstrap 3 entry point
 ], function ($, ko, _, initialPageData) {
     /**
      * This is an (HQ)AMD-formatted module, intended to be used with js_entry as follows:
@@ -16,7 +16,7 @@ hqDefine("prototype/js/webpack/bootstrap3_amd",[
      * look like.
      *
      * The most important difference between a requirejs module and a webpack module of this type
-     * is that the webpack module requires that the "commcarehq_b3" dependency is included
+     * is that the webpack module requires that the "commcarehq" dependency is included
      * in the list of dependencies above. Otherwise, everything else should function
      * identically to the requirejs module, provided the appropriate shims are in place
      * in the Webpack config for special dependencies.

--- a/corehq/apps/reports/static/reports/v2/js/views/bootstrap3/explore_case_data.js
+++ b/corehq/apps/reports/static/reports/v2/js/views/bootstrap3/explore_case_data.js
@@ -5,7 +5,7 @@ hqDefine('reports/v2/js/views/bootstrap3/explore_case_data', [
     'reports/v2/js/context',
     'reports/v2/js/bootstrap3/datagrid',
     'hqwebapp/js/components/bootstrap3/feedback',
-    'commcarehq_b3',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/messaging/smsbackends/telerivet/static/telerivet/js/telerivet_setup.js
+++ b/corehq/messaging/smsbackends/telerivet/static/telerivet/js/telerivet_setup.js
@@ -1,7 +1,7 @@
 hqDefine("telerivet/js/telerivet_setup", [
     'knockout',
     'hqwebapp/js/initial_page_data',
-    'commcarehq_b3',
+    'commcarehq',
 ], function (
     ko,
     initialPageData

--- a/docs/js-guide/amd-to-esm.rst
+++ b/docs/js-guide/amd-to-esm.rst
@@ -163,8 +163,7 @@ to
     ...
 
 Note that ``import "commcarehq";`` has been moved to the top of the file. The ordering is
-for consistency purposes, but it's important that either ``import "commcarehq";`` or
-``import "commcarehq_b3";`` (for Bootstrap 3 / ``js_entry_b3``) is present in the list
+for consistency purposes, but it's important that either ``import "commcarehq";`` is present in the list
 of imports for Webpack Entry Point modules. If this import is not present in an entry point,
 then site-wide navigation, notifications, modals, and other global widgets will not
 work on that page.

--- a/docs/js-guide/migrating.rst
+++ b/docs/js-guide/migrating.rst
@@ -137,7 +137,7 @@ module’s encompassing function:
       "jquery",
       "otherApp/js/utils",
       "commcarehq"  // REQUIRED: always list this module that imports all site-level dependencies
-                    // This can be at the end of the list. Use ``commcarehq_b3`` for Bootstrap 3 pages.
+                    // This can be at the end of the list.
    ], function(
       $,
       otherUtils

--- a/docs/js-guide/requirejs-to-webpack.rst
+++ b/docs/js-guide/requirejs-to-webpack.rst
@@ -94,7 +94,7 @@ tag to ``js_entry_b3``, so that the final usage looks like:
 
     {% js_entry_b3 "domain/js/my_project_settings" %}
 
-Then, in the file itself, we add the ``commcarehq_b3`` dependency to the list of dependencies:
+Then, in the file itself, we add the ``commcarehq`` dependency to the list of dependencies:
 
 ::
 
@@ -102,7 +102,7 @@ Then, in the file itself, we add the ``commcarehq_b3`` dependency to the list of
         'jquery',
         'knockout',
         'hqwebapp/js/initial_page_data',
-        'commcarehq_b3',  // <--- dependency added for webpack
+        'commcarehq',  // <--- dependency added for webpack
     ], function (
         $,
         ko,

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
 const path = require('path');
 const fs = require('fs');
-const utils = require('./utils');
 const appPaths = require('./appPaths');
 
 class EntryChunksPlugin {

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 const path = require('path');
 const fs = require('fs');
+const utils = require('./utils');
 const appPaths = require('./appPaths');
 
 class EntryChunksPlugin {

--- a/webpack/webpack.b3.common.js
+++ b/webpack/webpack.b3.common.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 const commonDefault = require("./webpack.common");
+const path = require('path');
 const webpack = require('webpack');
 const utils = require('./utils');
 const hqPlugins = require('./plugins');
@@ -18,6 +19,12 @@ module.exports = Object.assign({}, commonDefault, {
             filename: 'manifest_b3.json',
         }),
     ],
+
+    resolve: {
+        alias: Object.assign({}, commonDefault.resolve.alias, {
+            "commcarehq_bx": path.resolve(utils.getStaticPathForApp('hqwebapp', 'js/bootstrap3/'), 'commcarehq'),
+        }),
+    },
 
     optimization: {
         splitChunks: {

--- a/webpack/webpack.b3.common.js
+++ b/webpack/webpack.b3.common.js
@@ -22,7 +22,7 @@ module.exports = Object.assign({}, commonDefault, {
 
     resolve: {
         alias: Object.assign({}, commonDefault.resolve.alias, {
-            "commcarehq_bx": path.resolve(utils.getStaticPathForApp('hqwebapp', 'js/bootstrap3/'), 'commcarehq'),
+            "commcarehq": path.resolve(utils.getStaticPathForApp('hqwebapp', 'js/bootstrap3/'), 'commcarehq'),
         }),
     },
 

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -7,8 +7,6 @@ const hqPlugins = require('./plugins');
 const aliases = {
     "commcarehq": path.resolve(utils.getStaticPathForApp('hqwebapp', 'js/bootstrap5/'),
         'commcarehq'),
-    "commcarehq_b3": path.resolve(utils.getStaticPathForApp('hqwebapp', 'js/bootstrap3/'),
-        'commcarehq'),
     "jquery": "jquery/dist/jquery.min",
 
     // todo after completing requirejs migration,


### PR DESCRIPTION
## Technical Summary
Use `commcarehq` as the main, bootstrap-including dependency for all webpack pages, instead of using `commcarehq` for B5 and `commcarehq_b3` for B3 pages. This allows a single module using webpack to be used on both B3 and B5 pages, which reduces the number of js files that need to be split into a B3 and a B5 version.

## Safety Assurance

### Safety story
Changing the webpack config seems potentially risky, but relatively few pages on HQ are using webpack live in prod: see [this PR](https://github.com/dimagi/commcare-hq/pull/35305) that migrated a bunch of internal and flagged UIs, and [this PR](https://github.com/dimagi/commcare-hq/pull/35239) that migrated most of data_interfaces.

I've smoke tested the following pages on staging:
* Webpack + B3: messaging > case groups
* Webpack + B5: inbound API config
* RequireJS + B3: mobile workers
* RequireJS + B5: dashboard

### Automated test coverage

no

### QA Plan

not requesting QA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
