### PR TITLE
use AppsAPI instead of appselect:getApp

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -490,7 +490,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", [
             if (!FormplayerFrontend.syncInterval) {
                 FormplayerFrontend.syncInterval = setInterval(function () {
                     const urlObject = Utils.currentUrlToObject(),
-                        currentApp = AppsAPI.getAppEntity(appId);
+                        currentApp = AppsAPI.getAppEntity(urlObject.appId);
                     let customProperties = {};
                     if (currentApp && currentApp.attributes && currentApp.attributes.profile) {
                         customProperties = currentApp.attributes.profile.custom_properties || {};

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -8,6 +8,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", [
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
     "cloudcare/js/formplayer/constants",
+    'cloudcare/js/formplayer/apps/api',
 ], function (
     $,
     _,
@@ -16,7 +17,8 @@ hqDefine("cloudcare/js/formplayer/utils/utils", [
     bootstrap,
     initialPageData,
     toggles,
-    constants
+    constants,
+    AppsAPI
 ) {
     var Utils = {};
 
@@ -452,7 +454,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", [
 
     Utils.setSyncInterval = function (appId, restartInterval) {
         hqRequire(["cloudcare/js/formplayer/app"], function (FormplayerFrontend) {
-            const currentApp = FormplayerFrontend.getChannel().request("appselect:getApp", appId);
+            const currentApp = AppsAPI.getAppEntity(appId);
             let customProperties = {};
             if (currentApp && currentApp.attributes && currentApp.attributes.profile) {
                 customProperties = currentApp.attributes.profile.custom_properties || {};
@@ -488,7 +490,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", [
             if (!FormplayerFrontend.syncInterval) {
                 FormplayerFrontend.syncInterval = setInterval(function () {
                     const urlObject = Utils.currentUrlToObject(),
-                        currentApp = FormplayerFrontend.getChannel().request("appselect:getApp", urlObject.appId);
+                        currentApp = AppsAPI.getAppEntity(appId);
                     let customProperties = {};
                     if (currentApp && currentApp.attributes && currentApp.attributes.profile) {
                         customProperties = currentApp.attributes.profile.custom_properties || {};

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -453,26 +453,24 @@ hqDefine("cloudcare/js/formplayer/utils/utils", [
     };
 
     Utils.setSyncInterval = function (appId, restartInterval) {
-        hqRequire(["cloudcare/js/formplayer/app"], function (FormplayerFrontend) {
-            const currentApp = AppsAPI.getAppEntity(appId);
-            let customProperties = {};
-            if (currentApp && currentApp.attributes && currentApp.attributes.profile) {
-                customProperties = currentApp.attributes.profile.custom_properties || {};
-            }
+        const currentApp = AppsAPI.getAppEntity(appId);
+        let customProperties = {};
+        if (currentApp && currentApp.attributes && currentApp.attributes.profile) {
+            customProperties = currentApp.attributes.profile.custom_properties || {};
+        }
 
-            const useAggressiveSyncTiming = (customProperties[constants.POST_FORM_SYNC] === "yes");
-            if (!useAggressiveSyncTiming) {
-                return;
-            }
+        const useAggressiveSyncTiming = (customProperties[constants.POST_FORM_SYNC] === "yes");
+        if (!useAggressiveSyncTiming) {
+            return;
+        }
 
-            const FIVE_MINUTES_IN_MILLISECONDS = 1000 * 60 * 5;
-            if (restartInterval) {
-                stopSyncInterval();
-                startSyncInterval(FIVE_MINUTES_IN_MILLISECONDS);
-            } else {
-                startSyncInterval(FIVE_MINUTES_IN_MILLISECONDS);
-            }
-        });
+        const FIVE_MINUTES_IN_MILLISECONDS = 1000 * 60 * 5;
+        if (restartInterval) {
+            stopSyncInterval();
+            startSyncInterval(FIVE_MINUTES_IN_MILLISECONDS);
+        } else {
+            startSyncInterval(FIVE_MINUTES_IN_MILLISECONDS);
+        }
     };
 
     function startSyncInterval(delayInMilliseconds) {


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Replaces call to `appselect:getApp`, which has been [removed](https://github.com/dimagi/commcare-hq/commit/3b5f59be26a17d3052163ddf9c42c546fe1b4db1#diff-047b5470339deb0181a716ebe47cc28224e0131a3946ce48dd5c7c51c7b5e93fR94), with `AppsAPI.getAppEntity`
Came upon the issue while investigating a [QA bug ticket ](https://dimagi.atlassian.net/browse/QA-7252)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
