### PR TITLE
Automatically determine setup_class attr

### DIFF
--- a/corehq/apps/accounting/tests/test_tasks.py
+++ b/corehq/apps/accounting/tests/test_tasks.py
@@ -12,7 +12,7 @@ from corehq.form_processor.utils.xform import TestFormMetadata
 from corehq.util.test_utils import make_es_ready_form
 
 
-@es_test(requires=[form_adapter], setup_class=True)
+@es_test(requires=[form_adapter])
 class TestCalculateFormSubmittingMobileWorkers(BaseInvoiceTestCase):
 
     @classmethod

--- a/corehq/apps/analytics/tests/test_partner_analytics_utils.py
+++ b/corehq/apps/analytics/tests/test_partner_analytics_utils.py
@@ -60,7 +60,7 @@ def _get_fake_number_of_submissions(domain, _year, _month):
     }[domain]
 
 
-@es_test(requires=[user_adapter, form_adapter], setup_class=True)
+@es_test(requires=[user_adapter, form_adapter])
 class TestPartnerAnalyticsDataUtils(TestCase):
 
     @classmethod

--- a/corehq/apps/api/odata/tests/test_auth.py
+++ b/corehq/apps/api/odata/tests/test_auth.py
@@ -16,7 +16,7 @@ from .utils import (
 )
 
 
-@es_test(requires=[case_adapter], setup_class=True)
+@es_test(requires=[case_adapter])
 @mock.patch('corehq.apps.api.odata.views.get_document_or_404', new=mock.MagicMock)
 class TestOdataAuth(TestCase, CaseOdataTestMixin):
 

--- a/corehq/apps/api/odata/tests/test_feed.py
+++ b/corehq/apps/api/odata/tests/test_feed.py
@@ -20,7 +20,7 @@ from corehq.apps.es.users import user_adapter
 from corehq.util.test_utils import flag_enabled
 
 
-@es_test(requires=[case_adapter, user_adapter], setup_class=True)
+@es_test(requires=[case_adapter, user_adapter])
 @flag_enabled('API_THROTTLE_WHITELIST')
 class TestODataCaseFeed(TestCase, CaseOdataTestMixin):
 
@@ -106,7 +106,7 @@ class TestODataCaseFeed(TestCase, CaseOdataTestMixin):
         )
 
 
-@es_test(requires=[form_adapter, user_adapter], setup_class=True)
+@es_test(requires=[form_adapter, user_adapter])
 @flag_enabled('API_THROTTLE_WHITELIST')
 class TestODataFormFeed(TestCase, FormOdataTestMixin):
 

--- a/corehq/apps/api/tests/group_resources.py
+++ b/corehq/apps/api/tests/group_resources.py
@@ -77,8 +77,8 @@ class TestGroupResource(APIResourceTest):
             "reporting": True,
         }
         response = self._assert_auth_post_resource(self.list_endpoint,
-                                    json.dumps(group_json),
-                                    content_type='application/json')
+                                                   json.dumps(group_json),
+                                                   content_type='application/json')
         self.assertEqual(response.status_code, 201)
         [group_back] = Group.by_domain(self.domain.name)
         self.addCleanup(group_back.delete)

--- a/corehq/apps/api/tests/group_resources.py
+++ b/corehq/apps/api/tests/group_resources.py
@@ -8,7 +8,7 @@ from corehq.apps.groups.models import Group
 from .utils import APIResourceTest
 
 
-@es_test(requires=[group_adapter], setup_class=True)
+@es_test(requires=[group_adapter])
 class TestGroupResource(APIResourceTest):
 
     resource = v0_5.GroupResource

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -43,7 +43,7 @@ from ..resources.v0_5 import BadRequest, UserDomainsResource
 from .utils import APIResourceTest
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class TestCommCareUserResource(APIResourceTest):
     """
     Basic sanity checking of v0_5.CommCareUserResource

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -236,7 +236,7 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         self.assertEqual(len([abv for abv in app_build_versions if abv.app_id != '1234']), 0)
 
 
-@es_test(requires=[app_adapter], setup_class=True)
+@es_test(requires=[app_adapter])
 class TestAppGetters(TestCase):
     domain = 'test-app-getters'
 

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -80,7 +80,7 @@ class ViewsBase(TestCase):
 
 @flag_enabled('CUSTOM_PROPERTIES')
 @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
-@es_test(requires=[app_adapter], setup_class=True)
+@es_test(requires=[app_adapter])
 class TestViews(ViewsBase):
     domain = 'app-manager-testviews-domain'
     username = 'cornelius'
@@ -595,7 +595,7 @@ def apps_modules_setup(test_case):
 
 
 @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
-@es_test(requires=[app_adapter], setup_class=True)
+@es_test(requires=[app_adapter])
 class TestViewGeneric(ViewsBase):
     domain = 'test-view-generic'
 

--- a/corehq/apps/app_manager/tests/views/test_paginate_releases.py
+++ b/corehq/apps/app_manager/tests/views/test_paginate_releases.py
@@ -14,7 +14,7 @@ from corehq.apps.users.models import WebUser
 from corehq.util.test_utils import flag_enabled
 
 
-@es_test(requires=[app_adapter], setup_class=True)
+@es_test(requires=[app_adapter])
 class TestPaginateReleases(TestCase):
     @classmethod
     @patch_validate_xform()

--- a/corehq/apps/callcenter/tests/test_owner_options_view.py
+++ b/corehq/apps/callcenter/tests/test_owner_options_view.py
@@ -22,7 +22,7 @@ CASE_TYPE = "cc-case-type"
 LOCATION_TYPE = "my-location"
 
 
-@es_test(requires=[group_adapter, user_adapter], setup_class=True)
+@es_test(requires=[group_adapter, user_adapter])
 class CallCenterLocationOwnerOptionsViewTest(TestCase):
 
     @classmethod

--- a/corehq/apps/callcenter/tests/test_owner_options_view.py
+++ b/corehq/apps/callcenter/tests/test_owner_options_view.py
@@ -58,7 +58,7 @@ class CallCenterLocationOwnerOptionsViewTest(TestCase):
         cls.locations = [
             make_loc('loc{}'.format(i), type=LOCATION_TYPE, domain=TEST_DOMAIN) for i in range(4)
         ]
-        cls.location_ids = {l._id for l in cls.locations}
+        cls.location_ids = {location._id for location in cls.locations}
 
         # Create users
         cls.users = [CommCareUser.create(TEST_DOMAIN, 'user{}'.format(i), '***', None, None) for i in range(3)]

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -24,7 +24,7 @@ from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from ..utils import get_case_search_results
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestCaseSearchEndpoint(TestCase):
     domain = "TestCaseSearchEndpoint"
 

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -87,7 +87,7 @@ patch_get_app_cached = mock.patch('corehq.apps.case_search.utils.get_app_cached'
                                   lambda domain, _: get_app_with_case_search(domain))
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 @mock.patch.object(DataRegistryHelper, '_check_user_has_access', new=mock.Mock())
 class TestCaseSearchRegistry(TestCase):
 

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -279,7 +279,7 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestFilterDslLookups(ElasticTestMixin, TestCase):
     maxDiff = None
 

--- a/corehq/apps/case_search/tests/test_fixtures.py
+++ b/corehq/apps/case_search/tests/test_fixtures.py
@@ -19,7 +19,7 @@ from ..fixtures import _get_template_renderer, case_search_fixture_generator
 
 
 @flag_enabled('MODULE_BADGES')
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestCaseSearchFixtures(TestCase):
     domain_name = 'test-case-search-fixtures'
 

--- a/corehq/apps/cleanup/tests/test_dbaccessors.py
+++ b/corehq/apps/cleanup/tests/test_dbaccessors.py
@@ -79,8 +79,7 @@ class TestFindSQLCasesForDeletedDomains(TestCase):
     requires=[
         form_adapter, case_adapter, group_adapter,
         user_adapter, case_search_adapter, app_adapter
-    ],
-    setup_class=True
+    ]
 )
 class TestFindESDocsForDeletedDomains(TestCase):
 

--- a/corehq/apps/cleanup/tests/test_delete_es_docs_for_domain.py
+++ b/corehq/apps/cleanup/tests/test_delete_es_docs_for_domain.py
@@ -19,8 +19,7 @@ from corehq.form_processor.tests.utils import create_form_for_test
     requires=[
         form_adapter, case_adapter, group_adapter,
         user_adapter, case_search_adapter, app_adapter
-    ],
-    setup_class=True
+    ]
 )
 class TestDeleteESDocsForDomain(TestCase):
 

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -347,7 +347,7 @@ class MiscUtilTest(TestCase):
         )
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class UsedPropsByCaseTypeTest(TestCase):
 
     domain = uuid.uuid4().hex

--- a/corehq/apps/data_interfaces/tests/test_case_deduplication.py
+++ b/corehq/apps/data_interfaces/tests/test_case_deduplication.py
@@ -39,7 +39,7 @@ from corehq.apps.locations.models import SQLLocation, LocationType
 
 
 @es_test(requires=[case_search_adapter])
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class FindingDuplicatesQueryTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -1192,7 +1192,7 @@ class TestDeduplicationRuleRuns(TestCase):
 
 
 @flag_enabled('CASE_DEDUPE_UPDATES')
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class DeduplicationBackfillTest(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/corehq/apps/data_interfaces/tests/test_deduplication_rules.py
+++ b/corehq/apps/data_interfaces/tests/test_deduplication_rules.py
@@ -14,7 +14,7 @@ from corehq.apps.es.cases import case_adapter
 from corehq.apps.es.tests.utils import es_test
 
 
-@es_test(requires=[case_adapter], setup_class=True)
+@es_test(requires=[case_adapter])
 class DeduplicationRuleCreateViewTest(TestCase):
 
     @classmethod
@@ -95,7 +95,7 @@ class DeduplicationRuleCreateViewTest(TestCase):
         return res.id
 
 
-@es_test(requires=[case_adapter], setup_class=True)
+@es_test(requires=[case_adapter])
 class DeduplicationRuleEditViewTest(TestCase):
 
     @classmethod

--- a/corehq/apps/data_interfaces/tests/test_xform_management.py
+++ b/corehq/apps/data_interfaces/tests/test_xform_management.py
@@ -10,7 +10,7 @@ from corehq.apps.es.users import user_adapter
 from corehq.apps.es.forms import form_adapter
 
 
-@es_test(requires=[form_adapter, user_adapter], setup_class=True)
+@es_test(requires=[form_adapter, user_adapter])
 class XFormManagementTest(TestCase):
 
     @classmethod

--- a/corehq/apps/enterprise/tests/test_enterprise_mobile_worker_settings.py
+++ b/corehq/apps/enterprise/tests/test_enterprise_mobile_worker_settings.py
@@ -21,7 +21,7 @@ from corehq.form_processor.utils import TestFormMetadata
 from corehq.util.test_utils import make_es_ready_form
 
 
-@es_test(requires=[user_adapter, form_adapter], setup_class=True)
+@es_test(requires=[user_adapter, form_adapter])
 class TestEnterpriseMobileWorkerSettings(TestCase):
 
     @classmethod

--- a/corehq/apps/es/tests/test_aggregations.py
+++ b/corehq/apps/es/tests/test_aggregations.py
@@ -508,7 +508,7 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
         self.checkQuery(query, json_output)
 
 
-@es_test(requires=[form_adapter], setup_class=True)
+@es_test(requires=[form_adapter])
 class TestDateHistogram(SimpleTestCase):
     domain = str(uuid.uuid4())
 

--- a/corehq/apps/es/tests/test_app_adapter.py
+++ b/corehq/apps/es/tests/test_app_adapter.py
@@ -5,7 +5,7 @@ from corehq.apps.es.apps import app_adapter
 from corehq.apps.es.tests.utils import es_test
 
 
-@es_test(requires=[app_adapter], setup_class=True)
+@es_test(requires=[app_adapter])
 class TestFromPythonInApplication(TestCase):
 
     @classmethod

--- a/corehq/apps/es/tests/test_case_adapter.py
+++ b/corehq/apps/es/tests/test_case_adapter.py
@@ -5,7 +5,7 @@ from corehq.apps.es.tests.utils import es_test
 from corehq.form_processor.tests.utils import create_case
 
 
-@es_test(requires=[case_adapter], setup_class=True)
+@es_test(requires=[case_adapter])
 class TestFromPythonInCases(TestCase):
 
     @classmethod

--- a/corehq/apps/es/tests/test_case_search_adapter.py
+++ b/corehq/apps/es/tests/test_case_search_adapter.py
@@ -18,7 +18,7 @@ from corehq.apps.es.tests.utils import es_test
 from corehq.form_processor.tests.utils import create_case
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestFromPythonInCaseSearch(TestCase):
 
     @classmethod
@@ -58,7 +58,7 @@ class TestFromPythonInCaseSearch(TestCase):
         self.assertEqual(es_case, case)
 
 
-@es_test(requires=[case_search_adapter, case_search_bha_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter, case_search_bha_adapter])
 class TestCaseSearchAdapterAlsoWritesToAnotherIndex(TestCase):
 
     @classmethod

--- a/corehq/apps/es/tests/test_domain_adapter.py
+++ b/corehq/apps/es/tests/test_domain_adapter.py
@@ -4,7 +4,7 @@ from corehq.apps.es.tests.utils import es_test
 from corehq.apps.es.domains import domain_adapter
 
 
-@es_test(requires=[domain_adapter], setup_class=True)
+@es_test(requires=[domain_adapter])
 class TestFromPythonInDomain(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
+++ b/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
@@ -308,8 +308,7 @@ class TestESSyncUtil(SimpleTestCase):
     requires=[
         _get_patched_adapter(case_adapter, True, False, 'test_cases_secondary'),
         _get_patched_adapter(case_search_adapter, True, False, 'test_casesearch_secondary')
-    ],
-    setup_class=True
+    ]
 )
 class TestCopyCheckpointsBeforeIndexSwap(TestCase):
 

--- a/corehq/apps/es/tests/test_form_adapter.py
+++ b/corehq/apps/es/tests/test_form_adapter.py
@@ -5,7 +5,7 @@ from corehq.apps.es.tests.utils import es_test
 from corehq.form_processor.tests.utils import create_form_for_test
 
 
-@es_test(requires=[form_adapter], setup_class=True)
+@es_test(requires=[form_adapter])
 class TestFromPythonInForms(TestCase):
 
     @classmethod

--- a/corehq/apps/es/tests/test_test_utils.py
+++ b/corehq/apps/es/tests/test_test_utils.py
@@ -92,7 +92,7 @@ def test_setup_cleanup_index():
 
 def test_setup_cleanup_class_index():
 
-    @es_test(requires=[pigs_adapter], setup_class=True)
+    @es_test(requires=[pigs_adapter])
     class Test(SimpleTestCase):
         def test_index_exists(self):
             assert_index_exists(pigs_adapter)
@@ -149,7 +149,7 @@ def assert_not_index_exists(adapter):
 @es_test_attr
 def test_setup_class_expects_classmethod():
     with assert_raises(ValueError, msg=re.compile("^'setup_class' expects a classmethod")):
-        @es_test(requires=[pigs_adapter], setup_class=True)
+        @es_test(requires=[pigs_adapter])
         class TestExpectsClassmethod:
             def setUpClass(self):
                 pass

--- a/corehq/apps/es/tests/test_test_utils.py
+++ b/corehq/apps/es/tests/test_test_utils.py
@@ -58,6 +58,7 @@ def test_setup_tolerates_existing_index():
 
     @es_test(requires=[cats_adapter])
     class TestCatsRequired(SimpleTestCase):
+
         def test_index_exists(self):
             assert_index_exists(cats_adapter)
 
@@ -94,6 +95,11 @@ def test_setup_cleanup_class_index():
 
     @es_test(requires=[pigs_adapter])
     class Test(SimpleTestCase):
+
+        @classmethod
+        def setUpClass(cls):
+            pass
+
         def test_index_exists(self):
             assert_index_exists(pigs_adapter)
 

--- a/corehq/apps/es/tests/test_user_adapter.py
+++ b/corehq/apps/es/tests/test_user_adapter.py
@@ -6,7 +6,7 @@ from corehq.apps.es.users import user_adapter
 from corehq.apps.users.models import CommCareUser, WebUser
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class TestFromPythonInElasticUser(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/corehq/apps/events/tests/test_es.py
+++ b/corehq/apps/events/tests/test_es.py
@@ -16,7 +16,7 @@ from ...case_search.models import CaseSearchConfig
 DOMAIN = 'test-domain'
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestAttendeeLocationFilter(TestCase):
 
     @classmethod
@@ -168,7 +168,7 @@ class TestAttendeeLocationFilter(TestCase):
         self.assertEqual(case_ids, [])
 
 
-@es_test(requires=[case_adapter], setup_class=True)
+@es_test(requires=[case_adapter])
 class TestGetPaginatedAttendees(TestCase):
 
     @classmethod

--- a/corehq/apps/events/tests/test_models.py
+++ b/corehq/apps/events/tests/test_models.py
@@ -71,7 +71,7 @@ class TestAttendeeCaseManager(TestCase):
             self.assertCountEqual(case_ids, [open_case_id, closed_case_id])
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestByLocationId(TestCase):
 
     @classmethod

--- a/corehq/apps/events/tests/test_views.py
+++ b/corehq/apps/events/tests/test_views.py
@@ -38,7 +38,7 @@ from ..views import (
 from corehq.apps.users.models import CommCareUser
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class BaseEventViewTestClass(TestCase):
 
     domain = 'test-domain'
@@ -449,7 +449,7 @@ class TestAttendeesDeleteView(BaseEventViewTestClass):
             )
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestGetAttendeesAndAttendanceTakersView(BaseEventViewTestClass):
 
     urlname = 'get_attendees_and_attendance_takers'

--- a/corehq/apps/export/tests/test_esaccessors.py
+++ b/corehq/apps/export/tests/test_esaccessors.py
@@ -8,7 +8,7 @@ from corehq.apps.export.esaccessors import get_groups_user_ids
 from corehq.apps.groups.models import Group
 
 
-@es_test(requires=[group_adapter], setup_class=True)
+@es_test(requires=[group_adapter])
 class TestGroupUserIds(SimpleTestCase):
     domain = 'group-es-domain'
 

--- a/corehq/apps/export/tests/test_export_filters.py
+++ b/corehq/apps/export/tests/test_export_filters.py
@@ -44,8 +44,7 @@ class ExportFilterTest(SimpleTestCase):
 
 
 @es_test(
-    requires=[case_adapter, form_adapter, group_adapter],
-    setup_class=True
+    requires=[case_adapter, form_adapter, group_adapter]
 )
 class ExportFilterResultTest(SimpleTestCase):
 

--- a/corehq/apps/export/tests/test_export_forms.py
+++ b/corehq/apps/export/tests/test_export_forms.py
@@ -527,7 +527,7 @@ class TestFilterCaseESExportDownloadForm(TestCase):
         self.assertEqual(case_filters, [])
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class TestFormExportFilterBuilder(TestCase):
     @classmethod
     @patch('corehq.apps.users.tasks.remove_users_test_cases')

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -670,7 +670,7 @@ class WriterTest(SimpleTestCase):
         self.assertTrue(export_save.called)
 
 
-@es_test(requires=[case_adapter], setup_class=True)
+@es_test(requires=[case_adapter])
 class ExportTest(SimpleTestCase):
 
     @classmethod

--- a/corehq/apps/geospatial/tests/test_es.py
+++ b/corehq/apps/geospatial/tests/test_es.py
@@ -35,7 +35,7 @@ def test_find_precision():
         assert_equal(precision, 4)
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestGetMaxDocCount(TestCase):
     """
     Verify ``get_max_doc_count()`` using an example pulled from

