### PR TITLE
Add django-tables2 and utils, example, docs for usage with HTMX

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_base.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_base.js
@@ -26,6 +26,8 @@ import htmx from 'htmx.org';
 
 import 'hqwebapp/js/htmx_utils/hq_hx_action';
 import 'hqwebapp/js/htmx_utils/csrf_token';
+import 'hqwebapp/js/htmx_utils/hq_hx_loading';
+import 'hqwebapp/js/htmx_utils/hq_hx_refresh';
 import retryHtmxRequest from 'hqwebapp/js/htmx_utils/retry_request';
 import { showHtmxErrorModal } from 'hqwebapp/js/htmx_utils/errors';
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_loading.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_loading.js
@@ -1,0 +1,25 @@
+/*
+    Adds an `is-loading` class to the element with ID specified in the `hq-hx-loading` attribute.
+    This `is-loading` class is applied when to that ID before an HTMX request begins, and is
+    removed after an HTMX swap is completed.
+
+    This is useful for adding loading indicators to elements outside the parent heirarchy available
+    through using `hx-indicator` alone. Right now, this is used to add an `is-loading` style to a django tables
+    table, which overlays a loading indicator across the entire table (seen in hqwebapp/tables/bootstrap5_htmx.html)
+ */
+document.body.addEventListener('htmx:beforeRequest', (evt) => {
+    if (evt.detail.elt.hasAttribute('hq-hx-loading')) {
+        let loadingElt = document.getElementById(evt.detail.elt.getAttribute('hq-hx-loading'));
+        if (loadingElt) {
+            loadingElt.classList.add('is-loading');
+        }
+    }
+});
+document.body.addEventListener('htmx:afterSwap', (evt) => {
+    if (evt.detail.elt.hasAttribute('hq-hx-loading')) {
+        let loadingElt = document.getElementById(evt.detail.elt.getAttribute('hq-hx-loading'));
+        if (loadingElt && loadingElt.classList.contains('is-loading')) {
+            loadingElt.classList.remove('is-loading');
+        }
+    }
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_refresh.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_refresh.js
@@ -1,0 +1,10 @@
+/*
+    Sends an `hqRefresh` event to the selector (element) specified in the `hq-hx-refresh` attribute.
+ */
+import htmx from 'htmx.org';
+
+document.body.addEventListener('htmx:afterSwap', (evt) => {
+    if (evt.detail.elt.hasAttribute('hq-hx-refresh')) {
+        htmx.trigger(evt.detail.elt.getAttribute('hq-hx-refresh'), 'hqRefresh');
+    }
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_refresh.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_refresh.js
@@ -1,10 +1,32 @@
 /*
-    Sends an `hqRefresh` event to the selector (element) specified in the `hq-hx-refresh` attribute.
+    Used to chain an `hqRefresh` event to a related HTMX element making a request.
+
+    The attribute `hq-hx-refresh-after` sends the `hqRefresh` event to the target selector
+    element on `htmx:afterRequest`.
+
+    THe attribute `hq-hx-refresh-swap` sends the `hqRefresh` event to the target selector
+    element on `htmx:afterSwap`.
+
+    The value of the attributes should be a css selector--for example, `#element` where element is the CSS id.
+
+    The target element can then apply `hx-trigger="hqRefresh"`, effectively chaining a refresh event to the
+    original triggering request.
+
+    This is commonly used to trigger a refresh of tabular data with Django Tables using the `BaseHtmxTable`
+    subclass. However, it can be used to chain other HTMX elements together
  */
 import htmx from 'htmx.org';
 
-document.body.addEventListener('htmx:afterSwap', (evt) => {
-    if (evt.detail.elt.hasAttribute('hq-hx-refresh')) {
-        htmx.trigger(evt.detail.elt.getAttribute('hq-hx-refresh'), 'hqRefresh');
+const handleRefresh = (evt, attribute) => {
+    if (evt.detail.elt.hasAttribute(attribute)) {
+        htmx.trigger(evt.detail.elt.getAttribute(attribute), 'hqRefresh');
     }
+};
+
+document.body.addEventListener('htmx:afterRequest', (evt) => {
+    handleRefresh(evt, 'hq-hx-refresh-after');
+});
+
+document.body.addEventListener('htmx:afterSwap', (evt) => {
+    handleRefresh(evt, 'hq-hx-refresh-swap');
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_tables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_tables.scss
@@ -128,3 +128,43 @@
     background-color: $blue-700;
   }
 }
+
+.table-container {
+  position: relative;
+
+  .table-loading-indicator {
+    z-index: 1000;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    background: rgba(255, 255, 255, 0.25);
+    display: none;
+
+    &.is-loading {
+      display: block;
+    }
+
+    .spinner-border {
+      position: absolute;
+      border-width: $table-loading-spinner-border-width;
+      color: rgba(0, 0, 0, 0.25);
+      width: $table-loading-spinner-size;
+      height: $table-loading-spinner-size;
+      $_offset: $table-loading-spinner-size / 2;
+      left: calc(50% - $_offset);
+      top: calc(50% - $_offset);
+    }
+
+    .table-loading-progress {
+      z-index: 1000;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      background-color: $white;
+      font-weight: bold;
+    }
+  }
+}

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_tables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_tables.scss
@@ -76,3 +76,55 @@
 .table-editprops-filterval {
   min-width: 115px;
 }
+
+.table thead tr th.orderable {
+  position: relative;
+  padding: 0;
+
+  a {
+    display: block;
+    background-color: $blue-800;
+    color: $white;
+    padding: 0.5rem 0.5rem;
+  }
+  &:nth-child(odd) a {
+    background-color: $blue-700;
+  }
+
+  &::before,
+  &::after {
+    position: absolute;
+    display: block;
+    right: 10px;
+    line-height: 9px;
+    font-size: .8em;
+    color: $white;
+    opacity: 0.3;
+  }
+
+  &::before {
+    bottom: 50%;
+    content: "▲" / "";
+  }
+
+  &::after {
+    top: 50%;
+    content: "▼" / "";
+  }
+
+  &.asc::before {
+    opacity: 1.0;
+  }
+  &.desc::after {
+    opacity: 1.0;
+  }
+}
+
+.table thead tr th.select-header {
+  width: 28px;
+  background-color: $blue-800;
+
+  &:nth-child(odd) {
+    background-color: $blue-700;
+  }
+}

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables.scss
@@ -230,3 +230,7 @@ $form-validation-states: (
 // Make pagination-lg the same height as other lg inputs
 $pagination-padding-x-lg: 1.0rem;
 $pagination-padding-y-lg: 0.5rem;
+
+// Table loading indicator
+$table-loading-spinner-size: 150px;
+$table-loading-spinner-border-width: 20px;

--- a/corehq/apps/hqwebapp/tables/htmx.py
+++ b/corehq/apps/hqwebapp/tables/htmx.py
@@ -1,0 +1,50 @@
+from django_tables2 import tables
+
+DEFAULT_HTMX_TEMPLATE = "hqwebapp/tables/bootstrap5_htmx.html"
+
+
+class BaseHtmxTable(tables.Table):
+    """
+    This class provides a starting point for using HTMX with Django Tables.
+
+    usage:
+
+        class MyNewTable(BaseHtmxTable):
+
+            class Meta(BaseHtmxTable.Meta):
+                pass  # or you can override or add table attributes here -- see Django Tables docs
+
+    Optional class properties:
+
+        :container_id: -  a string
+            The `container_id` is used as the css `id` of the parent div surrounding table,
+            its pagination, and related elements.
+
+            You can then use `hq-hx-refresh="#{{ container_id }}"` to trigger a
+            refresh on the table from another HTMX request on the page.
+
+            When not specified, `container_id` is the table's class name
+
+        :loading_indicator_id: - a string
+            By default this is ":container_id:-loading". It is the css id of the table's
+            loading indicator that covers the whole table. The loading indicator for the table
+            can be triggered by any element making an HTMX request using
+            `hq-hx-loading="{{ loading_indicator_id }}"`.
+
+    See `hqwebapp/tables/bootstrap5_htmx.html` and `hqwebapp/tables/bootstrap5.html` for usage of the
+    above properties and related `hq-hx-` attributes. There is also an example in the styleguide.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not hasattr(self, 'container_id'):
+            self.container_id = self.__class__.__name__
+        if not hasattr(self, 'loading_indicator_id'):
+            self.loading_indicator_id = f"{self.container_id}-loading"
+
+    class Meta:
+        attrs = {
+            'class': 'table table-striped',
+        }
+        template_name = DEFAULT_HTMX_TEMPLATE

--- a/corehq/apps/hqwebapp/tables/pagination.py
+++ b/corehq/apps/hqwebapp/tables/pagination.py
@@ -1,0 +1,52 @@
+from django.core.paginator import Paginator
+from django.views.generic.list import ListView
+
+from django_tables2 import SingleTableMixin
+
+
+class SelectablePaginator(Paginator):
+    paging_options = [10, 25, 50, 100]
+    default_option = 25
+
+
+class SelectablePaginatedTableMixin(SingleTableMixin):
+    """
+    Use this mixin with django-tables2's SingleTableView
+
+    Specify a `urlname` attribute to assist with naming the pagination cookie,
+    otherwise the cookie slug will default to using the class name.
+    """
+    # `paginator_class` should always be a subclass of `SelectablePaginator`
+    paginator_class = SelectablePaginator
+
+    @property
+    def paginate_by_cookie_slug(self):
+        slug = self.urlname if hasattr(self, "urlname") else self.__class__.__name__
+        return f'{slug}-paginate_by'
+
+    @property
+    def default_paginate_by(self):
+        return self.request.COOKIES.get(
+            self.paginate_by_cookie_slug,
+            self.paginator_class.default_option
+        )
+
+    @property
+    def current_paginate_by(self):
+        return self.request.GET.get('per_page', self.default_paginate_by)
+
+    def get_paginate_by(self, table_data):
+        return self.current_paginate_by
+
+
+class SelectablePaginatedTableView(SelectablePaginatedTableMixin, ListView):
+    """
+    Based on SingleTableView, which inherits from `SingleTableMixin`, `ListView`
+    we instead extend the `SingleTableMixin` with `SavedPaginatedTableMixin`.
+    """
+    template_name = "hqwebapp/tables/single_table.html"
+
+    def get(self, request, *args, **kwargs):
+        response = super().get(request, *args, **kwargs)
+        response.set_cookie(self.paginate_by_cookie_slug, self.current_paginate_by)
+        return response

--- a/corehq/apps/hqwebapp/tables/pagination.py
+++ b/corehq/apps/hqwebapp/tables/pagination.py
@@ -21,7 +21,7 @@ class SelectablePaginatedTableMixin(SingleTableMixin):
 
     @property
     def paginate_by_cookie_slug(self):
-        slug = self.urlname if hasattr(self, "urlname") else self.__class__.__name__
+        slug = getattr(self, "urlname", self.__class__.__name__)
         return f'{slug}-paginate_by'
 
     @property

--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5.html
@@ -1,0 +1,122 @@
+{% extends 'django_tables2/bootstrap5.html' %}
+{% load i18n %}
+{% load django_tables2 %}
+{% load hq_shared_tags %}
+{% load hq_tables_tags %}
+
+{% block table-wrapper %}
+  <div
+    class="table-container"
+    {% if table.container_id %}
+      id="{{ table.container_id }}"
+    {% endif %}
+    {% block table-container-attrs %}{% endblock %}
+  >
+
+    {% block before_table %}{% endblock %}
+
+    {% block table %}{{ block.super }}{% endblock table %}
+
+    <div class="pb-3 d-flex justify-content-between">
+      <div>
+        {% block num_entries %}
+          <div class="input-group">
+            <div class="input-group-text">
+              {% block num_entries.text %}
+                {% with start=table.page.start_index end=table.page.end_index total=table.page.paginator.count %}
+                  {% blocktranslate %}
+                    Showing {{ start }} to {{ end }} of {{ total }} entries
+                  {% endblocktranslate %}
+                {% endwith %}
+              {% endblock num_entries.text %}
+            </div>
+            {% block num_entries.select %}
+              <select
+                class="form-select"
+                {% block select-per-page-attr %}{% endblock %}
+              >
+                {% for p in table.paginator.paging_options %}
+                  <option
+                    value="{{ p }}"
+                    {% if p == table.paginator.per_page %} selected{% endif %}
+                  >
+                    {% blocktrans %}
+                      {{ p }} per page
+                    {% endblocktrans %}
+                  </option>
+                {% endfor %}
+              </select>
+            {% endblock %}
+          </div>
+        {% endblock num_entries %}
+      </div>
+      <div>
+        {% block pagination %}
+          {% if table.page and table.paginator.num_pages > 1 %}
+            <nav aria-label="Table navigation">
+              <ul class="pagination">
+
+                {% block pagination.previous %}
+                  <li class="previous page-item{% if not table.page.has_previous %} disabled{% endif %}">
+                    <a
+                      class="page-link"
+                      {% if table.page.has_previous %}
+                        {% block prev-page-link-attr %}
+                          href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}"
+                        {% endblock %}
+                      {% endif %}
+                    >
+                      {% trans 'Previous' %}
+                    </a>
+                  </li>
+                {% endblock pagination.previous %}
+
+                {% if table.page.has_previous or table.page.has_next %}
+                  {% block pagination.range %}
+                    {% for p in table.page|table_page_range:table.paginator %}
+                      <li class="page-item{% if table.page.number == p %} active{% endif %}">
+                        <a
+                          class="page-link"
+                          {% if p != '...' %}
+                            href="{% querystring table.prefixed_page_field=p %}"
+                          {% endif %}
+                        >
+                          {{ p }}
+                        </a>
+                      </li>
+                    {% endfor %}
+                  {% endblock pagination.range %}
+                {% endif %}
+
+                {% block pagination.next %}
+                  <li class="next page-item{% if not table.page.has_next %} disabled{% endif %}">
+                    <a
+                      class="page-link"
+                      {% if table.page.has_next %}
+                        {% block next-page-link-attr %}
+                          href="{% querystring table.prefixed_page_field=table.page.next_page_number %}"
+                        {% endblock %}
+                      {% endif %}
+                    >
+                      {% trans 'Next' %}
+                    </a>
+                  </li>
+                {% endblock pagination.next %}
+
+              </ul>
+            </nav>
+          {% endif %}
+        {% endblock pagination %}
+      </div>
+    </div>
+
+    {% block after_table %}{% endblock %}
+
+  </div>
+{% endblock table-wrapper %}
+
+{% block table.thead %}
+  {% if table.show_header %}
+    {% render_header %}
+  {% endif %}
+{% endblock table.thead %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5_htmx.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5_htmx.html
@@ -1,0 +1,78 @@
+{% extends "hqwebapp/tables/bootstrap5.html" %}
+{% load i18n %}
+{% load django_tables2 %}
+{% load hq_shared_tags %}
+{% load hq_tables_tags %}
+
+{% block table.thead %}
+  {% if table.show_header %}
+    {% render_header 'htmx' %}
+  {% endif %}
+{% endblock table.thead %}
+
+{% block table-container-attrs %}
+  hx-get="{{ request.path_info }}{% querystring %}"
+  hx-replace-url="{% querystring %}"
+  hx-swap="outerHTML"
+  hx-trigger="hqRefresh"
+  hq-hx-loading="{{ table.loading_indicator_id  }}"
+{% endblock %}
+
+{% block after_table %}
+  <div
+    class="table-loading-indicator"
+    {% if table.loading_indicator_id %}
+      id="{{ table.loading_indicator_id  }}"
+    {% endif %}
+  >
+    <div class="spinner-border" role="status">
+      <span class="visually-hidden">{% trans "Loading..." %}</span>
+    </div>
+  </div>
+{% endblock %}
+
+{% block select-per-page-attr %}
+  name="{{ table.per_page_field }}"
+  hx-get="{{ request.path_info }}"
+  hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+  hx-swap="outerHTML"
+  hq-hx-loading="{{ table.loading_indicator_id  }}"
+{% endblock %}
+
+{% block prev-page-link-attr %}
+  hx-get="{{ request.path_info }}{% querystring table.prefixed_page_field=table.page.previous_page_number %}"
+  hx-replace-url="{% querystring table.prefixed_page_field=table.page.previous_page_number %}"
+  hx-trigger="click"
+  hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+  hx-swap="outerHTML"
+  hq-hx-loading="{{ table.loading_indicator_id  }}"
+{% endblock %}
+
+{% block next-page-link-attr %}
+  hx-get="{{ request.path_info }}{% querystring table.prefixed_page_field=table.page.next_page_number %}"
+  hx-replace-url="{% querystring table.prefixed_page_field=table.page.next_page_number %}"
+  hx-trigger="click"
+  hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+  hx-swap="outerHTML"
+  hq-hx-loading="{{ table.loading_indicator_id  }}"
+{% endblock %}
+
+{% block pagination.range %}
+  {% for p in table.page|table_page_range:table.paginator %}
+    <li class="page-item{% if table.page.number == p %} active{% endif %}">
+      <a
+        class="page-link"
+        {% if p != '...' %}
+          hx-get="{{ request.path_info }}{% querystring table.prefixed_page_field=p %}"
+          hx-replace-url="{% querystring table.prefixed_page_field=p %}"
+          hx-trigger="click"
+          hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+          hx-swap="outerHTML"
+          hq-hx-loading="{{ table.loading_indicator_id  }}"
+        {% endif %}
+      >
+        {{ p }}
+      </a>
+    </li>
+  {% endfor %}
+{% endblock pagination.range %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5_htmx.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5_htmx.html
@@ -15,7 +15,7 @@
   hx-replace-url="{% querystring %}"
   hx-swap="outerHTML"
   hx-trigger="hqRefresh"
-  hq-hx-loading="{{ table.loading_indicator_id  }}"
+  hq-hx-loading="{{ table.loading_indicator_id }}"
 {% endblock %}
 
 {% block after_table %}
@@ -36,7 +36,7 @@
   hx-get="{{ request.path_info }}"
   hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
   hx-swap="outerHTML"
-  hq-hx-loading="{{ table.loading_indicator_id  }}"
+  hq-hx-loading="{{ table.loading_indicator_id }}"
 {% endblock %}
 
 {% block prev-page-link-attr %}
@@ -45,7 +45,7 @@
   hx-trigger="click"
   hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
   hx-swap="outerHTML"
-  hq-hx-loading="{{ table.loading_indicator_id  }}"
+  hq-hx-loading="{{ table.loading_indicator_id }}"
 {% endblock %}
 
 {% block next-page-link-attr %}
@@ -54,7 +54,7 @@
   hx-trigger="click"
   hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
   hx-swap="outerHTML"
-  hq-hx-loading="{{ table.loading_indicator_id  }}"
+  hq-hx-loading="{{ table.loading_indicator_id }}"
 {% endblock %}
 
 {% block pagination.range %}
@@ -68,7 +68,7 @@
           hx-trigger="click"
           hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
           hx-swap="outerHTML"
-          hq-hx-loading="{{ table.loading_indicator_id  }}"
+          hq-hx-loading="{{ table.loading_indicator_id }}"
         {% endif %}
       >
         {{ p }}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5_htmx.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5_htmx.html
@@ -34,7 +34,7 @@
 {% block select-per-page-attr %}
   name="{{ table.per_page_field }}"
   hx-get="{{ request.path_info }}"
-  hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+  hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"
   hx-swap="outerHTML"
   hq-hx-loading="{{ table.loading_indicator_id }}"
 {% endblock %}
@@ -43,7 +43,7 @@
   hx-get="{{ request.path_info }}{% querystring table.prefixed_page_field=table.page.previous_page_number %}"
   hx-replace-url="{% querystring table.prefixed_page_field=table.page.previous_page_number %}"
   hx-trigger="click"
-  hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+  hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"
   hx-swap="outerHTML"
   hq-hx-loading="{{ table.loading_indicator_id }}"
 {% endblock %}
@@ -52,7 +52,7 @@
   hx-get="{{ request.path_info }}{% querystring table.prefixed_page_field=table.page.next_page_number %}"
   hx-replace-url="{% querystring table.prefixed_page_field=table.page.next_page_number %}"
   hx-trigger="click"
-  hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+  hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"
   hx-swap="outerHTML"
   hq-hx-loading="{{ table.loading_indicator_id }}"
 {% endblock %}
@@ -66,7 +66,7 @@
           hx-get="{{ request.path_info }}{% querystring table.prefixed_page_field=p %}"
           hx-replace-url="{% querystring table.prefixed_page_field=p %}"
           hx-trigger="click"
-          hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+          hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"
           hx-swap="outerHTML"
           hq-hx-loading="{{ table.loading_indicator_id }}"
         {% endif %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/header.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/header.html
@@ -1,0 +1,46 @@
+{% load querystring from django_tables2 %}
+
+<thead {{ table.attrs.thead.as_html }}>
+  <tr>
+    {% for column in table.columns %}
+      <th
+        scope="col"
+        {{ column.attrs.th.as_html }}
+      >
+        {% if column.orderable %}
+          {% if column.sort_done %}
+            <a
+              {% if use_htmx_links %}
+                class="link"
+                hx-get="{{ request.path_info }}{% querystring without table.prefixed_order_by_field %}"
+                hx-replace-url="{% querystring without table.prefixed_order_by_field %}"
+                hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+                hx-swap="outerHTML"
+              {% else %}
+                href="{% querystring without table.prefixed_order_by_field %}"
+              {% endif %}
+            >
+              {{ column.header }}
+            </a>
+          {% else %}
+            <a
+              {% if use_htmx_links %}
+                class="link"
+                hx-get="{{ request.path_info }}{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}"
+                hx-replace-url="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}"
+                hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+                hx-swap="outerHTML"
+              {% else %}
+                href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}"
+              {% endif %}
+            >
+              {{ column.header }}
+            </a>
+          {% endif %}
+        {% else %}
+          {{ column.header }}
+        {% endif %}
+      </th>
+    {% endfor %}
+  </tr>
+</thead>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/header.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/header.html
@@ -14,7 +14,7 @@
                 class="link"
                 hx-get="{{ request.path_info }}{% querystring without table.prefixed_order_by_field %}"
                 hx-replace-url="{% querystring without table.prefixed_order_by_field %}"
-                hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+                hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"
                 hx-swap="outerHTML"
               {% else %}
                 href="{% querystring without table.prefixed_order_by_field %}"
@@ -28,7 +28,7 @@
                 class="link"
                 hx-get="{{ request.path_info }}{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}"
                 hx-replace-url="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}"
-                hx-target="{% if table.css_id %}#{{ table.css_id }}{% else %}div.table-container{% endif %}"
+                hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"
                 hx-swap="outerHTML"
               {% else %}
                 href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/header.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/header.html
@@ -8,7 +8,7 @@
         {{ column.attrs.th.as_html }}
       >
         {% if column.orderable %}
-          {% if column.sort_done %}
+          {% if column.sort_desc %}
             <a
               {% if use_htmx_links %}
                 class="link"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/header.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/header.html
@@ -16,6 +16,9 @@
                 hx-replace-url="{% querystring without table.prefixed_order_by_field %}"
                 hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"
                 hx-swap="outerHTML"
+                {% if table.loading_indicator_id %}
+                  hq-hx-loading="{{ table.loading_indicator_id }}"
+                {% endif %}
               {% else %}
                 href="{% querystring without table.prefixed_order_by_field %}"
               {% endif %}
@@ -30,6 +33,9 @@
                 hx-replace-url="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}"
                 hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"
                 hx-swap="outerHTML"
+                {% if table.loading_indicator_id %}
+                  hq-hx-loading="{{ table.loading_indicator_id }}"
+                {% endif %}
               {% else %}
                 href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}"
               {% endif %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/single_table.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/single_table.html
@@ -1,0 +1,2 @@
+{% load render_table from django_tables2 %}
+{% render_table table %}

--- a/corehq/apps/hqwebapp/templatetags/hq_tables_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_tables_tags.py
@@ -1,0 +1,19 @@
+from django import template
+
+register = template.Library()
+
+
+@register.inclusion_tag('hqwebapp/tables/header.html', takes_context=True)
+def render_header(context, link_type=None):
+    """
+    Based on
+    https://stackoverflow.com/questions/31838533/django-table2-multi-column-sorting-ui/31865765#31865765
+    For allowing multiple column sorting
+    """
+    context['use_htmx_links'] = link_type == 'htmx'
+    sorted_columns = context['request'].GET.getlist('sort')
+    for column in context['table'].columns:
+        column.sort_existing = column.name in sorted_columns
+        column.sort_done = f"-{column.name}" in sorted_columns
+        column.sort_new = not column.sort_existing and not column.sort_done
+    return context

--- a/corehq/apps/hqwebapp/templatetags/hq_tables_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_tables_tags.py
@@ -13,7 +13,5 @@ def render_header(context, link_type=None):
     context['use_htmx_links'] = link_type == 'htmx'
     sorted_columns = context['request'].GET.getlist('sort')
     for column in context['table'].columns:
-        column.sort_existing = column.name in sorted_columns
-        column.sort_done = f"-{column.name}" in sorted_columns
-        column.sort_new = not column.sort_existing and not column.sort_done
+        column.sort_desc = f"-{column.name}" in sorted_columns
     return context

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,121 +1,232 @@
+@@ -1,121 +1,236 @@
 -@import "@{b3-import-variables}";
 -
 -// Nunito Sans is used on dimagi.com and embedded in hqwebapp/base.html
@@ -334,3 +334,7 @@
 +// Make pagination-lg the same height as other lg inputs
 +$pagination-padding-x-lg: 1.0rem;
 +$pagination-padding-y-lg: 0.5rem;
++
++// Table loading indicator
++$table-loading-spinner-size: 150px;
++$table-loading-spinner-border-width: 20px;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/tables._tables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/tables._tables.style.diff.txt
@@ -18,3 +18,99 @@
      }
    }
  }
+@@ -76,3 +76,95 @@
+ .table-editprops-filterval {
+   min-width: 115px;
+ }
++
++.table thead tr th.orderable {
++  position: relative;
++  padding: 0;
++
++  a {
++    display: block;
++    background-color: $blue-800;
++    color: $white;
++    padding: 0.5rem 0.5rem;
++  }
++  &:nth-child(odd) a {
++    background-color: $blue-700;
++  }
++
++  &::before,
++  &::after {
++    position: absolute;
++    display: block;
++    right: 10px;
++    line-height: 9px;
++    font-size: .8em;
++    color: $white;
++    opacity: 0.3;
++  }
++
++  &::before {
++    bottom: 50%;
++    content: "▲" / "";
++  }
++
++  &::after {
++    top: 50%;
++    content: "▼" / "";
++  }
++
++  &.asc::before {
++    opacity: 1.0;
++  }
++  &.desc::after {
++    opacity: 1.0;
++  }
++}
++
++.table thead tr th.select-header {
++  width: 28px;
++  background-color: $blue-800;
++
++  &:nth-child(odd) {
++    background-color: $blue-700;
++  }
++}
++
++.table-container {
++  position: relative;
++
++  .table-loading-indicator {
++    z-index: 1000;
++    position: absolute;
++    width: 100%;
++    height: 100%;
++    top: 0;
++    left: 0;
++    background: rgba(255, 255, 255, 0.25);
++    display: none;
++
++    &.is-loading {
++      display: block;
++    }
++
++    .spinner-border {
++      position: absolute;
++      border-width: $table-loading-spinner-border-width;
++      color: rgba(0, 0, 0, 0.25);
++      width: $table-loading-spinner-size;
++      height: $table-loading-spinner-size;
++      $_offset: $table-loading-spinner-size / 2;
++      left: calc(50% - $_offset);
++      top: calc(50% - $_offset);
++    }
++
++    .table-loading-progress {
++      z-index: 1000;
++      position: absolute;
++      top: 0;
++      left: 0;
++      width: 100%;
++      background-color: $white;
++      font-weight: bold;
++    }
++  }
++}

--- a/corehq/apps/prototype/utils/fake_data.py
+++ b/corehq/apps/prototype/utils/fake_data.py
@@ -39,6 +39,16 @@ def get_fake_app():
     return random.choice(apps)
 
 
-def get_past_date():
+def get_owner():
+    owners = ('worker1', 'worker2', 'worker3', 'worker4')
+    return random.choice(owners)
+
+
+def get_status():
+    return random.choice(['open', 'closed'])
+
+
+def get_past_date(months_away=None):
+    months_away = months_away or [6, 12, 24, 48]
     today = datetime.datetime.today()
-    return months_from_date(today, -1 * random.choice([6, 12, 24, 48])).strftime("%Y-%m-%d")
+    return months_from_date(today, -1 * random.choice(months_away)).strftime("%Y-%m-%d")

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_pagination_data.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_pagination_data.py
@@ -1,0 +1,22 @@
+from corehq.apps.prototype.utils import fake_data
+from corehq.util.quickcache import quickcache
+
+
+@quickcache(['num_entries'])
+def generate_example_pagination_data(num_entries):
+    """
+    This function just generates some fake data made to look somewhat like a CommCare Case.
+    """
+    rows = []
+    for row in range(0, num_entries):
+        rows.append({
+            "name": f"{fake_data.get_first_name()} {fake_data.get_last_name()}",
+            "color": fake_data.get_color(),
+            "big_cat": fake_data.get_big_cat(),
+            "dob": fake_data.get_past_date(),
+            "app": fake_data.get_fake_app(),
+            "status": fake_data.get_status(),
+            "owner": fake_data.get_owner(),
+            "date_opened": fake_data.get_past_date(months_away=[0, 1, 2, 3]),
+        })
+    return rows

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_pagination_host_view.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_pagination_host_view.py
@@ -1,0 +1,18 @@
+from django.utils.decorators import method_decorator
+from django.urls import reverse
+
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.hqwebapp.views import BasePageView
+
+
+@method_decorator(use_bootstrap5, name='dispatch')
+class HtmxPaginationView(BasePageView):
+    """
+    This view hosts the Django Tables `ExamplePaginatedTableView`.
+    """
+    urlname = "styleguide_b5_htmx_pagination_view"
+    template_name = "styleguide/bootstrap5/examples/htmx_pagination.html"
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname)

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_pagination_table.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_pagination_table.py
@@ -1,0 +1,45 @@
+from django.utils.translation import gettext_lazy
+from django_tables2 import columns
+
+from corehq.apps.hqwebapp.tables.htmx import BaseHtmxTable
+
+
+class ExampleFakeDataTable(BaseHtmxTable):
+    """
+    This defines the columns for the table rendered by `ExamplePaginatedTableView`.
+
+    The variable names for each column match the keys available in
+    `generate_example_pagination_data` below, and the `verbose_name` specifies
+    the name shown to the user.
+
+    We are using the `BaseHtmxTable` parent class and defining its Meta class
+    below based on `BaseHtmxTable.Meta`, as it provides some shortcuts
+    and default styling for our use of django-tables2 with HTMX.
+    """
+    class Meta(BaseHtmxTable.Meta):
+        pass
+
+    name = columns.Column(
+        verbose_name=gettext_lazy("Name"),
+    )
+    color = columns.Column(
+        verbose_name=gettext_lazy("Color"),
+    )
+    big_cat = columns.Column(
+        verbose_name=gettext_lazy("Big Cats"),
+    )
+    dob = columns.Column(
+        verbose_name=gettext_lazy("Date of Birth"),
+    )
+    app = columns.Column(
+        verbose_name=gettext_lazy("Application"),
+    )
+    date_opened = columns.Column(
+        verbose_name=gettext_lazy("Opened On"),
+    )
+    owner = columns.Column(
+        verbose_name=gettext_lazy("Owner"),
+    )
+    status = columns.Column(
+        verbose_name=gettext_lazy("Status"),
+    )

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_pagination_table_view.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_pagination_table_view.py
@@ -1,0 +1,19 @@
+from corehq.apps.hqwebapp.tables.pagination import SelectablePaginatedTableView
+from corehq.apps.styleguide.examples.bootstrap5.htmx_pagination_data import generate_example_pagination_data
+from corehq.apps.styleguide.examples.bootstrap5.htmx_pagination_table import ExampleFakeDataTable
+
+
+class ExamplePaginatedTableView(SelectablePaginatedTableView):
+    """
+    This view returns a partial template of a table, along with its
+    page controls and page size selection. Its parent classes handle
+    pagination of a given queryset based on GET parameters in the request.
+
+    This view will be fetched by the "host" `HtmxPaginationView`
+    via an HTMX GET request.
+    """
+    urlname = "styleguide_b5_paginated_table_view"
+    table_class = ExampleFakeDataTable
+
+    def get_queryset(self):
+        return generate_example_pagination_data(100)

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/htmx_pagination.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/htmx_pagination.html
@@ -1,0 +1,47 @@
+{% extends "hqwebapp/bootstrap5/base_navigation.html" %}
+{% load hq_shared_tags %}
+{% load django_tables2 %}
+{% load i18n %}
+
+{# This is the basic entry point for pages using HTMX and Alpine that do not need additional JavaScript: #}
+{% js_entry "hqwebapp/js/htmx_and_alpine" %}
+
+{% block content %}
+  <div class="container p-5">
+    <h1 class="py-3 m-0">
+      {% trans "Simple Pagination: HTMX + Django Tables2" %}
+    </h1>
+    <p>
+      {% blocktrans %}
+        This button will trigger a refresh on the table once its HTMX request is complete:
+      {% endblocktrans %}
+      <br />
+      <button
+        class="btn btn-primary" type="button"
+        hx-get="{% url 'styleguide_a_hanging_view' %}"
+        {# the attribute below triggers an `hqRefresh` event on `ExampleFakeDataTable` after the button's request is complete #}
+        hq-hx-refresh-after="#ExampleFakeDataTable"
+        {# we use none for `hx-swap` because the URL from `hx-get` above returns nothing in this example #}
+        hx-swap="none"
+      >
+        <i class="fa fa-refresh"></i> {% trans "Refresh Table After Request" %}
+      </button>
+    </p>
+    <div
+      hx-trigger="load"
+      {# `hx-get` asynchronously loads the table from HtmxPaginationView on page load, triggered by `hx-trigger` above #}
+      {# The `{% querystring %}` template tag below is from django-tables2. It retrieves the GET parameters from the URL to properly initialize the table when they are present. #}
+      hx-get="{% url "styleguide_b5_paginated_table_view" %}{% querystring %}"
+    >
+      <div class="htmx-indicator">
+        <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading..." %}
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block modals %}
+  {# you can either include this template or include an extension of this template to show HTMX errors to the user #}
+  {% include "hqwebapp/htmx/error_modal.html" %}
+  {{ block.super }}
+{% endblock modals %}

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
@@ -259,22 +259,19 @@
     Loading Indicators
   </h2>
   <p>
-    You can use the <code>hx-indicator</code> attribute
-    (<a href="https://htmx.org/attributes/hx-indicator/" target="_blank">see docs here</a>)
-    to mark which element gets the <code>htmx-request</code> class appended to it during a request.
-    We've added custom styling to <code>_htmx.scss</code> to support the common states outlined
+    By default, if an element triggers an HTMX request, it will automatically get an <code>htmx-request</code>
+    CSS class applied to it. We've added custom styling to <code>_htmx.scss</code> to support the common states outlined
     later in this section.
   </p>
   <p>
-    By default, if an element triggers an HTMX request, it will automatically get the <code>htmx-request</code>
-    CSS class applied to it. No extra usage of the <code>hx-indicator</code> attribute is necessary. The
-    example submitting elements below showcase this default behavior <strong>without</strong> the need for
-    specific <code>hx-indicator</code> usage.
+    If you want to create new types of loading indicators for non-standard elements, you can explore using
+    the <code>hx-indicator</code> attribute
+    (<a href="https://htmx.org/attributes/hx-indicator/" target="_blank">see docs here</a>).
   </p>
   <p>
     It's often a great idea to pair button requests with <code>hx-disabled-elt="this"</code>
     (<a href="https://htmx.org/attributes/hx-disabled-elt/" target="_blank`">see docs for hx-disabled-elt</a>),
-    like the examples below, so that the requesting element or related element is disabled during the request.
+    like the examples below, so that the requesting <code>button</code> is disabled during the request.
   </p>
   <h3 id="button-loading" class="pt-4">
     Buttons

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/pagination.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/pagination.html
@@ -13,9 +13,14 @@
   <nav id="TableOfContents">
     <ul>
       <li><a href="#overview">Overview</a></li>
-      <li><a href="#using-pagination">Using Pagination</a>
+      <li><a href="#using-pagination-htmx">Using Pagination with HTMX + Django-Tables2</a>
         <ul>
-          <li><a href="#quick-example">Quick Example</a></li>
+          <li><a href="#htmx-example">An Example</a></li>
+        </ul>
+      </li>
+      <li><a href="#using-knockout-pagination">Using Pagination with Knockout</a>
+        <ul>
+          <li><a href="#ko-example">An Example</a></li>
         </ul>
       </li>
     </ul>
@@ -25,17 +30,109 @@
 {% block content %}
   <h2 id="overview">Overview</h2>
   <p>
-    HQ has a custom pagination component that uses
+    With the introduction of HTMX and Alpine as preferred front-end libraries in late 2024,
+    and phasing out Knockout beginning in 2025, newer pages using paginated data should
+    rely on <code>HTMX</code> + <code>django-tables2</code> for handling pagination moving forward.
+  </p>
+  <p>
+    HQ has previously relied on a custom pagination component that uses
     <a href="https://knockoutjs.com/documentation/component-overview.html"
        target="_blank">Knockout Components</a>.
     See
     <a href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js"
        target="_blank">pagination.js</a>
-    for full documentation.
+    for full documentation. We will cover that example here, as it's still relevant to understand
+    older code using this component.
   </p>
-  <h2 id="using-pagination" class="pt-4">
-    Using Pagination
+
+  <h2 id="using-pagination-htmx" class="pt-4">
+    Pagination with HTMX and Django Tables
   </h2>
+  <p>
+    As covered in the <a href="{% url "styleguide_htmx_and_alpine_b5" %}">HTMX + Alpine.JS</a> guide,
+    HTMX works by sending partial HTML responses to asynchronous requests triggered by special <code>hx-</code>
+    attributes added to buttons, forms, links, and other elements.
+  </p>
+  <p>
+    To assist with rendering this partial HTML template, we use
+    <a href="https://django-tables2.readthedocs.io/en/latest/" target="_blank">django-tables2</a> to paginate,
+    sort, and format tabular data.
+  </p>
+
+  <h3 id="htmx-example" class="pt-3">
+    An Example
+  </h3>
+  <p>
+    <a href="{% url "styleguide_b5_htmx_pagination_view" %}">Here is an example</a> of what this solution
+    looks like. We will go over its components in the sections below. Please make sure to also review the
+    comments within the code.
+  </p>
+
+  <h4 id="htmx-pagination-definition" class="pt-3">
+    Table Definition
+  </h4>
+  <p>
+    First, we begin with the Table Definition&mdash;<code>ExampleFakeDataTable</code> in this example.
+    It subclasses <code>BaseHtmxTable</code>, which inherits from <code>django-tables2</code>'s <code>Table</code>.
+    This object defines the table's visual style, template, and sets up the column structure and typing.
+    The template and default styling are already taken care of by <code>BaseHtmxTable.Meta</code>,
+    so most use cases just need to specify the columns when starting from <code>BaseHtmxTable</code>.
+  </p>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_pagination_table %}
+
+  <h4 id="htmx-pagination-table-view" class="pt-3">
+    Table View
+  </h4>
+  <p>
+    Next we have the Table View, <code>ExamplePaginatedTableView</code> . This view renders a page of the
+    <code>ExampleFakeDataTable</code> based on <code>GET</code> parameters and a <code>queryset</code>.
+  </p>
+  <p>
+    Since we are using HTMX, <code>ExamplePaginatedTableView</code> only returns a partial template response
+    that is just the table itself, page navigation, and page size selection&mdash;nothing else.
+    The <code>SelectablePaginatedTableView</code> parent class handles page size selection and saving that choice
+    in a cookie. It inherits from <code>django-tables2</code>'s classes and mixins, which handle pagination
+    within a given queryset.
+  </p>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_pagination_table_view %}
+  <p>
+    The queryset in this example is just an in-memory list of dicts for simplicity (seen below).
+    However, <code>django-tables2</code> also has support for Django QuerySets. We will be adding
+    support for <code>elasticsearch</code> queries soon.
+  </p>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_pagination_data %}
+
+  <h4 id="htmx-pagination-host" class="pt-3">
+    Host View
+  </h4>
+  <p>
+    Lastly, we have the host view, <code>HtmxPaginationView</code>. This view "hosts" the partial template
+    HTML returned from HTMX requests to <code>ExamplePaginatedTableView</code>.
+  </p>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_pagination_host_view %}
+  <p>
+    Its template (seen below) sets up the JavaScript context and inherits from the appropriate
+    CommCare HQ base template. A <code>div</code> makes the initial <code>hx-get</code> request to
+    <code>ExamplePaginatedTableView</code> on page load (<code>hx-trigger="load"</code>). Subsequent
+    requests are controlled by <code>hx-</code> attributes within the table's template.
+  </p>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_pagination_template %}
+  <p>
+    The host view can also interact with the table from outside the original <code>div</code>
+    that contains the partial HTML responses from <code>ExamplePaginatedTableView</code>. This example demonstrates
+    sending a refresh event to the table using the <code>hq-hx-refresh-after</code> attribute placed
+    on a <code>button</code>. After this button's own HTMX request completes, the table is reloaded.
+    This example is very simple, but you can imagine chaining a refresh event to a <code>form</code>
+    (perhaps a column filter form) that triggers table refresh after submission.
+  </p>
+
+  <h2 id="using-knockout-pagination" class="pt-4">
+    Using Knockout Pagination
+  </h2>
+  <div class="alert alert-warning">
+    Note that these steps will be deprecated in 2025, and the section will be here for reference with older
+    code, until it is no longer needed.
+  </div>
   <p>
     The best way to understand the different ways of using pagination is to see its use in HQ directly. The best
     sources for this are the Web Users and Mobile Workers pages.
@@ -63,8 +160,8 @@
       </a> that returns the pagination information
     </li>
   </ul>
-  <h3 id="quick-example" class="pt-3">
-    A Quick Example
+  <h3 id="ko-example" class="pt-3">
+    An Example
   </h3>
   <p>
     Here is a quick example simulating the pagination that should otherwise be done asynchronously as in the Web Users

--- a/corehq/apps/styleguide/urls.py
+++ b/corehq/apps/styleguide/urls.py
@@ -6,6 +6,8 @@ from corehq.apps.styleguide.examples.bootstrap5.htmx_alpine_form_views import (
     FilterDemoFormView,
 )
 from corehq.apps.styleguide.examples.bootstrap5.htmx_hq_hx_action import TodoListDemoView
+from corehq.apps.styleguide.examples.bootstrap5.htmx_pagination_host_view import HtmxPaginationView
+from corehq.apps.styleguide.examples.bootstrap5.htmx_pagination_table_view import ExamplePaginatedTableView
 from corehq.apps.styleguide.views import (
     AtomsStyleGuideView,
     MainStyleGuideView,
@@ -28,6 +30,10 @@ advanced_demo_urlpatterns = [
     url(r'^htmx_todo/$', TodoListDemoView.as_view(), name=TodoListDemoView.urlname),
     url(r'^htmx_alpine_form/$', HtmxAlpineFormDemoView.as_view(), name=HtmxAlpineFormDemoView.urlname),
     url(r'^htmx_alpine_form/form/$', FilterDemoFormView.as_view(), name=FilterDemoFormView.urlname),
+    url(r'^htmx_pagination/$', HtmxPaginationView.as_view(),
+        name=HtmxPaginationView.urlname),
+    url(r'^htmx_pagination/table/$', ExamplePaginatedTableView.as_view(),
+        name=ExamplePaginatedTableView.urlname),
 ]
 
 urlpatterns = [

--- a/corehq/apps/styleguide/utils.py
+++ b/corehq/apps/styleguide/utils.py
@@ -8,7 +8,7 @@ def get_fake_tabular_data(num_entries):
     for row in range(0, num_entries):
         rows.append([
             "patient",
-            fake_data.get_first_name() + fake_data.get_last_name(),
+            f"{fake_data.get_first_name()} {fake_data.get_last_name()}",
             fake_data.get_color(),
             fake_data.get_big_cat(),
             fake_data.get_past_date(),

--- a/corehq/apps/styleguide/utils.py
+++ b/corehq/apps/styleguide/utils.py
@@ -1,35 +1,20 @@
-import datetime
-import random
-
-from corehq.apps.accounting.utils import months_from_date
+from corehq.apps.prototype.utils import fake_data
 from corehq.util.quickcache import quickcache
 
 
 @quickcache(['num_entries'])
 def get_fake_tabular_data(num_entries):
-    case_owners = ('worker1', 'worker2', 'worker3', 'worker4')
-    status = ('open', 'closed')
-    first_names = (
-        'Arundhati', 'Karan', 'Salman', 'Aravind', 'Katherine', 'Ethan', 'Luna', 'Olivia', 'Stella', 'Aiden',
-        'Santiago', 'Sophia', 'Parry', 'Vahan', 'Vaishnavi', 'Wambui', 'Trish', 'Prakash',
-    )
-    last_names = (
-        'Rosalynne', 'Edwena', 'Karla', 'Zak', 'Eddy', 'Meg', 'Kelebogile', 'Monday', 'Coba', 'Zenzi', 'Rebecca',
-        'Sindy', 'Earline', 'Joeri', 'Hartmann', 'Elicia', 'Marianna', 'Jonathon', 'Emilia', 'Srinivas',
-    )
-    colors = ('blue', 'green', 'red', 'purple', 'salmon')
-    big_cats = ('cheetah', 'lion', 'tiger', 'panther')
-    apps = ('MCH V2', 'MCH V1', 'MCH V5')
-    today = datetime.datetime.today()
     rows = []
     for row in range(0, num_entries):
-        rows.append(
-            ["patient", random.choice(first_names) + " " + random.choice(last_names),
-             random.choice(colors),
-             random.choice(big_cats),
-             months_from_date(today, -1 * random.choice([6, 12, 24, 48])).strftime("%Y-%m-%d"),
-             random.choice(apps),
-             months_from_date(today, -1 * random.choice([0, 1, 2, 3])).strftime("%Y-%m-%d"),
-             random.choice(case_owners), random.choice(status)]
-        )
+        rows.append([
+            "patient",
+            fake_data.get_first_name() + fake_data.get_last_name(),
+            fake_data.get_color(),
+            fake_data.get_big_cat(),
+            fake_data.get_past_date(),
+            fake_data.get_fake_app(),
+            fake_data.get_past_date(months_away=[0, 1, 2, 3]),
+            fake_data.get_owner(),
+            fake_data.get_status(),
+        ])
     return rows

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -273,6 +273,26 @@ def styleguide_molecules_pagination(request):
     context.update({
         'examples': {
             'pagination': get_example_context('styleguide/bootstrap5/examples/pagination.html'),
+            'htmx_pagination_data': CodeForDisplay(
+                code=get_python_example_context('htmx_pagination_data.py'),
+                language="Python",
+            ),
+            'htmx_pagination_host_view': CodeForDisplay(
+                code=get_python_example_context('htmx_pagination_host_view.py'),
+                language="Python",
+            ),
+            'htmx_pagination_table': CodeForDisplay(
+                code=get_python_example_context('htmx_pagination_table.py'),
+                language="Python",
+            ),
+            'htmx_pagination_table_view': CodeForDisplay(
+                code=get_python_example_context('htmx_pagination_table_view.py'),
+                language="Python",
+            ),
+            'htmx_pagination_template': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/htmx_pagination.html'),
+                language="Django",
+            ),
         }
     })
     return render(request, 'styleguide/bootstrap5/molecules/pagination.html', context)

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -35,6 +35,7 @@ django-redis-sessions
 django-redis
 django-recaptcha
 django-statici18n
+django-tables2
 django-tastypie
 django-transfer
 django-two-factor-auth @ git+https://github.com/jazzband/django-two-factor-auth.git@16f688bf329526d897a33594ab598bcd3fc8eaae  # waiting for next release after 1.16.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -166,6 +166,7 @@ django==4.2.16
     #   django-recaptcha
     #   django-redis
     #   django-statici18n
+    #   django-tables2
     #   django-two-factor-auth
     #   django-user-agents
     #   djangorestframework
@@ -222,6 +223,8 @@ django-redis==5.3.0
 django-redis-sessions==0.6.2
     # via -r base-requirements.in
 django-statici18n==2.4.0
+    # via -r base-requirements.in
+django-tables2==2.7.0
     # via -r base-requirements.in
 django-tastypie==0.14.6
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -148,6 +148,7 @@ django==4.2.16
     #   django-recaptcha
     #   django-redis
     #   django-statici18n
+    #   django-tables2
     #   django-two-factor-auth
     #   django-user-agents
     #   djangorestframework
@@ -202,6 +203,8 @@ django-redis==5.3.0
 django-redis-sessions==0.6.2
     # via -r base-requirements.in
 django-statici18n==2.4.0
+    # via -r base-requirements.in
+django-tables2==2.7.0
     # via -r base-requirements.in
 django-tastypie==0.14.6
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -150,6 +150,7 @@ django==4.2.16
     #   django-recaptcha
     #   django-redis
     #   django-statici18n
+    #   django-tables2
     #   django-two-factor-auth
     #   django-user-agents
     #   djangorestframework
@@ -201,6 +202,8 @@ django-redis==5.3.0
 django-redis-sessions==0.6.2
     # via -r base-requirements.in
 django-statici18n==2.4.0
+    # via -r base-requirements.in
+django-tables2==2.7.0
     # via -r base-requirements.in
 django-tastypie==0.14.6
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -143,6 +143,7 @@ django==4.2.16
     #   django-recaptcha
     #   django-redis
     #   django-statici18n
+    #   django-tables2
     #   django-two-factor-auth
     #   django-user-agents
     #   djangorestframework
@@ -194,6 +195,8 @@ django-redis==5.3.0
 django-redis-sessions==0.6.2
     # via -r base-requirements.in
 django-statici18n==2.4.0
+    # via -r base-requirements.in
+django-tables2==2.7.0
     # via -r base-requirements.in
 django-tastypie==0.14.6
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -150,6 +150,7 @@ django==4.2.16
     #   django-recaptcha
     #   django-redis
     #   django-statici18n
+    #   django-tables2
     #   django-two-factor-auth
     #   django-user-agents
     #   djangorestframework
@@ -201,6 +202,8 @@ django-redis==5.3.0
 django-redis-sessions==0.6.2
     # via -r base-requirements.in
 django-statici18n==2.4.0
+    # via -r base-requirements.in
+django-tables2==2.7.0
     # via -r base-requirements.in
 django-tastypie==0.14.6
     # via -r base-requirements.in

--- a/settings.py
+++ b/settings.py
@@ -232,6 +232,7 @@ DEFAULT_APPS = (
     'django_otp',
     'django_otp.plugins.otp_static',
     'django_otp.plugins.otp_totp',
+    'django_tables2',
     'two_factor',
     'two_factor.plugins.phonenumber',
     'ws4redis',


### PR DESCRIPTION
## Technical Summary
This PR introduces a new python dependency `django-tables2`, which we will use to paginate and sort tabular data. In combination with HTMX, this library allows us to quickly render partial template responses of a table's page based on a `queryset` and a `requests` `GET` parameters. In combination with `HTMX`, this introduces a powerful way to easily asynchronously paginate through tabular data.

To support this combination of libraries, this PR introduces:
- custom `django-tables2` templates for Bootstrap 5 tables and Bootstrap 5 tables with `HTMX`
- A `SelectablePaginatedTableView` base class based on `django-tables2` `SingleTableView` which handles the widget selecting page length and saving that selection to a cookie (and fetching the saved value later)—similar to how our Knockout pagination component handles selecting pagination length.
- New `scss` styles for sortable headers in a `django-tables2` table
- A new custom `hq-hx` plugin called `hq-hx-loading` for triggering a loading overlay (in addition to the usual `hx-indicator` functionality...you can't easily do both at once with `hx-indicator`). We use this in our `django-tables2` `HTMX` table.
- A new `hq-hx-refresh` plugin for "chaining" an `hqRefresh` event to a target selector (the value of the `hq-hx-refresh` attribute) once the `HTMX` request on the originating element with that attribute completes. (`hq-hx-refresh-after` for `htmx:afterRequest` and `hq-hx-refresh-swap` for `htmx:afterSwap`).
- A `BaseHTmxTable` class to make setting up the `django-tables2` table definition object easier.
- A working example added to the styleguide using all the features described above.
- Documentation updates

![Screenshot 2024-12-03 at 9 19 33 PM](https://github.com/user-attachments/assets/9653d1dd-7213-4a0c-86f5-9d1c5010434b)
![Screenshot 2024-12-03 at 9 20 20 PM](https://github.com/user-attachments/assets/c8ea735a-3e97-4b85-bcc3-30405c2bb176)
![Screenshot 2024-12-03 at 9 20 00 PM](https://github.com/user-attachments/assets/97ef2cfe-4232-4a87-8ddc-9fcfb33c8f08)
![Screenshot 2024-12-03 at 9 19 45 PM](https://github.com/user-attachments/assets/68707469-15ea-4807-be94-595a3dbaa645)


## Safety Assurance

### Safety story
Safe change. Documentation updates and utilities. No changes to active pages.

### Automated test coverage
No

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
