### PR TITLE
Write DomainMetrics and add FF to switch reads from calculated properties

### DIFF
--- a/corehq/apps/data_analytics/models.py
+++ b/corehq/apps/data_analytics/models.py
@@ -159,6 +159,66 @@ class GIRRow(models.Model):
         )
 
 
+DOMAIN_METRICS_TO_PROPERTIES_MAP = {
+    'active_cases': 'cp_n_active_cases',
+    'active_mobile_workers': 'cp_n_active_cc_users',
+    'active_mobile_workers_in_last_365_days': 'cp_n_active_cc_users_365_days',
+    'apps': 'cp_n_apps',
+    'apps_with_icon': 'cp_n_apps_with_icon',
+    'apps_with_multiple_languages': 'cp_n_apps_with_multi_lang',
+    'case_exports': 'cp_n_case_exports',
+    'case_sharing_groups': 'cp_n_case_sharing_groups',
+    'case_sharing_locations': 'cp_n_case_sharing_olevels',
+    'cases': 'cp_n_cases',
+    'cases_modified_in_last_30_days': 'cp_n_30_day_cases',
+    'cases_modified_in_last_60_days': 'cp_n_60_day_cases',
+    'cases_modified_in_last_90_days': 'cp_n_90_day_cases',
+    'custom_exports': 'cp_n_saved_custom_exports',
+    'custom_roles': 'cp_n_custom_roles',
+    'deid_exports': 'cp_n_deid_exports',
+    'first_form_submission': 'cp_first_form',
+    'forms': 'cp_n_forms',
+    'forms_submitted_in_last_30_days': 'cp_n_forms_30_d',
+    'forms_submitted_in_last_60_days': 'cp_n_forms_60_d',
+    'forms_submitted_in_last_90_days': 'cp_n_forms_90_d',
+    'has_app': 'cp_has_app',  # read-only property
+    'has_project_icon': 'cp_has_project_icon',
+    'has_used_sms': 'cp_sms_ever',  # read-only property
+    'has_used_sms_in_last_30_days': 'cp_sms_30_d',  # read-only property
+    'has_users_with_location': 'cp_using_locations',
+    'has_security_settings': 'cp_use_domain_security',
+    'inactive_cases': 'cp_n_inactive_cases',
+    'incoming_sms': 'cp_n_in_sms',
+    'incoming_sms_in_last_30_days': 'cp_n_sms_in_30_d',
+    'incoming_sms_in_last_60_days': 'cp_n_sms_in_60_d',
+    'incoming_sms_in_last_90_days': 'cp_n_sms_in_90_d',
+    'is_active': 'cp_is_active',
+    'is_first_domain_for_creating_user': 'cp_first_domain_for_user',
+    'last_modified': 'cp_last_updated',
+    'location_restricted_roles': 'cp_n_loc_restricted_roles',
+    'lookup_tables': 'cp_n_lookup_tables',
+    'mobile_workers': 'cp_n_cc_users',
+    'most_recent_form_submission': 'cp_last_form',
+    'outgoing_sms': 'cp_n_out_sms',
+    'outgoing_sms_in_last_30_days': 'cp_n_sms_out_30_d',
+    'outgoing_sms_in_last_60_days': 'cp_n_sms_out_60_d',
+    'outgoing_sms_in_last_90_days': 'cp_n_sms_out_90_d',
+    'repeaters': 'cp_n_repeaters',
+    'report_builder_reports': 'cp_n_rb_reports',
+    'saved_exports': 'cp_n_saved_exports',
+    'sms_in_last_30_days': 'cp_n_sms_30_d',
+    'sms_in_last_60_days': 'cp_n_sms_60_d',
+    'sms_in_last_90_days': 'cp_n_sms_90_d',
+    'telerivet_backends': 'cp_n_trivet_backends',
+    'three_hundredth_form_submission': 'cp_300th_form',
+    'total_sms': 'cp_n_sms_ever',
+    'ucrs': 'cp_n_ucr_reports',
+    'usercases_modified_in_last_30_days': 'cp_n_30_day_user_cases',
+    'users_with_submission': 'cp_n_users_submitted_form',
+    'web_users': 'cp_n_web_users',
+}
+
+
 class DomainMetrics(models.Model):
 
     domain = models.TextField(unique=True, db_index=True)
@@ -249,3 +309,9 @@ class DomainMetrics(models.Model):
     @property
     def has_used_sms_in_last_30_days(self):
         return bool(self.sms_in_last_30_days)
+
+    def instance_to_calculated_properties(self):
+        return {
+            calced_props_key: getattr(self, metrics_attr, None)
+            for metrics_attr, calced_props_key in DOMAIN_METRICS_TO_PROPERTIES_MAP.items()
+        }

