### PR TITLE
Added jquery cookie dependency to hq.helpers.js

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js
@@ -4,6 +4,7 @@ hqDefine("hqwebapp/js/bootstrap3/hq.helpers", [
     'underscore',
     'analytix/js/google',
     'bootstrap',  // for popover constructor override
+    'jquery.cookie/jquery.cookie',  // $.cookie
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
@@ -4,6 +4,7 @@ hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
     'underscore',
     'analytix/js/google',
     'es6!hqwebapp/js/bootstrap5_loader',
+    'jquery.cookie/jquery.cookie',  // $.cookie
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,14 +1,15 @@
+@@ -1,15 +1,16 @@
 -hqDefine("hqwebapp/js/bootstrap3/hq.helpers", [
 +hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
      'jquery',
@@ -9,6 +9,7 @@
      'analytix/js/google',
 -    'bootstrap',  // for popover constructor override
 +    'es6!hqwebapp/js/bootstrap5_loader',
+     'jquery.cookie/jquery.cookie',  // $.cookie
  ], function (
      $,
      ko,
@@ -19,7 +20,7 @@
  ) {
      // disable-on-submit is a class for form submit buttons so they're automatically disabled when the form is submitted
      $(document).on('submit', 'form', function (ev) {
-@@ -55,19 +56,6 @@
+@@ -56,19 +57,6 @@
          return false; // let default handler run
      };
  
@@ -39,7 +40,7 @@
      $.fn.hqHelp = function (opts) {
          var self = this;
          self.each(function (i) {
-@@ -84,22 +72,19 @@
+@@ -85,22 +73,19 @@
              if (opts) {
                  options = _.extend(options, opts);
              }


### PR DESCRIPTION
## Technical Summary
I'm occasionally seeing errors locally while working on webpack migrations. Haven't seen them on prod yet, but this change makes sense: this file depends on `$.cookie` (see [here](https://github.com/dimagi/commcare-hq/blob/5f8a8a90bcdedd06dc7be2ba83dd176fe422fcb4/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js#L155) and [here](https://github.com/dimagi/commcare-hq/blob/5f8a8a90bcdedd06dc7be2ba83dd176fe422fcb4/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js#L140)), so the dependency should be included.

We should probably deprecate usage of jquery cookie, but that's another ticket for another day.

## Safety Assurance

### Safety story
This is a safe kind of change.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
