### PR TITLE
Mobile UCR: Apply RESTORE_ACCESSIBLE_REPORTS_ONLY logic uniformly

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -139,12 +139,7 @@ class ReportFixturesProvider(FixtureProvider):
 
         if app_aware_sync_app:
             apps = [app_aware_sync_app]
-        elif (
-            toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY.enabled(restore_user.domain)
-            and restore_state.params.is_webapps
-            # only way to reliably know that this is a web apps restore, not live preview
-            and not restore_user.request_user.can_view_apps(restore_user.domain)
-        ):
+        elif toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY.enabled(restore_user.domain):
             apps = []
             for app in get_web_apps_available_to_user(restore_user.domain, restore_user._couch_user):
                 if not is_remote_app(app):


### PR DESCRIPTION
## Product Description


## Technical Summary

`restore_state.params.is_webapps` - Normal restores from mobile devices are app aware, and should hit the first branch of this conditional. Further, this feature flag is only used by two projects, both USH, both webapps only, so I'm not super concerned about knock-on effects.  I think this is also a better fallback mechanism anyways - defaulting to the more restrictive/secure option where there's doubt.

`not restore_user.request_user.can_view_apps(restore_user.domain)` - this one is trickier.  The original logic for having this line here was because app builders can access live preview, and from there they can log in as any user, including those that don't have access to the app. This I'd consider a bug, honestly, but I do think a better way to deal with that situation is to _exclude_ the report fixtures from the restricted restore user.  If an app builder tests an app with a user that doesn't have access to a report fixture, they shouldn't have the fixture either, so the app fails in the same way.  This will also be useful in testing performance, as mobile UCR syncs will be the same whether logged in directly as a user or using login-as with the same user.  Another way this could fail is with app builders testing an app they don't have access to without using login as.  This type of failure feels similar to other considerations in user provisioning, such as location assignment and user data setup.  It's reasonable to expect app builders to test with a properly provisioned user.

These changes in conjunction will make it so the admin restore more accurately reflects what real users see as well.

## Feature Flag
RESTORE_ACCESSIBLE_REPORTS_ONLY: Only restore reports in apps that are accessible to the restoring user

## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
