### PR TITLE
[SC-4053] DataDog metric for historic app dependency feature usage

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -329,20 +329,29 @@ def get_build_ids_after_version(domain, app_id, version):
     return [result['id'] for result in results]
 
 
-def get_build_ids(domain, app_id):
-    """
-    Returns all the built apps for an application id, in descending order of time built.
-    """
+def _get_builds_by_app_id(domain, app_id):
     from .models import Application
-    results = Application.get_db().view(
+    return Application.get_db().view(
         'app_manager/saved_app',
         startkey=[domain, app_id, {}],
         endkey=[domain, app_id],
         descending=True,
         reduce=False,
-        include_docs=False,
+        include_docs=True,
     ).all()
-    return [result['id'] for result in results]
+
+def get_build_docs(domain, app_id):
+    """
+    Returns all the built app documents for an application id, in descending order of time built.
+    """
+    return [result['doc'] for result in _get_builds_by_app_id(domain, app_id)]
+
+
+def get_build_ids(domain, app_id):
+    """
+    Returns all the built app ids for an application id, in descending order of time built.
+    """
+    return [result['id'] for result in _get_builds_by_app_id(domain, app_id)]
 
 
 def get_built_app_ids_with_submissions_for_app_id(domain, app_id, version=None):

--- a/corehq/apps/domain/dbaccessors.py
+++ b/corehq/apps/domain/dbaccessors.py
@@ -110,13 +110,15 @@ def get_domain_ids_by_names(names):
     )}
 
 
-def iter_domains():
+def iter_domains(exclude_test_domains=False):
     for row in paginate_view(
             Domain.get_db(),
             'domain/domains',
             100,
             reduce=False,
-            include_docs=False):
+            include_docs=exclude_test_domains):
+        if exclude_test_domains and row['doc']['is_test'] == 'true':
+            continue
         yield row['key']
 
 


### PR DESCRIPTION
## Product Description
No visible change on HQ, simply sending a metric through to data dog.

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-4053)

Note: This PR is one of two, since there's 2 different metrics that we need to track on DataDog. I decided to spilt the implementation into two separate PRs to keep each PR short. Also, they're not dependant on one another.  

This PR collects and reports a new metric to DataDog. This metric is aimed to give more insight into the app dependency feature usage and tracks specifically the following:
Check for application which had the app dependency feature enabled for any build in the past, but does not have it enabled anymore.

I'm not 100% sure how the current solution will perform at scale, so planning to check out what happens on staging.

## Safety Assurance

### Safety story
Local testing was done. Planning to test on staging as well to see what the implementation does, since we're iterating over all domains's applications, and for each application iterating over a bunch, mostly all, of the app builds. This happens every hour.

### Automated test coverage
Added some unit tests

### QA Plan
No formal QA planned.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