--- a/corehq/apps/geospatial/tests/test_index_geolocation_case_properties.py
+++ b/corehq/apps/geospatial/tests/test_index_geolocation_case_properties.py
@@ -11,7 +11,7 @@ from corehq.apps.geospatial.management.commands.index_geolocation_case_propertie
 from corehq.apps.geospatial.models import GeoConfig
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestGetFormCases(TestCase):
     domain = 'foobar'
     primary_case_type = 'primary'

--- a/corehq/apps/geospatial/tests/test_reports.py
+++ b/corehq/apps/geospatial/tests/test_reports.py
@@ -58,7 +58,7 @@ def test_validate_geometry_schema():
 
 
 @flag_enabled('MICROPLANNING')
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestCaseGroupingReport(BaseReportTest):
 
     @classmethod

--- a/corehq/apps/geospatial/tests/test_tasks.py
+++ b/corehq/apps/geospatial/tests/test_tasks.py
@@ -14,7 +14,7 @@ from corehq.apps.geospatial.tasks import index_es_docs_with_location_props
 from corehq.apps.geospatial.utils import get_celery_task_tracker
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestIndexESDocsWithLocationProps(TestCase):
     domain = 'test'
     gps_prop_name = 'gps-stuff'

--- a/corehq/apps/geospatial/tests/test_utils.py
+++ b/corehq/apps/geospatial/tests/test_utils.py
@@ -55,7 +55,7 @@ class TestGetGeoProperty(TestCase):
         self.assertEqual(get_geo_user_property(None), GPS_POINT_CASE_PROPERTY)
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestSetGPSProperty(TestCase):
     DOMAIN = 'test-domain'
 

