### PR TITLE
Update translations for CommCare 2.54 and 2.55

### DIFF
--- a/corehq/apps/app_manager/tests/test_translation_file_paths.py
+++ b/corehq/apps/app_manager/tests/test_translation_file_paths.py
@@ -20,7 +20,7 @@ def test_version_paths_with_two_versions():
 def test_version_paths_with_latest_commcare_version():
     eq(
         commcare_translations.get_translation_file_paths('en', version=1, commcare_version='latest'),
-        ['../historical-translations-by-version/2.53-messages_en-2.txt', '../messages_en-1.txt']
+        ['../historical-translations-by-version/2.55-messages_en-2.txt', '../messages_en-1.txt']
     )
 
 
@@ -28,7 +28,7 @@ def test_version_paths_with_latest_commcare_version_and_two_versions():
     eq(
         commcare_translations.get_translation_file_paths('en', version=2, commcare_version='latest'),
         [
-            '../historical-translations-by-version/2.53-messages_en-2.txt',
+            '../historical-translations-by-version/2.55-messages_en-2.txt',
             '../messages_en-2.txt',
             '../messages_en-1.txt',
         ]


### PR DESCRIPTION
## Product Description
CommCare 2.54 and 2.55 translations update.

commcare-translations PRs: https://github.com/dimagi/commcare-translations/pull/82 and https://github.com/dimagi/commcare-translations/pull/83

Note: The [PR](https://github.com/dimagi/commcare-hq/pull/35082) to update translations related to 2.54 didn't get merge due to some failed unit tests. These tests verify the translation file path and it seems that these tests need to be updated every time a new version is released