### PR TITLE
Rate limit devices per user on short window

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -295,10 +295,6 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
         silently.
     :return: Tuple of (http response, timing context or None)
     """
-    should_limit = device_rate_limiter.rate_limit_device(domain, user_id, device_id)
-    if should_limit:
-        return HttpNotAcceptable(DEVICE_RATE_LIMIT_MESSAGE)
-
     if user_id and user_id != couch_user.user_id:
         # sync with a user that has been deleted but a new
         # user was created with the same username and password
@@ -320,6 +316,11 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     if uses_login_as and not as_user_obj:
         msg = _('Invalid restore as user {}').format(as_user)
         return HttpResponse(msg, status=401), None
+
+    should_limit = device_rate_limiter.rate_limit_device(domain, as_user_obj._id, device_id)
+    if should_limit:
+        return HttpNotAcceptable(DEVICE_RATE_LIMIT_MESSAGE)
+
     is_permitted, message = is_permitted_to_restore(
         domain,
         couch_user,

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -317,7 +317,8 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
         msg = _('Invalid restore as user {}').format(as_user)
         return HttpResponse(msg, status=401), None
 
-    should_limit = device_rate_limiter.rate_limit_device(domain, as_user_obj._id, device_id)
+    restoring_user_id = as_user_obj._id if uses_login_as else couch_user._id
+    should_limit = device_rate_limiter.rate_limit_device(domain, restoring_user_id, device_id)
     if should_limit:
         return HttpNotAcceptable(DEVICE_RATE_LIMIT_MESSAGE)
 

--- a/corehq/apps/receiverwrapper/tests/test_audit_logging.py
+++ b/corehq/apps/receiverwrapper/tests/test_audit_logging.py
@@ -23,6 +23,7 @@ def return_submission_run_resp(*args, **kwargs):
 
 @patch('corehq.apps.receiverwrapper.views.couchforms.get_instance_and_attachment',
        new=Mock(return_value=(Mock(), Mock())))
+@patch('corehq.apps.receiverwrapper.views.convert_xform_to_json', new=Mock())
 @patch('corehq.apps.receiverwrapper.views._record_metrics', new=Mock())
 @patch('corehq.apps.receiverwrapper.views.SubmissionPost.run', new=return_submission_run_resp)
 class TestAuditLoggingForFormSubmission(TestCase):

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -138,13 +138,14 @@ def _process_form(request, domain, app_id, user_id, authenticated,
         _record_metrics(metric_tags, 'blacklisted', response)
         return response
 
+    instance_json = None
     try:
-        form_json = convert_xform_to_json(instance)
+        instance_json = convert_xform_to_json(instance)
     except couchforms.XMLSyntaxError:
         # let normal response handle invalid xml
         pass
     else:
-        device_id = form_json.get('meta', {}).get('deviceID')
+        device_id = instance_json.get('meta', {}).get('deviceID')
         should_limit = device_rate_limiter.rate_limit_device(domain, user_id, device_id)
         if should_limit:
             return HttpNotAcceptable(DEVICE_RATE_LIMIT_MESSAGE)
@@ -153,6 +154,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
         app_id, build_id = get_app_and_build_ids(domain, app_id)
         submission_post = SubmissionPost(
             instance=instance,
+            instance_json=instance_json,
             attachments=attachments,
             domain=domain,
             app_id=app_id,

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -10,6 +10,7 @@ import couchforms
 from casexml.apps.case.xform import get_case_updates, is_device_report
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.users.decorators import require_permission
+from corehq.apps.users.device_rate_limiter import device_rate_limiter, DEVICE_RATE_LIMIT_MESSAGE
 from corehq.apps.users.models import HqPermissions
 from couchforms import openrosa_response
 from couchforms.const import MAGIC_PROPERTY
@@ -58,7 +59,7 @@ from corehq.form_processor.utils import convert_xform_to_json
 from corehq.util.metrics import metrics_counter, metrics_histogram
 from corehq.util.timer import TimingContext, set_request_duration_reporting_threshold
 from couchdbkit import ResourceNotFound
-from tastypie.http import HttpTooManyRequests
+from tastypie.http import HttpNotAcceptable, HttpTooManyRequests
 
 PROFILE_PROBABILITY = float(os.getenv('COMMCARE_PROFILE_SUBMISSION_PROBABILITY', 0))
 PROFILE_LIMIT = os.getenv('COMMCARE_PROFILE_SUBMISSION_LIMIT')
@@ -136,6 +137,17 @@ def _process_form(request, domain, app_id, user_id, authenticated,
         response = openrosa_response.BLACKLISTED_RESPONSE
         _record_metrics(metric_tags, 'blacklisted', response)
         return response
+
+    try:
+        form_json = convert_xform_to_json(instance)
+    except couchforms.XMLSyntaxError:
+        # let normal response handle invalid xml
+        pass
+    else:
+        device_id = form_json.get('meta', {}).get('deviceID')
+        should_limit = device_rate_limiter.rate_limit_device(domain, user_id, device_id)
+        if should_limit:
+            return HttpNotAcceptable(DEVICE_RATE_LIMIT_MESSAGE)
 
     with TimingContext() as timer:
         app_id, build_id = get_app_and_build_ids(domain, app_id)

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -146,7 +146,8 @@ def _process_form(request, domain, app_id, user_id, authenticated,
         pass
     else:
         device_id = instance_json.get('meta', {}).get('deviceID')
-        should_limit = device_rate_limiter.rate_limit_device(domain, user_id, device_id)
+        submitting_user_id = instance_json.get('meta', {}).get('userID')
+        should_limit = device_rate_limiter.rate_limit_device(domain, submitting_user_id, device_id)
         if should_limit:
             return HttpNotAcceptable(DEVICE_RATE_LIMIT_MESSAGE)
 

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -59,7 +59,7 @@ class DeviceRateLimiter:
         metrics_counter(
             'commcare.devices_per_user.rate_limit_exceeded', tags={'domain': domain, 'user_id': user_id}
         )
-        return True
+        return settings.ENABLE_DEVICE_RATE_LIMITER
 
     def _get_redis_key(self, user_id):
         """

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -9,7 +9,6 @@ from corehq.apps.cloudcare.const import DEVICE_ID as CLOUDCARE_DEVICE_ID
 from corehq.util.metrics import metrics_counter
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 DEVICE_RATE_LIMIT_MESSAGE = "Current usage for this user is too high. Please try again in a minute."
 # intentionally set to > 1 minute to allow for a buffer at minute boundaries

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -52,7 +52,7 @@ class DeviceRateLimiter:
                 'commcare.devices_per_user.device_count',
                 device_count + 1,
                 bucket_tag='count',
