### PR TITLE
Add HTMX loading styles and related documentation in styleguide

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq.scss
@@ -77,6 +77,7 @@
 @import "commcarehq/form_steps";
 @import "commcarehq/helpbubble";
 @import "commcarehq/hubspot";
+@import "commcarehq/htmx";
 @import "commcarehq/icons";
 @import "commcarehq/inline_edit";
 @import "commcarehq/label";

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_htmx.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_htmx.scss
@@ -1,0 +1,72 @@
+@mixin htmx-spinner($width) {
+  position: absolute;
+  height: $width;
+  width: $width;
+  $offset: $width / 2;
+  left: calc(50% - $offset);
+  top: calc(50% - $offset);
+}
+
+form.htmx-request {
+  .htmx-loading {
+    position: relative;
+    &::before {
+      content: " ";
+      @extend .spinner-border;
+      @extend .spinner-border-sm;
+      @include htmx-spinner(22px);
+    }
+    &.btn-sm::before {
+      @include htmx-spinner(18px);
+    }
+  }
+  .input-group .btn.htmx-loading::before {
+    vertical-align: -0.28em;
+  }
+}
+
+.htmx-request.page-link {
+  background-color: $blue-300;
+  color: $white;
+  position: relative;
+
+  &::after {
+    content: " ";
+    @extend .spinner-border;
+    @extend .spinner-border-sm;
+    @include htmx-spinner(22px);
+  }
+}
+
+.htmx-request[type="checkbox"] {
+  position: relative;
+
+  &::after {
+    content: " ";
+    color: $blue-400;
+    @extend .spinner-border;
+    @extend .spinner-border-sm;
+    @include htmx-spinner(22px);
+  }
+}
+
+.htmx-request.form-check-input {
+  &::after {
+    @include htmx-spinner(30px);
+  }
+}
+
+button.htmx-request {
+  position: relative;
+  &::before {
+    content: " ";
+    @extend .spinner-border;
+    @extend .spinner-border-sm;
+    @include htmx-spinner(22px);
+    opacity: .5;
+  }
+
+  &.btn-sm::before {
+    @include htmx-spinner(18px);
+  }
+}

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_htmx.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_htmx.scss
@@ -8,7 +8,7 @@
 }
 
 form.htmx-request {
-  .htmx-loading {
+  button[type="submit"] {
     position: relative;
     &::before {
       content: " ";
@@ -20,7 +20,7 @@ form.htmx-request {
       @include htmx-spinner(18px);
     }
   }
-  .input-group .btn.htmx-loading::before {
+  .input-group button[type="submit"]::before {
     vertical-align: -0.28em;
   }
 }

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/style-imports.commcarehq.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/style-imports.commcarehq.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,44 +1,95 @@
+@@ -1,44 +1,96 @@
 -@import "_hq/includes/variables.less";
 -@import "_hq/includes/mixins.less";
  
@@ -123,6 +123,7 @@
 +@import "commcarehq/form_steps";
 +@import "commcarehq/helpbubble";
 +@import "commcarehq/hubspot";
++@import "commcarehq/htmx";
 +@import "commcarehq/icons";
 +@import "commcarehq/inline_edit";
 +@import "commcarehq/label";

--- a/corehq/apps/styleguide/context.py
+++ b/corehq/apps/styleguide/context.py
@@ -8,6 +8,7 @@ Color = namedtuple('Color', 'slug hex')
 CrispyFormsDemo = namedtuple('CrispyFormsDemo', 'form code')
 CrispyFormsWithJsDemo = namedtuple('CrispyFormsWithJsDemo', 'form code_python code_js')
 CodeForDisplay = namedtuple('CodeForDisplay', 'code language')
+CodeForDisplayWithPartial = namedtuple('CodeForDisplayWithPartial', 'code language partial')
 ThemeColor = namedtuple('ThemeColor', 'slug hex theme_equivalent')
 
 

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_alpine_form_demo.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_alpine_form_demo.py
@@ -83,7 +83,7 @@ class FilterDemoForm(forms.Form):
                 twbscrispy.StrictButton(
                     _("Add Filter"),
                     type="submit",
-                    css_class="btn-primary htmx-loading",
+                    css_class="btn btn-primary",
                 ),
                 # The Alpine data model is easily bound to the form
                 # to control hiding/showing the value field:

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/base.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/base.html
@@ -54,6 +54,9 @@
       <script src="{% static '@eonasdan/tempus-dominus/dist/js/tempus-dominus.min.js' %}"></script>
     {% endcompress %}
 
+    {% block head %}
+    {% endblock head %}
+
     <script src="{% statici18n LANGUAGE_CODE %}"></script>
   </head>
   <body>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/code_display.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/code_display.html
@@ -1,3 +1,8 @@
+{% if content.partial %}
+  <div>
+    {% include content.partial %}
+  </div>
+{% endif %}
 <div class="pb-3">
   {% include 'styleguide/bootstrap5/partials/readable_code_block.html' with content=content.code language=content.language %}
 </div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/htmx_loading_button.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/htmx_loading_button.html
@@ -1,0 +1,8 @@
+<button
+  class="btn btn-primary" type="button"
+  hx-get="{% url 'styleguide_a_hanging_view' %}"
+  hx-disabled-elt="this"
+  hx-swap="none"  {# example view returns nothing to display #}
+>
+  Click Me
+</button>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/htmx_loading_checkbox.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/htmx_loading_checkbox.html
@@ -1,0 +1,11 @@
+<div class="form-check">
+  <input
+    class="form-check-input" type="checkbox" value="" id="flexCheckDefault"
+    hx-get="{% url 'styleguide_a_hanging_view' %}"
+    hx-disabled-elt="this"
+    hx-swap="none"  {# example view returns nothing to display #}
+  />
+  <label class="form-check-label" for="flexCheckDefault">
+    Try to check me
+  </label>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/htmx_loading_form.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/htmx_loading_form.html
@@ -1,0 +1,13 @@
+<form
+  hx-get="{% url 'styleguide_a_hanging_view' %}"
+  hx-disabled-elt="find button"
+  hx-swap="none"  {# example view returns nothing to display #}
+>
+  <div class="mb-3">
+    <label for="id_value" class="form-label">Value</label>
+    <input type="text" name="value" class="textinput form-control" id="id_value"/>
+  </div>
+  <button class="btn btn-primary" type="submit">
+    Submit Me!
+  </button>
+</form>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
@@ -1,4 +1,9 @@
 {% extends 'styleguide/bootstrap5/base.html' %}
+{% load hq_shared_tags %}
+
+{% block head %}
+  <script src="{% static 'htmx.org/dist/htmx.min.js' %}"></script>
+{% endblock head %}
 
 {% block intro %}
   <h1 class="sg-title mb-0" id="content">HTMX and Alpine</h1>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
@@ -36,6 +36,14 @@
         </ul>
       </li>
       <li><a href="#debugging">Debugging During Development</a></li>
+      <li>
+        <a href="#loading-indicators">Loading Indicators</a>
+        <ul>
+          <a href="#button-loading">Buttons</a></li>
+          <a href="#checkbox-loading">Checkboxes</a></li>
+          <a href="#form-loading">Forms</a></li>
+        </ul>
+      </li>
     </ul>
   </nav>
 {% endblock toc %}
@@ -246,4 +254,49 @@
     You can check out the <code>HqHtmxDebugMixin</code> directly for additional documentation and usage
     guidance.
   </p>
+
+  <h2 id="loading-indicators" class="pt-4">
+    Loading Indicators
+  </h2>
+  <p>
+    You can use the <code>hx-indicator</code> attribute
+    (<a href="https://htmx.org/attributes/hx-indicator/" target="_blank">see docs here</a>)
+    to mark which element gets the <code>htmx-request</code> class appended to it during a request.
+    We've added custom styling to <code>_htmx.scss</code> to support the common states outlined
+    later in this section.
+  </p>
+  <p>
+    By default, if an element triggers an HTMX request, it will automatically get the <code>htmx-request</code>
+    CSS class applied to it. No extra usage of the <code>hx-indicator</code> attribute is necessary. The
+    example submitting elements below showcase this default behavior <strong>without</strong> the need for
+    specific <code>hx-indicator</code> usage.
+  </p>
+  <p>
+    It's often a great idea to pair button requests with <code>hx-disabled-elt="this"</code>
+    (<a href="https://htmx.org/attributes/hx-disabled-elt/" target="_blank`">see docs for hx-disabled-elt</a>),
+    like the examples below, so that the requesting element or related element is disabled during the request.
+  </p>
+  <h3 id="button-loading" class="pt-4">
+    Buttons
+  </h3>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.loading_button %}
+
+  <h3 id="checkbox-loading" class="pt-4">
+    Checkboxes
+  </h3>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.loading_checkbox %}
+
+  <h3 id="form-loading" class="pt-4">
+    Forms
+  </h3>
+  <p>
+    In the example below, note that the <code>form</code> is the triggering element, so the
+    <code>hx-disabled-elt</code> value is set to <code>find button</code> to disable all button children
+    of that form during an HTMX request. Since <code>form</code> is the submitting element, by default
+    it has the <code>htmx-request</code> class applied. Our styles ensure that
+    <code>button type="submit"</code> elements of a submitting form show the loading indicator during
+    an HTMX request.
+  </p>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.loading_form %}
+
 {% endblock content %}

--- a/corehq/apps/styleguide/templates/styleguide/htmx_todo/item.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_todo/item.html
@@ -73,7 +73,7 @@
               x-model="itemValue"
           >
           <button
-              class="btn btn-primary htmx-loading"
+              class="btn btn-primary"
               type="submit"
               @click="isSubmitting = true"
           >

--- a/corehq/apps/styleguide/urls.py
+++ b/corehq/apps/styleguide/urls.py
@@ -57,6 +57,8 @@ urlpatterns = [
         name="styleguide_datatables_data"),
     url(r'^b5/data/paginated_table_data$', bootstrap5_data.paginated_table_data,
         name="styleguide_paginated_table_data"),
+    url(r'^b5/data/a_hanging_view$', bootstrap5_data.a_hanging_view,
+        name="styleguide_a_hanging_view"),
     url(r'^b5/example/', include(example_urlpatterns)),
     url(r'^b5/guidelines/$', bootstrap5.styleguide_code_guidelines,
         name="styleguide_code_guidelines_b5"),

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -14,6 +14,7 @@ from corehq.apps.styleguide.context import (
     get_js_example_context,
     get_gradient_colors,
     CodeForDisplay,
+    CodeForDisplayWithPartial,
 )
 from corehq.apps.styleguide.examples.bootstrap5.checkbox_form import CheckboxDemoForm
 from corehq.apps.styleguide.examples.bootstrap5.crispy_forms_basic import BasicCrispyExampleForm
@@ -100,6 +101,21 @@ def styleguide_htmx_and_alpine(request):
             ),
             'htmx_todo_item_done': CodeForDisplay(
                 code=get_example_context('styleguide/htmx_todo/item_done.html'),
+                language="Django",
+            ),
+            'loading_button': CodeForDisplayWithPartial(
+                code=get_example_context('styleguide/bootstrap5/examples/htmx_loading_button.html'),
+                partial="styleguide/bootstrap5/examples/htmx_loading_button.html",
+                language="Django",
+            ),
+            'loading_checkbox': CodeForDisplayWithPartial(
+                code=get_example_context('styleguide/bootstrap5/examples/htmx_loading_checkbox.html'),
+                partial="styleguide/bootstrap5/examples/htmx_loading_checkbox.html",
+                language="Django",
+            ),
+            'loading_form': CodeForDisplayWithPartial(
+                code=get_example_context('styleguide/bootstrap5/examples/htmx_loading_form.html'),
+                partial="styleguide/bootstrap5/examples/htmx_loading_form.html",
                 language="Django",
             ),
         }

--- a/corehq/apps/styleguide/views/bootstrap5_data.py
+++ b/corehq/apps/styleguide/views/bootstrap5_data.py
@@ -3,7 +3,7 @@ import time
 from collections import namedtuple
 from gettext import gettext
 
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render
 
 from corehq.apps.styleguide.utils import get_fake_tabular_data
@@ -111,3 +111,8 @@ def paginated_table_data(request):
         "total": len(fake_data),
         "rows": fake_data[start:end],
     })
+
+
+def a_hanging_view(request):
+    time.sleep(10)
+    return HttpResponse("Done")


### PR DESCRIPTION
## Technical Summary
This PR adds new styles for HTMX loading states of:
- buttons
- checkboxes
- forms and their submit button

Documentation has been added to the HTMX and Alpine styleguide page which demos those common examples, and points out `hx-indicator` and `hx-disabled-elt` attributes to help with creating good loading states for the user.

![Screenshot 2024-11-21 at 10 35 22 PM](https://github.com/user-attachments/assets/39485396-67c0-42b3-aeca-9c4ce60a4605)
![Screenshot 2024-11-21 at 10 35 49 PM](https://github.com/user-attachments/assets/3a4135a6-b29a-4464-a6af-6989bb4ed480)
![Screenshot 2024-11-21 at 10 35 38 PM](https://github.com/user-attachments/assets/f05cc2bf-7a10-4e52-8249-c1322c9f86d9)
![Screenshot 2024-11-21 at 10 35 29 PM](https://github.com/user-attachments/assets/707ccfbd-2710-47dc-99b6-643c72febe3f)


## Safety Assurance

### Safety story
Change to docs and to styling. very safe change

### Automated test coverage
no

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
