### PR TITLE
Added logic to reset leaflet images

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports_core/js/maps.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports_core/js/maps.js.diff.txt
@@ -7,6 +7,6 @@
      'underscore',
 -    'reports/js/bootstrap3/maps_utils',
 +    'reports/js/bootstrap5/maps_utils',
+     'leaflet',
  ], function (
      $,
-     _,

--- a/corehq/apps/reports_core/static/reports_core/js/bootstrap3/maps.js
+++ b/corehq/apps/reports_core/static/reports_core/js/bootstrap3/maps.js
@@ -2,11 +2,22 @@ hqDefine('reports_core/js/bootstrap3/maps', [
     'jquery',
     'underscore',
     'reports/js/bootstrap3/maps_utils',
+    'leaflet',
 ], function (
     $,
     _,
-    mapsUtils
+    mapsUtils,
+    L
 ) {
+    // Reset images needed for map markers, which don't play well with webpack.
+    // See https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-483402699
+    delete L.Icon.Default.prototype._getIconUrl;
+    L.Icon.Default.mergeOptions({
+        iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
+        iconUrl: require('leaflet/dist/images/marker-icon.png'),
+        shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
+    });
+
     var module = {},
         privates = {};
 

--- a/corehq/apps/reports_core/static/reports_core/js/bootstrap5/maps.js
+++ b/corehq/apps/reports_core/static/reports_core/js/bootstrap5/maps.js
@@ -2,11 +2,22 @@ hqDefine('reports_core/js/bootstrap5/maps', [
     'jquery',
     'underscore',
     'reports/js/bootstrap5/maps_utils',
+    'leaflet',
 ], function (
     $,
     _,
-    mapsUtils
+    mapsUtils,
+    L
 ) {
+    // Reset images needed for map markers, which don't play well with webpack.
+    // See https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-483402699
+    delete L.Icon.Default.prototype._getIconUrl;
+    L.Icon.Default.mergeOptions({
+        iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
+        iconUrl: require('leaflet/dist/images/marker-icon.png'),
+        shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
+    });
+
     var module = {},
         privates = {};
 

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -38,6 +38,10 @@ module.exports = {
                 loader: 'babel-loader',
                 exclude: /node_modules/,
             },
+            {
+                test: /\.png/,
+                type: 'asset/resource',
+            },
 
             // this rule ensures that hqDefine is renamed to define AMD module
             // definition syntax that webpack understands


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SAAS-16447

## Technical Summary
Apparently it's a known issue that leaflet doesn't work nicely with webpack out of the box.

Introduced in https://github.com/dimagi/commcare-hq/pull/35599

## Feature Flag
UCR

## Safety Assurance

### Safety story
Risk is limited to UCR, where maps are already displaying poorly.

### Automated test coverage

no

### QA Plan

No. I tested the fix on staging.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
