### PR TITLE
[webpack] Multiselect pages

### DIFF
--- a/corehq/apps/events/static/events/js/new_event.js
+++ b/corehq/apps/events/static/events/js/new_event.js
@@ -6,6 +6,7 @@ hqDefine("events/js/new_event", [
     "locations/js/widgets",
     "hqwebapp/js/bootstrap3/widgets",
     "jquery-ui/ui/widgets/datepicker",
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/events/templates/events/new_event.html
+++ b/corehq/apps/events/templates/events/new_event.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main 'events/js/new_event' %}
+{% js_entry_b3 'events/js/new_event' %}
 
 {% block page_content %}
   {% initial_page_data 'current_values' form.current_values %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -100,10 +100,15 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                     selectionSearchString = '#' + that.$container.attr('id') + ' .ms-elem-selection.ms-selected';
 
                 const _search = function (query, itemSelector) {
-                    query = query.toLowerCase();
+                    const queries = (query || '').toLowerCase().split(/\s+/);
                     $(itemSelector).each(function (index, item) {
-                        const $item = $(item);
-                        if (!query || $item.text().toLowerCase().indexOf(query) !== -1) {
+                        const $item = $(item),
+                            itemText = $item.text().toLowerCase();
+                        let found = _.every(queries, function (q) {
+                            return !q || itemText.indexOf(q) !== -1;
+                        });
+
+                        if (found) {
                             $item.removeClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
                         } else {
                             $item.addClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -100,9 +100,10 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                     selectionSearchString = '#' + that.$container.attr('id') + ' .ms-elem-selection.ms-selected';
 
                 const _search = function (query, itemSelector) {
+                    query = query.toLowerCase();
                     $(itemSelector).each(function (index, item) {
                         const $item = $(item);
-                        if (!query || $item.text().indexOf(query) !== -1) {
+                        if (!query || $item.text().toLowerCase().indexOf(query) !== -1) {
                             $item.removeClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
                         } else {
                             $item.addClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -5,7 +5,6 @@ hqDefine('hqwebapp/js/multiselect_utils', [
     "underscore",
     "hqwebapp/js/assert_properties",
     "multiselect/js/jquery.multi-select",
-    "quicksearch/dist/jquery.quicksearch.min",
 ], function (
     $,
     ko,
@@ -100,7 +99,18 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                     selectableSearchString = '#' + that.$container.attr('id') + ' .ms-elem-selectable:not(.ms-selected)',
                     selectionSearchString = '#' + that.$container.attr('id') + ' .ms-elem-selection.ms-selected';
 
-                that.search_left = $selectableSearch.quicksearch(selectableSearchString)
+                const _search = function (query, itemSelector) {
+                    $(itemSelector).each(function (index, item) {
+                        const $item = $(item);
+                        if (!query || $item.text().indexOf(query) !== -1) {
+                            $item.removeClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
+                        } else {
+                            $item.addClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
+                        }
+                    });
+                };
+
+                that.search_left = $selectableSearch
                     .on('keydown', function (e) {
                         if (e.which === 40) {  // down arrow, was recommended by loudev docs
                             that.$selectableUl.focus();
@@ -108,7 +118,9 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                         }
                     })
                     .on('keyup change search input', function () {
-                    // disable add all functionality so that user is not confused
+                        _search($selectableSearch.val(), selectableSearchString);
+
+                        // disable add all functionality so that user is not confused
                         if (that.search_left.val().length > 0) {
                             $('#' + selectAllId).addClass('disabled').prop('disabled', true);
                         } else {
@@ -118,7 +130,7 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                         }
                     });
 
-                that.search_right = $selectionSearch.quicksearch(selectionSearchString)
+                that.search_right = $selectionSearch
                     .on('keydown', function (e) {
                         if (e.which === 40) {  // down arrow, was recommended by loudev docs
                             that.$selectionUl.focus();
@@ -126,7 +138,9 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                         }
                     })
                     .on('keyup change search input', function () {
-                    // disable remove all functionality so that user is not confused
+                        _search($selectionSearch.val(), selectionSearchString);
+
+                        // disable remove all functionality so that user is not confused
                         if (that.search_right.val().length > 0) {
                             $('#' + removeAllId).addClass('disabled').prop('disabled', true);
                         } else if (!disableModifyAllActions) {
@@ -135,22 +149,14 @@ hqDefine('hqwebapp/js/multiselect_utils', [
                     });
             },
             afterSelect: function () {
-                this.search_left.cache();
-                // remove search option so that user doesn't get confused
-                this.search_right.val('').search('');
                 if (!disableModifyAllActions) {
                     $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
                 }
-                this.search_right.cache();
             },
             afterDeselect: function () {
-                // remove search option so that user doesn't get confused
-                this.search_left.val('').search('');
                 if (!disableModifyAllActions) {
                     $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
                 }
-                this.search_left.cache();
-                this.search_right.cache();
             },
         });
 

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -408,7 +408,6 @@
     {% if request.use_multiselect and not use_js_bundler %}
       {% compress js %}
         <script src="{% static 'multiselect/js/jquery.multi-select.js' %}"></script>
-        <script src="{% static 'quicksearch/dist/jquery.quicksearch.min.js' %}"></script>
         <script src="{% static 'hqwebapp/js/multiselect_utils.js' %}"></script>
       {% endcompress %}
     {% endif %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/edit_scheduled_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/edit_scheduled_report.js.diff.txt
@@ -13,4 +13,4 @@
 +    "hqwebapp/js/bootstrap5/widgets",  // autocomplete widget for email recipient list
      "jquery-ui/ui/widgets/datepicker",
      'hqwebapp/js/components/select_toggle',
- ], function (
+     "commcarehq",

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/edit_scheduled_report.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/edit_scheduled_report.html.diff.txt
@@ -8,8 +8,8 @@
  {% load i18n %}
  
  
--{% requirejs_main 'reports/js/bootstrap3/edit_scheduled_report' %}
-+{% requirejs_main_b5 'reports/js/bootstrap5/edit_scheduled_report' %}
+-{% js_entry_b3 'reports/js/bootstrap3/edit_scheduled_report' %}
++{% js_entry 'reports/js/bootstrap5/edit_scheduled_report' %}
  
  {% block page_content %}
    {% initial_page_data 'is_configurable_map' is_configurable_map %}

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -9,6 +9,7 @@ hqDefine("linked_domain/js/domain_links", [
     'hqwebapp/js/components/pagination',
     'hqwebapp/js/components/search_box',
     'hqwebapp/js/select2_knockout_bindings.ko',     // selects2 for fields
+    'commcarehq',
 ], function (
     RMI,
     initialPageData,

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main "linked_domain/js/domain_links" %}
+{% js_entry_b3 "linked_domain/js/domain_links" %}
 
 {% block additional_initial_page_data %}
 {% initial_analytics_data 'appcues.linked_status' linked_status %}

--- a/corehq/apps/registry/static/registry/js/registry_edit.js
+++ b/corehq/apps/registry/static/registry/js/registry_edit.js
@@ -13,6 +13,7 @@ hqDefine("registry/js/registry_edit", [
     'hqwebapp/js/bootstrap5/main', // makeHqHelp
     'hqwebapp/js/multiselect_utils',
     'hqwebapp/js/components/inline_edit',
+    'commcarehq',
 ], function (
     moment,
     ko,

--- a/corehq/apps/registry/templates/registry/registry_edit.html
+++ b/corehq/apps/registry/templates/registry/registry_edit.html
@@ -16,7 +16,7 @@
   {% endcompress %}
 {% endblock %}
 
-{% requirejs_main_b5 'registry/js/registry_edit' %}
+{% js_entry 'registry/js/registry_edit' %}
 
 {% block page_content %}
 {% initial_page_data "registry" registry %}

--- a/corehq/apps/reports/static/reports/js/bootstrap3/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/edit_scheduled_report.js
@@ -8,6 +8,7 @@ hqDefine("reports/js/bootstrap3/edit_scheduled_report", [
     "hqwebapp/js/bootstrap3/widgets",  // autocomplete widget for email recipient list
     "jquery-ui/ui/widgets/datepicker",
     'hqwebapp/js/components/select_toggle',
+    "commcarehq",
 ], function (
     $,
     _,

--- a/corehq/apps/reports/static/reports/js/bootstrap5/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/edit_scheduled_report.js
@@ -8,6 +8,7 @@ hqDefine("reports/js/bootstrap5/edit_scheduled_report", [
     "hqwebapp/js/bootstrap5/widgets",  // autocomplete widget for email recipient list
     "jquery-ui/ui/widgets/datepicker",
     'hqwebapp/js/components/select_toggle',
+    "commcarehq",
 ], function (
     $,
     _,

--- a/corehq/apps/reports/templates/reports/bootstrap3/edit_scheduled_report.html
+++ b/corehq/apps/reports/templates/reports/bootstrap3/edit_scheduled_report.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 
 
-{% requirejs_main 'reports/js/bootstrap3/edit_scheduled_report' %}
+{% js_entry_b3 'reports/js/bootstrap3/edit_scheduled_report' %}
 
 {% block page_content %}
   {% initial_page_data 'is_configurable_map' is_configurable_map %}

--- a/corehq/apps/reports/templates/reports/bootstrap5/edit_scheduled_report.html
+++ b/corehq/apps/reports/templates/reports/bootstrap5/edit_scheduled_report.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 
 
-{% requirejs_main_b5 'reports/js/bootstrap5/edit_scheduled_report' %}
+{% js_entry 'reports/js/bootstrap5/edit_scheduled_report' %}
 
 {% block page_content %}
   {% initial_page_data 'is_configurable_map' is_configurable_map %}

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap3/base.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap3/base.html
@@ -36,7 +36,6 @@
       <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
       <script src="{% static 'hqwebapp/js/bootstrap3/main.js' %}"></script>
       <script src="{% static 'multiselect/js/jquery.multi-select.js' %}"></script>
-      <script src="{% static 'quicksearch/dist/jquery.quicksearch.min.js' %}"></script>
       <script src="{% static 'hqwebapp/js/multiselect_utils.js' %}"></script>
     {% endcompress %}
   </head>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/base.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/base.html
@@ -122,7 +122,6 @@
       <script src="{% static 'hqwebapp/js/bootstrap5/main.js' %}"></script>
       <script src="{% static 'hqwebapp/js/select_2_ajax_widget.js' %}"></script>
       <script src="{% static 'multiselect/js/jquery.multi-select.js' %}"></script>
-      <script src="{% static 'quicksearch/dist/jquery.quicksearch.min.js' %}"></script>
       <script src="{% static 'hqwebapp/js/multiselect_utils.js' %}"></script>
       <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
       <script src="{% static 'ace-builds/src-min-noconflict/mode-python.js' %}"></script>

--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -15,6 +15,7 @@ hqDefine('users/js/edit_commcare_user', [
     'registration/js/bootstrap3/password',
     'select2/dist/js/select2.full.min',
     'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/users/static/users/js/edit_web_user.js
+++ b/corehq/apps/users/static/users/js/edit_web_user.js
@@ -5,6 +5,7 @@ hqDefine('users/js/edit_web_user', [
     'hqwebapp/js/initial_page_data',
     'users/js/custom_data_fields',
     'locations/js/widgets',
+    'commcarehq',
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/users/static/users/js/filtered_download.js
+++ b/corehq/apps/users/static/users/js/filtered_download.js
@@ -7,6 +7,7 @@ hqDefine('users/js/filtered_download', [
     'locations/js/widgets',     // location search
     'hqwebapp/js/components/select_toggle',
     'hqwebapp/js/bootstrap3/knockout_bindings.ko', // slideVisible binding
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/users/static/users/js/invite_web_user.js
+++ b/corehq/apps/users/static/users/js/invite_web_user.js
@@ -3,7 +3,6 @@ hqDefine('users/js/invite_web_user',[
     'knockout',
     'hqwebapp/js/initial_page_data',
     'users/js/custom_data_fields',
-    'hqwebapp/js/toggles',
     'hqwebapp/js/bootstrap3/validators.ko',
     'locations/js/widgets',
     'commcarehq',
@@ -11,8 +10,7 @@ hqDefine('users/js/invite_web_user',[
     $,
     ko,
     initialPageData,
-    customDataFields,
-    toggles
+    customDataFields
 ) {
     'use strict';
 

--- a/corehq/apps/users/static/users/js/invite_web_user.js
+++ b/corehq/apps/users/static/users/js/invite_web_user.js
@@ -6,6 +6,7 @@ hqDefine('users/js/invite_web_user',[
     'hqwebapp/js/toggles',
     'hqwebapp/js/bootstrap3/validators.ko',
     'locations/js/widgets',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -32,6 +32,7 @@ hqDefine("users/js/mobile_workers",[
     'hqwebapp/js/components/search_box',
     'hqwebapp/js/bootstrap3/validators.ko', // email address validation
     'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -4,7 +4,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'users/js/edit_commcare_user' %}
+{% js_entry_b3 'users/js/edit_commcare_user' %}
 
 {% block page_content %}
   {% initial_page_data "couch_user_id" couch_user.user_id %}

--- a/corehq/apps/users/templates/users/edit_web_user.html
+++ b/corehq/apps/users/templates/users/edit_web_user.html
@@ -4,7 +4,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'users/js/edit_web_user' %}
+{% js_entry_b3 'users/js/edit_web_user' %}
 
 {% block page_content %}
   {% initial_page_data 'can_edit_original_profile' can_edit_original_profile %}

--- a/corehq/apps/users/templates/users/filter_and_download.html
+++ b/corehq/apps/users/templates/users/filter_and_download.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main 'users/js/filtered_download' %}
+{% js_entry_b3 'users/js/filtered_download' %}
 
 {% block page_content %}
   {% initial_page_data 'count_users_url' count_users_url %}

--- a/corehq/apps/users/templates/users/invite_web_user.html
+++ b/corehq/apps/users/templates/users/invite_web_user.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main 'users/js/invite_web_user' %}
+{% js_entry_b3 'users/js/invite_web_user' %}
 
 {% block page_content %}
   {% initial_page_data 'custom_fields_slugs' custom_fields_slugs %}

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -4,7 +4,7 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main 'users/js/mobile_workers' %}
+{% js_entry_b3 'users/js/mobile_workers' %}
 
 {% block page_content %}
   {% initial_page_data 'can_access_all_locations' can_access_all_locations %}

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
         "nprogress": "0.2.0",
         "nvd3": "1.1.10",
         "nvd3-1.8.6": "npm:nvd3#1.8.6",
-        "quicksearch": "DeuxHuitHuit/quicksearch#2.2.1",
         "requirejs": "2.3.7",
         "requirejs-babel7": "^1.3.2",
         "select2": "4.1.0-rc.0",

--- a/webpack/webpack.b3.common.js
+++ b/webpack/webpack.b3.common.js
@@ -14,7 +14,7 @@ module.exports = Object.assign({}, commonDefault, {
         new webpack.ProvidePlugin({
             '$': 'jquery',
             'jQuery': 'jquery',  // needed for bootstrap 3 to work
-            'window.jQuery': 'jquery',
+            'window.jQuery': 'jquery',  // needed for some third-party libraries that depend on jQuery, such as multiselect
         }),
         new hqPlugins.EntryChunksPlugin({
             filename: 'manifest_b3.json',

--- a/webpack/webpack.b3.common.js
+++ b/webpack/webpack.b3.common.js
@@ -14,6 +14,7 @@ module.exports = Object.assign({}, commonDefault, {
         new webpack.ProvidePlugin({
             '$': 'jquery',
             'jQuery': 'jquery',  // needed for bootstrap 3 to work
+            'window.jQuery': 'jquery',
         }),
         new hqPlugins.EntryChunksPlugin({
             filename: 'manifest_b3.json',

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -85,6 +85,7 @@ module.exports = {
         new webpack.ProvidePlugin({
             '$': 'jquery',
             'jQuery': 'jquery',  // needed for bootstrap to work
+            'window.jQuery': 'jquery',
         }),
         new hqPlugins.EntryChunksPlugin(),
     ],

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -85,7 +85,7 @@ module.exports = {
         new webpack.ProvidePlugin({
             '$': 'jquery',
             'jQuery': 'jquery',  // needed for bootstrap to work
-            'window.jQuery': 'jquery',
+            'window.jQuery': 'jquery',  // needed for some third-party libraries that depend on jQuery, such as multiselect
         }),
         new hqPlugins.EntryChunksPlugin(),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4081,7 +4081,7 @@ jquery@3.5.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
-"jquery@>= 1.7.1", jquery@>=1.10, jquery@>=1.7, jquery@>=1.8, "jquery@>=1.8.0 <4.0.0", jquery@^3.5.1:
+"jquery@>= 1.7.1", jquery@>=1.10, jquery@>=1.7, "jquery@>=1.8.0 <4.0.0", jquery@^3.5.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
@@ -5750,12 +5750,6 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-quicksearch@DeuxHuitHuit/quicksearch#2.2.1:
-  version "2.2.1"
-  resolved "https://codeload.github.com/DeuxHuitHuit/quicksearch/tar.gz/05089bc3aa95a68eee2f7f484a304be06a8f1303"
-  dependencies:
-    jquery ">=1.8"
-
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -6312,7 +6306,16 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6358,7 +6361,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6371,6 +6374,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -7018,7 +7028,7 @@ workerpool@6.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.0.tgz#827d93c9ba23ee2019c3ffaff5c27fccea289e8b"
   integrity sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7031,6 +7041,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Technical Summary
This adds support for multiselect, migrates some pages that depend on it, and removes the `quicksearch` dependency from HQ, which wasn't adding enough value to justify maintaining it. See commit messages for detail.

https://dimagi.atlassian.net/browse/SAAS-16271

## Safety Assurance

### Safety story
I've tested the multiselect changes and the migrations locally. The multiselect changes are pretty small, and the migrations are pretty standard (i.e., the pages being migrated aren't dependent on any libraries that aren't used on webpack pages, other than multiselect).

### Automated test coverage

Little if any

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
