### PR TITLE
Update footer links

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/footer.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/footer.html
@@ -12,7 +12,7 @@
                  alt="CommCare"
                  height="30"  />
           </a>
-          <a href="https://dimagi.com/ class="dimagi-logo">
+          <a href="https://dimagi.com/" class="dimagi-logo">
             {% include "hqwebapp/svg/dimagi_logo.html" %}
           </a>
           &nbsp;

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/footer.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/footer.html
@@ -12,7 +12,7 @@
                  alt="CommCare"
                  height="30"  />
           </a>
-          <a href="http://www.dimagi.com/" class="dimagi-logo">
+          <a href="https://dimagi.com/ class="dimagi-logo">
             {% include "hqwebapp/svg/dimagi_logo.html" %}
           </a>
           &nbsp;
@@ -20,7 +20,7 @@
             <a href="https://dimagi.com/commcare/">CommCare</a>
             is copyright &copy;
           {% endblocktrans %}{% now "Y" %}
-          <a href="http://www.dimagi.com/">Dimagi, Inc.</a>
+          <a href="https://dimagi.com/">Dimagi, Inc.</a>
 
           <div class="visible-sm-inline visible-md-inline visible-lg-inline">&nbsp;|&nbsp;</div>
           <br class="hidden-sm hidden-md hidden-lg" />
@@ -30,15 +30,15 @@
           <div class="visible-md-inline visible-lg-inline">&nbsp;|&nbsp;</div>
           <br class="hidden-md hidden-lg" />
 
-          <a href="http://www.dimagi.com/terms/latest/privacy/" target="_blank">
+          <a href="https://dimagi.com/terms-privacy/" target="_blank">
             {% trans "Privacy" %}
           </a>
           &nbsp;|&nbsp;
-          <a href="http://www.dimagi.com/terms/latest/tos/" target="_blank">
+          <a href="https://dimagi.com/terms-of-service/" target="_blank">
             {% trans "Terms of Service" %}
           </a>
           &nbsp;|&nbsp;
-          <a href="http://www.dimagi.com/terms/latest/ba/" target="_blank">
+          <a href="https://dimagi.com/terms-ba/" target="_blank">
             {% trans "Business Agreement" %}
           </a>
         </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/footer.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/footer.html
@@ -11,7 +11,7 @@
                alt="CommCare"
                height="30"  />
         </a>
-        <a href="https://www.dimagi.com/" class="dimagi-logo">
+        <a href="https://dimagi.com/" class="dimagi-logo">
           {% include "hqwebapp/svg/dimagi_logo.html" %}
         </a>
         &nbsp;
@@ -19,21 +19,21 @@
           <a href="https://dimagi.com/commcare/">CommCare</a>
           is copyright &copy;
         {% endblocktrans %}{% now "Y" %}
-        <a href="https://www.dimagi.com/">Dimagi, Inc.</a>
+        <a href="https://dimagi.com/">Dimagi, Inc.</a>
 
         <span class="d-inline-md d-inline-lg">&nbsp;|&nbsp;</span>
         <a href="https://dimagi.com/commcare/">{% trans 'Learn more about CommCare HQ' %}</a>
 
         <span class="d-inline-md d-inline-lg">&nbsp;|&nbsp;</span>
-        <a href="https://www.dimagi.com/terms/latest/privacy/" target="_blank">
+        <a href="https://dimagi.com/terms-privacy/" target="_blank">
           {% trans "Privacy" %}
         </a>
         &nbsp;|&nbsp;
-        <a href="https://www.dimagi.com/terms/latest/tos/" target="_blank">
+        <a href="https://dimagi.com/terms-of-service/" target="_blank">
           {% trans "Terms of Service" %}
         </a>
         &nbsp;|&nbsp;
-        <a href="https://www.dimagi.com/terms/latest/ba/" target="_blank">
+        <a href="https://dimagi.com/terms-ba/" target="_blank">
           {% trans "Business Agreement" %}
         </a>
       </p>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/footer.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/footer.html.diff.txt
@@ -14,7 +14,7 @@
 -                 alt="CommCare"
 -                 height="30"  />
 -          </a>