--- a/corehq/apps/geospatial/tests/test_views.py
+++ b/corehq/apps/geospatial/tests/test_views.py
@@ -219,7 +219,7 @@ class GeoConfigViewTestClass(TestCase):
         self.assertEqual(config.selected_disbursement_algorithm, GeoConfig.RADIAL_ALGORITHM)
 
 
-@es_test(requires=[case_adapter], setup_class=True)
+@es_test(requires=[case_adapter])
 class TestGPSCaptureView(BaseGeospatialViewClass):
     urlname = GPSCaptureView.urlname
 
@@ -240,7 +240,7 @@ class TestGPSCaptureView(BaseGeospatialViewClass):
 
 
 @flag_enabled('MICROPLANNING')
-@es_test(requires=[case_search_adapter, user_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter, user_adapter])
 class TestGetPaginatedCasesOrUsers(BaseGeospatialViewClass):
     urlname = 'get_paginated_cases_or_users'
 
@@ -327,7 +327,7 @@ class TestGetPaginatedCasesOrUsers(BaseGeospatialViewClass):
         self.assertEqual(response.json(), expected_output)
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class TestGetUsersWithGPS(BaseGeospatialViewClass):
     urlname = 'get_users_with_gps'
 

--- a/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
+++ b/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
@@ -29,7 +29,7 @@ class ExitEarlyException(Exception):
     pass
 
 
