### PR TITLE
HqHtmxActionMixin: fix issue with missing default error template

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/htmx/htmx_action_error.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/htmx/htmx_action_error.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+
+{% blocktrans %}
+  Encountered error "{{ htmx_error }}" while performing action {{ action }}.
+{% endblocktrans %}

--- a/corehq/util/htmx_action.py
+++ b/corehq/util/htmx_action.py
@@ -49,14 +49,20 @@ class HqHtmxActionMixin:
     Example docs here: commcarehq.org/styleguide/b5/htmx_alpine/
     See working demo here: commcarehq.org/styleguide/demo/htmx_todo/
     """
-    default_htmx_error_template = "prototype/htmx/partials/htmx_action_error.html"
+    default_htmx_error_template = ""
 
-    def get_htmx_error_context(self, **kwargs):
+    def get_htmx_error_context(self, action, htmx_error, **kwargs):
         """
         Use this method to return the context for the HTMX error template.
+
+        :param action: string (the slug for the HTMX action taken)
+        :param htmx_error: HtmxResponseException
         :return: dict
         """
-        return {}
+        return {
+            "action": action,
+            "htmx_error": htmx_error,
+        }
 
     def get_htmx_error_template(self, action, htmx_error):
         """
@@ -117,8 +123,7 @@ class HqHtmxActionMixin:
         try:
             response = handler(request, *args, **kwargs)
         except HtmxResponseException as err:
-            context = self.get_htmx_error_context(**kwargs)
-            context["htmx_error"] = err
+            context = self.get_htmx_error_context(action, err, **kwargs)
             self.template_name = self.get_htmx_error_template(action, err)
             return self.render_to_response(context)
         return response

--- a/corehq/util/htmx_action.py
+++ b/corehq/util/htmx_action.py
@@ -49,7 +49,7 @@ class HqHtmxActionMixin:
     Example docs here: commcarehq.org/styleguide/b5/htmx_alpine/
     See working demo here: commcarehq.org/styleguide/demo/htmx_todo/
     """
-    default_htmx_error_template = ""
+    default_htmx_error_template = "hqwebapp/htmx/htmx_action_error.html"
 
     def get_htmx_error_context(self, action, htmx_error, **kwargs):
         """


### PR DESCRIPTION
## Technical Summary
Looks like I kept the prototype HTMX action template string (which doesn't exist in master). This correctly adds a default error template and updates a couple methods to correctly populate template context and make it more extensible for future.

## Safety Assurance

### Safety story
Very safe change. No GA'd features currently rely on this, and it fixes a bug (effectively)

### Automated test coverage
No

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
