### PR TITLE
Treat OSErrors as exceptions, not payload failures

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1194,6 +1194,9 @@ class RepeatRecord(models.Model):
         if force_send or not self.succeeded:
             try:
                 self.repeater.fire_for_record(self, timing_context=timing_context)
+            except OSError as e:
+                self.handle_exception(str(e))
+                raise
             except Exception as e:
                 self.handle_payload_error(str(e), traceback_str=traceback.format_exc())
                 raise


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-16323

Occasionally we have stale celery workers that ultimately run into an OSError when attempting to access code that no longer exists if the release it is running on has been cleaned up. See this stack trace for example:
```
Traceback (most recent call last):
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/motech/repeaters/tasks.py", line 192, in _process_repeat_record
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/motech/repeaters/models.py", line 1196, in fire
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/motech/repeaters/models.py", line 453, in fire_for_record
  File "/home/cchq/www/production/releases/2024-11-21_08.58/python_env-3.9/lib/python3.9/site-packages/memoized.py", line 20, in _memoized
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/motech/repeaters/expression/repeaters.py", line 93, in get_payload
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/motech/repeaters/expression/repeater_generators.py", line 19, in get_payload
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/motech/repeaters/expression/repeater_generators.py", line 71, in _generate_payload
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/apps/userreports/expressions/specs.py", line 453, in __call__
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/apps/userreports/expressions/specs.py", line 901, in __call__
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/apps/userreports/expressions/specs.py", line 850, in __call__
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/apps/userreports/expressions/extension_expressions.py", line 61, in __call__
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/apps/userreports/expressions/specs.py", line 605, in __call__
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/apps/userreports/expressions/specs.py", line 626, in get_value
  File "/home/cchq/www/production/releases/2024-11-21_08.58/corehq/apps/userreports/decorators.py", line 50, in _inner
  File "/usr/lib/python3.9/inspect.py", line 1024, in getsource
    lines, lnum = getsourcelines(object)
  File "/usr/lib/python3.9/inspect.py", line 1006, in getsourcelines
    lines, lnum = findsource(object)
  File "/usr/lib/python3.9/inspect.py", line 835, in findsource
    raise OSError('could not get source code')
```

Since this was happening when attempting to fetch the payload, this was being treated as a payload error and therefore not being retried. However this is an issue on our end, and while this isn't the perfect solution (ideally we wouldn't get into this state in the first place), we should at least treat OSErrors as non-payload related failures that will be retried, since there is a chance it will succeed on the next attempt.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
