### PR TITLE
Whitelist domains using post endpoint as API

### DIFF
--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -79,6 +79,10 @@ def _verify_access(domain, user_id, request):
             cache.set(cache_key, True, CACHE_EXPIRY_7_DAYS_IN_SECS)
             message = f"NoMobileEndpointsAccess: invalid request by {user_id} on {domain}"
             notify_exception(request, message=message)
+            if not toggles.OPEN_SUBMISSION_ENDPOINT.enabled(domain):
+                # Once we're confident this has enabled the flag for all active
+                # usage, we can make domains without the toggle fail hard
+                toggles.OPEN_SUBMISSION_ENDPOINT.set(domain, enabled=True, namespace=toggles.NAMESPACE_DOMAIN)
 
 
 @profile_dump('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1705,7 +1705,6 @@ DATA_MIGRATION = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-
 DISABLE_MOBILE_ENDPOINTS = StaticToggle(
     'disable_mobile_endpoints',
     'Disable mobile endpoints for form submissions and restores',
@@ -1719,6 +1718,12 @@ DISABLE_MOBILE_ENDPOINTS = StaticToggle(
     )
 )
 
+OPEN_SUBMISSION_ENDPOINT = StaticToggle(
+    'open_submission_endpoint',
+    'Leave submission endpoint open to let old APIs keep working',
+    TAG_DEPRECATED,
+    [NAMESPACE_DOMAIN],
+)
 
 EMWF_WORKER_ACTIVITY_REPORT = StaticToggle(
     'emwf_worker_activity_report',


### PR DESCRIPTION
## Product Description


## Technical Summary

https://dimagi.atlassian.net/browse/USH-5146

We'd like to phase out this code path - doing this will at least let us prevent new projects from using it accidentally.  That will happen once we merge the follow-up PR: https://github.com/dimagi/commcare-hq/pull/35435

This PR should have no user-facing changes.

I've previously tried other methods of doing this: https://dimagi.atlassian.net/browse/USH-1458

## Feature Flag

OPEN_SUBMISSION_ENDPOINT

## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
