### PR TITLE
Simplify Enterprise OData Report

### DIFF
--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -371,7 +371,7 @@ class ODataFeedResource(ODataEnterpriseReportResource):
 
     domain = fields.CharField()
     report_name = fields.CharField()
-    report_rows = fields.IntegerField(null=True)
+    report_rows = fields.IntegerField()
 
     REPORT_SLUG = EnterpriseReport.ODATA_FEEDS
 

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -369,10 +369,8 @@ class ODataFeedResource(ODataEnterpriseReportResource):
     Currently includes summary rows as well as individual reports
     '''
 
-    domain = fields.CharField(null=True)
-    num_feeds_used = fields.IntegerField(null=True)
-    num_feeds_available = fields.IntegerField(null=True)
-    report_name = fields.CharField(null=True)
+    domain = fields.CharField()
+    report_name = fields.CharField()
     report_rows = fields.IntegerField(null=True)
 
     REPORT_SLUG = EnterpriseReport.ODATA_FEEDS
@@ -386,16 +384,14 @@ class ODataFeedResource(ODataEnterpriseReportResource):
         )
 
     def dehydrate(self, bundle):
-        bundle.data['num_feeds_used'] = bundle.obj[0]
-        bundle.data['num_feeds_available'] = bundle.obj[1]
-        bundle.data['report_name'] = bundle.obj[2]
-        bundle.data['report_rows'] = bundle.obj[3]
-        bundle.data['domain'] = bundle.obj[5] if len(bundle.obj) >= 5 else None
+        bundle.data['domain'] = bundle.obj[0]
+        bundle.data['report_name'] = bundle.obj[1]
+        bundle.data['report_rows'] = bundle.obj[2]
 
         return bundle
 
     def get_primary_keys(self):
-        return ('report_name',)  # very odd report that makes coming up with an actual key challenging
+        return ('domain', 'report_name',)
 
 
 class FormSubmissionResource(ODataEnterpriseReportResource):

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -211,6 +211,8 @@ class DomainResource(ODataEnterpriseReportResource):
     num_web_users = fields.IntegerField()
     num_sms_last_30_days = fields.IntegerField()
     last_form_submission = fields.DateTimeField()
+    num_odata_feeds_used = fields.IntegerField(null=True)
+    num_odata_feeds_available = fields.IntegerField(null=True)
 
     REPORT_SLUG = EnterpriseReport.DOMAINS
 
@@ -230,6 +232,8 @@ class DomainResource(ODataEnterpriseReportResource):
         bundle.data['num_web_users'] = bundle.obj[3]
         bundle.data['num_sms_last_30_days'] = bundle.obj[4]
         bundle.data['last_form_submission'] = self.convert_datetime(bundle.obj[5])
+        bundle.data['num_odata_feeds_used'] = bundle.obj[6]
+        bundle.data['num_odata_feeds_available'] = bundle.obj[7]
 
         return bundle
 

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -358,7 +358,7 @@ class EnterpriseODataReport(EnterpriseReport):
 
     @property
     def headers(self):
-        return [_('Project Space'), _('Report Names'), _('Number of rows')]
+        return [_('Project Space'), _('Name'), _('Number of Rows')]
 
     def total_for_domain(self, domain_obj):
         return self.export_fetcher.get_export_count(domain_obj.name)

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -130,11 +130,16 @@ class EnterpriseDomainReport(EnterpriseReport):
     title = gettext_lazy('Project Spaces')
     total_description = gettext_lazy('# of Project Spaces')
 
+    def __init__(self, account, couch_user):
+        super().__init__(account, couch_user)
+        self.export_fetcher = ODataExportFetcher()
+
     @property
     def headers(self):
         headers = super().headers
         return [_('Created On [UTC]'), _('# of Apps'), _('# of Mobile Users'), _('# of Web Users'),
-                _('# of SMS (last 30 days)'), _('Last Form Submission [UTC]')] + headers
+                _('# of SMS (last 30 days)'), _('Last Form Submission [UTC]'),
+                _('OData Feeds Used'), _('OData Feeds Available')] + headers
 
     def rows_for_domain(self, domain_obj):
         return [[
@@ -144,6 +149,8 @@ class EnterpriseDomainReport(EnterpriseReport):
             get_web_user_count(domain_obj.name, include_inactive=False),
             sms_in_last(domain_obj.name, 30),
             self.format_date(get_last_form_submission_received(domain_obj.name)),
+            self.export_fetcher.get_export_count(domain_obj.name),
+            domain_obj.get_odata_feed_limit(),
         ] + self.domain_properties(domain_obj)]
 
     def total_for_domain(self, domain_obj):

--- a/corehq/apps/enterprise/tests/test_enterprise.py
+++ b/corehq/apps/enterprise/tests/test_enterprise.py
@@ -19,8 +19,7 @@ class EnterpriseODataReportTests(SimpleTestCase):
     def test_headers(self):
         report = self._create_report_for_domains()
         self.assertEqual(report.headers, [
-            'Odata feeds used', 'Odata feeds available', 'Report Names', 'Number of rows',
-            'Project Space Name', 'Project Name', 'Project URL'
+            'Project Space', 'Report Names', 'Number of rows',
         ])
 
     def test_total_number_display_odata_reports_across_enterprise(self):
@@ -48,9 +47,8 @@ class EnterpriseODataReportTests(SimpleTestCase):
 
         report = self._create_report_for_domains(domain_one)
         self.assertEqual(report.rows, [
-            [2, 10, None, 12, 'domain_one', None, 'http://localhost:8000/a/domain_one/settings/project/'],
-            [None, None, 'ExportOne', 5],
-            [None, None, 'ExportTwo', 7]
+            ['domain_one', 'ExportOne', 5],
+            ['domain_one', 'ExportTwo', 7]
         ])
 
     def test_full_report_for_multiple_domains(self):
@@ -63,35 +61,30 @@ class EnterpriseODataReportTests(SimpleTestCase):
         report = self._create_report_for_domains(domain_one, domain_two)
 
         self.assertEqual(report.rows, [
-            [1, 25, None, 9, 'domain_one', None, 'http://localhost:8000/a/domain_one/settings/project/'],
-            [None, None, 'ExportOne', 9],
-            [1, 50, None, 15, 'domain_two', None, 'http://localhost:8000/a/domain_two/settings/project/'],
-            [None, None, 'ExportTwo', 15]
+            ['domain_one', 'ExportOne', 9],
+            ['domain_two', 'ExportTwo', 15]
         ])
 
     @patch.object(ODataExportFetcher, 'get_export_count')
-    def test_report_replaces_row_count_with_error_when_too_many_exports(self, mock_export_count):
+    def test_report_includes_error_when_too_many_exports(self, mock_export_count):
         mock_export_count.return_value = 151
         domain_one = self._create_domain(name='domain_one', max_exports=200)
 
         report = self._create_report_for_domains(domain_one)
 
         self.assertEqual(report.rows, [
-            [151, 200, None,
-            'ERROR: Too many exports. Please contact customer service',
-            'domain_one', None, 'http://localhost:8000/a/domain_one/settings/project/']
+            ['domain_one', 'ERROR: Too many exports. Please contact customer service', None]
         ])
 
     @patch.object(ODataExportFetcher, 'get_export_count')
-    def test_no_exports_for_domain_shows_0_rowcount(self, mock_export_count):
+    def test_no_exports_for_domain_includes_no_rows(self, mock_export_count):
         mock_export_count.return_value = 0
         domain_one = self._create_domain(name='domain_one', max_exports=25)
+        self.domain_to_export_map['domain_one'] = []
 
         report = self._create_report_for_domains(domain_one)
 
-        self.assertEqual(report.rows, [
-            [0, 25, None, 0, 'domain_one', None, 'http://localhost:8000/a/domain_one/settings/project/']
-        ])
+        self.assertEqual(report.rows, [])
 
 # setup / helpers
 

--- a/corehq/apps/enterprise/tests/test_enterprise.py
+++ b/corehq/apps/enterprise/tests/test_enterprise.py
@@ -19,7 +19,7 @@ class EnterpriseODataReportTests(SimpleTestCase):
     def test_headers(self):
         report = self._create_report_for_domains()
         self.assertEqual(report.headers, [
-            'Project Space', 'Report Names', 'Number of rows',
+            'Project Space', 'Name', 'Number of Rows',
         ])
 
     def test_total_number_display_odata_reports_across_enterprise(self):


### PR DESCRIPTION
## Product Description
The previous OData Feed report contained summary fields which made normal tabular data awkward. This PR shifts the summary fields to the Domain report while modernizing the remaining fields.

Domain Report:
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ca39c663-d507-490c-9fd7-ebd19dd040ea" />

Domain API:
<img width="771" alt="image" src="https://github.com/user-attachments/assets/96b5a45f-1b2f-48d5-8a61-766296e27d98" />

OData Feeds Report:
<img width="263" alt="image" src="https://github.com/user-attachments/assets/0455073e-995f-4af8-81da-9f1effc62cac" />

OData Feeds Report, too many exports:
<img width="522" alt="image" src="https://github.com/user-attachments/assets/003a38ca-5443-446a-950b-9908145df59e" />

OData Feeds API:
<img width="793" alt="image" src="https://github.com/user-attachments/assets/fb5dd971-eb83-4654-be2c-80d2514b354d" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This is being tracked by mainly https://dimagi.atlassian.net/browse/SAAS-16358 and https://dimagi.atlassian.net/browse/SAAS-16357

## Safety Assurance

### Safety story
Verified these changes locally

### Automated test coverage

Updated previous OData Report tests

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
