### PR TITLE
Added check that template does not use both requirejs and webpack

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -726,6 +726,7 @@ class RequireJSMainNode(template.Node):
     def __init__(self, name, value):
         self.name = name
         self.value = value
+        self.origin = None
 
     def __repr__(self):
         return "<RequireJSMain Node: %r>" % (self.value,)
@@ -733,6 +734,12 @@ class RequireJSMainNode(template.Node):
     def render(self, context):
         if self.name not in context and self.value:
             # set name in block parent context
+            other_name = "js_entry" if self.name == "requirejs_main" else "requirejs_main"
+            other_values = [d.get(other_name) for d in context.dicts if other_name in d]
+            if any(other_values):
+                raise TemplateSyntaxError(f"""
+                    Cannot use both {self.name} ({self.value}) and {other_name} ({other_values[0]})
+                """.strip())
             context.dicts[-2]['use_js_bundler'] = True
             context.dicts[-2][self.name] = self.value
         return ''

--- a/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
+++ b/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
@@ -240,3 +240,14 @@ class TagTest(SimpleTestCase):
                 {% load hq_shared_tags %}
                 {% js_entry 'x" %}
             """)
+
+    def test_requirejs_main_js_entry_conflict(self):
+        with self.assertRaises(TemplateSyntaxError) as e:
+            self.render("""
+                {% load hq_shared_tags %}
+                {% requirejs_main "module/one" %}
+                {% js_entry "module/two" %}
+            """)
+        self.assertEqual("""
+            Cannot use both js_entry (module/two) and requirejs_main (module/one)
+        """.strip(), str(e.exception))


### PR DESCRIPTION
## Technical Summary
This would have prevented https://dimagi.atlassian.net/browse/SAAS-16313, which was caused by a template using requirejs while inheriting from a template that used webpack.

## Safety Assurance

### Safety story
Adds a check for an error condition that breaks pages.

### Automated test coverage

In PR

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
