### PR TITLE
Fix inddex reports

### DIFF
--- a/corehq/apps/reports/static/reports/js/bootstrap3/tabular.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/tabular.js
@@ -68,6 +68,9 @@ hqDefine("reports/js/bootstrap3/tabular", [
 
     // Handle async reports
     $(document).on('ajaxSuccess', function (e, xhr, ajaxOptions, data) {
+        if (!data || !data.slug) {
+            return;
+        }
         var jsOptions = initialPageData.get("js_options");
         if (jsOptions && ajaxOptions.url.indexOf(jsOptions.asyncUrl) === -1) {
             return;
@@ -81,4 +84,8 @@ hqDefine("reports/js/bootstrap3/tabular", [
             renderPage(initialPageData.get("js_options").slug, initialPageData.get("report_table_js_options"));
         }
     });
+
+    return {
+        renderPage: renderPage,
+    };
 });

--- a/corehq/apps/reports/static/reports/js/bootstrap3/tabular.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/tabular.js
@@ -69,6 +69,9 @@ hqDefine("reports/js/bootstrap3/tabular", [
     // Handle async reports
     $(document).on('ajaxSuccess', function (e, xhr, ajaxOptions, data) {
         if (!data || !data.slug) {
+            // This file is imported by inddex/main, which then gets this event handler, which it doesn't need,
+            // and which errors sometimes (presumably because there are ajax requests happening that aren't the
+            // same as what this handler expects). Checking for data.slug is pretty innocuous and fixes the issue.
             return;
         }
         var jsOptions = initialPageData.get("js_options");

--- a/corehq/apps/reports/static/reports/js/bootstrap5/tabular.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/tabular.js
@@ -68,6 +68,9 @@ hqDefine("reports/js/bootstrap5/tabular", [
 
     // Handle async reports
     $(document).on('ajaxSuccess', function (e, xhr, ajaxOptions, data) {
+        if (!data || !data.slug) {
+            return;
+        }
         var jsOptions = initialPageData.get("js_options");
         if (jsOptions && ajaxOptions.url.indexOf(jsOptions.asyncUrl) === -1) {
             return;
@@ -81,4 +84,8 @@ hqDefine("reports/js/bootstrap5/tabular", [
             renderPage(initialPageData.get("js_options").slug, initialPageData.get("report_table_js_options"));
         }
     });
+
+    return {
+        renderPage: renderPage,
+    };
 });

--- a/corehq/apps/reports/static/reports/js/bootstrap5/tabular.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/tabular.js
@@ -69,6 +69,9 @@ hqDefine("reports/js/bootstrap5/tabular", [
     // Handle async reports
     $(document).on('ajaxSuccess', function (e, xhr, ajaxOptions, data) {
         if (!data || !data.slug) {
+            // This file is imported by inddex/main, which then gets this event handler, which it doesn't need,
+            // and which errors sometimes (presumably because there are ajax requests happening that aren't the
+            // same as what this handler expects). Checking for data.slug is pretty innocuous and fixes the issue.
             return;
         }
         var jsOptions = initialPageData.get("js_options");

--- a/custom/inddex/reports/utils.py
+++ b/custom/inddex/reports/utils.py
@@ -15,11 +15,21 @@ class MultiTabularReport(DatespanMixin, CustomProjectReport, GenericTabularRepor
     exportable = True
     exportable_all = True
     export_only = False
+    fix_left_col = True
 
     @property
     def data_providers(self):
         # data providers should supply a title, slug, headers, and rows
         return []
+
+    @property
+    def fixed_cols_spec(self):
+        """
+            Override
+            Returns a dict formatted like:
+            dict(num=<num_cols_to_fix>, width=<width_of_total_fixed_cols>)
+        """
+        return dict(num=1, width=130)
 
     @property
     def report_context(self):
@@ -34,10 +44,11 @@ class MultiTabularReport(DatespanMixin, CustomProjectReport, GenericTabularRepor
                 'rows': list(data_provider.rows),
             }
 
-        context = {
+        context = super().report_context
+        context.update({
             'name': self.name,
             'export_only': self.export_only
-        }
+        })
         if not self.export_only and not self.needs_filters:
             try:
                 context['data_providers'] = list(map(_to_context_dict, self.data_providers))

--- a/custom/inddex/static/inddex/js/main.js
+++ b/custom/inddex/static/inddex/js/main.js
@@ -3,7 +3,6 @@ hqDefine("inddex/js/main", function () {
         tabular = hqImport("reports/js/bootstrap3/tabular");
     $(document).on('ajaxSuccess', function (e, xhr, ajaxOptions, data) {
         $(".datatable[data-slug]").each(function (index, table) {
-            const tableData = $(table).data();
             tabular.renderPage(data.slug, initialPageData.get("report_table_js_options"));
         });
     });

--- a/custom/inddex/static/inddex/js/main.js
+++ b/custom/inddex/static/inddex/js/main.js
@@ -1,45 +1,10 @@
 hqDefine("inddex/js/main", function () {
-    $(function () {
-        $("[data-report-table]").each(function (table) {
-            const $table = $(table),
-                reportTable = $table.data("report-table");
-
-            if (!reportTable || !reportTable.datatables) {
-                return;
-            }
-
-            let options = {
-                dataTableElem: '#report_table_' + reportTable.slug,
-                defaultRows: reportTable.default_rows || 10,
-                startAtRowNum: reportTable.default_rows || 10,
-                showAllRowsOption: reportTable.show_all_rows,
-                loadingTemplateSelector: '#js-template-loading-report',
-                defaultSort: true,
-                autoWidth: reportTable.headers.auto_width,
-                fixColumns: true,
-                fixColsNumLeft: 1,
-                fixColsWidth: 130,
-            };
-            if (reportTable.headers.render_aoColumns) {
-                options.aoColumns = reportTable.headers.render_aoColumns;
-            }
-            if (reportTable.headers.custom_sort) {
-                options.customSort = reportTable.headers.custom_sort;
-            }
-            if (reportTable.pagination.is_on) {
-                options.ajaxSource = reportTable.pagination.source;
-                options.ajaxParams = reportTable.pagination.params;
-            }
-            if (reportTable.bad_request_error_text) {
-                options.badRequestErrorText = "<span class='label label-danger'>Sorry!</span> " + reportTable.bad_request_error_text;
-            }
-
-            var reportTables = hqImport("reports/js/bootstrap3/datatables_config").HQReportDataTables(options);
-            var standardHQReport = hqImport("reports/js/bootstrap3/standard_hq_report").getStandardHQReport();
-            if (typeof standardHQReport !== 'undefined') {
-                standardHQReport.handleTabularReportCookies(reportTables);
-            }
-            reportTables.render();
+    const initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+        tabular = hqImport("reports/js/bootstrap3/tabular");
+    $(document).on('ajaxSuccess', function (e, xhr, ajaxOptions, data) {
+        $(".datatable[data-slug]").each(function (index, table) {
+            const tableData = $(table).data();
+            tabular.renderPage(data.slug, initialPageData.get("report_table_js_options"));
         });
     });
 });

--- a/custom/inddex/templates/inddex/partials/report_table.html
+++ b/custom/inddex/templates/inddex/partials/report_table.html
@@ -1,7 +1,11 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<table id="report_table_{{ report_table.slug }}" class="table table-striped datatable" {% if pagination.filter %} data-filter="true"{% endif %} data-report-table="{{ report_table|JSON }}">
+<table id="report_table_{{ report_table.slug }}"
+       class="table table-striped datatable"
+       {% if pagination.filter %} data-filter="true"{% endif %}
+       data-slug="{{ report_table.slug }}"
+>
     <thead>
         {%  if report_table.headers.complex %}
             {{ report_table.headers.render_html }}


### PR DESCRIPTION
## Product Description
Followup for https://github.com/dimagi/commcare-hq/pull/35586, which caused these reports to 500.

## Technical Summary
The 500 resulted from the data discussed [here](https://github.com/dimagi/commcare-hq/pull/35586/files#r1907617409) not being JSON serializable. 

The bulk of the inddex js is the same logic that's in [tabular.js](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/static/reports/js/bootstrap3/tabular.js), with the major difference being that some of the inddex reports have multiple datatables. The general change here is to update the inddex code to rely more on `tabular.js`.

This PR assumes that all of the inddex tables in a single report have the same datatables options, which from looking at the reports in python I believe is true. The different reports have different slugs & titles, but I didn't see any different display options.

## Feature Flag
inddex reports

## Safety Assurance
I've tested on staging that the reports now load, and it appears to behave the same as a browser window of the reports on prod that I've had open since before the deploy of https://github.com/dimagi/commcare-hq/pull/35586.

While working on this I realized that I could have tested the previous PR on staging. I had initially hit errors there, eventually rebuilt the underlying table, and was still running into errors. But I think I just didn't wait long enough after rebuilding.

### Safety story
There are minor changes to `tabular.js`, but most of the work is in custom code.

As in https://github.com/dimagi/commcare-hq/pull/35586, the impact of problems here is limited. The only live projects using them are on a third party env, so the changes won't be "live" for real users until that env deploys.

### Automated test coverage

Not at the UI level.

### QA Plan

Not requesting QA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