-@es_test(requires=[case_search_adapter, case_adapter, form_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter, case_adapter, form_adapter])
 class TestStaleDataInESSQL(TestCase):
 
     project_name = 'sql-project'

--- a/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
@@ -25,7 +25,7 @@ from corehq.util.test_utils import (
 from corehq.apps.data_dictionary.models import CaseType
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 @disable_quickcache
 @privilege_enabled(privileges.API_ACCESS)
 @flag_enabled('CASE_API_V0_6')

--- a/corehq/apps/hqcase/tests/test_case_api_permissions.py
+++ b/corehq/apps/hqcase/tests/test_case_api_permissions.py
@@ -33,7 +33,7 @@ from corehq.util.test_utils import (
     form_adapter,
     user_adapter,
     case_adapter,
-], setup_class=True)
+])
 @disable_quickcache
 @privilege_enabled(privileges.API_ACCESS)
 @flag_enabled('CASE_API_V0_6')

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -25,7 +25,7 @@ GOOD_GUYS_ID = str(uuid.uuid4())
 BAD_GUYS_ID = str(uuid.uuid4())
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 @privilege_enabled(privileges.API_ACCESS)
 class TestCaseListAPI(TestCase):
     domain = 'test-case-list-api'

--- a/corehq/apps/hqcase/tests/test_serialization.py
+++ b/corehq/apps/hqcase/tests/test_serialization.py
@@ -15,7 +15,7 @@ from ..api.core import serialize_case, serialize_es_case
 from ..utils import submit_case_blocks
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestAPISerialization(TestCase):
     domain = 'test-update-cases'
     maxDiff = None

