### PR TITLE
[webpack] fix jquery/select2/bootstrap5/webpack interaction and migrate locations app

### DIFF
--- a/corehq/apps/locations/static/locations/js/filtered_download.js
+++ b/corehq/apps/locations/static/locations/js/filtered_download.js
@@ -6,6 +6,7 @@ hqDefine('locations/js/filtered_download', [
     'locations/js/widgets',     // location search
     'hqwebapp/js/components/select_toggle',
     'hqwebapp/js/bootstrap5/knockout_bindings.ko', // slideVisible binding
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/locations/static/locations/js/import.js
+++ b/corehq/apps/locations/static/locations/js/import.js
@@ -2,6 +2,7 @@ hqDefine('locations/js/import', [
     'jquery',
     'knockout',
     'analytix/js/google',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/locations/static/locations/js/location.js
+++ b/corehq/apps/locations/static/locations/js/location.js
@@ -11,6 +11,7 @@ hqDefine("locations/js/location", [
     'hqwebapp/js/select_2_ajax_widget',
     'hqwebapp/js/bootstrap5/widgets',       // custom data fields use a .hqwebapp-select2
     'locations/js/widgets',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/locations/static/locations/js/location_types.js
+++ b/corehq/apps/locations/static/locations/js/location_types.js
@@ -7,6 +7,7 @@ hqDefine('locations/js/location_types', [
     'analytix/js/google',
     'select2/dist/js/select2.full.min',
     'hqwebapp/js/bootstrap5/hq.helpers',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/locations/static/locations/js/locations.js
+++ b/corehq/apps/locations/static/locations/js/locations.js
@@ -2,6 +2,7 @@ hqDefine('locations/js/locations', [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'locations/js/location_tree',
+    'commcarehq',
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/locations/templates/locations/filter_and_download.html
+++ b/corehq/apps/locations/templates/locations/filter_and_download.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main_b5 'locations/js/filtered_download' %}
+{% js_entry 'locations/js/filtered_download' %}
 
 {% block page_content %}
   {% initial_page_data 'locations_count_url' locations_count_url %}

--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'locations/js/location_types' %}
+{% js_entry 'locations/js/location_types' %}
 
 {% block page_content %}
   {% initial_page_data 'location_types' location_types %}

--- a/corehq/apps/locations/templates/locations/manage/import.html
+++ b/corehq/apps/locations/templates/locations/manage/import.html
@@ -1,7 +1,7 @@
 {% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load hq_shared_tags %}
 
-{% requirejs_main_b5 'locations/js/import' %}
+{% js_entry 'locations/js/import' %}
 
 {% block page_content %}
   {% include "locations/manage/partials/bulk_upload.html" %}

--- a/corehq/apps/locations/templates/locations/manage/location.html
+++ b/corehq/apps/locations/templates/locations/manage/location.html
@@ -8,7 +8,7 @@
   {{ block.super }}
 {% endblock title %}
 
-{% requirejs_main_b5 'locations/js/location' %}
+{% js_entry 'locations/js/location' %}
 
 {% block page_content %}
   {% initial_page_data 'api_root' api_root %}

--- a/corehq/apps/locations/templates/locations/manage/locations.html
+++ b/corehq/apps/locations/templates/locations/manage/locations.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main_b5 'locations/js/locations' %}
+{% js_entry 'locations/js/locations' %}
 
 {% block page_content %}
   {% registerurl 'archive_location' domain '---' %}

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -82,6 +82,7 @@ module.exports = {
     plugins: [
         new webpack.ProvidePlugin({
             '$': 'jquery',
+            'jQuery': 'jquery',  // needed for bootstrap to work
         }),
         new hqPlugins.EntryChunksPlugin(),
     ],


### PR DESCRIPTION
## Technical Summary
First commit is a config update, which is already present in B3. Once that's done, locations is trivial to migrate.

## Safety Assurance

### Safety story
Most of the risk here is because we're still early in the webpack mgiration. I've smoke tested locally and will do so on staging. Marking "don't merge" in the meantime.

### Automated test coverage

no

### QA Plan

not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
