### PR TITLE
Fix former ckeditor binding

### DIFF
--- a/corehq/messaging/scheduling/templates/scheduling/partials/rich_text_message_configuration.html
+++ b/corehq/messaging/scheduling/templates/scheduling/partials/rich_text_message_configuration.html
@@ -10,12 +10,12 @@
 </div>
 
 <div class="controls translation-controls" data-bind="visible: !translate()">
-  <textarea rows=10 class="form-control" data-bind="text: nonTranslatedMessage" data-image-upload-url="upload_messaging_image"></textarea>
+  <textarea rows=10 class="form-control" data-bind="value: nonTranslatedMessage" data-image-upload-url="upload_messaging_image"></textarea>
 </div>
 
 <div data-bind="visible: translate(), foreach: translatedMessages">
   <div class="controls translation-controls">
     <label>{% trans "Translation" %} (<span data-bind="text: language_code"></span>):</label>
-    <textarea rows=10 class="form-control" data-bind="text: html_message" data-image-upload-url="upload_messaging_image"></textarea>
+    <textarea rows=10 class="form-control" data-bind="value: html_message" data-image-upload-url="upload_messaging_image"></textarea>
   </div>
 </div>

--- a/corehq/messaging/scheduling/templates/scheduling/partials/rich_text_message_configuration.html
+++ b/corehq/messaging/scheduling/templates/scheduling/partials/rich_text_message_configuration.html
@@ -3,19 +3,36 @@
 <div class="controls translation-controls">
   <div class="checkbox">
     <label>
-      <input type="checkbox" data-bind="checked: translate" class="checkboxinput" />
+      <input
+        type="checkbox"
+        data-bind="checked: translate"
+        class="checkboxinput"
+      />
       {% trans "Translate this message" %}
     </label>
   </div>
 </div>
 
 <div class="controls translation-controls" data-bind="visible: !translate()">
-  <textarea rows=10 class="form-control" data-bind="value: nonTranslatedMessage" data-image-upload-url="upload_messaging_image"></textarea>
+  <textarea
+    rows="10"
+    class="form-control"
+    data-bind="value: nonTranslatedMessage"
+    data-image-upload-url="upload_messaging_image"
+  ></textarea>
 </div>
 
 <div data-bind="visible: translate(), foreach: translatedMessages">
   <div class="controls translation-controls">
-    <label>{% trans "Translation" %} (<span data-bind="text: language_code"></span>):</label>
-    <textarea rows=10 class="form-control" data-bind="value: html_message" data-image-upload-url="upload_messaging_image"></textarea>
+    <label
+      >{% trans "Translation" %} (<span data-bind="text: language_code"></span
+      >):</label
+    >
+    <textarea
+      rows="10"
+      class="form-control"
+      data-bind="value: html_message"
+      data-image-upload-url="upload_messaging_image"
+    ></textarea>
   </div>
 </div>


### PR DESCRIPTION
## Product Description
This is an error in https://github.com/dimagi/commcare-hq/pull/35507/ causing rich text content not to get saved.

Discussed in https://dimagi.atlassian.net/browse/USH-5187

## Feature Flag
Rich text emails

## Safety Assurance

### Safety story
Very safe. Flagged feature that is currently broken. Switching knockout bindings is a low-risk change.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
