### PR TITLE
Make prettify-changed script handle multi-lines

### DIFF
--- a/scripts/prettify-changed.sh
+++ b/scripts/prettify-changed.sh
@@ -8,7 +8,7 @@ get_changed() {
 prettify() {
     FILES=$1
     echo "Formatting files changed on this branch:"
-    ./node_modules/.bin/prettier --write "$FILES"
+    echo "$FILES" | xargs ./node_modules/.bin/prettier --write
     echo
 }
 


### PR DESCRIPTION
## Product Description


## Technical Summary
The git command outputs each filename on its own line, and passing that to `prettier` fails.  Instead, using `xargs` seems to do the trick


## Feature Flag


## Safety Assurance


### Safety story
only affects a script run on dev environments


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
