### PR TITLE
Don't send email to inactive user

### DIFF
--- a/corehq/apps/settings/tasks.py
+++ b/corehq/apps/settings/tasks.py
@@ -34,7 +34,8 @@ def notify_about_to_expire_api_keys():
         .filter(is_active=True) \
         .exclude(expiration_date=None) \
         .exclude(expiration_date__lt=datetime.now()) \
-        .exclude(expiration_date__gt=datetime.today() + timedelta(days=5))
+        .exclude(expiration_date__gt=datetime.today() + timedelta(days=5)) \
+        .filter(user__is_active=True)
 
     url = absolute_reverse(ApiKeyView.urlname)
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-16390

There is a chance that a web user is disabled but it's HQApiKey is still active, in this case, when its key is about to expire, we shouldn't send email notification to the inactive user.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
