### PR TITLE
[webpack] Migrate pages I've been procrastinating on

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/renew_plan_selection.js
+++ b/corehq/apps/accounting/static/accounting/js/renew_plan_selection.js
@@ -4,6 +4,7 @@ hqDefine('accounting/js/renew_plan_selection', [
     'knockout',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/accounting/templates/accounting/accounting_admins.html
+++ b/corehq/apps/accounting/templates/accounting/accounting_admins.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main "hqwebapp/js/bootstrap3/crud_paginated_list_init" %}
+{% js_entry_b3 "hqwebapp/js/bootstrap3/crud_paginated_list_init" %}
 
 {% block pagination_header %}
   <h2>{% trans 'Manage Accounting Admins' %}</h2>

--- a/corehq/apps/domain/static/domain/js/internal_settings.js
+++ b/corehq/apps/domain/static/domain/js/internal_settings.js
@@ -5,6 +5,7 @@ hqDefine("domain/js/internal_settings", [
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/multiselect_utils',
     'jquery-ui/ui/widgets/datepicker',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/domain/templates/domain/admin/bootstrap5/global_sms_rates.html
+++ b/corehq/apps/domain/templates/domain/admin/bootstrap5/global_sms_rates.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'smsbillables/js/smsbillables.rate_calc' %}
+{% js_entry 'smsbillables/js/rate_calc' %}
 
 {% block title %}{% trans "SMS Pricing" %}{% endblock %}
 

--- a/corehq/apps/domain/templates/domain/admin/bootstrap5/sms_rates.html
+++ b/corehq/apps/domain/templates/domain/admin/bootstrap5/sms_rates.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'smsbillables/js/smsbillables.rate_calc' %}
+{% js_entry 'smsbillables/js/rate_calc' %}
 
 {% block page_content %}
   <div class="card">  {# todo B5: css-well #}

--- a/corehq/apps/domain/templates/domain/bootstrap3/confirm_subscription_renewal.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/confirm_subscription_renewal.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'accounting/js/widgets' %}
+{% js_entry_b3 'accounting/js/widgets' %}
 
 {% block plan_breadcrumbs %}{% endblock %}
 

--- a/corehq/apps/domain/templates/domain/bootstrap3/internal_settings.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/internal_settings.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main 'domain/js/internal_settings' %}
+{% js_entry_b3 'domain/js/internal_settings' %}
 
 {% block stylesheets %}
   {{ block.super }}

--- a/corehq/apps/domain/templates/domain/bootstrap3/renew_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/renew_plan.html
@@ -4,7 +4,7 @@
 {% load compress %}
 {% load menu_tags %}
 
-{% requirejs_main 'accounting/js/renew_plan_selection' %}
+{% js_entry_b3 'accounting/js/renew_plan_selection' %}
 
 {% block plan_breadcrumbs %}{% endblock %}
 

--- a/corehq/apps/domain/templates/domain/bootstrap5/confirm_subscription_renewal.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/confirm_subscription_renewal.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'accounting/js/widgets' %}
+{% js_entry 'accounting/js/widgets' %}
 
 {% block plan_breadcrumbs %}{% endblock %}
 

--- a/corehq/apps/domain/templates/domain/bootstrap5/internal_settings.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/internal_settings.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'domain/js/internal_settings' %}
+{% js_entry 'domain/js/internal_settings' %}
 
 {% block stylesheets %}
   {{ block.super }}

