### PR TITLE
Retry when get_by_hash timeout

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -27,7 +27,7 @@ from dimagi.ext.couchdbkit import (
     StringListProperty,
     StringProperty,
 )
-from dimagi.utils.couch.database import get_safe_read_kwargs, iter_docs
+from dimagi.utils.couch.database import get_safe_read_kwargs, iter_docs, retry_on_couch_error
 from dimagi.utils.couch.resource_conflict import retry_resource
 
 from corehq import privileges, toggles
@@ -255,6 +255,7 @@ class CommCareMultimedia(BlobMixin, SafeSaveDocument):
         return hashlib.md5(data).hexdigest()
 
     @classmethod
+    @retry_on_couch_error
     def get_by_hash(cls, file_hash):
         result = cls.view('hqmedia/by_hash', key=file_hash, include_docs=True).first()
         if not result:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-15344

`load_template_app` tasks is failing frequently, 1.6k in 30 days. This result in a user not receiving the email to activate their account, [since the email will only be sent after all template apps loaded](https://github.com/dimagi/commcare-hq/blob/747e096f0430b5753f26b9ed6534223a540f8f11/corehq/apps/registration/utils.py#L205). 

Example [sentry error](https://dimagi.sentry.io/issues/3592159477/events/41d271c9285347449e2df5ade30b1549/).

I tried multiple file_hash from the failed task in django shell, and they all succeeded. So no issue with our hashing, the file did exist, it's just the query itself (or couch) is unstable.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe as I just add a retry mechanism

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
