### PR TITLE
Always return a value from `_update_or_create_domain_metrics`

### DIFF
--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -151,6 +151,7 @@ def _update_or_create_domain_metrics(domain, all_stats):
         notify_exception(
             None, message='Failed to create or update domain metrics for {domain}: {}'.format(e, domain=domain)
         )
+        return None, False
 
 
 def get_domains_to_update():

--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -132,7 +132,7 @@ def update_domain_metrics_for_domains(domains):
     all_stats = all_domain_stats()
     active_users_by_domain = {}
     for domain in domains:
-        metrics, __ = _update_or_create_domain_metrics(domain, all_stats)
+        metrics = _update_or_create_domain_metrics(domain, all_stats)
         if metrics:
             active_users_by_domain[domain] = metrics.active_mobile_workers
 
@@ -143,7 +143,7 @@ def _update_or_create_domain_metrics(domain, all_stats):
     try:
         domain_obj = Domain.get_by_name(domain)
         metrics_dict = domain_metrics(domain_obj, domain_obj['_id'], all_stats)
-        return DomainMetrics.objects.update_or_create(
+        metrics, __ = DomainMetrics.objects.update_or_create(
             defaults=metrics_dict,
             domain=domain_obj.name,
         )
@@ -151,7 +151,9 @@ def _update_or_create_domain_metrics(domain, all_stats):
         notify_exception(
             None, message='Failed to create or update domain metrics for {domain}: {}'.format(e, domain=domain)
         )
-        return None, False
+        metrics = None
+
+    return metrics
 
 
 def get_domains_to_update():


### PR DESCRIPTION
Otherwise it will TypeError on unpacking `metrics, __` and fail the whole `update_domain_metrics_for_domains` task

## Technical Summary
Just a bugfix for an in-development feature.

## Safety Assurance

### Safety story
We're not swallowing any additional errors here, just returning a tuple of _something_ that can be unpacked. The caller, `update_domain_metrics_for_domains` already accounts for `metrics` potentially being `None`.

### Automated test coverage
No tests for this particular return value.

### QA Plan
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
