### PR TITLE
Disable toggles on domain deletion

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -266,6 +266,14 @@ def _delete_sms_content_events_schedules(domain_name):
     ])
 
 
+def _disable_toggles(domain_name):
+    from corehq.toggles import NAMESPACE_DOMAIN, toggles_enabled_for_domain
+    from corehq.toggles.shortcuts import set_toggle
+
+    for slug in toggles_enabled_for_domain(domain_name):
+        set_toggle(slug, domain_name, False, NAMESPACE_DOMAIN)
+
+
 def _delete_django_users(domain_name):
     total, counts = User.objects.filter(
         username__contains=f"@{domain_name}.{HQ_ACCOUNT_ROOT}"
@@ -433,6 +441,7 @@ DOMAIN_DELETE_OPERATIONS = [
     ModelDeletion('reports', 'TableauUser', 'server__domain'),
     ModelDeletion('reports', 'QueryStringHash', 'domain'),
     ModelDeletion('smsforms', 'SQLXFormsSession', 'domain'),
+    CustomDeletion('toggles', _disable_toggles, []),
     ModelDeletion('translations', 'TransifexOrganization', 'transifexproject__domain'),
     ModelDeletion('translations', 'SMSTranslations', 'domain'),
     ModelDeletion('translations', 'TransifexBlacklist', 'domain'),

--- a/corehq/apps/domain/management/commands/disable_toggles_for_deleted_domains.py
+++ b/corehq/apps/domain/management/commands/disable_toggles_for_deleted_domains.py
@@ -37,7 +37,6 @@ class Command(BaseCommand):
             else:
                 domains = find_domains_with_toggle_enabled(toggle)
 
-            print(f"Toggle {toggle.slug}, {len(domains)} domains")
             for domain in domains:
                 if domain not in domain_existence:
                     domain_existence[domain] = bool(Domain.get_by_name(domain))


### PR DESCRIPTION
## Technical Summary
As discussed in cross-divisional dev owners meeting: when a domain is deleted, disable any toggles it's using.

## Safety Assurance

### Safety story
The test coverage in this PR is an appropriate safety check for this change.

### Automated test coverage

Test added in this PR.

### QA Plan

Not requesting QA.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
