### PR TITLE
[webpack] Migrate a few tempus dominus pages

### DIFF
--- a/corehq/apps/app_execution/static/app_execution/js/workflow_charts.js
+++ b/corehq/apps/app_execution/static/app_execution/js/workflow_charts.js
@@ -3,7 +3,8 @@ hqDefine("app_execution/js/workflow_charts", [
     'jquery',
     'moment/moment',
     'd3/d3.min',
-    'nvd3/nv.d3.latest.min',  // version 1.1.10 has a bug that affects line charts with multiple series
+    'nvd3-1.8.6',  // version 1.1.10 has a bug that affects line charts with multiple series
+    'commcarehq',
 ], function (
     $, moment, d3, nv
 ) {

--- a/corehq/apps/app_execution/static/app_execution/js/workflow_charts.js
+++ b/corehq/apps/app_execution/static/app_execution/js/workflow_charts.js
@@ -3,7 +3,7 @@ hqDefine("app_execution/js/workflow_charts", [
     'jquery',
     'moment/moment',
     'd3/d3.min',
-    'nvd3-1.8.6',  // version 1.1.10 has a bug that affects line charts with multiple series
+    'nvd3/nv.d3.latest.min',  // version 1.1.10 has a bug that affects line charts with multiple series
     'commcarehq',
 ], function (
     $, moment, d3, nv

--- a/corehq/apps/app_execution/static/app_execution/js/workflow_logs.js
+++ b/corehq/apps/app_execution/static/app_execution/js/workflow_logs.js
@@ -6,6 +6,7 @@ hqDefine("app_execution/js/workflow_logs", [
     'hqwebapp/js/tempus_dominus',
     'app_execution/js/workflow_charts',
     'hqwebapp/js/components/pagination',
+    'commcarehq',
 ], function ($, ko, initialPageData, hqTempusDominus) {
     let logsModel = function () {
         let self = {};

--- a/corehq/apps/app_execution/templates/app_execution/workflow_list.html
+++ b/corehq/apps/app_execution/templates/app_execution/workflow_list.html
@@ -12,7 +12,7 @@
   {% endcompress %}
 {% endblock %}
 
-{% requirejs_main_b5 'app_execution/js/workflow_charts' %}
+{% js_entry 'app_execution/js/workflow_charts' %}
 
 {% block page_content %}
   <div>

--- a/corehq/apps/app_execution/templates/app_execution/workflow_log_list.html
+++ b/corehq/apps/app_execution/templates/app_execution/workflow_log_list.html
@@ -16,7 +16,7 @@
   {% endcompress %}
 {% endblock %}
 
-{% requirejs_main_b5 'app_execution/js/workflow_logs' %}
+{% js_entry 'app_execution/js/workflow_logs' %}
 
 {% block page_content %}
   {% initial_page_data 'total_items' total %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
@@ -17,7 +17,9 @@ hqDefine("hqwebapp/js/tempus_dominus", [
     initialPageData
 ) {
     // https://github.com/Eonasdan/tempus-dominus/discussions/2698
-    window.Popper = Popper;
+    if (!window.USE_WEBPACK) {
+        window.Popper = Popper;
+    }
 
     let createDatePicker = function (el, options) {
         let picker = new tempusDominus.TempusDominus(el, _addDefaultOptions(options, {

--- a/corehq/apps/registry/static/registry/js/registry_list.js
+++ b/corehq/apps/registry/static/registry/js/registry_list.js
@@ -8,6 +8,7 @@ hqDefine("registry/js/registry_list", [
     'registry/js/registry_actions',
     'hqwebapp/js/bootstrap5/knockout_bindings.ko', // openModal
     'hqwebapp/js/select2_knockout_bindings.ko',
+    'commcarehq',
 ], function (
     $,
     _,

--- a/corehq/apps/registry/templates/registry/registry_list.html
+++ b/corehq/apps/registry/templates/registry/registry_list.html
@@ -16,7 +16,7 @@
   {% endcompress %}
 {% endblock %}
 
-{% requirejs_main_b5 'registry/js/registry_list' %}
+{% js_entry 'registry/js/registry_list' %}
 
 {% block page_content %}
   {% initial_page_data "owned_registries" owned_registries %}

--- a/corehq/apps/settings/static/settings/js/user_api_keys.js
+++ b/corehq/apps/settings/static/settings/js/user_api_keys.js
@@ -8,6 +8,7 @@ hqDefine("settings/js/user_api_keys", [
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap5/crud_paginated_list",
     "hqwebapp/js/tempus_dominus",
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/settings/templates/settings/user_api_keys.html
+++ b/corehq/apps/settings/templates/settings/user_api_keys.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main_b5 "settings/js/user_api_keys" %}
+{% js_entry "settings/js/user_api_keys" %}
 
 {% block page_content %}
   {% initial_page_data 'always_show_user_api_keys' always_show_user_api_keys %}

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -13,6 +13,7 @@ const aliases = {
     //  remove this file and the yarn modernizr post-install step
     "modernizr": "hqwebapp/js/lib/modernizr",
 
+    "nvd3/nv.d3.latest.min": "nvd3-1.8.6/build/nv.d3.min",
     "popper": "@popperjs/core/dist/cjs/popper.js",
     "sentry_browser": path.resolve(utils.getStaticFolderForApp('hqwebapp'),
         'sentry/js/sentry.browser.7.28.0.min'),

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -13,6 +13,7 @@ const aliases = {
     //  remove this file and the yarn modernizr post-install step
     "modernizr": "hqwebapp/js/lib/modernizr",
 
+    "popper": "@popperjs/core/dist/cjs/popper.js",
     "sentry_browser": path.resolve(utils.getStaticFolderForApp('hqwebapp'),
         'sentry/js/sentry.browser.7.28.0.min'),
     "sentry_captureconsole": path.resolve(utils.getStaticFolderForApp('hqwebapp'),


### PR DESCRIPTION
## Technical Summary
Update tempus dominus config for webpack, migrated a couple of pages.

## Safety Assurance

### Safety story
The only non-flagged page is user API keys, which I've smoke tested on staging.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
