### PR TITLE
Bugfixes for domain metrics

### DIFF
--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -55,11 +55,11 @@ class DomainMetadataResource(CouchResourceMixin, HqBaseResource):
         }
 
     def dehydrate_calculated_properties(self, bundle):
-        from corehq.toggles import CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS
+        from corehq.toggles import CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS, NAMESPACE_DOMAIN
         calc_prop_prefix = 'cp_'
         domain_obj = _get_domain(bundle)
         try:
-            if CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS.enabled(domain_obj.name):
+            if CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS.enabled(domain_obj.name, namespace=NAMESPACE_DOMAIN):
                 base_properties = self._get_base_properties_from_domain_metrics(domain_obj.name)
             else:
                 base_properties = self._get_base_properties_from_elasticsearch(domain_obj.name, calc_prop_prefix)

--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -134,7 +134,7 @@ def update_domain_metrics_for_domains(domains):
     for domain in domains:
         metrics, __ = _update_or_create_domain_metrics(domain, all_stats)
         if metrics:
-            active_users_by_domain[domain] = metrics['active_mobile_workers']
+            active_users_by_domain[domain] = metrics.active_mobile_workers
 
     datadog_report_user_stats('commcare.active_mobile_workers.count', active_users_by_domain)
 
@@ -144,7 +144,8 @@ def _update_or_create_domain_metrics(domain, all_stats):
         domain_obj = Domain.get_by_name(domain)
         metrics_dict = domain_metrics(domain_obj, domain_obj['_id'], all_stats)
         return DomainMetrics.objects.update_or_create(
-            **metrics_dict,
+            defaults=metrics_dict,
+            domain=domain_obj.name,
         )
     except Exception as e:
         notify_exception(

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -359,9 +359,9 @@ def domain_metrics(domain_obj, id, all_stats):
     metrics_dict['last_modified'] = datetime.now(tz=timezone.utc)
 
     # these are calculated fields on the Django model, so don't try to write them
-    del metrics_dict['cp_has_app']
-    del metrics_dict['cp_sms_30_d']
-    del metrics_dict['cp_sms_ever']
+    for key in ['has_app', 'has_used_sms', 'has_used_sms_in_last_30_days']:
+        del metrics_dict[key]
+
     return metrics_dict
 
 


### PR DESCRIPTION
## Product Description
Fixes the temporarily broken `project_space_metadata` API endpoint, which is admin only, and fixes bugs with the as-of-yet invisible `update_domain_metrics` task.

## Technical Summary
Initially was just fixing the feature flag check, but found several other issues in re-testing on staging.
 - FF check was failing, causing a 500 error, because namespace wasn't specified:
```
PredictablyRandomToggle.enabled() cannot be determined for toggle "calced_props_from_domain_metrics" because it is not available for all namespaces
```
- `active_mobile_workers` was being used as a dict key instead of a property when getting from `DomainMetrics`
- `update_or_create` was failing when trying to update an existing object, because of passing in the whole dict as `**kwargs` instead of `defaults`
- deleting calculated fields from `metrics_dict` was failing because it used the wrong key names

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Tested locally and on staging that these changes do resolve the bugs above -- by running the `update_domain_metrics_for_domains` task for a given project space twice (to make sure it creates, then updates the `DomainMetrics`) and retrieving them via the `project_space_metadata` API endpoint.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
