### PR TITLE
UCR metrics using Datadog for Rebuild and Rebuild-in-place functionality

### DIFF
--- a/corehq/apps/userreports/const.py
+++ b/corehq/apps/userreports/const.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 from corehq.apps.change_feed import topics
 
 
-TEMP_REPORT_PREFIX = '__tmp'  # reports made by the report bulider use this
+TEMP_REPORT_PREFIX = '__tmp'  # reports made by the report builder use this
 
 REPORT_BUILDER_EVENTS_KEY = 'REPORT_BUILDER_EVENTS_KEY'
 

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -392,10 +392,6 @@ def get_indicator_table(indicator_config, metadata, override_table_name=None):
     )
 
 
-def get_current_indicator_table_from_db(metadata, table_name):
-    return metadata.tables[table_name]
-
-
 def _custom_index_name(table_name, column_ids):
     base_name = "ix_{}_{}".format(table_name, ','.join(column_ids))
     base_hash = hashlib.md5(base_name.encode('utf-8')).hexdigest()

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -58,8 +58,10 @@ class IndicatorSqlAdapter(IndicatorAdapter):
     @memoized
     def get_existing_table_from_db(self):
         """Loads existing table directly from database if one exists"""
-        if self.table_exists:
+        try:
             return sqlalchemy.Table(self.get_table().name, sqlalchemy.MetaData(), autoload_with=self.engine)
+        except sqlalchemy.exc.NoSuchTableError:
+            pass
 
     @property
     def table_exists(self):

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -55,6 +55,12 @@ class IndicatorSqlAdapter(IndicatorAdapter):
             self.config, get_metadata(self.engine_id), override_table_name=self.override_table_name
         )
 
+    @memoized
+    def get_existing_table_from_db(self):
+        """Loads existing table directly from database if one exists"""
+        if self.table_exists:
+            return sqlalchemy.Table(self.get_table().name, sqlalchemy.MetaData(), autoload_with=self.engine)
+
     @property
     def table_exists(self):
         return self.engine.has_table(self.get_table().name)
@@ -384,6 +390,10 @@ def get_indicator_table(indicator_config, metadata, override_table_name=None):
         metadata,
         *columns_and_indices
     )
