### PR TITLE
Updated geospatial js to use global statement instead of disabling li…

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
+++ b/corehq/apps/geospatial/static/geospatial/js/gps_capture.js
@@ -1,3 +1,4 @@
+/* globals mapboxgl, MapboxGeocoder */
 hqDefine("geospatial/js/gps_capture", [
     "jquery",
     "knockout",
@@ -18,7 +19,7 @@ hqDefine("geospatial/js/gps_capture", [
 
     var map;
     var selectedDataListObject;
-    var mapMarker = new mapboxgl.Marker({  // eslint-disable-line no-undef
+    var mapMarker = new mapboxgl.Marker({
         draggable: true,
     });
     mapMarker.on('dragend', function () {
@@ -312,11 +313,11 @@ hqDefine("geospatial/js/gps_capture", [
     var initMap = function () {
         'use strict';
 
-        mapboxgl.accessToken = initialPageData.get('mapbox_access_token');  // eslint-disable-line no-undef
+        mapboxgl.accessToken = initialPageData.get('mapbox_access_token');
 
         let centerCoordinates = [2.43333330, 9.750]; // should be domain specific
 
-        map = new mapboxgl.Map({  // eslint-disable-line no-undef
+        map = new mapboxgl.Map({
             container: MAP_CONTAINER_ID, // container ID
             style: 'mapbox://styles/mapbox/streets-v12', // style URL
             center: centerCoordinates, // starting position [lng, lat]
@@ -326,8 +327,8 @@ hqDefine("geospatial/js/gps_capture", [
         });
 
         map.addControl(
-            new MapboxGeocoder({  // eslint-disable-line no-undef
-                accessToken: mapboxgl.accessToken,  // eslint-disable-line no-undef
+            new MapboxGeocoder({
+                accessToken: mapboxgl.accessToken,
                 mapboxgl: map,
                 types: 'address',
                 proximity: centerCoordinates.toString(),  // bias results to this point

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -1,3 +1,4 @@
+/* globals mapboxgl, MapboxDraw, turf */
 'use strict';
 hqDefine('geospatial/js/models', [
     'jquery',
@@ -134,12 +135,12 @@ hqDefine('geospatial/js/models', [
         self.DISBURSEMENT_LINES_LAYER_ID = 'disbursement-lines';
 
         self.initMap = function (mapDivId, centerCoordinates) {
-            mapboxgl.accessToken = initialPageData.get('mapbox_access_token');  // eslint-disable-line no-undef
+            mapboxgl.accessToken = initialPageData.get('mapbox_access_token');
             if (!centerCoordinates) {
                 centerCoordinates = [-91.874, 42.76]; // should be domain specific
             }
 
-            self.mapInstance = new mapboxgl.Map({  // eslint-disable-line no-undef
+            self.mapInstance = new mapboxgl.Map({
                 container: mapDivId, // container ID
                 style: 'mapbox://styles/mapbox/streets-v12', // style URL
                 center: centerCoordinates, // starting position [lng, lat]
@@ -148,7 +149,7 @@ hqDefine('geospatial/js/models', [
                              ' <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
             });
 
-            self.drawControls = new MapboxDraw({  // eslint-disable-line no-undef
+            self.drawControls = new MapboxDraw({
                 // API: https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/API.md
                 displayControlsDefault: false,
                 boxSelect: true, // enables box selection
@@ -160,7 +161,7 @@ hqDefine('geospatial/js/models', [
             self.mapInstance.addControl(self.drawControls);
 
             // Add zoom and rotation controls to the map.
-            self.mapInstance.addControl(new mapboxgl.NavigationControl());  // eslint-disable-line no-undef
+            self.mapInstance.addControl(new mapboxgl.NavigationControl());
 
             if (self.usesClusters) {
                 createClusterLayers();
@@ -370,7 +371,7 @@ hqDefine('geospatial/js/models', [
         function addMarker(itemId, itemData, colors) {
             const coordinates = itemData.coordinates;
             // Create the marker
-            const marker = new mapboxgl.Marker({ color: colors.default, draggable: false });  // eslint-disable-line no-undef
+            const marker = new mapboxgl.Marker({ color: colors.default, draggable: false });
             marker.setLngLat(coordinates);
 
             // Add the marker to the map
@@ -474,8 +475,8 @@ hqDefine('geospatial/js/models', [
                 return false;
             }
             const coordinatesArr = [coordinates.lng, coordinates.lat];
-            const point = turf.point(coordinatesArr);  // eslint-disable-line no-undef
-            return turf.booleanPointInPolygon(point, polygonFeature.geometry);  // eslint-disable-line no-undef
+            const point = turf.point(coordinatesArr);
+            return turf.booleanPointInPolygon(point, polygonFeature.geometry);
         }
 
         self.mapHasPolygons = function () {
@@ -506,7 +507,7 @@ hqDefine('geospatial/js/models', [
                 if (coord) {
                     return bounds.extend(coord);
                 }
-            }, new mapboxgl.LngLatBounds(firstCoord, firstCoord));  // eslint-disable-line no-undef
+            }, new mapboxgl.LngLatBounds(firstCoord, firstCoord));
 
             self.mapInstance.fitBounds(bounds, {
                 padding: 50,  // in pixels

--- a/corehq/apps/geospatial/static/geospatial/js/utils.js
+++ b/corehq/apps/geospatial/static/geospatial/js/utils.js
@@ -1,3 +1,4 @@
+/* globals mapboxgl */
 'use strict';
 hqDefine('geospatial/js/utils', [], function () {
 
@@ -26,7 +27,7 @@ hqDefine('geospatial/js/utils', [], function () {
 
     var createMapPopup = function (coordinates, popupDiv, openEventFunc, closeEventFunc) {
         popupDiv.setAttribute("data-bind", "template: 'select-case'");
-        const popup = new mapboxgl.Popup({ offset: 25, anchor: "bottom" })  // eslint-disable-line no-undef
+        const popup = new mapboxgl.Popup({ offset: 25, anchor: "bottom" })
             .setLngLat(coordinates)
             .setDOMContent(popupDiv)
             .on('open', openEventFunc)


### PR DESCRIPTION
…nt errors

## Technical Summary
This PR switches from disabling linting on each line where a global is used to "declaring" the globals at the top of the file.

This is to reduce (maybe eliminate?) the conflicts on staging between the reports webpack branch (which adds these globals as real dependencies, eliminating the need for these comments) and functional changes to these reports.

https://eslint.org/docs/latest/use/configure/language-options#specifying-globals

## Feature Flag
Microplanning

## Safety Assurance

### Safety story
Updates comments only.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
