### PR TITLE
Empty strings in recipient filter match unset prop

### DIFF
--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -261,12 +261,8 @@ class ScheduleInstance(PartitionedModel):
         else:
             user_data = contact.get_user_data(self.domain)
         for key, value_or_property_name in self.memoized_schedule.user_data_filter.items():
-            if key not in user_data:
-                actual_values_set = {""}
-            else:
-                actual_values_set = self.convert_to_set(user_data[key])
-
             allowed_values_set = {self._get_filter_value(v) for v in self.convert_to_set(value_or_property_name)}
+            actual_values_set = self.convert_to_set(user_data.get(key, ""))
 
             if actual_values_set.isdisjoint(allowed_values_set):
                 return False

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -262,10 +262,11 @@ class ScheduleInstance(PartitionedModel):
             user_data = contact.get_user_data(self.domain)
         for key, value_or_property_name in self.memoized_schedule.user_data_filter.items():
             if key not in user_data:
-                return False
+                actual_values_set = {""}
+            else:
+                actual_values_set = self.convert_to_set(user_data[key])
 
             allowed_values_set = {self._get_filter_value(v) for v in self.convert_to_set(value_or_property_name)}
-            actual_values_set = self.convert_to_set(user_data[key])
 
             if actual_values_set.isdisjoint(allowed_values_set):
                 return False


### PR DESCRIPTION
## Product Description

If a user field/property is created after the user and the user has not been updated yet, it is not in the user data or user case properties. In that case the conditional alert recipient filter will fail if it uses said field. With this change a filter value "" will match if a field does not exist yet in the user data or user case properties.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-5172

## Feature Flag

No, but you have to be a system admin or contractor to see the recipient filter options.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

Yes, see changes

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
