### PR TITLE
Improve handling of conflicting js bundle tools

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -29,6 +29,7 @@ from corehq.apps.hqwebapp.exceptions import (
 )
 from corehq.apps.hqwebapp.models import Alert
 from corehq.motech.utils import pformat_json
+from corehq.util.soft_assert import soft_assert
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone
 
@@ -733,15 +734,20 @@ class RequireJSMainNode(template.Node):
 
     def render(self, context):
         if self.name not in context and self.value:
+            # Check that there isn't already an entry point from the other bundler tool
+            # If there is, don't add this one, because having both set will cause js errors
+            other_tag = "js_entry" if self.name == "requirejs_main" else "requirejs_main"
+            other_value = None
+            for context_dict in context.dicts:
+                if other_tag in context_dict:
+                    other_value = context_dict.get(other_tag)
+                    msg = f"Discarding {self.value} {self.name} value because {other_value} is using {other_tag}"
+                    soft_assert('jschweers@dimagi.com', notify_admins=False, send_to_ops=False)(False, msg)
             # set name in block parent context
-            other_name = "js_entry" if self.name == "requirejs_main" else "requirejs_main"
-            other_values = [d.get(other_name) for d in context.dicts if other_name in d]
-            if any(other_values):
-                raise TemplateSyntaxError(f"""
-                    Cannot use both {self.name} ({self.value}) and {other_name} ({other_values[0]})
-                """.strip())
-            context.dicts[-2]['use_js_bundler'] = True
-            context.dicts[-2][self.name] = self.value
+            if not other_value:
+                context.dicts[-2]['use_js_bundler'] = True
+                context.dicts[-2][self.name] = self.value
+
         return ''
 
 

--- a/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
+++ b/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
@@ -242,12 +242,10 @@ class TagTest(SimpleTestCase):
             """)
 
     def test_requirejs_main_js_entry_conflict(self):
-        with self.assertRaises(TemplateSyntaxError) as e:
+        msg = "Discarding module/two js_entry value because module/one is using requirejs_main"
+        with self.assertRaisesMessage(AssertionError, msg):
             self.render("""
                 {% load hq_shared_tags %}
                 {% requirejs_main "module/one" %}
                 {% js_entry "module/two" %}
             """)
-        self.assertEqual("""
-            Cannot use both js_entry (module/two) and requirejs_main (module/one)
-        """.strip(), str(e.exception))


### PR DESCRIPTION
## Technical Summary
This is a followup for https://github.com/dimagi/commcare-hq/pull/35449 and a fix for https://dimagi.atlassian.net/browse/SAAS-16317

Instead of erroring out, discard one of the bundles. Keep the bundle in the leaf-most node of the inheritance tree. Templates appear to be processed from the bottom of the tree upwards, so that means discarding the bundle currently being processed if any bundles already exist in the template context that's already been processed.

## Safety Assurance

### Safety story
This ought to affect a fairly small set of templates that have an inheritance tree using both requirejs and webpack. I believe that's only the accounting app (although this situation may come up again as UCR and reports get migrated to webpack).

Templates in this situation currently break with js errors, so this PR shouldn't make the situation any worse.

### Automated test coverage

There's test coverage in the PR, although it's not as fleshed out as I'd like - it doesn't cover template inheritance.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
