### PR TITLE
Fixed js_entry tag on B5 page

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/bootstrap5/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/bootstrap5/flags_and_privileges.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% js_entry_b3 'domain/js/bootstrap5/toggles' %}
+{% js_entry 'domain/js/bootstrap5/toggles' %}
 
 {% block page_content %}
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/admin/flags_and_privileges.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/admin/flags_and_privileges.html.diff.txt
@@ -7,7 +7,7 @@
  {% load i18n %}
  
 -{% js_entry_b3 'domain/js/bootstrap3/toggles' %}
-+{% js_entry_b3 'domain/js/bootstrap5/toggles' %}
++{% js_entry 'domain/js/bootstrap5/toggles' %}
  
  {% block page_content %}
  


### PR DESCRIPTION
## Technical Summary
`js_entry_b3` is only for B3 pages. This is doubtless an error I made when doing the B3/B5 split and the webpack migration on the domain app at the same time.

This does affect the composition of the webpack bundles that get built for B3/B5, which is why it's worth fixing now.

## Safety Assurance

### Safety story
Very safe, this template isn't live.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
