### PR TITLE
no longer treat "0 0" as null since it is a valid coordinate

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -940,14 +940,13 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
                 L.mapbox.accessToken = token;
 
                 const allCoordinates = [];
-                const nullCoordinate = ['0', '0'];
                 const markers = [];
                 this.options.collection.models
                     .forEach(model => {
                         const addressCoordinates = model.attributes.data[addressIndex];
                         if (addressCoordinates) {
                             let markerCoordinates = addressCoordinates.split(" ").slice(0,2);
-                            if (markerCoordinates.length > 1 && JSON.stringify(markerCoordinates) !== JSON.stringify(nullCoordinate)) {
+                            if (markerCoordinates.length > 1) {
                                 const rowId = `row-${model.id}`;
                                 const popupText = markdown.render(model.attributes.data[popupIndex]);
                                 let marker = L.marker(markerCoordinates, {icon: locationIcon});


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Revert changes applied in this [PR](https://github.com/dimagi/commcare-hq/pull/35340) for "0 0" coordinates

Revert changes such that it is as below.

|   | A. If the case list contains only that case | B. If the case list also contains other cases that have non-empty coordinates |
| -- | -- | -- |
| A case in the case list has map coordinates of 0 0 | The 0 0 coordinate is (arguably correctly) shown on the map<img src="https://github.com/user-attachments/assets/1b069741-5991-4bbc-926c-2c9f1888a4ca" width="300"/> | The 0 0 coordinate is (arguably correctly) shown on the map<img src="https://github.com/user-attachments/assets/20e1085a-f2b5-4f0e-b30e-f74c8285e6fc" width="300"/> |

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
After further discussion on this [ticket](https://dimagi.atlassian.net/browse/SUPPORT-22079?focusedCommentId=354459), we decided it was more appropriate to clean data input such that values are empty instead of "0 0".

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[USH: Allow use of a map in the case list in Web Apps
](https://www.commcarehq.org/hq/flags/edit/case_list_map/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. Impacts only case list address mapping

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
