### PR TITLE
[webpack] jQuery UI pages

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/base_subscriptions_main.js
+++ b/corehq/apps/accounting/static/accounting/js/base_subscriptions_main.js
@@ -5,6 +5,7 @@ hqDefine('accounting/js/base_subscriptions_main', [
     'accounting/js/widgets',
     'accounting/js/credits_tab',
     'jquery-ui/ui/widgets/datepicker',
+    'commcarehq',
 ], function (
     $,
     ko,
@@ -71,6 +72,8 @@ hqDefine('accounting/js/base_subscriptions_main', [
         // fieldset is not unique enough a css identifier
         // historically this has taken the first one without checking
         // todo: use a more specific identifier to make less brittle
-        $('fieldset').first().koApplyBindings(invoice);
+        if ($('fieldset').length) {
+            $('fieldset').first().koApplyBindings(invoice);
+        }
     });
 });

--- a/corehq/apps/accounting/templates/accounting/plan_version.html
+++ b/corehq/apps/accounting/templates/accounting/plan_version.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main "accounting/js/base_subscriptions_main" %}
+{% js_entry "accounting/js/base_subscriptions_main" %}
 
 {% block page_content %}
   {% include 'accounting/partials/version_summary_tab.html' %}

--- a/corehq/apps/accounting/templates/accounting/subscriptions_base.html
+++ b/corehq/apps/accounting/templates/accounting/subscriptions_base.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'accounting/js/base_subscriptions_main' %}
+{% js_entry_b3 'accounting/js/base_subscriptions_main' %}
 
 {% block page_content %}
   <form class="form form-horizontal" method="post">

--- a/corehq/apps/case_importer/static/case_importer/js/main.js
+++ b/corehq/apps/case_importer/static/case_importer/js/main.js
@@ -7,6 +7,7 @@ hqDefine("case_importer/js/main", [
     'case_importer/js/excel_fields',
     'hqwebapp/js/bootstrap5/widgets',
     'hqwebapp/js/components/select_toggle',
+    'commcarehq',
 ], function (
     $,
     _,

--- a/corehq/apps/case_importer/templates/case_importer/excel_config.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_config.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 "case_importer/js/main" %}
+{% js_entry "case_importer/js/main" %}
 
 {% block page_content %}
   {% include 'case_importer/partials/help_message.html' %}

--- a/corehq/apps/case_importer/templates/case_importer/excel_fields.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_fields.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 "case_importer/js/main" %}
+{% js_entry "case_importer/js/main" %}
 
 {% block page_content %}
   {% include 'case_importer/partials/help_message.html' %}

--- a/corehq/apps/case_importer/templates/case_importer/import_cases.html
+++ b/corehq/apps/case_importer/templates/case_importer/import_cases.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 "case_importer/js/main" %}
+{% js_entry "case_importer/js/main" %}
 
 {% block page_title %}
   {{ current_page.title }}

