### PR TITLE
[webpack] hqmedia

### DIFF
--- a/corehq/apps/hqmedia/static/hqmedia/js/bulk_upload.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/bulk_upload.js
@@ -1,6 +1,7 @@
 hqDefine("hqmedia/js/bulk_upload", [
     "hqwebapp/js/bulk_upload_file",
     "app_manager/js/download_async_modal",
+    "commcarehq",
 ], function () {
     return 1;
 });

--- a/corehq/apps/hqmedia/static/hqmedia/js/manage_paths_main.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/manage_paths_main.js
@@ -3,6 +3,7 @@ hqDefine("hqmedia/js/manage_paths_main", [
     "knockout",
     "hqwebapp/js/assert_properties",
     "hqwebapp/js/components/select_toggle",
+    "commcarehq",
 ], function (
     $,
     ko,

--- a/corehq/apps/hqmedia/static/hqmedia/js/references_main.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/references_main.js
@@ -1,4 +1,20 @@
-hqDefine("hqmedia/js/references_main", function () {
+hqDefine("hqmedia/js/references_main", [
+    "jquery",
+    "knockout",
+    "underscore",
+    "hqwebapp/js/bootstrap3/alert_user",
+    "hqwebapp/js/initial_page_data",
+    "hqmedia/js/media_reference_models",
+    "app_manager/js/download_async_modal",    // for the 'Download ZIP' button
+    "hqwebapp/js/components/pagination",
+], function (
+    $,
+    ko,
+    _,
+    alertUser,
+    initialPageData,
+    mediaReferenceModels
+) {
     function MultimediaReferenceController() {
         var self = {};
         self.references = ko.observableArray();
@@ -28,7 +44,7 @@ hqDefine("hqmedia/js/references_main", function () {
             self.showPaginationSpinner(true);
             var includeTotal = page === 1;
             $.ajax({
-                url: hqImport("hqwebapp/js/initial_page_data").reverse('hqmedia_references'),
+                url: initialPageData.reverse('hqmedia_references'),
                 data: {
                     json: 1,
                     page: page,
@@ -45,15 +61,15 @@ hqDefine("hqmedia/js/references_main", function () {
                     self.references(_.map(data.references, function (ref) {
                         var objRef = data.object_map[ref.path];
                         if (ref.media_class === "CommCareImage") {
-                            var imageRef = hqImport('hqmedia/js/media_reference_models').ImageReference(ref);
+                            var imageRef = mediaReferenceModels.ImageReference(ref);
                             imageRef.setObjReference(objRef);
                             return imageRef;
                         } else if (ref.media_class === "CommCareAudio") {
-                            var audioRef = hqImport('hqmedia/js/media_reference_models').AudioReference(ref);
+                            var audioRef = mediaReferenceModels.AudioReference(ref);
                             audioRef.setObjReference(objRef);
                             return audioRef;
                         } else if (ref.media_class === "CommCareVideo") {
-                            var videoRef = hqImport('hqmedia/js/media_reference_models').VideoReference(ref);
+                            var videoRef = mediaReferenceModels.VideoReference(ref);
                             videoRef.setObjReference(objRef);
                             return videoRef;
                         }
@@ -69,7 +85,7 @@ hqDefine("hqmedia/js/references_main", function () {
                 },
                 error: function () {
                     self.showPaginationSpinner(false);
-                    hqImport('hqwebapp/js/bootstrap3/alert_user').alert_user(gettext("Error fetching multimedia, " +
+                    alertUser.alert_user(gettext("Error fetching multimedia, " +
                         "please try again or report an issue if the problem persists."), 'danger');
                 },
             });

--- a/corehq/apps/hqmedia/static/hqmedia/js/translations_coverage.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/translations_coverage.js
@@ -1,0 +1,6 @@
+hqDefine("hqmedia/js/translations_coverage", [
+    'hqwebapp/js/bootstrap3/widgets',
+    'app_manager/js/widgets',
+], function () {
+    // nothing to do here, this module just groups the above dependencies
+});

--- a/corehq/apps/hqmedia/static/hqmedia/js/uploaders.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/uploaders.js
@@ -1,7 +1,14 @@
-hqDefine("hqmedia/js/uploaders", function () {
-    const assertProperties = hqImport("hqwebapp/js/assert_properties"),
-        initialPageData = hqImport("hqwebapp/js/initial_page_data");
-
+hqDefine("hqmedia/js/uploaders", [
+    "jquery",
+    "underscore",
+    "hqwebapp/js/assert_properties",
+    "hqwebapp/js/initial_page_data",
+], function (
+    $,
+    _,
+    assertProperties,
+    initialPageData
+) {
     const uploader = function (slug, options) {
         assertProperties.assertRequired(options, [
             'uploadURL', 'uploadParams',

--- a/corehq/apps/hqmedia/templates/hqmedia/audio_translator.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/audio_translator.html
@@ -3,11 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% block js %}{{ block.super }}
-  {% compress js %}
-    <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
-  {% endcompress js %}
-{% endblock js %}
+{% js_entry_b3 'hqwebapp/js/bootstrap3/widgets' %}
 
 {% block page_content %}
   <p class="lead">{{ current_page.page_name }}</p>

--- a/corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html
@@ -1,7 +1,7 @@
 {% extends "hqmedia/uploader_base.html" %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "hqmedia/js/bulk_upload" %}
+{% js_entry_b3 "hqmedia/js/bulk_upload" %}
 
 {% block page_content %}
   {% include "hqmedia/partials/bulk_upload.html" with include_modal=True %}

--- a/corehq/apps/hqmedia/templates/hqmedia/manage_paths.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/manage_paths.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'hqmedia/js/manage_paths_main' %}
+{% js_entry_b3 'hqmedia/js/manage_paths_main' %}
 
 {% block page_content %}
   {% include "hqmedia/partials/manage_paths.html" %}

--- a/corehq/apps/hqmedia/templates/hqmedia/references.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/references.html
@@ -2,6 +2,8 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
+{% js_entry_b3 'hqmedia/js/references_main' %}
+
 {% block stylesheets %}{{ block.super }}
   <style type="text/css">
     .media-type-icon,
@@ -9,12 +11,6 @@
       font-size: 22px;
     }
   </style>
-{% endblock %}
-
-{% block js %} {{ block.super }}
-  <script src="{% static 'hqmedia/js/media_reference_models.js' %}"></script>
-  <script src="{% static 'hqmedia/js/references_main.js' %}"></script>
-  <script src="{% static 'app_manager/js/download_async_modal.js' %}"></script>
 {% endblock %}
 
 {% block page_content %}

--- a/corehq/apps/hqmedia/templates/hqmedia/translations_coverage.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/translations_coverage.html
@@ -3,12 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% block js %}{{ block.super }}
-  {% compress js %}
-    <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
-    <script src="{% static 'app_manager/js/widgets.js' %}"></script>
-  {% endcompress js %}
-{% endblock js %}
+{% js_entry_b3 'hqmedia/js/translations_coverage' %}
 
 {% block page_content %}
   {% registerurl "paginate_releases" domain app.get_id %}

--- a/corehq/apps/hqmedia/templates/hqmedia/uploader_base.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/uploader_base.html
@@ -4,7 +4,3 @@
 {% block page_navigation %}
   {% include 'hqwebapp/partials/bootstrap3/navigation_left_sidebar.html' with sections=navigation_sections %}
 {% endblock page_navigation %}
-
-{% block js %} {{ block.super }}
-  <script src="{% static "hqmedia/js/uploaders.js" %}"></script>
-{% endblock %}


### PR DESCRIPTION
## Technical Summary
This app was partially using requirejs and partially not using javascript bundles at all. This PR moves the entire app to webpack, which is pretty easy now that YUI is gone.

## Safety Assurance

### Safety story
Most of these pages are behind the transifex feature flag. The multimedia references page is much more heavily used, but I'm pretty confident in the changes there. I'll do some testing on staging.

### Automated test coverage

no

### QA Plan
Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
