### PR TITLE
[webpack] migrate easy, higher-visibility apps

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_exchange.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_exchange.js
@@ -4,6 +4,7 @@ hqDefine("app_manager/js/app_exchange", [
     "knockout",
     'analytix/js/kissmetrix',
     "hqwebapp/js/bootstrap3/widgets",  // hqwebapp-select2 for versions
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/app_manager/static/app_manager/js/download_index_main.js
+++ b/corehq/apps/app_manager/static/app_manager/js/download_index_main.js
@@ -8,6 +8,7 @@ hqDefine('app_manager/js/download_index_main',[
     'app_manager/js/multimedia_size_util',
     'app_manager/js/download_async_modal',
     'app_manager/js/source_files',
+    'commcarehq',
 ], function ($, _, ko, baseAce, initialPageData, multimediaSizeUtil) {
     $(function () {
         var elements = $('.prettyprint');

--- a/corehq/apps/app_manager/static/app_manager/js/source_files.js
+++ b/corehq/apps/app_manager/static/app_manager/js/source_files.js
@@ -5,6 +5,7 @@ hqDefine('app_manager/js/source_files', [
     'hqwebapp/js/initial_page_data',
     'app_manager/js/multimedia_size_util',
     'app_manager/js/widgets',       // version dropdown
+    'commcarehq',
 ], function ($, _, ko, initialPageData, multimediaSizeUtil) {
     $(function () {
         $('.toggle-next').click(function (e) {

--- a/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
@@ -8,6 +8,7 @@ hqDefine('app_manager/js/summary/case_summary',[
     'app_manager/js/menu',  // enable lang switcher and "Updates to publish" banner
     'hqwebapp/js/bootstrap3/knockout_bindings.ko', // popover
     'hqwebapp/js/components/search_box',
+    'commcarehq',
 ], function ($, _, ko, initialPageData, assertProperties, models) {
 
     var caseTypeModel = function (caseType) {

--- a/corehq/apps/app_manager/static/app_manager/js/summary/form_diff.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/form_diff.js
@@ -11,6 +11,7 @@ hqDefine('app_manager/js/summary/form_diff',[
     'app_manager/js/menu',  // enable lang switcher and "Updates to publish" banner
     'hqwebapp/js/bootstrap3/knockout_bindings.ko', // popover
     'hqwebapp/js/components/search_box',
+    'commcarehq',
 ], function ($, _, ko, initialPageData, assertProperties, models, formModels, utils, layout) {
 
     $(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/summary/form_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/form_summary.js
@@ -10,6 +10,7 @@ hqDefine('app_manager/js/summary/form_summary',[
     'app_manager/js/menu',  // enable lang switcher and "Updates to publish" banner
     'hqwebapp/js/bootstrap3/knockout_bindings.ko', // popover
     'hqwebapp/js/components/search_box',
+    'commcarehq',
 ], function ($, _, ko, initialPageData, assertProperties, models, formModels, utils) {
     $(function () {
         var lang = initialPageData.get('lang'),

--- a/corehq/apps/app_manager/templates/app_manager/app_diff.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_diff.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load compress %}
 {% load i18n %}
-{% requirejs_main 'app_manager/js/source_files' %}
+{% js_entry_b3 'app_manager/js/source_files' %}
 {% block stylesheets %}{{ block.super }}
   {% compress css %}
     <link type="text/css" rel="stylesheet" href="{% static 'app_manager/css/diff.css' %}"/>

--- a/corehq/apps/app_manager/templates/app_manager/app_exchange.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_exchange.html
@@ -5,7 +5,7 @@
 
 {% block title %}{% trans "COVID-19 CommCare Applications" %}{% endblock title %}
 
-{% requirejs_main 'app_manager/js/app_exchange' %}
+{% js_entry_b3 'app_manager/js/app_exchange' %}
 
 {% block content %}
 <div class="container" id="hq-content">

--- a/corehq/apps/app_manager/templates/app_manager/case_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/case_summary.html
@@ -4,7 +4,7 @@
 
 {% block title %}{% trans "Case Summary" %} - {% trans "Version" %} {{ app_version }}{% endblock %}
 
-{% requirejs_main 'app_manager/js/summary/case_summary' %}
+{% js_entry_b3 'app_manager/js/summary/case_summary' %}
 
 {% block content_extra %}
   <div class="ko-template" id="case-summary-header">

--- a/corehq/apps/app_manager/templates/app_manager/download_index.html
+++ b/corehq/apps/app_manager/templates/app_manager/download_index.html
@@ -2,8 +2,8 @@
 {% load hq_shared_tags %}
 {% load compress %}
 {% load i18n %}
-{% requirejs_main 'app_manager/js/download_index_main' %}
 
+{% js_entry_b3 'app_manager/js/download_index_main' %}
 
 {% block page_title %}
   {{ app.name }}: Build #{{ app.version }}{% if app.build_comment %}: {{ app.build_comment }}{% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/form_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary.html
@@ -8,7 +8,7 @@
   {% endblocktrans %}
 {% endblock %}
 
-{% requirejs_main "app_manager/js/summary/form_summary" %}
+{% js_entry_b3 "app_manager/js/summary/form_summary" %}
 
 {% block content_extra %}
   {% initial_page_data 'errors' errors %}

--- a/corehq/apps/app_manager/templates/app_manager/form_summary_diff.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary_diff.html
@@ -8,7 +8,7 @@
   {% endblocktrans %}
 {% endblock %}
 
-{% requirejs_main "app_manager/js/summary/form_diff" %}
+{% js_entry_b3 "app_manager/js/summary/form_diff" %}
 
 {% block content_extra %}
   {% registerurl 'form_source' domain app_id '---' %}

--- a/corehq/apps/case_search/static/case_search/js/case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/case_search.js
@@ -6,6 +6,7 @@ hqDefine('case_search/js/case_search', [
     'knockout',
     'hqwebapp/js/bootstrap5/alert_user',
     'hqwebapp/js/initial_page_data',
+    'commcarehq',
 ], function (
     $,
     _,

--- a/corehq/apps/case_search/static/case_search/js/profile_case_search.js
+++ b/corehq/apps/case_search/static/case_search/js/profile_case_search.js
@@ -5,6 +5,7 @@ hqDefine('case_search/js/profile_case_search', [
     'underscore',
     'knockout',
     'hqwebapp/js/bootstrap5/alert_user',
+    'commcarehq',
 ], function (
     $,
     _,

--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -3,7 +3,7 @@
 {% load compress %}
 {% load i18n %}
 
-{% requirejs_main_b5 'case_search/js/case_search' %}
+{% js_entry 'case_search/js/case_search' %}
 
 {% block page_content %}
   {% registerurl 'case_data' request.domain '___' %}

--- a/corehq/apps/case_search/templates/case_search/profile_case_search.html
+++ b/corehq/apps/case_search/templates/case_search/profile_case_search.html
@@ -3,7 +3,7 @@
 {% load compress %}
 {% load i18n %}
 
-{% requirejs_main_b5 'case_search/js/profile_case_search' %}
+{% js_entry 'case_search/js/profile_case_search' %}
 
 {% block page_content %}
 

--- a/corehq/apps/email/static/email/js/email_settings.js
+++ b/corehq/apps/email/static/email/js/email_settings.js
@@ -1,6 +1,7 @@
 hqDefine('email/js/email_settings', [
     "knockout",
     "jquery",
+    "commcarehq",
 ], function (ko, $) {
 
     function initFormBindings() {

--- a/corehq/apps/email/templates/email/email_settings.html
+++ b/corehq/apps/email/templates/email/email_settings.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main 'email/js/email_settings' %}
+{% js_entry_b3 'email/js/email_settings' %}
 
 {% block page_content %}
 

--- a/corehq/apps/geospatial/static/geospatial/js/geo_config.js
+++ b/corehq/apps/geospatial/static/geospatial/js/geo_config.js
@@ -5,6 +5,7 @@ hqDefine("geospatial/js/geo_config", [
     "knockout",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap3/alert_user",
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/geospatial/templates/geospatial/settings.html
+++ b/corehq/apps/geospatial/templates/geospatial/settings.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main 'geospatial/js/geo_config' %}
+{% js_entry_b3 'geospatial/js/geo_config' %}
 
 {% block page_content %}
 {% initial_page_data 'config' config %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list_init.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list_init.js
@@ -3,6 +3,7 @@ hqDefine("hqwebapp/js/bootstrap5/crud_paginated_list_init", [
     "knockout",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap5/crud_paginated_list",
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bulk_upload_file.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bulk_upload_file.js
@@ -1,6 +1,7 @@
 hqDefine("hqwebapp/js/bulk_upload_file", [
     "jquery",
     "knockout",
+    "commcarehq",
 ], function (
     $,
     ko

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list_init.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list_init.js.diff.txt
@@ -1,14 +1,13 @@
 --- 
 +++ 
-@@ -1,9 +1,8 @@
+@@ -1,8 +1,8 @@
 -hqDefine("hqwebapp/js/bootstrap3/crud_paginated_list_init", [
 +hqDefine("hqwebapp/js/bootstrap5/crud_paginated_list_init", [
      "jquery",
      "knockout",
      "hqwebapp/js/initial_page_data",
 -    "hqwebapp/js/bootstrap3/crud_paginated_list",
--    "commcarehq",
 +    "hqwebapp/js/bootstrap5/crud_paginated_list",
+     "commcarehq",
  ], function (
      $,
-     ko,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/form_data_main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/form_data_main.js.diff.txt
@@ -8,5 +8,5 @@
 -    "reports/js/bootstrap3/single_form",
 +    "reports/js/bootstrap5/single_form",
      "analytix/js/kissmetrix",
+     "commcarehq",
  ], function (
-     $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/reportdata/form_data.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/reportdata/form_data.html.diff.txt
@@ -10,8 +10,8 @@
    <link rel="stylesheet" type="text/css" href="{% static "hqwebapp/css/proptable.css" %}">
  {% endblock %}
  
--{% requirejs_main 'reports/js/bootstrap3/form_data_main' %}
-+{% requirejs_main_b5 'reports/js/bootstrap5/form_data_main' %}
+-{% js_entry_b3 'reports/js/bootstrap3/form_data_main' %}
++{% js_entry 'reports/js/bootstrap5/form_data_main' %}
  
  {% block title %}Form: {{ form_name }} {% if form_received_on %} ({{ form_received_on|to_user_time:request }}){% endif %}{% endblock %}
  

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/tableau_visualization.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/tableau_visualization.html.diff.txt
@@ -6,8 +6,8 @@
  {% load i18n %}
  {% load hq_shared_tags %}
  
--{% requirejs_main "hqwebapp/js/bootstrap3/crud_paginated_list_init" %}
-+{% requirejs_main_b5 "hqwebapp/js/bootstrap5/crud_paginated_list_init" %}
+-{% js_entry "hqwebapp/js/bootstrap3/crud_paginated_list_init" %}
++{% js_entry "hqwebapp/js/bootstrap5/crud_paginated_list_init" %}
  
  {% block pagination_header %}
    <h2>{% trans "Tableau Visualizations" %}</h2>

--- a/corehq/apps/reports/static/reports/js/bootstrap3/form_data_main.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/form_data_main.js
@@ -3,6 +3,7 @@ hqDefine("reports/js/bootstrap3/form_data_main", [
     "hqwebapp/js/initial_page_data",
     "reports/js/bootstrap3/single_form",
     "analytix/js/kissmetrix",
+    "commcarehq",
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/reports/static/reports/js/bootstrap5/form_data_main.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/form_data_main.js
@@ -3,6 +3,7 @@ hqDefine("reports/js/bootstrap5/form_data_main", [
     "hqwebapp/js/initial_page_data",
     "reports/js/bootstrap5/single_form",
     "analytix/js/kissmetrix",
+    "commcarehq",
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/reports/templates/reports/bootstrap3/tableau_visualization.html
+++ b/corehq/apps/reports/templates/reports/bootstrap3/tableau_visualization.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "hqwebapp/js/bootstrap3/crud_paginated_list_init" %}
+{% js_entry "hqwebapp/js/bootstrap3/crud_paginated_list_init" %}
 
 {% block pagination_header %}
   <h2>{% trans "Tableau Visualizations" %}</h2>

--- a/corehq/apps/reports/templates/reports/bootstrap5/tableau_visualization.html
+++ b/corehq/apps/reports/templates/reports/bootstrap5/tableau_visualization.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main_b5 "hqwebapp/js/bootstrap5/crud_paginated_list_init" %}
+{% js_entry "hqwebapp/js/bootstrap5/crud_paginated_list_init" %}
 
 {% block pagination_header %}
   <h2>{% trans "Tableau Visualizations" %}</h2>

--- a/corehq/apps/reports/templates/reports/reportdata/bootstrap3/form_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/bootstrap3/form_data.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" type="text/css" href="{% static "hqwebapp/css/proptable.css" %}">
 {% endblock %}
 
-{% requirejs_main 'reports/js/bootstrap3/form_data_main' %}
+{% js_entry_b3 'reports/js/bootstrap3/form_data_main' %}
 
 {% block title %}Form: {{ form_name }} {% if form_received_on %} ({{ form_received_on|to_user_time:request }}){% endif %}{% endblock %}
 

--- a/corehq/apps/reports/templates/reports/reportdata/bootstrap5/form_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/bootstrap5/form_data.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" type="text/css" href="{% static "hqwebapp/css/proptable.css" %}">
 {% endblock %}
 
-{% requirejs_main_b5 'reports/js/bootstrap5/form_data_main' %}
+{% js_entry 'reports/js/bootstrap5/form_data_main' %}
 
 {% block title %}Form: {{ form_name }} {% if form_received_on %} ({{ form_received_on|to_user_time:request }}){% endif %}{% endblock %}
 

--- a/corehq/apps/settings/static/settings/js/edit_my_account.js
+++ b/corehq/apps/settings/static/settings/js/edit_my_account.js
@@ -1,6 +1,7 @@
 hqDefine('settings/js/edit_my_account', [
     'jquery',
     'select2/dist/js/select2.full.min',
+    'commcarehq',
 ], function (
     $
 ) {

--- a/corehq/apps/settings/templates/settings/edit_my_account.html
+++ b/corehq/apps/settings/templates/settings/edit_my_account.html
@@ -4,7 +4,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'settings/js/edit_my_account' %}
+{% js_entry 'settings/js/edit_my_account' %}
 
 {% block modals %}{{ block.super }}
   {% if user_type == 'web' %}

--- a/corehq/apps/sms/static/sms/js/add_gateway.js
+++ b/corehq/apps/sms/static/sms/js/add_gateway.js
@@ -3,6 +3,7 @@ hqDefine('sms/js/add_gateway',[
     "underscore",
     "hqwebapp/js/initial_page_data",
     "sms/js/add_gateway_form_handler",
+    "commcarehq",
 ], function ($, _, initialPageData,addGatewayFormHandler) {
     function addParam($widget, count, nm, val) {
         $widget.append('<tr> \

--- a/corehq/apps/sms/static/sms/js/backend_map.js
+++ b/corehq/apps/sms/static/sms/js/backend_map.js
@@ -3,6 +3,7 @@ hqDefine('sms/js/backend_map',[
     "jquery",
     "knockout",
     "hqwebapp/js/initial_page_data",
+    "commcarehq",
 ], function (_, $, ko, initialPageData) {
     function backendMapping(prefix, backendId) {
         'use strict';

--- a/corehq/apps/sms/static/sms/js/compose.js
+++ b/corehq/apps/sms/static/sms/js/compose.js
@@ -3,6 +3,7 @@ hqDefine("sms/js/compose",[
     "hqwebapp/js/initial_page_data",
     'jquery-ui/ui/widgets/sortable',
     "hqwebapp/js/bootstrap-multi-typeahead",
+    "commcarehq",
 ], function ($, intialPageData) {
     $(function () {
         $("#hint_id_recipients").addClass("alert alert-info");

--- a/corehq/apps/sms/static/sms/js/gateway_list.js
+++ b/corehq/apps/sms/static/sms/js/gateway_list.js
@@ -1,6 +1,7 @@
 hqDefine("sms/js/gateway_list", [
     "hqwebapp/js/bootstrap3/crud_paginated_list_init",
     "hqwebapp/js/bootstrap3/widgets",
+    "commcarehq",
 ], function () {
     // No page-specific logic, just need to collect the dependencies above
 });

--- a/corehq/apps/sms/static/sms/js/settings.js
+++ b/corehq/apps/sms/static/sms/js/settings.js
@@ -6,6 +6,7 @@ hqDefine("sms/js/settings", [
     'hqwebapp/js/components/select_toggle',
     'bootstrap-timepicker/js/bootstrap-timepicker',
     'hqwebapp/js/bootstrap3/widgets', //multi-emails
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/sms/templates/sms/add_gateway.html
+++ b/corehq/apps/sms/templates/sms/add_gateway.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main 'sms/js/add_gateway' %}
+{% js_entry_b3 'sms/js/add_gateway' %}
 
 {% block page_content %}
   {% initial_page_data 'give_other_domains_access' form.give_other_domains_access.value %}

--- a/corehq/apps/sms/templates/sms/backend_map.html
+++ b/corehq/apps/sms/templates/sms/backend_map.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main "sms/js/backend_map" %}
+{% js_entry_b3 "sms/js/backend_map" %}
 
 {% block page_content %}
   {% initial_page_data 'form.backend_map' form.backend_map.value %}

--- a/corehq/apps/sms/templates/sms/compose.html
+++ b/corehq/apps/sms/templates/sms/compose.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main "sms/js/compose" %}
+{% js_entry_b3 "sms/js/compose" %}
 
 {% block page_content %}
   {% initial_page_data 'sms_contacts' sms_contacts %}

--- a/corehq/apps/sms/templates/sms/gateway_list.html
+++ b/corehq/apps/sms/templates/sms/gateway_list.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main "sms/js/gateway_list" %}
+{% js_entry_b3 "sms/js/gateway_list" %}
 
 {% block pagination_header %}
 

--- a/corehq/apps/sms/templates/sms/global_gateway_list.html
+++ b/corehq/apps/sms/templates/sms/global_gateway_list.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main "sms/js/gateway_list" %}
+{% js_entry_b3 "sms/js/gateway_list" %}
 
 {% block pagination_footer %}
   <div class="help-block">

--- a/corehq/apps/sms/templates/sms/settings.html
+++ b/corehq/apps/sms/templates/sms/settings.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main 'sms/js/settings' %}
+{% js_entry_b3 'sms/js/settings' %}
 
 {% block stylesheets %}
   <style>

--- a/corehq/apps/sso/static/sso/js/edit_identity_provider.js
+++ b/corehq/apps/sso/static/sso/js/edit_identity_provider.js
@@ -5,6 +5,7 @@ hqDefine('sso/js/edit_identity_provider', [
     'hqwebapp/js/utils/email',
     "hqwebapp/js/initial_page_data",
     'sso/js/models',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/sso/static/sso/js/new_identity_provider.js
+++ b/corehq/apps/sso/static/sso/js/new_identity_provider.js
@@ -3,6 +3,7 @@ hqDefine('sso/js/new_identity_provider', [
     'knockout',
     'accounting/js/widgets',
     'hqwebapp/js/initial_page_data',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/sso/templates/sso/accounting_admin/edit_identity_provider.html
+++ b/corehq/apps/sso/templates/sso/accounting_admin/edit_identity_provider.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'sso/js/edit_identity_provider' %}
+{% js_entry_b3 'sso/js/edit_identity_provider' %}
 
 {% block page_content %}
   {% initial_page_data 'idp_slug' idp_slug %}

--- a/corehq/apps/sso/templates/sso/accounting_admin/new_identity_provider.html
+++ b/corehq/apps/sso/templates/sso/accounting_admin/new_identity_provider.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'sso/js/new_identity_provider' %}
+{% js_entry_b3 'sso/js/new_identity_provider' %}
 
 {% block page_content %}
   {% initial_page_data 'idp_types_by_protocol' idp_types_by_protocol|JSON %}

--- a/corehq/apps/users/static/users/js/bulk_lookup.js
+++ b/corehq/apps/users/static/users/js/bulk_lookup.js
@@ -1,6 +1,7 @@
 hqDefine("users/js/bulk_lookup", [
     "jquery",
     "hqwebapp/js/bulk_upload_file",
+    "commcarehq",
 ], function (
     $
 ) {

--- a/corehq/apps/users/static/users/js/enterprise_users.js
+++ b/corehq/apps/users/static/users/js/enterprise_users.js
@@ -12,6 +12,7 @@ hqDefine("users/js/enterprise_users", [
     "users/js/web_users_list",
     "hqwebapp/js/components/pagination",
     "hqwebapp/js/components/search_box",
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/users/static/users/js/roles_and_permissions.js
+++ b/corehq/apps/users/static/users/js/roles_and_permissions.js
@@ -5,6 +5,7 @@ hqDefine("users/js/roles_and_permissions",[
     "hqwebapp/js/initial_page_data",
     'users/js/roles',
     'hqwebapp/js/bootstrap3/knockout_bindings.ko', // for roles modal
+    'commcarehq',
 ], function ($, ko, _, initialPageData, userRoles) {
 
     ko.bindingHandlers.permissionIcon = {

--- a/corehq/apps/users/static/users/js/web_users.js
+++ b/corehq/apps/users/static/users/js/web_users.js
@@ -12,6 +12,7 @@ hqDefine("users/js/web_users",[
     'hqwebapp/js/components/pagination',
     'hqwebapp/js/components/search_box',
     'hqwebapp/js/bootstrap3/knockout_bindings.ko', // for modals
+    'commcarehq',
 ], function ($, ko, _, moment, assertProperties, initialPageData, webUsersList) {
 
     /* Web Users panel */

--- a/corehq/apps/users/templates/users/bulk_clear.html
+++ b/corehq/apps/users/templates/users/bulk_clear.html
@@ -4,7 +4,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'hqwebapp/js/bulk_upload_file' %}
+{% js_entry_b3 'hqwebapp/js/bulk_upload_file' %}
 
 {% block page_content %}
   {% blocktrans %}

--- a/corehq/apps/users/templates/users/bulk_delete.html
+++ b/corehq/apps/users/templates/users/bulk_delete.html
@@ -4,7 +4,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'hqwebapp/js/bulk_upload_file' %}
+{% js_entry_b3 'hqwebapp/js/bulk_upload_file' %}
 
 {% block page_content %}
   {% blocktrans %}

--- a/corehq/apps/users/templates/users/bulk_lookup.html
+++ b/corehq/apps/users/templates/users/bulk_lookup.html
@@ -4,7 +4,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'users/js/bulk_lookup' %}
+{% js_entry_b3 'users/js/bulk_lookup' %}
 
 {% block page_content %}
   {% blocktrans %}

--- a/corehq/apps/users/templates/users/enterprise_users.html
+++ b/corehq/apps/users/templates/users/enterprise_users.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'users/js/enterprise_users' %}
+{% js_entry_b3 'users/js/enterprise_users' %}
 
 {% block page_content %}
   {% registerurl "paginate_enterprise_users" domain %}

--- a/corehq/apps/users/templates/users/extra_users_confirm_billing.html
+++ b/corehq/apps/users/templates/users/extra_users_confirm_billing.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main 'accounting/js/widgets' %}
+{% js_entry_b3 'accounting/js/widgets' %}
 
 {% block page_content %}
   <div class="alert alert-info">

--- a/corehq/apps/users/templates/users/roles_and_permissions.html
+++ b/corehq/apps/users/templates/users/roles_and_permissions.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'users/js/roles_and_permissions' %}
+{% js_entry_b3 'users/js/roles_and_permissions' %}
 {% block page_content %}
   {% registerurl "post_user_role" domain %}
   {% registerurl "delete_user_role" domain %}

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'users/js/web_users' %}
+{% js_entry_b3 'users/js/web_users' %}
 
 {% block page_content %}
   {% initial_page_data "invitations" invitations %}


### PR DESCRIPTION
## Technical Summary
Similar to https://github.com/dimagi/commcare-hq/pull/35305, this handles a handful of apps/pages that are trivial to migrate.

## Safety Assurance

### Safety story
It's still early in the migration, so there' still risk of the unknown. I've smoke tested all of these pages on staging.

### Automated test coverage

not really

### QA Plan

not requesting QA

### Rollback instructions

This PR **can** be reverted, but since it touches so many apps, if there are issues with a particular page/app it'd be better to roll back only the relevant commit. If reverting, it's a good idea to run `yarn build` to verify no problems were introduced in the webpack build (otherwise, problems will cause deploy to fail).

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
