### PR TITLE
[B5] Migrate email app

### DIFF
--- a/corehq/apps/email/forms.py
+++ b/corehq/apps/email/forms.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext as _
 
 from corehq.apps.email.models import EmailSettings
 from corehq.apps.hqwebapp import crispy as hqcrispy
+from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
 from corehq.motech.const import PASSWORD_PLACEHOLDER
 
 
@@ -45,14 +46,18 @@ class EmailSMTPSettingsForm(forms.ModelForm):
     use_this_gateway = forms.BooleanField(
         label=_("Use Gateway?"),
         required=False,
-        help_text=_("Select this option to use this email gateway for sending emails")
+        widget=BootstrapCheckboxInput(
+            inline_label=_("Select this option to use this email gateway for sending emails")
+        )
     )
 
     use_tracking_headers = forms.BooleanField(
         label=_("Use Tracking Headers"),
         required=False,
-        help_text=_("Applicable for Amazon's gateway. When selected, "
-                    "emails will be sent with tracking headers along with other headers.")
+        widget=BootstrapCheckboxInput(
+            inline_label=_("Applicable for Amazon's gateway. When selected, "
+                           "emails will be sent with tracking headers along with other headers.")
+        )
     )
 
     sns_secret = forms.CharField(
@@ -100,24 +105,22 @@ class EmailSMTPSettingsForm(forms.ModelForm):
         helper = hqcrispy.HQFormHelper()
         helper.form_id = "email_settings_form"
         helper.layout = crispy.Layout(
-            twbscrispy.PrependedText('use_this_gateway', ''),
+            hqcrispy.CheckboxField('use_this_gateway'),
             crispy.Field('username'),
             crispy.Field('plaintext_password'),
             crispy.Field('server'),
             crispy.Field('port'),
             crispy.Field('from_email'),
             crispy.Field('return_path_email'),
-            twbscrispy.PrependedText('use_tracking_headers', ''),
+            hqcrispy.CheckboxField('use_tracking_headers'),
             crispy.Field('sns_secret'),
             crispy.Field('ses_config_set_name'),
-            hqcrispy.FormActions(
-                twbscrispy.StrictButton(
-                    _("Saved"),
-                    type="submit",
-                    css_class="btn-primary disable-on-submit",
-                    data_bind="text: buttonText, enable: isFormChanged",
-                ),
-            )
+            twbscrispy.StrictButton(
+                _("Saved"),
+                type="submit",
+                css_class="btn-primary disable-on-submit",
+                data_bind="text: buttonText, enable: isFormChanged",
+            ),
         )
         return helper
 

--- a/corehq/apps/email/templates/email/email_settings.html
+++ b/corehq/apps/email/templates/email/email_settings.html
@@ -1,4 +1,4 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
@@ -10,6 +10,6 @@
   <h2>{% trans "Add Email Gateway Settings" %}</h2>
   <div class="spacer"></div>
 
-  {% crispy form %}
+  {% crispy form %}  {# todo B5: crispy #}
 
 {% endblock %}

--- a/corehq/apps/email/templates/email/email_settings.html
+++ b/corehq/apps/email/templates/email/email_settings.html
@@ -3,13 +3,13 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% js_entry_b3 'email/js/email_settings' %}
+{% js_entry 'email/js/email_settings' %}
 
 {% block page_content %}
 
   <h2>{% trans "Add Email Gateway Settings" %}</h2>
   <div class="spacer"></div>
 
-  {% crispy form %}  {# todo B5: crispy #}
+  {% crispy form %}
 
 {% endblock %}

--- a/corehq/apps/email/views.py
+++ b/corehq/apps/email/views.py
@@ -11,9 +11,11 @@ from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.email.forms import EmailSMTPSettingsForm
 from corehq.apps.email.models import EmailSettings
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.messaging.scheduling.views import MessagingDashboardView
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 @method_decorator(domain_admin_required, name='dispatch')
 @method_decorator(toggles.CUSTOM_EMAIL_GATEWAY.required_decorator(), name='dispatch')
 class EmailSMTPSettingsView(BaseDomainView):

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -54,6 +54,9 @@
   "dropbox": {
     "is_complete": true
   },
+  "email": {
+    "is_complete": true
+  },
   "enterprise": {
     "is_complete": true
   },


### PR DESCRIPTION
## Product Description
Found a couple of small apps that aren't on the migration tracking spreadsheet, they were probably created after it was. This one just has one view.

### Before
<img width="1008" alt="Screenshot 2024-11-14 at 8 59 59 PM" src="https://github.com/user-attachments/assets/e25492cf-c19a-464b-8ae0-c8fa94f0c803">

### After
<img width="1113" alt="Screenshot 2024-11-14 at 8 59 38 PM" src="https://github.com/user-attachments/assets/5c7d2d86-3bf8-474f-9a91-b65e6017ddf2">

## Feature Flag
Allows user to define custom email gateway that can be used to send emails from HQ

## Safety Assurance

### Safety story
Simple migration on a page that's barely used. This is a config page used for one project, likely configured by an internal team.

### Automated test coverage

unlikely

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
