### PR TITLE
check toggle in other places where user reporting metadata is processed

### DIFF
--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.http import Http404
 
+from corehq import toggles
 from dimagi.utils.parsing import string_to_utc_datetime
 
 from corehq.apps.app_manager.dbaccessors import get_app
@@ -65,6 +66,9 @@ class FormSubmissionMetadataTrackerProcessor(PillowProcessor):
 
         user_id = doc.get('form', {}).get('meta', {}).get('userID')
         if user_id in WEIRD_USER_IDS:
+            return
+
+        if toggles.SKIP_UPDATING_USER_REPORTING_METADATA.enabled(domain):
             return
 
         try:

--- a/corehq/pillows/synclog.py
+++ b/corehq/pillows/synclog.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS
 
 from casexml.apps.phone.models import SyncLogSQL
+from corehq import toggles
 from corehq.sql_db.util import handle_connection_failure
 from dimagi.utils.parsing import string_to_utc_datetime
 from pillowtop.checkpoints.manager import KafkaPillowCheckpoint
@@ -89,6 +90,9 @@ class UserSyncHistoryProcessor(PillowProcessor):
         domain = synclog.get('domain')
 
         if not user_id or not domain:
+            return
+
+        if toggles.SKIP_UPDATING_USER_REPORTING_METADATA.enabled(domain):
             return
 
         try:

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2105,9 +2105,11 @@ SKIP_FIXTURES_ON_RESTORE = StaticToggle(
 
 SKIP_UPDATING_USER_REPORTING_METADATA = StaticToggle(
     'skip_updating_user_reporting_metadata',
-    'ICDS: Skip updates to user reporting metadata to avoid expected load on couch',
-    TAG_CUSTOM,
+    'Disable user reporting metadata updates',
+    TAG_INTERNAL,
     [NAMESPACE_DOMAIN],
+    description="This is used as a temporary block in case of issues caused by the metadata updates. This"
+                "typically occurs if a large number of devices share the same user account.",
 )
 
 DOMAIN_PERMISSIONS_MIRROR = StaticToggle(


### PR DESCRIPTION
## Product Description
This updates the `FormSubmissionMetadataTrackerProcessor` and the `UserSyncHistoryProcessor` to respect the [SKIP_UPDATING_USER_REPORTING_METADATA](https://github.com/dimagi/commcare-hq/blob/4e0b8c65e5bd1d8a887eaecf91cda8eecdca2354/corehq/toggles/__init__.py#L2106-L2113) toggle.

There are a number of longer term improvements that could be made:
1. Move the metadata from the user document to a SQL table
2. Detect and deactivate users that have an unreasonable number of recent devices (the current issue is caused by >6000 devices sharing the same user account during a training excercise)

## Technical Summary
This toggle is useful in emergency situations to temporarily disable the reporting metadata updates.

## Feature Flag
SKIP_UPDATING_USER_REPORTING_METADATA

## Safety Assurance

### Safety story
This is an existing toggle that is used in the `heartbeat` view and is now being extended to the pillows.

### Automated test coverage
None

### QA Plan
None


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
