### PR TITLE
Create Invitation API [Validation]

### DIFF
--- a/corehq/apps/api/tests/test_validation.py
+++ b/corehq/apps/api/tests/test_validation.py
@@ -1,0 +1,107 @@
+from django.test import TestCase
+from unittest.mock import patch
+
+from corehq.apps.api.validation import WebUserResourceValidator
+from corehq.apps.domain.models import Domain
+from corehq.apps.users.models import WebUser
+from corehq.util.test_utils import flag_enabled, flag_disabled
+
+
+class TestWebUserResourceValidator(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = Domain(name="test-domain", is_active=True)
+        cls.domain.save()
+        cls.addClassCleanup(cls.domain.delete)
+        cls.requesting_user = WebUser.create(cls.domain.name, "test@example.com", "123", None, None)
+        cls.validator = WebUserResourceValidator(cls.domain.name, cls.requesting_user)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.requesting_user.delete(None, None)
+        super().tearDownClass()
+
+    def test_validate_parameters(self):
+        params = {"email": "test@example.com", "role": "Admin"}
+        self.assertIsNone(self.validator.validate_parameters(params))
+
+        invalid_params = {"invalid_param": "value"}
+        self.assertEqual(self.validator.validate_parameters(invalid_params), "Invalid parameter(s): invalid_param")
+
+    @flag_enabled('TABLEAU_USER_SYNCING')
+    @patch('corehq.apps.users.models.WebUser.has_permission', return_value=True)
+    def test_validate_parameters_with_tableau_edit_permission(self, mock_has_permission):
+        params = {"email": "test@example.com", "role": "Admin", "tableau_role": "Viewer"}
+        self.assertIsNone(self.validator.validate_parameters(params))
+
+    @flag_disabled('TABLEAU_USER_SYNCING')
+    @patch('corehq.apps.users.models.WebUser.has_permission', return_value=False)
+    def test_validate_parameters_without_tableau_edit_permission(self, mock_has_permission):
+        params = {"email": "test@example.com", "role": "Admin", "tableau_role": "Viewer"}
+        self.assertEqual(self.validator.validate_parameters(params),
+                         "You do not have permission to edit Tableau Configuration.")
+
+    @patch('corehq.apps.registration.validation.domain_has_privilege', return_value=True)
+    def test_validate_parameters_with_profile_permission(self, mock_domain_has_privilege):
+        params = {"email": "test@example.com", "role": "Admin", "profile": "some_profile"}
+        self.assertIsNone(self.validator.validate_parameters(params))
+
+    @patch('corehq.apps.accounting.utils.domain_has_privilege', return_value=False)
+    def test_validate_parameters_without_profile_permission(self, mock_domain_has_privilege):
+        params = {"email": "test@example.com", "role": "Admin", "profile": "some_profile"}
+        self.assertEqual(self.validator.validate_parameters(params),
+                         "This domain does not have user profile privileges.")
+
+    @patch('corehq.apps.registration.validation.domain_has_privilege', return_value=True)
+    def test_validate_parameters_with_location_privilege(self, mock_domain_has_privilege):
+        params = {"email": "test@example.com", "role": "Admin", "primary_location": "some_location"}
+        self.assertIsNone(self.validator.validate_parameters(params))
+        params = {"email": "test@example.com", "role": "Admin", "assigned_locations": "some_location"}
+        self.assertIsNone(self.validator.validate_parameters(params))
+
+    @patch('corehq.apps.registration.validation.domain_has_privilege', return_value=False)
+    def test_validate_parameters_without_location_privilege(self, mock_domain_has_privilege):
+        params = {"email": "test@example.com", "role": "Admin", "primary_location": "some_location"}
+        self.assertEqual(self.validator.validate_parameters(params),
+                         "This domain does not have locations privileges.")
+
+        params = {"email": "test@example.com", "role": "Admin", "assigned_locations": "some_location"}
+        self.assertEqual(self.validator.validate_parameters(params),
+                         "This domain does not have locations privileges.")
+
+    def test_validate_email(self):
+        self.assertIsNone(self.validator.validate_email("newtest@example.com", True))
+
+        self.assertEqual(self.validator.validate_email("test@example.com", True),
+                        "A user with this email address is already in "
+                        "this project or has a pending invitation.")
+
+        deactivated_user = WebUser.create(self.domain.name, "deactivated@example.com", "123", None, None)
+        deactivated_user.is_active = False
+        deactivated_user.save()
+        self.assertEqual(self.validator.validate_email("deactivated@example.com", True),
+                         "A user with this email address is deactivated. ")
+
+    def test_validate_locations(self):
+        with patch('corehq.apps.user_importer.validation.LocationValidator.validate_spec') as mock_validate_spec:
+            mock_validate_spec.return_value = None
+            self.assertIsNone(self.validator.validate_locations(self.requesting_user.username,
+                                                                ["loc1", "loc2"], "loc1"))
+
+            expected_spec = {
+                'location_code': ["loc1", "loc2"],
+                'username': self.requesting_user.username
+            }
+            mock_validate_spec.assert_called_once_with(expected_spec)
+
+        self.assertEqual(
+            self.validator.validate_locations(self.requesting_user.username, ["loc1", "loc2"], "loc3"),
+            "Primary location must be one of the user's locations"
+        )
+
+        self.assertEqual(
+            self.validator.validate_locations(self.requesting_user.username, ["loc1", "loc2"], ""),
+            "Primary location can't be empty if the user has any locations set"
+        )

--- a/corehq/apps/api/tests/test_validation.py
+++ b/corehq/apps/api/tests/test_validation.py
@@ -90,11 +90,9 @@ class TestWebUserResourceValidator(TestCase):
             self.assertIsNone(self.validator.validate_locations(self.requesting_user.username,
                                                                 ["loc1", "loc2"], "loc1"))
 
-            expected_spec = {
-                'location_code': ["loc1", "loc2"],
-                'username': self.requesting_user.username
-            }
-            mock_validate_spec.assert_called_once_with(expected_spec)
+            actual_spec = mock_validate_spec.call_args[0][0]
+            self.assertEqual(actual_spec['username'], self.requesting_user.username)
+            self.assertCountEqual(actual_spec['location_code'], ["loc1", "loc2"])
 
         self.assertEqual(
             self.validator.validate_locations(self.requesting_user.username, ["loc1", "loc2"], "loc3"),

--- a/corehq/apps/api/tests/test_validation.py
+++ b/corehq/apps/api/tests/test_validation.py
@@ -48,7 +48,7 @@ class TestWebUserResourceValidator(TestCase):
         params = {"email": "test@example.com", "role": "Admin", "profile": "some_profile"}
         self.assertIsNone(self.validator.validate_parameters(params))
 
-    @patch('corehq.apps.accounting.utils.domain_has_privilege', return_value=False)
+    @patch('corehq.apps.registration.validation.domain_has_privilege', return_value=False)
     def test_validate_parameters_without_profile_permission(self, mock_domain_has_privilege):
         params = {"email": "test@example.com", "role": "Admin", "profile": "some_profile"}
         self.assertEqual(self.validator.validate_parameters(params),

--- a/corehq/apps/api/validation.py
+++ b/corehq/apps/api/validation.py
@@ -2,11 +2,11 @@ from memoized import memoized
 
 from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
 from corehq.apps.reports.util import get_allowed_tableau_groups_for_domain
+from corehq.apps.user_importer.importer import SiteCodeToLocationCache
 from corehq.apps.user_importer.validation import (
     RoleValidator,
     ProfileValidator,
     LocationValidator,
-    SiteCodeToLocationCache,
     TableauGroupsValidator,
     TableauRoleValidator,
     CustomDataValidator,

--- a/corehq/apps/api/validation.py
+++ b/corehq/apps/api/validation.py
@@ -61,7 +61,7 @@ class WebUserResourceValidator():
 
     def validate_email(self, email, is_post):
         if is_post:
-            error = AdminInvitesUserFormValidator.validate_email(self.domain, email, is_post)
+            error = AdminInvitesUserFormValidator.validate_email(self.domain, email)
             if error:
                 return error
         email_validator = EmailValidator(self.domain, 'email')

--- a/corehq/apps/api/validation.py
+++ b/corehq/apps/api/validation.py
@@ -10,6 +10,7 @@ from corehq.apps.user_importer.validation import (
     TableauGroupsValidator,
     TableauRoleValidator,
     CustomDataValidator,
+    EmailValidator,
 )
 from corehq.apps.users.validation import validate_primary_location_assignment
 from corehq.apps.registration.validation import AdminInvitesUserFormValidator
@@ -59,7 +60,13 @@ class WebUserResourceValidator():
         return custom_data_validator.validate_spec(spec)
 
     def validate_email(self, email, is_post):
-        return AdminInvitesUserFormValidator.validate_email(self.domain, email, is_post)
+        if is_post:
+            error = AdminInvitesUserFormValidator.validate_email(self.domain, email, is_post)
+            if error:
+                return error
+        email_validator = EmailValidator(self.domain, 'email')
+        spec = {'email': email}
+        return email_validator.validate_spec(spec)
 
     def validate_locations(self, editable_user, assigned_location_codes, primary_location_code):
         error = validate_primary_location_assignment(primary_location_code, assigned_location_codes)

--- a/corehq/apps/api/validation.py
+++ b/corehq/apps/api/validation.py
@@ -1,0 +1,75 @@
+from memoized import memoized
+
+from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
+from corehq.apps.reports.util import get_allowed_tableau_groups_for_domain
+from corehq.apps.user_importer.validation import (
+    RoleValidator,
+    ProfileValidator,
+    LocationValidator,
+    SiteCodeToLocationCache,
+    TableauGroupsValidator,
+    TableauRoleValidator,
+    CustomDataValidator,
+)
+from corehq.apps.users.validation import validate_primary_location_assignment
+from corehq.apps.registration.validation import AdminInvitesUserFormValidator
+
+
+class WebUserResourceValidator():
+    def __init__(self, domain, requesting_user):
+        self.domain = domain
+        self.requesting_user = requesting_user
+
+    @property
+    def roles_by_name(self):
+        from corehq.apps.users.views.utils import get_editable_role_choices
+        return {role[1]: role[0] for role in get_editable_role_choices(self.domain, self.requesting_user,
+                                                  allow_admin_role=True)}
+
+    @property
+    @memoized
+    def profiles_by_name(self):
+        from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
+        return CustomDataFieldsDefinition.get_profiles_by_name(self.domain, UserFieldsView.field_type)
+
+    @property
+    def location_cache(self):
+        return SiteCodeToLocationCache(self.domain)
+
+    def validate_parameters(self, parameters):
+        AdminInvitesUserFormValidator.validate_parameters(self.domain, self.requesting_user, parameters)
+
+    def validate_role(self, role):
+        spec = {'role': role}
+        return RoleValidator(self.domain, self.roles_by_name()).validate_spec(spec)
+
+    def validate_profile(self, new_profile_name):
+        profile_validator = ProfileValidator(self.domain, self.requesting_user, True, self.profiles_by_name())
+        spec = {'user_profile': new_profile_name}
+        return profile_validator.validate_spec(spec)
+
+    def validate_custom_data(self, custom_data, profile_name):
+        custom_data_validator = CustomDataValidator(self.domain, self.profiles_by_name())
+        spec = {'data': custom_data, 'user_profile': profile_name}
+        return custom_data_validator.validate_spec(spec)
+
+    def validate_email(self, email, is_post):
+        return AdminInvitesUserFormValidator.validate_email(self.domain, email, is_post)
+
+    def validate_locations(self, editable_user, assigned_location_codes, primary_location_code):
+        error = validate_primary_location_assignment(primary_location_code, assigned_location_codes)
+        if error:
+            return error
+
+        location_validator = LocationValidator(self.domain, self.requesting_user, self.location_cache, True)
+        location_codes = assigned_location_codes + [primary_location_code]
+        spec = {'location_code': location_codes,
+                'username': editable_user}
+        return location_validator.validate_spec(spec)
+
+    def validate_tableau_group(self, tableau_groups):
+        allowed_groups_for_domain = get_allowed_tableau_groups_for_domain(self.domain) or []
+        return TableauGroupsValidator.validate_tableau_groups(allowed_groups_for_domain, tableau_groups)
+
+    def validate_tableau_role(self, tableau_role):
+        return TableauRoleValidator.validate_tableau_role(tableau_role)

--- a/corehq/apps/api/validation.py
+++ b/corehq/apps/api/validation.py
@@ -37,7 +37,12 @@ class WebUserResourceValidator():
         return SiteCodeToLocationCache(self.domain)
 
     def validate_parameters(self, parameters):
-        AdminInvitesUserFormValidator.validate_parameters(self.domain, self.requesting_user, parameters)
+        allowed_params = ['email', 'role', 'primary_location', 'assigned_locations',
+                          'profile', 'custom_user_data', 'tableau_role', 'tableau_groups']
+        invalid_params = [param for param in parameters if param not in allowed_params]
+        if invalid_params:
+            return f"Invalid parameter(s): {', '.join(invalid_params)}"
+        return AdminInvitesUserFormValidator.validate_parameters(self.domain, self.requesting_user, parameters)
 
     def validate_role(self, role):
         spec = {'role': role}
@@ -62,7 +67,7 @@ class WebUserResourceValidator():
             return error
 
         location_validator = LocationValidator(self.domain, self.requesting_user, self.location_cache, True)
-        location_codes = assigned_location_codes + [primary_location_code]
+        location_codes = list(set(assigned_location_codes + [primary_location_code]))
         spec = {'location_code': location_codes,
                 'username': editable_user}
         return location_validator.validate_spec(spec)

--- a/corehq/apps/custom_data_fields/models.py
+++ b/corehq/apps/custom_data_fields/models.py
@@ -120,6 +120,18 @@ class CustomDataFieldsDefinition(models.Model):
             return profile_required_for_user_type_list
         return None
 
+    @classmethod
+    def get_profiles_by_name(cls, domain, field_type):
+        definition = cls.get(domain, field_type)
+        if definition:
+            profiles = definition.get_profiles()
+            return {
+                profile.name: profile
+                for profile in profiles
+            }
+        else:
+            return {}
+
     class FieldFilterConfig:
         def __init__(self, required_only=False, is_required_check_func=None):
             self.required_only = required_only

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -433,7 +433,7 @@ class BaseUserInvitationForm(NoAutocompleteMixin, forms.Form):
         return data
 
 
-class WebUserInvitationForm(BaseUserInvitationForm):
+class AcceptedWebUserInvitationForm(BaseUserInvitationForm):
     """
     Form for a brand new user, before they've created a domain or done anything on CommCare HQ.
     """

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -594,9 +594,9 @@ class AdminInvitesUserForm(SelectUserLocationForm):
         email = self.cleaned_data['email'].strip()
 
         from corehq.apps.registration.validation import AdminInvitesUserFormValidator
-        errors = AdminInvitesUserFormValidator.validate_email(self.domain, email, self.request.method == 'POST')
-        if errors:
-            raise forms.ValidationError(errors)
+        error = AdminInvitesUserFormValidator.validate_email(self.domain, email, self.request.method == 'POST')
+        if error:
+            raise forms.ValidationError(error)
         return email
 
     def clean(self):
@@ -623,13 +623,13 @@ class AdminInvitesUserForm(SelectUserLocationForm):
             cleaned_data['custom_user_data'] = get_prefixed(custom_user_data, self.custom_data.prefix)
 
         from corehq.apps.registration.validation import AdminInvitesUserFormValidator
-        errors = AdminInvitesUserFormValidator.validate_parameters(
+        error = AdminInvitesUserFormValidator.validate_parameters(
             self.domain,
             self.request.couch_user,
             cleaned_data.keys()
         )
-        if errors:
-            raise forms.ValidationError(errors)
+        if error:
+            raise forms.ValidationError(error)
         return cleaned_data
 
     def _initialize_tableau_fields(self, data, domain):

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -594,7 +594,7 @@ class AdminInvitesUserForm(SelectUserLocationForm):
         email = self.cleaned_data['email'].strip()
 
         from corehq.apps.registration.validation import AdminInvitesUserFormValidator
-        error = AdminInvitesUserFormValidator.validate_email(self.domain, email, self.request.method == 'POST')
+        error = AdminInvitesUserFormValidator.validate_email(self.domain, email)
         if error:
             raise forms.ValidationError(error)
         return email

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -589,13 +589,6 @@ class AdminInvitesUserForm(SelectUserLocationForm):
             ),
         )
 
-    def _validate_profile(self, profile_id):
-        valid_profile_ids = {choice[0] for choice in self.custom_data.form.fields[PROFILE_SLUG].widget.choices}
-        if profile_id and profile_id not in valid_profile_ids:
-            raise forms.ValidationError(
-                _('Invalid profile selected. Please select a valid profile.'),
-            )
-
     def clean_email(self):
         email = self.cleaned_data['email'].strip()
         if email.lower() in self.excluded_emails:
@@ -631,7 +624,6 @@ class AdminInvitesUserForm(SelectUserLocationForm):
 
             if prefixed_profile_key in custom_user_data:
                 profile_id = custom_user_data.pop(prefixed_profile_key)
-                self._validate_profile(profile_id)
                 cleaned_data['profile'] = profile_id
             cleaned_data['custom_user_data'] = get_prefixed(custom_user_data, self.custom_data.prefix)
 

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -598,11 +598,6 @@ class AdminInvitesUserForm(SelectUserLocationForm):
 
     def clean(self):
         cleaned_data = super(AdminInvitesUserForm, self).clean()
-
-        if (('tableau_role' in cleaned_data or 'tableau_group_indices' in cleaned_data)
-        and not self.can_edit_tableau_config):
-            raise forms.ValidationError(_("You do not have permission to edit Tableau Configuraion."))
-
         if 'tableau_group_indices' in cleaned_data:
             cleaned_data['tableau_group_ids'] = [
                 self.tableau_form.allowed_tableau_groups[int(i)].id
@@ -624,6 +619,9 @@ class AdminInvitesUserForm(SelectUserLocationForm):
                 cleaned_data['profile'] = profile_id
             cleaned_data['custom_user_data'] = get_prefixed(custom_user_data, self.custom_data.prefix)
 
+        errors = self._validator.validate_parameters(cleaned_data.keys())
+        if errors:
+            raise forms.ValidationError(errors)
         return cleaned_data
 
     def _initialize_tableau_fields(self, data, domain):

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -552,6 +552,9 @@ class AdminInvitesUserForm(SelectUserLocationForm):
                     'primary_location',
                 )
             )
+        else:
+            self.fields.pop('assigned_locations', None)
+            self.fields.pop('primary_location', None)
         if self.can_edit_tableau_config:
             fields.append(
                 crispy.Fieldset(

--- a/corehq/apps/registration/tests/test_forms.py
+++ b/corehq/apps/registration/tests/test_forms.py
@@ -60,7 +60,6 @@ def create_form(data=None, **kw):
     defaults = {
         "domain": "test",
         "request": request,
-        "excluded_emails": [],
         "role_choices": [("admin", "admin")],
     }
     return AdminInvitesUserForm(request.POST, **(defaults | kw))

--- a/corehq/apps/registration/tests/test_forms.py
+++ b/corehq/apps/registration/tests/test_forms.py
@@ -4,7 +4,7 @@ from django.test import RequestFactory
 from testil import Regex
 
 from ..forms import AdminInvitesUserForm
-from corehq.apps.users.models import WebUser
+from corehq.apps.users.models import WebUser, Invitation
 
 
 patch_query = patch.object(
@@ -19,21 +19,50 @@ mock_couch_user = WebUser(
     domain="test-domain",
 )
 
+mock_existing_user = WebUser(
+    username="existinguser@test.com",
+    _id="existinguser123",
+    domain="test-domain",
+)
+
+mock_existing_pending_invitation = Invitation(
+    email="existinguser@test.com",
+    domain="test-domain",
+)
+
 
 @patch_query
 @patch("corehq.apps.users.models.WebUser.get_by_username", return_value=None)
-def test_minimal_valid_form(mock_web_user):
+@patch("corehq.apps.users.models.WebUser.by_domain")
+@patch("corehq.apps.users.models.Invitation.by_domain")
+def test_minimal_valid_form(mock_web_user, mock_by_domain, mock_invitation):
     form = create_form()
-
     assert form.is_valid(), form.errors
 
 
 @patch_query
 @patch("corehq.apps.users.models.WebUser.get_by_username", return_value=None)
-def test_form_is_invalid_when_invite_existing_email_with_case_mismatch(mock_web_user):
+@patch("corehq.apps.users.models.WebUser.by_domain")
+@patch("corehq.apps.users.models.Invitation.by_domain", return_value=[mock_existing_pending_invitation])
+def test_form_is_invalid_when_invite_existing_email_with_case_mismatch(
+    mock_web_user, mock_by_domain, mock_invitation
+):
     form = create_form(
-        {"email": "test@TEST.com"},
-        excluded_emails=["TEST@test.com"],
+        {"email": "existinguser@TEST.com"},
+    )
+
+    msg = "this email address is already in this project"
+    assert not form.is_valid()
+    assert form.errors["email"] == [Regex(msg)], form.errors
+
+
+@patch_query
+@patch("corehq.apps.users.models.WebUser.get_by_username", return_value=None)
+@patch("corehq.apps.users.models.WebUser.by_domain", return_value=[mock_existing_user])
+@patch("corehq.apps.users.models.Invitation.by_domain")
+def test_form_is_invalid_when_existing_user_with_case_mismatch(mock_web_user, mock_by_domain, mock_invitation):
+    form = create_form(
+        {"email": "existinguser@TEST.com"},
     )
 
     msg = "this email address is already in this project"
@@ -43,7 +72,9 @@ def test_form_is_invalid_when_invite_existing_email_with_case_mismatch(mock_web_
 
 @patch_query
 @patch("corehq.apps.users.models.WebUser.get_by_username", return_value=mock_couch_user)
-def test_form_is_invalid_when_invite_deactivated_user(mock_web_user):
+@patch("corehq.apps.users.models.WebUser.by_domain")
+@patch("corehq.apps.users.models.Invitation.by_domain")
+def test_form_is_invalid_when_invite_deactivated_user(mock_web_user, mock_by_domain, mock_invitation):
     mock_web_user.is_active = False
     form = create_form(
         {"email": "test@TEST.com"},
@@ -57,6 +88,7 @@ def test_form_is_invalid_when_invite_deactivated_user(mock_web_user):
 def create_form(data=None, **kw):
     form_defaults = {"email": "test@test.com", "role": "admin"}
     request = RequestFactory().post("/", form_defaults | (data or {}))
+    request.couch_user = mock_couch_user
     defaults = {
         "domain": "test",
         "request": request,

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -13,7 +13,8 @@ from corehq.apps.user_importer.validation import (
     LocationValidator,
     SiteCodeToLocationCache,
     TableauGroupsValidator,
-    TableauRoleValidator
+    TableauRoleValidator,
+    CustomDataValidator,
 )
 from corehq.apps.users.models import Invitation, WebUser
 from corehq.apps.users.validation import validate_primary_location_assignment
@@ -82,6 +83,11 @@ class AdminInvitesUserValidator():
         profile_validator = ProfileValidator(self.domain, self.upload_user, True, self.profiles_by_name())
         spec = {'user_profile': new_profile_name}
         return profile_validator.validate_spec(spec)
+
+    def validate_custom_data(self, custom_data, profile_name):
+        custom_data_validator = CustomDataValidator(self.domain, self.profiles_by_name())
+        spec = {'data': custom_data, 'user_profile': profile_name}
+        return custom_data_validator.validate_spec(spec)
 
     def validate_email(self, email, is_post):
         if is_post:

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -2,6 +2,8 @@ from memoized import memoized
 
 from django.utils.translation import gettext_lazy as _
 
+from corehq import privileges
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
 from corehq.apps.user_importer.validation import (
     RoleValidator,
@@ -9,6 +11,7 @@ from corehq.apps.user_importer.validation import (
     EmailValidator
 )
 from corehq.apps.users.models import Invitation, WebUser
+from corehq.toggles import TABLEAU_USER_SYNCING
 
 
 class AdminInvitesUserValidator():
@@ -43,6 +46,17 @@ class AdminInvitesUserValidator():
         current_users = [user.username.lower() for user in WebUser.by_domain(self.domain)]
         pending_invites = [di.email.lower() for di in Invitation.by_domain(self.domain)]
         return current_users + pending_invites
+
+    def validate_parameters(self, parameters):
+        can_edit_tableau_config = (self.upload_user.has_permission(self.domain, 'edit_user_tableau_config')
+                        and TABLEAU_USER_SYNCING.enabled(self.domain))
+        if (('tableau_role' in parameters or 'tableau_group_indices' in parameters)
+        and not can_edit_tableau_config):
+            return _("You do not have permission to edit Tableau Configuraion.")
+
+        has_profile_privilege = domain_has_privilege(self.domain, privileges.APP_USER_PROFILES)
+        if 'profile' in parameters and not has_profile_privilege:
+            return _("This domain does not have user profile privileges.")
 
     def validate_role(self, role):
         spec = {'role': role}

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -6,6 +6,7 @@ from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
 from corehq.apps.user_importer.validation import (
     RoleValidator,
     ProfileValidator,
+    EmailValidator
 )
 from corehq.apps.users.models import Invitation, WebUser
 
@@ -60,3 +61,7 @@ class AdminInvitesUserValidator():
             web_user = WebUser.get_by_username(email)
             if web_user and not web_user.is_active:
                 return _("A user with this email address is deactivated. ")
+
+        email_validator = EmailValidator(self.domain, 'email')
+        spec = {'email': email}
+        return email_validator.validate_spec(spec)

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -27,7 +27,6 @@ class AdminInvitesUserValidator():
         self.upload_user = upload_user
 
     @property
-    @memoized
     def roles_by_name(self):
         from corehq.apps.users.views.utils import get_editable_role_choices
         return {role[1]: role[0] for role in get_editable_role_choices(self.domain, self.upload_user,
@@ -48,14 +47,12 @@ class AdminInvitesUserValidator():
             return {}
 
     @property
-    @memoized
     def current_users_and_pending_invites(self):
         current_users = [user.username.lower() for user in WebUser.by_domain(self.domain)]
         pending_invites = [di.email.lower() for di in Invitation.by_domain(self.domain)]
         return current_users + pending_invites
 
     @property
-    @memoized
     def location_cache(self):
         return SiteCodeToLocationCache(self.domain)
 

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -36,15 +36,7 @@ class AdminInvitesUserValidator():
     @memoized
     def profiles_by_name(self):
         from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
-        definition = CustomDataFieldsDefinition.get(self.domain, UserFieldsView.field_type)
-        if definition:
-            profiles = definition.get_profiles()
-            return {
-                profile.name: profile
-                for profile in profiles
-            }
-        else:
-            return {}
+        return CustomDataFieldsDefinition.get_profiles_by_name(self.domain, UserFieldsView.field_type)
 
     @property
     def current_users_and_pending_invites(self):

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -5,12 +5,14 @@ from django.utils.translation import gettext_lazy as _
 from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
+from corehq.apps.reports.util import get_allowed_tableau_groups_for_domain
 from corehq.apps.user_importer.validation import (
     RoleValidator,
     ProfileValidator,
     EmailValidator,
     LocationValidator,
     SiteCodeToLocationCache,
+    TableauGroupsValidator
 )
 from corehq.apps.users.models import Invitation, WebUser
 from corehq.apps.users.validation import validate_primary_location_assignment
@@ -103,3 +105,7 @@ class AdminInvitesUserValidator():
         spec = {'location_code': location_codes,
                 'username': editable_user}
         return location_validator.validate_spec(spec)
+
+    def validate_tableau_group(self, tableau_groups):
+        allowed_groups_for_domain = get_allowed_tableau_groups_for_domain(self.domain) or []
+        return TableauGroupsValidator.validate_tableau_groups(allowed_groups_for_domain, tableau_groups)

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -1,6 +1,9 @@
 from memoized import memoized
 
 from corehq.apps.user_importer.validation import RoleValidator
+from corehq.apps.user_importer.validation import ProfileValidator
+
+from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
 
 
 class AdminInvitesUserValidator():
@@ -15,6 +18,25 @@ class AdminInvitesUserValidator():
         return {role[1]: role[0] for role in get_editable_role_choices(self.domain, self.upload_user,
                                                   allow_admin_role=True)}
 
+    @property
+    @memoized
+    def profiles_by_name(self):
+        from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
+        definition = CustomDataFieldsDefinition.get(self.domain, UserFieldsView.field_type)
+        if definition:
+            profiles = definition.get_profiles()
+            return {
+                profile.name: profile
+                for profile in profiles
+            }
+        else:
+            return {}
+
     def validate_role(self, role):
         spec = {'role': role}
         return RoleValidator(self.domain, self.roles_by_name()).validate_spec(spec)
+
+    def validate_profile(self, new_profile_name):
+        profile_validator = ProfileValidator(self.domain, self.upload_user, True, self.profiles_by_name())
+        spec = {'user_profile': new_profile_name}
+        return profile_validator.validate_spec(spec)

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -2,7 +2,6 @@ from django.utils.translation import gettext_lazy as _
 
 from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.apps.user_importer.validation import EmailValidator
 from corehq.apps.users.models import WebUser, Invitation
 from corehq.toggles import TABLEAU_USER_SYNCING
 
@@ -27,19 +26,14 @@ class AdminInvitesUserFormValidator():
             return _("This domain does not have locations privileges.")
 
     @staticmethod
-    def validate_email(domain, email, is_post):
-        if is_post:
-            current_users = [user.username.lower() for user in WebUser.by_domain(domain)]
-            pending_invites = [di.email.lower() for di in Invitation.by_domain(domain)]
-            current_users_and_pending_invites = current_users + pending_invites
+    def validate_email(domain, email):
+        current_users = [user.username.lower() for user in WebUser.by_domain(domain)]
+        pending_invites = [di.email.lower() for di in Invitation.by_domain(domain)]
+        current_users_and_pending_invites = current_users + pending_invites
 
-            if email.lower() in current_users_and_pending_invites:
-                return _("A user with this email address is already in "
-                        "this project or has a pending invitation.")
-            web_user = WebUser.get_by_username(email)
-            if web_user and not web_user.is_active:
-                return _("A user with this email address is deactivated. ")
-
-        email_validator = EmailValidator(domain, 'email')
-        spec = {'email': email}
-        return email_validator.validate_spec(spec)
+        if email.lower() in current_users_and_pending_invites:
+            return _("A user with this email address is already in "
+                    "this project or has a pending invitation.")
+        web_user = WebUser.get_by_username(email)
+        if web_user and not web_user.is_active:
+            return _("A user with this email address is deactivated. ")

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -1,0 +1,20 @@
+from memoized import memoized
+
+from corehq.apps.user_importer.validation import RoleValidator
+
+
+class AdminInvitesUserValidator():
+    def __init__(self, domain, upload_user):
+        self.domain = domain
+        self.upload_user = upload_user
+
+    @property
+    @memoized
+    def roles_by_name(self):
+        from corehq.apps.users.views.utils import get_editable_role_choices
+        return {role[1]: role[0] for role in get_editable_role_choices(self.domain, self.upload_user,
+                                                  allow_admin_role=True)}
+
+    def validate_role(self, role):
+        spec = {'role': role}
+        return RoleValidator(self.domain, self.roles_by_name()).validate_spec(spec)

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -1,110 +1,45 @@
-from memoized import memoized
-
 from django.utils.translation import gettext_lazy as _
 
 from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
-from corehq.apps.reports.util import get_allowed_tableau_groups_for_domain
-from corehq.apps.user_importer.validation import (
-    RoleValidator,
-    ProfileValidator,
-    EmailValidator,
-    LocationValidator,
-    SiteCodeToLocationCache,
-    TableauGroupsValidator,
-    TableauRoleValidator,
-    CustomDataValidator,
-)
-from corehq.apps.users.models import Invitation, WebUser
-from corehq.apps.users.validation import validate_primary_location_assignment
+from corehq.apps.user_importer.validation import EmailValidator
+from corehq.apps.users.models import WebUser, Invitation
 from corehq.toggles import TABLEAU_USER_SYNCING
 
 
-class AdminInvitesUserValidator():
-    def __init__(self, domain, upload_user):
-        self.domain = domain
-        self.upload_user = upload_user
+class AdminInvitesUserFormValidator():
 
-    @property
-    def roles_by_name(self):
-        from corehq.apps.users.views.utils import get_editable_role_choices
-        return {role[1]: role[0] for role in get_editable_role_choices(self.domain, self.upload_user,
-                                                  allow_admin_role=True)}
-
-    @property
-    @memoized
-    def profiles_by_name(self):
-        from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
-        return CustomDataFieldsDefinition.get_profiles_by_name(self.domain, UserFieldsView.field_type)
-
-    @property
-    def current_users_and_pending_invites(self):
-        current_users = [user.username.lower() for user in WebUser.by_domain(self.domain)]
-        pending_invites = [di.email.lower() for di in Invitation.by_domain(self.domain)]
-        return current_users + pending_invites
-
-    @property
-    def location_cache(self):
-        return SiteCodeToLocationCache(self.domain)
-
-    def validate_parameters(self, parameters):
-        can_edit_tableau_config = (self.upload_user.has_permission(self.domain, 'edit_user_tableau_config')
-                        and TABLEAU_USER_SYNCING.enabled(self.domain))
+    @staticmethod
+    def validate_parameters(domain, upload_user, parameters):
+        can_edit_tableau_config = (upload_user.has_permission(domain, 'edit_user_tableau_config')
+                        and TABLEAU_USER_SYNCING.enabled(domain))
         if (('tableau_role' in parameters or 'tableau_group_indices' in parameters)
         and not can_edit_tableau_config):
             return _("You do not have permission to edit Tableau Configuraion.")
 
-        has_profile_privilege = domain_has_privilege(self.domain, privileges.APP_USER_PROFILES)
+        has_profile_privilege = domain_has_privilege(domain, privileges.APP_USER_PROFILES)
         if 'profile' in parameters and not has_profile_privilege:
             return _("This domain does not have user profile privileges.")
 
-        has_locations_privilege = domain_has_privilege(self.domain, privileges.LOCATIONS)
+        has_locations_privilege = domain_has_privilege(domain, privileges.LOCATIONS)
         if (('primary_location' in parameters or 'assigned_locations' in parameters)
         and not has_locations_privilege):
             return _("This domain does not have locations privileges.")
 
-    def validate_role(self, role):
-        spec = {'role': role}
-        return RoleValidator(self.domain, self.roles_by_name()).validate_spec(spec)
-
-    def validate_profile(self, new_profile_name):
-        profile_validator = ProfileValidator(self.domain, self.upload_user, True, self.profiles_by_name())
-        spec = {'user_profile': new_profile_name}
-        return profile_validator.validate_spec(spec)
-
-    def validate_custom_data(self, custom_data, profile_name):
-        custom_data_validator = CustomDataValidator(self.domain, self.profiles_by_name())
-        spec = {'data': custom_data, 'user_profile': profile_name}
-        return custom_data_validator.validate_spec(spec)
-
-    def validate_email(self, email, is_post):
+    @staticmethod
+    def validate_email(domain, email, is_post):
         if is_post:
-            if email.lower() in self.current_users_and_pending_invites:
+            current_users = [user.username.lower() for user in WebUser.by_domain(domain)]
+            pending_invites = [di.email.lower() for di in Invitation.by_domain(domain)]
+            current_users_and_pending_invites = current_users + pending_invites
+
+            if email.lower() in current_users_and_pending_invites:
                 return _("A user with this email address is already in "
                         "this project or has a pending invitation.")
             web_user = WebUser.get_by_username(email)
             if web_user and not web_user.is_active:
                 return _("A user with this email address is deactivated. ")
 
-        email_validator = EmailValidator(self.domain, 'email')
+        email_validator = EmailValidator(domain, 'email')
         spec = {'email': email}
         return email_validator.validate_spec(spec)
-
-    def validate_locations(self, editable_user, assigned_location_codes, primary_location_code):
-        error = validate_primary_location_assignment(primary_location_code, assigned_location_codes)
-        if error:
-            return error
-
-        location_validator = LocationValidator(self.domain, self.upload_user, self.location_cache, True)
-        location_codes = assigned_location_codes + [primary_location_code]
-        spec = {'location_code': location_codes,
-                'username': editable_user}
-        return location_validator.validate_spec(spec)
-
-    def validate_tableau_group(self, tableau_groups):
-        allowed_groups_for_domain = get_allowed_tableau_groups_for_domain(self.domain) or []
-        return TableauGroupsValidator.validate_tableau_groups(allowed_groups_for_domain, tableau_groups)
-
-    def validate_tableau_role(self, tableau_role):
-        return TableauRoleValidator.validate_tableau_role(tableau_role)

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -12,7 +12,8 @@ from corehq.apps.user_importer.validation import (
     EmailValidator,
     LocationValidator,
     SiteCodeToLocationCache,
-    TableauGroupsValidator
+    TableauGroupsValidator,
+    TableauRoleValidator
 )
 from corehq.apps.users.models import Invitation, WebUser
 from corehq.apps.users.validation import validate_primary_location_assignment
@@ -109,3 +110,6 @@ class AdminInvitesUserValidator():
     def validate_tableau_group(self, tableau_groups):
         allowed_groups_for_domain = get_allowed_tableau_groups_for_domain(self.domain) or []
         return TableauGroupsValidator.validate_tableau_groups(allowed_groups_for_domain, tableau_groups)
+
+    def validate_tableau_role(self, tableau_role):
+        return TableauRoleValidator.validate_tableau_role(tableau_role)

--- a/corehq/apps/registration/validation.py
+++ b/corehq/apps/registration/validation.py
@@ -11,19 +11,19 @@ class AdminInvitesUserFormValidator():
 
     @staticmethod
     def validate_parameters(domain, upload_user, parameters):
-        can_edit_tableau_config = (upload_user.has_permission(domain, 'edit_user_tableau_config')
-                        and TABLEAU_USER_SYNCING.enabled(domain))
-        if (('tableau_role' in parameters or 'tableau_group_indices' in parameters)
-        and not can_edit_tableau_config):
-            return _("You do not have permission to edit Tableau Configuraion.")
+        if 'tableau_role' in parameters or 'tableau_group_indices' in parameters:
+            can_edit_tableau_config = (
+                upload_user.has_permission(domain, 'edit_user_tableau_config')
+                and TABLEAU_USER_SYNCING.enabled(domain)
+            )
+            if not can_edit_tableau_config:
+                return _("You do not have permission to edit Tableau Configuration.")
 
-        has_profile_privilege = domain_has_privilege(domain, privileges.APP_USER_PROFILES)
-        if 'profile' in parameters and not has_profile_privilege:
+        if 'profile' in parameters and not domain_has_privilege(domain, privileges.APP_USER_PROFILES):
             return _("This domain does not have user profile privileges.")
 
-        has_locations_privilege = domain_has_privilege(domain, privileges.LOCATIONS)
         if (('primary_location' in parameters or 'assigned_locations' in parameters)
-        and not has_locations_privilege):
+           and not domain_has_privilege(domain, privileges.LOCATIONS)):
             return _("This domain does not have locations privileges.")
 
     @staticmethod

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -4,7 +4,6 @@ import string
 import random
 from collections import defaultdict
 from datetime import datetime
-from typing import List
 from corehq.util.soft_assert.api import soft_assert
 
 from memoized import memoized
@@ -74,7 +73,7 @@ old_headers = {
 }
 
 
-def check_headers(user_specs, domain, is_web_upload=False):
+def check_headers(user_specs, domain, upload_couch_user, is_web_upload=False):
     messages = []
     headers = set(user_specs.fieldnames)
 
@@ -92,9 +91,16 @@ def check_headers(user_specs, domain, is_web_upload=False):
 
     if not is_web_upload and EnterpriseMobileWorkerSettings.is_domain_using_custom_deactivation(domain):
         allowed_headers.add('deactivate_after')
-
-    if TABLEAU_USER_SYNCING.enabled(domain):
+    if TABLEAU_USER_SYNCING.enabled(domain) and upload_couch_user.has_permission(
+            domain,
+            get_permission_name(HqPermissions.edit_user_tableau_config)
+    ):
         allowed_headers.update({'tableau_role', 'tableau_groups'})
+    elif "tableau_role" in headers or "tableau_groups" in headers:
+        messages.append(_(
+            "Only users with 'Manage Tableau Configuration' edit permission in domains where Tableau"
+            "User Syncing is enabled can upload files with 'Tableau Role and/or 'Tableau Groups' fields."
+        ))
 
     illegal_headers = headers - allowed_headers
 
@@ -876,8 +882,6 @@ class WebImporter:
 
     def run(self):
         ret = {"errors": [], "rows": []}
-        column_headers = self.user_specs[0].keys() if self.user_specs else []
-        check_field_edit_permissions(column_headers, self.upload_user, self.upload_domain)
         for i, row in enumerate(self.user_specs):
             if self.update_progress:
                 self.update_progress(i)
@@ -1025,18 +1029,6 @@ def create_or_update_web_users(upload_domain, user_specs, upload_user, upload_re
         upload_domain, user_specs, upload_user, upload_record_id,
         update_progress=update_progress
     ).run()
-
-
-def check_field_edit_permissions(field_names: List, upload_couch_user, domain: str):
-    if "tableau_role" in field_names or "tableau_groups" in field_names:
-        if not upload_couch_user.has_permission(
-            domain,
-            get_permission_name(HqPermissions.edit_user_tableau_config)
-        ):
-            raise UserUploadError(_(
-                "Only users with 'Manage Tableau Configuration' edit permission can upload files with"
-                "'Tableau Role and/or 'Tableau Groups' fields. Please remove those fields from your file."
-            ))
 
 
 def check_user_role(username, role):

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -963,15 +963,7 @@ class DomainInfo:
     @memoized
     def profiles_by_name(self):
         from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
-        definition = CustomDataFieldsDefinition.get(self.domain, UserFieldsView.field_type)
-        if definition:
-            profiles = definition.get_profiles()
-            return {
-                profile.name: profile
-                for profile in profiles
-            }
-        else:
-            return {}
+        return CustomDataFieldsDefinition.get_profiles_by_name(self.domain, UserFieldsView.field_type)
 
     @property
     @memoized

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -99,8 +99,8 @@ def check_headers(user_specs, domain, upload_couch_user, is_web_upload=False):
         conditionally_allowed_headers.update({'tableau_role', 'tableau_groups'})
     elif "tableau_role" in headers or "tableau_groups" in headers:
         messages.append(_(
-            "Only users with 'Manage Tableau Configuration' edit permission in domains where Tableau"
-            "User Syncing is enabled can upload files with 'Tableau Role and/or 'Tableau Groups' fields."
+            "Only users with 'Manage Tableau Configuration' edit permission in domains where Tableau "
+            "User Syncing is enabled can upload files with 'Tableau Role' and/or 'Tableau Groups' fields."
         ))
 
     illegal_headers = headers - allowed_headers - conditionally_allowed_headers

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -76,6 +76,7 @@ old_headers = {
 def check_headers(user_specs, domain, upload_couch_user, is_web_upload=False):
     messages = []
     headers = set(user_specs.fieldnames)
+    conditionally_allowed_headers = set()
 
     # Backwards warnings
     for (old_name, new_name) in old_headers.items():
@@ -87,22 +88,22 @@ def check_headers(user_specs, domain, upload_couch_user, is_web_upload=False):
             headers.discard(old_name)
 
     if DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
-        allowed_headers.add('domain')
+        conditionally_allowed_headers.add('domain')
 
     if not is_web_upload and EnterpriseMobileWorkerSettings.is_domain_using_custom_deactivation(domain):
-        allowed_headers.add('deactivate_after')
+        conditionally_allowed_headers.add('deactivate_after')
     if TABLEAU_USER_SYNCING.enabled(domain) and upload_couch_user.has_permission(
             domain,
             get_permission_name(HqPermissions.edit_user_tableau_config)
     ):
-        allowed_headers.update({'tableau_role', 'tableau_groups'})
+        conditionally_allowed_headers.update({'tableau_role', 'tableau_groups'})
     elif "tableau_role" in headers or "tableau_groups" in headers:
         messages.append(_(
             "Only users with 'Manage Tableau Configuration' edit permission in domains where Tableau"
             "User Syncing is enabled can upload files with 'Tableau Role and/or 'Tableau Groups' fields."
         ))
 
-    illegal_headers = headers - allowed_headers
+    illegal_headers = headers - allowed_headers - conditionally_allowed_headers
 
     if is_web_upload:
         missing_headers = web_required_headers - headers

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -2146,38 +2146,6 @@ class TestWebUserBulkUpload(TestCase, DomainSubscriptionMixin, TestUserDataMixin
             TableauUser.Roles.UNLICENSED.value)
         local_tableau_users.get(username='george@eliot.com')
 
-        # Test user without permission to edit Tableau Configs
-        self.uploading_user.is_superuser = False
-        role_with_upload_permission = UserRole.create(
-            self.domain, 'edit-web-users', permissions=HqPermissions(edit_web_users=True)
-        )
-        self.uploading_user.set_role(self.domain_name, role_with_upload_permission.get_qualified_id())
-        self.uploading_user.save()
-        with self.assertRaises(UserUploadError):
-            import_users_and_groups(
-                self.domain.name,
-                [
-                    self._get_spec(
-                        username='edith@wharton.com',
-                        tableau_role=TableauUser.Roles.EXPLORER.value,
-                        tableau_groups="""group1,group2"""
-                    ),
-                ],
-                [],
-                self.uploading_user.get_id,
-                self.upload_record.pk,
-                True
-            )
-
-        # Test user with permission to edit Tableau Configs
-        role_with_upload_and_edit_tableau_permission = UserRole.create(
-            self.domain, 'edit-tableau', permissions=HqPermissions(edit_web_users=True,
-                                                                   edit_user_tableau_config=True)
-        )
-        self.uploading_user.set_role(self.domain_name,
-                                     role_with_upload_and_edit_tableau_permission.get_qualified_id())
-        self.uploading_user.save()
-
         import_users_and_groups(
             self.domain.name,
             [

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -355,6 +355,10 @@ class TestLocationValidator(LocationHierarchyTestCase):
         validation_result = self.validator.validate_spec(user_spec)
         assert validation_result == self.validator.error_message_user_access
 
+        user_spec = {'username': self.editable_user.username}
+        validation_result = self.validator.validate_spec(user_spec)
+        assert validation_result == self.validator.error_message_user_access
+
     def test_cant_edit_commcare_user(self):
         self.cc_user_validator = LocationValidator(self.domain, self.upload_user,
                                                 SiteCodeToLocationCache(self.domain), False)
@@ -363,6 +367,10 @@ class TestLocationValidator(LocationHierarchyTestCase):
         user_spec = {'user_id': self.editable_cc_user._id,
                      'location_code': [self.locations['Middlesex'].site_code,
                                        self.locations['Cambridge'].site_code]}
+        validation_result = self.cc_user_validator.validate_spec(user_spec)
+        assert validation_result == self.validator.error_message_user_access
+
+        user_spec = {'user_id': self.editable_cc_user._id}
         validation_result = self.cc_user_validator.validate_spec(user_spec)
         assert validation_result == self.validator.error_message_user_access
 

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -398,6 +398,15 @@ class TestLocationValidator(LocationHierarchyTestCase):
         assert validation_result == self.validator.error_message_location_access.format(
             self.locations['Suffolk'].site_code)
 
+    def test_cant_remove_all_locations(self):
+        self.editable_user.reset_locations(self.domain, [self.locations['Suffolk'].location_id,
+                                                         self.locations['Cambridge'].location_id])
+        user_spec = {'username': self.editable_user.username,
+                     'location_code': []}
+        validation_result = self.validator.validate_spec(user_spec)
+        assert validation_result == self.validator.error_message_location_access.format(
+            self.locations['Suffolk'].site_code)
+
     @flag_enabled('USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION')
     def test_location_not_has_users(self):
         self.editable_user.reset_locations(self.domain, [self.locations['Middlesex'].location_id])

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -388,6 +388,10 @@ class TestLocationValidator(LocationHierarchyTestCase):
         validation_result = self.validator.validate_spec(user_spec)
         assert validation_result == self.validator.error_message_user_access
 
+        user_spec = {'username': self.invitation.email}
+        validation_result = self.validator.validate_spec(user_spec)
+        assert validation_result == self.validator.error_message_user_access
+
     def test_cant_add_location(self):
         self.editable_user.reset_locations(self.domain, [self.locations['Cambridge'].location_id])
         user_spec = {'username': self.editable_user.username,

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -407,7 +407,11 @@ class TestLocationValidator(LocationHierarchyTestCase):
                      'location_code': [self.locations['Cambridge'].site_code,
                                        self.locations['Middlesex'].site_code]}
         validation_result = self.validator.validate_spec(user_spec)
-        assert validation_result == self.validator.error_message_location_not_has_users.format(
+        error_message_location_not_has_users = (
+            "These locations cannot have users assigned because of their "
+            "organization level settings: {}."
+        )
+        assert validation_result == error_message_location_not_has_users.format(
             self.locations['Cambridge'].site_code)
 
     @classmethod

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -740,7 +740,6 @@ class TestTableauGroupsValidator(TestCase):
             domain=cls.domain,
             allowed_tableau_groups=cls.allowed_groups
         )
-        cls.addClassCleanup(cls.tableau_server.delete)
         cls.all_specs = [{'tableau_groups': 'group1,group2'}]
 
     def test_valid_groups(self):

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -172,12 +172,16 @@ class TableauGroupsValidator(ImportValidator):
         tableau_groups = spec.get('tableau_groups') or []
         if tableau_groups:
             tableau_groups = tableau_groups.split(',')
+        return self.validate_tableau_groups(self.allowed_groups_for_domain, tableau_groups)
+
+    @classmethod
+    def validate_tableau_groups(cls, allowed_groups_for_domain, tableau_groups):
         invalid_groups = []
         for group in tableau_groups:
-            if group not in self.allowed_groups_for_domain:
+            if group not in allowed_groups_for_domain:
                 invalid_groups.append(group)
         if invalid_groups:
-            return self._error_message.format(', '.join(invalid_groups), ', '.join(self.allowed_groups_for_domain))
+            return cls._error_message.format(', '.join(invalid_groups), ', '.join(allowed_groups_for_domain))
 
 
 class DuplicateValidator(ImportValidator):

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -22,7 +22,7 @@ from corehq.apps.users.dbaccessors import get_existing_usernames
 from corehq.apps.users.forms import get_mobile_worker_max_username_length
 from corehq.apps.users.models import CouchUser, Invitation
 from corehq.apps.users.util import normalize_username, raw_username
-from corehq.apps.users.validation import validate_assigned_locations_has_users
+from corehq.apps.users.validation import validate_assigned_locations_allow_users
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.apps.users.views.utils import (
     user_can_access_invite
@@ -520,7 +520,7 @@ class LocationValidator(ImportValidator):
             user_access_error = self._validate_uploading_user_access(locs_being_assigned, user_result)
             location_cannot_have_users_error = None
             if toggles.USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION.enabled(self.domain):
-                location_cannot_have_users_error = self._validate_location_has_users(locs_being_assigned)
+                location_cannot_have_users_error = self._validate_locations_allow_users(locs_being_assigned)
             return user_access_error or location_cannot_have_users_error
 
     def _get_locs_ids_being_assigned(self, spec):
@@ -551,10 +551,10 @@ class LocationValidator(ImportValidator):
                 ', '.join(SQLLocation.objects.filter(
                     location_id__in=problem_location_ids).values_list('site_code', flat=True)))
 
-    def _validate_location_has_users(self, locs_ids_being_assigned):
+    def _validate_locations_allow_users(self, locs_ids_being_assigned):
         if not locs_ids_being_assigned:
             return
-        return validate_assigned_locations_has_users(self.domain, locs_ids_being_assigned)
+        return validate_assigned_locations_allow_users(self.domain, locs_ids_being_assigned)
 
 
 class UserRetrievalResult(NamedTuple):

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -151,12 +151,16 @@ class TableauRoleValidator(ImportValidator):
 
     def __init__(self, domain):
         super().__init__(domain)
-        self.valid_role_options = [e.value for e in TableauUser.Roles]
 
     def validate_spec(self, spec):
         tableau_role = spec.get('tableau_role')
-        if tableau_role is not None and tableau_role not in self.valid_role_options:
-            return self._error_message.format(tableau_role, ', '.join(self.valid_role_options))
+        return self.validate_tableau_role(tableau_role)
+
+    @classmethod
+    def validate_tableau_role(cls, tableau_role):
+        valid_role_options = [e.value for e in TableauUser.Roles]
+        if tableau_role is not None and tableau_role not in valid_role_options:
+            return cls._error_message.format(tableau_role, ', '.join(valid_role_options))
 
 
 class TableauGroupsValidator(ImportValidator):

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -148,6 +148,7 @@ class RequiredWebFieldsValidator(ImportValidator):
 
 class TableauRoleValidator(ImportValidator):
     _error_message = _("Invalid tableau role: '{}'. Please choose one of the following: {}")
+    valid_role_options = [e.value for e in TableauUser.Roles]
 
     def __init__(self, domain):
         super().__init__(domain)
@@ -158,9 +159,8 @@ class TableauRoleValidator(ImportValidator):
 
     @classmethod
     def validate_tableau_role(cls, tableau_role):
-        valid_role_options = [e.value for e in TableauUser.Roles]
-        if tableau_role is not None and tableau_role not in valid_role_options:
-            return cls._error_message.format(tableau_role, ', '.join(valid_role_options))
+        if tableau_role is not None and tableau_role not in cls.valid_role_options:
+            return cls._error_message.format(tableau_role, ', '.join(cls.valid_role_options))
 
 
 class TableauGroupsValidator(ImportValidator):

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -505,8 +505,6 @@ class LocationValidator(ImportValidator):
     error_message_user_access = _("Based on your locations you do not have permission to edit this user or user "
                                   "invitation")
     error_message_location_access = _("You do not have permission to assign or remove these locations: {}")
-    error_message_location_not_has_users = _("These locations cannot have users assigned because of their "
-                                             "organization level settings: {}.")
 
     def __init__(self, domain, upload_user, location_cache, is_web_user_import):
         super().__init__(domain)

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -505,17 +505,28 @@ class LocationValidator(ImportValidator):
         self.location_cache = location_cache
         self.is_web_user_import = is_web_user_import
 
-    def _get_locs_being_assigned(self, spec):
+    def validate_spec(self, spec):
+        locs_being_assigned = self._get_locs_ids_being_assigned(spec)
+        user_result = _get_invitation_or_editable_user(spec, self.is_web_user_import, self.domain)
+
+        user_access_error = self._validate_uploading_user_access(locs_being_assigned, user_result)
+        location_cannot_have_users_error = None
+        if toggles.USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION.enabled(self.domain):
+            location_cannot_have_users_error = self._validate_location_has_users(locs_being_assigned)
+        return user_access_error or location_cannot_have_users_error
+
+    def _get_locs_ids_being_assigned(self, spec):
         from corehq.apps.user_importer.importer import find_location_id
-        location_codes = (spec['location_code'] if isinstance(spec['location_code'], list)
-                          else [spec['location_code']])
-        locs_ids_being_assigned = find_location_id(location_codes, self.location_cache)
+        locs_ids_being_assigned = []
+        if 'location_code' in spec:
+            location_codes = (spec['location_code'] if isinstance(spec['location_code'], list)
+                              else [spec['location_code']])
+            locs_ids_being_assigned = find_location_id(location_codes, self.location_cache)
         return locs_ids_being_assigned
 
-    def _validate_uploading_user_access(self, spec):
+    def _validate_uploading_user_access(self, locs_ids_being_assigned, user_result):
         # 1. Get current locations for user or user invitation and ensure user can edit it
         current_locs = []
-        user_result = _get_invitation_or_editable_user(spec, self.is_web_user_import, self.domain)
         if user_result.invitation:
             if not user_can_access_invite(self.domain, self.upload_user, user_result.invitation):
                 return self.error_message_user_access.format(user_result.invitation.email)
@@ -527,30 +538,22 @@ class LocationValidator(ImportValidator):
 
         # 2. Ensure the user is only adding the user to/removing from *new locations* that they have permission
         # to access.
-        if 'location_code' in spec:
-            locs_being_assigned = self._get_locs_being_assigned(spec)
+        if locs_ids_being_assigned:
             problem_location_ids = user_can_change_locations(self.domain, self.upload_user,
-                                                            current_locs, locs_being_assigned)
+                                                            current_locs, locs_ids_being_assigned)
             if problem_location_ids:
                 return self.error_message_location_access.format(
                     ', '.join(SQLLocation.objects.filter(
                         location_id__in=problem_location_ids).values_list('site_code', flat=True)))
 
-    def _validate_location_has_users(self, spec):
-        if 'location_code' not in spec:
+    def _validate_location_has_users(self, locs_ids_being_assigned):
+        if not locs_ids_being_assigned:
             return
-        locs_being_assigned = SQLLocation.objects.filter(location_id__in=self._get_locs_being_assigned(spec))
+        locs_being_assigned = SQLLocation.objects.filter(location_id__in=locs_ids_being_assigned)
         problem_locations = locs_being_assigned.filter(location_type__has_users=False)
         if problem_locations:
             return self.error_message_location_not_has_users.format(
                 ', '.join(problem_locations.values_list('site_code', flat=True)))
-
-    def validate_spec(self, spec):
-        user_access_error = self._validate_uploading_user_access(spec)
-        location_cannot_have_users_error = None
-        if toggles.USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION.enabled(self.domain):
-            location_cannot_have_users_error = self._validate_location_has_users(spec)
-        return user_access_error or location_cannot_have_users_error
 
 
 class UserRetrievalResult(NamedTuple):

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -22,6 +22,7 @@ from corehq.apps.users.dbaccessors import get_existing_usernames
 from corehq.apps.users.forms import get_mobile_worker_max_username_length
 from corehq.apps.users.models import CouchUser, Invitation
 from corehq.apps.users.util import normalize_username, raw_username
+from corehq.apps.users.validation import validate_assigned_locations_has_users
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.apps.users.views.utils import (
     user_can_access_invite
@@ -549,11 +550,7 @@ class LocationValidator(ImportValidator):
     def _validate_location_has_users(self, locs_ids_being_assigned):
         if not locs_ids_being_assigned:
             return
-        locs_being_assigned = SQLLocation.objects.filter(location_id__in=locs_ids_being_assigned)
-        problem_locations = locs_being_assigned.filter(location_type__has_users=False)
-        if problem_locations:
-            return self.error_message_location_not_has_users.format(
-                ', '.join(problem_locations.values_list('site_code', flat=True)))
+        return validate_assigned_locations_has_users(self.domain, locs_ids_being_assigned)
 
 
 class UserRetrievalResult(NamedTuple):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1132,18 +1132,11 @@ class SelectUserLocationForm(forms.Form):
                 'assigned_locations',
                 _("You do not have permissions to assign one of those locations.")
             )
-        if primary_location_id:
-            if primary_location_id not in assigned_location_ids:
-                self.add_error(
-                    'primary_location',
-                    _("Primary location must be one of the user's locations")
-                )
-        if assigned_location_ids and not primary_location_id:
-            self.add_error(
-                'primary_location',
-                _("Primary location can't be empty if the user has any "
-                  "locations set")
-            )
+        from corehq.apps.users.validation import validate_primary_location_assignment
+        error = validate_primary_location_assignment(primary_location_id, assigned_location_ids)
+        if error:
+            self.add_error('primary_location', error)
+
         return self.cleaned_data
 
 

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1121,7 +1121,7 @@ class SelectUserLocationForm(forms.Form):
         if locations.filter(location_type__has_users=False).exists():
             raise forms.ValidationError(
                 _('One or more of the locations you specified cannot have users assigned.'))
-        return [location.location_id for location in locations]
+        return location_ids
 
     def _user_has_permission_to_access_locations(self, new_location_ids):
         assigned_locations = SQLLocation.objects.filter(location_id__in=new_location_ids)

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1110,9 +1110,9 @@ class SelectUserLocationForm(forms.Form):
         )
 
     def clean_assigned_locations(self):
-        from corehq.apps.users.validation import validate_assigned_locations_has_users
+        from corehq.apps.users.validation import validate_assigned_locations_allow_users
         location_ids = self.data.getlist('assigned_locations')
-        error = validate_assigned_locations_has_users(self.domain, location_ids)
+        error = validate_assigned_locations_allow_users(self.domain, location_ids)
         if error:
             raise forms.ValidationError(error)
         return location_ids

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1110,17 +1110,11 @@ class SelectUserLocationForm(forms.Form):
         )
 
     def clean_assigned_locations(self):
-        from corehq.apps.locations.models import SQLLocation
-        from corehq.apps.locations.util import get_locations_from_ids
-
+        from corehq.apps.users.validation import validate_assigned_locations_has_users
         location_ids = self.data.getlist('assigned_locations')
-        try:
-            locations = get_locations_from_ids(location_ids, self.domain)
-        except SQLLocation.DoesNotExist:
-            raise forms.ValidationError(_('One or more of the locations was not found.'))
-        if locations.filter(location_type__has_users=False).exists():
-            raise forms.ValidationError(
-                _('One or more of the locations you specified cannot have users assigned.'))
+        error = validate_assigned_locations_has_users(self.domain, location_ids)
+        if error:
+            raise forms.ValidationError(error)
         return location_ids
 
     def _user_has_permission_to_access_locations(self, new_location_ids):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1125,7 +1125,7 @@ class SelectUserLocationForm(forms.Form):
     def clean(self):
         self.cleaned_data = super(SelectUserLocationForm, self).clean()
 
-        primary_location_id = self.cleaned_data['primary_location']
+        primary_location_id = self.cleaned_data.get('primary_location', '')
         assigned_location_ids = self.cleaned_data.get('assigned_locations', [])
         if not self._user_has_permission_to_access_locations(assigned_location_ids):
             self.add_error(

--- a/corehq/apps/users/tests/test_user_invitation.py
+++ b/corehq/apps/users/tests/test_user_invitation.py
@@ -3,7 +3,7 @@ import datetime
 from unittest.mock import Mock, patch
 
 from corehq.apps.users.models import Invitation, WebUser
-from corehq.apps.users.views.web import UserInvitationView, WebUserInvitationForm
+from corehq.apps.users.views.web import UserInvitationView, AcceptedWebUserInvitationForm
 
 from django import forms
 from django.contrib.auth.models import AnonymousUser
@@ -17,7 +17,7 @@ class InvitationTestException(Exception):
     pass
 
 
-class StubbedWebUserInvitationForm(WebUserInvitationForm):
+class StubbedAcceptedWebUserInvitationForm(AcceptedWebUserInvitationForm):
 
     def __init__(self, *args, **kwargs):
         self.request_email = kwargs.pop('request_email', False)
@@ -76,7 +76,7 @@ class TestUserInvitation(TestCase):
         self.assertEqual("/accounts/login/", response.url)
 
     def test_redirect_if_invite_email_does_not_match(self):
-        form = StubbedWebUserInvitationForm(
+        form = StubbedAcceptedWebUserInvitationForm(
             {
                 "email": "other_test@dimagi.com",
                 "full_name": "asdf",
@@ -95,7 +95,7 @@ class TestUserInvitation(TestCase):
             str(ve.exception),
             "['You can only sign up with the email address your invitation was sent to.']")
 
-        form = WebUserInvitationForm(
+        form = AcceptedWebUserInvitationForm(
             {
                 "email": "other_test@dimagi.com",
                 "full_name": "asdf",
@@ -110,7 +110,7 @@ class TestUserInvitation(TestCase):
         print(form.errors)
         self.assertTrue(form.is_valid())
 
-        form = WebUserInvitationForm(
+        form = AcceptedWebUserInvitationForm(
             {
                 "email": "test@dimagi.com",
                 "full_name": "asdf",

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -629,6 +629,13 @@ class BulkUserUploadAPITest(TestCase):
 
 
 class BaseUploadUserTest(TestCase):
+
+    mock_couch_user = WebUser(
+        username="testuser",
+        _id="user123",
+        domain="test-domain",
+    )
+
     def setUp(self):
         self.domain = 'test-domain'
         self.factory = RequestFactory()
@@ -651,6 +658,7 @@ class BaseUploadUserTest(TestCase):
         mock_reverse.return_value = '/success/'
 
         request = self.factory.post('/', {'bulk_upload_file': Mock()})
+        request.couch_user = self.mock_couch_user
         response = self.view.post(request)
 
         mock_reverse.assert_called_once_with(

--- a/corehq/apps/users/validation.py
+++ b/corehq/apps/users/validation.py
@@ -74,3 +74,11 @@ def validate_assigned_locations_has_users(domain, assigned_location_ids):
     if problem_locations:
         return error_message_location_not_has_users.format(
             ', '.join(problem_locations.values_list('site_code', flat=True)))
+
+
+def validate_primary_location_assignment(primary_location, assigned_locations):
+    if primary_location:
+        if primary_location not in assigned_locations:
+            return _("Primary location must be one of the user's locations")
+    if assigned_locations and not primary_location:
+        return _("Primary location can't be empty if the user has any locations set")

--- a/corehq/apps/users/validation.py
+++ b/corehq/apps/users/validation.py
@@ -63,7 +63,7 @@ def validate_profile_required(profile_name, domain):
         )
 
 
-def validate_assigned_locations_has_users(domain, assigned_location_ids):
+def validate_assigned_locations_allow_users(domain, assigned_location_ids):
     error_message_location_not_has_users = _("These locations cannot have users assigned because of their "
                                              "organization level settings: {}.")
     try:

--- a/corehq/apps/users/validation.py
+++ b/corehq/apps/users/validation.py
@@ -4,6 +4,8 @@ from django.utils.translation import gettext as _
 
 from corehq.apps.users.util import is_username_available
 from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
+from corehq.apps.locations.models import SQLLocation
+from corehq.apps.locations.util import get_locations_from_ids
 from corehq.apps.users.views.mobile import BAD_MOBILE_USERNAME_REGEX
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 
@@ -59,3 +61,16 @@ def validate_profile_required(profile_name, domain):
         raise ValidationError(
             _("A profile assignment is required for Mobile Workers.")
         )
+
+
+def validate_assigned_locations_has_users(domain, assigned_location_ids):
+    error_message_location_not_has_users = _("These locations cannot have users assigned because of their "
+                                             "organization level settings: {}.")
+    try:
+        locs_being_assigned = get_locations_from_ids(assigned_location_ids, domain)
+    except SQLLocation.DoesNotExist:
+        return _('One or more of the locations was not found.')
+    problem_locations = locs_being_assigned.filter(location_type__has_users=False)
+    if problem_locations:
+        return error_message_location_not_has_users.format(
+            ', '.join(problem_locations.values_list('site_code', flat=True)))

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1277,7 +1277,12 @@ class BaseUploadUser(BaseUserSettingsView):
         """View's dispatch method automatically calls this"""
         try:
             workbook = get_workbook(request.FILES.get("bulk_upload_file"))
-            user_specs, group_specs = self.process_workbook(workbook, self.domain, self.is_web_upload)
+            user_specs, group_specs = self.process_workbook(
+                workbook,
+                self.domain,
+                self.is_web_upload,
+                request.couch_user
+            )
             task_ref = self.upload_users(
                 request, user_specs, group_specs, self.domain, self.is_web_upload)
             return self._get_success_response(request, task_ref)
@@ -1291,7 +1296,7 @@ class BaseUploadUser(BaseUserSettingsView):
             return HttpResponseRedirect(reverse(self.urlname, args=[self.domain]))
 
     @staticmethod
-    def process_workbook(workbook, domain, is_web_upload):
+    def process_workbook(workbook, domain, is_web_upload, upload_user):
         from corehq.apps.user_importer.importer import check_headers
 
         try:
@@ -1302,7 +1307,7 @@ class BaseUploadUser(BaseUserSettingsView):
             except WorksheetNotFound as e:
                 raise WorksheetNotFound("Workbook has no worksheets") from e
 
-        check_headers(user_specs, domain, is_web_upload=is_web_upload)
+        check_headers(user_specs, domain, upload_couch_user=upload_user, is_web_upload=is_web_upload)
 
         try:
             group_specs = workbook.get_worksheet(title="groups")

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1146,11 +1146,8 @@ class InviteWebUserView(BaseManageWebUserView):
         can_edit_tableau_config = (self.request.couch_user.has_permission(self.domain, 'edit_user_tableau_config')
                                 and toggles.TABLEAU_USER_SYNCING.enabled(self.domain))
         if self.request.method == 'POST':
-            current_users = [user.username for user in WebUser.by_domain(self.domain)]
-            pending_invites = [di.email for di in Invitation.by_domain(self.domain)]
             return AdminInvitesUserForm(
                 self.request.POST,
-                excluded_emails=current_users + pending_invites,
                 role_choices=role_choices,
                 domain=self.domain,
                 is_add_user=is_add_user,

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1613,7 +1613,12 @@ def bulk_user_upload_api(request, domain):
         if file is None:
             raise UserUploadError(_('no file uploaded'))
         workbook = get_workbook(file)
-        user_specs, group_specs = BaseUploadUser.process_workbook(workbook, domain, is_web_upload=False)
+        user_specs, group_specs = BaseUploadUser.process_workbook(
+            workbook,
+            domain,
+            is_web_upload=False,
+            upload_user=request.couch_user
+        )
         BaseUploadUser.upload_users(request, user_specs, group_specs, domain, is_web_upload=False)
         return json_response({'success': True})
     except (WorkbookJSONError, WorksheetNotFound, UserUploadError) as e:

--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -32,7 +32,7 @@ from corehq.apps.domain.extension_points import has_custom_clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.views import BasePageView, logout
 from corehq.apps.locations.permissions import location_restricted_response, location_safe
-from corehq.apps.registration.forms import WebUserInvitationForm
+from corehq.apps.registration.forms import AcceptedWebUserInvitationForm
 from corehq.apps.registration.utils import activate_new_user_via_reg_form
 from corehq.apps.users.audit.change_messages import UserChangeMessage
 from corehq.apps.users.decorators import require_can_edit_web_users
@@ -156,7 +156,7 @@ class UserInvitationView(object):
                 idp = IdentityProvider.get_required_identity_provider(invitation.email)
 
             if request.method == "POST":
-                form = WebUserInvitationForm(
+                form = AcceptedWebUserInvitationForm(
                     request.POST,
                     is_sso=idp is not None,
                     allow_invite_email_only=allow_invite_email_only,
@@ -212,7 +212,7 @@ class UserInvitationView(object):
                         f"?next={accept_invitation_url}"
                         f"&username={invitation.email}"
                     )
-                form = WebUserInvitationForm(
+                form = AcceptedWebUserInvitationForm(
                     initial={
                         'email': invitation.email,
                     },


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-4757
](https://dimagi.atlassian.net/browse/USH-4757)

The main change in this PR is the addition of an API validation file. This will support the upcoming API for creating Invitations and updating Web Users. The remaining changes involve refactoring to consolidate validations used when bulk uploading Web Users or creating Invitations via the AdminInvitesUserForm.

I reused relevant validations already defined for bulk user import (in user_importer.validation) since the same checks are needed. Some validations previously implemented via the clean method in Django forms were consolidated, while built-in form validations were left as-is.

The key distinction between Invitation creation via the API and via bulk user import is how existing Web Users are handled. Bulk user import checks if the Web User exists and updates it if so. In contrast, the API will have a dedicated POST endpoint for creation. This endpoint will require validating whether the Invitation or Web User already exists and returning an error if it does, mirroring the behavior of the AdminInvitesUserForm.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No feature flag

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The main changes (addition of validation for Web User creation API) will not be used yet. The changes to the existing validation code are solely refactors and I tested locally that those areas still work as expected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There exists extensive testing on bulk user imports and surrounding validation. `test_importer` checks that web user and mobile workers can be successfully uploaded/updated. `test_validators` test that Location, Profile, Custom Data, etc.. validation catches invalid or unauthorized changes. I will add missing Tableau Group and Role validation.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
