### PR TITLE
Silence export poll error

### DIFF
--- a/corehq/apps/export/static/export/js/download_export.js
+++ b/corehq/apps/export/static/export/js/download_export.js
@@ -367,7 +367,7 @@ hqDefine('export/js/download_export', [
         };
 
         self._dealWithErrors = function (data) {
-            if (self._numErrors > 3) {
+            if (self._numErrors > 3 || data.retry === false) {
                 if (data && data.error) {
                     self.downloadError(data.error);
                 } else {

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -390,6 +390,12 @@ def poll_custom_export_download(request, domain):
     permissions = ExportsPermissionsManager(form_or_case, domain, request.couch_user)
     permissions.access_download_export_or_404()
     download_id = request.GET.get('download_id')
+
+    if not download_id:
+        return JsonResponse({
+            'error': _('Could not find download. Please refresh page and try again.'),
+        })
+
     try:
         context = get_download_context(download_id)
     except TaskFailedError as e:

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -394,6 +394,7 @@ def poll_custom_export_download(request, domain):
     if not download_id:
         return JsonResponse({
             'error': _('Could not find download. Please refresh page and try again.'),
+            'retry': False,
         })
 
     try:
@@ -403,7 +404,8 @@ def poll_custom_export_download(request, domain):
             return JsonResponse({
                 'error': _(
                     'This file has more than 256 columns, which is not supported by xls. '
-                    'Please change the output type to csv or xlsx to export this file.')
+                    'Please change the output type to csv or xlsx to export this file.'),
+                'retry': False,
             })
         else:
             notify_exception(


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SAAS-16176

## Technical Summary
I'm not in love with this solution, but it should quiet the error without putting undue burden on users. Sentry history suggests this error is relatively rare, and it has not been reproducible. This page's error handling logic (`_numErrors`) suggests that it's already prone to flakiness (not saying the blank download id is related to celery errors, just that an occasional "try again later" isn't unusual).

## Safety Assurance

### Safety story
Locally tested the error workflow (by forcing js to send a blank string for download id) and the normal workflow.

### Automated test coverage

no

### QA Plan

Not requesting QA.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