--- a/corehq/apps/data_analytics/models.py
+++ b/corehq/apps/data_analytics/models.py
@@ -310,7 +310,7 @@ class DomainMetrics(models.Model):
     def has_used_sms_in_last_30_days(self):
         return bool(self.sms_in_last_30_days)
 
-    def instance_to_calculated_properties(self):
+    def to_calculated_properties(self):
         return {
             calced_props_key: getattr(self, metrics_attr, None)
             for metrics_attr, calced_props_key in DOMAIN_METRICS_TO_PROPERTIES_MAP.items()

--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -1,22 +1,28 @@
-import datetime
+from datetime import date, datetime, timedelta, timezone
 
 from django.conf import settings
+from django.db.models import Q
 
 from celery.schedules import crontab
 from celery.utils.log import get_task_logger
 
 from dimagi.utils.chunked import chunked
 from dimagi.utils.dates import DateSpan
+from dimagi.utils.logging import notify_exception
 
 from corehq.apps.celery import periodic_task, task
 from corehq.apps.data_analytics.gir_generator import GIRTableGenerator
 from corehq.apps.data_analytics.malt_generator import generate_malt
+from corehq.apps.data_analytics.models import DomainMetrics
 from corehq.apps.data_analytics.util import (
     last_month_datespan,
     last_month_dict,
 )
+from corehq.apps.domain.calculations import all_domain_stats, domain_metrics
 from corehq.apps.domain.models import Domain
+from corehq.apps.es import DomainES, FormES, filters
 from corehq.util.log import send_HTML_email
+from corehq.util.metrics import metrics_gauge
 from corehq.util.soft_assert import soft_assert
 
 logger = get_task_logger(__name__)
@@ -34,7 +40,7 @@ def build_last_month_MALT():
 @periodic_task(queue=settings.CELERY_PERIODIC_QUEUE, run_every=crontab(hour=2, minute=0, day_of_week='*'),
                ignore_result=True)
 def update_current_MALT():
-    today = datetime.date.today()
+    today = date.today()
     this_month_dict = {'month': today.month, 'year': today.year}
     domains = Domain.get_all_names()
     for chunk in chunked(domains, 1000):
@@ -69,3 +75,111 @@ def build_last_month_GIR():
 def update_malt(month_dict, domains):
     month = DateSpan.from_month(month_dict['month'], month_dict['year'])
     generate_malt([month], domains=domains)
+
+
+@periodic_task(run_every=timedelta(minutes=1), queue='background_queue')
+def run_datadog_user_stats():
+    all_stats = all_domain_stats()
+
+    datadog_report_user_stats(
+        'commcare.mobile_workers.count',
+        commcare_users_by_domain=all_stats['commcare_users'],
+    )
+
+
+def datadog_report_user_stats(metric_name, commcare_users_by_domain):
+    commcare_users_by_domain = summarize_user_counts(commcare_users_by_domain, n=50)
+    for domain, user_count in commcare_users_by_domain.items():
+        metrics_gauge(metric_name, user_count, tags={
+            'domain': '_other' if domain == () else domain
+        }, multiprocess_mode='max')
+
+
+def summarize_user_counts(commcare_users_by_domain, n):
+    """
+    Reduce (domain => user_count) to n entries, with all other entries summed to a single one
+
+    This allows us to report individual domain data to datadog for the domains that matter
+    and report a single number that combines the users for all other domains.
+
+    :param commcare_users_by_domain: the source data
+    :param n: number of domains to reduce the map to
+    :return: (domain => user_count) of top domains
+             with a single entry under () for all other domains
+    """
+    user_counts = sorted((user_count, domain) for domain, user_count in commcare_users_by_domain.items())
+    if n:
+        top_domains, other_domains = user_counts[-n:], user_counts[:-n]
+    else:
+        top_domains, other_domains = [], user_counts[:]
+    other_entry = (sum(user_count for user_count, _ in other_domains), ())
+    return {domain: user_count for user_count, domain in top_domains + [other_entry]}
+
+
+@periodic_task(run_every=crontab(hour="22", minute="0", day_of_week="*"), queue='background_queue')
+def update_domain_metrics():
+    domains = get_domains_to_update()
+    for chunk in chunked(domains, 5000):
+        update_domain_metrics_for_domains.delay(chunk)
+
+
+@task(queue='background_queue')
+def update_domain_metrics_for_domains(domains):
+    """
+    :param domains: list of domain names
+    """
+    # relying on caching for efficiency
+    all_stats = all_domain_stats()
+    active_users_by_domain = {}
+    for domain in domains:
+        metrics, __ = _update_or_create_domain_metrics(domain, all_stats)
+        if metrics:
+            active_users_by_domain[domain] = metrics['active_mobile_workers']
+
+    datadog_report_user_stats('commcare.active_mobile_workers.count', active_users_by_domain)
+
+
+def _update_or_create_domain_metrics(domain, all_stats):
+    try:
+        domain_obj = Domain.get_by_name(domain)
+        metrics_dict = domain_metrics(domain_obj, domain_obj['_id'], all_stats)
+        return DomainMetrics.objects.update_or_create(
+            **metrics_dict,
+        )
+    except Exception as e:
+        notify_exception(
+            None, message='Failed to create or update domain metrics for {domain}: {}'.format(e, domain=domain)
+        )
+
+
+def get_domains_to_update():
+    """
+    Returns a list of domains that are active and meet one or more
+    of the following criteria:
+     - never had DomainMetrics created
+     - DomainMetrics was updated over one week ago
+     - new form submissions within the last day
+    """
+    is_domain_active = filters.term('is_active', True)
+    active_domains = (
+        DomainES().filter(is_domain_active)
+        .terms_aggregation('name.exact', 'domain')
+        .size(0).run().aggregations.domain.keys
+    )
+
+    now = datetime.now(tz=timezone.utc)
+    yesterday = now - timedelta(days=1)
+    domains_submitted_within_day = (
+        FormES().submitted(gte=yesterday)
+        .terms_aggregation('domain.exact', 'domain')
+        .size(0).run().aggregations.domain.keys
+    )
+
+    last_week = now - timedelta(days=7)
+    domains_up_to_date = DomainMetrics.objects.filter(
+        Q(domain__in=active_domains)
+        & Q(last_modified__gte=last_week)
+        & ~Q(domain__in=domains_submitted_within_day)
+    ).values_list('domain', flat=True)
+
+    return set(active_domains) - set(domains_up_to_date)

--- a/corehq/apps/data_analytics/tests/test_tasks.py
+++ b/corehq/apps/data_analytics/tests/test_tasks.py
@@ -1,0 +1,105 @@
+from datetime import datetime
+
+from django.db.models import BooleanField, DateTimeField, IntegerField
+from django.test import TestCase
+
+from freezegun import freeze_time
+
+from dimagi.utils.parsing import json_format_datetime
+
+from corehq.apps.data_analytics.models import DomainMetrics
+from corehq.apps.data_analytics.tasks import get_domains_to_update
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.es import domain_adapter, form_adapter
+from corehq.apps.es.tests.utils import es_test
+from corehq.form_processor.tests.utils import create_form_for_test
+
+
+@es_test(requires=[domain_adapter, form_adapter], setup_class=True)
+class TestGetDomainsToUpdate(TestCase):
+    def test_domain_metrics_never_updated_is_included(self):
+        domain = self.index_domain('never-updated')
+        with self.assertRaises(DomainMetrics.DoesNotExist):
+            DomainMetrics.objects.get(domain=domain.name)
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, {domain.name})
+
+    @freeze_time('2024-01-10')
+    def test_domain_metrics_updated_over_one_week_ago_is_included(self):
+        domain = self.index_domain('cp-over-one-week')
+        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 2, 23, 59))
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, {domain.name})
+
+    @freeze_time('2024-01-10')
+    def test_domain_metrics_updated_exactly_one_week_ago_is_excluded(self):
+        domain = self.index_domain('cp-one-week')
+        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 3))
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, set())
+
+    @freeze_time('2024-01-10')
+    def test_domain_metrics_updated_less_than_one_week_ago_is_excluded(self):
+        domain = self.index_domain('cp-less-than-one-week')
+        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 4))
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, set())
+
+    @freeze_time('2024-01-10')
+    def test_form_submission_in_the_last_day_is_included(self):
+        domain = self.index_domain('form-from-today')
+        self.index_form(domain.name, received_on=datetime(2024, 1, 9, 0, 0))
+        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 9))
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, {domain.name})
+
+    @freeze_time('2024-01-10')
+    def test_form_submission_over_one_day_ago_is_excluded(self):
+        domain = self.index_domain('form-from-yesterday')
+        self.index_form(domain.name, received_on=datetime(2024, 1, 8, 23, 59))
+        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 9))
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, set())
+
+    @freeze_time('2024-01-10')
+    def test_inactive_domain_is_excluded(self):
+        domain = self.index_domain('inactive-domain', active=False)
+        self.create_domain_metrics(domain.name)
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, set())
+
+    def index_domain(self, name, active=True, cp_last_updated=None):
+        domain = create_domain(name, active)
+        self.addCleanup(domain.delete)
+        if cp_last_updated:
+            domain.cp_last_updated = json_format_datetime(cp_last_updated)
+        domain_adapter.index(domain, refresh=True)
+        self.addCleanup(domain_adapter.delete, domain._id, refresh=True)
+        return domain
+
+    def index_form(self, domain, received_on):
+        xform = create_form_for_test(domain, received_on=received_on)
+        form_adapter.index(xform, refresh=True)
+        self.addCleanup(form_adapter.delete, xform.form_id, refresh=True)
+        return xform
+
+    def create_domain_metrics(self, domain, last_modified=None):
+        metrics_dict = {}
+        for metrics_field in DomainMetrics._meta.get_fields():
+            if isinstance(metrics_field, BooleanField):
+                metrics_dict[metrics_field.name] = False
+            if isinstance(metrics_field, DateTimeField):
+                metrics_dict[metrics_field.name] = datetime(2024, 1, 1)
+            if isinstance(metrics_field, IntegerField):
+                metrics_dict[metrics_field.name] = 0
+        domain_metrics = DomainMetrics.objects.create(domain=domain, **metrics_dict)
+        self.addCleanup(domain_metrics.delete)
+        if last_modified:
+            DomainMetrics.objects.filter(domain=domain).update(last_modified=last_modified)

