### PR TITLE
Fix attribute error when export auditcare

### DIFF
--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -1,5 +1,5 @@
 import csv
-from datetime import datetime, timedelta
+from datetime import timedelta
 from itertools import chain
 
 from django.contrib.auth.models import User
@@ -22,9 +22,6 @@ def navigation_events_by_user(user, start_date=None, end_date=None):
 
 
 def write_log_events(writer, user, domain=None, override_user=None, start_date=None, end_date=None):
-    start_date = string_to_datetime(start_date).replace(tzinfo=None) if start_date else None
-    end_date = string_to_datetime(end_date).replace(tzinfo=None) if end_date else None
-
     for event in navigation_events_by_user(user, start_date, end_date):
         if not domain or domain == event.domain:
             write_log_event(writer, event, override_user)
@@ -138,9 +135,11 @@ def get_date_range_where(start_date, end_date):
     """Get ORM filter kwargs for inclusive event_date range"""
     where = {}
     if start_date:
-        where["event_date__gt"] = start_date.date()
+        start_date = string_to_datetime(start_date).replace(tzinfo=None)
+        where["event_date__gt"] = start_date
     if end_date:
-        where["event_date__lt"] = end_date.date() + timedelta(days=1)
+        end_date = string_to_datetime(end_date).replace(tzinfo=None)
+        where["event_date__lt"] = end_date + timedelta(days=1)
     return where
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
I was asked to fulfill this request in this ticket: https://dimagi.atlassian.net/browse/SAAS-16225

I noticed we already have some management commands in auditcare app so plan to reuse it to generate report for the customer, but when I call export_domain_logins, I encountered [AttributeError](https://dimagi.sentry.io/issues/6057832945/)

`get_date_range_where` is expecting `datetime` object while we passed `datetime.date`. This is [because both start_date and end_date has date_type](https://github.com/dimagi/commcare-hq/blob/cff71258616ce62b5ff838b357a6e90972065c36/corehq/apps/auditcare/management/commands/export_domain_logins.py#L36-L39). Definition for date_type [here](https://github.com/dimagi/commcare-hq/blob/2002b522c3529d793f094b01b07857ab7fed2f5b/corehq/util/argparse_types.py#L15-L22), which always return `datetime.date`

Biyeun made a fix for `generate_request_report` command to convert them to `datetime` in https://github.com/dimagi/commcare-hq/pull/29957/commits/f4df3b3ff66de6205caf4d85686aed2e34b0ae10

I'm moving this fix to `get_date_range_where`, making it flexible to accept either `datetime.date` or `datetime` object

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This PR just moves an existing fix to two levels down so it can be used by other methods who called this method.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
