### PR TITLE
Swap in defusedxml.parseString

### DIFF
--- a/corehq/messaging/smsbackends/push/views.py
+++ b/corehq/messaging/smsbackends/push/views.py
@@ -4,6 +4,7 @@ from corehq.messaging.smsbackends.push.models import PushBackend
 from django.http import HttpResponse, HttpResponseBadRequest
 
 from defusedxml.minidom import parseString
+from xml.dom import Node
 from xml.parsers.expat import ExpatError
 from xml.sax.saxutils import unescape
 
@@ -31,11 +32,12 @@ class PushIncomingView(IncomingBackendView):
             return None, None
 
         for element in xml:
-            name = element.getAttribute('name')
-            if name == 'MobileNumber':
-                number = self.clean_value(element.childNodes[0].nodeValue)
-            elif name == 'Text':
-                text = self.clean_value(element.childNodes[0].nodeValue)
+            if element.nodeType == Node.ELEMENT_NODE:
+                name = element.getAttribute('name')
+                if name == 'MobileNumber':
+                    number = self.clean_value(element.childNodes[0].nodeValue)
+                elif name == 'Text':
+                    text = self.clean_value(element.childNodes[0].nodeValue)
 
         return number, text
 

--- a/corehq/messaging/smsbackends/push/views.py
+++ b/corehq/messaging/smsbackends/push/views.py
@@ -2,7 +2,9 @@ from corehq.apps.sms.api import incoming
 from corehq.apps.sms.views import IncomingBackendView
 from corehq.messaging.smsbackends.push.models import PushBackend
 from django.http import HttpResponse, HttpResponseBadRequest
-from lxml import etree
+
+from defusedxml.minidom import parseString
+from xml.parsers.expat import ExpatError
 from xml.sax.saxutils import unescape
 
 
@@ -24,16 +26,16 @@ class PushIncomingView(IncomingBackendView):
         number = None
         text = None
         try:
-            xml = etree.fromstring(request.body)
-        except etree.XMLSyntaxError:
+            xml = parseString(request.body).documentElement.childNodes
+        except (ExpatError, ValueError):
             return None, None
 
         for element in xml:
-            name = element.get('name')
+            name = element.getAttribute('name')
             if name == 'MobileNumber':
-                number = self.clean_value(element.text)
+                number = self.clean_value(element.childNodes[0].nodeValue)
             elif name == 'Text':
-                text = self.clean_value(element.text)
+                text = self.clean_value(element.childNodes[0].nodeValue)
 
         return number, text
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/SAAS-16183)
[Code Scan alert](https://github.com/dimagi/commcare-hq/security/code-scanning/352)

This PR swaps out `lxml.fromString` to `defusedxml.minidom.parseString` to mitigate risks of an XXE attack. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Manually tested in shell using the example xml string `'<bspostevent><field name="MobileNumber" type="string">000000000</field><field name="Text" type="string">sample text</field></bspostevent>'` and verified it returns the same names, numbers and text.  

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

I don't have a way of testing this locally so I think it's a good idea to ask QA to take a quick pass on it. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
