### PR TITLE
Added webpack template tags to bootstrap migration tool

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -228,9 +228,16 @@ def check_bootstrap3_references_in_template(line, spec):
                              "It should also use requirejs_main_b5 instead of requirejs_main.")
             if tag == "requirejs_main_b5":
                 issues.append("This template references a bootstrap 3 requirejs file.")
+            if tag == "js_entry_b3":
+                issues.append("This template references a bootstrap 3 webpack entry point. "
+                             "It should also use js_entry instead of js_entry_b3.")
+            if tag == "js_entry":
+                issues.append("This template references a bootstrap 3 webpack entry point.")
         elif re.search(tag_only_regex, line):
             if tag == "requirejs_main":
                 issues.append("This template should use requirejs_main_b5 instead of requirejs_main.")
+            if tag == "js_entry_b3":
+                issues.append("This template should use js_entry instead of js_entry_b3.")
     regex = r"(=[\"\'][\w\/]+)(\/bootstrap3\/)"
     if re.search(regex, line):
         issues.append("This template references a bootstrap 3 file.")

--- a/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
@@ -68,7 +68,8 @@
         "col-xs-offset-<num>": "offset-sm-<num>"
     },
     "template_tag_renames": {
-        "requirejs_main": "requirejs_main_b5"
+        "requirejs_main": "requirejs_main_b5",
+        "js_entry_b3": "js_entry"
     },
     "data_attribute_renames": {
         "data-toggle": "data-bs-toggle",
@@ -113,6 +114,8 @@
     ],
     "template_tags_with_dependencies": [
         "extends",
+        "js_entry",
+        "js_entry_b3",
         "requirejs_main",
         "requirejs_main_b5",
         "static",


### PR DESCRIPTION
## Technical Summary
This will ensure that `js_entry_b3` gets renamed to `js_entry` when a B3 file is migrated, and it adds `js_entry`/`js_entry_b3` to automated checks for B3/B5 consistency within files.

## Safety Assurance

### Safety story
This is a config change to an internal engineering tool.

### Automated test coverage

yes

### QA Plan

no


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
