### PR TITLE
Upgrade redis and async-timeout

### DIFF
--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -3,10 +3,10 @@ import logging
 import uuid
 from itertools import chain
 
-import redis
 from contextlib import ExitStack
 from django.db import transaction, DatabaseError
 from lxml import etree
+from redis import RedisError
 
 from casexml.apps.case import const
 from casexml.apps.case.xform import get_case_updates
@@ -330,7 +330,7 @@ class FormProcessorSQL(object):
             if lock:
                 try:
                     return CommCareCase.get_locked_obj(_id=case_id)
-                except redis.RedisError:
+                except RedisError:
                     case = CommCareCase.objects.get_case(case_id)
             else:
                 case = CommCareCase.objects.get_case(case_id)

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -3,7 +3,7 @@ import re
 from collections import namedtuple
 
 from couchdbkit.exceptions import BulkSaveError
-from redis.exceptions import RedisError
+from redis import RedisError
 
 from casexml.apps.case import const
 from corehq.form_processor.exceptions import (

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -28,7 +28,7 @@ asttokens==2.0.5
     # via
     #   stack-data
     #   transifex-python
-async-timeout==4.0.2
+async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
@@ -624,7 +624,7 @@ radon==6.0.1
     # via -r test-requirements.in
 rcssmin==1.1.1
     # via django-compressor
-redis==4.5.4
+redis==5.2.1
     # via
     #   -r base-requirements.in
     #   django-redis

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -28,7 +28,7 @@ asgiref==3.7.2
     # via django
 asttokens==2.4.1
     # via transifex-python
-async-timeout==4.0.2
+async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
@@ -520,7 +520,7 @@ quickcache==0.5.4
     # via -r base-requirements.in
 rcssmin==1.1.1
     # via django-compressor
-redis==4.5.4
+redis==5.2.1
     # via
     #   -r base-requirements.in
     #   django-redis

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -28,7 +28,7 @@ asttokens==2.0.5
     # via
     #   stack-data
     #   transifex-python
-async-timeout==4.0.2
+async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
@@ -527,7 +527,7 @@ quickcache==0.5.4
     # via -r base-requirements.in
 rcssmin==1.1.1
     # via django-compressor
-redis==4.5.4
+redis==5.2.1
     # via
     #   -r base-requirements.in
     #   django-redis

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -26,7 +26,7 @@ asgiref==3.7.2
     # via django
 asttokens==2.4.1
     # via transifex-python
-async-timeout==4.0.2
+async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
@@ -490,7 +490,7 @@ quickcache==0.5.4
     # via -r base-requirements.in
 rcssmin==1.1.1
     # via django-compressor
-redis==4.5.4
+redis==5.2.1
     # via
     #   -r base-requirements.in
     #   django-redis

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -26,7 +26,7 @@ asgiref==3.7.2
     # via django
 asttokens==2.4.1
     # via transifex-python
-async-timeout==4.0.2
+async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
@@ -537,7 +537,7 @@ radon==6.0.1
     # via -r test-requirements.in
 rcssmin==1.1.1
     # via django-compressor
-redis==4.5.4
+redis==5.2.1
     # via
     #   -r base-requirements.in
     #   django-redis


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[redis changelog](https://github.com/redis/redis-py/releases)
In adding support for Python 3.12, the required version of async-timeout was bumped from 4.0.2 to 4.0.3. The other changes for async-timeout are minimal, so upgrading all the way to v5 makes sense.

[async-timeout changelog](https://github.com/aio-libs/async-timeout/blob/master/CHANGES.rst)
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
