### PR TITLE
Display "--" for percentage number when divisor is 0

### DIFF
--- a/corehq/apps/enterprise/static/enterprise/js/project_dashboard.js
+++ b/corehq/apps/enterprise/static/enterprise/js/project_dashboard.js
@@ -216,6 +216,8 @@ hqDefine("enterprise/js/project_dashboard", [
                 undefined,
                 {minimumFractionDigits: 1,  maximumFractionDigits: 1}
             ) + '%';
+        } else if (input === "--") {
+            return input;
         } else {
             return Number(input).toLocaleString();
         }


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/c3180d8e-4f7e-4cc6-baaa-24ef010f244c" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
It's been captured by QA's post-deploy verification on production. [Related comment](https://dimagi.atlassian.net/browse/QA-7315?focusedCommentId=359733).
We already [return "--" when format percentage number](https://github.com/dimagi/commcare-hq/blob/d7388d0a2e4eb1596fceb43f7e7b099adc953048/corehq/apps/enterprise/enterprise.py#L506-L509). But the javascript code only takes care of number or the string of number. Add a new condition to return "--" when receive "--"

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Straightforward frontend change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
