### PR TITLE
Allow enterprise console to handle percent summary data

### DIFF
--- a/corehq/apps/enterprise/static/enterprise/js/project_dashboard.js
+++ b/corehq/apps/enterprise/static/enterprise/js/project_dashboard.js
@@ -169,13 +169,25 @@ hqDefine("enterprise/js/project_dashboard", [
         return self;
     };
 
+    function localizeNumberlikeString(input) {
+        if ((typeof input === "string") && (input.endsWith('%'))) {
+            const number = input.slice(0, -1);
+            return Number(number).toLocaleString(
+                undefined,
+                {minimumFractionDigits: 1,  maximumFractionDigits: 1}
+            ) + '%';
+        } else {
+            return Number(input).toLocaleString();
+        }
+    }
+
     function updateDisplayTotal($element, kwargs) {
         const $display = $element.find(".total");
         const slug = $element.data("slug");
         const requestParams = {
             url: initialPageData.reverse("enterprise_dashboard_total", slug),
             success: function (data) {
-                $display.html(Number(data.total).toLocaleString());
+                $display.html(localizeNumberlikeString(data.total));
             },
             error: function (request) {
                 if (request.responseJSON) {


### PR DESCRIPTION
## Product Description
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/2e436795-a597-416b-87a2-12fc9b03f0eb">
(The above is meant to show that the console can now display percent summary information, not that the OData Tile will now display percents)

## Technical Summary
The current enterprise console expects numbers for summary information. Upcoming tiles need to return percent information, so this PR prepares for that.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Tested locally. This is only  display logic.

### Automated test coverage

None

### QA Plan
None

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
