### PR TITLE
[webpack] UCR config pages

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
@@ -54,6 +54,8 @@ hqDefine('hqwebapp/js/base_ace', [
         editor.getSession().on('change', function () {
             $element.val(editor.getSession().getValue());
         });
+
+        return editor;
     };
 
     var getEditors = function () {

--- a/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
@@ -4,6 +4,7 @@ hqDefine("userreports/js/configurable_reports_home", [
     'DOMPurify/dist/purify.min',
     'hqwebapp/js/initial_page_data',
     'select2/dist/js/select2.full.min',
+    'commcarehq',
 ], function (
     $,
     _,

--- a/corehq/apps/userreports/static/userreports/js/data_source_evaluator.js
+++ b/corehq/apps/userreports/static/userreports/js/data_source_evaluator.js
@@ -1,4 +1,13 @@
-hqDefine('userreports/js/data_source_evaluator', function () {
+hqDefine('userreports/js/data_source_evaluator', [
+    'jquery',
+    'knockout',
+    'hqwebapp/js/initial_page_data',
+    'commcarehq',
+], function (
+    $,
+    ko,
+    initialPageData
+) {
     var dataSourceModel = function (submitUrl) {
         var self = {};
         self.submitUrl = submitUrl;
@@ -58,7 +67,7 @@ hqDefine('userreports/js/data_source_evaluator', function () {
     };
 
     $(function () {
-        var submitUrl = hqImport("hqwebapp/js/initial_page_data").reverse("data_source_evaluator");
+        var submitUrl = initialPageData.reverse("data_source_evaluator");
         ko.applyBindings(
             dataSourceModel(submitUrl),
             document.getElementById('data-source-debugger')

--- a/corehq/apps/userreports/static/userreports/js/data_source_from_app.js
+++ b/corehq/apps/userreports/static/userreports/js/data_source_from_app.js
@@ -1,6 +1,12 @@
-hqDefine('userreports/js/data_source_from_app', function () {
+hqDefine('userreports/js/data_source_from_app', [
+    'jquery',
+    'userreports/js/data_source_select_model',
+    'commcarehq',
+], function (
+    $,
+    dataModel
+) {
     $(function () {
-        let dataModel = hqImport("userreports/js/data_source_select_model");
         $("#data-source-config").koApplyBindings(dataModel);
     });
 });

--- a/corehq/apps/userreports/static/userreports/js/data_source_select_model.js
+++ b/corehq/apps/userreports/static/userreports/js/data_source_select_model.js
@@ -1,9 +1,15 @@
-hqDefine("userreports/js/data_source_select_model", function () {
+hqDefine("userreports/js/data_source_select_model", [
+    'knockout',
+    'hqwebapp/js/initial_page_data',
+], function (
+    ko,
+    initialPageData
+) {
     return {
         application: ko.observable(""),
         sourceType: ko.observable(""),
-        sourcesMap: hqImport("hqwebapp/js/initial_page_data").get("sources_map"),
-        dropdownMap: hqImport("hqwebapp/js/initial_page_data").get("dropdown_map"),
+        sourcesMap: initialPageData.get("sources_map"),
+        dropdownMap: initialPageData.get("dropdown_map"),
         labelMap: {
             'case': gettext('Case'),
             'form': gettext('Form'),

--- a/corehq/apps/userreports/static/userreports/js/edit_report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/edit_report_config.js
@@ -1,6 +1,7 @@
 hqDefine('userreports/js/edit_report_config', [
     'jquery',
     'hqwebapp/js/multiselect_utils',
+    'commcarehq',
 ], function (
     $,
     multiselectUtils

--- a/corehq/apps/userreports/static/userreports/js/expression_debugger.js
+++ b/corehq/apps/userreports/static/userreports/js/expression_debugger.js
@@ -1,11 +1,23 @@
-/* globals ace */
-hqDefine('userreports/js/expression_debugger', function () {
+hqDefine('userreports/js/expression_debugger', [
+    "jquery",
+    "underscore",
+    "hqwebapp/js/base_ace",
+    "hqwebapp/js/initial_page_data",
+    "userreports/js/expression_evaluator",
+    "hqwebapp/js/bootstrap3/widgets",
+    "hqwebapp/js/components/select_toggle",
+    "commcarehq",
+], function (
+    $,
+    _,
+    baseAce,
+    initialPageData,
+    expressionModel
+) {
     $(function () {
-        var expressionModel = hqImport('userreports/js/expression_evaluator').expressionModel;
-        var initialPageData = hqImport("hqwebapp/js/initial_page_data");
         var submitUrl = initialPageData.reverse("expression_evaluator");
-        var expressionEditor = ace.edit($('#expression ~pre')[0]);
-        var docEditor = ace.edit($('#raw_document ~pre')[0]);
+        var expressionEditor = baseAce.initJsonWidget($("#expression"));
+        var docEditor = baseAce.initJsonWidget($("#raw_document"));
         docEditor.getSession().setValue("{}");
         var sampleExpression = {
             "type": "property_name",
@@ -21,7 +33,7 @@ hqDefine('userreports/js/expression_debugger', function () {
             ucrExpressionId: initialPageData.get('ucr_expression_id'),
         };
         $('#expression-debugger').koApplyBindings(
-            expressionModel(expressionEditor, docEditor, submitUrl, initialData)
+            expressionModel.expressionModel(expressionEditor, docEditor, submitUrl, initialData)
         );
     });
 });

--- a/corehq/apps/userreports/static/userreports/js/expression_evaluator.js
+++ b/corehq/apps/userreports/static/userreports/js/expression_evaluator.js
@@ -1,4 +1,10 @@
-hqDefine('userreports/js/expression_evaluator', function () {
+hqDefine('userreports/js/expression_evaluator', [
+    'jquery',
+    'knockout',
+], function (
+    $,
+    ko
+) {
     var expressionModel = function (expressionEditor, docEditor, submitUrl, initialData) {
         var self = {};
         initialData = initialData || {};

--- a/corehq/apps/userreports/static/userreports/js/widgets.js
+++ b/corehq/apps/userreports/static/userreports/js/widgets.js
@@ -1,5 +1,7 @@
 hqDefine("userreports/js/widgets", [
     'jquery',
+    'hqwebapp/js/base_ace',
+    'commcarehq',
 ], function ($) {
     $(function () {
         $('[data-toggle="popover"]').popover();

--- a/corehq/apps/userreports/templates/userreports/configurable_reports_home.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_reports_home.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'userreports/js/configurable_reports_home' %}
+{% js_entry_b3 'userreports/js/configurable_reports_home' %}
 
 {% block page_content %}
   {% if use_updated_ucr_naming %}

--- a/corehq/apps/userreports/templates/userreports/data_source_debugger.html
+++ b/corehq/apps/userreports/templates/userreports/data_source_debugger.html
@@ -1,9 +1,9 @@
 {% extends "userreports/userreports_base.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
-{% block js %}{{ block.super }}
-  <script src="{% static 'userreports/js/data_source_evaluator.js' %}"></script>
-{% endblock %}
+
+{% js_entry_b3 'userreports/js/data_source_evaluator' %}
+
 {% block page_content %}
   {% registerurl "data_source_evaluator" domain %}
   <h1>

--- a/corehq/apps/userreports/templates/userreports/data_source_from_app.html
+++ b/corehq/apps/userreports/templates/userreports/data_source_from_app.html
@@ -4,12 +4,7 @@
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 
-{% block js %}{{ block.super }}
-  {% compress js %}
-  <script src="{% static 'userreports/js/data_source_select_model.js' %}"></script>
-  <script src="{% static 'userreports/js/data_source_from_app.js' %}"></script>
-  {% endcompress %}
-{% endblock %}
+{% js_entry_b3 'userreports/js/data_source_from_app' %}
 
 {% block page_content %}
   {% initial_page_data "sources_map" sources_map %}

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -3,6 +3,8 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
+{% js_entry_b3 'userreports/js/widgets' %}
+
 {% block page_content %}
   {% if data_source.meta.build.is_rebuild_in_progress %}
         <div id="built-warning" class="alert alert-warning">

--- a/corehq/apps/userreports/templates/userreports/edit_report_config.html
+++ b/corehq/apps/userreports/templates/userreports/edit_report_config.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "userreports/js/edit_report_config" %}
+{% js_entry_b3 "userreports/js/edit_report_config" %}
 
 {% block page_content %}
   <div class="pull-right page-actions-toolbar">

--- a/corehq/apps/userreports/templates/userreports/expression_debugger.html
+++ b/corehq/apps/userreports/templates/userreports/expression_debugger.html
@@ -1,10 +1,9 @@
 {% extends "userreports/userreports_base.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
-{% block js %}{{ block.super }}
-  <script src="{% static 'userreports/js/expression_evaluator.js' %}"></script>
-  <script src="{% static 'userreports/js/expression_debugger.js' %}"></script>
-{% endblock %}
+
+{% js_entry_b3 'userreports/js/expression_debugger' %}
+
 {% block page_content %}
   {% registerurl "expression_evaluator" domain %}
   {% initial_page_data "input_type" request.GET.input_type %}
@@ -73,7 +72,7 @@
      <div class="form-group" data-bind="visible: inputType() === 'raw', css: {'has-error': hasDocParseError}">
       <label for="" class="col-sm-2 control-label">{% trans "Document JSON" %}</label>
       <div class="col-sm-10">
-        <textarea id="raw_document" class="form-control jsonwidget" ></textarea>
+        <textarea id="raw_document" class="form-control" ></textarea>
         <div class="help-block" data-bind="visible: hasDocParseError">
           {% blocktrans %}
             Your document JSON has parse errors!
@@ -128,7 +127,7 @@
     <div class="form-group" data-bind="hidden: ucrExpressionId, css: {'has-error': hasParseError}">
       <label for="" class="col-sm-2 control-label">{% trans "Expression JSON" %}</label>
       <div class="col-sm-10">
-        <textarea id="expression" class="form-control jsonwidget"></textarea>
+        <textarea id="expression" class="form-control"></textarea>
         <div class="help-block" data-bind="visible: hasParseError">
           {% blocktrans %}
             Your expression has parse errors!

--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -3,19 +3,6 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
-{% block js %}{{ block.super }}
-  {% if not use_js_bundler %}
-    {% compress js %}
-      <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
-      <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
-      <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
-      <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
-      <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
-      <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
-      <script src="{% static 'userreports/js/widgets.js' %}"></script>
-    {% endcompress %}
-  {% endif %}
-{% endblock %}
 
 {% block page_navigation %}
   {% initial_page_data 'useUpdatedUcrNaming' use_updated_ucr_naming %}

--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -4,15 +4,17 @@
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 {% block js %}{{ block.super }}
-  {% compress js %}
-    <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
-    <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
-    <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
-    <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
-    <script src="{% static 'userreports/js/widgets.js' %}"></script>
-  {% endcompress %}
+  {% if not use_js_bundler %}
+    {% compress js %}
+      <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
+      <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
+      <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
+      <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
+      <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
+      <script src="{% static 'hqwebapp/js/bootstrap3/widgets.js' %}"></script>
+      <script src="{% static 'userreports/js/widgets.js' %}"></script>
+    {% endcompress %}
+  {% endif %}
 {% endblock %}
 
 {% block page_navigation %}


### PR DESCRIPTION
## Technical Summary
This migrates all pages that inherit from `userreports_base.html`

It's a mix of pages that were already using requirejs, which are pretty trivial to migrate, and pages that never got migrated to requirejs, which are also pretty simple. None of this code depends on core reports js, and there are no libraries added here that aren't already used in webpack.

## Feature Flag
UCR

## Safety Assurance

### Safety story
UI-level changes to a flagged (although widely used) feature. I've tested locally and will do a bit of testing on staging, ~~marking "don't merge" until that's complete~~ (done).

### Automated test coverage

no

### QA Plan

not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
