### PR TITLE
Make lookup tables ignore the "skip fixtures" flag

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -104,6 +104,7 @@ def get_global_items_by_domain(domain, case_id):
 
 class ItemListsProvider(FixtureProvider):
     id = 'item-list'
+    ignore_skip_fixtures_flag = True
 
     def __call__(self, restore_state):
         restore_user = restore_state.restore_user

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from corehq.blobs import get_blob_db
 from casexml.apps.phone.utils import MockDevice
 from corehq.apps.domain.models import Domain
+from corehq.apps.fixtures.fixturegenerators import item_lists
 from corehq.apps.fixtures.models import (
     FIXTURE_BUCKET,
     Field,
@@ -49,8 +50,14 @@ class OtaFixtureTest(TestCase):
         device = MockDevice(self.domain, self.restore_user)
         restore = device.sync().payload.decode('utf-8')
         self.assertIn('<fixture ', restore)
-        restore_without_fixture = device.sync(skip_fixtures=True).payload.decode('utf-8')
-        self.assertNotIn('<fixture ', restore_without_fixture)
+
+        restore = device.sync(skip_fixtures=True).payload.decode('utf-8')
+        self.assertIn('<fixture ', restore)
+
+        item_lists.ignore_skip_fixtures_flag = False
+        restore = device.sync(skip_fixtures=True).payload.decode('utf-8')
+        self.assertNotIn('<fixture ', restore)
+        item_lists.ignore_skip_fixtures_flag = True  # reset
 
     def test_fixture_ownership(self):
         device = MockDevice(self.domain, self.restore_user)


### PR DESCRIPTION
## Product Description

There are currently users who get an error about a missing lookup table, and have been for the last ~6 weeks. The lookup table is definitely in their restore file, and the error is resolved on the next manual sync.  This sounds strongly like the problem is that the users just haven't synced, except that the app has `cc-sync-after-form` set, meaning that it should sync after every form submission, or if it's been 5 minutes since the last sync.

However, they also use the `cc-skip-fixtures-after-submit` setting, which skips all fixtures when syncing after a submission.  What about the 5 minutes thing, you ask?  Well it turns out that that only applies if `permitAggressiveSyncs` is `true`, but it's disabled inside `navigateToEndpoint` and `FormSession`.  My theory (as-yet unproven) is that these users might have a usage pattern that means that those post-submission syncs are the only ones ever performed.  This sounds believable if they only access HQ via something using `navigateToEndpoint`, and never go to the home screen and click "start"

## Technical Summary
https://dimagi.atlassian.net/browse/USH-5375
https://dimagi.atlassian.net/browse/SUPPORT-22827

## Feature Flag


## Safety Assurance

That "skip fixtures" flag is [on its way out](https://dimagi.atlassian.net/browse/USH-5186) anyways, so carving an exemption for that here seems reasonable, with the expectation that we'll be removing all that logic in the near future anyways.  From @MartinRiese 's analysis, there are two real projects using the setting, and neither have fixtures big enough to be slow, so I anticipate minimal performance pains from this change.


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change