### PR TITLE
Enterprise Date Range Tiles do not display for translated languages

### DIFF
--- a/corehq/apps/enterprise/static/enterprise/js/project_dashboard.js
+++ b/corehq/apps/enterprise/static/enterprise/js/project_dashboard.js
@@ -258,12 +258,12 @@ hqDefine("enterprise/js/project_dashboard", [
         const maxDateRangeDays = initialPageData.get("max_date_range_days");
 
         const displayMap = {
-            "form_submission": formSubmissionsDisplay,
+            "form_submissions": formSubmissionsDisplay,
             "sms": smsDisplay,
         };
         const dateRangeModal = DateRangeModal($dateRangeModal, datePicker, dateRangePresetOptions, maxDateRangeDays, displayMap);
 
-        $("#form_submission_dateRangeDisplay").koApplyBindings(formSubmissionsDisplay);
+        $("#form_submissions_dateRangeDisplay").koApplyBindings(formSubmissionsDisplay);
         $("#sms_dateRangeDisplay").koApplyBindings(smsDisplay);
         $dateRangeModal.koApplyBindings(
             dateRangeModal

--- a/corehq/apps/enterprise/templates/enterprise/partials/project_tile.html
+++ b/corehq/apps/enterprise/templates/enterprise/partials/project_tile.html
@@ -23,7 +23,7 @@
             data-sender="{{ report.slug }}"
           >&nbsp;</button>
         {% else %}
-          <div class="form-control-plaintext fs-6">{{ "&nbsp;" }}</div>
+          <div class="form-control-plaintext fs-6">&nbsp;</div>
         {% endif %}
       </div>
       <button class="btn btn-primary btn-lg">

--- a/corehq/apps/enterprise/templates/enterprise/partials/project_tile.html
+++ b/corehq/apps/enterprise/templates/enterprise/partials/project_tile.html
@@ -14,21 +14,13 @@
       </div>
       <div class="fs-5">{{ report.total_description }}</div>
       <div class="py-2">
-        {% if report.title == "Mobile Form Submissions" %}
+        {% if report.slug in uses_date_range %}
           <button
-            class="btn btn-link fs-6" id="form_submission_dateRangeDisplay" type="button"
+            class="btn btn-link fs-6" id="{{ report.slug }}_dateRangeDisplay" type="button"
             data-bind="text: presetText"
             data-bs-toggle="modal"
             data-bs-target="#enterpriseFormsDaterange"
-            data-sender="form_submission"
-          >&nbsp;</button>
-        {% elif report.title == "SMS Usage" %}
-          <button
-            class="btn btn-link fs-6" id="sms_dateRangeDisplay" type="button"
-            data-bind="text: presetText"
-            data-bs-toggle="modal"
-            data-bs-target="#enterpriseFormsDaterange"
-            data-sender="sms"
+            data-sender="{{ report.slug }}"
           >&nbsp;</button>
         {% else %}
           <div class="form-control-plaintext fs-6">{{ "&nbsp;" }}</div>

--- a/corehq/apps/enterprise/templates/enterprise/project_dashboard.html
+++ b/corehq/apps/enterprise/templates/enterprise/project_dashboard.html
@@ -15,7 +15,7 @@
 
   <div class="row mt-4">
     {% for report in reports %}
-      {% include 'enterprise/partials/project_tile.html' with report=report %}
+      {% include 'enterprise/partials/project_tile.html' with report=report uses_date_range=uses_date_range %}
     {% endfor %}
   </div>
 

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -93,6 +93,7 @@ def platform_overview(request, domain):
             EnterpriseReport.ODATA_FEEDS,
             EnterpriseReport.SMS,
         )],
+        'uses_date_range': [EnterpriseReport.FORM_SUBMISSIONS, EnterpriseReport.SMS],
         'metric_type': 'Platform Overview',
     })
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
We display a partial template for each enterprise tile. Within that template, there is conditional logic for whether or not to display the date range picker. That logic is currently based on the translated title of the report. This PR switches that to instead be based on the slug, so that translated languages still see the tiles correctly.

It also generalizes the date range logic.

## Feature Flag
None

## Safety Assurance

### Safety story
Locally verified that the tiles continue to display and respond correctly.

### Automated test coverage

None

### QA Plan
No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
