### PR TITLE
Fix uwsgi error in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
+     build-essential \
      bzip2 \
      default-jre \
      gettext \
@@ -37,6 +38,9 @@ RUN apt-get update \
      libxmlsec1-openssl \
      make \
   && rm -rf /var/lib/apt/lists/* /src/*.deb
+# build-essential allows uv to build uwsgi; increases image size by 240 MB
+# libpq-dev is for make-requirements-test.sh; increases image size by ~20 MB
+# libpq-dev can be replaced with libpq5 if pip-tools is replaced with uv in make-requirements-test.sh
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \


### PR DESCRIPTION
`Exception: you need a C compiler to build uWSGI` from [docker hub build](https://hub.docker.com/repository/registry-1.docker.io/dimagi/commcarehq_base/builds/baef7459-31a7-44f0-9ff6-ab96f252cce5) (requires login).

I didn't catch this in local testing because the `uv` cache had been primed when my local docker image still contained build tools. The build tools were removed later, but the cache remained, masking the error. I was able to reproduce the error locally by clearing the `uv` cache.

## Safety Assurance

### Safety story

This only affects the docker image used to run tests.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations except that it will re-introduce a bug.