### PR TITLE
Removed duplicate script tag from form_view.html

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -16,7 +16,6 @@
 
 {% block js %}{{ block.super }}
   {% compress js %}
-    <script src="{% static 'hqwebapp/js/knockout_subscribables.ko.js' %}"></script>
     <script src="{% static 'app_manager/js/forms/form_view.js' %}"></script>
   {% endcompress %}
 {% endblock %}


### PR DESCRIPTION
## Technical Summary
Fixes a js error on the form settings page introduced in https://github.com/dimagi/commcare-hq/pull/35599 (specifically https://github.com/dimagi/commcare-hq/commit/cffc0040e53e3b2bc011a633a1c266090a33c2be) which hasn't yet been deployed anywhere.

This library is already included in app manager because it's one of the core libraries [here](https://github.com/dimagi/commcare-hq/blob/4b14da011bd6ec6521de510b42d0c97a71620f10/corehq/apps/hqwebapp/templates/hqwebapp/includes/core_libraries.html#L121). Now that it uses `hqDefine`, including it twice throws an error.

## Safety Assurance

### Safety story
Small change, with risk limited to the form settings page. I tested locally that the js error on form settings is gone and that the library is still loaded.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
