### PR TITLE
Add type checking

### DIFF
--- a/.github/workflows/check-type-hints.yml
+++ b/.github/workflows/check-type-hints.yml
@@ -1,0 +1,19 @@
+name: Check type hints
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  mypy:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - run: pip install mypy
+      - run: mypy --install-types --non-interactive --explicit-package-bases @mypy_modules.txt

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -18,8 +18,11 @@ seem to be a good fit.
 
 
 """
+from __future__ import annotations
+
 import re
 import uuid
+from typing import Optional
 
 from lxml import etree
 from lxml.builder import E
@@ -424,13 +427,18 @@ class XFormBuilder(object):
 
 class Question(object):
 
-    def __init__(self, name, xform, groups=None):
+    def __init__(
+        self,
+        name: str,
+        xform: XFormBuilder,
+        groups: Optional[list[str]] = None,
+    ) -> None:
         self.name = name
         self.xform = xform
         self.groups = groups
 
     @property
-    def form(self) -> "XFormBuilder":
+    def form(self) -> XFormBuilder:
         return self.xform
 
 

--- a/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
+++ b/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
@@ -95,7 +95,7 @@ class TestElasticSyncMultiplexedCommand(SimpleTestCase):
 
     def tearDown(self) -> None:
         manager.cluster_routing(enabled=True)
-        return super().tearDown()
+        super().tearDown()
 
     def test_invalid_index_canonical_raises(self):
         with self.assertRaises(CommandError):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -228,6 +228,8 @@ class DataSourceBuildInformation(DocumentSchema):
             return args[0] == data_source_config_id
 
         def iter_tasks():
+            if not flower_url:
+                return
             task_names = (
                 'corehq.apps.userreports.tasks.rebuild_indicators',
                 'corehq.apps.userreports.tasks.rebuild_indicators_in_place',

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -65,7 +65,7 @@ class TestDataSourceConfigAllowedExpressionsValidation(TestCase):
             "type": "property_name"
         }
         cls.config = DataSourceConfiguration.wrap(cls.config)
-        return super().setUpClass()
+        super().setUpClass()
 
     def test_raises_when_domain_has_no_permission(self):
         self.config.domain = 'domain_nopermission'

--- a/corehq/messaging/smsbackends/twilio/models.py
+++ b/corehq/messaging/smsbackends/twilio/models.py
@@ -131,7 +131,10 @@ class SQLTwilioBackend(SQLSMSBackend, PhoneLoadBalancingMixin):
         msg.backend_message_id = message.sid
         msg.save()
 
-    def from_or_messaging_service_sid(self, phone_number: str) -> (Optional[str], Optional[str]):
+    def from_or_messaging_service_sid(
+        self,
+        phone_number: str,
+    ) -> tuple[Optional[str], Optional[str]]:
         if self.phone_number_is_messaging_service_sid(phone_number):
             return None, phone_number
         else:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,20 @@
+[mypy]
+python_version = 3.9
+
+# Check configuration
+warn_unused_configs = True
+warn_redundant_casts = True
+
+# Type checking
+disallow_any_generics = True
+check_untyped_defs = True
+warn_unused_ignores = True
+warn_return_any = True
+strict_equality = True
+
+# Parse but don't check imported libraries
+follow_imports = silent
+ignore_missing_imports = True
+
+# Reporting
+pretty = True

--- a/mypy_modules.txt
+++ b/mypy_modules.txt
@@ -1,0 +1,16 @@
+corehq/apps/app_manager/xform_builder.py
+corehq/apps/case_search/xpath_functions/subcase_functions.py
+corehq/apps/commtrack/fixtures.py
+corehq/apps/domain/tests/test_forms.py
+corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
+corehq/apps/events/tests/test_tasks.py
+corehq/apps/linked_domain/tests/test_migrate_feature_flag_domains.py
+corehq/apps/reports/tests/test_case_data.py
+corehq/apps/sms/forms.py
+corehq/apps/userreports/models.py
+corehq/apps/userreports/tests/test_data_source_config.py
+corehq/apps/users/management/commands/add_data_dict_permissions.py
+corehq/messaging/smsbackends/twilio/forms.py
+corehq/messaging/smsbackends/twilio/models.py
+corehq/motech/serializers.py
+custom/onse/models.py


### PR DESCRIPTION
## Technical Summary

Adds a Github workflow for mypy to check the type hints that already exist in the codebase.

Only modules listed in `mypy_modules.txt` are checked, and type-checking ignores functions and methods in the module that don't have type hints. (In other words, type hints are treated the same as doctests: Not all functions or methods in a module need to have doctests, and modules that do have doctests need to be added to a test suite for them to be tested.)

## Safety Assurance

### Safety story

There is only one code change: Fixes a bug, exposed by type checking, when `flower_url` is not set. 

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