+
+
+def get_current_indicator_table_from_db(metadata, table_name):
+    return metadata.tables[table_name]
 
 
 def _custom_index_name(table_name, column_ids):

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -160,9 +160,8 @@ def rebuild_indicators_in_place(indicator_config_id, initiated_by=None, source=N
 
 def _get_rows_count_from_existing_table(adapter):
     table = adapter.get_existing_table_from_db()
-    if not table:
-        return None
-    return adapter.session_helper.Session.query(table).count()
+    if table is not None:
+        return adapter.session_helper.Session.query(table).count()
 
 
 def _report_ucr_rebuild_metrics(config, source, action, adapter, rows_count_before_rebuild, error=False):

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -119,8 +119,12 @@ def rebuild_indicators(
             config.save()
 
         skip_log = bool(limit > 0)  # don't store log for temporary report builder UCRs
-        adapter.rebuild_table(initiated_by=initiated_by, source=source, skip_log=skip_log, diffs=diffs)
-        _iteratively_build_table(config, limit=limit)
+        try:
+            adapter.rebuild_table(initiated_by=initiated_by, source=source, skip_log=skip_log, diffs=diffs)
+            _iteratively_build_table(config, limit=limit)
+        except Exception:
+            _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource', error=True)
+            raise
         _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource')
 
 
@@ -140,16 +144,22 @@ def rebuild_indicators_in_place(indicator_config_id, initiated_by=None, source=N
             config.meta.build.rebuilt_asynchronously = False
             config.save()
 
-        adapter.build_table(initiated_by=initiated_by, source=source)
-        _iteratively_build_table(config, in_place=True)
+        try:
+            adapter.build_table(initiated_by=initiated_by, source=source)
+            _iteratively_build_table(config, in_place=True)
+        except Exception:
+            _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource_in_place', error=True)
+            raise
         _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource_in_place')
 
 
-def _report_ucr_rebuild_metrics(config, source, action):
+def _report_ucr_rebuild_metrics(config, source, action, error=False):
     if source not in ('edit_data_source_rebuild', 'edit_data_source_build_in_place'):
         return
     try:
         _report_metric_number_of_days_since_first_build(config.domain, config.get_id, action)
+        if error:
+            _report_metric_rebuild_error(config, action)
     except Exception:
         pass
 
@@ -166,6 +176,16 @@ def _report_metric_number_of_days_since_first_build(domain, config_id, action):
     else:
         no_of_days = (datetime.utcnow() - earliest_entry.date_created).days
         metrics_gauge(f'commcare.ucr.{action}.days_since_first_build', no_of_days, tags={'domain': domain})
+
+
+def _report_metric_rebuild_error(config, action):
+    from corehq.apps.userreports.views import _number_of_records_to_be_iterated_for_rebuild
+    expected_rows_to_process = _number_of_records_to_be_iterated_for_rebuild(config)
+    metrics_gauge(
+        f'commcare.ucr.{action}.failed.expected_rows_to_process',
+        expected_rows_to_process,
+        tags={'domain': config.domain}
+    )
 
 
 @task(serializer='pickle', queue=UCR_CELERY_QUEUE, ignore_result=True, acks_late=True)

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -119,13 +119,15 @@ def rebuild_indicators(
             config.save()
 
         skip_log = bool(limit > 0)  # don't store log for temporary report builder UCRs
+        rows_count_before_rebuild = adapter.get_query_object().count() if adapter.table_exists else None
         try:
             adapter.rebuild_table(initiated_by=initiated_by, source=source, skip_log=skip_log, diffs=diffs)
             _iteratively_build_table(config, limit=limit)
         except Exception:
-            _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource', error=True)
+            _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource', adapter,
+                                        rows_count_before_rebuild, error=True)
             raise
-        _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource')
+        _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource', adapter, rows_count_before_rebuild)
 
 
 @serial_task(
@@ -144,22 +146,27 @@ def rebuild_indicators_in_place(indicator_config_id, initiated_by=None, source=N
             config.meta.build.rebuilt_asynchronously = False
             config.save()
 
+        rows_count_before_rebuild = adapter.get_query_object().count() if adapter.table_exists else None
         try:
             adapter.build_table(initiated_by=initiated_by, source=source)
             _iteratively_build_table(config, in_place=True)
         except Exception:
-            _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource_in_place', error=True)
+            _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource_in_place', adapter,
+                                        rows_count_before_rebuild, error=True)
             raise
-        _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource_in_place')
+        _report_ucr_rebuild_metrics(config, source, 'rebuild_datasource_in_place', adapter,
+                                    rows_count_before_rebuild)
 
 
-def _report_ucr_rebuild_metrics(config, source, action, error=False):
+def _report_ucr_rebuild_metrics(config, source, action, adapter, rows_count_before_rebuild, error=False):
     if source not in ('edit_data_source_rebuild', 'edit_data_source_build_in_place'):
         return
     try:
         _report_metric_number_of_days_since_first_build(config.domain, config.get_id, action)
         if error:
             _report_metric_rebuild_error(config, action)
+        if not error:
+            _report_metric_increase_in_rows_count(config, action, adapter, rows_count_before_rebuild)
     except Exception:
         pass
 
@@ -186,6 +193,15 @@ def _report_metric_rebuild_error(config, action):
         expected_rows_to_process,
         tags={'domain': config.domain}
     )
+
+
+def _report_metric_increase_in_rows_count(config, action, adapter, rows_count_before_rebuild):
+    if rows_count_before_rebuild is not None:
+        # Row count can only be obtained for synchronous rebuilds.
+        if not config.asynchronous:
+            rows_count_after_rebuild = adapter.get_query_object().count()
+            if rows_count_after_rebuild > rows_count_before_rebuild:
+                metrics_counter(f'commcare.ucr.{action}.increase_in_rows', tags={'domain': config.domain})
 
 
 @task(serializer='pickle', queue=UCR_CELERY_QUEUE, ignore_result=True, acks_late=True)

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -159,9 +159,9 @@ def rebuild_indicators_in_place(indicator_config_id, initiated_by=None, source=N
 
 
 def _get_rows_count_from_existing_table(adapter):
-    if not adapter.table_exists:
-        return None
     table = adapter.get_existing_table_from_db()
+    if not table:
+        return None
     return adapter.session_helper.Session.query(table).count()
 
 

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -1,26 +1,33 @@
 import collections
 import hashlib
+import logging
 import re
+from dataclasses import dataclass
 from typing import Any, Optional
 
 from couchdbkit import ResourceNotFound
 from django_prbac.utils import has_privilege
-from dataclasses import dataclass
+
+from dimagi.utils.couch.undo import is_deleted, remove_deleted_doc_type_suffix
 
 from corehq import privileges, toggles
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.linked_domain.util import is_linked_report
 from corehq.apps.userreports.adapter import IndicatorAdapterLoadTracker
-from corehq.apps.userreports.const import REPORT_BUILDER_EVENTS_KEY, TEMP_REPORT_PREFIX
-from corehq.apps.userreports.exceptions import BadSpecError, ReportConfigurationNotFoundError, \
-    DataSourceConfigurationNotFoundError
+from corehq.apps.userreports.const import (
+    REPORT_BUILDER_EVENTS_KEY,
+    TEMP_REPORT_PREFIX,
+)
+from corehq.apps.userreports.exceptions import (
+    BadSpecError,
+    DataSourceConfigurationNotFoundError,
+    ReportConfigurationNotFoundError,
+)
 from corehq.toggles import ENABLE_UCR_MIRRORS
 from corehq.util import reverse
 from corehq.util.couch import DocumentNotFound
 from corehq.util.metrics.load_counters import ucr_load_counter
-from dimagi.utils.couch.undo import is_deleted, remove_deleted_doc_type_suffix
-import logging
 
 UCR_TABLE_PREFIX = 'ucr_'
 LEGACY_UCR_TABLE_PREFIX = 'config_report_'
@@ -197,8 +204,12 @@ def number_of_ucr_reports(domain):
 
 
 def get_indicator_adapter(config, raise_errors=False, load_source="unknown"):
-    from corehq.apps.userreports.sql.adapter import IndicatorSqlAdapter, ErrorRaisingIndicatorSqlAdapter, \
-        MultiDBSqlAdapter, ErrorRaisingMultiDBAdapter
+    from corehq.apps.userreports.sql.adapter import (
+        ErrorRaisingIndicatorSqlAdapter,
+        ErrorRaisingMultiDBAdapter,
+        IndicatorSqlAdapter,
+        MultiDBSqlAdapter,
+    )
     requires_mirroring = config.mirrored_engine_ids
     if requires_mirroring and ENABLE_UCR_MIRRORS.enabled(config.domain):
         adapter_cls = ErrorRaisingMultiDBAdapter if raise_errors else MultiDBSqlAdapter
@@ -270,8 +281,11 @@ def get_async_indicator_modify_lock_key(doc_id):
 
 
 def get_static_report_mapping(from_domain, to_domain):
-    from corehq.apps.userreports.models import StaticReportConfiguration, STATIC_PREFIX, \
-        CUSTOM_REPORT_PREFIX
+    from corehq.apps.userreports.models import (
+        CUSTOM_REPORT_PREFIX,
+        STATIC_PREFIX,
+        StaticReportConfiguration,
+    )
 
     report_map = {}
 
@@ -321,9 +335,9 @@ def get_report_config_or_not_found(domain, config_id):
 
 def get_ucr_datasource_config_by_id(indicator_config_id, allow_deleted=False):
     from corehq.apps.userreports.models import (
-        id_is_static,
-        StaticDataSourceConfiguration,
         DataSourceConfiguration,
+        StaticDataSourceConfiguration,
+        id_is_static,
     )
     if id_is_static(indicator_config_id):
         return StaticDataSourceConfiguration.by_id(indicator_config_id)
@@ -349,8 +363,8 @@ def _wrap_data_source_by_doc_type(doc, allow_deleted=False):
 
 def wrap_report_config_by_type(config, allow_deleted=False):
     from corehq.apps.userreports.models import (
-        ReportConfiguration,
         RegistryReportConfiguration,
+        ReportConfiguration,
     )
     if is_deleted(config) and not allow_deleted:
         raise ReportConfigurationNotFoundError()

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -168,7 +168,7 @@ def allowed_report_builder_reports(request):
     return 0
 
 
-def get_configurable_and_static_reports_by_data_source(domain, data_source_id):
+def get_configurable_and_static_reports_for_data_source(domain, data_source_id):
     reports = get_configurable_and_static_reports(domain)
     return [report for report in reports if report.config_id == data_source_id]
 

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -161,6 +161,11 @@ def allowed_report_builder_reports(request):
     return 0
 
 
+def get_configurable_and_static_reports_by_data_source(domain, data_source_id):
+    reports = get_configurable_and_static_reports(domain)
+    return [report for report in reports if report.config_id == data_source_id]
+
+
 def get_configurable_and_static_reports(domain):
     from corehq.apps.userreports.models import StaticReportConfiguration
     return get_existing_reports(domain) + StaticReportConfiguration.by_domain(domain)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1354,7 +1354,13 @@ def rebuild_data_source(request, domain, config_id):
 
 
 def _report_ucr_rebuild_metrics(domain, config, action):
-    metrics_counter(f'commcare.ucr.{action}.count', tags={'domain': domain})
+    metrics_counter(
+        f'commcare.ucr.{action}.count',
+        tags={
+            'domain': domain,
+            'datasource_id': config.get_id,
+        }
+    )
     metrics_gauge(
         f'commcare.ucr.{action}.columns.count',
         len(config.get_columns()),

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1346,7 +1346,7 @@ def rebuild_data_source(request, domain, config_id):
         )
     )
 
-    rebuild_indicators.delay(config_id, request.user.username, domain=domain)
+    rebuild_indicators.delay(config_id, request.user.username, domain=domain, source='edit_data_source_rebuild')
     _report_ucr_rebuild_metrics(domain, config, 'rebuild_datasource')
     return HttpResponseRedirect(reverse(
         EditDataSourceView.urlname, args=[domain, config._id]

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -27,7 +27,6 @@ from no_exceptions.exceptions import HttpException
 from sqlalchemy import exc, types
 from sqlalchemy.exc import ProgrammingError
 
-from corehq.util.metrics import metrics_counter
 from couchexport.export import export_from_tables
 from couchexport.files import Temp
 from couchexport.models import Format
@@ -180,6 +179,7 @@ from corehq.motech.repeaters.models import DataSourceRepeater
 from corehq.tabs.tabclasses import ProjectReportsTab
 from corehq.util import reverse
 from corehq.util.couch import get_document_or_404
+from corehq.util.metrics import metrics_counter, metrics_gauge
 from corehq.util.quickcache import quickcache
 from corehq.util.soft_assert import soft_assert
 
@@ -1354,6 +1354,11 @@ def rebuild_data_source(request, domain, config_id):
 
 def _report_ucr_rebuild_metrics(domain, config, action):
     metrics_counter(f'commcare.ucr.{action}.count', tags={'domain': domain})
+    metrics_gauge(
+        f'commcare.ucr.{action}.columns.count',
+        len(config.get_columns()),
+        tags={'domain': domain}
+    )
 
 
 def _number_of_records_to_be_iterated_for_rebuild(datasource_configuration):

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -161,6 +161,7 @@ from corehq.apps.userreports.ui.forms import (
 from corehq.apps.userreports.util import (
     add_event,
     allowed_report_builder_reports,
+    get_configurable_and_static_reports_by_data_source,
     get_indicator_adapter,
     get_referring_apps,
     has_report_builder_access,
@@ -1359,6 +1360,20 @@ def _report_ucr_rebuild_metrics(domain, config, action):
         len(config.get_columns()),
         tags={'domain': domain}
     )
+    _report_metric_report_counts_by_datasource(domain, config.get_id, action)
+
+
+def _report_metric_report_counts_by_datasource(domain, data_source_id, action):
+    try:
+        reports = get_configurable_and_static_reports_by_data_source(domain, data_source_id)
+    except Exception:
+        pass
+    else:
+        metrics_gauge(
+            f'commcare.ucr.{action}.reports_per_datasource.count',
+            len(reports),
+            tags={'domain': domain}
+        )
 
 
 def _number_of_records_to_be_iterated_for_rebuild(datasource_configuration):

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -161,7 +161,7 @@ from corehq.apps.userreports.ui.forms import (
 from corehq.apps.userreports.util import (
     add_event,
     allowed_report_builder_reports,
-    get_configurable_and_static_reports_by_data_source,
+    get_configurable_and_static_reports_for_data_source,
     get_indicator_adapter,
     get_referring_apps,
     has_report_builder_access,
@@ -1365,7 +1365,7 @@ def _report_ucr_rebuild_metrics(domain, config, action):
 
 def _report_metric_report_counts_by_datasource(domain, data_source_id, action):
     try:
-        reports = get_configurable_and_static_reports_by_data_source(domain, data_source_id)
+        reports = get_configurable_and_static_reports_for_data_source(domain, data_source_id)
     except Exception:
         pass
     else:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Adds metrics related to Rebuild and Rebuild-in-place functionality to be captured on DataDog.
No user facing change.

DataDog Dashboard Screenshot
![image](https://github.com/user-attachments/assets/ca9f2ebe-57d8-4e46-809e-9ac3c361fe56)


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-3840). 
This is a part of feature analytics wherein intention is to understand the usage of  Rebuild and Rebuild-in-place functionality for UCRs.

Some of the metrics are nuanced and required either database access or some minor calculations.  Any exceptions raised by them are ignored intentionally to not block the original functionality. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
User Configurable Reports

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local.  Some metrics are simple and ones that involved code for metrics calculation will ignores any exception raised.
To be tested on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
