### PR TITLE
Bump Jinja2 to 3.1.5

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -372,7 +372,7 @@ isort==5.10.1
     # via -r dev-requirements.in
 jedi==0.18.1
     # via ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -r base-requirements.in
     #   myst-parser

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -320,7 +320,7 @@ importlib-metadata==8.5.0
     #   sphinx
 iso8601==2.0.0
     # via -r base-requirements.in
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -r base-requirements.in
     #   myst-parser

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -324,7 +324,7 @@ isodate==0.6.1
     # via python3-saml
 jedi==0.18.1
     # via ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r base-requirements.in
 jmespath==0.10.0
     # via

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -306,7 +306,7 @@ iso8601==2.0.0
     # via -r base-requirements.in
 isodate==0.6.1
     # via python3-saml
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r base-requirements.in
 jmespath==0.10.0
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -326,7 +326,7 @@ iso8601==2.0.0
     # via -r base-requirements.in
 isodate==0.6.1
     # via python3-saml
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r base-requirements.in
 jmespath==0.10.0
     # via


### PR DESCRIPTION
From the [Jinja2 release notes](https://github.com/pallets/jinja/releases/tag/3.1.5)

> This is the Jinja 3.1.5 security fix release, which fixes security issues and bugs but does not otherwise change behavior and should not result in breaking changes compared to the latest feature release.

https://dimagi.atlassian.net/browse/SAAS-16432

## Safety Assurance

### Safety story

Reviewed commits lightly, release notes more thoroughly. Looks safe. Jinja2 is a very widely used library.

### Automated test coverage

Maybe some indirect coverage?

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations