### PR TITLE
Updated accounting reports to count as admin reports

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -143,6 +143,7 @@ class AccountingInterface(AddItemInterface):
     slug = "accounts"
     dispatcher = AccountingAdminInterfaceDispatcher
     hide_filters = False
+    is_admin_report = True
     item_name = "Billing Account"
 
     fields = [


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/QA-7375

This change removes the "Save..." and "Favorites" buttons from accounting reports. The save button 404s, and the favorites button is irrelevant if saving doesn't work.

Old screenshot showing the buttons:
<img width="809" alt="Screenshot 2025-01-06 at 2 57 58 PM" src="https://github.com/user-attachments/assets/a53892d1-4fbd-4634-9251-21de574bfd12" />

## Feature Flag
Limited to accounting admins

## Safety Assurance

### Safety story
I'm 80% confident that this PR only makes the change I say it does, based on reviewing all usages of `is_admin_report` and `is_admin` (`is_admin` because of [this line](https://github.com/dimagi/commcare-hq/blob/bed6bc0fff6afd1d74b3bd23102531d36a88e570/corehq/apps/reports/generic.py#L487)). These pages are also internal only, so the blast radius of a problem is relatively small.

### Automated test coverage

Probably not at the UI level.

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
