### PR TITLE
Use --strip-extras when compiling requirements

### DIFF
--- a/requirements/Makefile
+++ b/requirements/Makefile
@@ -2,29 +2,29 @@
 
 requirements: export CUSTOM_COMPILE_COMMAND=`make requirements` or `make upgrade-requirements`
 requirements:
-	pip-compile -qo requirements.txt requirements.in --allow-unsafe
-	pip-compile -qo prod-requirements.txt prod-requirements.in --allow-unsafe
-	pip-compile -qo test-requirements.txt test-requirements.in --allow-unsafe
-	pip-compile -qo dev-requirements.txt dev-requirements.in --allow-unsafe
-	pip-compile -qo docs-requirements.txt docs-requirements.in --allow-unsafe
+	pip-compile -qo requirements.txt requirements.in --allow-unsafe --strip-extras
+	pip-compile -qo prod-requirements.txt prod-requirements.in --allow-unsafe --strip-extras
+	pip-compile -qo test-requirements.txt test-requirements.in --allow-unsafe --strip-extras
+	pip-compile -qo dev-requirements.txt dev-requirements.in --allow-unsafe --strip-extras
+	pip-compile -qo docs-requirements.txt docs-requirements.in --allow-unsafe --strip-extras
 	python ../scripts/purge-platform-pkgs.py ./*requirements.txt
 
 upgrade-requirements: export CUSTOM_COMPILE_COMMAND=`make requirements` or `make upgrade-requirements`
 upgrade-requirements:
-	pip-compile --upgrade -qo requirements.txt requirements.in --allow-unsafe
-	pip-compile --upgrade -qo prod-requirements.txt prod-requirements.in --allow-unsafe
-	pip-compile --upgrade -qo test-requirements.txt test-requirements.in --allow-unsafe
-	pip-compile --upgrade -qo dev-requirements.txt dev-requirements.in --allow-unsafe
-	pip-compile --upgrade -qo docs-requirements.txt docs-requirements.in --allow-unsafe
+	pip-compile --upgrade -qo requirements.txt requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade -qo prod-requirements.txt prod-requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade -qo test-requirements.txt test-requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade -qo dev-requirements.txt dev-requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade -qo docs-requirements.txt docs-requirements.in --allow-unsafe --strip-extras
 	python ../scripts/purge-platform-pkgs.py ./*requirements.txt
 
 # To upgrade a specific package to latest version use this command
 # make upgrade-package package={package_name}
 upgrade-package: export CUSTOM_COMPILE_COMMAND=`make requirements` or `make upgrade-requirements`
 upgrade-package:
-	pip-compile --upgrade-package $(package) -qo requirements.txt requirements.in --allow-unsafe
-	pip-compile --upgrade-package $(package) -qo prod-requirements.txt prod-requirements.in --allow-unsafe
-	pip-compile --upgrade-package $(package) -qo test-requirements.txt test-requirements.in --allow-unsafe
-	pip-compile --upgrade-package $(package) -qo dev-requirements.txt dev-requirements.in --allow-unsafe
-	pip-compile --upgrade-package $(package) -qo docs-requirements.txt docs-requirements.in --allow-unsafe
+	pip-compile --upgrade-package $(package) -qo requirements.txt requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade-package $(package) -qo prod-requirements.txt prod-requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade-package $(package) -qo test-requirements.txt test-requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade-package $(package) -qo dev-requirements.txt dev-requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade-package $(package) -qo docs-requirements.txt docs-requirements.in --allow-unsafe --strip-extras
 	python ../scripts/purge-platform-pkgs.py ./*requirements.txt

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -49,7 +49,7 @@ beautifulsoup4==4.10.0
     # via -r base-requirements.in
 billiard==3.6.4.0
     # via celery
-bleach[css]==6.1.0
+bleach==6.1.0
     # via -r base-requirements.in
 boto3==1.24.96
     # via -r base-requirements.in
@@ -291,7 +291,7 @@ git-build-branch==0.1.16
     # via -r dev-requirements.in
 gnureadline==8.1.2
     # via -r dev-requirements.in
-google-api-core[grpc]==2.11.0
+google-api-core==2.11.0
     # via
     #   firebase-admin
     #   google-api-python-client
@@ -561,7 +561,7 @@ pygments==2.15.0
     #   sphinx
 pyjwkest==1.4.2
     # via oic
-pyjwt[crypto]==2.7.0
+pyjwt==2.7.0
     # via
     #   -r base-requirements.in
     #   firebase-admin

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -45,7 +45,7 @@ beautifulsoup4==4.12.2
     # via -r base-requirements.in
 billiard==3.6.4.0
     # via celery
-bleach[css]==6.1.0
+bleach==6.1.0
     # via -r base-requirements.in
 boto3==1.24.96
     # via -r base-requirements.in
@@ -250,7 +250,7 @@ gevent==23.9.1
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
-google-api-core[grpc]==2.11.0
+google-api-core==2.11.0
     # via
     #   firebase-admin
     #   google-api-python-client
@@ -475,7 +475,7 @@ pygments==2.15.0
     # via sphinx
 pyjwkest==1.4.2
     # via oic
-pyjwt[crypto]==2.7.0
+pyjwt==2.7.0
     # via
     #   -r base-requirements.in
     #   firebase-admin

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -45,7 +45,7 @@ beautifulsoup4==4.12.2
     # via -r base-requirements.in
 billiard==3.6.4.0
     # via celery
-bleach[css]==6.1.0
+bleach==6.1.0
     # via -r base-requirements.in
 boto3==1.24.96
     # via -r base-requirements.in
@@ -248,7 +248,7 @@ gevent==23.9.1
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
-google-api-core[grpc]==2.11.0
+google-api-core==2.11.0
     # via
     #   firebase-admin
     #   google-api-python-client
@@ -483,7 +483,7 @@ pygments==2.15.0
     # via ipython
 pyjwkest==1.4.2
     # via oic
-pyjwt[crypto]==2.7.0
+pyjwt==2.7.0
     # via
     #   -r base-requirements.in
     #   firebase-admin

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -41,7 +41,7 @@ beautifulsoup4==4.12.2
     # via -r base-requirements.in
 billiard==3.6.4.0
     # via celery
-bleach[css]==6.1.0
+bleach==6.1.0
     # via -r base-requirements.in
 boto3==1.24.96
     # via -r base-requirements.in
@@ -237,7 +237,7 @@ gevent==23.9.1
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
-google-api-core[grpc]==2.11.0
+google-api-core==2.11.0
     # via
     #   firebase-admin
     #   google-api-python-client
@@ -447,7 +447,7 @@ pygithub==1.55
     # via -r base-requirements.in
 pyjwkest==1.4.2
     # via oic
-pyjwt[crypto]==2.7.0
+pyjwt==2.7.0
     # via
     #   -r base-requirements.in
     #   firebase-admin

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -41,7 +41,7 @@ beautifulsoup4==4.10.0
     # via -r base-requirements.in
 billiard==3.6.4.0
     # via celery
-bleach[css]==6.1.0
+bleach==6.1.0
     # via -r base-requirements.in
 boto3==1.24.96
     # via -r base-requirements.in
@@ -254,7 +254,7 @@ gevent==23.9.1
     # via
     #   -r base-requirements.in
     #   django-websocket-redis
-google-api-core[grpc]==2.11.0
+google-api-core==2.11.0
     # via
     #   firebase-admin
     #   google-api-python-client
@@ -478,7 +478,7 @@ pygithub==1.55
     # via -r base-requirements.in
 pyjwkest==1.4.2
     # via oic
-pyjwt[crypto]==2.7.0
+pyjwt==2.7.0
     # via
     #   -r base-requirements.in
     #   firebase-admin


### PR DESCRIPTION
Resolves pip-tools WARNING: `--strip-extras` is becoming the default in version 8.0.0. To silence this warning, either use `--strip-extras` to opt into the new default or use `--no-strip-extras` to retain the existing behavior.

## Safety Assurance

### Safety story

Changes requirements compilation script. Has no effect on installed requirements.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations