### PR TITLE
Filter out Paused subscriptions after ensuring full coverage during invoicing

### DIFF
--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import patch
 
 from corehq.apps.accounting.invoicing import (
     CustomerAccountInvoiceFactory,
@@ -136,9 +137,10 @@ class TestDomainInvoiceFactory(BaseAccountingTest):
             self.account, self.domain.name, paused_plan,
             date_start=self.invoice_start,
             date_end=self.invoice_end + datetime.timedelta(days=1),
-
         )
-        self.assertListEqual(self.invoice_factory._get_subscriptions(), [])
+        with patch.object(self.invoice_factory, '_create_invoice_for_subscription') as mock_create_invoice:
+            self.invoice_factory.create_invoices()
+            mock_create_invoice.assert_not_called()
 
 
 class TestInvoicingMethods(BaseAccountingTest):

--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -1,5 +1,4 @@
 import datetime
-from unittest.mock import patch
 
 from corehq.apps.accounting.invoicing import (
     CustomerAccountInvoiceFactory,
@@ -9,6 +8,7 @@ from corehq.apps.accounting.invoicing import (
 from corehq.apps.accounting.models import (
     BillingAccount,
     DefaultProductPlan,
+    DomainUserHistory,
     SoftwarePlanEdition,
     Subscription,
 )
@@ -126,21 +126,39 @@ class TestDomainInvoiceFactory(BaseAccountingTest):
         community_ranges = self.invoice_factory._get_community_ranges(subscriptions)
         self.assertEqual(community_ranges, [(self.invoice_start, self.invoice_end + datetime.timedelta(days=1))])
 
+    def test_community_plan_generates_invoice(self):
+        """
+        Ensure that Community plans can generate invoices.
+        """
+        community_plan = DefaultProductPlan.get_default_plan_version()
+        subscription = Subscription.new_domain_subscription(
+            self.account, self.domain.name, community_plan,
+            date_start=self.invoice_start,
+            date_end=self.invoice_end + datetime.timedelta(days=1),
+        )
+        DomainUserHistory.objects.create(
+            domain=self.domain.name, record_date=self.invoice_end, num_users=10)
+
+        self.invoice_factory.create_invoices()
+        invoice_count = subscription.invoice_set.count()
+        self.assertEqual(invoice_count, 1)
+
     def test_paused_plan_generates_no_invoice(self):
         """
-        Ensure that paused plans do not generate invoices.
+        Ensure that Paused plans do not generate invoices.
         """
         paused_plan = generator.subscribable_plan_version(
             edition=SoftwarePlanEdition.PAUSED
         )
-        Subscription.new_domain_subscription(
+        subscription = Subscription.new_domain_subscription(
             self.account, self.domain.name, paused_plan,
             date_start=self.invoice_start,
             date_end=self.invoice_end + datetime.timedelta(days=1),
         )
-        with patch.object(self.invoice_factory, '_create_invoice_for_subscription') as mock_create_invoice:
-            self.invoice_factory.create_invoices()
-            mock_create_invoice.assert_not_called()
+
+        self.invoice_factory.create_invoices()
+        invoice_count = subscription.invoice_set.count()
+        self.assertEqual(invoice_count, 0)
 
 
 class TestInvoicingMethods(BaseAccountingTest):


### PR DESCRIPTION
## Technical Summary
[SAAS-16023](https://dimagi.atlassian.net/browse/SAAS-16023)
Fixes a bug where unnecessary extra subscriptions and charges could be created. Because Paused plans were not returned by `_get_subscriptions`, `_ensure_full_coverage` would incorrectly see a Paused plan subscription as a gap in coverage, retroactively applying a Community subscription for the time period.

## Safety Assurance

### Safety story
Tested locally to see that a Community subscription and related charges are _not_ applied for periods with a Paused subscription active, and that paused partial-month subscriptions invoice correctly (e.g., a Standard subscription paused on the 15th of a month would show invoice charges for the 1st - 15th of that month only). There is also good automated test coverage in this area.

### Automated test coverage
Coverage in `TestDomainInvoiceFactory` and specifically the `test_x_coverage` test cases.
Updated `test_paused_plan_generates_no_invoice` to see explicitly that the method that creates an invoice for a subscription _is not called_ when there is only a Paused subscription - previously it checked that Paused subscriptions _were not returned_ by the `_get_subscriptions` helper method.

### QA Plan
Not planning QA, but could see an argument for it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16023]: https://dimagi.atlassian.net/browse/SAAS-16023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