--- a/corehq/apps/data_analytics/tests/test_util.py
+++ b/corehq/apps/data_analytics/tests/test_util.py
@@ -1,0 +1,27 @@
+from django.test import SimpleTestCase
+
+from corehq.apps.data_analytics.tasks import summarize_user_counts
+
+
+class TestSummarizeUserCounts(SimpleTestCase):
+    def test_summarize_user_counts(self):
+        self.assertEqual(
+            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=0),
+            {(): 13},
+        )
+        self.assertEqual(
+            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=1),
+            {'b': 10, (): 3},
+        )
+        self.assertEqual(
+            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=2),
+            {'b': 10, 'c': 2, (): 1},
+        )
+        self.assertEqual(
+            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=3),
+            {'a': 1, 'b': 10, 'c': 2, (): 0},
+        )
+        self.assertEqual(
+            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=4),
+            {'a': 1, 'b': 10, 'c': 2, (): 0},
+        )

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -250,6 +250,7 @@ def uses_reminders(domain, *args):
 def not_implemented(domain, *args):
     return '<p class="text-danger">not implemented</p>'
 
+
 CALC_ORDER = [
     'num_web_users', 'num_mobile_users', 'forms', 'cases',
     'active_mobile_users', 'inactive_mobile_users', 'active_mobile_users--365',
@@ -464,7 +465,7 @@ def num_location_restricted_roles(domain):
 
 
 def num_case_sharing_loc_types(domain):
-    loc_types = [l for l in LocationType.objects.by_domain(domain) if l.shares_cases]
+    loc_types = [l_type for l_type in LocationType.objects.by_domain(domain) if l_type.shares_cases]
     return len(loc_types)
 
 

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -358,7 +358,7 @@ def domain_metrics(domain_obj, id, all_stats):
     metrics_dict['domain'] = domain_obj.name
     metrics_dict['last_modified'] = datetime.now(tz=timezone.utc)
 
-    # these are properties on the Django model, so don't try to write them
+    # these are calculated fields on the Django model, so don't try to write them
     del metrics_dict['cp_has_app']
     del metrics_dict['cp_sms_30_d']
     del metrics_dict['cp_sms_ever']

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
@@ -17,6 +17,7 @@ from dimagi.utils.parsing import json_format_datetime
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.dbaccessors import domain_has_apps
 from corehq.apps.data_analytics.esaccessors import get_mobile_users
+from corehq.apps.data_analytics.models import DOMAIN_METRICS_TO_PROPERTIES_MAP
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.cases import CaseES
 from corehq.apps.es.forms import FormES
@@ -345,6 +346,22 @@ def all_domain_stats():
         "web_users": webuser_counts,
         "commcare_users": commcare_counts,
     }
