### PR TITLE
Removed redundant script tags from ucr_expression.html

### DIFF
--- a/corehq/apps/userreports/templates/userreports/ucr_expression.html
+++ b/corehq/apps/userreports/templates/userreports/ucr_expression.html
@@ -3,16 +3,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% block js %}{{ block.super }}
-  {% compress js %}
-    <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
-    <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
-    <script src="{% static 'userreports/js/widgets.js' %}"></script>
-  {% endcompress %}
-{% endblock %}
-
 {% js_entry_b3 "userreports/js/ucr_expression" %}
 
 {% block page_content %}


### PR DESCRIPTION
## Technical Summary
Similar to https://github.com/dimagi/commcare-hq/pull/35438

The ace scripts aren't needed because they're included in `base_ace` which is included [here](https://github.com/dimagi/commcare-hq/blob/e56ef3ef69cd0e5e22ea35cc4b2a306e7502b97e/corehq/apps/userreports/static/userreports/js/ucr_expression.js#L6).

The hqwebapp and userreports widgets don't appear to be needed on this page - I don't see any of the widgets in those files being used here. I'm guessing this template was originally copied from [userreports_base.html](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/templates/userreports/userreports_base.html#L7).

## Feature Flag
UCR expression registry

## Safety Assurance

### Safety story
Pretty minor change. Local testing and code review should be sufficient for this.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