--          <a href="http://www.dimagi.com/" class="dimagi-logo">
+-          <a href="https://dimagi.com/" class="dimagi-logo">
 -            {% include "hqwebapp/svg/dimagi_logo.html" %}
 -          </a>
 -          &nbsp;
@@ -22,14 +22,14 @@
 -            <a href="https://dimagi.com/commcare/">CommCare</a>
 -            is copyright &copy;
 -          {% endblocktrans %}{% now "Y" %}
--          <a href="http://www.dimagi.com/">Dimagi, Inc.</a>
+-          <a href="https://dimagi.com/">Dimagi, Inc.</a>
 +      <p class="text-center align-middle mb-0 w-100">
 +        <a href="https://dimagi.com/commcare/" class="footer-link-img">
 +          <img src="{% static 'hqwebapp/images/commcare-flower-footer.png' %}"
 +               alt="CommCare"
 +               height="30"  />
 +        </a>
-+        <a href="https://www.dimagi.com/" class="dimagi-logo">
++        <a href="https://dimagi.com/" class="dimagi-logo">
 +          {% include "hqwebapp/svg/dimagi_logo.html" %}
 +        </a>
 +        &nbsp;
@@ -37,7 +37,7 @@
 +          <a href="https://dimagi.com/commcare/">CommCare</a>
 +          is copyright &copy;
 +        {% endblocktrans %}{% now "Y" %}
-+        <a href="https://www.dimagi.com/">Dimagi, Inc.</a>
++        <a href="https://dimagi.com/">Dimagi, Inc.</a>
  
 -          <div class="visible-sm-inline visible-md-inline visible-lg-inline">&nbsp;|&nbsp;</div>
 -          <br class="hidden-sm hidden-md hidden-lg" />
@@ -49,29 +49,29 @@
 -          <div class="visible-md-inline visible-lg-inline">&nbsp;|&nbsp;</div>
 -          <br class="hidden-md hidden-lg" />
 -
--          <a href="http://www.dimagi.com/terms/latest/privacy/" target="_blank">
+-          <a href="https://dimagi.com/terms-privacy/" target="_blank">
 -            {% trans "Privacy" %}
 -          </a>
 -          &nbsp;|&nbsp;
--          <a href="http://www.dimagi.com/terms/latest/tos/" target="_blank">
+-          <a href="https://dimagi.com/terms-of-service/" target="_blank">
 -            {% trans "Terms of Service" %}
 -          </a>
 -          &nbsp;|&nbsp;
--          <a href="http://www.dimagi.com/terms/latest/ba/" target="_blank">
+-          <a href="https://dimagi.com/terms-ba/" target="_blank">
 -            {% trans "Business Agreement" %}
 -          </a>
 -        </div>
 -      </div>
 +        <span class="d-inline-md d-inline-lg">&nbsp;|&nbsp;</span>
-+        <a href="https://www.dimagi.com/terms/latest/privacy/" target="_blank">
++        <a href="https://dimagi.com/terms-privacy/" target="_blank">
 +          {% trans "Privacy" %}
 +        </a>
 +        &nbsp;|&nbsp;
-+        <a href="https://www.dimagi.com/terms/latest/tos/" target="_blank">
++        <a href="https://dimagi.com/terms-of-service/" target="_blank">
 +          {% trans "Terms of Service" %}
 +        </a>
 +        &nbsp;|&nbsp;
-+        <a href="https://www.dimagi.com/terms/latest/ba/" target="_blank">
++        <a href="https://dimagi.com/terms-ba/" target="_blank">
 +          {% trans "Business Agreement" %}
 +        </a>
 +      </p>


### PR DESCRIPTION
## Product Description
Updates footer links to be consistent with dimagi.com site redesign urls. Normally these links would redirect on the dimagi.com side, but they break when tracking params are appended on the HQ side, which we do in production environments.

## Technical Summary
Straightforward, updated links and rebuilt bootstrap5 diffs. A couple related links were also changed to `https` or removed `www` for consistency.

## Safety Assurance

### Safety story
Very safe, just updating plain links.

### Automated test coverage
None here.

### QA Plan
Not planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
