### PR TITLE
Skip migrations when running pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
       run: >-
         scripts/docker test
         --exitfirst
-        -vv
+        --verbosity=2
         --reusedb=1
         --divided-we-run=${{ matrix.DIVIDED_WE_RUN }}
         --showlocals

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,15 @@ jobs:
         JS_SETUP: yes
         KAFKA_HOSTNAME: kafka
         STRIPE_PRIVATE_KEY: ${{ secrets.STRIPE_PRIVATE_KEY }}
-      run: scripts/docker test --exitfirst -vv --reusedb=1 --divided-we-run=${{ matrix.DIVIDED_WE_RUN }} --showlocals --max-test-time=29 -p no:cacheprovider
+      run: >-
+        scripts/docker test
+        --exitfirst
+        -vv
+        --reusedb=1
+        --divided-we-run=${{ matrix.DIVIDED_WE_RUN }}
+        --showlocals
+        --max-test-time=29
+        -p no:cacheprovider
     - name: "Codecov upload"
       env:
         TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,7 @@ jobs:
         --exitfirst
         --verbosity=2
         --reusedb=1
+        --no-migrations
         --divided-we-run=${{ matrix.DIVIDED_WE_RUN }}
         --showlocals
         --max-test-time=29


### PR DESCRIPTION
Decrease test run time by skipping redundant database migrations. We had done [something like this with nose](https://github.com/dimagi/commcare-hq/blob/a513405e94f5a99f1c7bd9e67c877190be8371d5/corehq/tests/noseplugins/djangomigrations.py).


Context: https://github.com/dimagi/commcare-hq/pull/34778#discussion_r1829847980

https://dimagi.atlassian.net/browse/SAAS-16291

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Github Actions test options changed, nothing else.

### Automated test coverage

Indirect.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
