### PR TITLE
mark multimedia export as location safe

### DIFF
--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -445,6 +445,7 @@ class DownloadNewFormExportView(BaseDownloadExportView):
 
 @require_POST
 @login_and_domain_required
+@location_safe
 def prepare_form_multimedia(request, domain):
     """Gets the download_id for the multimedia zip and sends it to the
     exportDownloadService in download_export.ng.js to begin polling for the


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-12925

Location-restricted user is not able to export multimedia because the view to export multimedia doesn't have @location_safe decorator. The view to export multimedia will use ExpandedMobileWorkerFilter to limit its access only to the assigned locations.

Context about `@location_safe` decorator [here](https://github.com/dimagi/commcare-hq/blob/d5ccaf4807da801ac58548b86d5104e08899bfd4/corehq/apps/locations/permissions.py#L65-L71).

This ticket is similar to https://dimagi.atlassian.net/browse/HI-208

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Test on staging: setting up a location restricted web user who is able to download multimedia, and the multimedia is only restricted to the location that he have access to.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA: https://dimagi.atlassian.net/browse/QA-7285

QA plan: make sure location restricted user can only export multimedia from their assigned locations.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
