### PR TITLE
Quote package specifier on make upgrade-package

### DIFF
--- a/requirements/Makefile
+++ b/requirements/Makefile
@@ -22,9 +22,9 @@ upgrade-requirements:
 # make upgrade-package package={package_name}
 upgrade-package: export CUSTOM_COMPILE_COMMAND=`make requirements` or `make upgrade-requirements`
 upgrade-package:
-	pip-compile --upgrade-package $(package) -qo requirements.txt requirements.in --allow-unsafe --strip-extras
-	pip-compile --upgrade-package $(package) -qo prod-requirements.txt prod-requirements.in --allow-unsafe --strip-extras
-	pip-compile --upgrade-package $(package) -qo test-requirements.txt test-requirements.in --allow-unsafe --strip-extras
-	pip-compile --upgrade-package $(package) -qo dev-requirements.txt dev-requirements.in --allow-unsafe --strip-extras
-	pip-compile --upgrade-package $(package) -qo docs-requirements.txt docs-requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade-package '$(package)' -qo requirements.txt requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade-package '$(package)' -qo prod-requirements.txt prod-requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade-package '$(package)' -qo test-requirements.txt test-requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade-package '$(package)' -qo dev-requirements.txt dev-requirements.in --allow-unsafe --strip-extras
+	pip-compile --upgrade-package '$(package)' -qo docs-requirements.txt docs-requirements.in --allow-unsafe --strip-extras
 	python ../scripts/purge-platform-pkgs.py ./*requirements.txt


### PR DESCRIPTION
Allows passing package version specifiers containing characters that have special meaning in the shell, such as

    make upgrade-package package='xyz>1.2'

Previously this would have redirected the output of `pip-compile --upgrade-package xyz` to a file named `1.2`

## Safety Assurance

### Safety story

Small change to requirements maintenance script. Does not directly affect production code.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations