### PR TITLE
Don't fail on system prop datetime eq matches

### DIFF
--- a/corehq/apps/case_search/xpath_functions/comparison.py
+++ b/corehq/apps/case_search/xpath_functions/comparison.py
@@ -126,6 +126,8 @@ def _create_system_datetime_query(domain, meta_property, op, value, node):
         raise CaseFilterError(str(e), serialize(node))
 
     if isinstance(date_or_datetime, datetime):
+        if op == EQ:
+            return filters.term(meta_property.es_field_name, value)
         range_kwargs = {RANGE_OP_MAPPING[op]: date_or_datetime}
     else:
         timezone = get_timezone_for_domain(domain)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
When I made it possible to do datetime queries in https://github.com/dimagi/commcare-hq/pull/35404, I neglected to implement `=`.  Apparently someone tried to do just that:

https://dimagi.sentry.io/issues/6096595278/?project=136860

It doesn't seem super useful to be able to do this (you'd have to get it right to the millisecond), but at least it shouldn't fail...

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
