### PR TITLE
Extract DateTime logic

### DIFF
--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -16,7 +16,7 @@ from memoized import memoized
 
 from dimagi.utils.dates import DateSpan
 from dimagi.utils.logging import notify_exception
-from dimagi.utils.parsing import ISO_DATETIME_FORMAT
+from dimagi.ext.jsonobject import DateTimeProperty
 
 from celery.schedules import crontab
 
@@ -879,6 +879,6 @@ def get_commcare_version_and_date_from_last_usage(last_submission=None, last_dev
     if version:
         version_in_use = format_commcare_version(version) if formatted else version
 
-    date_of_use = datetime.strptime(date_of_use, ISO_DATETIME_FORMAT)
+    date_of_use = DateTimeProperty.deserialize(date_of_use)
 
     return version_in_use, date_of_use

--- a/corehq/ex-submodules/dimagi/ext/jsonobject.py
+++ b/corehq/ex-submodules/dimagi/ext/jsonobject.py
@@ -1,7 +1,8 @@
 import datetime
 import decimal
 from jsonobject.base_properties import AbstractDateProperty
-from jsonobject import *
+from jsonobject import *  # noqa: F401 unnamed jsonobject imports are imported from here by other modules
+from jsonobject import DateTimeProperty, JsonObject
 import re
 from jsonobject.api import re_date, re_time, re_decimal
 from dimagi.utils.dates import safe_strftime

--- a/corehq/ex-submodules/dimagi/ext/jsonobject.py
+++ b/corehq/ex-submodules/dimagi/ext/jsonobject.py
@@ -46,7 +46,7 @@ class DateTimeProperty(AbstractDateProperty):
     def _unwrap(self, value):
         _assert(value.tzinfo is None,
                 "Can't set a USecDateTimeProperty to an offset-aware datetime")
-        return value, safe_strftime(value, '%Y-%m-%dT%H:%M:%S.%fZ')
+        return value, safe_strftime(value, ISO_DATETIME_FORMAT)
 
     @classmethod
     def deserialize(cls, value):

--- a/corehq/ex-submodules/dimagi/ext/jsonobject.py
+++ b/corehq/ex-submodules/dimagi/ext/jsonobject.py
@@ -41,6 +41,15 @@ class DateTimeProperty(AbstractDateProperty):
     _type = datetime.datetime
 
     def _wrap(self, value):
+        return self.deserialize(value)
+
+    def _unwrap(self, value):
+        _assert(value.tzinfo is None,
+                "Can't set a USecDateTimeProperty to an offset-aware datetime")
+        return value, safe_strftime(value, '%Y-%m-%dT%H:%M:%S.%fZ')
+
+    @classmethod
+    def deserialize(cls, value):
         if '.' in value:
             fmt = ISO_DATETIME_FORMAT
             if len(value.split('.')[-1]) != 7:
@@ -61,11 +70,6 @@ class DateTimeProperty(AbstractDateProperty):
         _assert(result.tzinfo is None,
                 "USecDateTimeProperty shouldn't ever return offset-aware!")
         return result
-
-    def _unwrap(self, value):
-        _assert(value.tzinfo is None,
-                "Can't set a USecDateTimeProperty to an offset-aware datetime")
-        return value, safe_strftime(value, '%Y-%m-%dT%H:%M:%S.%fZ')
 
 
 re_trans_datetime = re.compile(r"""

--- a/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
+++ b/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
@@ -47,3 +47,10 @@ class TestDateRegex(SimpleTestCase):
         ]
         for candidate, expected in cases:
             self.assertEqual(bool(re_trans_datetime.match(candidate)), expected, candidate)
+
+
+class DateTimePropertyTests(SimpleTestCase):
+    def test_wrap(self):
+        prop = DateTimeProperty()
+        result = prop.wrap('2015-01-01T12:00:00.120054Z')
+        self.assertEqual(result, datetime(year=2015, month=1, day=1, hour=12, microsecond=120054))

--- a/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
+++ b/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
@@ -54,3 +54,7 @@ class DateTimePropertyTests(SimpleTestCase):
         prop = DateTimeProperty()
         result = prop.wrap('2015-01-01T12:00:00.120054Z')
         self.assertEqual(result, datetime(year=2015, month=1, day=1, hour=12, microsecond=120054))
+
+    def test_deserialize(self):
+        result = DateTimeProperty.deserialize('2015-01-01T12:00:00.120054Z')
+        self.assertEqual(result, datetime(year=2015, month=1, day=1, hour=12, microsecond=120054))

--- a/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
+++ b/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
@@ -55,6 +55,12 @@ class DateTimePropertyTests(SimpleTestCase):
         result = prop.wrap('2015-01-01T12:00:00.120054Z')
         self.assertEqual(result, datetime(year=2015, month=1, day=1, hour=12, microsecond=120054))
 
+    def test_unwrap(self):
+        prop = DateTimeProperty()
+        (value, unwrapped) = prop.unwrap(datetime(year=2015, month=1, day=1, hour=12, microsecond=120054))
+        self.assertEqual(value, datetime(year=2015, month=1, day=1, hour=12, microsecond=120054))
+        self.assertEqual(unwrapped, '2015-01-01T12:00:00.120054Z')
+
     def test_deserialize(self):
         result = DateTimeProperty.deserialize('2015-01-01T12:00:00.120054Z')
         self.assertEqual(result, datetime(year=2015, month=1, day=1, hour=12, microsecond=120054))

--- a/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
+++ b/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 from django.test import SimpleTestCase
 import jsonobject
 from jsonobject.exceptions import BadValueError
@@ -12,13 +12,12 @@ class Foo(jsonobject.JsonObject):
 class TransitionalExactDateTimePropertyTest(SimpleTestCase):
     def test_wrap_old(self):
         foo = Foo.wrap({'bar': '2015-01-01T12:00:00Z'})
-        self.assertEqual(foo.bar, datetime.datetime(2015, 1, 1, 12, 0, 0, 0))
+        self.assertEqual(foo.bar, datetime(2015, 1, 1, 12, 0, 0, 0))
         self.assertEqual(foo.to_json()['bar'], '2015-01-01T12:00:00.000000Z')
 
     def test_wrap_new(self):
         foo = Foo.wrap({'bar': '2015-01-01T12:00:00.120054Z'})
-        self.assertEqual(foo.bar, datetime.datetime(2015, 1, 1, 12, 0, 0,
-                                                    120054))
+        self.assertEqual(foo.bar, datetime(2015, 1, 1, 12, 0, 0, 120054))
         self.assertEqual(foo.to_json()['bar'], '2015-01-01T12:00:00.120054Z')
 
     def test_wrap_milliseconds_only(self):


### PR DESCRIPTION
## Product Description
Purely a backend change.

## Technical Summary
The recent CommCare Version Tile made me aware that we're inconsistent in how we're treating deserialization. The full logic is in `DateTimeProperty._wrap()`, but because it is an instance method, we ended up doing our own manual deserialization with `datetime.strptime(date_of_use, ISO_DATETIME_FORMAT)`. Although this works, it ignores the additional checks that `DateTimeProperty` does. Since, in both cases, we're handling data from the same source (data that was serialized by `DateTimeProperty`), I've added a class method to allow us to re-use the same logic.

## Safety Assurance

### Safety story
I haven't done any testing beyond the unit tests, but I believe those tests are sufficient to prove that the existing behavior has been preserved.

### Automated test coverage

Added new tests to verify that the existing behavior has not been disrupted while adding the `deserialize` method.

### QA Plan
No  QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
