### PR TITLE
Stop using ES calculated properties and remove feature flag

### DIFF
--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -55,16 +55,12 @@ class DomainMetadataResource(CouchResourceMixin, HqBaseResource):
         }
 
     def dehydrate_calculated_properties(self, bundle):
-        from corehq.toggles import CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS, NAMESPACE_DOMAIN
         calc_prop_prefix = 'cp_'
         domain_obj = _get_domain(bundle)
         try:
-            if CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS.enabled(domain_obj.name, namespace=NAMESPACE_DOMAIN):
-                base_properties = self._get_base_properties_from_domain_metrics(domain_obj.name)
-            else:
-                base_properties = self._get_base_properties_from_elasticsearch(domain_obj.name, calc_prop_prefix)
+            base_properties = self._get_base_properties_from_domain_metrics(domain_obj.name)
             properties = self._add_extra_calculated_properties(base_properties, domain_obj.name, calc_prop_prefix)
-        except (DomainMetrics.DoesNotExist, IndexError):
+        except (DomainMetrics.DoesNotExist):
             logging.exception('Problem getting calculated properties for {}'.format(domain_obj.name))
             return {}
         return properties

--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -71,19 +71,6 @@ class DomainMetadataResource(CouchResourceMixin, HqBaseResource):
         return domain_metrics.to_calculated_properties()
 
     @staticmethod
-    def _get_base_properties_from_elasticsearch(domain, calc_prop_prefix):
-        es_data = (DomainES()
-                   .in_domains([domain])
-                   .size(1)
-                   .run()
-                   .hits[0])
-        return {
-            prop_name: es_data[prop_name]
-            for prop_name in es_data
-            if prop_name.startswith(calc_prop_prefix)
-        }
-
-    @staticmethod
     def _add_extra_calculated_properties(properties, domain, calc_prop_prefix):
         try:
             audit_record = DomainAuditRecordEntry.objects.get(domain=domain)

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -8,17 +8,10 @@ from celery.utils.log import get_task_logger
 from text_unidecode import unidecode
 
 from casexml.apps.case.xform import extract_case_blocks
-from dimagi.utils.chunked import chunked
-from dimagi.utils.logging import notify_exception
 from soil import DownloadBase
 from soil.util import expose_blob_download
 
 from corehq.apps.celery import periodic_task, task
-from corehq.apps.data_analytics.tasks import datadog_report_user_stats
-from corehq.apps.domain.calculations import all_domain_stats, calced_props
-from corehq.apps.domain.models import Domain
-from corehq.apps.es import DomainES, FormES, filters
-from corehq.apps.es.domains import domain_adapter
 from corehq.apps.export.const import MAX_MULTIMEDIA_EXPORT_SIZE
 from corehq.apps.reports.models import QueryStringHash
 from corehq.apps.reports.util import send_report_download_email