+
+
+def domain_metrics(domain_obj, id, all_stats):
+    props = calced_props(domain_obj, id, all_stats)
+    metrics_dict = {
+        metrics_attr: props.get(props_key)
+        for metrics_attr, props_key in DOMAIN_METRICS_TO_PROPERTIES_MAP.items()
+    }
+    metrics_dict['domain'] = domain_obj.name
+    metrics_dict['last_modified'] = datetime.now(tz=timezone.utc)
+
+    # these are properties on the Django model, so don't try to write them
+    del metrics_dict['cp_has_app']
+    del metrics_dict['cp_sms_30_d']
+    del metrics_dict['cp_sms_ever']
+    return metrics_dict
 
 
 def calced_props(domain_obj, id, all_stats):

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -143,7 +143,7 @@ def _update_or_create_domain_metrics(domain, all_stats):
         )
     except Exception as e:
         notify_exception(
-            None, message='Domain {} failed on stats calculations with {}'.format(domain, e)
+            None, message='Failed to create or update domain metrics for {domain}: {}'.format(domain, e)
         )
 
 

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -143,7 +143,7 @@ def _update_or_create_domain_metrics(domain, all_stats):
         )
     except Exception as e:
         notify_exception(
-            None, message='Failed to create or update domain metrics for {domain}: {}'.format(domain, e)
+            None, message='Failed to create or update domain metrics for {domain}: {}'.format(e, domain=domain)
         )
 
 

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -1,9 +1,7 @@
 import os
 import uuid
 import zipfile
-from datetime import datetime, timedelta, timezone
-
-from django.db.models import Q
+from datetime import datetime, timedelta
 
 from celery.schedules import crontab
 from celery.utils.log import get_task_logger
@@ -16,12 +14,8 @@ from soil import DownloadBase
 from soil.util import expose_blob_download
 
 from corehq.apps.celery import periodic_task, task
-from corehq.apps.data_analytics.models import DomainMetrics
-from corehq.apps.domain.calculations import (
-    all_domain_stats,
-    calced_props,
-    domain_metrics,
-)
+from corehq.apps.data_analytics.tasks import datadog_report_user_stats
+from corehq.apps.domain.calculations import all_domain_stats, calced_props
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import DomainES, FormES, filters
 from corehq.apps.es.domains import domain_adapter
@@ -33,7 +27,6 @@ from corehq.const import ONE_DAY
 from corehq.form_processor.models import XFormInstance
 from corehq.util.dates import get_timestamp_for_filename
 from corehq.util.files import TransientTempfile, safe_filename_header
-from corehq.util.metrics import metrics_gauge
 from corehq.util.view_utils import absolute_reverse
 
 from .analytics.esaccessors import (
@@ -109,114 +102,6 @@ def get_domains_to_update_es_filter():
             filters.term('name', domains_submitted_today)
         )
     )
-
-
-@periodic_task(run_every=crontab(hour="22", minute="0", day_of_week="*"), queue='background_queue')
-def update_domain_metrics():
-    domains = get_domains_to_update()
-    for chunk in chunked(domains, 5000):
-        update_domain_metrics_for_domains.delay(chunk)
-
-
-@task(queue='background_queue')
-def update_domain_metrics_for_domains(domains):
-    """
-    :param domains: list of domain names
-    """
-    # relying on caching for efficiency
-    all_stats = all_domain_stats()
-    active_users_by_domain = {}
-    for domain in domains:
-        metrics, __ = _update_or_create_domain_metrics(domain, all_stats)
-        if metrics:
-            active_users_by_domain[domain] = metrics['active_mobile_workers']
-
-    datadog_report_user_stats('commcare.active_mobile_workers.count', active_users_by_domain)
-
-
-def _update_or_create_domain_metrics(domain, all_stats):
-    try:
-        domain_obj = Domain.get_by_name(domain)
-        metrics_dict = domain_metrics(domain_obj, domain_obj['_id'], all_stats)
-        return DomainMetrics.objects.update_or_create(
-            **metrics_dict,
-        )
-    except Exception as e:
-        notify_exception(
-            None, message='Failed to create or update domain metrics for {domain}: {}'.format(e, domain=domain)
-        )
-
-
-def get_domains_to_update():
-    """
-    Returns a list of domains that are active and meet one or more
-    of the following criteria:
-     - never had DomainMetrics created
-     - DomainMetrics was updated over one week ago
-     - new form submissions within the last day
-    """
-    is_domain_active = filters.term('is_active', True)
-    active_domains = (
-        DomainES().filter(is_domain_active)
-        .terms_aggregation('name.exact', 'domain')
-        .size(0).run().aggregations.domain.keys
-    )
-
-    now = datetime.now(tz=timezone.utc)
-    yesterday = now - timedelta(days=1)
-    domains_submitted_within_day = (
-        FormES().submitted(gte=yesterday)
-        .terms_aggregation('domain.exact', 'domain')
-        .size(0).run().aggregations.domain.keys
-    )
-
-    last_week = now - timedelta(days=7)
-    domains_up_to_date = DomainMetrics.objects.filter(
-        Q(domain__in=active_domains)
-        & Q(last_modified__gte=last_week)
-        & ~Q(domain__in=domains_submitted_within_day)
-    ).values_list('domain', flat=True)
-
-    return set(active_domains) - set(domains_up_to_date)
-
-
-@periodic_task(run_every=timedelta(minutes=1), queue='background_queue')
-def run_datadog_user_stats():
-    all_stats = all_domain_stats()
-
-    datadog_report_user_stats(
-        'commcare.mobile_workers.count',
-        commcare_users_by_domain=all_stats['commcare_users'],
-    )
-
-
-def datadog_report_user_stats(metric_name, commcare_users_by_domain):
-    commcare_users_by_domain = summarize_user_counts(commcare_users_by_domain, n=50)
-    for domain, user_count in commcare_users_by_domain.items():
-        metrics_gauge(metric_name, user_count, tags={
-            'domain': '_other' if domain == () else domain
-        }, multiprocess_mode='max')
-
-
-def summarize_user_counts(commcare_users_by_domain, n):
-    """
-    Reduce (domain => user_count) to n entries, with all other entries summed to a single one
-
-    This allows us to report individual domain data to datadog for the domains that matter
-    and report a single number that combines the users for all other domains.
-
-    :param commcare_users_by_domain: the source data
-    :param n: number of domains to reduce the map to
-    :return: (domain => user_count) of top domains
-             with a single entry under () for all other domains
-    """
-    user_counts = sorted((user_count, domain) for domain, user_count in commcare_users_by_domain.items())
-    if n:
-        top_domains, other_domains = user_counts[-n:], user_counts[:-n]
-    else:
-        top_domains, other_domains = [], user_counts[:]
-    other_entry = (sum(user_count for user_count, _ in other_domains), ())
-    return {domain: user_count for user_count, domain in top_domains + [other_entry]}
 
 
 @task(serializer='pickle', ignore_result=True)

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 from uuid import uuid4
 from zipfile import ZipFile
 
-from django.db.models import BooleanField, DateTimeField, IntegerField
 from django.test import SimpleTestCase, TestCase
 
 from attrs import define, field
@@ -12,7 +11,6 @@ from freezegun import freeze_time
 
 from dimagi.utils.parsing import json_format_datetime
 
-from corehq.apps.data_analytics.models import DomainMetrics
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es import DomainES, form_adapter
 from corehq.apps.es.domains import domain_adapter
@@ -21,7 +19,6 @@ from corehq.apps.reports.tasks import (
     _get_question_id_for_attachment,
     _make_unique_filename,
     _write_attachments_to_file,
-    get_domains_to_update,
     get_domains_to_update_es_filter,
 )
 from corehq.form_processor.tests.utils import create_form_for_test
@@ -76,96 +73,6 @@ class GetQuestionIdTests(SimpleTestCase):
 
         result = _get_question_id_for_attachment(form, 'attachment.ext')
         self.assertIsNone(result)
-
-
-@es_test(requires=[domain_adapter, form_adapter], setup_class=True)
-class TestGetDomainsToUpdate(TestCase):
-    def test_domain_metrics_never_updated_is_included(self):
-        domain = self.index_domain('never-updated')
-        with self.assertRaises(DomainMetrics.DoesNotExist):
-            DomainMetrics.objects.get(domain=domain.name)
-
-        domains = get_domains_to_update()
-        self.assertEqual(domains, {domain.name})
-
-    @freeze_time('2024-01-10')
-    def test_domain_metrics_updated_over_one_week_ago_is_included(self):
-        domain = self.index_domain('cp-over-one-week')
-        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 2, 23, 59))
-
-        domains = get_domains_to_update()
-        self.assertEqual(domains, {domain.name})
-
-    @freeze_time('2024-01-10')
-    def test_domain_metrics_updated_exactly_one_week_ago_is_excluded(self):
-        domain = self.index_domain('cp-one-week')
-        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 3))
-
-        domains = get_domains_to_update()
-        self.assertEqual(domains, set())
-
-    @freeze_time('2024-01-10')
-    def test_domain_metrics_updated_less_than_one_week_ago_is_excluded(self):
-        domain = self.index_domain('cp-less-than-one-week')
-        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 4))
-
-        domains = get_domains_to_update()
-        self.assertEqual(domains, set())
-
-    @freeze_time('2024-01-10')
-    def test_form_submission_in_the_last_day_is_included(self):
-        domain = self.index_domain('form-from-today')
-        self.index_form(domain.name, received_on=datetime(2024, 1, 9, 0, 0))
-        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 9))
-
-        domains = get_domains_to_update()
-        self.assertEqual(domains, {domain.name})
-
-    @freeze_time('2024-01-10')
-    def test_form_submission_over_one_day_ago_is_excluded(self):
-        domain = self.index_domain('form-from-yesterday')
-        self.index_form(domain.name, received_on=datetime(2024, 1, 8, 23, 59))
-        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 9))
-
-        domains = get_domains_to_update()
-        self.assertEqual(domains, set())
-
-    @freeze_time('2024-01-10')
-    def test_inactive_domain_is_excluded(self):
-        domain = self.index_domain('inactive-domain', active=False)
-        self.create_domain_metrics(domain.name)
-
-        domains = get_domains_to_update()
-        self.assertEqual(domains, set())
-
-    def index_domain(self, name, active=True, cp_last_updated=None):
-        domain = create_domain(name, active)
-        self.addCleanup(domain.delete)
-        if cp_last_updated:
-            domain.cp_last_updated = json_format_datetime(cp_last_updated)
-        domain_adapter.index(domain, refresh=True)
-        self.addCleanup(domain_adapter.delete, domain._id, refresh=True)
-        return domain
-
-    def index_form(self, domain, received_on):
-        xform = create_form_for_test(domain, received_on=received_on)
-        form_adapter.index(xform, refresh=True)
-        self.addCleanup(form_adapter.delete, xform.form_id, refresh=True)
-        return xform
-
-    def create_domain_metrics(self, domain, last_modified=None):
-        metrics_dict = {}
-        for metrics_field in DomainMetrics._meta.get_fields():
-            if isinstance(metrics_field, BooleanField):
-                metrics_dict[metrics_field.name] = False
-            if isinstance(metrics_field, DateTimeField):
-                metrics_dict[metrics_field.name] = datetime(2024, 1, 1)
-            if isinstance(metrics_field, IntegerField):
-                metrics_dict[metrics_field.name] = 0
-        domain_metrics = DomainMetrics.objects.create(domain=domain, **metrics_dict)
-        self.addCleanup(domain_metrics.delete)
-        if last_modified:
-            DomainMetrics.objects.filter(domain=domain).update(last_modified=last_modified)
 
 
 @es_test(requires=[domain_adapter, form_adapter], setup_class=True)

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from uuid import uuid4
 from zipfile import ZipFile
 
