### PR TITLE
Encrypt API Key Bug Fix

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3124,7 +3124,7 @@ class HQApiKey(models.Model):
     @property
     def plaintext_key(self):
         try:
-            decrypted_key = b64_aes_cbc_decrypt(self.encrypted_key)
+            decrypted_key = b64_aes_cbc_decrypt(self.encrypted_key) if self.encrypted_key else ''
             if decrypted_key == self.key:
                 return decrypted_key
             else:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
N/A

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Follow up to https://github.com/dimagi/commcare-hq/pull/35471 to fix [this sentry error](https://dimagi.sentry.io/discover/results/?dataset=errors&field=title&field=release&field=environment&field=tags%5Buser.username%5D&field=timestamp&name=ValueError%3A%20Incorrect%20IV%20length%20%28it%20must%20be%2016%20bytes%20long%29&project=136860&query=issue%3ACOMMCAREHQ-DFAX&queryDataset=error-events&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. This continues to fall back to using stored plaintext key if there's a failure with using the decrypted value.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There exists tests that checks creating an HQApiKey and using its stored plaintext key for authentication.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
