### PR TITLE
Add max row limit to case imports

### DIFF
--- a/corehq/apps/case_importer/const.py
+++ b/corehq/apps/case_importer/const.py
@@ -4,9 +4,11 @@
 # DATA_UPLOAD_MAX_NUMBER_FIELDS defaults to 1000 but there are
 # a few other fields as well. Also 300 is a nice round number.
 MAX_CASE_IMPORTER_COLUMNS = 300
+MAX_CASE_IMPORTER_ROWS = 100_000
 
 # Special case type used to identify when doing a bulk case import
 ALL_CASE_TYPE_IMPORT = 'commcare-all-case-types'
+
 
 class LookupErrors(object):
     NotFound, MultipleResults = list(range(2))

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -1,7 +1,8 @@
-from django.utils.translation import gettext_lazy, gettext_noop
+from django.utils.translation import gettext, gettext_lazy, gettext_noop
 
 import xlrd
 
+from corehq.apps.case_importer.const import MAX_CASE_IMPORTER_ROWS
 from corehq.form_processor.models import STANDARD_CHARFIELD_LENGTH
 
 
@@ -32,6 +33,19 @@ class ImporterExcelError(ImporterError, xlrd.XLRDError):
 
 class ImporterExcelFileEncrypted(ImporterExcelError):
     """Raised when a file cannot be open because it is encrypted (password-protected)"""
+
+
+class ImporterExcelTooManyRows(ImporterError):
+    """Raised when case import exceeds MAX_CASE_IMPORTER_ROWS"""
+
+    def __init__(self, row_count):
+        self.row_count = row_count
+
+    def __str__(self):
+        return gettext(
+            f"Case imports can contain a maximum of {MAX_CASE_IMPORTER_ROWS} rows. "
+            f"The uploaded file contains {self.row_count} rows."
+        )
 
 
 class InvalidCustomFieldNameException(ImporterError):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
In talking to those in delivery and CS positions, our external communications to customers already recommend limiting case imports to ~10k, and certainly no more than 100k rows. This is just codifying that suggestion.

![image](https://github.com/user-attachments/assets/ec91d1c8-0f04-4c78-baab-6854e06bf43f)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15626

We don't have any limit on the number of rows a user can import at once, and we should.

While the initial ask of the linked ticket was to detect unintentionally formatted rows in case imports, the fundamental issue is the lack of a row limit on case imports. Rather than add the complexity of attempting to detect scenarios where a user uploads a file with more rows than they've realized, it is much simpler to implement a limit on the number of rows a user can import at any given time. The times we've seen issues related to this problem, the number of rows well exceeded 100k, so this code would have caught those issues too. 

Other considerations were that attempting to detect unintentionally formatted rows in case imports added an additional step to what is already a cumbersome process. This implementation instead fails as soon as the user attempts to start the case import after uploading the file.

[Documentation](https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143946828/Importing+Cases+Using+Excel) has already been updated (thanks @orangejenny)!

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This adds an upper limit to the number of cases that can be imported at a time.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No. Tested locally and will confirm case imports work on staging. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
