### PR TITLE
Ensure related resource URIs use same version

### DIFF
--- a/corehq/apps/locations/resources/v0_5.py
+++ b/corehq/apps/locations/resources/v0_5.py
@@ -60,8 +60,8 @@ class LocationTypeResource(BaseLocationsResource):
         })
 
     def dehydrate_parent(self, bundle):
-        if parent := bundle.obj.parent_type:
-            return self.get_resource_uri(parent)
+        if bundle.obj.parent_type:
+            return self.get_resource_uri(bundle.obj.parent_type)
 
 
 class LocationResource(BaseLocationsResource):
@@ -113,14 +113,14 @@ class LocationResource(BaseLocationsResource):
         })
 
     def dehydrate_location_type(self, bundle):
-        if location_type_id := bundle.obj.location_type_id:
+        if bundle.obj.location_type_id:
             return absolute_reverse('api_dispatch_detail', kwargs={
                 'resource_name': 'location_type',
                 'domain': bundle.obj.domain,
                 'api_name': self.api_name,
-                'pk': location_type_id
+                'pk': bundle.obj.location_type_id,
             })
 
     def dehydrate_parent(self, bundle):
-        if parent := bundle.obj.parent:
-            return self.get_resource_uri(parent)
+        if bundle.obj.parent:
+            return self.get_resource_uri(bundle.obj.parent)

--- a/corehq/apps/locations/resources/v0_5.py
+++ b/corehq/apps/locations/resources/v0_5.py
@@ -59,6 +59,10 @@ class LocationTypeResource(BaseLocationsResource):
             'pk': obj.pk
         })
 
+    def dehydrate_parent(self, bundle):
+        if parent := bundle.obj.parent_type:
+            return self.get_resource_uri(parent)
+
 
 class LocationResource(BaseLocationsResource):
     location_data = fields.DictField('metadata')
@@ -107,3 +111,16 @@ class LocationResource(BaseLocationsResource):
             'api_name': self.api_name,
             'location_id': obj.location_id
         })
+
+    def dehydrate_location_type(self, bundle):
+        if location_type_id := bundle.obj.location_type_id:
+            return absolute_reverse('api_dispatch_detail', kwargs={
+                'resource_name': 'location_type',
+                'domain': bundle.obj.domain,
+                'api_name': self.api_name,
+                'pk': location_type_id
+            })
+
+    def dehydrate_parent(self, bundle):
+        if parent := bundle.obj.parent:
+            return self.get_resource_uri(parent)


### PR DESCRIPTION
## Product Description


## Technical Summary
Followup from https://github.com/dimagi/commcare-hq/pull/35048
The old v0.5 location and location type APIs have URIs for related models (`location.parent` and `location.location type`, and `location_type.parent_type`).  The above PR did not preserve the same API version when constructing those URIs.

## Feature Flag


## Safety Assurance
Local testing

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change