### PR TITLE
Clean up global mocks

### DIFF
--- a/corehq/apps/api/resources/v0_3.py
+++ b/corehq/apps/api/resources/v0_3.py
@@ -15,11 +15,6 @@ from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase
 from no_exceptions.exceptions import Http400
 
-# By the time a test case is running, the resource is already instantiated,
-# so as a hack until this can be remedied, there is a global that
-# can be set to provide a mock.
-MOCK_CASE_ES_VIEW = None
-
 
 class CommCareCaseResource(HqBaseResource, DomainSpecificResourceMixin):
     type = "case"
@@ -52,7 +47,7 @@ class CommCareCaseResource(HqBaseResource, DomainSpecificResourceMixin):
 
     def case_es(self, domain):
         # Note that CaseESView is used only as an ES client, for `run_query` against the proper index
-        return MOCK_CASE_ES_VIEW or CaseESView(domain)
+        return CaseESView(domain)
 
     def obj_get(self, bundle, **kwargs):
         case_id = kwargs['pk']

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -7,7 +7,6 @@ from django.http import (
 from memoized import memoized
 
 from tastypie import fields
-from tastypie.authentication import Authentication
 from tastypie.exceptions import BadRequest
 
 from casexml.apps.case.xform import get_case_updates

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -57,11 +57,6 @@ from corehq.motech.repeaters.models import CommCareCase
 from corehq.util.view_utils import absolute_reverse
 from no_exceptions.exceptions import Http400
 
-# By the time a test case is running, the resource is already instantiated,
-# so as a hack until this can be remedied, there is a global that
-# can be set to provide a mock.
-MOCK_XFORM_ES = None
-
 
 class XFormInstanceResource(SimpleSortableResourceMixin, HqBaseResource, DomainSpecificResourceMixin):
     """This version of the form resource is built of Elasticsearch data
@@ -143,7 +138,7 @@ class XFormInstanceResource(SimpleSortableResourceMixin, HqBaseResource, DomainS
         return self.xform_es(domain).get_document(instance_id)
 
     def xform_es(self, domain):
-        return MOCK_XFORM_ES or FormESView(domain)
+        return FormESView(domain)
 
     def obj_get_list(self, bundle, domain, **kwargs):
         try:

--- a/corehq/apps/api/tests/form_resources.py
+++ b/corehq/apps/api/tests/form_resources.py
@@ -354,7 +354,10 @@ class TestXFormPillow(TestCase):
         cleaned = form_adapter.to_json(bad_appVersion)
         self.assertFalse(isinstance(cleaned['form']['meta']['appVersion'], dict))
         self.assertTrue(isinstance(cleaned['form']['meta']['appVersion'], str))
-        self.assertTrue(cleaned['form']['meta']['appVersion'], "CCODK:\"2.5.1\"(11126). v236 CC2.5b[11126] on April-15-2013")
+        self.assertTrue(
+            cleaned['form']['meta']['appVersion'],
+            "CCODK:\"2.5.1\"(11126). v236 CC2.5b[11126] on April-15-2013",
+        )
 
 
 class TestViewFormAttachment(TestCase):

--- a/corehq/apps/api/tests/form_resources.py
+++ b/corehq/apps/api/tests/form_resources.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.urls import reverse
@@ -235,22 +236,16 @@ class TestXFormInstanceResourceQueries(APIResourceTest, ElasticTestMixin):
     resource = v0_4.XFormInstanceResource
 
     def _test_es_query(self, url_params, expected_query):
-
-        fake_xform_es = FakeFormESView()
-
-        prior_run_query = fake_xform_es.run_query
-
-        # A bit of a hack since none of Python's mocking libraries seem to do basic spies easily...
-        def mock_run_query(es_query):
-            actual = es_query['query']['bool']['filter']
-            self.checkQuery(actual, expected_query, is_raw_query=True)
-            return prior_run_query(es_query)
-
-        fake_xform_es.run_query = mock_run_query
-        v0_4.MOCK_XFORM_ES = fake_xform_es
-
         response = self._assert_auth_get_resource('%s?%s' % (self.list_endpoint, urlencode(url_params)))
         self.assertEqual(response.status_code, 200)
+        actual = self.fake_es.queries[0]['query']['bool']['filter']
+        self.checkQuery(actual, expected_query, is_raw_query=True)
+        assert len(self.fake_es.queries) == 1
+
+    def _assert_auth_get_resource(self, *args, **kw):
+        self.fake_es = FakeFormESView()
+        with patch.object(self.resource, "xform_es", lambda *a: self.fake_es):
+            return super()._assert_auth_get_resource(*args, **kw)
 
     def test_get_list_xmlns(self):
         expected = [
@@ -296,34 +291,17 @@ class TestXFormInstanceResourceQueries(APIResourceTest, ElasticTestMixin):
         Forms can be ordering ascending or descending on received_on; by default
         ascending.
         '''
-
-        fake_xform_es = FakeFormESView()
-
-        # A bit of a hack since none of Python's mocking libraries seem to do basic spies easily...
-        prior_run_query = fake_xform_es.run_query
-        prior_count_query = fake_xform_es.count_query
-        queries = []
-
-        def mock_run_query(es_query):
-            queries.append(es_query)
-            return prior_run_query(es_query)
-
-        def mock_count_query(es_query):
-            queries.append(es_query)
-            return prior_count_query(es_query)
-
-        fake_xform_es.run_query = mock_run_query
-        fake_xform_es.count_query = mock_count_query
-        v0_4.MOCK_XFORM_ES = fake_xform_es
-
-        # Runs *2* queries
+        # Runs *2* queries, but the *count_query* one is not recorded
         response = self._assert_auth_get_resource('%s?order_by=received_on' % self.list_endpoint)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(queries[0]['sort'], [{'received_on': {'missing': '_first', 'order': 'asc'}}])
-        # Runs *2* queries
+        self.assertEqual(self.fake_es.queries[0]['sort'], [{'received_on': {'missing': '_first', 'order': 'asc'}}])
+        assert len(self.fake_es.queries) == 1
+
+        # Runs *2* queries, but the *count_query* one is not recorded
         response = self._assert_auth_get_resource('%s?order_by=-received_on' % self.list_endpoint)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(queries[2]['sort'], [{'received_on': {'missing': '_last', 'order': 'desc'}}])
+        self.assertEqual(self.fake_es.queries[0]['sort'], [{'received_on': {'missing': '_last', 'order': 'desc'}}])
+        assert len(self.fake_es.queries) == 1
 
     def test_get_list_archived(self):
         expected = [


### PR DESCRIPTION
Once assigned, these mocks affected all tests that ran after them.

## Safety Assurance

### Safety story

Only affects tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations