### PR TITLE
XPath Vars in Case Search

### DIFF
--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -21,6 +21,7 @@ CLAIM_CASE_TYPE = 'commcare-case-claim'
 FUZZY_PROPERTIES = "fuzzy_properties"
 CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY = 'commcare_blacklisted_owner_ids'
 CASE_SEARCH_XPATH_QUERY_KEY = '_xpath_query'
+CASE_SEARCH_XPATH_VAR_PREFIX = '_xpath_var_'
 CASE_SEARCH_CASE_TYPE_KEY = "case_type"
 CASE_SEARCH_INDEX_KEY_PREFIX = "indices."
 CASE_SEARCH_SORT_KEY = "commcare_sort"
@@ -187,6 +188,7 @@ class CaseSearchRequestConfig:
     custom_related_case_property = attr.ib(kw_only=True, default=None, converter=_flatten_singleton_list)
     include_all_related_cases = attr.ib(kw_only=True, default=None, converter=_flatten_singleton_list)
     commcare_sort = attr.ib(kw_only=True, default=None, converter=_parse_commcare_sort_properties)
+    xpath_vars = attr.ib(kw_only=True, factory=dict)
 
     @case_types.validator
     def _require_case_type(self, attribute, value):
@@ -209,8 +211,12 @@ def extract_search_request_config(request_dict):
         config_name: params.pop(param_name, None)
         for param_name, config_name in CONFIG_KEYS_MAPPING.items()
     }
+    xpath_vars = {
+        k.removeprefix(CASE_SEARCH_XPATH_VAR_PREFIX): _flatten_singleton_list(params.pop(k))
+        for k in list(params.keys()) if k.startswith(CASE_SEARCH_XPATH_VAR_PREFIX)
+    }
     criteria = criteria_dict_to_criteria_list(params)
