### PR TITLE
Standardize initial_page_data usage in app manager js

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/add_ons.js
+++ b/corehq/apps/app_manager/static/app_manager/js/add_ons.js
@@ -1,6 +1,7 @@
 "use strict";
 hqDefine("app_manager/js/add_ons", function () {
-    var sectionChanger = hqImport("app_manager/js/section_changer");
+    var sectionChanger = hqImport("app_manager/js/section_changer"),
+        initialPageData = hqImport("hqwebapp/js/initial_page_data");
 
     function EditAddOns(addOns, layout, saveUrl) {
         var self = this;
@@ -36,9 +37,9 @@ hqDefine("app_manager/js/add_ons", function () {
         var $addOns = $("#add-ons");
         if ($addOns.length) {
             $addOns.koApplyBindings(new EditAddOns(
-                hqImport("hqwebapp/js/initial_page_data").get("add_ons"),
-                hqImport("hqwebapp/js/initial_page_data").get("add_ons_layout"),
-                hqImport("hqwebapp/js/initial_page_data").reverse("edit_add_ons")
+                initialPageData.get("add_ons"),
+                initialPageData.get("add_ons_layout"),
+                initialPageData.reverse("edit_add_ons")
             ));
             sectionChanger.attachToForm($addOns.find("form"));
         }

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
@@ -3,9 +3,9 @@ hqDefine('app_manager/js/app_manager_media', function () {
     var appMenuMediaManager = function (o) {
         /* This interfaces the media reference for a form or module menu
         (as an icon or image) with the upload manager.*/
-        var initialPageData = hqImport("hqwebapp/js/initial_page_data").get,
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
             self = {
-                isDefaultLanguage: initialPageData('current_language') === initialPageData('default_language'),
+                isDefaultLanguage: initialPageData.get('current_language') === initialPageData.get('default_language'),
             };
 
         self.enabled = ko.observable(

--- a/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
@@ -1,6 +1,6 @@
 "use strict";
 hqDefine('app_manager/js/custom_assertions', function () {
-    var initialPageData = hqImport("hqwebapp/js/initial_page_data").get;
+    var initialPageData = hqImport("hqwebapp/js/initial_page_data");
 
     var customAssertion = function (test, text) {
         var self = {};
@@ -57,7 +57,7 @@ hqDefine('app_manager/js/custom_assertions', function () {
     $(function () {
         if (hqImport('hqwebapp/js/toggles').toggleEnabled('CUSTOM_ASSERTIONS')) {
             var assertions = customAssertions().wrap({
-                'customAssertions': initialPageData('custom_assertions'),
+                'customAssertions': initialPageData.get('custom_assertions'),
             });
             $('#custom-assertions').koApplyBindings(assertions);
         }

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -1,6 +1,6 @@
 "use strict";
 hqDefine("app_manager/js/details/case_claim", function () {
-    var get = hqImport('hqwebapp/js/initial_page_data').get,
+    var initialPageData = hqImport('hqwebapp/js/initial_page_data'),
         generateSemiRandomId = function () {
             // https://stackoverflow.com/a/2117523
             return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, function (c) {
@@ -35,7 +35,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                     self.nodeset(null);
                 } else {
                     self.instance_id(value);
-                    var itemList = _.filter(get('js_options').item_lists, function (item) {
+                    var itemList = _.filter(initialPageData.get('js_options').item_lists, function (item) {
                         return item.id === value;
                     });
                     if (itemList && itemList.length === 1) {
@@ -53,7 +53,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
             if (self.nodeset() === null) {
                 return true;
             }
-            var itemLists = _.map(get('js_options').item_lists, function (item) {
+            var itemLists = _.map(initialPageData.get('js_options').item_lists, function (item) {
                 return itemsetValue(item);
             });
             if (self.nodeset().split("/").length === 0) {
@@ -139,7 +139,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
 
         self.receiverExpression = ko.observable(options.receiverExpression);
         self.itemListOptions = ko.computed(function () {
-            var itemLists = get('js_options').item_lists;
+            var itemLists = initialPageData.get('js_options').item_lists;
             return _.map(
                 _.filter(itemLists, function (p) {
                     return (

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -13,7 +13,7 @@
  */
 hqDefine("app_manager/js/details/column", function () {
     const uiElement = hqImport('hqwebapp/js/bootstrap3/ui-element');
-    const initialPageData = hqImport('hqwebapp/js/initial_page_data').get;
+    const initialPageData = hqImport('hqwebapp/js/initial_page_data');
     const microCaseImageName = 'cc_case_image';
 
     return function (col, screen) {
@@ -289,7 +289,7 @@ hqDefine("app_manager/js/details/column", function () {
         self.endpointActionLabel = $('<span>Form to submit on click:</span>');
         const formEndpointOptions = [{value: "-1", label: 'Select a form endpoint'}];
         let moduleName = "";
-        const formEndpoints = Object.entries(initialPageData('form_endpoint_options'));
+        const formEndpoints = Object.entries(initialPageData.get('form_endpoint_options'));
         formEndpoints.forEach(([, endpoint]) => {
             if (endpoint.module_name !== moduleName) {
                 moduleName = endpoint.module_name;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -2,8 +2,8 @@
 hqDefine('app_manager/js/forms/case_config_ui', function () {
     $(function () {
         var caseConfigUtils = hqImport('app_manager/js/case_config_utils'),
-            initial_page_data = hqImport("hqwebapp/js/initial_page_data").get,
-            addOnsPrivileges = initial_page_data('add_ons_privileges'),
+            initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+            addOnsPrivileges = initialPageData.get('add_ons_privileges'),
             privileges = hqImport('hqwebapp/js/privileges'),
             toggles = hqImport("hqwebapp/js/toggles");
         var action_names = ["open_case", "update_case", "close_case", "case_preload",
@@ -841,10 +841,10 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             },
         };
 
-        if (initial_page_data('has_form_source')) {
-            var caseConfigObj = caseConfig(_.extend({}, initial_page_data("case_config_options"), {
+        if (initialPageData.get('has_form_source')) {
+            var caseConfigObj = caseConfig(_.extend({}, initialPageData.get("case_config_options"), {
                 home: $('#case-config-ko'),
-                requires: ko.observable(initial_page_data("form_requires")),
+                requires: ko.observable(initialPageData.get("form_requires")),
             }));
             caseConfigObj.init();
         }

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -1,6 +1,6 @@
 /* globals define, require, WS4Redis */
 hqDefine("app_manager/js/forms/form_designer", function () {
-    var initialPageData = hqImport("hqwebapp/js/initial_page_data").get,
+    var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         appcues = hqImport('analytix/js/appcues'),
         FORM_TYPES = {
             REGISTRATION: "registration",
@@ -9,16 +9,16 @@ hqDefine("app_manager/js/forms/form_designer", function () {
         },
         trackFormEvent = function (eventType) {
             var formType = FORM_TYPES.FOLLOWUP;
-            if (initialPageData("is_registration_form")) {
+            if (initialPageData.get("is_registration_form")) {
                 formType = FORM_TYPES.REGISTRATION;
-            } else if (initialPageData("is_survey")) {
+            } else if (initialPageData.get("is_survey")) {
                 formType = FORM_TYPES.SURVEY;
             }
             appcues.trackEvent(eventType + " (" + formType + ")");
         };
 
     $(function () {
-        var VELLUM_OPTIONS = _.extend({}, initialPageData("vellum_options"), {
+        var VELLUM_OPTIONS = _.extend({}, initialPageData.get("vellum_options"), {
             itemset: {
                 dataSourcesFilter: function (sources) {
                     return _.filter(sources, function (source) {
@@ -58,7 +58,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                     $('#fd-hq-edit-formname-button').html()
                 // and we replace the form name Vellum put there
                 // with one that's translated to the app builder's currently selected language:
-                ).text(initialPageData('form_name'));
+                ).text(initialPageData.get('form_name'));
             },
         });
         VELLUM_OPTIONS.core = _.extend(VELLUM_OPTIONS.core, {
@@ -66,13 +66,13 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                 var appManager = hqImport('app_manager/js/app_manager');
                 appManager.updateDOM(data.update);
                 $('.js-preview-toggle').removeAttr('disabled');
-                if (initialPageData("days_since_created") === 0) {
+                if (initialPageData.get("days_since_created") === 0) {
                     hqImport('analytix/js/kissmetrix').track.event('Saved the Form Builder within first 24 hours');
                 }
                 trackFormEvent(appcues.EVENT_TYPES.FORM_SAVE);
             },
             onReady: function () {
-                if (initialPageData('vellum_debug') === 'dev') {
+                if (initialPageData.get('vellum_debug') === 'dev') {
                     var lessErrorId = "#less-error-message\\:static-style-less-hqstyle-core",
                         lessError = $(lessErrorId);
                     if (lessError.length) {
@@ -83,7 +83,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                 }
 
                 var kissmetrixTrack = function () {};
-                if (initialPageData('days_since_created') === 0) {
+                if (initialPageData.get('days_since_created') === 0) {
                     kissmetrixTrack = function () {
                         hqImport('analytix/js/kissmetrix').track.event(
                             'Added question in Form Builder within first 24 hours'
@@ -99,7 +99,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
             },
         });
 
-        window.CKEDITOR_BASEPATH = initialPageData('CKEDITOR_BASEPATH');     // eslint-disable-line no-unused-vars, no-undef
+        window.CKEDITOR_BASEPATH = initialPageData.get('CKEDITOR_BASEPATH');     // eslint-disable-line no-unused-vars, no-undef
 
         // This unfortunate chain of import callbacks was required because
         // appcues appears to make an attempt to use the same requirejs
@@ -109,7 +109,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
         // appcues to have completed its init prior to importing requirejs
         // or using it to incorporate vellum, these issues disappear.
         var initFormBuilder = function () {
-            $.getScript(initialPageData("requirejs_static_url"), function () {
+            $.getScript(initialPageData.get("requirejs_static_url"), function () {
                 define("jquery", [], function () { return window.jQuery; });
                 define("jquery.bootstrap", ["jquery"], function () {});
                 define("underscore", [], function () { return window._; });
@@ -140,10 +140,10 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                         * Run make in that directory (requires node.js)
                         * set settings.VELLUM_DEBUG to "dev" or "dev-min"
                     */
-                    baseUrl: initialPageData('requirejs_url'),
+                    baseUrl: initialPageData.get('requirejs_url'),
                     // handle very bad connections
                     waitSeconds: 60,
-                    urlArgs: initialPageData('requirejs_args'),
+                    urlArgs: initialPageData.get('requirejs_args'),
                     paths: {
                         'jquery.vellum': 'main',
                     },
@@ -154,7 +154,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                         $("#edit").hide();
                         $('#hq-footer').hide();
                         $('#formdesigner').vellum(VELLUM_OPTIONS);
-                        var notificationOptions = initialPageData("notification_options");
+                        var notificationOptions = initialPageData.get("notification_options");
                         if (notificationOptions) {
                             var notifications = hqImport('app_manager/js/forms/app_notifications'),
                                 vellum = $("#formdesigner").vellum("get");
@@ -172,7 +172,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                 hqImport('app_manager/js/app_manager').setPrependedPageTitle("\u270E ", true);
                 hqImport('app_manager/js/app_manager').setAppendedPageTitle(gettext("Edit Form"));
 
-                if (initialPageData('form_uses_cases')) {
+                if (initialPageData.get('form_uses_cases')) {
                     // todo make this a more broadly used util, perhaps? actually add buttons to formplayer?
                     var _prependTemplateToSelector = function (selector, layout, attempts, callback) {
                         attempts = attempts || 0;
@@ -196,16 +196,15 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                     );
                 }
 
-                var reverse = hqImport("hqwebapp/js/initial_page_data").reverse,
-                    editDetails = hqImport('app_manager/js/forms/edit_form_details');
-                hqImport('app_manager/js/app_manager').updatePageTitle(initialPageData("form_name"));
+                var editDetails = hqImport('app_manager/js/forms/edit_form_details');
+                hqImport('app_manager/js/app_manager').updatePageTitle(initialPageData.get("form_name"));
                 editDetails.initName(
-                    initialPageData("form_name"),
-                    reverse("edit_form_attr", "name")
+                    initialPageData.get("form_name"),
+                    initialPageData.reverse("edit_form_attr", "name")
                 );
                 editDetails.initComment(
-                    initialPageData("form_comment").replace(/\\n/g, "\n"),
-                    reverse("edit_form_attr", "comment")
+                    initialPageData.get("form_comment").replace(/\\n/g, "\n"),
+                    initialPageData.reverse("edit_form_attr", "comment")
                 );
                 editDetails.setUpdateCallbackFn(function (name) {
                     $('#formdesigner .fd-content-left .fd-head-text').text(name);

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -1,9 +1,9 @@
 hqDefine("app_manager/js/forms/form_view", function () {
-    var initialPageData = hqImport("hqwebapp/js/initial_page_data").get,
+    var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         appManagerUtils = hqImport('app_manager/js/app_manager');
     appManagerUtils.setPrependedPageTitle("\u2699 ", true);
     appManagerUtils.setAppendedPageTitle(gettext("Form Settings"));
-    appManagerUtils.updatePageTitle(initialPageData("form_name"));
+    appManagerUtils.updatePageTitle(initialPageData.get("form_name"));
 
     function formFilterMatches(filter, substringMatches) {
         if (typeof(filter) !== 'string') {
@@ -20,13 +20,13 @@ hqDefine("app_manager/js/forms/form_view", function () {
 
     function formFilterModel() {
         var self = {};
-        var patterns = initialPageData('form_filter_patterns');
+        var patterns = initialPageData.get('form_filter_patterns');
 
-        self.formFilter = ko.observable(initialPageData('form_filter'));
+        self.formFilter = ko.observable(initialPageData.get('form_filter'));
 
         self.caseReferenceNotAllowed = ko.computed(function () {
-            var moduleUsesCase = initialPageData('all_other_forms_require_a_case') && initialPageData('form_requires') === 'case';
-            if (!moduleUsesCase || (initialPageData('put_in_root') && !initialPageData('root_requires_same_case'))) {
+            var moduleUsesCase = initialPageData.get('all_other_forms_require_a_case') && initialPageData.get('form_requires') === 'case';
+            if (!moduleUsesCase || (initialPageData.get('put_in_root') && !initialPageData.get('root_requires_same_case'))) {
                 // We want to determine here if the filter expression references
                 // any case but the user case.
                 var filter = self.formFilter();
@@ -45,7 +45,7 @@ hqDefine("app_manager/js/forms/form_view", function () {
             return false;
         });
 
-        self.isUsercaseInUse = ko.observable(initialPageData('is_usercase_in_use'));
+        self.isUsercaseInUse = ko.observable(initialPageData.get('is_usercase_in_use'));
         self.usercaseReferenceNotAllowed = ko.computed(function () {
             return !self.isUsercaseInUse() && formFilterMatches(
                 self.formFilter(), patterns.usercase_substring
@@ -56,7 +56,7 @@ hqDefine("app_manager/js/forms/form_view", function () {
         self.enableUsercaseError = ko.observable();
         self.enableUsercase = function () {
             self.enableUsercaseInProgress(true);
-            const url = hqImport("hqwebapp/js/initial_page_data").reverse("enable_usercase");
+            const url = initialPageData.reverse("enable_usercase");
             $.ajax(url, {
                 method: "POST",
                 success: function () {
@@ -79,7 +79,7 @@ hqDefine("app_manager/js/forms/form_view", function () {
     $(function () {
         // Validation for build
         var setupValidation = hqImport('app_manager/js/app_manager').setupValidation;
-        setupValidation(hqImport("hqwebapp/js/initial_page_data").reverse("validate_form_for_build"));
+        setupValidation(initialPageData.reverse("validate_form_for_build"));
 
         // Analytics for renaming form
         $(".appmanager-edit-title").on('click', '.btn-primary', function () {
@@ -88,36 +88,36 @@ hqDefine("app_manager/js/forms/form_view", function () {
 
         // Settings > Logic
         var $formFilter = $('#form-filter');
-        if ($formFilter.length && initialPageData('allow_form_filtering')) {
+        if ($formFilter.length && initialPageData.get('allow_form_filtering')) {
             $('#form-filter').koApplyBindings(formFilterModel());
         }
 
         var FormWorkflow = hqImport('app_manager/js/forms/form_workflow').FormWorkflow,
-            labels = initialPageData('form_workflows');
+            labels = initialPageData.get('form_workflows');
         var options = {
             labels: labels,
-            workflow: initialPageData('post_form_workflow'),
-            workflow_fallback: initialPageData('post_form_workflow_fallback'),
+            workflow: initialPageData.get('post_form_workflow'),
+            workflow_fallback: initialPageData.get('post_form_workflow_fallback'),
         };
 
         if (_.has(labels, FormWorkflow.Values.FORM)) {
-            options.forms = initialPageData('linkable_forms');
-            options.formLinks = initialPageData('form_links');
-            options.formDatumsUrl = hqImport('hqwebapp/js/initial_page_data').reverse('get_form_datums');
+            options.forms = initialPageData.get('linkable_forms');
+            options.formLinks = initialPageData.get('form_links');
+            options.formDatumsUrl = initialPageData.reverse('get_form_datums');
         }
 
         $('#form-workflow').koApplyBindings(new FormWorkflow(options));
 
         // Settings > Advanced
         $('#auto-gps-capture').koApplyBindings({
-            auto_gps_capture: ko.observable(initialPageData('auto_gps_capture')),
+            auto_gps_capture: ko.observable(initialPageData.get('auto_gps_capture')),
         });
 
-        if (initialPageData('is_training_module')) {
+        if (initialPageData.get('is_training_module')) {
             $('#release-notes-setting').koApplyBindings({
-                is_release_notes_form: ko.observable(initialPageData('is_release_notes_form')),
-                enable_release_notes: ko.observable(initialPageData('enable_release_notes')),
-                is_allowed_to_be_release_notes_form: ko.observable(initialPageData('is_allowed_to_be_release_notes_form')),
+                is_release_notes_form: ko.observable(initialPageData.get('is_release_notes_form')),
+                enable_release_notes: ko.observable(initialPageData.get('enable_release_notes')),
+                is_allowed_to_be_release_notes_form: ko.observable(initialPageData.get('is_allowed_to_be_release_notes_form')),
                 toggle_enable: function () {
                     var allowed = this.is_release_notes_form();
                     if (!allowed) {
@@ -131,13 +131,13 @@ hqDefine("app_manager/js/forms/form_view", function () {
         var $shadowParent = $('#shadow-parent');
         if ($shadowParent.length) {
             $shadowParent.koApplyBindings({
-                shadow_parent: ko.observable(initialPageData('shadow_parent_form_id')),
+                shadow_parent: ko.observable(initialPageData.get('shadow_parent_form_id')),
             });
         }
 
         if (hqImport('hqwebapp/js/toggles').toggleEnabled('CUSTOM_INSTANCES')) {
             var customInstances = hqImport('app_manager/js/forms/custom_instances').wrap({
-                customInstances: initialPageData('custom_instances'),
+                customInstances: initialPageData.get('custom_instances'),
             });
             $('#custom-instances').koApplyBindings(customInstances);
         }

--- a/corehq/apps/app_manager/static/app_manager/js/managed_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/managed_app.js
@@ -1,13 +1,13 @@
 hqDefine("app_manager/js/managed_app", function () {
     $(function () {
-        var initial_page_data = hqImport('hqwebapp/js/initial_page_data').get,
+        var initialPageData = hqImport('hqwebapp/js/initial_page_data'),
             init = hqImport('app_manager/js/app_manager').init,
-            app = initial_page_data('app_subset');
+            app = initialPageData.get('app_subset');
 
         init({
             appVersion: app.version || -1,
             commcareVersion: String(app.commcare_minor_release),
-            latestCommcareVersion: initial_page_data('latest_commcare_version') || null,
+            latestCommcareVersion: initialPageData.get('latest_commcare_version') || null,
         });
 
         $('.btn-langcode-preprocessed').each(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -4,15 +4,15 @@ hqDefine("app_manager/js/modules/module_view", function () {
         $('.overwrite-danger').on("click", function () {
             hqImport('analytix/js/kissmetrix').track.event("Overwrite Case Lists/Case Details");
         });
-        var initial_page_data = hqImport('hqwebapp/js/initial_page_data').get,
-            moduleBrief = initial_page_data('module_brief'),
+        var initialPageData = hqImport('hqwebapp/js/initial_page_data'),
+            moduleBrief = initialPageData.get('module_brief'),
             moduleType = moduleBrief.module_type,
-            options = initial_page_data('js_options') || {};
+            options = initialPageData.get('js_options') || {};
 
         hqImport('app_manager/js/app_manager').setAppendedPageTitle(gettext("Menu Settings"));
         // Set up details
         if (moduleBrief.case_type) {
-            var details = initial_page_data('details');
+            var details = initialPageData.get('details');
             for (var i = 0; i < details.length; i++) {
                 var detail = details[i];
                 var detailScreenConfigOptions = {
@@ -28,16 +28,16 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     properties: detail.properties,
                     lang: moduleBrief.lang,
                     langs: moduleBrief.langs,
-                    saveUrl: hqImport('hqwebapp/js/initial_page_data').reverse('edit_module_detail_screens'),
-                    parentModules: initial_page_data('parent_case_modules'),
-                    allCaseModules: initial_page_data('all_case_modules'),
+                    saveUrl: initialPageData.reverse('edit_module_detail_screens'),
+                    parentModules: initialPageData.get('parent_case_modules'),
+                    allCaseModules: initialPageData.get('all_case_modules'),
                     caseTileTemplateOptions: options.case_tile_template_options,
                     caseTileTemplateConfigs: options.case_tile_template_configs,
                     childCaseTypes: detail.subcase_types,
                     fixture_columns_by_type: options.fixture_columns_by_type || {},
                     parentSelect: detail.parent_select,
                     fixtureSelect: detail.fixture_select,
-                    multimedia: initial_page_data('multimedia_object_map'),
+                    multimedia: initialPageData.get('multimedia_object_map'),
                 };
                 _.extend(detailScreenConfigOptions, options.search_config);
                 var detailScreenConfig = hqImport("app_manager/js/details/screen_config")(detailScreenConfigOptions);
@@ -52,14 +52,14 @@ hqDefine("app_manager/js/modules/module_view", function () {
             }
         }
 
-        var originalCaseType = initial_page_data('case_type');
+        var originalCaseType = initialPageData.get('case_type');
         var casesExist = false;
         var deprecatedCaseTypes = [];
         // If this async request is slow or fails, we will default to hiding the case type changed and
         // deprecated case type warnings.
         $.ajax({
             method: 'GET',
-            url: hqImport('hqwebapp/js/initial_page_data').reverse('existing_case_types'),
+            url: initialPageData.reverse('existing_case_types'),
             success: function (data) {
                 casesExist = data.existing_case_types.includes(originalCaseType);
                 deprecatedCaseTypes = data.deprecated_case_types;
@@ -155,7 +155,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
         // Module filter
         var $moduleFilter = $('#module-filter');
         if ($moduleFilter.length) {
-            $moduleFilter.koApplyBindings({xpath: initial_page_data("module_filter") || ''});
+            $moduleFilter.koApplyBindings({xpath: initialPageData.get("module_filter") || ''});
         }
 
         // UCR last updated tile
@@ -169,7 +169,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
         var lazyloadCaseListFields = $('#lazy-load-case-list-fields')
         if (lazyloadCaseListFields.length > 0) {
            lazyloadCaseListFields.koApplyBindings({
-                lazy_load_case_list_fields: ko.observable(initial_page_data('lazy_load_case_list_fields')),
+                lazy_load_case_list_fields: ko.observable(initialPageData.get('lazy_load_case_list_fields')),
             });
         }
 
@@ -181,7 +181,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
 
                 self.caseListForm = ko.observable(originalFormId);
                 self.caseListFormSettingsUrl = ko.computed(function () {
-                    return hqImport("hqwebapp/js/initial_page_data").reverse("view_form", self.caseListForm());
+                    return initialPageData.reverse("view_form", self.caseListForm());
                 });
                 self.postFormWorkflow = ko.observable(postFormWorkflow);
                 self.endOfRegistrationOptions = ko.computed(function () {
@@ -229,7 +229,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
 
                 return self;
             };
-            var case_list_form_options = initial_page_data('case_list_form_options');
+            var case_list_form_options = initialPageData.get('case_list_form_options');
             var caseListForm = caseListFormModel(
                 case_list_form_options ? case_list_form_options.form.form_id : null,
                 case_list_form_options ? case_list_form_options.options : [],
@@ -247,7 +247,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
         if (moduleType === 'shadow') {
             // Shadow module checkboxes for including/excluding forms
             var ShadowModule = hqImport('app_manager/js/modules/shadow_module_settings').ShadowModule,
-                shadowOptions = initial_page_data('shadow_module_options');
+                shadowOptions = initialPageData.get('shadow_module_options');
             $('#sourceModuleForms').koApplyBindings(new ShadowModule(
                 shadowOptions.modules,
                 shadowOptions.source_module_id,
@@ -260,10 +260,10 @@ hqDefine("app_manager/js/modules/module_view", function () {
                 var VisitScheduler = hqImport('app_manager/js/visit_scheduler');
                 var visitScheduler = VisitScheduler.moduleScheduler({
                     home: $('#module-scheduler'),
-                    saveUrl: hqImport('hqwebapp/js/initial_page_data').reverse('edit_schedule_phases'),
+                    saveUrl: initialPageData.reverse('edit_schedule_phases'),
                     hasSchedule: moduleBrief.has_schedule,
-                    schedulePhases: initial_page_data('schedule_phases'),
-                    caseProperties: initial_page_data('details')[0].properties,
+                    schedulePhases: initialPageData.get('schedule_phases'),
+                    caseProperties: initialPageData.get('details')[0].properties,
                 });
                 visitScheduler.init();
             }
@@ -274,7 +274,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
         }
 
         var setupValidation = hqImport('app_manager/js/app_manager').setupValidation;
-        setupValidation(hqImport('hqwebapp/js/initial_page_data').reverse('validate_module_for_build'));
+        setupValidation(initialPageData.reverse('validate_module_for_build'));
 
         // show display style options only when module configured to show module and then forms
         var $menu_mode = $('#put_in_root');

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view_report.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view_report.js
@@ -17,7 +17,7 @@ hqDefine("app_manager/js/modules/module_view_report", function () {
             navMenuMediaItem.default_file_name
         );
 
-        var saveURL = hqImport("hqwebapp/js/initial_page_data").reverse("edit_report_module");
+        var saveURL = initialPageData.reverse("edit_report_module");
         var staticData = staticFilterDataModel(initialPageData.get('static_data_options'));
         var reportModule = reportModuleModel(_.extend({}, initialPageData.get("report_module_options"), {
             lang: initialPageData.get('lang'),
@@ -72,7 +72,7 @@ hqDefine("app_manager/js/modules/module_view_report", function () {
                 allowClear: true,
                 placeholder: " ",   // allowClear only respected if there is a non empty placeholder
                 ajax: {
-                    url: (hqImport("hqwebapp/js/initial_page_data").reverse("choice_list_api").split('report_id')[0]
+                    url: (initialPageData.reverse("choice_list_api").split('report_id')[0]
                           + element.data("filter-name") + "/"),
                     dataType: 'json',
                     delay: 250,

--- a/corehq/apps/app_manager/static/app_manager/js/releases/app_diff.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/app_diff.js
@@ -44,7 +44,7 @@
  * and is taken advantage of in this code.
  * */
 hqDefine('app_manager/js/releases/app_diff', function () {
-    var reverse = hqImport('hqwebapp/js/initial_page_data').reverse;
+    var initialPageData = hqImport('hqwebapp/js/initial_page_data');
     var sanitize = DOMPurify.sanitize;
 
     var init = function (selector, options) {
@@ -389,7 +389,7 @@ hqDefine('app_manager/js/releases/app_diff', function () {
         var cache = {};
 
         self.getAppData = function (appId) {
-            var url = reverse('app_data_json', appId),
+            var url = initialPageData.reverse('app_data_json', appId),
                 deferred = $.Deferred();
 
             if (_.has(cache, appId)) {


### PR DESCRIPTION
## Technical Summary
This is prep for migrating app manager to webpack.

## Safety Assurance

### Safety story
Mechanical changes. Code review is an appropriate safety check. I clicked around these pages locally checking for js errors.

### Automated test coverage

not much

### QA Plan

not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