-                buckets=[3, 5, 8, 10],
+                buckets=[3, 6, 11, 21, 51],
                 tags={'domain': domain, 'user_id': user_id},
             )
             return False

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -62,6 +62,7 @@ class DeviceRateLimiter:
             metrics_counter(
                 'commcare.devices_per_user.additional_device', tags={'domain': domain, 'user_id': user_id}
             )
+            return False
 
         metrics_counter(
             'commcare.devices_per_user.rate_limit_exceeded', tags={'domain': domain, 'user_id': user_id}

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timezone
+
+from django.conf import settings
+from django_redis import get_redis_connection
+
+from corehq import toggles
+from corehq.apps.cloudcare.const import DEVICE_ID as CLOUDCARE_DEVICE_ID
+
+DEVICE_SET_CACHE_TIMEOUT = 2 * 60  # 2 minutes
+
+
+class DeviceRateLimiter:
+    """
+    Operates on a time window of 1 minute
+    """
+
+    def __init__(self):
+        # need to use raw redis connection to use srem and scard functions
+        self.client = get_redis_connection()
+
+    def device_limit_per_user(self, domain):
+        if toggles.INCREASE_DEVICE_LIMIT_PER_USER.enabled(domain):
+            return settings.INCREASED_DEVICE_LIMIT_PER_USER
+        return settings.DEVICE_LIMIT_PER_USER
+
+    def rate_limit_device(self, domain, user_id, device_id):
+        """
+        Returns boolean representing if this user_id + device_id combo is rate limited or not
+        NOTE: calling this method will result in the device_id being added to the list of used device_ids
+        """
+        if not device_id or self._is_formplayer(device_id):
+            # do not track formplayer activity
+            return False
+
+        key = self._get_redis_key(user_id)
+
+        if not self._exists(key):
+            self._track_usage(key, device_id, is_key_new=True)
+            return False
+
+        if self._device_has_been_used(key, device_id):
+            return False
+
+        if self._device_count(key) < self.device_limit_per_user(domain):
+            self._track_usage(key, device_id)
+            return False
+
+        return True
+
+    def _get_redis_key(self, user_id):
+        """
+        Create a redis key using the user_id and current time to the floored minute
+        This ensures a new key is used every minute
+        """
+        time = datetime.now(timezone.utc)
+        formatted_time = time.strftime('%Y-%m-%d_%H:%M')
+        key = f"device-limiter_{user_id}_{formatted_time}"
+        return key
+
+    def _track_usage(self, redis_key, device_id, is_key_new=False):
+        self.client.sadd(redis_key, device_id)
+        if is_key_new:
+            self.client.expire(redis_key, DEVICE_SET_CACHE_TIMEOUT)
+
+    def _device_has_been_used(self, redis_key, device_id):
+        # check if device_id is member of the set for this key
+        return self.client.srem(redis_key, device_id)
+
+    def _device_count(self, redis_key):
+        return self.client.scard(redis_key)
+
+    def _exists(self, redis_key):
+        return self.client.exists(redis_key)
+
+    def _is_formplayer(self, device_id):
+        return device_id.startswith("WebAppsLogin") or device_id == CLOUDCARE_DEVICE_ID
+
+
+device_rate_limiter = DeviceRateLimiter()

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -17,7 +17,7 @@ class DeviceRateLimiter:
     """
 
     def __init__(self):
-        # need to use raw redis connection to use srem and scard functions
+        # need to use raw redis connection to use sismember and scard functions
         self.client = get_redis_connection()
 
     def device_limit_per_user(self, domain):
@@ -78,7 +78,7 @@ class DeviceRateLimiter:
 
     def _device_has_been_used(self, redis_key, device_id):
         # check if device_id is member of the set for this key
-        return self.client.srem(redis_key, device_id)
+        return self.client.sismember(redis_key, device_id)
 
     def _device_count(self, redis_key):
         return self.client.scard(redis_key)

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -6,7 +6,7 @@ from django_redis import get_redis_connection
 
 from corehq import toggles
 from corehq.apps.cloudcare.const import DEVICE_ID as CLOUDCARE_DEVICE_ID
-from corehq.util.metrics import metrics_counter, metrics_histogram
+from corehq.util.metrics import metrics_counter
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -59,14 +59,9 @@ class DeviceRateLimiter:
         if device_count < self.device_limit_per_user(domain):
             self._track_usage(key, device_id)
             # this intentionally doesn't capture users with 1 device, only those with multiple
-            metrics_histogram(
-                'commcare.devices_per_user.device_count',
-                device_count + 1,
-                bucket_tag='count',
-                buckets=[3, 6, 11, 21, 51],
-                tags={'domain': domain, 'user_id': user_id},
+            metrics_counter(
+                'commcare.devices_per_user.additional_device', tags={'domain': domain, 'user_id': user_id}
             )
-            return False
 
         metrics_counter(
             'commcare.devices_per_user.rate_limit_exceeded', tags={'domain': domain, 'user_id': user_id}

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -6,6 +6,7 @@ from django_redis import get_redis_connection
 from corehq import toggles
 from corehq.apps.cloudcare.const import DEVICE_ID as CLOUDCARE_DEVICE_ID
 
+DEVICE_RATE_LIMIT_MESSAGE = "Current usage for this user is too high. Please try again in a minute."
 DEVICE_SET_CACHE_TIMEOUT = 2 * 60  # 2 minutes
 
 

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -8,6 +8,7 @@ from corehq.apps.cloudcare.const import DEVICE_ID as CLOUDCARE_DEVICE_ID
 from corehq.util.metrics import metrics_counter, metrics_histogram
 
 DEVICE_RATE_LIMIT_MESSAGE = "Current usage for this user is too high. Please try again in a minute."
+# intentionally set to > 1 minute to allow for a buffer at minute boundaries
 DEVICE_SET_CACHE_TIMEOUT = 2 * 60  # 2 minutes
 
 

--- a/corehq/apps/users/tests/test_device_rate_limiter.py
+++ b/corehq/apps/users/tests/test_device_rate_limiter.py
@@ -66,3 +66,8 @@ class TestDeviceRateLimiter(SimpleTestCase):
     def test_allowed_if_rate_limiter_is_disabled(self):
         device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
         self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+
+    def test_allowed_if_user_id_or_device_id_is_none(self):
+        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', None))
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, None, 'new-device-id'))

--- a/corehq/apps/users/tests/test_device_rate_limiter.py
+++ b/corehq/apps/users/tests/test_device_rate_limiter.py
@@ -1,0 +1,62 @@
+from django.test import SimpleTestCase, override_settings
+from freezegun import freeze_time
+
+from corehq.apps.cloudcare.const import DEVICE_ID as CLOUDCARE_DEVICE_ID
+from corehq.apps.users.device_rate_limiter import device_rate_limiter
+from corehq.tests.pytest_plugins.reusedb import clear_redis
+from corehq.util.test_utils import flag_enabled
+
+
+@freeze_time("2024-12-10 12:05:43")
+@override_settings(DEVICE_LIMIT_PER_USER=1)
+class TestDeviceRateLimiter(SimpleTestCase):
+
+    domain = 'device-rate-limit-test'
+
+    def setUp(self):
+        self.addCleanup(clear_redis)
+
+    def test_allowed_if_no_devices_have_been_used_yet(self):
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+
+    @override_settings(DEVICE_LIMIT_PER_USER=2)
+    def test_allowed_if_device_count_is_under_limit(self):
+        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+
+    def test_rate_limited_if_device_count_exceeds_limit(self):
+        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
+        self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+
+    def test_allowed_if_device_has_already_been_used(self):
+        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id'))
+
+    def test_allowed_if_different_user(self):
+        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'new-user-id', 'existing-device-id'))
+
+    def test_allowed_after_waiting_one_minute(self):
+        with freeze_time("2024-12-10 12:05:43") as frozen_time:
+            device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
+            self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+            frozen_time.move_to("2024-12-10 12:06:15")
+            self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+
+    def test_formplayer_activity_is_always_allowed(self):
+        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'WebAppsLogin*newlogin'))
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', CLOUDCARE_DEVICE_ID))
+
+    def test_formplayer_activity_does_not_count_towards_limit(self):
+        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'WebAppsLogin*newlogin')
+        device_rate_limiter.rate_limit_device(self.domain, 'user-id', CLOUDCARE_DEVICE_ID)
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+
+    @override_settings(DEVICE_LIMIT_PER_USER=1)
+    @override_settings(INCREASED_DEVICE_LIMIT_PER_USER=2)
+    def test_allowed_after_enabling_ff_to_increase_limit(self):
+        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
+        self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+        with flag_enabled('INCREASE_DEVICE_LIMIT_PER_USER'):
+            self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))

--- a/corehq/apps/users/tests/test_device_rate_limiter.py
+++ b/corehq/apps/users/tests/test_device_rate_limiter.py
@@ -9,6 +9,7 @@ from corehq.util.test_utils import flag_enabled
 
 @freeze_time("2024-12-10 12:05:43")
 @override_settings(DEVICE_LIMIT_PER_USER=1)
+@override_settings(ENABLE_DEVICE_RATE_LIMITER=True)
 class TestDeviceRateLimiter(SimpleTestCase):
 
     domain = 'device-rate-limit-test'
@@ -60,3 +61,8 @@ class TestDeviceRateLimiter(SimpleTestCase):
         self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
         with flag_enabled('INCREASE_DEVICE_LIMIT_PER_USER'):
             self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+
+    @override_settings(ENABLE_DEVICE_RATE_LIMITER=False)
+    def test_allowed_if_rate_limiter_is_disabled(self):
+        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -58,7 +58,7 @@ class FormProcessingResult(object):
 
 
 @tracer.wrap(name='submission.process_form_xml')
-def process_xform_xml(domain, instance_xml, attachments=None, auth_context=None):
+def process_xform_xml(domain, instance_xml, attachments=None, auth_context=None, instance_json=None):
     """
     Create a new xform to ready to be saved to a database in a thread-safe manner
 
@@ -72,12 +72,14 @@ def process_xform_xml(domain, instance_xml, attachments=None, auth_context=None)
     attachments = attachments or {}
 
     try:
-        return _create_new_xform(domain, instance_xml, attachments=attachments, auth_context=auth_context)
+        return _create_new_xform(
+            domain, instance_xml, attachments=attachments, auth_context=auth_context, instance_json=instance_json
+        )
     except (MissingXMLNSError, XMLSyntaxError) as e:
         return _get_submission_error(domain, instance_xml, e, auth_context)
 
 
-def _create_new_xform(domain, instance_xml, attachments=None, auth_context=None):
+def _create_new_xform(domain, instance_xml, attachments=None, auth_context=None, instance_json=None):
     """
     create but do not save an XFormInstance from an xform payload (xml_string)
     optionally set the doc _id to a predefined value (_id)
@@ -96,13 +98,14 @@ def _create_new_xform(domain, instance_xml, attachments=None, auth_context=None)
     interface = FormProcessorInterface(domain)
 
     assert attachments is not None
-    form_data = convert_xform_to_json(instance_xml)
-    if not form_data.get('@xmlns'):
+    if not instance_json:
+        instance_json = convert_xform_to_json(instance_xml)
+    if not instance_json.get('@xmlns'):
         raise MissingXMLNSError("Form is missing a required field: XMLNS")
 
-    adjust_datetimes(form_data)
+    adjust_datetimes(instance_json)
 
-    xform = interface.new_xform(form_data)
+    xform = interface.new_xform(instance_json)
     xform.domain = domain
     xform.auth_context = auth_context
 

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -98,7 +98,7 @@ def _create_new_xform(domain, instance_xml, attachments=None, auth_context=None,
     interface = FormProcessorInterface(domain)
 
     assert attachments is not None
-    if not instance_json:
+    if instance_json is not None:
         instance_json = convert_xform_to_json(instance_xml)
     if not instance_json.get('@xmlns'):
         raise MissingXMLNSError("Form is missing a required field: XMLNS")

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -98,7 +98,7 @@ def _create_new_xform(domain, instance_xml, attachments=None, auth_context=None,
     interface = FormProcessorInterface(domain)
 
     assert attachments is not None
-    if instance_json is not None:
+    if instance_json is None:
         instance_json = convert_xform_to_json(instance_xml)
     if not instance_json.get('@xmlns'):
         raise MissingXMLNSError("Form is missing a required field: XMLNS")

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -71,7 +71,7 @@ class SubmissionPost(object):
                  location=None, submit_ip=None, openrosa_headers=None,
                  last_sync_token=None, received_on=None, date_header=None,
                  partial_submission=False, case_db=None, force_logs=False,
-                 timing_context=None):
+                 timing_context=None, instance_json=None):
         assert domain, "'domain' is required"
         assert instance, instance
         assert not isinstance(instance, HttpRequest), instance
@@ -86,6 +86,7 @@ class SubmissionPost(object):
         self.last_sync_token = last_sync_token
         self.openrosa_headers = openrosa_headers or {}
         self.instance = instance
+        self.instance_json = instance_json
         self.attachments = attachments or {}
         self.auth_context = auth_context or DefaultAuthContext()
         self.path = path
@@ -253,7 +254,13 @@ class SubmissionPost(object):
             if failure_response:
                 return FormProcessingResult(failure_response, None, [], [], 'known_failures')
 
-            result = process_xform_xml(self.domain, self.instance, self.attachments, self.auth_context.to_json())
+            result = process_xform_xml(
+                self.domain,
+                self.instance,
+                self.attachments,
+                self.auth_context.to_json(),
+                instance_json=self.instance_json,
+            )
             submitted_form = result.submitted_form
 
             self._post_process_form(submitted_form)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2988,3 +2988,12 @@ INCLUDE_ALL_LOCATIONS = StaticToggle(
     tag=TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
 )
+
+INCREASE_DEVICE_LIMIT_PER_USER = StaticToggle(
+    slug='increase_device_per_user_limit',
+    label='In the event that the DEVICE_LIMIT_PER_USER in settings becomes too restrictive, this flag can be used '
+          'to increase the limit without completely removing it. See INCREASED_DEVICE_LIMIT_PER_USER in settings '
+          'to see the exact value.',
+    tag=TAG_SAAS_CONDITIONAL,
+    namespaces=[NAMESPACE_DOMAIN],
+)

--- a/settings.py
+++ b/settings.py
@@ -1150,6 +1150,7 @@ MAX_MOBILE_UCR_SIZE = 100000  # max number of rows allowed when syncing a mobile
 
 DEVICE_LIMIT_PER_USER = 10  # number of devices allowed per user per minute
 INCREASED_DEVICE_LIMIT_PER_USER = 100  # value when INCREASE_DEVICE_LIMIT_PER_USER ff is enabled
+ENABLE_DEVICE_RATE_LIMITER = False
 
 # used by periodic tasks that delete soft deleted data older than PERMANENT_DELETION_WINDOW days
 PERMANENT_DELETION_WINDOW = 30  # days

--- a/settings.py
+++ b/settings.py
@@ -1148,6 +1148,9 @@ CONNECTID_USERINFO_URL = 'http://localhost:8080/o/userinfo'
 MAX_MOBILE_UCR_LIMIT = 300  # used in corehq.apps.cloudcare.util.should_restrict_web_apps_usage
 MAX_MOBILE_UCR_SIZE = 100000  # max number of rows allowed when syncing a mobile UCR
 
+DEVICE_LIMIT_PER_USER = 10  # number of devices allowed per user per minute
+INCREASED_DEVICE_LIMIT_PER_USER = 100  # value when INCREASE_DEVICE_LIMIT_PER_USER ff is enabled
+
 # used by periodic tasks that delete soft deleted data older than PERMANENT_DELETION_WINDOW days
 PERMANENT_DELETION_WINDOW = 30  # days
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
A 406 http response is returned when this limit is reached, which allows us to send a custom, non-translatable message. However given the mobile worker will be connected to the internet, I'm optimistic they will be able to translate it or send it to someone who can make better use of the error message if needed. While a 429 response would have fit here as well and is translatable, the message is too vague in my opinion. This way we can ensure we are communicating to the user that it is usage for _this specific user_ that is too high.

![image](https://github.com/user-attachments/assets/2daa85f7-2f66-4b9c-9dd4-d95b1f8dcf23)

Based on [android code](https://github.com/dimagi/commcare-android/blob/6604f7021697ebc4a1e98a85e5c9bb32d6104719/app/src/org/commcare/utils/FormUploadUtil.java#L217-L234), I'm pretty sure this will be displayed similarly on mobile, but will confirm with a physical device. **Update**: Confirmed this looks good on mobile device.
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-16355

Initial PR: https://github.com/dimagi/commcare-hq/pull/35515

**Note for reviewers**
By default, the device rate limiter is not enabled, but the code is in place to have the ability to enable this via `update-config`. Review this code as if it were being enabled immediately, but note that there will be time after this is deployed to collect metrics in datadog to determine how the current limits fit into current usage. 

**Summary**

The changes in this PR track usage for each user action that leads to updating user metadata which are:
- restores
- form submissions
- heartbeats

If the combined usage on these endpoints reaches 10 unique device IDs within a fixed minute time window, any other requests for that user within that minute from a new device ID are rejected. The exceptions are if a device ID is None or blank, or if the device ID is from Web Apps.

**Understanding past usage**

The easiest way to get a rough sense of current usage at a larger scale is to look at the `SyncLogSQL` table and see how many different devices are used by a single user in different windows of time. This fails to capture _all_ activity like form submissions, but gives a good sense of restore activity for a specific user. I've periodically looked at this over the last month for different days/weeks for day windows and have seen that these numbers are relatively consistent, with the exception of December 6th.

The smaller the time window, the less useful this data is, but gives a sense of the difference. The datadog metrics included in this PR will give a much better sense of usage at the minute window level.

***1 day window***
December 6th: [2781, 349, 346, 328, 54, 46, ...]  # the top 4 device counts are from the problematic domain
January 15th: [420, 224, 42, 41, 40, ...]

***Random 1 hour window***
December 6th: [776, 52, 36, 24, 5, ...]
January 17th: [17, 7, 5, 4, 3, ...]

***Random 1 minute window***
December 6th: [34, 3, 1, ...]
January 17th: [2, 1, ...]

Again, I don't think it is worth diving too deep into these numbers as the metric will be far more useful and accurate.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Based on [Clayton's comment](https://dimagi.atlassian.net/browse/SAAS-16355?focusedCommentId=360266), here are the considerations outlined for this change.

#### How will users become aware of this change?
Assuming that this limit is currently being reached or exceeded (we won't know until metrics are collected), here is how users will become aware.

The mobile users will attempt an action like a sync or form submission, and receive an error message explaining, in english, that current usage for this user is too high and that they should try again in a minute. Based on numbers pulled for devices used per user in a day (hardly ever exceeds 100 devices), in most cases where this limit is hit, trying again in a minute should succeed. If however there are thousands of devices attempting to take an action at roughly the same time, it will be a painful process to have every device be able to restore or submit successfully. We suspect this scenario is limited to large events like trainings. 

#### How are other legitimate use cases impacted?
Other use cases outside of simultaneous usage of a user across different physical devices that can lead to multiple device ids for one user are:
1. **Uninstalling and reinstalling the CommCare app**
  It seems nearly impossible to uninstall and reinstall CommCare 9 times in one minute, let alone logging into your user and triggering a restore or submission, so this scenario should not be a concern.

2. **Clearing user data**
   Clearing user data is easier to do frequently, and could lead to frequent device ID changes, but again, a user would have to do this 9 times in one minute. That seems well past the point of debugging an issue.

3. **Multiple CommCare app installations**
  Running with multiple installations of CommCare seems to be the most plausible for actually sending off 10 requests from 10 different installations for one user, but just because it is plausible doesn't mean it makes sense. I'm not too familiar with the use cases for different installations, but I imagine it is testing behavior between different mobile app versions or something along those lines, which should be limited to a few different device IDs at most.

#### Does this impact our offering?
I would say this does not impact our offering, but does make it more painful to use the product in a way we did not intend for (a significant number of devices for one user). This is a temporary rate limit for what we, SaaS, consider to be a reasonable number of devices per user in a minute window.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Created tests for the DeviceRateLimiter class (`corehq.apps.users.tests.test_device_rate_limiter.TestDeviceRateLimiter`)

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change