### PR TITLE
Added dependencies for fadeVisible

### DIFF
--- a/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
+++ b/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
@@ -7,6 +7,7 @@ hqDefine('commtrack/js/products_and_programs_main', [
     'es6!hqwebapp/js/bootstrap5_loader',
     'commtrack/js/base_list_view_model',
     'hqwebapp/js/bootstrap5/widgets',   // "Additional Information" on product page uses a .hqwebapp-select2
+    'hqwebapp/js/bootstrap5/knockout_bindings.ko',  // fadeVisible
     'commcarehq',
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/crud_paginated_list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/crud_paginated_list.js
@@ -3,6 +3,7 @@ hqDefine("hqwebapp/js/bootstrap3/crud_paginated_list", [
     "jquery",
     "knockout",
     "underscore",
+    "hqwebapp/js/bootstrap3/knockout_bindings.ko",  // fadeVisible
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list.js
@@ -4,6 +4,7 @@ hqDefine("hqwebapp/js/bootstrap5/crud_paginated_list", [
     "knockout",
     "underscore",
     "es6!hqwebapp/js/bootstrap5_loader",
+    'hqwebapp/js/bootstrap5/knockout_bindings.ko',  // fadeVisible
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list.js.diff.txt
@@ -1,13 +1,15 @@
 --- 
 +++ 
-@@ -1,12 +1,14 @@
+@@ -1,13 +1,15 @@
  // side effects: defines knockout bindings that are used in hqwebapp/partials/pagination.html
 -hqDefine("hqwebapp/js/bootstrap3/crud_paginated_list", [
 +hqDefine("hqwebapp/js/bootstrap5/crud_paginated_list", [
      "jquery",
      "knockout",
      "underscore",
+-    "hqwebapp/js/bootstrap3/knockout_bindings.ko",  // fadeVisible
 +    "es6!hqwebapp/js/bootstrap5_loader",
++    'hqwebapp/js/bootstrap5/knockout_bindings.ko',  // fadeVisible
  ], function (
      $,
      ko,
@@ -17,7 +19,7 @@
  ) {
      var CRUDPaginatedListModel = function (
          total,
-@@ -198,8 +200,9 @@
+@@ -199,8 +201,9 @@
              self.changePage(1);
          };
  
@@ -28,7 +30,7 @@
              paginatedItem.dismissModals();
              self.paginatedList(_(pList).without(paginatedItem));
              self.deletedList.push(paginatedItem);
-@@ -223,7 +226,7 @@
+@@ -224,7 +227,7 @@
              });
          };
  
@@ -37,7 +39,7 @@
              $.ajax({
                  url: '',
                  type: 'post',
-@@ -239,6 +242,7 @@
+@@ -240,6 +243,7 @@
                  statusCode: self.handleStatusCode,
                  success: function (data) {
                      self.utils.reloadList(data);
@@ -45,7 +47,7 @@
                  },
              });
          };
-@@ -270,15 +274,9 @@
+@@ -271,15 +275,9 @@
          };
  
          self.dismissModals = function () {
@@ -64,7 +66,7 @@
              }
          };
  
-@@ -321,15 +319,15 @@
+@@ -322,15 +320,15 @@
              var $deleteButton = $(elems).find('.delete-item-confirm');
              if ($deleteButton) {
                  $deleteButton.click(function () {

--- a/corehq/apps/locations/static/locations/js/location_tree.js
+++ b/corehq/apps/locations/static/locations/js/location_tree.js
@@ -7,6 +7,7 @@ hqDefine('locations/js/location_tree', [
     'hqwebapp/js/bootstrap5/alert_user',
     'analytix/js/google',
     'locations/js/search',
+    'hqwebapp/js/bootstrap5/knockout_bindings.ko',  // fadeVisible
 ], function (
     $,
     ko,


### PR DESCRIPTION
## Technical Summary
Noticed this while working on reports, checked to see if I'd missed it in any other migrations.

When the binding isn't available, the content is always visible, instead of fading in/out.

This is marked "all users" but it's barely visible. The products page is rarely used, and on the crud page and locations page I think the effect is just to possibly show content before it's fully loaded.

## Safety Assurance

### Safety story
Very safe, just makes a set of knockout bindings available to these pages.

### Automated test coverage

no

### QA Plan

no


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