@@ -37,71 +30,6 @@ from .analytics.esaccessors import (
 
 logger = get_task_logger(__name__)
 EXPIRE_TIME = ONE_DAY
-
-
-@periodic_task(run_every=crontab(hour="22", minute="0", day_of_week="*"), queue='background_queue')
-def update_calculated_properties():
-    domains_to_update = DomainES().filter(
-        get_domains_to_update_es_filter()
-    ).fields(["name", "_id"]).run().hits
-
-    for chunk in chunked(domains_to_update, 5000):
-        update_calculated_properties_for_domains.delay(chunk)
-
-
-@task(queue='background_queue')
-def update_calculated_properties_for_domains(domains):
-    """
-    :param domains: list of {'name': <name>, '_id': <id>} entries
-    """
-    # relying on caching for efficiency
-    all_stats = all_domain_stats()
-
-    active_users_by_domain = {}
-    for domain in domains:
-        domain_obj = Domain.get_by_name(domain['name'])
-        if not domain_obj:
-            domain_adapter.delete(domain['_id'])
-            continue
-        try:
-            props = calced_props(domain_obj, domain['_id'], all_stats)
-            active_users_by_domain[domain['name']] = props['cp_n_active_cc_users']
-            for key in ['cp_first_form', 'cp_last_form', 'cp_300th_form']:
-                if props.get(key) is None:
-                    del props[key]
-            if props.get('cp_n_forms') is None:
-                raise ValueError(f"Null value detected for 'cp_n_forms' in domain {domain['name']}")
-            domain_adapter.update(domain['_id'], props)
-        except Exception as e:
-            notify_exception(
-                None, message='Domain {} failed on stats calculations with {}'.format(domain['name'], e)
-            )
-
-    datadog_report_user_stats('commcare.active_mobile_workers.count', active_users_by_domain)
-
-
-def get_domains_to_update_es_filter():
-    """
-    Returns ES filter to obtain domains that are active, and meet one or more
-    of the following criteria:
-     - never had calculated properties updated
-     - calculated properties was updated over one week ago
-     - new form submissions within the last day
-    """
-    last_week = datetime.utcnow() - timedelta(days=7)
-    more_than_a_week_ago = filters.date_range('cp_last_updated', lt=last_week)
-    not_updated = filters.missing('cp_last_updated')
-    domains_submitted_today = (FormES().submitted(gte=datetime.utcnow() - timedelta(days=1))
-        .terms_aggregation('domain.exact', 'domain').size(0).run().aggregations.domain.keys)
-    is_domain_active = filters.term('is_active', True)
-    return filters.AND(
-        is_domain_active,
-        filters.OR(
-            not_updated,
-            more_than_a_week_ago,
-            filters.term('name', domains_submitted_today)
-        )
-    )
 
 
 @task(serializer='pickle', ignore_result=True)

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -1,27 +1,18 @@
-from datetime import datetime
+
 from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 from uuid import uuid4
 from zipfile import ZipFile
 
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase
 
 from attrs import define, field
-from freezegun import freeze_time
 
-from dimagi.utils.parsing import json_format_datetime
-
-from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.es import DomainES, form_adapter
-from corehq.apps.es.domains import domain_adapter
-from corehq.apps.es.tests.utils import es_test
 from corehq.apps.reports.tasks import (
     _get_question_id_for_attachment,
     _make_unique_filename,
     _write_attachments_to_file,
-    get_domains_to_update_es_filter,
 )
-from corehq.form_processor.tests.utils import create_form_for_test
 
 
 class GetQuestionIdTests(SimpleTestCase):
@@ -73,89 +64,6 @@ class GetQuestionIdTests(SimpleTestCase):
 
         result = _get_question_id_for_attachment(form, 'attachment.ext')
         self.assertIsNone(result)
-
-
-@es_test(requires=[domain_adapter, form_adapter], setup_class=True)
-class TestGetDomainsToUpdateESFilter(TestCase):
-    def test_calculated_properties_never_updated_is_included(self):
-        domain = self.index_domain('never-updated')
-        self.assertFalse(hasattr(domain, 'cp_last_updated'))
-
-        domains_filter = get_domains_to_update_es_filter()
-        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
-
-        self.assertEqual(results, [{'_id': domain._id, 'name': domain.name}])
-
-    @freeze_time('2020-01-10')
-    def test_calculated_properties_updated_over_one_week_ago_is_included(self):
-        domain = self.index_domain('cp-over-one-week', cp_last_updated=datetime(2020, 1, 2, 23, 59))
-
-        domains_filter = get_domains_to_update_es_filter()
-        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
-
-        self.assertEqual(results, [{'_id': domain._id, 'name': domain.name}])
-
-    @freeze_time('2020-01-10')
-    def test_calculated_properties_updated_exactly_one_week_ago_is_excluded(self):
-        self.index_domain('cp-one-week', cp_last_updated=datetime(2020, 1, 3))
-
-        domains_filter = get_domains_to_update_es_filter()
-        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
-
-        self.assertEqual(results, [])
-
-    @freeze_time('2020-01-10')
-    def test_calculated_properties_updated_less_than_one_week_ago_is_excluded(self):
-        self.index_domain('cp-less-than-one-week', cp_last_updated=datetime(2020, 1, 4))
-
-        domains_filter = get_domains_to_update_es_filter()
-        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
-
-        self.assertEqual(results, [])
-
-    @freeze_time('2020-01-10')
-    def test_form_submission_in_the_last_day_is_included(self):
-        domain = self.index_domain('form-from-today', cp_last_updated=datetime(2020, 1, 9))
-        self.index_form(domain.name, received_on=datetime(2020, 1, 9, 0, 0))
-
-        domains_filter = get_domains_to_update_es_filter()
-        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
-
-        self.assertEqual(results, [{'_id': domain._id, 'name': domain.name}])
-
-    @freeze_time('2020-01-10')
-    def test_form_submission_over_one_day_ago_is_excluded(self):
-        domain = self.index_domain('form-from-yesterday', cp_last_updated=datetime(2020, 1, 9))
-        self.index_form(domain.name, received_on=datetime(2020, 1, 8, 23, 59))
-
-        domains_filter = get_domains_to_update_es_filter()
-        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
-
-        self.assertEqual(results, [])
-
-    @freeze_time('2020-01-10')
-    def test_inactive_domain_is_excluded(self):
-        self.index_domain('inactive-domain', active=False)
-
-        domains_filter = get_domains_to_update_es_filter()
-        results = DomainES().filter(domains_filter).fields(['_id', 'name']).run().hits
-
-        self.assertEqual(results, [])
-
-    def index_domain(self, name, active=True, cp_last_updated=None):
-        domain = create_domain(name, active)
-        self.addCleanup(domain.delete)
-        if cp_last_updated:
-            domain.cp_last_updated = json_format_datetime(cp_last_updated)
-        domain_adapter.index(domain, refresh=True)
-        self.addCleanup(domain_adapter.delete, domain._id, refresh=True)
-        return domain
-
-    def index_form(self, domain, received_on):
-        xform = create_form_for_test(domain, received_on=received_on)
-        form_adapter.index(xform, refresh=True)
-        self.addCleanup(form_adapter.delete, xform.form_id, refresh=True)
-        return xform
 
 
 @patch("soil.DownloadBase.set_progress")

--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -1,4 +1,3 @@
-
 from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 from uuid import uuid4

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2569,14 +2569,6 @@ WEB_USER_INVITE_ADDITIONAL_FIELDS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS = FeatureRelease(
-    'calced_props_from_domain_metrics',
-    'Read domain calculated properties from DomainMetrics model instead of ElasticSearch doc.',
-    TAG_SAAS_CONDITIONAL,
-    namespaces=[NAMESPACE_DOMAIN],
-    owner='emapson@dimagi.com'
-)
-
 
 def _handle_attendance_tracking_role(domain, is_enabled):
     from corehq.apps.accounting.utils import domain_has_privilege


### PR DESCRIPTION
## Product Description
Moves the data source for calculated properties in the admin-only API endpoint `project_space_metadata` to the new `DomainMetrics` model, which should be an invisible change.

## Technical Summary
[SAAS-16284](https://dimagi.atlassian.net/browse/SAAS-16284)
This should only be merged after testing and fully enabling the `CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS` feature flag added in #35522, which conditionally moves calculated properties to read from `DomainMetrics`.

- Removes the feature flag noted above
- Removes unused code that reads and writes domain calculated properties in the Elasticsearch doc
- Removes automated tests specific to ES calculated properties code

## Safety Assurance

### Safety story
This is just code removal. The practical effect that this has is comparable to enabling the `CALCULATED_PROPERTIES_FROM_DOMAIN_METRICS` feature flag, which by the time this PR is reviewed and merged, should already be confirmed functional and have been enabled for all project spaces.

### Automated test coverage
Doesn't look like we have automated tests specifically for the `DomainMetadataResource`, which this affects. 

### QA Plan
No QA planned here.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16284]: https://dimagi.atlassian.net/browse/SAAS-16284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