### PR TITLE
Refactor Async Function for Case Grouping Page

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
+++ b/corehq/apps/geospatial/static/geospatial/js/case_grouping_map.js
@@ -5,7 +5,7 @@ hqDefine("geospatial/js/case_grouping_map",[
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/bootstrap3/alert_user',
     'geospatial/js/models',
-    'geospatial/js/utils'
+    'geospatial/js/utils',
 ], function (
     $,
     ko,
@@ -27,7 +27,7 @@ hqDefine("geospatial/js/case_grouping_map",[
         groupId: DEFAULT_GROUP_ID,
         name: gettext("No group"),
         color: `rgba(128,128,128,${OBSCURING_OPACITY})`,
-    }
+    };
 
     const MAP_CONTAINER_ID = 'case-grouping-map';
     const clusterStatsInstance = new clusterStatsModel();
@@ -41,7 +41,6 @@ hqDefine("geospatial/js/case_grouping_map",[
     let currentPage = 1;
 
     function clusterStatsModel() {
-        'use strict';
         let self = {};
         self.totalClusters = ko.observable(0);
         self.clusterMinCount = ko.observable(0);
@@ -59,7 +58,7 @@ hqDefine("geospatial/js/case_grouping_map",[
                 return;
             }
             // Only cases with belonging to groups should be exported
-            let exportableCases = self.casesToExport().filter(function(caseItem) {
+            let exportableCases = self.casesToExport().filter(function (caseItem) {
                 return caseItem.groupId !== DEFAULT_GROUP_ID;
             });
 
@@ -68,8 +67,8 @@ hqDefine("geospatial/js/case_grouping_map",[
                 exportableCases = self.casesToExport();
             }
 
-            const groupNameByID = _.object(_.map(caseGroupsInstance.generatedGroups, function(group) {
-                return [group.groupId, group.name]
+            const groupNameByID = _.object(_.map(caseGroupsInstance.generatedGroups, function (group) {
+                return [group.groupId, group.name];
             }));
 
             const casesToExport = _.map(exportableCases, function (caseItem) {
@@ -87,7 +86,7 @@ hqDefine("geospatial/js/case_grouping_map",[
                 gettext('Case Owner Name'),
                 gettext('Case Coordinates'),
                 gettext('Case ID'),
-            ]
+            ];
             const cols = [
                 'groupId',
                 'groupName',
@@ -95,47 +94,47 @@ hqDefine("geospatial/js/case_grouping_map",[
                 'caseName',
                 'owner_name',
                 'coordinates',
-                'caseId'
-            ]
+                'caseId',
+            ];
 
             utils.downloadCsv(casesToExport, headers, cols, 'Group Export');
         };
 
-        self.addGroupDataToCases = function(caseGroups, groupsData, assignDefaultGroup) {
-            const defaultGroup = groupsData.find((group) => {return group.groupId === DEFAULT_GROUP_ID});
+        self.addGroupDataToCases = function (caseGroups, groupsData, assignDefaultGroup) {
+            const defaultGroup = groupsData.find((group) => {return group.groupId === DEFAULT_GROUP_ID;});
             self.casesToExport().forEach(caseItem => {
                 const groupId = caseGroups[caseItem.itemId];
                 if (groupId !== undefined) {
-                    const group = groupsData.find((group) => {return group.groupId === groupId});
+                    const group = groupsData.find((group) => {return group.groupId === groupId;});
                     self.setItemGroup(caseItem, groupId, group.coordinates);
                 } else if (assignDefaultGroup) {
                     self.setItemGroup(caseItem, defaultGroup.groupId, {});
                 }
             });
-        }
+        };
 
-        self.setItemGroup = function(item, groupId, groupCoordinates) {
+        self.setItemGroup = function (item, groupId, groupCoordinates) {
             item.groupId = groupId;
             item.groupCoordinates = groupCoordinates;
-        }
+        };
 
-        self.updateCaseGroup = function(itemId, groupData) {
-            var item = self.casesToExport().find((caseItem) => {return caseItem.itemId == itemId});
+        self.updateCaseGroup = function (itemId, groupData) {
+            var item = self.casesToExport().find((caseItem) => {return caseItem.itemId === itemId;});
             self.setItemGroup(item, groupData.groupId, groupData.coordinates);
-        }
+        };
 
-        self.clearCaseGroups = function() {
+        self.clearCaseGroups = function () {
             self.casesToExport().forEach(caseItem => {
                 if (caseItem.groupId) {
                     caseItem.groupId = null;
                     caseItem.groupCoordinates = null;
                 }
             });
-        }
+        };
 
-        self.groupsReady = function() {
+        self.groupsReady = function () {
             return groupLockModelInstance.groupsLocked();
-        }
+        };
 
         return self;
     }
@@ -229,7 +228,6 @@ hqDefine("geospatial/js/case_grouping_map",[
     }
 
     function mapMarkerModel(itemId, itemData, marker, markerColors) {
-        'use strict';
         var self = {};
         self.title = gettext("Select group");
         self.itemId = itemId;
@@ -270,8 +268,8 @@ hqDefine("geospatial/js/case_grouping_map",[
         mapMarkers.forEach((marker) => marker.remove());
         mapMarkers = [];
 
-        let groupColorByID = _.object(_.map(caseGroupsInstance.generatedGroups, function(group) {
-            return [group.groupId, group.color]
+        let groupColorByID = _.object(_.map(caseGroupsInstance.generatedGroups, function (group) {
+            return [group.groupId, group.color];
         }));
 
         exportModelInstance.casesToExport().forEach(function (caseItem) {
@@ -281,7 +279,7 @@ hqDefine("geospatial/js/case_grouping_map",[
             }
             const caseGroupID = caseItem.groupId;
             if (caseGroupsInstance.groupIDInVisibleGroupIds(caseGroupID)) {
-                color = groupColorByID[caseGroupID];
+                const color = groupColorByID[caseGroupID];
                 const marker = new mapboxgl.Marker({ color: color, draggable: false });  // eslint-disable-line no-undef
                 marker.setLngLat([coordinates.lng, coordinates.lat]);
 
@@ -302,7 +300,6 @@ hqDefine("geospatial/js/case_grouping_map",[
     }
 
     function caseGroupSelectModel() {
-        'use strict';
         var self = {};
 
         self.groupsByCase;
@@ -313,63 +310,63 @@ hqDefine("geospatial/js/case_grouping_map",[
         self.visibleGroupIDs = ko.observableArray([]);
         self.casePerGroup = {};
 
-        self.groupIDInVisibleGroupIds = function(groupID) {
+        self.groupIDInVisibleGroupIds = function (groupID) {
             return self.visibleGroupIDs().indexOf(groupID) !== -1;
         };
 
-        self.getGroupByID = function(groupID) {
+        self.getGroupByID = function (groupID) {
             return self.generatedGroups.find((group) => group.groupId === groupID);
         };
 
-        self.updateCaseGroup = function(itemId, newGroupId) {
+        self.updateCaseGroup = function (itemId, newGroupId) {
             self.groupsByCase[itemId] = newGroupId;
         };
 
-        self.loadCaseGroups = function(caseGroups, groups) {
+        self.loadCaseGroups = function (caseGroups, groups) {
             self.groupsByCase = caseGroups;
             self.generatedGroups = groups;
 
             self.showAllGroups();
         };
 
-        self.clear = function() {
+        self.clear = function () {
             self.generatedGroups = [];
             self.caseGroupsForTable([]);
             self.visibleGroupIDs([]);
         };
 
-        self.restoreMarkerOpacity = function() {
-            mapMarkers.forEach(function(marker) {
+        self.restoreMarkerOpacity = function () {
+            mapMarkers.forEach(function (marker) {
                 setMarkerOpacity(marker, DEFAULT_MARKER_OPACITY);
             });
         };
 
-        self.highlightGroup = function(group) {
+        self.highlightGroup = function (group) {
             exportModelInstance.casesToExport().forEach(caseItem => {
-                    let caseIsInGroup = caseItem.groupId === group.groupId;
-                    let opacity = DEFAULT_MARKER_OPACITY
-                    if (!caseIsInGroup) {
-                        opacity = OBSCURING_OPACITY;
-                    }
-                    let marker = mapMarkers.find((marker) => {
-                        let markerCoordinates = marker.getLngLat();
-                        let caseCoordinates = caseItem.itemData.coordinates;
-                        let latEqual = markerCoordinates.lat === caseCoordinates.lat;
-                        let lonEqual = markerCoordinates.lng === caseCoordinates.lng;
-                        return latEqual && lonEqual;
-                    });
-                    if (marker) {
-                        setMarkerOpacity(marker, opacity);
-                    }
+                let caseIsInGroup = caseItem.groupId === group.groupId;
+                let opacity = DEFAULT_MARKER_OPACITY;
+                if (!caseIsInGroup) {
+                    opacity = OBSCURING_OPACITY;
+                }
+                let marker = mapMarkers.find((marker) => {
+                    let markerCoordinates = marker.getLngLat();
+                    let caseCoordinates = caseItem.itemData.coordinates;
+                    let latEqual = markerCoordinates.lat === caseCoordinates.lat;
+                    let lonEqual = markerCoordinates.lng === caseCoordinates.lng;
+                    return latEqual && lonEqual;
+                });
+                if (marker) {
+                    setMarkerOpacity(marker, opacity);
+                }
             });
         };
 
         function setMarkerOpacity(marker, opacity) {
             let element = marker.getElement();
             element.style.opacity = opacity;
-        };
+        }
 
-        self.showSelectedGroups = function() {
+        self.showSelectedGroups = function () {
             if (!self.groupsByCase) {
                 return;
             }
@@ -384,20 +381,20 @@ hqDefine("geospatial/js/case_grouping_map",[
             revealGroupsOnMap();
         };
 
-        self.showAllGroups = function() {
+        self.showAllGroups = function () {
             if (!self.groupsByCase) {
                 return;
             }
-            self.visibleGroupIDs(_.map(self.generatedGroups, function(group) {return group.groupId}));
+            self.visibleGroupIDs(_.map(self.generatedGroups, function (group) {return group.groupId;}));
             revealGroupsOnMap();
             self.setCaseGroupsForTable();
         };
 
-        self.setCaseGroupsForTable = function() {
+        self.setCaseGroupsForTable = function () {
             self.caseGroupsForTable(self.generatedGroups);
-        }
+        };
 
-        self.groupsReady = function() {
+        self.groupsReady = function () {
             return groupLockModelInstance.groupsLocked() && self.caseGroupsForTable().length;
         };
 
@@ -478,7 +475,6 @@ hqDefine("geospatial/js/case_grouping_map",[
     }
 
     function groupLockModel() {
-        'use strict';
         var self = {};
 
         self.groupsLocked = ko.observable(false);


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This PR does a refactor on the `setCaseGroups()` function so that it utilises promise chaining, removing the need to declare the function as async. This has been done purely as a linting fix, since the current eslint version does not support declaring async functions. Given that this is the only place in the code where a JS async function is declared I thought it would be better to simply rewrite this function instead of looking at upgrading the eslint version just for this one use case.

In refactoring the function, some new lint errors were revealed which have also been addressed in this PR.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`MICROPLANNING`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing has been done to ensure locking/unlocking case clusters still works as expected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
