### PR TITLE
Include soft deleted ConnectionSettings objects in dump

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -198,7 +198,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('case_importer.CaseUploadRecord', SimpleFilter('domain')),
     # Repeat Records might foreign key to deleted repeaters, override default manager to include deleted repeaters
     FilteredModelIteratorBuilder('repeaters.Repeater', SimpleFilter('domain'), use_all_objects=True),
-    FilteredModelIteratorBuilder('motech.ConnectionSettings', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('motech.ConnectionSettings', SimpleFilter('domain'), use_all_objects=True),
     FilteredModelIteratorBuilder('motech.RequestLog', SimpleFilter('domain')),
     # NH (2021-01-08): Including RepeatRecord because we dump (Couch)
     # RepeatRecord, but this does not seem like a good idea.


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
```
django.db.utils.IntegrityError: Problem loading data '_tmp_load__data-dump-ccqa-2024-11-15T170225Z.zip': ('insert or update on table "dhis2_sqldatasetmap" violates foreign key constraint "dhis2_sqldatasetmap_connection_settings__b9993574_fk_motech_co"\nDETAIL:  Key (connection_settings_id)=(217) is not present in table "motech_connectionsettings".\n', "Error in worker 'default'")
```

I'm in the process of testing the data dump and ran into this issue. I implemented this hacky `use_all_objects` option for Repeaters recently, and don't love that I need to use it here as well.

In this case, the SQLDataSetMap foreign keys to the ConnectionSettings object, and has on_delete=PROTECT setup. This makes me wonder if the protect rule should "apply" to soft deletions too? Should we avoid soft deleting a ConnectionSettings object if it foreign keys to a SQLDataSetMap object? 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