+from django.db.models import BooleanField, DateTimeField, IntegerField
 from django.test import SimpleTestCase, TestCase
 
 from attrs import define, field
@@ -11,6 +12,7 @@ from freezegun import freeze_time
 
 from dimagi.utils.parsing import json_format_datetime
 
+from corehq.apps.data_analytics.models import DomainMetrics
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es import DomainES, form_adapter
 from corehq.apps.es.domains import domain_adapter
@@ -19,6 +21,7 @@ from corehq.apps.reports.tasks import (
     _get_question_id_for_attachment,
     _make_unique_filename,
     _write_attachments_to_file,
+    get_domains_to_update,
     get_domains_to_update_es_filter,
 )
 from corehq.form_processor.tests.utils import create_form_for_test
@@ -73,6 +76,96 @@ class GetQuestionIdTests(SimpleTestCase):
 
         result = _get_question_id_for_attachment(form, 'attachment.ext')
         self.assertIsNone(result)
+
+
+@es_test(requires=[domain_adapter, form_adapter], setup_class=True)
+class TestGetDomainsToUpdate(TestCase):
+    def test_domain_metrics_never_updated_is_included(self):
+        domain = self.index_domain('never-updated')
+        with self.assertRaises(DomainMetrics.DoesNotExist):
+            DomainMetrics.objects.get(domain=domain.name)
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, {domain.name})
+
+    @freeze_time('2024-01-10')
+    def test_domain_metrics_updated_over_one_week_ago_is_included(self):
+        domain = self.index_domain('cp-over-one-week')
+        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 2, 23, 59))
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, {domain.name})
+
+    @freeze_time('2024-01-10')
+    def test_domain_metrics_updated_exactly_one_week_ago_is_excluded(self):
+        domain = self.index_domain('cp-one-week')
+        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 3))
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, set())
+
+    @freeze_time('2024-01-10')
+    def test_domain_metrics_updated_less_than_one_week_ago_is_excluded(self):
+        domain = self.index_domain('cp-less-than-one-week')
+        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 4))
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, set())
+
+    @freeze_time('2024-01-10')
+    def test_form_submission_in_the_last_day_is_included(self):
+        domain = self.index_domain('form-from-today')
+        self.index_form(domain.name, received_on=datetime(2024, 1, 9, 0, 0))
+        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 9))
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, {domain.name})
+
+    @freeze_time('2024-01-10')
+    def test_form_submission_over_one_day_ago_is_excluded(self):
+        domain = self.index_domain('form-from-yesterday')
+        self.index_form(domain.name, received_on=datetime(2024, 1, 8, 23, 59))
+        self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 9))
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, set())
+
+    @freeze_time('2024-01-10')
+    def test_inactive_domain_is_excluded(self):
+        domain = self.index_domain('inactive-domain', active=False)
+        self.create_domain_metrics(domain.name)
+
+        domains = get_domains_to_update()
+        self.assertEqual(domains, set())
+
+    def index_domain(self, name, active=True, cp_last_updated=None):
+        domain = create_domain(name, active)
+        self.addCleanup(domain.delete)
+        if cp_last_updated:
+            domain.cp_last_updated = json_format_datetime(cp_last_updated)
+        domain_adapter.index(domain, refresh=True)
+        self.addCleanup(domain_adapter.delete, domain._id, refresh=True)
+        return domain
+
+    def index_form(self, domain, received_on):
+        xform = create_form_for_test(domain, received_on=received_on)
+        form_adapter.index(xform, refresh=True)
+        self.addCleanup(form_adapter.delete, xform.form_id, refresh=True)
+        return xform
+
+    def create_domain_metrics(self, domain, last_modified=None):
+        metrics_dict = {}
+        for metrics_field in DomainMetrics._meta.get_fields():
+            if isinstance(metrics_field, BooleanField):
+                metrics_dict[metrics_field.name] = False
+            if isinstance(metrics_field, DateTimeField):
+                metrics_dict[metrics_field.name] = datetime(2024, 1, 1)
+            if isinstance(metrics_field, IntegerField):
+                metrics_dict[metrics_field.name] = 0
+        domain_metrics = DomainMetrics.objects.create(domain=domain, **metrics_dict)
+        self.addCleanup(domain_metrics.delete)
+        if last_modified:
+            DomainMetrics.objects.filter(domain=domain).update(last_modified=last_modified)
 
 
 @es_test(requires=[domain_adapter, form_adapter], setup_class=True)

