### PR TITLE
Upgrade setuptools and pip-tools

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -36,7 +36,7 @@ function setup {
         install -dm0755 -o cchq -g cchq ./artifacts
     fi
 
-    pip-sync requirements/test-requirements.txt
+    pip-sync --user requirements/test-requirements.txt
     pip check  # make sure there are no incompatibilities in test-requirements.txt
     python_preheat  # preheat the python libs
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -57,7 +57,7 @@ botocore==1.27.96
     # via
     #   boto3
     #   s3transfer
-build==0.8.0
+build==1.2.2.post1
     # via pip-tools
 bytecode==0.14.2
     # via ddtrace
@@ -365,6 +365,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==6.0.0
     # via
+    #   build
     #   markdown
     #   opentelemetry-api
     #   sphinx
@@ -476,8 +477,6 @@ parsimonious==0.10.0
     # via pyseeyou
 parso==0.8.3
     # via jedi
-pep517==0.10.0
-    # via build
 pexpect==4.8.0
     # via ipython
 phonenumberslite==8.12.48
@@ -490,7 +489,7 @@ pillow==10.3.0
     # via
     #   -r base-requirements.in
     #   reportlab
-pip-tools==7.3.0
+pip-tools==7.4.1
     # via -r test-requirements.in
 pluggy==1.5.0
     # via pytest
@@ -578,6 +577,10 @@ pyphonetics==0.5.3
     # via -r base-requirements.in
 pypng==0.20220715.0
     # via qrcode
+pyproject-hooks==1.2.0
+    # via
+    #   build
+    #   pip-tools
 pyrsistent==0.17.3
     # via jsonschema
 pyseeyou==1.0.2
@@ -775,8 +778,6 @@ text-unidecode==1.3
     # via -r base-requirements.in
 tinycss2==1.2.1
     # via bleach
-toml==0.10.2
-    # via pep517
 tomli==2.0.1
     # via
     #   build

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -870,7 +870,7 @@ zope-interface==6.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3
     # via pip-tools
-setuptools==72.1.0
+setuptools==75.4.0
     # via
     #   django-websocket-redis
     #   opentelemetry-api

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -727,7 +727,7 @@ zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==72.1.0
+setuptools==75.4.0
     # via
     #   django-websocket-redis
     #   opentelemetry-api

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -723,7 +723,7 @@ zope-interface==6.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3
     # via -r prod-requirements.in
-setuptools==72.1.0
+setuptools==75.4.0
     # via
     #   django-websocket-redis
     #   opentelemetry-api

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -672,7 +672,7 @@ zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==72.1.0
+setuptools==75.4.0
     # via
     #   django-websocket-redis
     #   opentelemetry-api

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -49,7 +49,7 @@ botocore==1.27.96
     # via
     #   boto3
     #   s3transfer
-build==0.8.0
+build==1.2.2.post1
     # via pip-tools
 bytecode==0.14.2
     # via ddtrace
@@ -326,6 +326,7 @@ idna==3.7
     #   yarl
 importlib-metadata==6.0.0
     # via
+    #   build
     #   markdown
     #   opentelemetry-api
 iniconfig==2.0.0
@@ -409,8 +410,6 @@ packaging==23.0
     #   pytest
 parsimonious==0.10.0
     # via pyseeyou
-pep517==0.10.0
-    # via build
 phonenumberslite==8.12.48
     # via -r base-requirements.in
 pickle5==0.0.11
@@ -419,7 +418,7 @@ pillow==10.3.0
     # via
     #   -r base-requirements.in
     #   reportlab
-pip-tools==7.3.0
+pip-tools==7.4.1
     # via -r test-requirements.in
 pluggy==1.5.0
     # via pytest
@@ -493,6 +492,10 @@ pyphonetics==0.5.3
     # via -r base-requirements.in
 pypng==0.20220715.0
     # via qrcode
+pyproject-hooks==1.2.0
+    # via
+    #   build
+    #   pip-tools
 pyrsistent==0.17.3
     # via jsonschema
 pyseeyou==1.0.2
@@ -653,8 +656,6 @@ text-unidecode==1.3
     # via -r base-requirements.in
 tinycss2==1.2.1
     # via bleach
-toml==0.10.2
-    # via pep517
 tomli==2.0.1
     # via
     #   build

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -740,7 +740,7 @@ zope-interface==6.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3
     # via pip-tools
-setuptools==72.1.0
+setuptools==75.4.0
     # via
     #   django-websocket-redis
     #   opentelemetry-api


### PR DESCRIPTION
- `setuptools` - [Change log](https://setuptools.pypa.io/en/latest/history.html). Packaging requirement. Used for installation of other requirements. If test setup succeeds it is a good indication that the upgrade is safe.
- `pip-tools` - [Change log](https://pip-tools.readthedocs.io/en/latest/changelog/). Originally upgraded as part of https://github.com/dimagi/commcare-hq/pull/35360, which ultimately didn't pan out. Now that the work has been done, why not keep it?

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Setuptools and pip-tools are packaging requirements, and thus are only used during initial setup.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations