### PR TITLE
Add text-break class to force breaking filenames

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_file.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_file.html
@@ -16,7 +16,7 @@
       ">
       Browse...
     </button>
-    <p data-bind="text: fileNameDisplay" style="margin-left: 7px; margin-right: auto;"></p>
+    <p data-bind="text: fileNameDisplay" class="text-break ms-2 me-auto"></p>
     <button class="btn btn-outline-primary btn-sm" data-bind="
       click: onClear,
       text: $root.getTranslation('upload.clear.title', '{% trans_html_attr 'Clear' %}'),

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_file.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_file.html
@@ -2,25 +2,35 @@
 
 <script type="text/html" id="file-entry-ko-template">
   <div class="d-flex align-items-center">
-    <input type="file" class="d-none" data-bind="
+    <input
+      type="file"
+      class="d-none"
+      data-bind="
           value: $data.rawAnswer,
           attr: {
               id: entryId,
               'aria-required': $parent.required() ? 'true' : 'false',
               accept: accept,
           },
-      "/>
-    <button id="input-button-alt" class="btn btn-outline-primary" data-bind="
+      "
+    />
+    <button
+      id="input-button-alt"
+      class="btn btn-outline-primary"
+      data-bind="
           click: uploadFile,
           css: { 'is-invalid': $parent.hasError() },
-      ">
+      "
+    >
       Browse...
     </button>
     <p data-bind="text: fileNameDisplay" class="text-break ms-2 me-auto"></p>
-    <button class="btn btn-outline-primary btn-sm" data-bind="
+    <button
+      class="btn btn-outline-primary btn-sm"
+      data-bind="
       click: onClear,
       text: $root.getTranslation('upload.clear.title', '{% trans_html_attr 'Clear' %}'),
-    ">
-    </button>
+    "
+    ></button>
   </div>
 </script>


### PR DESCRIPTION
## Product Description

### before
![2024-12-23_09-11-13](https://github.com/user-attachments/assets/ee3e215b-32d8-44c6-9cfc-5a51e414c743)

### after
![2024-12-23_09-10-22](https://github.com/user-attachments/assets/ca7b32d7-8616-4e1f-a927-4a7bca0d77da)

* Documentation: https://getbootstrap.com/docs/5.0/utilities/text/#word-break
* Some filename do not have natural places to break the text at. Force it.
* Replace some inline style with b5 classes. The left margin is not 1:1 but replaces 7px with 0.5rem which is equivalent to 8px.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-4219

## Feature Flag

web_apps_upload_questions

## Safety Assurance

Only affects styling. Tested locally

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

No QA needed for style only changes.

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