--- a/corehq/apps/reports/tests/test_util.py
+++ b/corehq/apps/reports/tests/test_util.py
@@ -9,7 +9,6 @@ from django.test import SimpleTestCase, TestCase
 from testil import eq
 from freezegun import freeze_time
 
-from corehq.apps.reports.tasks import summarize_user_counts
 from corehq.apps.reports.util import get_user_id_from_form, datespan_from_beginning
 from corehq.form_processor.exceptions import XFormNotFound
 from corehq.form_processor.models import XFormInstance
@@ -49,30 +48,6 @@ class TestDateSpanFromBeginning(SimpleTestCase):
 
         self.assertEqual(datespan.startdate, datetime(year=2020, month=4, day=4))
         self.assertEqual(datespan.enddate, datetime(year=2023, month=2, day=9))
-
-
-class TestSummarizeUserCounts(SimpleTestCase):
-    def test_summarize_user_counts(self):
-        self.assertEqual(
-            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=0),
-            {(): 13},
-        )
-        self.assertEqual(
-            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=1),
-            {'b': 10, (): 3},
-        )
-        self.assertEqual(
-            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=2),
-            {'b': 10, 'c': 2, (): 1},
-        )
-        self.assertEqual(
-            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=3),
-            {'a': 1, 'b': 10, 'c': 2, (): 0},
-        )
-        self.assertEqual(
-            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=4),
-            {'a': 1, 'b': 10, 'c': 2, (): 0},
-        )
 
 
 class TestGetUserType(SimpleTestCase):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2569,6 +2569,20 @@ WEB_USER_INVITE_ADDITIONAL_FIELDS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
+ENTERPRISE_DASHBOARD_IMPROVEMENTS = StaticToggle(
+    'enterprise_dashboard_improvements',
+    'Shows an improved version of enterprise dashboard during development',
+    TAG_PRODUCT,
+    namespaces=[NAMESPACE_USER]
+)
+
+CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS = FeatureRelease(
+    'calced_props_from_domain_metrics',
+    'Read domain calculated properties from DomainMetrics model instead of ElasticSearch doc.',
+    TAG_SAAS_CONDITIONAL,
+    namespaces=[NAMESPACE_DOMAIN],
+    owner='emapson@dimagi.com'
+)
 
 def _handle_attendance_tracking_role(domain, is_enabled):
     from corehq.apps.accounting.utils import domain_has_privilege

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2584,6 +2584,7 @@ CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS = FeatureRelease(
     owner='emapson@dimagi.com'
 )
 
+
 def _handle_attendance_tracking_role(domain, is_enabled):
     from corehq.apps.accounting.utils import domain_has_privilege
     from corehq.apps.users.role_utils import (

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2569,13 +2569,6 @@ WEB_USER_INVITE_ADDITIONAL_FIELDS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-ENTERPRISE_DASHBOARD_IMPROVEMENTS = StaticToggle(
-    'enterprise_dashboard_improvements',
-    'Shows an improved version of enterprise dashboard during development',
-    TAG_PRODUCT,
-    namespaces=[NAMESPACE_USER]
-)
-
 CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS = FeatureRelease(
     'calced_props_from_domain_metrics',
     'Read domain calculated properties from DomainMetrics model instead of ElasticSearch doc.',


### PR DESCRIPTION
## Technical Summary
[SAAS-16283
](https://dimagi.atlassian.net/browse/SAAS-16283)
Writes "calculated properties" currently stored on the `Domain` Elasticsearch doc to the new `DomainMetrics` SQL model and adds a feature flag so that reads can be switched from the ES doc to the SQL model once populated. This is part 2 of 3 for moving calculated properties into SQL, following https://github.com/dimagi/commcare-hq/pull/35415. This should be reviewable by commit.

Force-pushed to pull out migration commits #35574 

## Feature Flag
Adds the slightly wordy `CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS` feature flag, which can be used to switch calculated properties reads over to the SQL model for a single domain, to toggle on for all domains.

## Safety Assurance

### Safety story
This doesn't affect existing data or the write process for calculated properties on the ES doc. Reading from the new model is controlled by a feature flag, so if there are any issues after switching over, it can easily be switched back.

### Automated test coverage
Adds automated tests for identifying the correct project spaces to have their `DomainMetrics` updated. These are based on existing tests that look to see the right domains will get their calculated properties updated.

### QA Plan
I can see an argument for QA, but not planning it at this time. I think dev testing on staging will suffice.

### Migrations
No migrations here, but must follow migration applied in #35574 

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
