### PR TITLE
Add max height and scroll bar to log in as dialog

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users/user_data.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users/user_data.html
@@ -3,34 +3,34 @@
 <script type="text/template" id="user-data-template">
   <div class="module-table-case-detail-wrapper">
     <table class="table module-table module-table-case-detail">
-    <tbody>
-    <tr>
-      <th>{% trans "Name" %}</th>
-      <td><%- user.first_name + ' ' + user.last_name %></td>
-    </tr>
-    <% if (user.location) { %>
-    <tr>
-      <th>{% trans "Organization" %}</th>
-      <td><%- user.location.name %></td>
-    </tr>
-    <tr>
-      <th>{% trans "Organization Type" %}</th>
-      <td><%- user.location.location_type %></td>
-    </tr>
-    <% } %>
-    <tr>
-      <th>{% trans "Date Registered" %}</th>
-      <td><%- user.dateRegistered %></td>
-    </tr>
-    <% _.each(user.customFields, function(value, key) { %>
-    <% if (!key.startsWith('commcare_') && !key.startsWith('commtrack') && value) { %>
-    <tr>
-      <th><%- key %></th>
-      <td><%- value %></td>
-    </tr>
-    <% } %>
-    <% }) %>
-    </tbody>
-  </table>
+      <tbody>
+        <tr>
+          <th>{% trans "Name" %}</th>
+          <td><%- user.first_name + ' ' + user.last_name %></td>
+        </tr>
+        <% if (user.location) { %>
+        <tr>
+          <th>{% trans "Organization" %}</th>
+          <td><%- user.location.name %></td>
+        </tr>
+        <tr>
+          <th>{% trans "Organization Type" %}</th>
+          <td><%- user.location.location_type %></td>
+        </tr>
+        <% } %>
+        <tr>
+          <th>{% trans "Date Registered" %}</th>
+          <td><%- user.dateRegistered %></td>
+        </tr>
+        <% _.each(user.customFields, function(value, key) { %>
+        <% if (!key.startsWith('commcare_') && !key.startsWith('commtrack') && value) { %>
+        <tr>
+          <th><%- key %></th>
+          <td><%- value %></td>
+        </tr>
+        <% } %>
+        <% }) %>
+      </tbody>
+    </table>
   </div>
 </script>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/users/user_data.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/users/user_data.html
@@ -1,7 +1,8 @@
 {% load i18n %}
 
 <script type="text/template" id="user-data-template">
-  <table class="table module-table module-table-case-detail">
+  <div class="module-table-case-detail-wrapper">
+    <table class="table module-table module-table-case-detail">
     <tbody>
     <tr>
       <th>{% trans "Name" %}</th>
@@ -31,4 +32,5 @@
     <% }) %>
     </tbody>
   </table>
+  </div>
 </script>

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/module.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/module.scss
@@ -146,8 +146,10 @@ button.clickable-icon {
   margin-bottom: 0;
 }
 
-.module-table-case-detail {
+.module-table-case-detail-wrapper {
   margin-top: 10px;
+  max-height: calc(100vh - 180px);
+  overflow-y: auto;
 }
 
 .module-table-case-detail tbody tr {


### PR DESCRIPTION
## Product Description

If there are too many user properties on the dialog the bottom is outside the view port making the user scroll to login. Adding a maximum height to the table keeps the login button in view.

Before:
![2024-11-21_10-58-48](https://github.com/user-attachments/assets/bc095e7c-3e79-4f01-a0af-94b585b81db5)

After:
![2024-11-21_10-59-12](https://github.com/user-attachments/assets/cecefd9c-0c6d-4c5c-955e-d5dd29b9cb7d)

## Technical Summary

No story

## Feature Flag

None

## Safety Assurance

### Safety story

Testing locally and on staging

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
