### PR TITLE
Apply whitelist strictly - fail when misconfigured

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_audit_logging.py
+++ b/corehq/apps/receiverwrapper/tests/test_audit_logging.py
@@ -9,6 +9,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.receiverwrapper.views import post_api, secure_post
 from corehq.apps.users.models import CommCareUser, HqPermissions, WebUser
 from corehq.apps.users.models_role import UserRole
+from corehq.util.test_utils import flag_enabled
 
 
 def return_200(*args, **kwargs):
@@ -76,7 +77,13 @@ class TestAuditLoggingForFormSubmission(TestCase):
             self.assert_api_response(200, url)
             mock_notify_exception.assert_not_called()
 
-    def test_api_user_regular_submission_gets_logged(self):
+    def test_api_user_regular_submission_with_no_FF(self):
+        url = reverse(secure_post, args=[self.domain])
+        self._create_user(access_api=True, access_mobile_endpoints=False)
+        self.assert_api_response(403, url)
+
+    @flag_enabled('OPEN_SUBMISSION_ENDPOINT')
+    def test_api_user_regular_submission_with_FF(self):
         url = reverse(secure_post, args=[self.domain])
         user = self._create_user(access_api=True, access_mobile_endpoints=False)
         with patch('corehq.apps.receiverwrapper.views.notify_exception') as mock_notify_exception:


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.atlassian.net/browse/USH-4115

Follow-up to https://github.com/dimagi/commcare-hq/pull/35434

To be merged once we're confident the FF has been enabled for domains that would otherwise be broken by the change.

[Change management comms](https://docs.google.com/document/d/1wys3JsFmazy-KTDBTtydrQHJaTLWanlzXC1lstTyVdY/edit?tab=t.0)

## Feature Flag

OPEN_SUBMISSION_ENDPOINT

## Safety Assurance


### Safety story

I also back-populated the FF for all domains on www and india that had triggered the sentry error since Sept 24, 2024 (the oldest data we have available).

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change