### PR TITLE
Set allowed GTM tag types in data layer

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/gtx.js
+++ b/corehq/apps/analytics/static/analytix/js/gtx.js
@@ -23,6 +23,29 @@ hqDefine('analytix/js/gtx', [
 
     window.dataLayer = window.dataLayer || [];
 
+    function setAllowedTagTypes() {
+        // https://developers.google.com/tag-platform/tag-manager/restrict
+        // Only allow tags, triggers, and variables we actively use.
+        // Others may come with unknown security risks.
+        var allowList = [
+            'google',   // class that includes GA4 tags, built-in triggers and variables, etc.
+        ];
+
+        // Explicitly block tags, triggers, and variables with known security risks.
+        // Note: blocklist overrides allowlist
+        var blockList = [
+            // Higher risk: running arbitrary code in the browser, DOM manipulation
+            'jsm',      // custom javascript variable
+            'html',     // custom html tag
+
+            // Lower risk: data leakage
+            'img',      // custom image tag
+            'j',        // javascript variable
+            'k',        // first party cookie variable
+        ];
+        window.dataLayer.push({'gtm.allowlist': allowList, 'gtm.blocklist': blockList});
+    }
+
     function addUserPropertiesToDataLayer() {
         var userPropertiesEvent = {
             event: 'userProperties',
@@ -77,6 +100,7 @@ hqDefine('analytix/js/gtx', [
 
         // userProperties are added to dataLayer at earliest to be readily available once GTM loads
         if (apiId && initialAnalytics.getFn('global')(('isEnabled'))) {
+            setAllowedTagTypes();
             addUserPropertiesToDataLayer();
         }
 


### PR DESCRIPTION
## Technical Summary
[SAAS-16182](https://dimagi.atlassian.net/browse/SAAS-16182)
This change aims to improve security in Google Tag Manager usage by specifying which tag and variable types are allowed in HQ, through a blocklist and allowlist as described in [GTM documentation](https://developers.google.com/tag-platform/tag-manager/restrict).

## Safety Assurance

### Safety story
Tested on staging to see that only specified types of tags and variables are blocked or allowed, and that our existing GTM setup all appears to work as usual. This only affects GTM script initialization and essentially directly follows documentation, so potential issues are unlikely.

### Automated test coverage
Don't believe there is any here.

### QA Plan
We could QA this if reviewers deem it wise or necessary, but not planning on it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16182]: https://dimagi.atlassian.net/browse/SAAS-16182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