### PR TITLE
Add HTML Style Guide

### DIFF
--- a/corehq/apps/styleguide/context.py
+++ b/corehq/apps/styleguide/context.py
@@ -23,6 +23,7 @@ def get_navigation_context(current_page):
                     Page("Code Guidelines", 'styleguide_code_guidelines_b5'),
                     Page("Bootstrap Migration Guide", 'styleguide_migration_guide_b5'),
                     Page("Javascript Guide", 'styleguide_javascript_guide_b5'),
+                    Page("HTML Guide", 'styleguide_html_guide_b5'),
                     Page("HTMX + Alpine.JS", 'styleguide_htmx_and_alpine_b5'),
                 ],
             ),

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_js.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_js.html
@@ -1,0 +1,11 @@
+<div
+  class="editable-column-container" id="column1"
+  hx-get="/api/data"
+  hx-trigger="click"
+  x-data="{
+    isEditing: false,
+    isSubmitting: false,
+  }"
+>
+  ...
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_json.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_json.html
@@ -1,0 +1,12 @@
+<div
+  hx-post="{{ request.path_info }}"
+  hq-hx-action="edit_cell_value"
+  hx-vals='{
+    "recordId": {{ record.id }},
+    "column": "{{ column.accessor }}"
+  }'
+  hx-disabled-elt="find button"
+  hx-swap="outerHTML"
+>
+  ...
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_no_wrap.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_no_wrap.html
@@ -1,0 +1,3 @@
+<div class="mb-3" x-show="isEditing">
+  ...
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_wrap_data.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_wrap_data.html
@@ -1,0 +1,10 @@
+<button
+  class="btn btn-outline-primary" id="my-offcanvas-button" type="button"
+  data-bs-toggle="offcanvas"
+  data-bs-target="#configureColumnsOffcanvas"
+  hx-post="{% url "my_new_view" %}"
+  hq-hx-action="test_button"
+  x-show="isReadyToSubmit"
+>
+  ...
+</button>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_wrap_data.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_wrap_data.html
@@ -2,7 +2,7 @@
   class="btn btn-outline-primary" id="my-offcanvas-button" type="button"
   data-bs-toggle="offcanvas"
   data-bs-target="#configureColumnsOffcanvas"
-  hx-post="{% url "my_new_view" %}"
+  hx-post="{% url 'my_new_view' %}"
   hq-hx-action="test_button"
   x-show="isReadyToSubmit"
 >

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_wrap_length.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_wrap_length.html
@@ -1,6 +1,6 @@
 <button
   class="btn btn-outline-primary mb-3 pe-3" id="my-offcanvas-button"
-  type="button" aria-label="{% trans "Close" %}" tabindex="1"
+  type="button" aria-label="{% trans 'Close' %}" tabindex="1"
 >
   ...
 </button>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_wrap_length.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/attribute_wrap_length.html
@@ -1,0 +1,6 @@
+<button
+  class="btn btn-outline-primary mb-3 pe-3" id="my-offcanvas-button"
+  type="button" aria-label="{% trans "Close" %}" tabindex="1"
+>
+  ...
+</button>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/block_and_inline.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/block_and_inline.html
@@ -1,0 +1,40 @@
+<div class="row mt-4">
+  <h1>Short titles: one line ok</h1>
+  <h2>
+    However, longer titles (like a sentence) should be indented.
+  </h2>
+  <p>
+    This is paragraph text within a block element. It should always follow
+    standard indentation nested within its parent element. If you have a
+    <a href="https://dimagi.com">link</a> within the paragraph, that's fine to
+    leave inline with text, as well as <code>code</code> tags or
+    <span data-somedata="foo">span</span> tags, etc. However, if the
+    tag is a block element like a <code>div</code>, <code>p</code>
+    (paragraph), or header (e.g. <code>h1</code>),
+  </p>
+  <p>
+    Short paragraph text should also be on its own line within a <code>p</code> parent.
+  </p>
+  <p>
+    {% blocktrans %}
+      Translated text within a paragraph tag should always be indented like this
+    {% endblocktrans %}
+  </p>
+  <h3>
+    {% trans "Short titles are fine" %}
+  </h3>
+  <p>
+    If you have <img alt="{% trans "Translated text within attributes" %}">, then use
+    <code>trans</code> instead of <code>blocktrans</code>.
+  </p>
+  <p>
+    And if you have lists....
+  </p>
+  <ul>
+    <li>
+      <p>
+        The Indentation structure should look like this.
+      </p>
+    </li>
+  </ul>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/block_and_inline.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/block_and_inline.html
@@ -8,9 +8,13 @@
     standard indentation nested within its parent element. If you have a
     <a href="https://dimagi.com">link</a> within the paragraph, that's fine to
     leave inline with text, as well as <code>code</code> tags or
