### PR TITLE
Limit phone number fields that use validation regex to 20 characters

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -40,6 +40,7 @@ class RegisterWebUserForm(forms.Form):
     phone_number = forms.CharField(
         label=_("Phone Number"),
         required=False,
+        max_length=20,
     )
     persona = forms.ChoiceField(
         label=_("I will primarily be using CommCare to..."),

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1418,7 +1418,7 @@ class ConfirmExtraUserChargesForm(EditBillingAccountInfoForm):
 
 class AddPhoneNumberForm(forms.Form):
     phone_number = forms.CharField(
-        max_length=50, help_text=gettext_lazy('Please enter number, including country code, in digits only.')
+        max_length=20, help_text=gettext_lazy('Please enter number, including country code, in digits only.')
     )
 
     form_type = forms.CharField(initial='add-phonenumber', widget=forms.HiddenInput)


### PR DESCRIPTION
These particular fields have a validation regex on them that is flagged for time-complexity concern. By limiting the length of the input, we can mitigate the risk.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-16188

## Safety Assurance

### Safety story
Valid phone numbers are a maximum length of 15 digits when excluding separators _( ), -, ., etc_ -- we already use 20 in some other places _just in case_ some country is using numbers longer than recommended, and this just follows that standard. Tested to confirm this still works in both forms the changes are made.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
  - the `registration` app is set as "High" risk automatically. This change is quite low risk.
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
