### PR TITLE
[webpack] Migrated reminders app

### DIFF
--- a/corehq/apps/reminders/static/reminders/js/keyword.js
+++ b/corehq/apps/reminders/static/reminders/js/keyword.js
@@ -1,8 +1,9 @@
-hqDefine("reminders/js/reminders.keywords.ko", [
+hqDefine("reminders/js/keyword", [
     "jquery",
     "knockout",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap5/widgets",      // .hqwebapp-select2 for survey dropdown
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/reminders/static/reminders/js/keywords_list.js
+++ b/corehq/apps/reminders/static/reminders/js/keywords_list.js
@@ -2,22 +2,9 @@ hqDefine('reminders/js/keywords_list', [
     "jquery",
     "knockout",
     "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/multiselect_utils",
     "hqwebapp/js/bootstrap5/crud_paginated_list",
-], function ($, ko, initialPageData, multiselectUtils, CRUDPaginatedList) {
+], function ($, ko, initialPageData, CRUDPaginatedList) {
     $(function () {
-        multiselectUtils.createFullMultiselectWidget('keyword-selector', {
-            selectableHeaderTitle: gettext("Keywords"),
-            selectedHeaderTitle: gettext("Keywords to copy"),
-            searchItemTitle: gettext("Search keywords"),
-        });
-
-        multiselectUtils.createFullMultiselectWidget('domain-selector', {
-            selectableHeaderTitle: gettext("Linked Project Spaces"),
-            selectedHeaderTitle: gettext("Projects to copy to"),
-            searchItemTitle: gettext("Search projects"),
-        });
-
         var paginatedListModel = CRUDPaginatedList.CRUDPaginatedListModel(
             initialPageData.get('total'),
             initialPageData.get('limit'),

--- a/corehq/apps/reminders/static/reminders/js/keywords_list.js
+++ b/corehq/apps/reminders/static/reminders/js/keywords_list.js
@@ -3,6 +3,7 @@ hqDefine('reminders/js/keywords_list', [
     "knockout",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap5/crud_paginated_list",
+    "commcarehq",
 ], function ($, ko, initialPageData, CRUDPaginatedList) {
     $(function () {
         var paginatedListModel = CRUDPaginatedList.CRUDPaginatedListModel(

--- a/corehq/apps/reminders/templates/reminders/keyword.html
+++ b/corehq/apps/reminders/templates/reminders/keyword.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'reminders/js/reminders.keywords.ko' %}
+{% js_entry 'reminders/js/keyword' %}
 
 {% block page_content %}
   {% initial_page_data 'current_values' form.current_values %}

--- a/corehq/apps/reminders/templates/reminders/keyword_list.html
+++ b/corehq/apps/reminders/templates/reminders/keyword_list.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main_b5 "reminders/js/keywords_list" %}
+{% js_entry "reminders/js/keywords_list" %}
 
 {% block pagination_header %}
   <h2>{% trans 'Manage Keywords' %}</h2>


### PR DESCRIPTION
## Technical Summary
I was waiting on this one because it depends on multiselect which isn't yet supported, but it turns out that it does not depend on multiselect.

## Safety Assurance

### Safety story
All the dependencies on these pages are also used on other pages that have already been migrated to webpack. Smoke tested locally.

### Automated test coverage

no

### QA Plan

no


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
