### PR TITLE
Add management command for updating Data Dog metric

### DIFF
--- a/corehq/apps/app_manager/management/commands/top_up_app_dependencies_dropout.py
+++ b/corehq/apps/app_manager/management/commands/top_up_app_dependencies_dropout.py
@@ -57,7 +57,7 @@ class Command(DomainAppsOperationCommand):
             endkey=[domain, app_id],
             descending=True,
             reduce=False,
-            include_docs=False,
+            include_docs=True,
         ).all()
 
     def _has_app_dependencies(self, app_build):

--- a/corehq/apps/app_manager/management/commands/top_up_app_dependencies_dropout.py
+++ b/corehq/apps/app_manager/management/commands/top_up_app_dependencies_dropout.py
@@ -1,0 +1,63 @@
+import logging
+from corehq.apps.app_manager.management.commands.helpers import (
+    DomainAppsOperationCommand,
+)
+from corehq.apps.app_manager.models import Application
+from corehq.util.couch import iter_update
+from corehq.util.metrics import metrics_counter
+from corehq.apps.domain.dbaccessors import iter_domains
+
+logger = logging.getLogger('app_migration')
+logger.setLevel('DEBUG')
+
+
+class Command(DomainAppsOperationCommand):
+    help = """
+    This command is used to top up the app dependencies dropout count on Data Dog.
+    """
+
+    include_builds = False
+    include_linked_apps = True
+    include_deleted_apps = False
+
+    DOMAIN_LIST_FILENAME = 'top_up_app_dependencies_dropout_domain.txt'
+    DOMAIN_PROGRESS_NUMBER_FILENAME = 'top_up_app_dependencies_dropout_progress.txt'
+
+    def get_domains(self):
+        return [domain for domain in iter_domains()]
+
+    def run(self, domains, domain_list_position):
+        for domain in domains:
+            app_ids = self.get_app_ids(domain)
+            logger.info('Processing {} apps{}'.format(len(app_ids), f" in {domain}" if domain else ""))
+            iter_update(
+                Application.get_db(), self.check_application, app_ids, verbose=True, chunksize=self.chunk_size,
+            )
+            domain_list_position = self.increment_progress(domain_list_position)
+
+    def check_application(self, app_doc):
+        app_builds = self._get_app_builds(app_doc['domain'], app_doc['_id'])
+        if not app_builds:
+            return
+
+        if self._has_app_dependencies(app_builds[0]['value']):
+            return
+
+        for build_doc in app_builds[1:]:
+            if self._has_app_dependencies(build_doc['value']):
+                metrics_counter('commcare.app_build.dependencies_removed')
+                break
+        return None
+
+    def _get_app_builds(self, domain, app_id):
+        return Application.get_db().view(
+            'app_manager/saved_app',
+            startkey=[domain, app_id, {}],
+            endkey=[domain, app_id],
+            descending=True,
+            reduce=False,
+            include_docs=False,
+        ).all()
+
+    def _has_app_dependencies(self, app_build):
+        return app_build.get('profile', {}).get('features', {}).get('dependencies')

--- a/corehq/apps/app_manager/management/commands/top_up_app_dependencies_dropout.py
+++ b/corehq/apps/app_manager/management/commands/top_up_app_dependencies_dropout.py
@@ -41,6 +41,7 @@ class Command(DomainAppsOperationCommand):
             return
 
         if self._has_app_dependencies(app_builds[0]['value']):
+            metrics_counter('commcare.app_build.dependencies_added')
             return
 
         for build_doc in app_builds[1:]:

--- a/corehq/apps/app_manager/management/commands/top_up_app_dependencies_dropout.py
+++ b/corehq/apps/app_manager/management/commands/top_up_app_dependencies_dropout.py
@@ -5,7 +5,7 @@ from corehq.apps.app_manager.management.commands.helpers import (
 from corehq.apps.app_manager.models import Application
 from corehq.util.couch import iter_update
 from corehq.util.metrics import metrics_counter
-from corehq.apps.domain.dbaccessors import iter_domains
+from corehq.toggles import APP_DEPENDENCIES
 
 logger = logging.getLogger('app_migration')
 logger.setLevel('DEBUG')
@@ -24,7 +24,7 @@ class Command(DomainAppsOperationCommand):
     DOMAIN_PROGRESS_NUMBER_FILENAME = 'top_up_app_dependencies_dropout_progress.txt'
 
     def get_domains(self):
-        return [domain for domain in iter_domains()]
+        return APP_DEPENDENCIES.get_enabled_domains()
 
     def run(self, domains, domain_list_position):
         for domain in domains:

--- a/corehq/apps/app_manager/tests/test_management_helper.py
+++ b/corehq/apps/app_manager/tests/test_management_helper.py
@@ -1,0 +1,21 @@
+import pytest
+from unittest.mock import patch
+from corehq.apps.app_manager.management.commands.helpers import AppMigrationCommandBase
+
+
+@pytest.mark.django_db
+def test_migrate_app():
+    # Create a mock instance of AppMigrationCommandBase
+    command = AppMigrationCommandBase()
+    command.DOMAIN_LIST_FILENAME = "DOMAIN_LIST_FILENAME"
+    command.DOMAIN_PROGRESS_NUMBER_FILENAME = "DOMAIN_PROGRESS_NUMBER_FILENAME"
+
+    with patch('corehq.apps.app_manager.management.commands.helpers.iter_update') as mock_iter_update:
+        with patch.object(command, 'get_app_ids', return_value={'test_app_id'}):
+            command.handle(
+                domain=None,
+                start_from_scratch=False,
+                dry_run=False,
+                failfast=False,
+            )
+        mock_iter_update.assert_called_once()


### PR DESCRIPTION
Related to [this PR](https://github.com/dimagi/commcare-hq/pull/35455).

## Technical Summary
This PR adds a management command for updating a counter metric on Data Dog. The idea is that this command will only run once. As such, it would probably be run as part of a limited release (I only thought of running it as part of a limited release after I've completed most of this PR).

### What does the command do?
The command counts for how many applications the app dependencies feature was enabled and disabled again at some point. 

The command will iterate through all application builds on all domains and check if a certain feature was disabled at any point after it was enabled for a particular application. If it was, a datadog counter will be increased by 1 and the particular application builds iteration will move on to the next one. 

Knowing this information will give us a sense of feature dropout.

### How is the command implemented?
The management command is built on top of the `AppMigrationCommandBase`. Well, technically only certain parts of the `AppMigrationCommandBase`, which was pulled out into a super class (see [this comment](https://github.com/dimagi/commcare-hq/pull/35445#issuecomment-2500624093); maybe because I'm planning to run it as a limited release this wasn't strictly necessary, I could simply have copied and modified the class). The super class manages the processed domains and the progress of the command by persisting it to the disk (and cleans up the temp files afterwards).

Please note: this command will probably put some load on the system, so I'll be testing it first on staging to see how it performs before moving forward.   

## Feature Flag
No specific feature flag

## Safety Assurance

### Safety story
To test on staging. Tested locally

### Automated test coverage
No automated testing 

### QA Plan
No QA required

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
