### PR TITLE
Mark selected language as active in dropdown

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1371,8 +1371,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             this.languageOptionsEnabled = options.languageOptionsEnabled;
         },
         templateContext: function () {
+            const currentLang = UsersModels.getCurrentUser().displayOptions.language;
             return {
                 languageOptionsEnabled: this.languageOptionsEnabled,
+                isLangSelected: this.options.model.get('lang_code') === currentLang,
             };
         },
         onKeyActionChangeLang: function (e) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1368,13 +1368,14 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             'keydown .lang': 'onKeyActionChangeLang',
         },
         initialize: function (options) {
+            const currentLang = UsersModels.getCurrentUser().displayOptions.language;
+            this.isLangSelected = this.options.model.get('lang_code') === currentLang;
             this.languageOptionsEnabled = options.languageOptionsEnabled;
         },
         templateContext: function () {
-            const currentLang = UsersModels.getCurrentUser().displayOptions.language;
             return {
                 languageOptionsEnabled: this.languageOptionsEnabled,
-                isLangSelected: this.options.model.get('lang_code') === currentLang,
+                isLangSelected: this.isLangSelected,
             };
         },
         onKeyActionChangeLang: function (e) {
@@ -1383,8 +1384,10 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             }
         },
         onChangeLang: function (e) {
-            const lang = e.target.id;
-            $.publish('formplayer.change_lang', lang);
+            if (!this.isLangSelected) {
+                const lang = e.target.id;
+                $.publish('formplayer.change_lang', lang);
+            }
         },
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1370,8 +1370,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             click: 'change:lang'
         },
         initialize: function (options) {
-            const currentLang = UsersModels.getCurrentUser().displayOptions.language;
-            this.isLangSelected = options.model.get('lang_code') === currentLang;
+            this.isLangSelected = options.model.get('lang_code') === options.currentLang;
             this.languageOptionsEnabled = options.languageOptionsEnabled;
         },
         templateContext: function () {
@@ -1427,6 +1426,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
         childViewOptions: function () {
             return {
                 languageOptionsEnabled: Boolean(this.options.collection),
+                currentLang: UsersModels.getCurrentUser().displayOptions.language,
             };
         },
         templateContext: function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1364,12 +1364,14 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
         tagName: "li",
         template: _.template($("#language-option-template").html() || ""),
         events: {
-            'click': 'onChangeLang',
             'keydown .lang': 'onKeyActionChangeLang',
+        },
+        triggers: {
+            click: 'change:lang'
         },
         initialize: function (options) {
             const currentLang = UsersModels.getCurrentUser().displayOptions.language;
-            this.isLangSelected = this.options.model.get('lang_code') === currentLang;
+            this.isLangSelected = options.model.get('lang_code') === currentLang;
             this.languageOptionsEnabled = options.languageOptionsEnabled;
         },
         templateContext: function () {
@@ -1383,7 +1385,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
                 this.onChangeLang(e);
             }
         },
-        onChangeLang: function (e) {
+        onChangeLang: function (view, e) {
             if (!this.isLangSelected) {
                 const lang = e.target.id;
                 $.publish('formplayer.change_lang', lang);
@@ -1418,6 +1420,9 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
         },
         behaviors: {
             print: printBehavior,
+        },
+        childViewEvents: {
+            'change:lang': 'render',
         },
         childViewOptions: function () {
             return {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1,4 +1,3 @@
-'use strict';
 hqDefine("cloudcare/js/formplayer/menus/views", [
     'jquery',
     'underscore',
@@ -1367,7 +1366,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             'keydown .lang': 'onKeyActionChangeLang',
         },
         triggers: {
-            click: 'change:lang'
+            click: 'change:lang',
         },
         initialize: function (options) {
             this.isLangSelected = options.model.get('lang_code') === options.currentLang;
@@ -1683,5 +1682,4 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             return new PersistentMenuView(options);
         },
     };
-})
-;
+});

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/dropdown.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/dropdown.html
@@ -25,8 +25,9 @@
   <% if (languageOptionsEnabled) { %>
     <a
       tabindex="0"
-      class="lang dropdown-item <% if (isLangSelected) { %>active<% } %>"
+      class="lang dropdown-item <% if (isLangSelected) { %>active pe-none<% } %>"
       id="<%- lang_code %>"
+      <% if (isLangSelected) { %>aria-disabled="true"<% } %>
     >
       <%- lang_label %>
     </a>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/dropdown.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/dropdown.html
@@ -23,6 +23,12 @@
 
 <script type="text/template" id="language-option-template">
   <% if (languageOptionsEnabled) { %>
-  <a tabindex="0" class="lang dropdown-item" id="<%- lang_code %>"><%- lang_label %></a>
+    <a
+      tabindex="0"
+      class="lang dropdown-item <% if (isLangSelected) { %>active<% } %>"
+      id="<%- lang_code %>"
+    >
+      <%- lang_label %>
+    </a>
   <% } %>
 </script>


### PR DESCRIPTION
## Product Description

Show currently selected language as "active" in the web apps language selection dropdown

![image](https://github.com/user-attachments/assets/430b2b11-2748-46d4-ac18-328a1c57e898)

This also makes the selected language no longer clickable.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-5114

Shout out to @avazirna for https://github.com/dimagi/commcare-hq/pull/35444


## Feature Flag


## Safety Assurance


### Safety story

This is pretty straightforward a change - I'm happy with local testing

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
