### PR TITLE
Rename a few reports js files

### DIFF
--- a/corehq/apps/export/static/export/js/download_export.js
+++ b/corehq/apps/export/static/export/js/download_export.js
@@ -17,7 +17,7 @@ hqDefine('export/js/download_export', [
     'analytix/js/google',
     'analytix/js/kissmetrix',
     'reports/js/filters/bootstrap5/main',
-    'reports/js/reports.util',
+    'reports/js/util',
     'export/js/utils',
     'jquery.cookie/jquery.cookie',      // for resuming export downloads on refresh
 ], function (

--- a/corehq/apps/fixtures/static/fixtures/js/view-table.js
+++ b/corehq/apps/fixtures/static/fixtures/js/view-table.js
@@ -2,7 +2,7 @@ hqDefine("fixtures/js/view-table", [
     "jquery",
     "hqwebapp/js/initial_page_data",
     "reports/js/bootstrap3/standard_hq_report",
-    "reports/js/bootstrap3/config.dataTables.bootstrap",
+    "reports/js/bootstrap3/datatables_config",
     "reports/js/filters/bootstrap3/main",
     "datatables.fixedColumns",
 ], function (

--- a/corehq/apps/hqadmin/static/hqadmin/js/hqadmin_base_report.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/hqadmin_base_report.js
@@ -1,7 +1,7 @@
 hqDefine('hqadmin/js/hqadmin_base_report', [
     'jquery',
     'hqwebapp/js/initial_page_data',
-    'reports/js/bootstrap3/config.dataTables.bootstrap',
+    'reports/js/bootstrap3/datatables_config',
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/async.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/async.js.diff.txt
@@ -1,8 +1,8 @@
 --- 
 +++ 
 @@ -1,4 +1,4 @@
--hqDefine("reports/js/bootstrap3/reports.async", function () {
-+hqDefine("reports/js/bootstrap5/reports.async", function () {
+-hqDefine("reports/js/bootstrap3/async", function () {
++hqDefine("reports/js/bootstrap5/async", function () {
      return function (o) {
          'use strict';
          var self = {};

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
@@ -1,8 +1,8 @@
 --- 
 +++ 
 @@ -1,4 +1,4 @@
--hqDefine("reports/js/bootstrap3/config.dataTables.bootstrap", [
-+hqDefine("reports/js/bootstrap5/config.dataTables.bootstrap", [
+-hqDefine("reports/js/bootstrap3/datatables_config", [
++hqDefine("reports/js/bootstrap5/datatables_config", [
      'jquery',
      'underscore',
      'analytix/js/google',

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/maps_utils.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/maps_utils.js.diff.txt
@@ -10,8 +10,8 @@
              }
          );
          var table;
--        table = hqImport("reports/js/bootstrap3/config.dataTables.bootstrap").HQReportDataTables({
-+        table = hqImport("reports/js/bootstrap5/config.dataTables.bootstrap").HQReportDataTables({
+-        table = hqImport("reports/js/bootstrap3/datatables_config").HQReportDataTables({
++        table = hqImport("reports/js/bootstrap5/datatables_config").HQReportDataTables({
              aoColumns: colSorting,
          });
  

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/standard_hq_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/standard_hq_report.js.diff.txt
@@ -22,8 +22,8 @@
  
          var reportOptions = initialPageData.get('js_options') || {};
          if (reportOptions.slug && reportOptions.async) {
--            var asyncHQReport = hqImport("reports/js/bootstrap3/reports.async")({
-+            var asyncHQReport = hqImport("reports/js/bootstrap5/reports.async")({
+-            var asyncHQReport = hqImport("reports/js/bootstrap3/async")({
++            var asyncHQReport = hqImport("reports/js/bootstrap5/async")({
                  standardReport: getStandard(),
              });
              asyncHQReport.init();

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/tabular.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/tabular.js.diff.txt
@@ -6,9 +6,9 @@
      'jquery',
      'underscore',
      'hqwebapp/js/initial_page_data',
--    'reports/js/bootstrap3/config.dataTables.bootstrap',
+-    'reports/js/bootstrap3/datatables_config',
 -    'reports/js/bootstrap3/standard_hq_report',
-+    'reports/js/bootstrap5/config.dataTables.bootstrap',
++    'reports/js/bootstrap5/datatables_config',
 +    'reports/js/bootstrap5/standard_hq_report',
  ], function (
      $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
@@ -24,7 +24,7 @@
      <script src="{% static 'reports/js/datepicker.js' %}"></script>
 -    <script src="{% static 'reports/js/bootstrap3/hq_report.js' %}"></script>
 +    <script src="{% static 'reports/js/bootstrap5/hq_report.js' %}"></script>
-     <script src="{% static 'reports/js/reports.util.js' %}"></script>
+     <script src="{% static 'reports/js/util.js' %}"></script>
 -    <script src="{% static 'reports/js/bootstrap3/async.js' %}"></script>
 -    <script src="{% static 'reports/js/bootstrap3/standard_hq_report.js' %}"></script>
 +    <script src="{% static 'reports/js/bootstrap5/async.js' %}"></script>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
@@ -25,9 +25,9 @@
 -    <script src="{% static 'reports/js/bootstrap3/hq_report.js' %}"></script>
 +    <script src="{% static 'reports/js/bootstrap5/hq_report.js' %}"></script>
      <script src="{% static 'reports/js/reports.util.js' %}"></script>
--    <script src="{% static 'reports/js/bootstrap3/reports.async.js' %}"></script>
+-    <script src="{% static 'reports/js/bootstrap3/async.js' %}"></script>
 -    <script src="{% static 'reports/js/bootstrap3/standard_hq_report.js' %}"></script>
-+    <script src="{% static 'reports/js/bootstrap5/reports.async.js' %}"></script>
++    <script src="{% static 'reports/js/bootstrap5/async.js' %}"></script>
 +    <script src="{% static 'reports/js/bootstrap5/standard_hq_report.js' %}"></script>
      <script src="{% static 'userreports/js/report_analytix.js' %}"></script>
    {% endcompress %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
@@ -19,8 +19,8 @@
  {% block js %}{{ block.super }}
    {% compress js %}
      <script src="{% static 'hqwebapp/js/select2_knockout_bindings.ko.js' %}"></script>
--    <script src="{% static 'reports/js/bootstrap3/config.dataTables.bootstrap.js' %}"></script>
-+    <script src="{% static 'reports/js/bootstrap5/config.dataTables.bootstrap.js' %}"></script>
+-    <script src="{% static 'reports/js/bootstrap3/datatables_config.js' %}"></script>
++    <script src="{% static 'reports/js/bootstrap5/datatables_config.js' %}"></script>
      <script src="{% static 'reports/js/datepicker.js' %}"></script>
 -    <script src="{% static 'reports/js/bootstrap3/hq_report.js' %}"></script>
 +    <script src="{% static 'reports/js/bootstrap5/hq_report.js' %}"></script>

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -841,7 +841,7 @@ class GenericTabularReport(GenericReportView):
     bad_request_error_text = None
     exporting_as_excel = False
 
-    # Sets bSort in the datatables instance to true/false (config.dataTables.bootstrap.js)
+    # Sets bSort in the datatables instance to true/false (datatables_config.js)
     sortable = True
 
     # override old class properties

--- a/corehq/apps/reports/static/reports/js/bootstrap3/async.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/async.js
@@ -58,7 +58,7 @@ hqDefine("reports/js/bootstrap3/async", function () {
                 self.standardReport.filterSubmitButton.addClass('disabled');
             }
             self.filterForm.submit(function () {
-                var params = hqImport('reports/js/reports.util').urlSerialize(this);
+                var params = hqImport('reports/js/util').urlSerialize(this);
                 if (self.isCaseListRelated(pathName)) {
                     var url = window.location.href.replace(self.standardReport.urlRoot,
                         self.standardReport.urlRoot + 'async/') + "?" + "&" + params;

--- a/corehq/apps/reports/static/reports/js/bootstrap3/async.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/async.js
@@ -1,4 +1,4 @@
-hqDefine("reports/js/bootstrap3/reports.async", function () {
+hqDefine("reports/js/bootstrap3/async", function () {
     return function (o) {
         'use strict';
         var self = {};

--- a/corehq/apps/reports/static/reports/js/bootstrap3/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/datatables_config.js
@@ -1,4 +1,4 @@
-hqDefine("reports/js/bootstrap5/config.dataTables.bootstrap", [
+hqDefine("reports/js/bootstrap3/datatables_config", [
     'jquery',
     'underscore',
     'analytix/js/google',
@@ -86,7 +86,7 @@ hqDefine("reports/js/bootstrap5/config.dataTables.bootstrap", [
             });
             function applyBootstrapMagic() {
                 $('[data-datatable-tooltip]').each(function () {
-                    $(this).tooltip({  /* todo B5: plugin:tooltip */
+                    $(this).tooltip({
                         placement: $(this).attr('data-datatable-tooltip'),
                         title: $(this).attr('data-datatable-tooltip-text'),
                     });

--- a/corehq/apps/reports/static/reports/js/bootstrap3/maps_utils.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/maps_utils.js
@@ -1674,7 +1674,7 @@ hqDefine("reports/js/bootstrap3/maps_utils", function () {
             }
         );
         var table;
-        table = hqImport("reports/js/bootstrap3/config.dataTables.bootstrap").HQReportDataTables({
+        table = hqImport("reports/js/bootstrap3/datatables_config").HQReportDataTables({
             aoColumns: colSorting,
         });
 

--- a/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
@@ -65,7 +65,7 @@ hqDefine("reports/js/bootstrap3/standard_hq_report", [
 
         var reportOptions = initialPageData.get('js_options') || {};
         if (reportOptions.slug && reportOptions.async) {
-            var asyncHQReport = hqImport("reports/js/bootstrap3/reports.async")({
+            var asyncHQReport = hqImport("reports/js/bootstrap3/async")({
                 standardReport: getStandard(),
             });
             asyncHQReport.init();

--- a/corehq/apps/reports/static/reports/js/bootstrap3/tabular.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/tabular.js
@@ -2,7 +2,7 @@ hqDefine("reports/js/bootstrap3/tabular", [
     'jquery',
     'underscore',
     'hqwebapp/js/initial_page_data',
-    'reports/js/bootstrap3/config.dataTables.bootstrap',
+    'reports/js/bootstrap3/datatables_config',
     'reports/js/bootstrap3/standard_hq_report',
 ], function (
     $,

--- a/corehq/apps/reports/static/reports/js/bootstrap5/async.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/async.js
@@ -1,4 +1,4 @@
-hqDefine("reports/js/bootstrap5/reports.async", function () {
+hqDefine("reports/js/bootstrap5/async", function () {
     return function (o) {
         'use strict';
         var self = {};

--- a/corehq/apps/reports/static/reports/js/bootstrap5/async.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/async.js
@@ -58,7 +58,7 @@ hqDefine("reports/js/bootstrap5/async", function () {
                 self.standardReport.filterSubmitButton.addClass('disabled');
             }
             self.filterForm.submit(function () {
-                var params = hqImport('reports/js/reports.util').urlSerialize(this);
+                var params = hqImport('reports/js/util').urlSerialize(this);
                 if (self.isCaseListRelated(pathName)) {
                     var url = window.location.href.replace(self.standardReport.urlRoot,
                         self.standardReport.urlRoot + 'async/') + "?" + "&" + params;

--- a/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
@@ -1,4 +1,4 @@
-hqDefine("reports/js/bootstrap3/config.dataTables.bootstrap", [
+hqDefine("reports/js/bootstrap5/datatables_config", [
     'jquery',
     'underscore',
     'analytix/js/google',
@@ -86,7 +86,7 @@ hqDefine("reports/js/bootstrap3/config.dataTables.bootstrap", [
             });
             function applyBootstrapMagic() {
                 $('[data-datatable-tooltip]').each(function () {
-                    $(this).tooltip({
+                    $(this).tooltip({  /* todo B5: plugin:tooltip */
                         placement: $(this).attr('data-datatable-tooltip'),
                         title: $(this).attr('data-datatable-tooltip-text'),
                     });

--- a/corehq/apps/reports/static/reports/js/bootstrap5/maps_utils.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/maps_utils.js
@@ -1674,7 +1674,7 @@ hqDefine("reports/js/bootstrap5/maps_utils", function () {
             }
         );
         var table;
-        table = hqImport("reports/js/bootstrap5/config.dataTables.bootstrap").HQReportDataTables({
+        table = hqImport("reports/js/bootstrap5/datatables_config").HQReportDataTables({
             aoColumns: colSorting,
         });
 

--- a/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
@@ -65,7 +65,7 @@ hqDefine("reports/js/bootstrap5/standard_hq_report", [
 
         var reportOptions = initialPageData.get('js_options') || {};
         if (reportOptions.slug && reportOptions.async) {
-            var asyncHQReport = hqImport("reports/js/bootstrap5/reports.async")({
+            var asyncHQReport = hqImport("reports/js/bootstrap5/async")({
                 standardReport: getStandard(),
             });
             asyncHQReport.init();

--- a/corehq/apps/reports/static/reports/js/bootstrap5/tabular.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/tabular.js
@@ -2,7 +2,7 @@ hqDefine("reports/js/bootstrap5/tabular", [
     'jquery',
     'underscore',
     'hqwebapp/js/initial_page_data',
-    'reports/js/bootstrap5/config.dataTables.bootstrap',
+    'reports/js/bootstrap5/datatables_config',
     'reports/js/bootstrap5/standard_hq_report',
 ], function (
     $,

--- a/corehq/apps/reports/static/reports/js/util.js
+++ b/corehq/apps/reports/static/reports/js/util.js
@@ -1,4 +1,4 @@
-hqDefine('reports/js/reports.util', ['jquery'], function ($) {
+hqDefine('reports/js/util', ['jquery'], function ($) {
     return {
         urlSerialize: function (filters, exclude) {
             exclude = exclude || [];

--- a/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
@@ -16,7 +16,7 @@
     <script src="{% static 'reports/js/bootstrap3/config.dataTables.bootstrap.js' %}"></script>
     <script src="{% static 'reports/js/datepicker.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap3/hq_report.js' %}"></script>
-    <script src="{% static 'reports/js/reports.util.js' %}"></script>
+    <script src="{% static 'reports/js/util.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap3/async.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap3/standard_hq_report.js' %}"></script>
     <script src="{% static 'userreports/js/report_analytix.js' %}"></script>

--- a/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
@@ -13,7 +13,7 @@
 {% block js %}{{ block.super }}
   {% compress js %}
     <script src="{% static 'hqwebapp/js/select2_knockout_bindings.ko.js' %}"></script>
-    <script src="{% static 'reports/js/bootstrap3/config.dataTables.bootstrap.js' %}"></script>
+    <script src="{% static 'reports/js/bootstrap3/datatables_config.js' %}"></script>
     <script src="{% static 'reports/js/datepicker.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap3/hq_report.js' %}"></script>
     <script src="{% static 'reports/js/util.js' %}"></script>

--- a/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
@@ -17,7 +17,7 @@
     <script src="{% static 'reports/js/datepicker.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap3/hq_report.js' %}"></script>
     <script src="{% static 'reports/js/reports.util.js' %}"></script>
-    <script src="{% static 'reports/js/bootstrap3/reports.async.js' %}"></script>
+    <script src="{% static 'reports/js/bootstrap3/async.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap3/standard_hq_report.js' %}"></script>
     <script src="{% static 'userreports/js/report_analytix.js' %}"></script>
   {% endcompress %}

--- a/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
@@ -13,7 +13,7 @@
 {% block js %}{{ block.super }}
   {% compress js %}
     <script src="{% static 'hqwebapp/js/select2_knockout_bindings.ko.js' %}"></script>
-    <script src="{% static 'reports/js/bootstrap5/config.dataTables.bootstrap.js' %}"></script>
+    <script src="{% static 'reports/js/bootstrap5/datatables_config.js' %}"></script>
     <script src="{% static 'reports/js/datepicker.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap5/hq_report.js' %}"></script>
     <script src="{% static 'reports/js/util.js' %}"></script>

--- a/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
@@ -17,7 +17,7 @@
     <script src="{% static 'reports/js/datepicker.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap5/hq_report.js' %}"></script>
     <script src="{% static 'reports/js/reports.util.js' %}"></script>
-    <script src="{% static 'reports/js/bootstrap5/reports.async.js' %}"></script>
+    <script src="{% static 'reports/js/bootstrap5/async.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap5/standard_hq_report.js' %}"></script>
     <script src="{% static 'userreports/js/report_analytix.js' %}"></script>
   {% endcompress %}

--- a/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
@@ -16,7 +16,7 @@
     <script src="{% static 'reports/js/bootstrap5/config.dataTables.bootstrap.js' %}"></script>
     <script src="{% static 'reports/js/datepicker.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap5/hq_report.js' %}"></script>
-    <script src="{% static 'reports/js/reports.util.js' %}"></script>
+    <script src="{% static 'reports/js/util.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap5/async.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap5/standard_hq_report.js' %}"></script>
     <script src="{% static 'userreports/js/report_analytix.js' %}"></script>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/organisms/tables.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/organisms/tables.html
@@ -179,7 +179,7 @@
   <p>
     In CommCare HQ, we have created a wrapper class around our reporting use of datatables called
     <code>GenericTabularReport</code>, which takes care of generating the datatables configuration in
-    <code>config.dataTables.bootstrap.js</code>. This was done in an effort to reduce the amount of HTML and
+    <code>datatables_config.js</code>. This was done in an effort to reduce the amount of HTML and
     javascript required to create a report, as generating custom reports for projects was once very common in HQ.
     With the introduction of User Configurable Reports (UCRs), this need for quickly creating these hard-coded
     custom reports has since been eliminated.
@@ -194,7 +194,7 @@
   </p>
   <p>
     When our reporting tools were created, DataTables was still a fairly young library and had its own set of issues,
-    which you can see in <code>config.dataTables.bootstrap.js</code> if you examine the strangely named variables in
+    which you can see in <code>datatables_config.js</code> if you examine the strangely named variables in
     still in "hungarian notation" style. Thankfully, the developers of dataTables have kept later versions
     backwards-compatible with this older notation, but for reference here is a
     <a href="https://datatables.net/upgrade/1.10-convert" target="_blank">conversion guide</a> for the older configuration
@@ -204,7 +204,7 @@
     {# todo future developer: remove with use_bootstrap5 removal cleanup and revisit text above too #}
     <strong>Important:</strong> As of the time of this writing, the Bootstrap 3 to 5 migration is still ongoing
     and the Reporting section has not yet been migrated. Please ensure that during that migration, the notation in
-    <code>config.dataTables.bootstrap.js</code> is updated. Thank you.
+    <code>datatables_config.js</code> is updated. Thank you.
   </div>
   <h3 id="datatables-simple" class="pt-3">
     Simple Example

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
@@ -3,7 +3,7 @@ hqDefine('toggle_ui/js/flags', [
     'knockout',
     'underscore',
     'hqwebapp/js/bootstrap3/alert_user',
-    'reports/js/bootstrap3/config.dataTables.bootstrap',
+    'reports/js/bootstrap3/datatables_config',
     'hqwebapp/js/components/select_toggle',
     'commcarehq',
 ], function (

--- a/corehq/apps/userreports/static/userreports/js/base.js
+++ b/corehq/apps/userreports/static/userreports/js/base.js
@@ -65,7 +65,7 @@ hqDefine('userreports/js/base', function () {
             }
         };
 
-        var reportTables = hqImport("reports/js/bootstrap3/config.dataTables.bootstrap").HQReportDataTables({
+        var reportTables = hqImport("reports/js/bootstrap3/datatables_config").HQReportDataTables({
             dataTableElem: '#report_table_' + initialPageData.get('report_slug'),
             defaultRows: initialPageData.get('table_default_rows'),
             startAtRowNum: initialPageData.get('table_start_at_row'),

--- a/corehq/apps/userreports/static/userreports/js/configurable_report.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_report.js
@@ -31,7 +31,7 @@ hqDefine("userreports/js/configurable_report", function () {
             hqImport('userreports/js/report_analytix').track.event.apply(this, e);
         });
 
-        var urlSerialize = hqImport('reports/js/reports.util').urlSerialize;
+        var urlSerialize = hqImport('reports/js/util').urlSerialize;
         var reportOptions = {
             domain: initialPageData.get('domain'),
             urlRoot: initialPageData.get('url_root'),

--- a/corehq/apps/userreports/templates/userreports/base.html
+++ b/corehq/apps/userreports/templates/userreports/base.html
@@ -13,7 +13,7 @@
 {% block js %}{{ block.super }}
   {% compress js %}
     <script src="{% static 'hqwebapp/js/select2_knockout_bindings.ko.js' %}"></script>
-    <script src="{% static 'reports/js/bootstrap3/config.dataTables.bootstrap.js' %}"></script>
+    <script src="{% static 'reports/js/bootstrap3/datatables_config.js' %}"></script>
     <script src="{% static 'reports_core/js/choice_list_utils.js' %}"></script>
     <script src="{% static 'reports_core/js/charts.js' %}"></script>
     <script src="{% static 'userreports/js/report_analytix.js' %}"></script>

--- a/corehq/apps/userreports/templates/userreports/configurable_report.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_report.html
@@ -5,7 +5,7 @@
 
 {% block js %}{{ block.super }}
   {% compress js %}
-    <script src="{% static 'reports/js/reports.util.js' %}"></script>
+    <script src="{% static 'reports/js/util.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap3/hq_report.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap3/standard_hq_report.js' %}"></script>
     <script src="{% static 'reports/js/bootstrap3/report_config_models.js' %}"></script>

--- a/custom/inddex/templates/inddex/partials/report_table.html
+++ b/custom/inddex/templates/inddex/partials/report_table.html
@@ -42,7 +42,7 @@
 <script>
    {% if report_table and report_table.datatables %}
    $(function() {
-        var reportTables = hqImport("reports/js/bootstrap3/config.dataTables.bootstrap").HQReportDataTables({
+        var reportTables = hqImport("reports/js/bootstrap3/datatables_config").HQReportDataTables({
             dataTableElem: '#report_table_{{ report_table.slug }}',
             defaultRows: {{ report_table.default_rows|default:10 }},
             startAtRowNum: {{ report_table.start_at_row|default:0 }},


### PR DESCRIPTION
## Technical Summary
Webpack tends to dislike files with `.` in the middle. This PR renames a few such files to simplify the eventual migration of reports to webpack.

## Safety Assurance

### Safety story
This is a mechanical change. Code review should be sufficient.

### Automated test coverage

little if any

### QA Plan

Not requesting QA


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
