### PR TITLE
Upgrade requirements that are multiple versions out of date

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -870,7 +870,7 @@ zope-interface==6.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3
     # via pip-tools
-setuptools==72.1.0
+setuptools==75.4.0
     # via
     #   django-websocket-redis
     #   pip-tools

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -363,7 +363,7 @@ idna==3.7
     #   yarl
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==8.5.0
     # via
     #   markdown
     #   opentelemetry-api
@@ -463,7 +463,7 @@ openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
-opentelemetry-api==1.18.0
+opentelemetry-api==1.28.1
     # via ddtrace
 packaging==23.0
     # via
@@ -860,7 +860,7 @@ yapf==0.31.0
     # via -r dev-requirements.in
 yarl==1.9.4
     # via aiohttp
-zipp==3.19.1
+zipp==3.21.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
@@ -873,7 +873,6 @@ pip==23.3
 setuptools==72.1.0
     # via
     #   django-websocket-redis
-    #   opentelemetry-api
     #   pip-tools
     #   zope-event
     #   zope-interface

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -57,7 +57,7 @@ botocore==1.27.96
     # via
     #   boto3
     #   s3transfer
-build==0.8.0
+build==1.2.2.post1
     # via pip-tools
 bytecode==0.14.2
     # via ddtrace
@@ -365,6 +365,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.5.0
     # via
+    #   build
     #   markdown
     #   opentelemetry-api
     #   sphinx
@@ -476,8 +477,6 @@ parsimonious==0.10.0
     # via pyseeyou
 parso==0.8.3
     # via jedi
-pep517==0.10.0
-    # via build
 pexpect==4.8.0
     # via ipython
 phonenumberslite==8.12.48
@@ -490,7 +489,7 @@ pillow==10.3.0
     # via
     #   -r base-requirements.in
     #   reportlab
-pip-tools==7.3.0
+pip-tools==7.4.1
     # via -r test-requirements.in
 pluggy==1.5.0
     # via pytest
@@ -578,6 +577,10 @@ pyphonetics==0.5.3
     # via -r base-requirements.in
 pypng==0.20220715.0
     # via qrcode
+pyproject-hooks==1.2.0
+    # via
+    #   build
+    #   pip-tools
 pyrsistent==0.17.3
     # via jsonschema
 pyseeyou==1.0.2
@@ -775,8 +778,6 @@ text-unidecode==1.3
     # via -r base-requirements.in
 tinycss2==1.2.1
     # via bleach
-toml==0.10.2
-    # via pep517
 tomli==2.0.1
     # via
     #   build

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -262,7 +262,7 @@ executing==2.0.1
     # via stack-data
 fakecouch==0.0.15
     # via -r test-requirements.in
-faker==26.0.0
+faker==32.1.0
     # via -r test-requirements.in
 firebase-admin==6.1.0
     # via -r base-requirements.in
@@ -805,6 +805,7 @@ typing-extensions==4.8.0
     #   cattrs
     #   ddtrace
     #   django-countries
+    #   faker
     #   jwcrypto
     #   oic
     #   qrcode

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -145,7 +145,7 @@ deprecated==1.2.10
     # via
     #   opentelemetry-api
     #   pygithub
-diff-match-patch==20230430
+diff-match-patch==20241021
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -322,7 +322,7 @@ idna==3.7
     #   yarl
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==8.5.0
     # via
     #   markdown
     #   opentelemetry-api
@@ -401,7 +401,7 @@ openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
-opentelemetry-api==1.18.0
+opentelemetry-api==1.28.1
     # via ddtrace
 packaging==23.0
     # via
@@ -719,7 +719,7 @@ xmltodict==0.13.0
     # via ddtrace
 yarl==1.9.4
     # via aiohttp
-zipp==3.19.1
+zipp==3.21.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
@@ -730,6 +730,5 @@ zope-interface==6.1
 setuptools==72.1.0
     # via
     #   django-websocket-redis
-    #   opentelemetry-api
     #   zope-event
     #   zope-interface

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -727,7 +727,7 @@ zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==72.1.0
+setuptools==75.4.0
     # via
     #   django-websocket-redis
     #   zope-event

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -127,7 +127,7 @@ deprecated==1.2.10
     # via
     #   opentelemetry-api
     #   pygithub
-diff-match-patch==20230430
+diff-match-patch==20241021
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -723,7 +723,7 @@ zope-interface==6.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3
     # via -r prod-requirements.in
-setuptools==72.1.0
+setuptools==75.4.0
     # via
     #   django-websocket-redis
     #   zope-event

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -130,7 +130,7 @@ deprecated==1.2.10
     # via
     #   opentelemetry-api
     #   pygithub
-diff-match-patch==20230430
+diff-match-patch==20241021
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -321,7 +321,7 @@ idna==3.7
     #   -r prod-requirements.in
     #   requests
     #   yarl
-importlib-metadata==6.0.0
+importlib-metadata==8.5.0
     # via
     #   markdown
     #   opentelemetry-api
@@ -398,7 +398,7 @@ openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
-opentelemetry-api==1.18.0
+opentelemetry-api==1.28.1
     # via ddtrace
 packaging==23.0
     # via
@@ -713,7 +713,7 @@ xmltodict==0.13.0
     # via ddtrace
 yarl==1.9.4
     # via aiohttp
-zipp==3.19.1
+zipp==3.21.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
@@ -726,6 +726,5 @@ pip==23.3
 setuptools==72.1.0
     # via
     #   django-websocket-redis
-    #   opentelemetry-api
     #   zope-event
     #   zope-interface

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -123,7 +123,7 @@ deprecated==1.2.10
     # via
     #   opentelemetry-api
     #   pygithub
-diff-match-patch==20230430
+diff-match-patch==20241021
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -672,7 +672,7 @@ zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==72.1.0
+setuptools==75.4.0
     # via
     #   django-websocket-redis
     #   zope-event

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -307,7 +307,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-importlib-metadata==6.0.0
+importlib-metadata==8.5.0
     # via
     #   markdown
     #   opentelemetry-api
@@ -378,7 +378,7 @@ openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
-opentelemetry-api==1.18.0
+opentelemetry-api==1.28.1
     # via ddtrace
 packaging==23.0
     # via
@@ -664,7 +664,7 @@ xmltodict==0.13.0
     # via ddtrace
 yarl==1.9.4
     # via aiohttp
-zipp==3.19.1
+zipp==3.21.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
@@ -675,6 +675,5 @@ zope-interface==6.1
 setuptools==72.1.0
     # via
     #   django-websocket-redis
-    #   opentelemetry-api
     #   zope-event
     #   zope-interface

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -130,7 +130,7 @@ deprecated==1.2.10
     # via
     #   opentelemetry-api
     #   pygithub
-diff-match-patch==20230430
+diff-match-patch==20241021
     # via -r base-requirements.in
 dimagi-memoized==1.1.3
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -234,7 +234,7 @@ exceptiongroup==1.1.1
     #   pytest
 fakecouch==0.0.15
     # via -r test-requirements.in
-faker==26.0.0
+faker==32.1.0
     # via -r test-requirements.in
 firebase-admin==6.1.0
     # via -r base-requirements.in
@@ -679,6 +679,7 @@ typing-extensions==4.8.0
     #   cattrs
     #   ddtrace
     #   django-countries
+    #   faker
     #   jwcrypto
     #   pydantic
     #   pydantic-core

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -324,7 +324,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-importlib-metadata==6.0.0
+importlib-metadata==8.5.0
     # via
     #   markdown
     #   opentelemetry-api
@@ -399,7 +399,7 @@ openpyxl==3.0.9
     # via
     #   -r base-requirements.in
     #   commcaretranslationchecker
-opentelemetry-api==1.18.0
+opentelemetry-api==1.28.1
     # via ddtrace
 packaging==23.0
     # via
@@ -730,7 +730,7 @@ xmltodict==0.13.0
     # via ddtrace
 yarl==1.9.4
     # via aiohttp
-zipp==3.19.1
+zipp==3.21.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
@@ -743,7 +743,6 @@ pip==23.3
 setuptools==72.1.0
     # via
     #   django-websocket-redis
-    #   opentelemetry-api
     #   pip-tools
     #   zope-event
     #   zope-interface

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -740,7 +740,7 @@ zope-interface==6.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3
     # via pip-tools
-setuptools==72.1.0
+setuptools==75.4.0
     # via
     #   django-websocket-redis
     #   pip-tools

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -49,7 +49,7 @@ botocore==1.27.96
     # via
     #   boto3
     #   s3transfer
-build==0.8.0
+build==1.2.2.post1
     # via pip-tools
 bytecode==0.14.2
     # via ddtrace
@@ -326,6 +326,7 @@ idna==3.7
     #   yarl
 importlib-metadata==8.5.0
     # via
+    #   build
     #   markdown
     #   opentelemetry-api
 iniconfig==2.0.0
@@ -409,8 +410,6 @@ packaging==23.0
     #   pytest
 parsimonious==0.10.0
     # via pyseeyou
-pep517==0.10.0
-    # via build
 phonenumberslite==8.12.48
     # via -r base-requirements.in
 pickle5==0.0.11
@@ -419,7 +418,7 @@ pillow==10.3.0
     # via
     #   -r base-requirements.in
     #   reportlab
-pip-tools==7.3.0
+pip-tools==7.4.1
     # via -r test-requirements.in
 pluggy==1.5.0
     # via pytest
@@ -493,6 +492,10 @@ pyphonetics==0.5.3
     # via -r base-requirements.in
 pypng==0.20220715.0
     # via qrcode
+pyproject-hooks==1.2.0
+    # via
+    #   build
+    #   pip-tools
 pyrsistent==0.17.3
     # via jsonschema
 pyseeyou==1.0.2
@@ -653,8 +656,6 @@ text-unidecode==1.3
     # via -r base-requirements.in
 tinycss2==1.2.1
     # via bleach
-toml==0.10.2
-    # via pep517
 tomli==2.0.1
     # via
     #   build


### PR DESCRIPTION
The four multi-major requirements upgraded here are

- `importlib-metadata` - [Change log](https://github.com/python/importlib_metadata/blob/main/NEWS.rst). Indirect dependency (not used directly by our code). This upgrade also required `zipp` and `opentelemetry-api` to be upgraded, which are indirect requirements as well.
- `setuptools` - [Change log](https://setuptools.pypa.io/en/latest/history.html). Packaging requirement. Used for installation of other requirements. If test setup succeeds it is a good indication that the upgrade is safe.
- `faker` - [Change log](https://github.com/joke2k/faker/blob/master/CHANGELOG.md). Test requirement, not used in production code.
- `diff-match-patch` - [Change log](https://github.com/diff-match-patch-python/diff-match-patch/blob/main/CHANGELOG.md). Not really a multimajor, but the versioning scheme makes it look that way. The new version is only one past the previous, and it's a bugfix release. Usage is covered by tests.
- `pip-tools` - [Change log](https://pip-tools.readthedocs.io/en/latest/changelog/). Upgraded to hopefully fix `make requirements` errors in tests.

All change logs have been reviewed with special attention to breaking changes. There were none that would affect us.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

`diff-match-patch` is the only one of these dependencies that is used by production code, and the new version contains only bugfixes. All others are either indirect, packaging, or test requirements.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations