### PR TITLE
HTMX CSQL Fixture UI

### DIFF
--- a/corehq/apps/case_search/fixtures.py
+++ b/corehq/apps/case_search/fixtures.py
@@ -11,7 +11,7 @@ from corehq.messaging.templating import (
     MessagingTemplateRenderer,
     NestedDictTemplateParam,
 )
-from corehq.toggles import MODULE_BADGES
+from corehq.toggles import CSQL_FIXTURE
 
 from .models import CSQLFixtureExpression
 
@@ -71,7 +71,7 @@ class CaseSearchFixtureProvider(FixtureProvider):
     ignore_skip_fixtures_flag = True
 
     def __call__(self, restore_state):
-        if not MODULE_BADGES.enabled(restore_state.domain):
+        if not CSQL_FIXTURE.enabled(restore_state.domain):
             return
         indicators = _get_indicators(restore_state.domain)
         if indicators:

--- a/corehq/apps/case_search/forms.py
+++ b/corehq/apps/case_search/forms.py
@@ -19,6 +19,7 @@ class CSQLFixtureExpressionForm(forms.ModelForm):
         self.fields['name'].widget.attrs = {
             'placeholder': "name",
             'class': "form-control",
+            'maxlength': "64",
         }
         self.fields['csql'].widget.attrs = {
             'placeholder': "@status = 'open'",

--- a/corehq/apps/case_search/forms.py
+++ b/corehq/apps/case_search/forms.py
@@ -1,0 +1,31 @@
+from django import forms
+
+from .models import CSQLFixtureExpression
+
+
+class CSQLFixtureExpressionForm(forms.ModelForm):
+    template_name = 'case_search/csql_expression_form.html'
+
+    class Meta:
+        model = CSQLFixtureExpression
+        fields = ["name", "csql"]
+        widgets = {
+            'csql': forms.Textarea(),
+        }
+
+    def __init__(self, domain, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.domain = domain
+        self.fields['name'].widget.attrs = {
+            'placeholder': "name",
+            'class': "form-control",
+        }
+        self.fields['csql'].widget.attrs = {
+            'placeholder': "@status = 'open'",
+            'class': "form-control vertical-resize",
+            'spellcheck': "false",
+        }
+
+    def save(self, commit=True):
+        self.instance.domain = self.domain
+        return super().save(commit)

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -480,11 +480,12 @@ class CSQLFixtureExpressionLog(models.Model):
 
 @receiver(post_save, sender=CSQLFixtureExpression)
 def after_save(sender, instance, created, **kwargs):
-    updated_or_created = (CSQLFixtureExpressionLog.Action.CREATE if created
-                          else CSQLFixtureExpressionLog.Action.UPDATE)
-    CSQLFixtureExpressionLog.objects.create(
-        expression=instance,
-        action=updated_or_created,
-        name=instance.name,
-        csql=instance.csql
-    )
+    if not instance.deleted:
+        updated_or_created = (CSQLFixtureExpressionLog.Action.CREATE if created
+                            else CSQLFixtureExpressionLog.Action.UPDATE)
+        CSQLFixtureExpressionLog.objects.create(
+            expression=instance,
+            action=updated_or_created,
+            name=instance.name,
+            csql=instance.csql
+        )

--- a/corehq/apps/case_search/templates/case_search/csql_expression_form.html
+++ b/corehq/apps/case_search/templates/case_search/csql_expression_form.html
@@ -1,31 +1,35 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<form hx-post="{{ request.path_info }}"
-      hq-hx-action="save_expression"
-      hx-swap="outerHTML"
-      x-data="{ isUnsaved: false }"
-      @change="isUnsaved = true;"
-      @submit="isUnsaved = false;">
+<form
+  hx-post="{{ request.path_info }}"
+  hq-hx-action="save_expression"
+  hx-swap="outerHTML"
+  x-data="{ isUnsaved: false }"
+  @change="isUnsaved = true;"
+  @submit="isUnsaved = false;"
+>
   {% if form.instance.pk %}
     <input type="hidden" name="pk" value="{{ form.instance.pk }}" />
   {% endif %}
   <div class="row pb-3">
+    <div class="col-2">{{ form.name }}</div>
+    <div class="col-8">{{ form.csql }}</div>
     <div class="col-2">
-      {{ form.name }}
-    </div>
-    <div class="col-8">
-      {{ form.csql }}
-    </div>
-    <div class="col-2">
-      <button type="submit" class="btn btn-outline-primary" x-bind:disabled="!isUnsaved">
+      <button
+        type="submit"
+        class="btn btn-outline-primary"
+        x-bind:disabled="!isUnsaved"
+      >
         <i class="fa-regular fa-save"></i> {% trans "Save" %}
       </button>
-      <button class="btn btn-outline-danger"
-              hx-post="{{ request.path_info }}"
-              hq-hx-action="delete_expression"
-              hx-swap="delete"
-              hx-target="closest form">
+      <button
+        class="btn btn-outline-danger"
+        hx-post="{{ request.path_info }}"
+        hq-hx-action="delete_expression"
+        hx-swap="delete"
+        hx-target="closest form"
+      >
         <i class="fa-regular fa-trash-can"></i> {% trans "Delete" %}
       </button>
     </div>

--- a/corehq/apps/case_search/templates/case_search/csql_expression_form.html
+++ b/corehq/apps/case_search/templates/case_search/csql_expression_form.html
@@ -3,10 +3,13 @@
 
 <form hx-post="{{ request.path_info }}"
       hq-hx-action="save_expression"
-      hx-swap="outerHTML">
+      hx-swap="outerHTML"
+      x-data="{ isUnsaved: false }"
+      @change="isUnsaved = true;"
+      @submit="isUnsaved = false;">
   {% if form.instance.pk %}
     <input type="hidden" name="pk" value="{{ form.instance.pk }}" />
-    {% endif %}
+  {% endif %}
   <div class="row pb-3">
     <div class="col-2">
       {{ form.name }}
@@ -15,7 +18,7 @@
       {{ form.csql }}
     </div>
     <div class="col-2">
-      <button type="submit" class="btn btn-outline-primary">
+      <button type="submit" class="btn btn-outline-primary" x-bind:disabled="!isUnsaved">
         <i class="fa-regular fa-save"></i> {% trans "Save" %}
       </button>
       <button class="btn btn-outline-danger"

--- a/corehq/apps/case_search/templates/case_search/csql_expression_form.html
+++ b/corehq/apps/case_search/templates/case_search/csql_expression_form.html
@@ -1,27 +1,18 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-
 <form hx-post="{{ request.path_info }}"
       hq-hx-action="save_expression"
       hx-swap="outerHTML">
-  <input type="hidden" name="pk" value="{{ expression.pk }}" />
+  {% if form.instance.pk %}
+    <input type="hidden" name="pk" value="{{ form.instance.pk }}" />
+    {% endif %}
   <div class="row pb-3">
     <div class="col-2">
-      <input name="name"
-             placeholder="name"
-             class="form-control"
-             type="text"
-             maxlength="64"
-             value="{{ expression.name }}"/>
+      {{ form.name }}
     </div>
     <div class="col-8">
-      <textarea name="csql"
-                placeholder="@status = 'open'"
-                class="form-control vertical-resize"
-                spellcheck="false"
-                rows="1"
-      >{{ expression.csql }}</textarea>
+      {{ form.csql }}
     </div>
     <div class="col-2">
       <button type="submit" class="btn btn-outline-primary">

--- a/corehq/apps/case_search/templates/case_search/csql_expression_row.html
+++ b/corehq/apps/case_search/templates/case_search/csql_expression_row.html
@@ -1,0 +1,39 @@
+{% load hq_shared_tags %}
+{% load i18n %}
+
+
+<form hx-post="{{ request.path_info }}"
+      hq-hx-action="save_expression"
+      hx-swap="outerHTML">
+  <input type="hidden" name="pk" value="{{ expression.pk }}" />
+  <div class="row pb-3">
+    <div class="col-2">
+      <input name="name"
+             placeholder="name"
+             class="form-control"
+             type="text"
+             maxlength="64"
+             value="{{ expression.name }}"/>
+    </div>
+    <div class="col-8">
+      <textarea name="csql"
+                placeholder="@status = 'open'"
+                class="form-control vertical-resize"
+                spellcheck="false"
+                rows="1"
+      >{{ expression.csql }}</textarea>
+    </div>
+    <div class="col-2">
+      <button type="submit" class="btn btn-outline-primary">
+        <i class="fa-regular fa-save"></i> {% trans "Save" %}
+      </button>
+      <button class="btn btn-outline-danger"
+              hx-post="{{ request.path_info }}"
+              hq-hx-action="delete_expression"
+              hx-swap="delete"
+              hx-target="closest form">
+        <i class="fa-regular fa-trash-can"></i> {% trans "Delete" %}
+      </button>
+    </div>
+  </div>
+</form>

--- a/corehq/apps/case_search/templates/case_search/csql_fixture_configuration.html
+++ b/corehq/apps/case_search/templates/case_search/csql_fixture_configuration.html
@@ -18,8 +18,8 @@
   </p>
 
   <div id="csql-fixture-rows">
-    {% for expression in csql_fixture_expressions %}
-      {% include 'case_search/csql_expression_row.html' %}
+    {% for form in csql_fixture_forms %}
+      {{ form }}
     {% endfor %}
   </div>
   <button type="button"

--- a/corehq/apps/case_search/templates/case_search/csql_fixture_configuration.html
+++ b/corehq/apps/case_search/templates/case_search/csql_fixture_configuration.html
@@ -10,7 +10,7 @@
 {% block page_content %}
   <p>
     Please see
-    <a href="https://dimagi.atlassian.net/wiki/spaces/USH/pages/2680389646/Module+Badges">
+    <a href="https://dimagi.atlassian.net/wiki/spaces/USH/pages/2884206593/CSQL+Fixtures">
       the documentation
     </a>
     for this feature.

--- a/corehq/apps/case_search/templates/case_search/csql_fixture_configuration.html
+++ b/corehq/apps/case_search/templates/case_search/csql_fixture_configuration.html
@@ -9,65 +9,31 @@
 {% endblock %}
 
 {% block page_content %}
-  {{ csql_fixture_configurations|json_script:"fixtureConfig" }}
-  <p>Please see <a href="https://dimagi.atlassian.net/wiki/spaces/USH/pages/2680389646/Module+Badges">the documentation</a> for this feature.</p>
-  <div x-data="{
-                validationFailed: false,
-                isDirty: false,
-                rows: JSON.parse(document.getElementById('fixtureConfig').textContent),
-                addRow() {
-                    this.rows.push({ row: '', csql: '', id: '' });
-                },
-                deleteRow(index) {
-                    this.rows.splice(index, 1);
-                    this.markDirty();
-                },
-                markDirty() {
-                    this.isDirty = true;
-                },
-                unmarkDirty() {
-                    this.isDirty = false;
-                }
-            }">
-    <form hx-post={{ save_url }} action="/submit" method="POST" hx-target="#response-message" hx-swap="innerHTML"
-        @change="markDirty" @submit="unmarkDirty">
-      <div id="response-message"></div>
-      <button type="submit" class="btn btn-primary" id="Save" x-bind:disabled="!isDirty">{% trans "Save" %}</button>
-      <p/>
-        <table class="table table-striped table-bordered">
-          <thead>
-            <tr>
-              <th class="col-sm-2">
-                {% trans "Name" %}
-              </th>
-              <th class="col-sm-7">
-                {% trans "Case Search QL Expression" %}
-              </th>
-              <th class="col-sm-1">
-                {% trans "Delete" %}
-              </th>
-          </thead>
-          <tbody>
-            <template x-for="(row, index) in rows" :key="index">
-              <tr>
-                  <td><input class="form-control" type="text" name="name" x-model="row.name" maxlength="64"></td>
-                  <td><textarea class="form-control vertical-resize" spellcheck="false" rows="1" name="csql"
-                    x-model="row.csql"></textarea></td>
-                  <td><button class="btn btn-outline-danger"
-                              @click="deleteRow(index)">
-                    <i class="fa-regular fa-trash-can"></i>
-                    {% trans "Delete" %}
-                  </button></td>
-                  <input type="hidden" name="id" x-model="row.id">
-              </tr>
-            </template>
-          </tbody>
-        </table>
-      <button type="button" class="btn btn-default" @click="addRow()">
-        <i class="fa fa-plus"></i>
-        {% trans "Add Expression" %}
-      </button>
-      <br>
-    </form>
+  <p>
+    Please see
+    <a href="https://dimagi.atlassian.net/wiki/spaces/USH/pages/2680389646/Module+Badges">
+      the documentation
+    </a>
+    for this feature.
+  </p>
+
+  <div id="csql-fixture-rows">
+    {% for expression in csql_fixture_expressions %}
+      {% include 'case_search/csql_expression_row.html' %}
+    {% endfor %}
   </div>
+  <button type="button"
+          class="btn btn-default"
+          hx-post="{{ request.path_info }}"
+          hq-hx-action="new_expression"
+          hx-target="#csql-fixture-rows"
+          hx-swap="beforeend">
+    <i class="fa fa-plus"></i> {% trans "Add Expression" %}
+  </button>
+
 {% endblock %}
+
+{% block modals %}
+  {% include "hqwebapp/htmx/error_modal.html" %}
+  {{ block.super }}
+{% endblock modals %}

--- a/corehq/apps/case_search/templates/case_search/csql_fixture_configuration.html
+++ b/corehq/apps/case_search/templates/case_search/csql_fixture_configuration.html
@@ -1,7 +1,6 @@
 {% extends 'hqwebapp/bootstrap5/base_section.html' %}
 {% load hq_shared_tags %}
 {% load i18n %}
-
 {% js_entry "hqwebapp/js/htmx_and_alpine" %}
 
 {% block page_title %}
@@ -22,15 +21,16 @@
       {{ form }}
     {% endfor %}
   </div>
-  <button type="button"
-          class="btn btn-default"
-          hx-post="{{ request.path_info }}"
-          hq-hx-action="new_expression"
-          hx-target="#csql-fixture-rows"
-          hx-swap="beforeend">
+  <button
+    type="button"
+    class="btn btn-default"
+    hx-post="{{ request.path_info }}"
+    hq-hx-action="new_expression"
+    hx-target="#csql-fixture-rows"
+    hx-swap="beforeend"
+  >
     <i class="fa fa-plus"></i> {% trans "Add Expression" %}
   </button>
-
 {% endblock %}
 
 {% block modals %}

--- a/corehq/apps/case_search/tests/test_fixtures.py
+++ b/corehq/apps/case_search/tests/test_fixtures.py
@@ -18,7 +18,7 @@ from corehq.util.test_utils import flag_enabled
 from ..fixtures import _get_template_renderer, case_search_fixture_generator
 
 
-@flag_enabled('MODULE_BADGES')
+@flag_enabled('CSQL_FIXTURE')
 @es_test(requires=[case_search_adapter], setup_class=True)
 class TestCaseSearchFixtures(TestCase):
     domain_name = 'test-case-search-fixtures'

--- a/corehq/apps/case_search/tests/test_views.py
+++ b/corehq/apps/case_search/tests/test_views.py
@@ -1,42 +1,16 @@
-from django.test import TestCase
 from django.urls import reverse
 
-from corehq.apps.case_search.models import (
-    CSQLFixtureExpression,
-    CSQLFixtureExpressionLog,
-)
-from corehq.apps.case_search.views import CSQLFixtureExpressionView
-from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.users.models import WebUser
+from corehq.tests.util.htmx import HtmxViewTestCase
 from corehq.util.test_utils import flag_enabled
+
+from ..models import CSQLFixtureExpression, CSQLFixtureExpressionLog
+from ..views import CSQLFixtureExpressionView
 
 
 @flag_enabled('CSQL_FIXTURE')
-class TestCSQLFixtureExpressionView(TestCase):
-    domain = 'test-domain'
-    username = 'username@test.com'
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.domain_obj = create_domain(cls.domain)
-        cls.user = WebUser.create(
-            cls.domain, cls.username, 'password', None, None, is_admin=True
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete(cls.domain, deleted_by=None)
-        cls.domain_obj.delete()
-        super().tearDownClass()
-
-    def hx_action(self, action, data):
-        self.client.login(username=self.username, password='password')
-        return self.client.post(
-            reverse(CSQLFixtureExpressionView.urlname, args=[self.domain]),
-            data,
-            headers={'HQ-HX-Action': action},
-        )
+class TestCSQLFixtureExpressionView(HtmxViewTestCase):
+    def get_url(self):
+        return reverse(CSQLFixtureExpressionView.urlname, args=[self.domain])
 
     def test_create_update_delete(self):
         # create

--- a/corehq/apps/case_search/tests/test_views.py
+++ b/corehq/apps/case_search/tests/test_views.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from unittest.mock import patch
 
 
-@flag_enabled('MODULE_BADGES')
+@flag_enabled('CSQL_FIXTURE')
 class TestCSQLFixtureExpressionView(TestCase):
 
     DOMAIN = 'test-domain'

--- a/corehq/apps/case_search/tests/test_views.py
+++ b/corehq/apps/case_search/tests/test_views.py
@@ -1,60 +1,74 @@
-from corehq.util.test_utils import flag_enabled
-from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.case_search.models import CSQLFixtureExpression, CSQLFixtureExpressionLog
-from corehq.apps.case_search.views import CSQLFixtureExpressionView
-from corehq.apps.users.dbaccessors import delete_all_users
-from corehq.apps.users.models import HqPermissions, WebUser
-from corehq.apps.users.models_role import UserRole
 from django.test import TestCase
 from django.urls import reverse
-from unittest.mock import patch
+
+from corehq.apps.case_search.models import (
+    CSQLFixtureExpression,
+    CSQLFixtureExpressionLog,
+)
+from corehq.apps.case_search.views import CSQLFixtureExpressionView
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import WebUser
+from corehq.util.test_utils import flag_enabled
 
 
 @flag_enabled('CSQL_FIXTURE')
 class TestCSQLFixtureExpressionView(TestCase):
-
-    DOMAIN = 'test-domain'
-    DEFAULT_USER_PASSWORD = 'password'
-    USERNAME = 'username@test.com'
+    domain = 'test-domain'
+    username = 'username@test.com'
 
     @classmethod
     def setUpClass(cls):
-        super(TestCSQLFixtureExpressionView, cls).setUpClass()
-        cls.domain_obj = create_domain(cls.DOMAIN)
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain)
         cls.user = WebUser.create(
-            cls.DOMAIN, cls.USERNAME, cls.DEFAULT_USER_PASSWORD, None, None, is_admin=True
+            cls.domain, cls.username, 'password', None, None, is_admin=True
         )
-        cls.role = UserRole.create(cls.DOMAIN, 'Fixtures Access', HqPermissions(edit_data=True))
-        cls.user.set_role(cls.DOMAIN, cls.role.get_qualified_id())
 
     @classmethod
     def tearDownClass(cls):
-        cls.user.delete(cls.DOMAIN, deleted_by=None)
+        cls.user.delete(cls.domain, deleted_by=None)
         cls.domain_obj.delete()
-        delete_all_users()
-        super(TestCSQLFixtureExpressionView, cls).tearDownClass()
+        super().tearDownClass()
 
-    def _get_view_response(self, data):
-        self.client.login(username=self.USERNAME, password=self.DEFAULT_USER_PASSWORD)
-        response = self.client.post(reverse(CSQLFixtureExpressionView.urlname, args=[self.DOMAIN]), data)
-        return response
+    def hx_action(self, action, data):
+        self.client.login(username=self.username, password='password')
+        return self.client.post(
+            reverse(CSQLFixtureExpressionView.urlname, args=[self.domain]),
+            data,
+            headers={'HQ-HX-Action': action},
+        )
 
-    @patch('django_prbac.decorators.has_privilege', return_value=True)
-    def test_create_update_delete(self, has_privilege):
-        deleted_exp = CSQLFixtureExpression.objects.create(domain=self.DOMAIN, name='deleted_exp', csql='asdf')
-        exp2 = CSQLFixtureExpression.objects.create(domain=self.DOMAIN, name='exp2', csql='asdf')
-        data = {
-            'id': [exp2.id, ''],
-            'name': ['exp2', 'exp3'],
-            'csql': ['asdfg', 'asdf'],
-        }
-        response = self._get_view_response(data)
+    def test_create_update_delete(self):
+        # create
+        response = self.hx_action('save_expression', {
+            'name': 'my_indicator_name',
+            'csql': 'original csql',
+        })
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(CSQLFixtureExpression.objects.filter(
-            domain=self.DOMAIN, name='deleted_exp', deleted=False).exists())
-        CSQLFixtureExpression.objects.get(domain=self.DOMAIN, name='exp2', id=exp2.id, csql='asdfg')
-        CSQLFixtureExpression.objects.get(domain=self.DOMAIN, name='exp3', csql='asdf')
-        CSQLFixtureExpressionLog.objects.get(expression=deleted_exp,
-                                             action=CSQLFixtureExpressionLog.Action.DELETE)
-        CSQLFixtureExpressionLog.objects.get(expression=exp2, action=CSQLFixtureExpressionLog.Action.UPDATE)
-        CSQLFixtureExpressionLog.objects.get(name='exp3', action=CSQLFixtureExpressionLog.Action.CREATE)
+        expression = CSQLFixtureExpression.objects.get(domain=self.domain, name='my_indicator_name')
+        self.assertEqual(expression.csql, 'original csql')
+
+        # update
+        response = self.hx_action('save_expression', {
+            'pk': expression.pk,
+            'name': expression.name,
+            'csql': 'updated csql',
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            CSQLFixtureExpression.objects.get(pk=expression.pk).csql,
+            'updated csql',
+        )
+
+        # delete
+        response = self.hx_action('delete_expression', {'pk': expression.pk})
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(CSQLFixtureExpression.objects.get(pk=expression.pk).deleted)
+
+        # check log
+        self.assertEqual(
+            list(expression.csqlfixtureexpressionlog_set.values_list('action', 'csql')),
+            [(CSQLFixtureExpressionLog.Action.CREATE.value, 'original csql'),
+             (CSQLFixtureExpressionLog.Action.UPDATE.value, 'updated csql'),
+             (CSQLFixtureExpressionLog.Action.DELETE.value, '')],
+        )

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -143,7 +143,7 @@ class ProfileCaseSearchView(_BaseCaseSearchView):
 
 @method_decorator([
     use_bootstrap5,
-    toggles.MODULE_BADGES.required_decorator(),
+    toggles.CSQL_FIXTURE.required_decorator(),
     require_can_edit_data,
 ], name='dispatch')
 class CSQLFixtureExpressionView(HqHtmxActionMixin, BaseProjectDataView):

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -2,7 +2,6 @@ import json
 import re
 from io import BytesIO
 
-from django.db.transaction import atomic
 from django.http import Http404
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -22,7 +21,6 @@ from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from django.http import HttpResponse
 from corehq.util.dates import get_timestamp_for_filename
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
-from dimagi.utils.logging import notify_exception
 from django.utils.translation import gettext as _
 from corehq.util.view_utils import BadRequest, json_error
 
@@ -148,7 +146,7 @@ class ProfileCaseSearchView(_BaseCaseSearchView):
 ], name='dispatch')
 class CSQLFixtureExpressionView(HqHtmxActionMixin, BaseDomainView):
     urlname = 'csql_fixture_configuration'
-    page_title = _('CSQL Fixture Confguration')
+    page_title = _('CSQL Fixture Configuration')
     template_name = 'case_search/csql_fixture_configuration.html'
 
     @property

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -2,7 +2,7 @@ import json
 import re
 from io import BytesIO
 
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
@@ -10,18 +10,20 @@ from django.utils.translation import gettext_lazy
 from dimagi.utils.web import json_response
 
 from corehq import toggles
-from corehq.apps.case_search.forms import CSQLFixtureExpressionForm
-from corehq.apps.case_search.models import case_search_enabled_for_domain, CSQLFixtureExpression
-from corehq.apps.case_search.utils import get_case_search_results_from_request
 from corehq.apps.case_importer.views import require_can_edit_data
+from corehq.apps.case_search.forms import CSQLFixtureExpressionForm
+from corehq.apps.case_search.models import (
+    CSQLFixtureExpression,
+    case_search_enabled_for_domain,
+)
+from corehq.apps.case_search.utils import get_case_search_results_from_request
 from corehq.apps.domain.decorators import cls_require_superuser_or_contractor
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqadmin.utils import get_download_url
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
-from django.http import HttpResponse
+from corehq.apps.settings.views import BaseProjectDataView
 from corehq.util.dates import get_timestamp_for_filename
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
-from django.utils.translation import gettext as _
 from corehq.util.view_utils import BadRequest, json_error
 
 
@@ -144,14 +146,10 @@ class ProfileCaseSearchView(_BaseCaseSearchView):
     toggles.MODULE_BADGES.required_decorator(),
     require_can_edit_data,
 ], name='dispatch')
-class CSQLFixtureExpressionView(HqHtmxActionMixin, BaseDomainView):
+class CSQLFixtureExpressionView(HqHtmxActionMixin, BaseProjectDataView):
     urlname = 'csql_fixture_configuration'
-    page_title = _('CSQL Fixture Configuration')
+    page_title = gettext_lazy('CSQL Fixture Configuration')
     template_name = 'case_search/csql_fixture_configuration.html'
-
-    @property
-    def section_url(self):
-        return reverse(self.urlname, args=[self.domain])
 
     @property
     def page_context(self):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -626,7 +626,7 @@ class ProjectDataTab(UITab):
             items.extend(FixtureInterfaceDispatcher.navigation_sections(
                 request=self._request, domain=self.domain))
 
-        if (toggles.MODULE_BADGES.enabled(self.domain) and self.couch_user.can_edit_data()):
+        if (toggles.CSQL_FIXTURE.enabled(self.domain) and self.couch_user.can_edit_data()):
             items.append([_('CSQL Fixtures'), [{
                 'title': _(CSQLFixtureExpressionView.page_title),
                 'url': reverse(CSQLFixtureExpressionView.urlname, args=[self.domain]),

--- a/corehq/tests/util/htmx.py
+++ b/corehq/tests/util/htmx.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import WebUser
+
+
+class HtmxViewTestCase(TestCase):
+    domain = 'htmx-view-test'
+    username = 'username@test.com'
+
+    def get_url(self):
+        raise NotImplementedError()
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+        cls.user = WebUser.create(
+            cls.domain, cls.username, 'password', None, None, is_admin=True
+        )
+        cls.addClassCleanup(cls.user.delete, cls.domain, None)
+
+    def hx_action(self, action, data):
+        """Call an HTMX view action (the view method decorated with @hq_hx_action) and receive the response"""
+        self.client.login(username=self.username, password='password')
+        return self.client.post(self.get_url(), data, headers={'HQ-HX-Action': action})

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2988,11 +2988,16 @@ SMART_LINKS_FOR_WEB_USERS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-MODULE_BADGES = StaticToggle(
+CSQL_FIXTURE = StaticToggle(
     slug='module_badges',
-    label='USH: Show case counts from CSQL queries as badges on modules',
+    label='USH: CSQL Fixture (FKA Module Badges)',
     tag=TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
+    description=(
+        'Configure fixture containing indicators specified as CSQL expressions, where each '
+        'indicator is a count of cases matching the expression.'
+    ),
+    help_link='https://dimagi.atlassian.net/wiki/spaces/USH/pages/2884206593/CSQL+Fixtures',
 )
 
 INCLUDE_ALL_LOCATIONS = StaticToggle(


### PR DESCRIPTION
## Product Description


## Technical Summary
Some changes to the CSQL fixture UI to make it use HTMX in a more idiomatic way.  I did this a couple months ago and then kinda dropped it.  I have a documentation ticket for the feature this sprint, so I'm taking the opportunity to wrap this up too.

https://dimagi.atlassian.net/browse/USH-4962

## Feature Flag
CSQL_FIXTURE

## Safety Assurance
FF used only by one project

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change