-    return CaseSearchRequestConfig(criteria=criteria, **kwargs_from_params)
+    return CaseSearchRequestConfig(criteria=criteria, xpath_vars=xpath_vars, **kwargs_from_params)
 
 
 class GetOrNoneManager(models.Manager):

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -12,13 +12,14 @@ from corehq.apps.app_manager.models import (
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.case_search.const import IS_RELATED_CASE
-from corehq.apps.case_search.models import CaseSearchConfig, SearchCriteria
+from corehq.apps.case_search.models import (
+    CaseSearchConfig,
+    CaseSearchRequestConfig,
+    SearchCriteria,
+)
 from corehq.apps.domain.shortcuts import create_user
 from corehq.apps.es.case_search import case_search_adapter
-from corehq.apps.es.tests.utils import (
-    case_search_es_setup,
-    es_test,
-)
+from corehq.apps.es.tests.utils import case_search_es_setup, es_test
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
 from ..utils import get_case_search_results
@@ -71,23 +72,28 @@ class TestCaseSearchEndpoint(TestCase):
         FormProcessorTestUtils.delete_all_cases()
         super().tearDownClass()
 
+    def get_case_search_results(self, case_types, criteria, app_id=None):
+        return get_case_search_results(self.domain, CaseSearchRequestConfig(
+            criteria=criteria, case_types=case_types,
+        ), app_id=app_id)
+
     def test_basic(self):
-        res = get_case_search_results(self.domain, ['person'], [])
+        res = self.get_case_search_results(['person'], [])
         self.assertItemsEqual(["Jane", "Xiomara", "Alba", "Rogelio", "Jane"], [
             case.name for case in res
         ])
 
     def test_case_id_criteia(self):
-        res = get_case_search_results(self.domain, ['household'], [SearchCriteria('case_id', self.household_1)])
+        res = self.get_case_search_results(['household'], [SearchCriteria('case_id', self.household_1)])
         self.assertItemsEqual(["Villanueva"], [case.name for case in res])
 
     def test_dynamic_property(self):
-        res = get_case_search_results(self.domain, ['person'], [SearchCriteria('family', 'Ramos')])
+        res = self.get_case_search_results(['person'], [SearchCriteria('family', 'Ramos')])
         self.assertItemsEqual(["Jane"], [case.name for case in res])
 
     def test_app_aware_related_cases(self):
         with mock.patch('corehq.apps.case_search.utils.get_app_cached', new=lambda _, __: self.factory.app):
-            res = get_case_search_results(self.domain, ['person'], [], app_id='fake_app_id')
+            res = self.get_case_search_results(['person'], [], app_id='fake_app_id')
         self.assertItemsEqual([
             (case.name, case.get_case_property(IS_RELATED_CASE)) for case in res
         ], [

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -14,6 +14,7 @@ from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.case_search.const import COMMCARE_PROJECT
 from corehq.apps.case_search.models import (
     CaseSearchConfig,
+    CaseSearchRequestConfig,
     SearchCriteria,
     criteria_dict_to_criteria_list,
 )
@@ -153,8 +154,11 @@ class TestCaseSearchRegistry(TestCase):
         super().tearDownClass()
 
     def _run_query(self, domain, case_types, criteria_dict, registry_slug):
-        criteria = criteria_dict_to_criteria_list(criteria_dict)
-        results = get_case_search_results(domain, case_types, criteria, registry_slug=registry_slug)
+        results = get_case_search_results(domain, CaseSearchRequestConfig(
+            criteria=criteria_dict_to_criteria_list(criteria_dict),
+            case_types=case_types,
+            data_registry=registry_slug,
+        ))
         return [(case.name, case.domain) for case in results]
 
     def test_query_all_domains_in_registry(self):
@@ -273,12 +277,11 @@ class TestCaseSearchRegistry(TestCase):
         self.assertItemsEqual([], results)
 
     def test_includes_project_property(self):
-        results = get_case_search_results(
-            self.domain_1,
-            ["person"],
-            [SearchCriteria("name", "Jane")],
-            registry_slug=self.registry_slug
-        )
+        results = get_case_search_results(self.domain_1, CaseSearchRequestConfig(
+            criteria=[SearchCriteria("name", "Jane")],
+            case_types=["person"],
+            data_registry=self.registry_slug,
+        ))
         self.assertItemsEqual([
             ("Jane", self.domain_1, self.domain_1),
             ("Jane", self.domain_1, self.domain_1),
@@ -291,13 +294,11 @@ class TestCaseSearchRegistry(TestCase):
 
     def test_related_cases_included(self):
         with patch_get_app_cached:
-            results = get_case_search_results(
-                self.domain_1,
-                ["creative_work"],
-                [SearchCriteria("name", "Jane Eyre")],  # from domain 2
-                app_id="mock_app_id",
-                registry_slug=self.registry_slug
-            )
+            results = get_case_search_results(self.domain_1, CaseSearchRequestConfig(
+                criteria=[SearchCriteria("name", "Jane Eyre")],  # from domain 2
+                case_types=["creative_work"],
+                data_registry=self.registry_slug,
+            ), app_id="mock_app_id")
         self.assertItemsEqual([
             ("Charlotte Brontë", "creator", self.domain_2),
             ("Jane Eyre", "creative_work", self.domain_2),

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -311,7 +311,7 @@ class TestCaseSearchRegistry(TestCase):
         with patch_get_app_cached:
             registry_helper = _get_helper(None, self.domain_1, ["creative_work"], self.registry_slug)
             primary_cases = get_primary_case_search_results(
-                registry_helper, ["creative_work"], [SearchCriteria("name", "Jane Eyre")])
+                registry_helper, ["creative_work"], [SearchCriteria("name", "Jane Eyre")], None, None)
             related_cases = registry_helper.get_all_related_live_cases(primary_cases)
 
             self.assertItemsEqual([

--- a/corehq/apps/case_search/tests/test_utils.py
+++ b/corehq/apps/case_search/tests/test_utils.py
@@ -1,6 +1,14 @@
 from unittest.mock import patch
 
-from corehq.apps.case_search.utils import get_expanded_case_results
+import pytest
+
+from corehq.apps.case_search.exceptions import CaseSearchUserError
+from corehq.apps.case_search.models import CaseSearchConfig
+from corehq.apps.case_search.utils import (
+    CaseSearchQueryBuilder,
+    QueryHelper,
+    get_expanded_case_results,
+)
 from corehq.form_processor.models import CommCareCase
 
 
@@ -16,3 +24,31 @@ def test_get_expanded_case_results(get_cases_mock):
     helper = None
     get_expanded_case_results(helper, "potential_duplicate_id", cases)
     get_cases_mock.assert_called_with(helper, {"123", "456"})
+
+
+@pytest.mark.parametrize("xpath_vars, xpath_query, result", [
+    ({'name': 'Ethan'}, "name = '{name}'", "name = 'Ethan'"),
+    ({'ssn_matches': 'social_security_number = "123abc"'},
+     '{ssn_matches} or subcase-exists("parent", @case_type = "alias" and {ssn_matches})',
+     'social_security_number = "123abc" or subcase-exists('
+     '"parent", @case_type = "alias" and social_security_number = "123abc")'),
+    ({'ssn_matches': 'social_security_number = "123abc"'}, 'match-all()', 'match-all()'),
+])
+def test_xpath_vars(xpath_vars, xpath_query, result):
+    helper = QueryHelper('mydomain')
+    helper.config = CaseSearchConfig(domain='mydomain')
+    builder = CaseSearchQueryBuilder(helper, ['mycasetype'], xpath_vars)
+    with patch("corehq.apps.case_search.utils.build_filter_from_xpath") as build:
+        builder._build_filter_from_xpath(xpath_query)
+        assert build.call_args.args[0] == result
+
+
+def test_xpath_vars_misconfigured():
+    xpath_vars = {}  # No variables defined!
+    xpath_query = "name = '{name}'"  # 'name' is not specified
+    helper = QueryHelper('mydomain')
+    helper.config = CaseSearchConfig(domain='mydomain')
+    builder = CaseSearchQueryBuilder(helper, ['mycasetype'], xpath_vars)
+    with pytest.raises(CaseSearchUserError) as e_info:
+        builder._build_filter_from_xpath(xpath_query)
+    e_info.match("Variable 'name' not found")


### PR DESCRIPTION
## Product Description
Add a new magic case search parameter prefix, `_xpath_var_` which can be used to declare template variables for use in `_xpath_query` expressions.

![image](https://github.com/user-attachments/assets/aa8e2796-671e-47a2-afc2-1be9b8dddb41)

The evaluation layers are:
* Process expressions as xpath in formplayer, which returns strings
* Interpolate those strings with the provided variables (python string templating syntax)
* Interpret those strings as CSQL expressions, returning an elasticsearch filter.

This seems like a pretty easy way to break up the massive xpath expressions USH projects use.  I'd be interested to hear what app builders think of it before merging.  It seemed easier to build than to write up and get feedback on in the abstract (only took a few hours of work).  Some thoughts I have from brief testing are:

* I don't love adding another layer of evaluation, especially as this doesn't solve all of the complexity problems
* When testing it out, I realized that I really want the ability to use variables _before_ the xpath evaluation step.  This might be doable if we instead treat this as a macro expansion kind of thing during the build step, but that's a different approach entirely.
* At present, variable declarations can't reference other variable declarations.  That might be fine, but we could certainly consider adding that capability if it sounds useful.  If default search filters have a deterministic ordering (I'm not certain whether that's the case), we could just interpolate top to bottom.  Otherwise we'd have to do dependency tree stuff, which sounds nasty.
* I still think a `template` function in xpath [would be a huge win for relatively low effort](https://dimagi.atlassian.net/jira/software/c/projects/USH/issues/USH-4121).  This operates similarly, but after the xpath evaluation is complete, so without that available context and a bit less cleanly, in my opinion.

## Technical Summary


## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
