### PR TITLE
Fix "Toggle Affected Row(s)" button for multiple error messages on Case Import

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
@@ -27,56 +27,56 @@
   <!--/ko-->
 </div>
 <!--ko if: !$root._.isEmpty(result.errors)-->
-<div class="alert alert-warning">
-  <ul class="list-unstyled">
-    <!--ko foreach: result.errors-->
-    <!--ko if: rows-->
-    <li>
-      <!--ko if: column-->
-      <p><strong>
-        <!-- ko if: rows.length == 1-->
-        {% blocktrans %}
-          <span data-bind="text: rows.length"></span> row had an invalid
-          "<span data-bind="text: column"></span>" cell and was not saved
-        {% endblocktrans %}
+  <!--ko foreach: result.errors-->
+    <div class="alert alert-warning">
+      <!--ko if: rows-->
+        <!--ko if: column-->
+          <h6>
+            <!-- ko if: rows.length == 1-->
+            {% blocktrans %}
+              <span data-bind="text: rows.length"></span> row had an invalid
+              "<span data-bind="text: column"></span>" cell and was not saved
+            {% endblocktrans %}
+            <!--/ko-->
+            <!-- ko if: rows.length > 1-->
+            {% blocktrans %}
+              <span data-bind="text: rows.length"></span> rows had invalid
+              "<span data-bind="text: column"></span>" cells and were not saved
+            {% endblocktrans %}
+            <!--/ko-->
+          </h6>
         <!--/ko-->
-        <!-- ko if: rows.length > 1-->
-        {% blocktrans %}
-          <span data-bind="text: rows.length"></span> rows had invalid
-          "<span data-bind="text: column"></span>" cells and were not saved
-        {% endblocktrans %}
+        <!--ko if: !column -->
+          <h6 data-bind="text: title"></h6>
         <!--/ko-->
-      </strong></p>
-      <!--/ko-->
-      <!--ko if: !column -->
-      <p><strong data-bind="text: title"></strong></p>
-      <!--/ko-->
-      <p data-bind="text: description">
-      </p>
-      <p data-bind="visible: sample, text: sample">
-      </p>
-      <div data-bind="visible: rows.length">
-        <button type="button"
-                class="btn btn-outline-primary btn-sm"
-                data-bs-toggle="collapse"
-                data-bind="attr: {
-                  'data-bs-target': '#rowDetailsCollapse-' + $parentContext.$index() + '-' + $index(),
-                  'aria-controls': 'rowDetailsCollapse-' + $parentContext.$index() + '-' + $index()
-                }"
-                aria-expanded="false">
-          {% trans "Toggle Affected Row(s)" %}
-        </button>
-        <div class="collapse"
-             data-bind="attr: { id: 'rowDetailsCollapse-' + $parentContext.$index() + '-' + $index() }">
-          <div class="card card-body mt-3"
-               data-bind="text: rows.join(', ')"></div>
+        <p data-bind="text: description"></p>
+        <p data-bind="visible: sample, text: sample"></p>
+        <div data-bind="visible: rows.length">
+          <button
+              type="button"
+              class="btn btn-outline-primary btn-sm"
+              data-bs-toggle="collapse"
+              data-bind="attr: {
+                'data-bs-target': '#rowDetailsCollapse-' + $parentContext.$index() + '-' + $index(),
+                'aria-controls': 'rowDetailsCollapse-' + $parentContext.$index() + '-' + $index()
+              }"
+              aria-expanded="false"
+          >
+            {% trans "Toggle Affected Row(s)" %}
+          </button>
+          <div
+              class="collapse"
+              data-bind="attr: { id: 'rowDetailsCollapse-' + $parentContext.$index() + '-' + $index() }"
+          >
+            <div
+                class="card card-body mt-3"
+                data-bind="text: rows.join(', ')"
+            ></div>
+          </div>
         </div>
-      </div>
-    </li>
-    <!--/ko-->
-    <!--/ko-->
-  </ul>
-</div>
+      <!--/ko-->
+    </div>
+  <!--/ko-->
 <!--/ko-->
 <!--/ko-->
 <!--ko if: state == $root.states.SUCCESS && !result-->

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
@@ -60,14 +60,14 @@
                 class="btn btn-outline-primary btn-sm"
                 data-bs-toggle="collapse"
                 data-bind="attr: {
-                  'data-bs-target': '#rowDetailsCollapse-' + $parentContext.$index(),
-                  'aria-controls': 'rowDetailsCollapse-' + $parentContext.$index()
+                  'data-bs-target': '#rowDetailsCollapse-' + $parentContext.$index() + '-' + $index(),
+                  'aria-controls': 'rowDetailsCollapse-' + $parentContext.$index() + '-' + $index()
                 }"
                 aria-expanded="false">
           {% trans "Toggle Affected Row(s)" %}
         </button>
         <div class="collapse"
-             data-bind="attr: { id: 'rowDetailsCollapse-' + $parentContext.$index() }">
+             data-bind="attr: { id: 'rowDetailsCollapse-' + $parentContext.$index() + '-' + $index() }">
           <div class="card card-body mt-3"
                data-bind="text: rows.join(', ')"></div>
         </div>


### PR DESCRIPTION
## Product Description
Fixes issue with "Toggle Affected Row(s)" button on Import Cases from Excel when there are multiple error messages (one for each sheet, for instance).

It's described in this ticket:
https://dimagi.atlassian.net/browse/QA-7065

## Technical Summary
This changes the HTML and knockout so that there is one alert per error message group, rather than lots of error messages per alert...which creates a weird UI. This updates the ID of the toggle rows collapsable to include both `$index()` and `$parent.index()`...otherwise all the toggles for an import with multiple error message will toggle all the collapse-ables as once (see ticket)

## Safety Assurance

### Safety story
Tested on staging. UI change only

### Automated test coverage
No

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
