### PR TITLE
Enterprise Two Factor Authentication Report

### DIFF
--- a/corehq/apps/enterprise/api/api.py
+++ b/corehq/apps/enterprise/api/api.py
@@ -8,6 +8,7 @@ from corehq.apps.enterprise.api.resources import (
     ODataFeedResource,
     WebUserResource,
     SMSResource,
+    TwoFactorAuthResource,
 )
 
 v1_api = Api(api_name='v1')
@@ -18,3 +19,4 @@ v1_api.register(FormSubmissionResource())
 v1_api.register(ODataFeedResource())
 v1_api.register(CommCareVersionComplianceResource())
 v1_api.register(SMSResource())
+v1_api.register(TwoFactorAuthResource())

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -409,16 +409,16 @@ class FormSubmissionResource(ODataEnterpriseReportResource):
 
 
 class TwoFactorAuthResource(ODataEnterpriseReportResource):
-    domain_not_having_2fa_enforced = fields.CharField()
+    domain_without_2fa = fields.CharField()
 
     REPORT_SLUG = EnterpriseReport.TWO_FACTOR_AUTH
 
     def dehydrate(self, bundle):
-        bundle.data['domain_not_having_2fa_enforced'] = bundle.obj[0]
+        bundle.data['domain_without_2fa'] = bundle.obj[0]
         return bundle
 
     def get_primary_keys(self):
-        return ('domain_not_having_2fa_enforced',)
+        return ('domain_without_2fa',)
 
 
 class CommCareVersionComplianceResource(ODataEnterpriseReportResource):

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -408,6 +408,19 @@ class FormSubmissionResource(ODataEnterpriseReportResource):
         return ('form_id', 'submitted',)
 
 
+class TwoFactorAuthResource(ODataEnterpriseReportResource):
+    domain_not_having_2fa_enforced = fields.CharField()
+
+    REPORT_SLUG = EnterpriseReport.TWO_FACTOR_AUTH
+
+    def dehydrate(self, bundle):
+        bundle.data['domain_not_having_2fa_enforced'] = bundle.obj[0]
+        return bundle
+
+    def get_primary_keys(self):
+        return ('domain_not_having_2fa_enforced',)
+
+
 class CommCareVersionComplianceResource(ODataEnterpriseReportResource):
     mobile_worker = fields.CharField()
     project_space = fields.CharField()

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -568,11 +568,11 @@ class EnterpriseSMSReport(EnterpriseReport):
 
 class Enterprise2FAReport(EnterpriseReport):
     title = gettext_lazy('Two Factor Authentication')
-    total_description = gettext_lazy('# of Project Spaces not having 2FA enforced')
+    total_description = gettext_lazy('# of Project Spaces without 2FA')
 
     @property
     def headers(self):
-        return [_('Project Space not having 2FA enforced'),]
+        return [_('Project Space without 2FA'),]
 
     def total_for_domain(self, domain_obj):
         if domain_obj.two_factor_auth:

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -47,6 +47,7 @@ class EnterpriseReport(ABC):
     ODATA_FEEDS = 'odata_feeds'
     COMMCARE_VERSION_COMPLIANCE = 'commcare_version_compliance'
     SMS = 'sms'
+    TWO_FACTOR_AUTH = '2fa'
 
     DATE_ROW_FORMAT = '%Y/%m/%d %H:%M:%S'
 
@@ -94,6 +95,8 @@ class EnterpriseReport(ABC):
             report = EnterpriseCommCareVersionReport(account, couch_user, **kwargs)
         elif slug == cls.SMS:
             report = EnterpriseSMSReport(account, couch_user, **kwargs)
+        elif slug == cls.TWO_FACTOR_AUTH:
+            report = Enterprise2FAReport(account, couch_user, **kwargs)
 
         if report:
             report.slug = slug
@@ -561,3 +564,22 @@ class EnterpriseSMSReport(EnterpriseReport):
         num_errors = sum([result['direction_count'] for result in results if result['error']])
 
         return [(domain_obj.name, num_sent, num_received, num_errors), ]
+
+
+class Enterprise2FAReport(EnterpriseReport):
+    title = gettext_lazy('Two Factor Authentication')
+    total_description = gettext_lazy('# of Domains not having 2FA enforced')
+
+    @property
+    def headers(self):
+        return [_('Domain not having 2FA enforced'),]
+
+    def total_for_domain(self, domain_obj):
+        if domain_obj.two_factor_auth:
+            return 0
+        return 1
+
+    def rows_for_domain(self, domain_obj):
+        if domain_obj.two_factor_auth:
+            return []
+        return [(domain_obj.name,)]

--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -568,11 +568,11 @@ class EnterpriseSMSReport(EnterpriseReport):
 
 class Enterprise2FAReport(EnterpriseReport):
     title = gettext_lazy('Two Factor Authentication')
-    total_description = gettext_lazy('# of Domains not having 2FA enforced')
+    total_description = gettext_lazy('# of Project Spaces not having 2FA enforced')
 
     @property
     def headers(self):
-        return [_('Domain not having 2FA enforced'),]
+        return [_('Project Space not having 2FA enforced'),]
 
     def total_for_domain(self, domain_obj):
         if domain_obj.two_factor_auth:

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -123,7 +123,11 @@ def security_center(request, domain):
     )
 
     context.update({
-        'reports': [],
+        'reports': [EnterpriseReport.create(slug, request.account.id, request.couch_user) for slug in (
+            EnterpriseReport.TWO_FACTOR_AUTH,
+        )],
+        'max_date_range_days': EnterpriseFormReport.MAX_DATE_RANGE_DAYS,
+        'uses_date_range': [],
         'metric_type': 'Security Center',
     })
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This is the PR for Two Factor Authentication Report. This tile will live in Security Center Page.

**UI:**
<img width="1379" alt="image" src="https://github.com/user-attachments/assets/3b875e83-89ed-4854-90c6-49cd52c4487e" />

**The downloaded report**
| Domain not having 2FA enforced |
|--------|
| enterpriseconsoletest |

**The API**
```shell
curl -s -X GET "http://localhost:8000/a/enterpriseconsoletest/enterprise/api/v1/twofactorauth/" -H "Authorization: ApiKey xxx:xxxxxxxx"

{"@odata.context": "http://localhost:8000/a/enterpriseconsoletest/enterprise/api/v1/twofactorauth/schema/#feed", "@odata.count": 1, "value": [{"domain_not_having_2fa_enfoced": "enterpriseconsoletest"}]}%
``` 

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-16310

If a domain has 2fa enforced, `Domain.two_factor_auth` will be `True`, otherwise `False`

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
The whole page is hidden behind `enterprise_dashboard_improvements`. The FF will be removed after this PR is merged.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Verified locally and on staging


### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Do not planning on QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
