### PR TITLE
[webpack] Migrate a couple more pages that are now trivial

### DIFF
--- a/corehq/apps/events/static/events/js/edit_attendee.js
+++ b/corehq/apps/events/static/events/js/edit_attendee.js
@@ -4,10 +4,6 @@ hqDefine('events/js/edit_attendee', [
     'hqwebapp/js/initial_page_data',
     'locations/js/widgets',
     "commcarehq",
-], function (
-    $,
-    ko,
-    initialPageData
-) {
+], function () {
     // Placeholder for Location & Primary location widgets
 });

--- a/corehq/apps/events/static/events/js/edit_attendee.js
+++ b/corehq/apps/events/static/events/js/edit_attendee.js
@@ -3,6 +3,7 @@ hqDefine('events/js/edit_attendee', [
     'knockout',
     'hqwebapp/js/initial_page_data',
     'locations/js/widgets',
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/events/static/events/js/event_attendees.js
+++ b/corehq/apps/events/static/events/js/event_attendees.js
@@ -8,6 +8,7 @@ hqDefine("events/js/event_attendees",[
     "hqwebapp/js/bootstrap3/widgets",
     "hqwebapp/js/components/pagination",
     "hqwebapp/js/components/search_box",
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/events/templates/edit_attendee.html
+++ b/corehq/apps/events/templates/edit_attendee.html
@@ -4,7 +4,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'events/js/edit_attendee' %}
+{% js_entry_b3 'events/js/edit_attendee' %}
 
 {% block page_content %}
   {% initial_page_data "attendee_id" attendee_id %}

--- a/corehq/apps/events/templates/event_attendees.html
+++ b/corehq/apps/events/templates/event_attendees.html
@@ -4,7 +4,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main 'events/js/event_attendees' %}
+{% js_entry_b3 'events/js/event_attendees' %}
 
 {% block page_title %}
   {{ current_page.title }}

--- a/corehq/apps/events/templates/events_list.html
+++ b/corehq/apps/events/templates/events_list.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "hqwebapp/js/bootstrap3/crud_paginated_list_init" %}
+{% js_entry_b3 "hqwebapp/js/bootstrap3/crud_paginated_list_init" %}
 
 {% block page_title %}
   {{ current_page.title }}

--- a/corehq/apps/hqcase/static/hqcase/js/explode_cases.js
+++ b/corehq/apps/hqcase/static/hqcase/js/explode_cases.js
@@ -3,6 +3,7 @@ hqDefine('hqcase/js/explode_cases', [
     'knockout',
     'hqwebapp/js/initial_page_data',
     'select2/dist/js/select2.full.min',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/hqcase/templates/hqcase/explode_cases.html
+++ b/corehq/apps/hqcase/templates/hqcase/explode_cases.html
@@ -1,7 +1,7 @@
 {% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load hq_shared_tags %}
 
-{% requirejs_main_b5 'hqcase/js/explode_cases' %}
+{% js_entry 'hqcase/js/explode_cases' %}
 
 {% block page_content %}
   {% registerurl "users_select2_options" domain %}

--- a/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
+++ b/corehq/motech/repeaters/static/repeaters/js/add_form_repeater.js
@@ -5,6 +5,7 @@ hqDefine("repeaters/js/add_form_repeater", [
     'hqwebapp/js/base_ace',     // expression repeaters use ace for the json editor
     'hqwebapp/js/bootstrap5/widgets',       // case repeaters ("Forward Cases") use .hqwebapp-select2
     'locations/js/widgets',         // openmrs repeaters use the LocationSelectWidget
+    'commcarehq',
 ], function () {
     // Keeping this for the widgets
 });

--- a/corehq/motech/repeaters/templates/repeaters/add_form_repeater.html
+++ b/corehq/motech/repeaters/templates/repeaters/add_form_repeater.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main_b5 'repeaters/js/add_form_repeater' %}
+{% js_entry 'repeaters/js/add_form_repeater' %}
 
 {% block page_content %}
     {% initial_page_data "repeater_type" repeater_type %}


### PR DESCRIPTION
## Technical Summary
A couple of pages that are now easy because of other configuration changes.

## Safety Assurance

### Safety story
I'm gaining confidence in the webpack migration. Tested locally. The page to add a new repeater is probably the most frequently used of these.

### Automated test coverage

no

### QA Plan

not requesting QA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
