### PR TITLE
Removed redundant software plan field causing error

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -2382,7 +2382,6 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
             self.fields['start_date'].initial = datetime.date.today()
             self.fields['end_date'].initial = datetime.date.today() + relativedelta(years=1)
             self.helper.layout = crispy.Layout(
-                hqcrispy.B3TextField('software_plan_edition', plan_edition),
                 crispy.Field('software_plan_edition'),
                 crispy.Field('fogbugz_client_name'),
                 crispy.Field('emails'),


### PR DESCRIPTION
## Product Description
On my local setup, the subscription page has stopped displaying entirely, complaining that software_plan_edition should only be rendered once.

![image](https://github.com/user-attachments/assets/e298fc2f-5f28-43dc-9ebe-45202157bb41)

This appears to be caused by what the contracted partner form would display, which itself looks like a bug:

![image](https://github.com/user-attachments/assets/a710b156-473f-40e6-bb83-1a2ee6a2863f)

This appears to work on staging, but showing two “Software Plan” fields does not seem intentional.

After removing the redundant field, the form now is:
![image](https://github.com/user-attachments/assets/e1fcebab-cdd9-452a-847a-c31f969009ed)


## Technical Summary
Link to ticket: https://dimagi.atlassian.net/browse/SAAS-16248

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Verified this locally, both making sure the form displays correctly, and that saving the form shifts my subscription to the selected subscription type.  But fundamentally, because two fields were storing the same field's data, this shouldn't change behavior. However this was displaying, for it to have worked in the past, it would have been grabbing the second field's value, which it continue to do.

### Automated test coverage
No tests

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
