### PR TITLE
prevent default click event behavior to preserve full url

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1340,7 +1340,8 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
             'click .js-home': 'onClickHome',
             'keydown .js-home': 'onKeyActionHome',
         },
-        onClickHome: function () {
+        onClickHome: function (e) {
+            e.preventDefault();
             if (!FormplayerFrontend.confirmUserWantsToNavigateAwayFromForm()) {
                 return;
             }


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
When there is a form in progress and the user clicks "Home" in the breadcrumbs menu and then clicks "Cancel" in the alert that pops up to cancel leaving the form, the url is stripped down to the base url excluding appId etc.
I believe the default behavior for `<a>` tags is to set the url to the `href` and this case that is `<a href="#">{% trans 'Home' %}</a>`. This will prevent that default behavior stop users from seeing "App Not Found" errors in this scenario and prevent the loss of in-progress forms that would have otherwise been preserved.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Jira ticket](https://dimagi.atlassian.net/browse/USH-5189)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
n/a
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

tested locally and on staging
Worst case scenario here is that an in-progress form is lost and that is happening now without this change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
