### PR TITLE
Add datetime support to CSQL

### DIFF
--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -79,6 +79,16 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         mock_get_timezone.assert_called_once()
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
+    @freeze_time('2023-05-16T13:01:51Z')
+    @flag_enabled('CASE_SEARCH_INDEXED_METADATA')
+    @patch("corehq.apps.case_search.xpath_functions.comparison.get_timezone_for_domain",
+           return_value=pytz.timezone('America/Los_Angeles'))
+    def test_system_date_property_comparison(self, mock_get_timezone):
+        parsed = parse_xpath("last_modified < datetime-add(now(), 'weeks', -2)")
+        expected_filter = filters.date_range('modified_on', lt='2023-05-02T13:01:51+00:00')
+        built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
+
     def test_not_filter(self):
         parsed = parse_xpath("not(name = 'farid')")
         expected_filter = filters.NOT(case_property_query('name', 'farid'))
@@ -105,11 +115,18 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         self.checkQuery(expected_filter, query, is_raw_query=True)
 
     @freeze_time('2021-08-02')
-    def test_date_comparison__today(self):
+    def test_date_comparison_today(self):
         parsed = parse_xpath("dob >= today()")
         expected_filter = case_property_date_range('dob', gte='2021-08-02')
         query = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, query, is_raw_query=True)
+
+    @freeze_time('2023-05-16T13:01:51Z')
+    def test_date_property_comparison_now(self):
+        parsed = parse_xpath("dob < datetime-add(now(), 'weeks', -2)")
+        expected_filter = case_property_date_range('dob', lt='2023-05-02T13:01:51+00:00')
+        built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
+        self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
     def test_numeric_comparison(self):
         parsed = parse_xpath("number <= '100.32'")

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -358,9 +358,9 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
             case_search_adapter.index(case, refresh=True)
 
     @classmethod
-    def tearDownClass(self):
+    def tearDownClass(cls):
         FormProcessorTestUtils.delete_all_cases()
-        super(TestFilterDslLookups, self).tearDownClass()
+        super().tearDownClass()
 
     def test_parent_lookups(self):
         parsed = parse_xpath("father/name = 'Mace'")

--- a/corehq/apps/case_search/tests/test_value_functions.py
+++ b/corehq/apps/case_search/tests/test_value_functions.py
@@ -12,6 +12,7 @@ from corehq.apps.case_search.xpath_functions.value_functions import (
     date_add,
     datetime_,
     datetime_add,
+    double,
     now,
     today,
 )
@@ -144,3 +145,23 @@ def test_date_add_errors(expression):
     with assert_raises(XPathFunctionException):
         fn = date_add if expression.startswith('date-add') else datetime_add
         fn(node, SearchFilterContext("domain"))
+
+
+@freeze_time('2021-08-02T22:03:16Z')
+@pytest.mark.parametrize("expression, expected", [
+    ("double('1.3')", 1.3),
+    ("double('13')", 13.0),
+    ("double(now())", 18841.918935185186),
+    ("double(today())", 18841.0),
+    ("double('2021-01-01')", 18628.0),
+])
+def test_double(expression, expected):
+    node = parse_xpath(expression)
+    result = double(node, SearchFilterContext("domain"))
+    eq(result, expected)
+
+
+def test_double_random_string():
+    node = parse_xpath("double('not double-able')")
+    with assert_raises(XPathFunctionException):
+        double(node, SearchFilterContext("domain"))

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -1,24 +1,26 @@
+from .ancestor_functions import ancestor_exists
 from .query_functions import (
     fuzzy_date,
     fuzzy_match,
+    match_all,
+    match_none,
     not_,
+    phonetic_match,
     selected_all,
     selected_any,
-    within_distance,
-    phonetic_match,
     starts_with,
-    match_all,
-    match_none
+    within_distance,
 )
 from .subcase_functions import subcase
