### PR TITLE
Removed ace script tags from motech pages

### DIFF
--- a/corehq/motech/dhis2/templates/dhis2/dataset_map_json.html
+++ b/corehq/motech/dhis2/templates/dhis2/dataset_map_json.html
@@ -2,17 +2,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{# Required to define ACE #}
-{% load compress %}
-{% block js %}{{ block.super }}
-  {% compress js %}
-    <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
-    <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
-    <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
-    <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
-  {% endcompress %}
-{% endblock %}
-
 {% js_entry "dhis2/js/dataset_map_json" %}
 
 {% block page_content %}

--- a/corehq/motech/openmrs/templates/openmrs/edit_config.html
+++ b/corehq/motech/openmrs/templates/openmrs/edit_config.html
@@ -3,15 +3,8 @@
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 {% block title %}Edit Config : OpenMRS :: {% endblock %}
-{% block js %}{{ block.super }}
-  {% compress js %}
-    <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
-    <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
-    <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
-    <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
-  {% endcompress %}
-{% endblock %}
+
+{% js_entry 'hqwebapp/js/base_ace' %}
 
 {% block page_content %}
   {% crispy form %}


### PR DESCRIPTION
## Technical Summary
Noticed while looking at some metrics for requirejs/webpack.

The DHIS2 page doesn't need these because they're already dependencies in the js modules (see [here](https://github.com/dimagi/commcare-hq/blob/40ed79dce8ff33259b017770b2efed535c429fe4/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js#L5) and [here](https://github.com/dimagi/commcare-hq/blob/40ed79dce8ff33259b017770b2efed535c429fe4/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js#L18-L20)).

The OpenMRS page can be switched to use requirejs, and then it, too, gets access to the necessary ace code via dependencies declared in js.

## Feature Flag
DHIS2 / OpenMRS

## Safety Assurance

### Safety story
These are pretty minor changes to flagged config pages. Tested locally.

### Automated test coverage

I don't think so

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
