### PR TITLE
Removed DeviceLogSoftAssertReport

### DIFF
--- a/corehq/apps/reports/filters/base.py
+++ b/corehq/apps/reports/filters/base.py
@@ -166,7 +166,7 @@ class BaseMultipleOptionFilter(BaseSingleOptionFilter):
         Displays a multiselect field.
     """
     template = "reports/filters/bootstrap3/multi_option.html"
-    default_options = [] # specify a list
+    default_options = []  # specify a list
 
     @classmethod
     def get_value(cls, request, domain):
@@ -294,7 +294,7 @@ class BaseDrilldownOptionFilter(BaseReportFilter):
             'val': val,
             'text': text,
             'next': next,
-            }
+        }
 
     @property
     def shared_pagination_GET_params(self):
@@ -313,23 +313,6 @@ class BaseDrilldownOptionFilter(BaseReportFilter):
     def get_value(cls, request, domain):
         instance = cls(request, domain)
         return instance.GET_values, instance
-
-
-class BaseTagsFilter(BaseReportFilter):
-    template = "reports/filters/bootstrap3/base_tags_filter.html"
-    tags = []
-
-    @property
-    def selected(self):
-        return self.get_value(self.request, self.domain) or ''
-
-    @property
-    def filter_context(self):
-        return {
-            'tags': self.tags,
-            'selected': self.selected,
-            'placeholder': self.placeholder,
-        }
 
 
 class BaseSimpleFilter(BaseReportFilter):

--- a/corehq/apps/reports/filters/devicelog.py
+++ b/corehq/apps/reports/filters/devicelog.py
@@ -6,10 +6,8 @@ from phonelog.models import DeviceReportEntry
 from corehq.apps.reports.filters.base import (
     BaseMultipleOptionFilter,
     BaseReportFilter,
-    BaseSingleOptionFilter,
-    BaseTagsFilter,
 )
-from corehq.util.queries import fast_distinct, fast_distinct_in_domain
+from corehq.util.queries import fast_distinct_in_domain
 from corehq.util.quickcache import quickcache
 
 
@@ -41,22 +39,6 @@ class DeviceLogTagFilter(BaseReportFilter):
             self.errors_only_slug: errors_only,
         }
         return context
-
-
-class DeviceLogDomainFilter(BaseSingleOptionFilter):
-    slug = "domain"
-    label = gettext_lazy("Filter Logs by Domain")
-
-    @property
-    @quickcache([], timeout=60 * 60)
-    def options(self):
-        return [(d, d) for d in fast_distinct(DeviceReportEntry, 'domain')]
-
-
-class DeviceLogCommCareVersionFilter(BaseTagsFilter):
-    slug = "commcare_version"
-    label = gettext_lazy("Filter Logs by CommCareVersion")
-    placeholder = gettext_lazy("Enter the CommCare Version you want e.g '2.28.1'")
 
 
 class BaseDeviceLogFilter(BaseMultipleOptionFilter):

--- a/corehq/apps/reports/templates/reports/filters/bootstrap3/base_tags_filter.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap3/base_tags_filter.html
@@ -1,9 +1,0 @@
-{% extends 'reports/filters/bootstrap3/base.html' %}
-{% load hq_shared_tags %}
-{% block filter_content %}
-  <select class="{{ css_class }} form-control report-filter-tags"
-          data-tags="{% html_attr tags %}"
-          name="{{ slug }}"
-          placeholder="{{ placeholder }}"
-          value="{{ selected }}"></select>
-{% endblock %}

--- a/corehq/apps/reports/templates/reports/filters/bootstrap5/base_tags_filter.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap5/base_tags_filter.html
@@ -1,9 +1,0 @@
-{% extends 'reports/filters/bootstrap5/base.html' %}
-{% load hq_shared_tags %}
-{% block filter_content %}
-  <select class="{{ css_class }} form-control report-filter-tags"
-          data-tags="{% html_attr tags %}"
-          name="{{ slug }}"
-          placeholder="{{ placeholder }}"
-          value="{{ selected }}"></select>
-{% endblock %}

--- a/corehq/apps/reports/tests/test_dispatcher.py
+++ b/corehq/apps/reports/tests/test_dispatcher.py
@@ -50,7 +50,6 @@ class AdminReportDispatcherTests(SimpleTestCase):
         self.assertEqual(report_names, {
             'user_list_report',
             'user_audit_report',
-            'device_log_soft_asserts',
             'deploy_history_report',
             'phone_number_report',
             'ucr_data_load',

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -35,7 +35,6 @@ from corehq.apps.fixtures.interface import (
 from corehq.apps.hqadmin.reports import (
     AdminPhoneNumberReport,
     DeployHistoryReport,
-    DeviceLogSoftAssertReport,
     UserAuditReport,
     UserListReport,
     UCRDataLoadReport,
@@ -326,7 +325,6 @@ ENTERPRISE_INTERFACES = (
 ADMIN_REPORTS = (
     (_('Domain Stats'), (
         UserListReport,
-        DeviceLogSoftAssertReport,
         AdminPhoneNumberReport,
         UserAuditReport,
         DeployHistoryReport,

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -49,7 +49,6 @@ from corehq.apps.case_search.views import CSQLFixtureExpressionView
 from corehq.apps.geospatial.dispatchers import CaseManagementMapDispatcher
 from corehq.apps.hqadmin.reports import (
     DeployHistoryReport,
-    DeviceLogSoftAssertReport,
     UserAuditReport,
     UserListReport,
     UCRDataLoadReport,
@@ -2625,7 +2624,7 @@ class AdminTab(UITab):
                     url=reverse('admin_report_dispatcher', args=(report.slug,)),
                     params="?{}".format(urlencode(report.default_params)) if report.default_params else ""
                 )
-            } for report in [DeviceLogSoftAssertReport, UserAuditReport, UCRDataLoadReport]
+            } for report in [UserAuditReport, UCRDataLoadReport]
         ]))
         return sections
 


### PR DESCRIPTION
## Product Description
Discussed with mobile team internally. This report is barely ever viewed and has no data on production, based on running `DeviceReportEntry.objects.filter(type='soft-assert')`

## Feature Flag
admin report

## Safety Assurance

### Safety story
Removal of barely-used report and a bit of related code.

### Automated test coverage

A little bit is being deleted in this PR.

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
