### PR TITLE
Add uv to docker test image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,11 @@ RUN apt-get update \
      git \
      google-chrome-stable \
      libmagic1 \
-     libpq5 \
+     libpq-dev \
      libxml2 \
      libxmlsec1 \
      libxmlsec1-openssl \
+     make \
   && rm -rf /var/lib/apt/lists/* /src/*.deb
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ ENV PYTHONUNBUFFERED=1 \
     NODE_VERSION=20.11.1 \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy
-# UV_COMPILE_BYTECODE: Compile bytecode during installation.
+# UV_COMPILE_BYTECODE: Compile bytecode during installation to improve module
+#   load performance. Also suppresses a couchdbkit syntax error that happens
+#   during bytecode compilation.
 # UV_LINK_MODE: Copy from the cache instead of linking since it's a mounted volume
 
 RUN mkdir /vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,3 +59,10 @@ RUN npm -g install \
  && cd /vendor \
  && npm shrinkwrap \
  && yarn global add phantomjs-prebuilt
+
+# For backward compatibility with commcarehq_base image containing
+# google-chrome-unstable. Can be removed after all test jobs with Gruntfile.js
+# referencing google-chrome-unstable have completed (at least a few weeks or
+# months after the PR in which this was introduced is merged). Old PRs can be
+# updated to use google-chrome-stable by merging master into them.
+RUN ln -s /usr/bin/google-chrome-stable /usr/bin/google-chrome-unstable

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ ENV PYTHONUNBUFFERED=1 \
     NODE_VERSION=20.11.1 \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy
+# UV_COMPILE_BYTECODE: Compile bytecode during installation.
+# UV_LINK_MODE: Copy from the cache instead of linking since it's a mounted volume
 
 RUN mkdir /vendor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,54 +3,45 @@
 # This Dockerfile is built as the `dimagi/commcarehq_base` image, which
 # is used for running tests.
 
-FROM python:3.9
+FROM ghcr.io/astral-sh/uv:0.5.2-python3.9-bookworm-slim
 MAINTAINER Dimagi <devops@dimagi.com>
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONUSERBASE=/vendor \
     PATH=/vendor/bin:$PATH \
-    NODE_VERSION=20.11.1
+    NODE_VERSION=20.11.1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
 
 RUN mkdir /vendor
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl gnupg \
+  && curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+     bzip2 \
+     default-jre \
+     gettext \
+     git \
+     google-chrome-stable \
+     libmagic1 \
+     libpq5 \
+     libxml2 \
+     libxmlsec1 \
+     libxmlsec1-openssl \
+  && rm -rf /var/lib/apt/lists/* /src/*.deb
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.gz"
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-     default-jdk \
-     wget \
-     libxml2-dev \
-     libxmlsec1-dev \
-     libxmlsec1-openssl \
-     gettext
-
-# Install latest chrome dev package and fonts to support major
-# charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version
-# of Chromium that Puppeteer installs, work.
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-     google-chrome-unstable \
-     fonts-ipafont-gothic \
-     fonts-wqy-zenhei \
-     fonts-thai-tlwg \
-     fonts-kacst \
-     fonts-freefont-ttf
-
-# Deletes all package sources, so don't apt-get install anything after this:
-RUN rm -rf /var/lib/apt/lists/* /src/*.deb
-
 COPY requirements/test-requirements.txt package.json /vendor/
 
-# prefer https for git checkouts made by pip
-RUN git config --global url."https://".insteadOf git:// \
- && pip install --upgrade pip \
- && pip install -r /vendor/test-requirements.txt --user --upgrade \
- && rm -rf /root/.cache/pip
+RUN --mount=type=cache,target=/root/.cache/uv \
+  uv venv --allow-existing /vendor \
+  && uv pip install --prefix=/vendor -r /vendor/test-requirements.txt
 
 # this keeps the image size down, make sure to set in mocha-headless-chrome options
 #   executablePath: 'google-chrome-unstable'

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
   && uv pip install --prefix=/vendor -r /vendor/test-requirements.txt
 
 # this keeps the image size down, make sure to set in mocha-headless-chrome options
-#   executablePath: 'google-chrome-unstable'
+#   executablePath: 'google-chrome-stable'
 ENV PUPPETEER_SKIP_DOWNLOAD true
 
 RUN npm -g install \

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,9 +70,9 @@ module.exports = function (grunt) {
                 reporter: reporter,
             };
 
-        // For running in docker/travis
+        // For running in docker
         if (process.env.PUPPETEER_SKIP_DOWNLOAD) {
-            runnerOptions.executablePath = 'google-chrome-unstable';
+            runnerOptions.executablePath = 'google-chrome-stable';
         }
 
         grunt.log.writeln("\n");

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM dimagi/commcarehq_base:latest
+# DO NOT MERGE. TODO: configure automated build on hub.docker.com or revert to commcarehq_base
+FROM dimagi/commcarehq-py39-uv:latest
 
 VOLUME /mnt/commcare-hq-ro /mnt/lib
 RUN ln -s /mnt/commcare-hq-ro/docker/run.sh /mnt/run.sh && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
-# DO NOT MERGE. TODO: configure automated build on hub.docker.com or revert to commcarehq_base
-FROM dimagi/commcarehq-py39-uv:latest
+FROM dimagi/commcarehq_base:latest
 
 VOLUME /mnt/commcare-hq-ro /mnt/lib
 RUN ln -s /mnt/commcare-hq-ro/docker/run.sh /mnt/run.sh && \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -36,7 +36,7 @@ function setup {
         install -dm0755 -o cchq -g cchq ./artifacts
     fi
 
-    pip-sync --user requirements/test-requirements.txt
+    uv pip sync requirements/test-requirements.txt
     pip check  # make sure there are no incompatibilities in test-requirements.txt
     python_preheat  # preheat the python libs
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -36,7 +36,14 @@ function setup {
         install -dm0755 -o cchq -g cchq ./artifacts
     fi
 
-    uv pip sync requirements/test-requirements.txt
+    # uv check, pip-sync, and symlink can be removed after the commcarehq_base
+    # Docker image containing uv has been published for use by Github Actions.
+    if which uv &> /dev/null; then
+        uv pip sync requirements/test-requirements.txt
+    else
+        pip-sync --user requirements/test-requirements.txt
+        ln -s /usr/bin/google-chrome-unstable /usr/bin/google-chrome-stable
+    fi
     pip check  # make sure there are no incompatibilities in test-requirements.txt
     python_preheat  # preheat the python libs
 


### PR DESCRIPTION
~Opening for tests. Review is not necessary until all tests are passing.~

The new image is backward-compatible with the existing pip-tools installation method, which means it will work with the old version of `run.sh` that uses `pip-sync` rather than `uv pip sync`.

Image size reducing changes:
- python:3.9 (1.02 GB) -> ghcr.io/astral-sh/uv:0.5.2-python3.9-bookworm-slim (163 MB) 
  python:3.9 is based on bookworm, the major size difference came from the -slim base image.
- install non-dev packages (libxml2, libxmlsec1, jre instead of jdk)
- use google-chrome-stable instead of google-chrome-unstable + fonts
- do all apt-get installs in one layer, removing apt cache at the end
- use uv to create virtualenv and install packages, faster and smaller

Overall image size reduced from 3.05GB to ~2.11~ 2.13 GB. - libpq-dev added 0.02 GB in https://github.com/dimagi/commcare-hq/pull/35375/commits/83fe22b89027e23b063b0560cd62fc6017cf5551

The new `docker/Dockerfile` base image (`commcarehq-py39-uv`) is a temporary image tag to verify that tests pass on the new uv-based image, which I built locally and manually pushed to Docker Hub. I have not been able to configure automated builds for that image on Docker Hub, and if I can't figure that out I will likely remove it before merging this PR.

## Safety Assurance

### Safety story

Only affects tests and people running HQ in docker.

### Automated test coverage

Yes, indirectly since tests run on this image.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