--- a/corehq/apps/domain/templates/domain/bootstrap5/internal_subscription_management.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/internal_subscription_management.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 
-{% requirejs_main_b5 'domain/js/bootstrap5/internal_subscription_management' %}
+{% js_entry 'domain/js/bootstrap5/internal_subscription_management' %}
 
 {% block page_content %}
   {% blocktrans %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/renew_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/renew_plan.html
@@ -4,7 +4,7 @@
 {% load compress %}
 {% load menu_tags %}
 
-{% requirejs_main_b5 'accounting/js/renew_plan_selection' %}
+{% js_entry 'accounting/js/renew_plan_selection' %}
 
 {% block plan_breadcrumbs %}{% endblock %}
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/soil.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/soil.js
@@ -2,6 +2,7 @@
 hqDefine("hqwebapp/js/soil", [
     "jquery",
     "hqwebapp/js/initial_page_data",
+    "commcarehq",
 ], function (
     $,
     initialPageData

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/sso_inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/sso_inactivity.js
@@ -3,7 +3,7 @@
  * Handles communication about the status of SSO login after the inactivity
  * timer has requested a re-login
  */
-hqDefine('hqwebapp/js/sso_inactivity', [], function () {
+hqDefine('hqwebapp/js/sso_inactivity', ['commcarehq'], function () {
     localStorage.setItem('ssoInactivityMessage', JSON.stringify({
         isLoggedIn: true,
     }));

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/iframe_sso_login_success.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/iframe_sso_login_success.html
@@ -5,7 +5,7 @@
 
 {% block title %}{% trans "Thank you for logging in with Single Sign-On!" %}{% endblock %}
 
-{% requirejs_main 'hqwebapp/js/sso_inactivity' %}
+{% js_entry_b3 'hqwebapp/js/sso_inactivity' %}
 
 {% block container_class %}container-fluid{% endblock %}
 

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/soil_status_full.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/soil_status_full.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "hqwebapp/js/soil" %}
+{% js_entry_b3 "hqwebapp/js/soil" %}
 
 {% block page_content %}
   {% initial_page_data 'download_id' download_id %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/iframe_sso_login_success.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/iframe_sso_login_success.html
@@ -5,7 +5,7 @@
 
 {% block title %}{% trans "Thank you for logging in with Single Sign-On!" %}{% endblock %}
 
-{% requirejs_main 'hqwebapp/js/sso_inactivity' %}
+{% js_entry 'hqwebapp/js/sso_inactivity' %}
 
 {% block container_class %}container-fluid{% endblock %}
 

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/soil_status_full.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/soil_status_full.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main_b5 "hqwebapp/js/soil" %}
+{% js_entry "hqwebapp/js/soil" %}
 
 {% block page_content %}
   {% initial_page_data 'download_id' download_id %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/admin/global_sms_rates.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/admin/global_sms_rates.html.diff.txt
@@ -8,7 +8,7 @@
  {% load i18n %}
  
 -{% js_entry_b3 'smsbillables/js/rate_calc' %}
-+{% requirejs_main_b5 'smsbillables/js/smsbillables.rate_calc' %}
++{% js_entry 'smsbillables/js/rate_calc' %}
  
  {% block title %}{% trans "SMS Pricing" %}{% endblock %}
  

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/admin/sms_rates.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/admin/sms_rates.html.diff.txt
@@ -8,7 +8,7 @@
  {% load i18n %}
  
 -{% js_entry_b3 'smsbillables/js/rate_calc' %}
-+{% requirejs_main_b5 'smsbillables/js/smsbillables.rate_calc' %}
++{% js_entry 'smsbillables/js/rate_calc' %}
  
  {% block page_content %}
 -  <div class="well">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_subscription_renewal.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_subscription_renewal.html.diff.txt
@@ -7,8 +7,8 @@
  {% load hq_shared_tags %}
  {% load i18n %}
  
--{% requirejs_main 'accounting/js/widgets' %}
-+{% requirejs_main_b5 'accounting/js/widgets' %}
+-{% js_entry_b3 'accounting/js/widgets' %}
++{% js_entry 'accounting/js/widgets' %}
  
  {% block plan_breadcrumbs %}{% endblock %}
  

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/internal_settings.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/internal_settings.html.diff.txt
@@ -7,8 +7,8 @@
  {% load crispy_forms_tags %}
  {% load i18n %}
  
--{% requirejs_main 'domain/js/internal_settings' %}
-+{% requirejs_main_b5 'domain/js/internal_settings' %}
+-{% js_entry_b3 'domain/js/internal_settings' %}
++{% js_entry 'domain/js/internal_settings' %}
  
  {% block stylesheets %}
    {{ block.super }}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/internal_subscription_management.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/internal_subscription_management.html.diff.txt
@@ -8,7 +8,7 @@
  {% load hq_shared_tags %}
  
 -{% js_entry_b3 'domain/js/bootstrap3/internal_subscription_management' %}
-+{% requirejs_main_b5 'domain/js/bootstrap5/internal_subscription_management' %}
++{% js_entry 'domain/js/bootstrap5/internal_subscription_management' %}
  
  {% block page_content %}
    {% blocktrans %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/renew_plan.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/renew_plan.html.diff.txt
@@ -8,8 +8,8 @@
  {% load compress %}
  {% load menu_tags %}
  
--{% requirejs_main 'accounting/js/renew_plan_selection' %}
-+{% requirejs_main_b5 'accounting/js/renew_plan_selection' %}
+-{% js_entry_b3 'accounting/js/renew_plan_selection' %}
++{% js_entry 'accounting/js/renew_plan_selection' %}
  
  {% block plan_breadcrumbs %}{% endblock %}
  

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/iframe_sso_login_success.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/iframe_sso_login_success.html.diff.txt
@@ -1,5 +1,14 @@
 --- 
 +++ 
+@@ -5,7 +5,7 @@
+ 
+ {% block title %}{% trans "Thank you for logging in with Single Sign-On!" %}{% endblock %}
+ 
+-{% js_entry_b3 'hqwebapp/js/sso_inactivity' %}
++{% js_entry 'hqwebapp/js/sso_inactivity' %}
+ 
+ {% block container_class %}container-fluid{% endblock %}
+ 
 @@ -15,7 +15,7 @@
      <h1>{% trans "Thank you for logging in with Single Sign-On!" %}</h1>
    </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/soil_status_full.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/soil_status_full.html.diff.txt
@@ -6,8 +6,8 @@
  {% load i18n %}
  {% load hq_shared_tags %}
  
--{% requirejs_main "hqwebapp/js/soil" %}
-+{% requirejs_main_b5 "hqwebapp/js/soil" %}
+-{% js_entry_b3 "hqwebapp/js/soil" %}
++{% js_entry "hqwebapp/js/soil" %}
  
  {% block page_content %}
    {% initial_page_data 'download_id' download_id %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/case_details.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/case_details.js.diff.txt
@@ -20,8 +20,8 @@
 +    'reports/js/bootstrap5/readable_form',
      'bootstrap',    // needed for $.tab
      'jquery-memoized-ajax/jquery.memoized.ajax.min',
- ], function (
-@@ -92,7 +92,7 @@
+     'commcarehq',
+@@ -93,7 +93,7 @@
                      // form data panel uses sticky tabs when it's its own page
                      // but that behavior would be disruptive here
                      $panel.find(".sticky-tabs").removeClass("sticky-tabs");
@@ -30,7 +30,7 @@
  
                      singleForm.initSingleForm({
                          instance_id: data.xform_id,
-@@ -275,7 +275,7 @@
+@@ -276,7 +276,7 @@
          $propertiesModal.koApplyBindings(modalData);
          $casePropertyNames.click(function () {
              modalData.init($(this).data('property-name'));

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/reportdata/case_data.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/reportdata/case_data.html.diff.txt
@@ -10,8 +10,8 @@
    <link rel="stylesheet" type="text/css" href="{% static "hqwebapp/css/proptable.css" %}">
  {% endblock %}
  
--{% requirejs_main 'reports/js/bootstrap3/case_details' %}
-+{% requirejs_main_b5 'reports/js/bootstrap5/case_details' %}
+-{% js_entry_b3 'reports/js/bootstrap3/case_details' %}
++{% js_entry 'reports/js/bootstrap5/case_details' %}
  
  {% block page_content %}
  

--- a/corehq/apps/registration/static/registration/js/register_new_user.js
+++ b/corehq/apps/registration/static/registration/js/register_new_user.js
@@ -6,6 +6,7 @@ hqDefine('registration/js/register_new_user', [
     'hqwebapp/js/initial_page_data',
     'analytix/js/kissmetrix',
     'registration/js/login',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -4,7 +4,7 @@
 {% load compress %}
 {% load crispy_forms_tags %}
 
-{% requirejs_main 'registration/js/register_new_user' %}
+{% js_entry_b3 'registration/js/register_new_user' %}
 
 {% block title %}{% trans "Create an Account" %}{% endblock title %}
 

--- a/corehq/apps/reports/static/reports/js/bootstrap3/case_details.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/case_details.js
@@ -14,6 +14,7 @@ hqDefine("reports/js/bootstrap3/case_details", [
     'reports/js/bootstrap3/readable_form',
     'bootstrap',    // needed for $.tab
     'jquery-memoized-ajax/jquery.memoized.ajax.min',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/reports/static/reports/js/bootstrap5/case_details.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/case_details.js
@@ -14,6 +14,7 @@ hqDefine("reports/js/bootstrap5/case_details", [
     'reports/js/bootstrap5/readable_form',
     'bootstrap',    // needed for $.tab
     'jquery-memoized-ajax/jquery.memoized.ajax.min',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/reports/templates/reports/reportdata/bootstrap3/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/bootstrap3/case_data.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" type="text/css" href="{% static "hqwebapp/css/proptable.css" %}">
 {% endblock %}
 
-{% requirejs_main 'reports/js/bootstrap3/case_details' %}
+{% js_entry_b3 'reports/js/bootstrap3/case_details' %}
 
 {% block page_content %}
 

--- a/corehq/apps/reports/templates/reports/reportdata/bootstrap5/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/bootstrap5/case_data.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" type="text/css" href="{% static "hqwebapp/css/proptable.css" %}">
 {% endblock %}
 
-{% requirejs_main_b5 'reports/js/bootstrap5/case_details' %}
+{% js_entry 'reports/js/bootstrap5/case_details' %}
 
 {% block page_content %}
 

--- a/corehq/apps/sms/static/sms/js/sms_language_main.js
+++ b/corehq/apps/sms/static/sms/js/sms_language_main.js
@@ -2,6 +2,7 @@ hqDefine("sms/js/sms_language_main",[
     "langcodes/js/langcodes",
     "hqwebapp/js/bulk_upload_file",
     "sms/js/languages",
+    "commcarehq",
 ],function () {
 
 });

--- a/corehq/apps/sms/templates/sms/languages.html
+++ b/corehq/apps/sms/templates/sms/languages.html
@@ -6,7 +6,7 @@
   {% trans "SMS Languages" %}
 {% endblock %}
 
-{% requirejs_main 'sms/js/sms_language_main' %}
+{% js_entry_b3 'sms/js/sms_language_main' %}
 
 {% block stylesheets %}{{ block.super }}
   <link rel="stylesheet" href="{% static 'jquery-ui-built-themes/redmond/jquery-ui.min.css' %}"/>

--- a/corehq/apps/userreports/static/userreports/js/ucr_expression.js
+++ b/corehq/apps/userreports/static/userreports/js/ucr_expression.js
@@ -5,6 +5,7 @@ hqDefine("userreports/js/ucr_expression", [
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/base_ace',
     'hqwebapp/js/bootstrap3/alert_user',
+    'commcarehq',
 ], function (
     moment,
     ko,

--- a/corehq/apps/userreports/static/userreports/js/ucr_expressions.js
+++ b/corehq/apps/userreports/static/userreports/js/ucr_expressions.js
@@ -3,6 +3,7 @@ hqDefine('userreports/js/ucr_expressions', [
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap3/crud_paginated_list_init",
     'hqwebapp/js/base_ace',
+    'commcarehq',
 ], function () {
     // used to include base_ace on the ucr_statements page
 

--- a/corehq/apps/userreports/templates/userreports/ucr_expression.html
+++ b/corehq/apps/userreports/templates/userreports/ucr_expression.html
@@ -13,7 +13,7 @@
   {% endcompress %}
 {% endblock %}
 
-{% requirejs_main "userreports/js/ucr_expression" %}
+{% js_entry_b3 "userreports/js/ucr_expression" %}
 
 {% block page_content %}
 {% initial_page_data "expression" expression %}

--- a/corehq/apps/userreports/templates/userreports/ucr_expressions.html
+++ b/corehq/apps/userreports/templates/userreports/ucr_expressions.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "userreports/js/ucr_expressions" %}
+{% js_entry_b3 "userreports/js/ucr_expressions" %}
 
 {% block pagination_templates %}
 <script type="text/html" id="base-ucr-statement-template">

--- a/corehq/apps/users/static/users/js/accept_invite.js
+++ b/corehq/apps/users/static/users/js/accept_invite.js
@@ -2,4 +2,5 @@ hqDefine('users/js/accept_invite', [
     'registration/js/login', // contains password obfuscation & login requirements
     'registration/js/bootstrap3/password',
     'hqwebapp/js/captcha',
+    'commcarehq',
 ], function () {});

--- a/corehq/apps/users/templates/users/accept_invite.html
+++ b/corehq/apps/users/templates/users/accept_invite.html
@@ -3,7 +3,7 @@
 {% load field_tags %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'users/js/accept_invite' %}
+{% js_entry_b3 'users/js/accept_invite' %}
 
 {% block title %}{% trans "Invitation to join the " %}{{ invite_to }} {{ invite_type }}{% endblock title %}
 

--- a/corehq/apps/users/templates/users/commcare_user_confirm_account.html
+++ b/corehq/apps/users/templates/users/commcare_user_confirm_account.html
@@ -3,7 +3,7 @@
 {% load field_tags %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'users/js/accept_invite' %}
+{% js_entry_b3 'users/js/accept_invite' %}
 
 {% block title %}{% blocktrans %}Confirm your account to join the {{ domain_name }} project{% endblocktrans %}{% endblock title %}
 {% block tabs %}{% endblock %}

--- a/webpack/appPaths.js
+++ b/webpack/appPaths.js
@@ -8,6 +8,7 @@ const BUILD_ARTIFACTS_DIR = path.resolve(__dirname, '_build');
 const TEMPLATES_DIR = 'templates';
 const APPS_PATH = path.resolve(__BASE, 'corehq', 'apps');
 const EX_SUBMODULES_PATH = path.resolve(__BASE, 'corehq', 'ex-submodules');
+const SUBMODULES_PATH = path.resolve(__BASE, 'submodules');
 const MESSAGING_PATH = path.resolve(__BASE, 'corehq', 'messaging');
 const MOTECH_PATH = path.resolve(__BASE, 'corehq', 'motech');
 const CUSTOM_PATH = path.resolve(__BASE, 'custom');
@@ -15,6 +16,7 @@ const CUSTOM_PATH = path.resolve(__BASE, 'custom');
 const nonStandardAppPaths = {
     "case": path.resolve(EX_SUBMODULES_PATH, 'casexml', 'apps', 'case'),
     "soil": path.resolve(EX_SUBMODULES_PATH, 'soil'),
+    "langcodes": path.resolve(SUBMODULES_PATH, 'langcodes'),
     "motech": MOTECH_PATH,
     "telerivet": path.resolve(MESSAGING_PATH, 'smsbackends', 'telerivet'),
     // the path itself is standard, but the app has no templates so getStandardAppPaths filters it out

--- a/webpack/generateDetails.js
+++ b/webpack/generateDetails.js
@@ -124,6 +124,7 @@ if (require.main === module) {
     // these apps, but there are no existing webpack entries from these apps (yet).
     const alwaysIncludeApps = [
         "analytix",
+        "case",
         "hqwebapp",
         "notifications",
         "registration",

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -8,6 +8,7 @@ const aliases = {
     "commcarehq": path.resolve(utils.getStaticPathForApp('hqwebapp', 'js/bootstrap5/'),
         'commcarehq'),
     "jquery": require.resolve('jquery'),
+    "langcodes/js/langcodes": path.resolve("submodules/langcodes/static/langcodes/js/langcodes"),
 
     // todo after completing requirejs migration,
     //  remove this file and the yarn modernizr post-install step


### PR DESCRIPTION
## Technical Summary
These are all pretty trivial migrations, in pages that are either a bit of a headache to test or are in particularly risky areas (registration/login).

## Safety Assurance

### Safety story
I'm pretty confident in this migration at this point, this PR shouldn't be adding any dependencies that haven't already been tested on webpack. I'll do some testing on staging. Marking "don't merge" until that's done.

### Automated test coverage

little if any

### QA Plan

Not requesting QA

### Rollback instructions

Since this is a large PR that touches a lot of disparate areas, if there are problems with any particular pages it'd be less disruptive to just turn off webpack for those pages. To do this, replace `js_entry` with `requirejs_main_b5`, or `js_entry_b3` with `requirejs_main` in the HTML file. The JS file doesn't need to be updated, it's fine for the `commcarehq` dependency to stay.

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
