### PR TITLE
Exempt case search fixture from skip_fixtures flag

### DIFF
--- a/corehq/apps/case_search/fixtures.py
+++ b/corehq/apps/case_search/fixtures.py
@@ -59,6 +59,7 @@ def _get_indicator_nodes(restore_state, indicators):
 
 class CaseSearchFixtureProvider(FixtureProvider):
     id = 'case-search-fixture'
+    ignore_skip_fixtures_flag = True
 
     def __call__(self, restore_state):
         if not MODULE_BADGES.enabled(restore_state.domain):

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/__init__.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/__init__.py
@@ -14,15 +14,11 @@ def get_element_providers(timing_context, skip_fixtures=False):
     """
     # note that ordering matters in this list as this is the order that the items
     # will appear in the XML, and have access to the RestoreState object
-    providers = [
+    return [
         SyncElementProvider(timing_context),
         RegistrationElementProvider(timing_context),
+        FixtureElementProvider(timing_context, skip_fixtures),
     ]
-
-    if not skip_fixtures:
-        providers.append(FixtureElementProvider(timing_context))
-
-    return providers
 
 def get_async_providers(timing_context, async_task=None):
     """

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/standard.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/standard.py
@@ -50,6 +50,10 @@ class FixtureElementProvider(RestoreDataProvider):
     Gets any associated fixtures.
     """
 
+    def __init__(self, timing_context, skip_fixtures):
+        super().__init__(timing_context)
+        self._skip_fixtures = skip_fixtures
+
     def get_elements(self, restore_state):
         # fixture block
         providers = generator.get_providers(
@@ -57,6 +61,8 @@ class FixtureElementProvider(RestoreDataProvider):
             version=restore_state.version,
         )
         for provider in providers:
+            if self._skip_fixtures and not getattr(provider, 'ignore_skip_fixtures_flag', False):
+                continue
             with self.timing_context('fixture:{}'.format(provider.id)):
                 elements = provider(restore_state)
                 for element in elements:


### PR DESCRIPTION
## Product Description


## Technical Summary
The aim here is for this change to be temporary.  I'd like to get us off this flag entirely, or scope it to only apply to lookup tables, as suggested on the original PR:
https://github.com/dimagi/commcare-hq/pull/28557#issuecomment-700061381

It would be better for each fixture to be able to manage its own syncing schedule.

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change