--- a/corehq/apps/locations/tests/test_dbaccessors.py
+++ b/corehq/apps/locations/tests/test_dbaccessors.py
@@ -28,7 +28,7 @@ from .util import make_loc, delete_all_locations
 from ..dbaccessors import get_filtered_locations_count
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class TestUsersByLocation(TestCase):
 
     @classmethod

--- a/corehq/apps/reports/tests/test_case_copy.py
+++ b/corehq/apps/reports/tests/test_case_copy.py
@@ -22,7 +22,7 @@ from corehq.util.test_utils import privilege_enabled, flag_enabled
 from corehq import privileges
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestCaseCopyAPI(TestCase):
     domain = 'test-domain'
     url_name = 'copy_cases'

--- a/corehq/apps/reports/tests/test_case_list_report.py
+++ b/corehq/apps/reports/tests/test_case_list_report.py
@@ -17,7 +17,7 @@ from corehq.form_processor.models import CommCareCase
 from corehq.util.test_utils import flag_enabled
 
 
-@es_test(requires=[case_adapter, group_adapter, user_adapter], setup_class=True)
+@es_test(requires=[case_adapter, group_adapter, user_adapter])
 class TestCaseListReport(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/corehq/apps/reports/tests/test_enterprise_user_filter.py
+++ b/corehq/apps/reports/tests/test_enterprise_user_filter.py
@@ -19,7 +19,7 @@ from corehq.apps.users.models import (
 from corehq.apps.locations.tests.util import setup_locations_and_types
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class BaseEnterpriseUserFilterTest(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -77,7 +77,7 @@ from corehq.util.test_utils import make_es_ready_form
 
 
 @es_test(requires=[form_adapter])
-@es_test(requires=[group_adapter], setup_class=True)
+@es_test(requires=[group_adapter])
 class TestFormESAccessors(TestCase):
 
     @classmethod
@@ -1121,7 +1121,7 @@ class TestGroupESAccessors(SimpleTestCase):
 
 
 @es_test(requires=[case_adapter])
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class TestCaseESAccessors(TestCase):
 
     def setUp(self):

--- a/corehq/apps/reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/reports/tests/test_scheduled_reports.py
@@ -21,7 +21,7 @@ from corehq.util.test_utils import disable_quickcache, privilege_enabled, flag_e
     case_search_adapter,
     form_adapter,
     user_adapter,
-], setup_class=True)
+])
 @disable_quickcache
 @privilege_enabled(privileges.API_ACCESS)
 class TestLocationRestrictedScheduledReportViews(TestCase):

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -75,7 +75,7 @@ class GetQuestionIdTests(SimpleTestCase):
         self.assertIsNone(result)
 
 