-from .ancestor_functions import ancestor_exists
-from .value_functions import date, date_add, today, unwrap_list
+from .value_functions import date, date_add, datetime_, now, today, unwrap_list
 
 # functions that transform or produce a value
 XPATH_VALUE_FUNCTIONS = {
     'date': date,
     'date-add': date_add,
     'today': today,
+    'datetime': datetime_,
+    'now': now,
     'unwrap-list': unwrap_list,
 }
 

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -12,12 +12,21 @@ from .query_functions import (
     within_distance,
 )
 from .subcase_functions import subcase
-from .value_functions import date, date_add, datetime_, now, today, unwrap_list
+from .value_functions import (
+    date,
+    date_add,
+    datetime_,
+    datetime_add,
+    now,
+    today,
+    unwrap_list,
+)
 
 # functions that transform or produce a value
 XPATH_VALUE_FUNCTIONS = {
     'date': date,
     'date-add': date_add,
+    'datetime-add': datetime_add,
     'today': today,
     'datetime': datetime_,
     'now': now,

--- a/corehq/apps/case_search/xpath_functions/__init__.py
+++ b/corehq/apps/case_search/xpath_functions/__init__.py
@@ -17,6 +17,7 @@ from .value_functions import (
     date_add,
     datetime_,
     datetime_add,
+    double,
     now,
     today,
     unwrap_list,
@@ -26,10 +27,11 @@ from .value_functions import (
 XPATH_VALUE_FUNCTIONS = {
     'date': date,
     'date-add': date_add,
-    'datetime-add': datetime_add,
-    'today': today,
     'datetime': datetime_,
+    'datetime-add': datetime_add,
+    'double': double,
     'now': now,
+    'today': today,
     'unwrap-list': unwrap_list,
 }
 

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -143,11 +143,11 @@ def _create_system_datetime_query(domain, meta_property, op, value, node):
     return case_property_date_range(meta_property.key, **range_kwargs)
 
 
-def adjust_input_date_by_timezone(date, timezone, op):
-    date = datetime(date.year, date.month, date.day)
+def adjust_input_date_by_timezone(date_, timezone, op):
+    date_ = datetime(date_.year, date_.month, date_.day)
     if op == '>' or op == '<=':
-        date += timedelta(days=1)
-    return UserTime(date, tzinfo=timezone).server_time().done()
+        date_ += timedelta(days=1)
+    return UserTime(date_, tzinfo=timezone).server_time().done()
 
 
 def _create_system_query(meta_property, op, value):

--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -14,9 +14,6 @@ from corehq.apps.case_search.const import (
 )
 from corehq.apps.case_search.dsl_utils import unwrap_value
 from corehq.apps.case_search.exceptions import CaseFilterError
-from corehq.apps.case_search.xpath_functions.value_functions import (
-    value_to_date,
-)
 from corehq.apps.es import filters
 from corehq.apps.es.case_search import (
     case_property_date_range,
@@ -123,15 +120,24 @@ def _create_system_datetime_query(domain, meta_property, op, value, node):
     if op == NEQ:
         return filters.NOT(_create_system_datetime_query(domain, meta_property, EQ, value, node))
 
-    timezone = get_timezone_for_domain(domain)
-    utc_equivalent_datetime_value = adjust_input_date_by_timezone(value_to_date(node, value), timezone, op)
-    if op == EQ:
-        range_kwargs = {
-            'gte': utc_equivalent_datetime_value,
-            'lt': utc_equivalent_datetime_value + timedelta(days=1),
-        }
+    try:
+        date_or_datetime = _parse_date_or_datetime(value)
+    except ValueError as e:
+        raise CaseFilterError(str(e), serialize(node))
+
+    if isinstance(date_or_datetime, datetime):
+        range_kwargs = {RANGE_OP_MAPPING[op]: date_or_datetime}
     else:
-        range_kwargs = {RANGE_OP_MAPPING[op]: utc_equivalent_datetime_value}
+        timezone = get_timezone_for_domain(domain)
+        utc_equivalent_datetime_value = adjust_input_date_by_timezone(date_or_datetime, timezone, op)
+        if op == EQ:
+            range_kwargs = {
+                'gte': utc_equivalent_datetime_value,
+                'lt': utc_equivalent_datetime_value + timedelta(days=1),
+            }
+        else:
+            range_kwargs = {RANGE_OP_MAPPING[op]: utc_equivalent_datetime_value}
+
     if CASE_SEARCH_INDEXED_METADATA.enabled(domain):
         return filters.date_range(meta_property.es_field_name, **range_kwargs)
     return case_property_date_range(meta_property.key, **range_kwargs)

--- a/corehq/apps/case_search/xpath_functions/value_functions.py
+++ b/corehq/apps/case_search/xpath_functions/value_functions.py
@@ -166,3 +166,30 @@ def unwrap_list(node, context):
 
     value = node.args[0]
     return json.loads(value)
+
+
+def double(node, context):
+    assert node.name == 'double'
+    confirm_args_count(node, 1)
+    value = unwrap_value(node.args[0], context)
+
+    if isinstance(value, str):
+        try:
+            parsed_date = parse_date(value)
+        except ValueError:
+            ...
+        if parsed_date:
+            return float((parsed_date - datetime.date(1970, 1, 1)).days)
+
+        try:
+            parsed_datetime = parse_datetime(value)
+        except ValueError:
+            ...
+        if parsed_datetime:
+            elapsed = parsed_datetime - datetime.datetime(1970, 1, 1, tzinfo=pytz.UTC)
+            return elapsed.total_seconds() / (24 * 3600)
+
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        raise XPathFunctionException(_("Cannot convert {} to a double").format(value), serialize(node))

--- a/corehq/apps/case_search/xpath_functions/value_functions.py
+++ b/corehq/apps/case_search/xpath_functions/value_functions.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 
-from django.utils.dateparse import parse_date
+from django.utils.dateparse import parse_date, parse_datetime
 from django.utils.translation import gettext as _
 
 import pytz
@@ -50,6 +50,37 @@ def value_to_date(node, value):
     return parsed_date
 
 
+def datetime_(node, context):
+    assert node.name == 'datetime'
+    confirm_args_count(node, 1)
+    arg = node.args[0]
+    arg = unwrap_value(arg, context)
+    parsed_date = _value_to_datetime(node, arg)
+    return parsed_date.isoformat()
+
+
+def _value_to_datetime(node, value):
+    if isinstance(value, (int, float)):
+        parsed_dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(days=value)
+    elif isinstance(value, str):
+        try:
+            parsed_dt = parse_datetime(value)
+        except ValueError:
+            raise XPathFunctionException(_("{} is not a valid datetime").format(value), serialize(node))
+    elif isinstance(value, datetime.datetime):
+        parsed_dt = value
+    else:
+        parsed_dt = None
+
+    if parsed_dt is None:
+        raise XPathFunctionException(
+            _("Invalid datetime value. Must be a number or a ISO 8601 string."),
+            serialize(node)
+        )
+
+    return parsed_dt.astimezone(pytz.UTC)
+
+
 def today(node, context):
     assert node.name == 'today'
 
@@ -58,6 +89,12 @@ def today(node, context):
     domain_obj = Domain.get_by_name(context.domain)
     timezone = domain_obj.get_default_timezone() if domain_obj else pytz.UTC
     return datetime.datetime.now(timezone).strftime(ISO_DATE_FORMAT)
+
+
+def now(node, context):
+    assert node.name == 'now'
+    confirm_args_count(node, 0)
+    return datetime.datetime.now(pytz.UTC).isoformat()
 
 
 def date_add(node, context):

--- a/corehq/apps/case_search/xpath_functions/value_functions.py
+++ b/corehq/apps/case_search/xpath_functions/value_functions.py
@@ -18,6 +18,12 @@ from .utils import confirm_args_count
 
 
 def date(node, context):
+    """Coerce the arg to a valid datestring
+
+    Integers are interpreted as days since Jan 1, 1970
+      date('2021-01-01') => '2021-01-01'
+      date(5) => '1970-01-06'
+    """
     assert node.name == 'date'
     confirm_args_count(node, 1)
     arg = node.args[0]
@@ -51,6 +57,10 @@ def value_to_date(node, value):
 
 
 def datetime_(node, context):
+    """Coerce the arg is a valid IS0 8601 datetime string
+
+    Numeric values are interpreted as days since Jan 1, 1970
+    """
     assert node.name == 'datetime'
     confirm_args_count(node, 1)
     arg = node.args[0]
@@ -82,6 +92,7 @@ def _value_to_datetime(node, value):
 
 
 def today(node, context):
+    """today() => '2024-11-20'"""
     assert node.name == 'today'
 
     confirm_args_count(node, 0)
@@ -92,18 +103,29 @@ def today(node, context):
 
 
 def now(node, context):
+    """now() => '2024-11-20T20:16:29.422120+00:00'"""
     assert node.name == 'now'
     confirm_args_count(node, 0)
     return datetime.datetime.now(pytz.UTC).isoformat()
 
 
 def date_add(node, context):
+    """Add a time interval to an input date
+
+        date-add('2022-01-01', 'days', -1) => '2021-12-31'
+        date-add('2020-03-31', 'weeks', 4) => '2020-04-28'
+        date-add('2020-04-30', 'months', -2) => '2020-02-29'
+        date-add('2020-02-29', 'years', 1) => '2021-02-28'
+
+    Valid intervals are seconds, minutes, hours, days, weeks, months, years
+    """
     assert node.name == 'date-add'
     result = _date_or_datetime_add(node, context, value_to_date)
     return result.strftime(ISO_DATE_FORMAT)
 
 
 def datetime_add(node, context):
+    """Same as date-add, but with datetimes"""
     assert node.name == 'datetime-add'
     result = _date_or_datetime_add(node, context, _value_to_datetime)
     return result.isoformat()
@@ -169,6 +191,11 @@ def unwrap_list(node, context):
 
 
 def double(node, context):
+    """Coerce the argument to a float where possible
+
+    Mirrors the CommCare XPath function `double`. Dates and datetimes are
+    converted to days since Jan 1, 1970.
+    """
     assert node.name == 'double'
     confirm_args_count(node, 1)
     value = unwrap_value(node.args[0], context)

--- a/corehq/apps/case_search/xpath_functions/value_functions.py
+++ b/corehq/apps/case_search/xpath_functions/value_functions.py
@@ -177,14 +177,14 @@ def double(node, context):
         try:
             parsed_date = parse_date(value)
         except ValueError:
-            ...
+            parsed_date = None
         if parsed_date:
             return float((parsed_date - datetime.date(1970, 1, 1)).days)
 
         try:
             parsed_datetime = parse_datetime(value)
         except ValueError:
-            ...
+            parsed_datetime = None
         if parsed_datetime:
             elapsed = parsed_datetime - datetime.datetime(1970, 1, 1, tzinfo=pytz.UTC)
             return elapsed.total_seconds() / (24 * 3600)


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.atlassian.net/browse/USH-5133
Similar to `date`, `today`, and `date-add`, this PR adds `datetime`, `now`, and `datetime-add`.  I considered just making `date-add` work for both dates and datetimes, but it does type coercion, and this seemed more explicit and less likely to break existing expressions.  It also adds `double`, to convert dates and datetimes to floats so they can be compared to case properties that store datetimes as `double(now())` from CommCare mobile.  Lastly, it modifies system property queries to work with datetime comparisons (non system properties already supported this).

## Feature Flag
Case Search and CLE

## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