-    <span data-somedata="foo">span</span> tags, etc. However, if the
-    tag is a block element like a <code>div</code>, <code>p</code>
-    (paragraph), or header (e.g. <code>h1</code>),
+    <span data-somedata="foo">span</span> tags, etc.
+    <a
+      class="btn-link"
+      href="http://dimagi.com" target="_blank"
+    >Long links</a>, even though they are inline elements, can also behave more
+    like block elements within the paragraph, to reduce the overall line
+    length of that text.
   </p>
   <p>
     Short paragraph text should also be on its own line within a <code>p</code> parent.

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/final_example.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/final_example.html
@@ -1,0 +1,14 @@
+<button
+  class="btn btn-primary" id="submit-button"
+  hx-post="/api/submit"
+  hx-swap="innerHTML"
+  x-data="{
+    isDisabled: false,
+    onClick() {
+      this.isDisabled = true;
+    },
+  }"
+  :disabled="isDisabled"
+>
+  Submit
+</button>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/indentation.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/indentation.html
@@ -1,0 +1,20 @@
+<div class="row mt-4">
+  {% for report in reports %}
+    <div class="col-md-6 col-lg-6 col-xl-3">
+      <div
+        class="card text-center report-panel mb-3" id="{{ report.slug }}"
+        data-slug="{{ report.slug }}"
+      >
+        {% if report.is_active %}
+          <div class="fs-5">{{ report.description }}</div>
+        {% else %}
+          <div class="fs-2">
+            {% blocktrans %}
+              Not Active
+            {% endblocktrans %}
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  {% endfor %}
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/self_closing.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/self_closing.html
@@ -1,0 +1,4 @@
+<input
+  class="form-control" type="text" name="newValue"
+  x-model="cellValue"
+/>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/self_closing_line.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/self_closing_line.html
@@ -1,0 +1,1 @@
+<input class="form-control" type="text" name="newValue" />

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/standard_attributes.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/html_guide/standard_attributes.html
@@ -1,0 +1,11 @@
+<div
+  class="editable-column-container" id="column1"
+  hx-get="/api/data"
+  hx-trigger="click"
+  x-data="{
+    isEditing: false,
+    isSubmitting: false,
+  }"
+>
+  ...
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/html_guide.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/html_guide.html
@@ -69,8 +69,8 @@
   </h2>
   <p>
     Elements that are <a href="https://www.w3schools.com/html/html_blocks.asp" target="_blank">block elements</a>
-    should always be on their own line. Text within block elements like <code>div</code> or <code>p</code> should
-    be indented on a new line as a paragraph within that element.
+    should start on their own line. Text within block elements should be indented on a new line as a paragraph
+    within that element if there is more than one line of text.
   </p>
   <p>
     Inline elements, like <code>a</code>, <code>span</code>, <code>code</code>, etc. can be inline with
@@ -85,7 +85,7 @@
     <li>
       <p>
         <strong>Standard Attributes:</strong> Place primary attributes (e.g., <code>class</code>,
-        <code>id</code>, <code>style</code>) first on the element, followed by a line break
+        <code>id</code>, <code>type</code>) first on the element, followed by a line break
         if additional attributes exist or if the line exceeds 115 characters when all attributes are inline.
       </p>
       {% include 'styleguide/bootstrap5/code_display.html' with content=examples.standard_attributes %}
@@ -197,7 +197,7 @@
     7.  Self-Closing Elements
   </h2>
   <p>
-    For self-closing elements, such as <code>&gt;input /&lt;</code>:
+    For self-closing elements, such as <code>&lt;input /&gt;</code>:
   </p>
   <ul>
     <li>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/html_guide.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/html_guide.html
