### PR TITLE
Extracted inddex inline js into a file

### DIFF
--- a/custom/inddex/static/inddex/js/main.js
+++ b/custom/inddex/static/inddex/js/main.js
@@ -1,0 +1,45 @@
+hqDefine("inddex/js/main", function () {
+    $(function () {
+        $("[data-report-table]").each(function (table) {
+            const $table = $(table),
+                reportTable = $table.data("report-table");
+
+            if (!reportTable || !reportTable.datatables) {
+                return;
+            }
+
+            let options = {
+                dataTableElem: '#report_table_' + reportTable.slug,
+                defaultRows: reportTable.default_rows || 10,
+                startAtRowNum: reportTable.default_rows || 10,
+                showAllRowsOption: reportTable.show_all_rows,
+                loadingTemplateSelector: '#js-template-loading-report',
+                defaultSort: true,
+                autoWidth: reportTable.headers.auto_width,
+                fixColumns: true,
+                fixColsNumLeft: 1,
+                fixColsWidth: 130,
+            };
+            if (reportTable.headers.render_aoColumns) {
+                options.aoColumns = reportTable.headers.render_aoColumns;
+            }
+            if (reportTable.headers.custom_sort) {
+                options.customSort = reportTable.headers.custom_sort;
+            }
+            if (reportTable.pagination.is_on) {
+                options.ajaxSource = reportTable.pagination.source;
+                options.ajaxParams = reportTable.pagination.params;
+            }
+            if (reportTable.bad_request_error_text) {
+                options.badRequestErrorText = "<span class='label label-danger'>Sorry!</span> " + reportTable.bad_request_error_text;
+            }
+
+            var reportTables = hqImport("reports/js/bootstrap3/datatables_config").HQReportDataTables(options);
+            var standardHQReport = hqImport("reports/js/bootstrap3/standard_hq_report").getStandardHQReport();
+            if (typeof standardHQReport !== 'undefined') {
+                standardHQReport.handleTabularReportCookies(reportTables);
+            }
+            reportTables.render();
+        });
+    });
+});

--- a/custom/inddex/templates/inddex/partials/report_table.html
+++ b/custom/inddex/templates/inddex/partials/report_table.html
@@ -1,7 +1,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<table id="report_table_{{ report_table.slug }}" class="table table-striped datatable" {% if pagination.filter %} data-filter="true"{% endif %}>
+<table id="report_table_{{ report_table.slug }}" class="table table-striped datatable" {% if pagination.filter %} data-filter="true"{% endif %} data-report-table="{{ report_table|JSON }}">
     <thead>
         {%  if report_table.headers.complex %}
             {{ report_table.headers.render_html }}
@@ -38,40 +38,3 @@
     {% endblock %}
     </tbody>
 </table>
-
-<script>
-   {% if report_table and report_table.datatables %}
-   $(function() {
-        var reportTables = hqImport("reports/js/bootstrap3/datatables_config").HQReportDataTables({
-            dataTableElem: '#report_table_{{ report_table.slug }}',
-            defaultRows: {{ report_table.default_rows|default:10 }},
-            startAtRowNum: {{ report_table.start_at_row|default:0 }},
-            showAllRowsOption: {{ report_table.show_all_rows|JSON }},
-            loadingTemplateSelector: '#js-template-loading-report',
-            defaultSort: true,
-            {% if report_table.headers.render_aoColumns %}aoColumns: {{ report_table.headers.render_aoColumns|JSON }},{% endif %}
-            autoWidth: {{ report_table.headers.auto_width|JSON }},
-            {% if report_table.headers.custom_sort %}customSort: {{ report_table.headers.custom_sort|JSON }},{% endif %}
-
-
-            {% if report_table.pagination.is_on %}
-                ajaxSource: '{{ report_table.pagination.source }}',
-                ajaxParams: {{ report_table.pagination.params|JSON }},
-            {% endif %}
-
-            {% if report_table.bad_request_error_text %}
-                badRequestErrorText: "<span class='label label-danger'>Sorry!</span> {{ report_table.bad_request_error_text }}",
-            {% endif %}
-
-            fixColumns: true,
-            fixColsNumLeft: 1,
-            fixColsWidth: 130
-        });
-        var standardHQReport = hqImport("reports/js/bootstrap3/standard_hq_report").getStandardHQReport();
-        if (typeof standardHQReport !== 'undefined') {
-            standardHQReport.handleTabularReportCookies(reportTables);
-        }
-        reportTables.render();
-    });
-    {% endif %}
-</script>

--- a/custom/inddex/templates/inddex/report_base.html
+++ b/custom/inddex/templates/inddex/report_base.html
@@ -2,6 +2,10 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
+{% block js %}{{ block.super }}
+  <script src="{% static 'inddex/js/main.js' %}"></script>
+{% endblock %}
+
 {% block filter_panel %}
     {% if report.description %}<p class="lead">{{ report.description }}</p>{% endif %}
     {{ block.super }}


### PR DESCRIPTION
## Technical Summary
Cherry picked from reports webpack migration.

## Feature Flag
custom reports

## Safety Assurance

### Safety story
I haven't been able to fully test this. There's a staging domain using these reports, but they 500. I've been troubleshooting that but haven't gotten it resolved yet. These are fairly mechanical changes. 

The impact of problems here is small. The only live projects using them are on a third party env, so the changes won't be "live" for real users until that env deploys. There's a test domain on our prod server that does display the reports properly, so I'm planning to test there once prod is deployed.

### Automated test coverage

no

### QA Plan

not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
