### PR TITLE
Pad version with zero if shorter than 3

### DIFF
--- a/corehq/apps/builds/tests/test_utils.py
+++ b/corehq/apps/builds/tests/test_utils.py
@@ -16,6 +16,8 @@ class TestVersionUtils(SimpleTestCase):
             ('2.53.1', 'invalid', False),   # Invalid latest version
             ('6', '7', True),               # Normal case - app version is integer
             (None, None, False),            # None version_in_use and latest_version
+            ('2.54', '2.54.0', False),      # Edge case - should not be out of date
+            ('2.54.0', '2.54', False),       # Edge case - should not be out of date
         ]
 
         for version_in_use, latest_version, expected in test_cases:

--- a/corehq/apps/builds/utils.py
+++ b/corehq/apps/builds/utils.py
@@ -98,10 +98,13 @@ def is_out_of_date(version_in_use, latest_version):
 
 
 def _parse_version(version_str):
-    """Convert version string to comparable tuple"""
+    """Convert version string to comparable tuple, padding with zeros."""
+    SEMANTIC_VERSION_PARTS = 3  # Major, minor, patch
     if version_str:
         try:
-            return tuple(int(n) for n in version_str.split('.'))
+            version_parts = [int(n) for n in version_str.split('.')]
+            # Pad the version tuple to ensure both versions have the same length
+            return tuple(version_parts + [0] * (SEMANTIC_VERSION_PARTS - len(version_parts)))
         except (ValueError, AttributeError):
             return None
     return None


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
The `commcare_version` in `LastSubmission` and `LastDevice` are truncated if the last digit it 0, say "2.54.0" will become "2.54"
When compare version in use "2.54" with latest version "2.54.0", we shouldn't consider it as out of date, we should consider both to be "2.54.0", and it is on the latest version.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Add test in corehq/apps/builds/tests/test_utils.py

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