@@ -1,0 +1,250 @@
+{% extends 'styleguide/bootstrap5/base.html' %}
+{% load hq_shared_tags %}
+
+{% block head %}
+  <script src="{% static 'htmx.org/dist/htmx.min.js' %}"></script>
+{% endblock head %}
+
+{% block intro %}
+  <h1 class="sg-title mb-0" id="content">HTML Style Guide</h1>
+  <p class="sg-lead">
+    Our standard for formatting HTML.
+  </p>
+{% endblock intro %}
+
+{% block toc %}
+  <h5 class="my-2 ms-3">On this page</h5>
+  <hr class="my-2 ms-3">
+  <nav id="TableOfContents">
+    <ul>
+      <li>
+        <a href="#overview">Overview</a>
+        <ul>
+          <a href="#tools">Tools for Consistency</a></li>
+        </ul>
+      </li>
+      <li><a href="#indentation">1. Two-Space Indentation</a></li>
+      <li><a href="#block-inline-text">2. Block vs Inline, Text, and Translations</a></li>
+      <li><a href="#attribute-order">3. Attribute Order and Line Breaks</a></li>
+      <li><a href="#attribute-js">4. In-Attribute JavaScript-Like Formatting for Alpine.js</a></li>
+      <li><a href="#attribute-json">5. In-Attribute JSON for <code>hx-vals</code></a></li>
+      <li><a href="#attribute-wrapping">6.  Attribute Wrapping and Line Length</a></li>
+      <li><a href="#self-closing">7.  Self-Closing Elements</a></li>
+      <li><a href="#htmx-alpine-best-practices">8.  Best Practices for Code Readability with HTMX and Alpine</a></li>
+      <li><a href="#example-structure">Example Structure</a></li>
+    </ul>
+  </nav>
+{% endblock toc %}
+
+{% block content %}
+  <h2 id="overview" class="pt-4">
+    Overview
+  </h2>
+  <p>
+    The guide offered here is a living document and by no means complete. The intention is to standardize and
+    improve the readability of our HTML, especially given an environment where we are making use of more
+    attribute-based frontend libraries like HTMX and Alpine.js.
+  </p>
+  <h3 id="tools" class="pt-3">
+    Tools for Consistency
+  </h3>
+  <p>
+    We are still working on finding a linter to raise formatting issues during pull requests. In the meantime,
+    we request that you make sure your git commit hooks are up-to-date. If you haven't done this in a while,
+    please run <code>git-hooks/install.sh</code> to install the latest commit hooks, including tools to ensure
+    committed HTML is formatted optimally.
+  </p>
+  <h2 id="indentation" class="pt-4">
+    1. Two-Space Indentation
+  </h2>
+  <p>
+    Use two-space indentation for nested content and multi-line attributes. This indentation rule
+    applies to <em>any</em> nested elements, including Django template <code>if</code>/<code>else</code>
+    tags, <code>for</code> loops, etc.
+  </p>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.indentation %}
+
+  <h2 id="block-inline-text" class="pt-4">
+    2. Block vs Inline, Text, and Translations
+  </h2>
+  <p>
+    Elements that are <a href="https://www.w3schools.com/html/html_blocks.asp" target="_blank">block elements</a>
+    should always be on their own line. Text within block elements like <code>div</code> or <code>p</code> should
+    be indented on a new line as a paragraph within that element.
+  </p>
+  <p>
+    Inline elements, like <code>a</code>, <code>span</code>, <code>code</code>, etc. can be inline with
+    text and other inline elements.
+  </p>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.block_and_inline %}
+
+  <h2 id="attribute-order" class="pt-4">
+    3. Attribute Order and Line Breaks
+  </h2>
+  <ul>
+    <li>
+      <p>
+        <strong>Standard Attributes:</strong> Place primary attributes (e.g., <code>class</code>,
+        <code>id</code>, <code>style</code>) first on the element, followed by a line break
+        if additional attributes exist or if the line exceeds 115 characters when all attributes are inline.
+      </p>
+      {% include 'styleguide/bootstrap5/code_display.html' with content=examples.standard_attributes %}
+    </li>
+    <li>
+      <p>
+        <strong>HTMX Attributes (<code>hx-</code>, <code>hq-hx-</code>):</strong> Place HTMX attributes
+        on their own line immediately after standard attributes. If there are multiple <code>hx-</code>
+        attributes, place each on a separate line.
+      </p>
+    </li>
+    <li>
+      <p>
+        <strong>Alpine.js Attributes:</strong> Place Alpine.js attributes (<code>x-</code>, <code>:&hellip;</code>
+        attributes) after <code>hx-</code> attributes, each on a separate line.
+      </p>
+    </li>
+  </ul>
+
+  <h2 id="attribute-js" class="pt-4">
+    4. In-Attribute JavaScript-Like Formatting for Alpine.js
+  </h2>
+  <p>
+    For complex JavaScript-like values, such as <code>x-data</code>, follow this indentation:
+  </p>
+  <ul>
+    <li>
+      <p>
+        Start the attribute on a new line.
+      </p>
+    </li>
+    <li>
+      <p>
+        Indent JSON or JavaScript-like values by 2 spaces.
+      </p>
+    </li>
+    <li>
+      <p>
+        Align closing brackets with the opening attribute line.
+      </p>
+    </li>
+    <li>
+      <p>
+        As with JavaScript objects, the last element should have a trailing comma.
+      </p>
+    </li>
+  </ul>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.attribute_js %}
+
+  <h2 id="attribute-json" class="pt-4">
+    5. In-Attribute JSON for <code>hx-vals</code>
+  </h2>
+  <p>
+    For hx-vals, JSON should be formatted similarly to point 4, with these additional JSON formatting rules:
+  </p>
+  <ul>
+    <li>
+      <p>
+        Use double quotes around JSON keys and values.
+      </p>
+    </li>
+    <li>
+      <p>
+        Do not include trailing commas for the final key-value pair in the object.
+      </p>
+    </li>
+    <li>
+      <p>
+        For Django Template tags within JSON (e.g., <code>{% verbatim %}{{ }}{% endverbatim %}</code> for variables
+        or <code>{% verbatim %}{% %}{% endverbatim %}</code> for logic), ensure template syntax doesn’t break
+        JSON formatting, paying attention to surrounding quotes.
+      </p>
+    </li>
+  </ul>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.attribute_json %}
+
+  <h2 id="attribute-wrapping" class="pt-4">
+    6.  Attribute Wrapping and Line Length
+  </h2>
+  <p>
+    Limit line length to improve readability, ideally keeping lines below 115 characters
+    maximum, with 80 characters being the best line length for readability.
+  </p>
+  <ul>
+    <li>
+      <p>
+        If the line is less than 80 characters with any attributes (including
+        Alpine and HTMX attributes) then it’s fine to keep all the attributes on a single line.
+      </p>
+      {% include 'styleguide/bootstrap5/code_display.html' with content=examples.attribute_no_wrap %}
+    </li>
+    <li>
+      <p>
+        If the line is more than 80 characters and has HTMX/Alpine/<code>data-</code> attributes, then the
+        HTMX/Alpine/<code>data-</code> attributes should all be on new lines.
+      </p>
+      {% include 'styleguide/bootstrap5/code_display.html' with content=examples.attribute_wrap_data %}
+    </li>
+    <li>
+      <p>
+        If non-HTMX/Alpine/<code>data-</code> attributes exceed 115 characters on one line, wrap
+        attributes so that each line does not exceed 115 characters. Each line may include multiple attributes.
+      </p>
+      {% include 'styleguide/bootstrap5/code_display.html' with content=examples.attribute_wrap_length %}
+    </li>
+  </ul>
+
+  <h2 id="self-closing" class="pt-4">
+    7.  Self-Closing Elements
+  </h2>
+  <p>
+    For self-closing elements, such as <code>&gt;input /&lt;</code>:
+  </p>
+  <ul>
+    <li>
+      <p>
+        Ensure that the trailing slash (<code>/</code>) is included to clearly indicate the element is self-closing.
+      </p>
+    </li>
+    <li>
+      <p>
+        Follow the same attribute ordering and indentation rules as outlined for other elements.
+      </p>
+    </li>
+  </ul>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.self_closing %}
+  <p>
+    If it fits on a single line, remember to still include the trailing slash. Please still follow the rules
+    from point 6 when it comes to attribute wrapping.
+  </p>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.self_closing_line %}
+
+  <h2 id="htmx-alpine-best-practices" class="pt-4">
+    8.  Best Practices for Code Readability with HTMX and Alpine
+  </h2>
+  <ul>
+    <li>
+      <p>
+        <strong>Consistency:</strong> Always follow this attribute order and indentation style
+        throughout the codebase.
+      </p>
+    </li>
+    <li>
+      <p>
+        <strong>Comments:</strong> Use Django template comments (<code>{% verbatim %}{# ... #}{% endverbatim %}</code>)
+        to explain complex Alpine or HTMX interactions when necessary.
+      </p>
+    </li>
+    <li>
+      <p>
+        <strong>Minimize Inline JavaScript:</strong> Keep JavaScript logic within the component or
+        JavaScript files rather than inline, except for simple Alpine data bindings or event handlers.
+      </p>
+    </li>
+  </ul>
+
+  <h2 id="example-structure" class="pt-4">
+    Example Structure
+  </h2>
+  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.final_example %}
+
+{% endblock content %}

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/html_guide.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/html_guide.html
@@ -20,7 +20,7 @@
       <li>
         <a href="#overview">Overview</a>
         <ul>
-          <a href="#tools">Tools for Consistency</a></li>
+          <li><a href="#tools">Tools for Consistency</a></li>
         </ul>
       </li>
       <li><a href="#indentation">1. Two-Space Indentation</a></li>

--- a/corehq/apps/styleguide/urls.py
+++ b/corehq/apps/styleguide/urls.py
@@ -66,6 +66,8 @@ urlpatterns = [
         name="styleguide_migration_guide_b5"),
     url(r'^b5/javascript/$', bootstrap5.styleguide_javascript_guide,
         name="styleguide_javascript_guide_b5"),
+    url(r'^b5/html/$', bootstrap5.styleguide_html_guide,
+        name="styleguide_html_guide_b5"),
     url(r'^b5/htmx_alpine/$', bootstrap5.styleguide_htmx_and_alpine,
         name="styleguide_htmx_and_alpine_b5"),
     url(r'^b5/atoms/accessibility/$', bootstrap5.styleguide_atoms_accessibility,

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -59,6 +59,60 @@ def styleguide_javascript_guide(request):
 
 
 @use_bootstrap5
+def styleguide_html_guide(request):
+    context = get_navigation_context("styleguide_html_guide_b5")
+    context.update({
+        "examples": {
+            'indentation': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/html_guide/indentation.html'),
+                language="Django",
+            ),
+            'block_and_inline': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/html_guide/block_and_inline.html'),
+                language="Django",
+            ),
+            'standard_attributes': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/html_guide/standard_attributes.html'),
+                language="Django",
+            ),
+            'attribute_js': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/html_guide/attribute_js.html'),
+                language="Django",
+            ),
+            'attribute_json': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/html_guide/attribute_json.html'),
+                language="Django",
+            ),
+            'attribute_no_wrap': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/html_guide/attribute_no_wrap.html'),
+                language="Django",
+            ),
+            'attribute_wrap_data': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/html_guide/attribute_wrap_data.html'),
+                language="Django",
+            ),
+            'attribute_wrap_length': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/html_guide/attribute_wrap_length.html'),
+                language="Django",
+            ),
+            'self_closing': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/html_guide/self_closing.html'),
+                language="Django",
+            ),
+            'self_closing_line': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/html_guide/self_closing_line.html'),
+                language="Django",
+            ),
+            'final_example': CodeForDisplay(
+                code=get_example_context('styleguide/bootstrap5/examples/html_guide/final_example.html'),
+                language="Django",
+            ),
+        },
+    })
+    return render(request, 'styleguide/bootstrap5/html_guide.html', context)
+
+
+@use_bootstrap5
 def styleguide_htmx_and_alpine(request):
     context = get_navigation_context("styleguide_htmx_and_alpine_b5")
     context.update({


### PR DESCRIPTION
## Technical Summary
This adds the HTML Style Guide to the HQ Style Guide.
<img width="1190" alt="Screenshot 2024-12-10 at 8 43 12 AM" src="https://github.com/user-attachments/assets/82f5c202-cb90-4aaf-9ba0-1275e755cce6">

## Safety Assurance

### Safety story
Just a styleguide update

### Automated test coverage
No

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
