### PR TITLE
Escape 'regex' in Case Search

### DIFF
--- a/corehq/apps/case_search/templates/case_search/case_search.html
+++ b/corehq/apps/case_search/templates/case_search/case_search.html
@@ -73,7 +73,7 @@
                       <input name="fuzzy" type="checkbox" data-bind="checked: fuzzy">
                     </td>
                     <td>
-                      <input name="value" type="text" spellcheck='false' data-bind="value: regex" placeholder="Regular Expression" class="form-control"/>
+                      <input name="value" type="text" spellcheck='false' data-bind="value: regex" placeholder="e.g. +" class="form-control"/>
                     </td>
                     <td>
                       <span class='btn btn-outline-danger' data-bind="click: $parent.removeParameter">

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -77,7 +77,7 @@ class CaseSearchView(_BaseCaseSearchView):
         if owner_id:
             search = search.owner(owner_id)
         for param in search_params:
-            value = re.sub(param.get('regex', ''), '', param.get('value'))
+            value = re.sub(re.escape(param.get('regex', '')), '', param.get('value'))
             if '/' in param.get('key'):
                 query = '{} = "{}"'.format(param.get('key'), value)
                 search = search.xpath_query(self.domain, query, fuzzy=param.get('fuzzy'))


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Limited to Superuser use.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/SAAS-16189)

This was most likely an effort to duplicate the behavior of Remove Special Characters (under project settings) where despite being referred to as regex in the code, everything user facing and it being eventually escaped suggests it's actually just supposed to be a string for use in a simple string replacement operation.

This is also to address this [code scan alert](https://github.com/dimagi/commcare-hq/security/code-scanning/253)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

Not an FF but limited to Superusers

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally. Escapes a string and changes a string so no real impact. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