--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -6,6 +6,7 @@ hqDefine('custom_data_fields/js/custom_data_fields', [
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/ui_elements/bootstrap5/ui-element-key-val-list',
     'hqwebapp/js/bootstrap5/knockout_bindings.ko',     // needed for sortable and jqueryElement bindings
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'custom_data_fields/js/custom_data_fields' %}
+{% js_entry 'custom_data_fields/js/custom_data_fields' %}
 
 {% block stylesheets %}
   {{ block.super }}

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -13,6 +13,7 @@ hqDefine("data_dictionary/js/data_dictionary", [
     "data_interfaces/js/make_read_only",
     'hqwebapp/js/select2_knockout_bindings.ko',
     'knockout-sortable/build/knockout-sortable',
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main "data_dictionary/js/data_dictionary" %}
+{% js_entry_b3 "data_dictionary/js/data_dictionary" %}
 
 {% block stylesheets %}{{ block.super }}
   {% compress css %}

--- a/corehq/apps/domain/static/domain/js/internal_subscription_management.js
+++ b/corehq/apps/domain/static/domain/js/internal_subscription_management.js
@@ -2,6 +2,7 @@ hqDefine('domain/js/internal_subscription_management', [
     'jquery',
     'knockout',
     'hqwebapp/js/bootstrap3/widgets',
+    'commcarehq',
 ], function (
     $,
     ko

--- a/corehq/apps/domain/templates/domain/internal_subscription_management.html
+++ b/corehq/apps/domain/templates/domain/internal_subscription_management.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'domain/js/internal_subscription_management' %}
+{% js_entry_b3 'domain/js/internal_subscription_management' %}
 
 {% block page_content %}
   {% blocktrans %}

--- a/corehq/apps/export/static/export/js/customize_export_new.js
+++ b/corehq/apps/export/static/export/js/customize_export_new.js
@@ -6,6 +6,7 @@ hqDefine('export/js/customize_export_new', [
     'export/js/models',
     'hqwebapp/js/toggles',
     'export/js/const',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/export/static/export/js/datasource_export.js
+++ b/corehq/apps/export/static/export/js/datasource_export.js
@@ -1,6 +1,7 @@
 hqDefine("export/js/datasource_export",[
     'jquery',
     'knockout',
+    'commcarehq',
 ], function ($, ko) {
 
     function datasourceExportViewModel() {

--- a/corehq/apps/export/static/export/js/download_data_files.js
+++ b/corehq/apps/export/static/export/js/download_data_files.js
@@ -3,6 +3,7 @@ hqDefine("export/js/download_data_files",[
     'hqwebapp/js/bootstrap5/alert_user',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/assert_properties',
+    'commcarehq',
 ], function ($, alertUserModule, initialPageData, assertProperties) {
     var alertUser = alertUserModule.alert_user;
     /**

--- a/corehq/apps/export/static/export/js/export_list_main.js
+++ b/corehq/apps/export/static/export/js/export_list_main.js
@@ -6,6 +6,7 @@ hqDefine("export/js/export_list_main", [
     'export/js/create_export',
     'export/js/export_list',
     'hqwebapp/js/select_2_ajax_widget',  // for case owner & user filters in DashboardFeedFilterForm
+    'commcarehq',
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'export/js/customize_export_new' %}
+{% js_entry 'export/js/customize_export_new' %}
 
 {% block page_content %}
   {% initial_page_data 'number_of_apps_to_process' number_of_apps_to_process %}

--- a/corehq/apps/export/templates/export/datasource_export_view.html
+++ b/corehq/apps/export/templates/export/datasource_export_view.html
@@ -4,7 +4,7 @@
 {% load compress %}
 {% load hq_shared_tags %}
 
-{% requirejs_main_b5 'export/js/datasource_export' %}
+{% js_entry 'export/js/datasource_export' %}
 
 {% block page_title %}
 {% trans "Export Data Source Data" %}

--- a/corehq/apps/export/templates/export/download_data_files.html
+++ b/corehq/apps/export/templates/export/download_data_files.html
@@ -5,9 +5,7 @@
 
 {% block title %}{% trans "Download Files" %}{% endblock %}
 
-
-{% requirejs_main_b5 'export/js/download_data_files' %}
-
+{% js_entry 'export/js/download_data_files' %}
 
 {% block page_content %}
   {% registerurl 'download_data_file' domain '---' '---' %}

--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -4,7 +4,7 @@
 {% load hq_shared_tags %}
 {% load compress %}
 
-{% requirejs_main_b5 'export/js/export_list_main' %}
+{% js_entry 'export/js/export_list_main' %}
 
 {% block page_title %}
   {{ current_page.title }}

--- a/corehq/apps/sso/templates/sso/enterprise_admin/edit_identity_provider.html
+++ b/corehq/apps/sso/templates/sso/enterprise_admin/edit_identity_provider.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'sso/js/enterprise_edit_identity_provider' %}
+{% js_entry_b3 'sso/js/enterprise_edit_identity_provider' %}
 
 {% block page_content %}
   {% initial_page_data 'idp_slug' idp_slug %}

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -7,7 +7,7 @@ const hqPlugins = require('./plugins');
 const aliases = {
     "commcarehq": path.resolve(utils.getStaticPathForApp('hqwebapp', 'js/bootstrap5/'),
         'commcarehq'),
-    "jquery": "jquery/dist/jquery.min",
+    "jquery": require.resolve('jquery'),
 
     // todo after completing requirejs migration,
     //  remove this file and the yarn modernizr post-install step


### PR DESCRIPTION
## Technical Summary
First commit updates webpack config to play nicely with jQuery UI. Remaining commits migrate some pages that depend on jQuery UI.

Prior to the config change, jQuery UI pages would throw errors along the lines of `$.datepicker is not a function`. I believe what was happening was that jQuery UI would `require('jquery')` which would load the [unminified version](https://github.com/jquery/jquery/blob/d5ebb464debab6ac39fe065e93c8a7ae1de8547e/package.json#L46) and attach the jQuery UI functions to that, and then HQ code was requiring the minified version, which would be missing them. Webpack minifies, so it's fine for us to load the unminified version.

## Safety Assurance

### Safety story
Smoke tested locally and on staging.

### Automated test coverage

little if any

### QA Plan

not requesting QA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