-@es_test(requires=[domain_adapter, form_adapter], setup_class=True)
+@es_test(requires=[domain_adapter, form_adapter])
 class TestGetDomainsToUpdateESFilter(TestCase):
     def test_calculated_properties_never_updated_is_included(self):
         domain = self.index_domain('never-updated')

--- a/corehq/apps/saved_reports/tests/end_to_end/test_scheduled_reports.py
+++ b/corehq/apps/saved_reports/tests/end_to_end/test_scheduled_reports.py
@@ -19,7 +19,7 @@ from ...models import ReportConfig, ReportNotification
 
 @patch('corehq.apps.reports.standard.monitoring.util.get_simplified_users',
        new=lambda q: [])
-@es_test(requires=[case_adapter, form_adapter], setup_class=True)
+@es_test(requires=[case_adapter, form_adapter])
 class TestScheduledReports(TestCase):
 
     def test_scheduled_reports_sends_to_recipients(self):

--- a/corehq/apps/saved_reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/saved_reports/tests/test_scheduled_reports.py
@@ -239,7 +239,7 @@ class ScheduledReportTest(TestCase):
 
 @patch('corehq.apps.reports.standard.monitoring.util.get_simplified_users',
        new=lambda q: [])
-@es_test(requires=[case_adapter, form_adapter], setup_class=True)
+@es_test(requires=[case_adapter, form_adapter])
 class ScheduledReportSendingTest(TestCase):
 
     domain = 'test-scheduled-reports'

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -427,7 +427,7 @@ class OwnerChoiceProviderTest(LocationHierarchyTestCase, ChoiceProviderTestMixin
         )
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class UserUserDataChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
     domain = 'user-meta-choice-provider'
 

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -474,7 +474,7 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
         self.assertEqual(can_edit_view.page_context['can_edit_report'], True)
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestDataSourceRebuild(ConfigurableReportTestMixin, TestCase):
     @classmethod
     def setUpClass(cls):

--- a/corehq/apps/users/tests/test_analytics.py
+++ b/corehq/apps/users/tests/test_analytics.py
@@ -14,7 +14,7 @@ from corehq.apps.es.users import user_adapter
 from corehq.apps.users.models import CommCareUser, WebUser
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class UserAnalyticsTest(TestCase):
 
     @classmethod

--- a/corehq/apps/users/tests/test_dbaccessors.py
+++ b/corehq/apps/users/tests/test_dbaccessors.py
@@ -35,7 +35,7 @@ from corehq.apps.users.models import (
 from corehq.apps.users.role_utils import initialize_domain_with_default_roles
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class AllCommCareUsersTest(TestCase):
 
     @classmethod

--- a/corehq/apps/users/tests/test_get_domain_language.py
+++ b/corehq/apps/users/tests/test_get_domain_language.py
@@ -6,7 +6,7 @@ from corehq.apps.es.tests.utils import es_test
 from corehq.apps.users.views import get_domain_languages
 
 
-@es_test(requires=[app_adapter], setup_class=True)
+@es_test(requires=[app_adapter])
 class TestDomainLanguages(TestCase):
 
     @classmethod

--- a/corehq/apps/users/tests/test_location_assignment.py
+++ b/corehq/apps/users/tests/test_location_assignment.py
@@ -12,7 +12,7 @@ from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.util.es.testing import sync_users_to_es
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class CCUserLocationAssignmentTest(TestCase):
 
     @classmethod

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -63,7 +63,7 @@ class TestUserSignals(SimpleTestCase):
 @patch('corehq.apps.analytics.signals.update_hubspot_properties')
 @patch('corehq.apps.callcenter.tasks.sync_usercases')
 @patch('corehq.apps.cachehq.signals.invalidate_document')
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class TestUserSyncToEs(SimpleTestCase):
 
     def setUp(self):

--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -368,7 +368,7 @@ class TestDeletePhoneNumberView(TestCase):
         self.assertEqual(user_history_log.changed_via, USER_CHANGE_VIA_WEB)
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 @patch('corehq.apps.users.decorators.can_use_filtered_user_download', return_value=True)
 class TestCountWebUsers(TestCase):
 

--- a/corehq/apps/users/tests/test_web_user_download.py
+++ b/corehq/apps/users/tests/test_web_user_download.py
@@ -14,7 +14,7 @@ from corehq.apps.reports.tests.test_tableau_api_util import _mock_create_session
 from corehq.util.test_utils import disable_quickcache, flag_enabled
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class TestDownloadWebUsers(TestCase):
 
     @classmethod

--- a/corehq/ex-submodules/couchforms/tests/test_analytics.py
+++ b/corehq/ex-submodules/couchforms/tests/test_analytics.py
@@ -36,7 +36,7 @@ from corehq.util.test_utils import (
 from testapps.test_pillowtop.utils import process_pillow_changes
 
 
-@es_test(requires=[form_adapter, app_adapter], setup_class=True)
+@es_test(requires=[form_adapter, app_adapter])
 @disable_quickcache
 class ExportsFormsAnalyticsTest(TestCase, DocTestMixin):
     maxDiff = None
@@ -165,7 +165,7 @@ class ExportsFormsAnalyticsTest(TestCase, DocTestMixin):
         }])
 
 
-@es_test(requires=[form_adapter, user_adapter], setup_class=True)
+@es_test(requires=[form_adapter, user_adapter])
 @disable_quickcache
 class CouchformsESAnalyticsTest(TestCase):
     domain = 'hqadmin-es-accessor'

--- a/corehq/ex-submodules/pillowtop/tests/test_bulk.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_bulk.py
@@ -49,7 +49,7 @@ class BulkTest(SimpleTestCase):
 
 
 @sharded
-@es_test(requires=[case_adapter], setup_class=True)
+@es_test(requires=[case_adapter])
 class TestBulkDocOperations(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/custom/covid/tests/test_management_commands.py
+++ b/custom/covid/tests/test_management_commands.py
@@ -378,7 +378,7 @@ class CaseCommandsTest(TestCase):
         self.assertEqual(patient2_case.get_case_property('owner_id'), '-')
 
 
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter])
 class TestUpdateAllActivityCompleteDate(TestCase):
     domain = 'all_activity_complete_date'
 

--- a/testapps/test_pillowtop/tests/test_form_pillow.py
+++ b/testapps/test_pillowtop/tests/test_form_pillow.py
@@ -19,7 +19,7 @@ from corehq.form_processor.utils import TestFormMetadata, get_simple_form_xml
 from corehq.pillows.xform import get_xform_pillow
 
 
-@es_test(requires=[form_adapter, user_adapter], setup_class=True)
+@es_test(requires=[form_adapter, user_adapter])
 class FormPillowTest(TestCase):
     domain = 'test-form-pillow-domain'
 

--- a/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
+++ b/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
@@ -189,7 +189,7 @@ def _group_to_change_meta(group):
     )
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class GroupsToUserReindexerTest(TestCase):
 
     def setUp(self):

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -201,7 +201,7 @@ def test_no_checkpoint_creation(self, reindexer_factory, pillow_name):
         )
 
 
-@es_test(requires=[user_adapter], setup_class=True)
+@es_test(requires=[user_adapter])
 class UserReindexerTest(TestCase):
 
     def setUp(self):
@@ -237,7 +237,7 @@ class UserReindexerTest(TestCase):
             self.assertEqual('WebUser', user_doc['doc_type'])
 
 
-@es_test(requires=[group_adapter], setup_class=True)
+@es_test(requires=[group_adapter])
 class GroupReindexerTest(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Product Description
Automatically determine setup_class attribute. No need to set it manually

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag

None

## Safety Assurance

Only covers automatic tests

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

That's the only change

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
