### PR TITLE
Avoid parallel builds

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -178,6 +178,10 @@ class DataSourceBuildInformation(DocumentSchema):
     app_version = IntegerProperty()
     # The registry_slug associated with the registry of the report.
     registry_slug = StringProperty()
+    # True if the data source has been requested for a rebuild by user
+    # or is to be built/rebuilt by HQ for a new/updated configuration
+    # and is waiting to be picked
+    awaiting = BooleanProperty(default=False)
     # True if the data source has been built, that is, if the corresponding SQL table has been populated.
     finished = BooleanProperty(default=False)
     # Start time of the most recent build SQL table celery task.

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -189,6 +189,7 @@ class DataSourceBuildInformation(DocumentSchema):
     # same as previous attributes but used for rebuilding tables in place
     finished_in_place = BooleanProperty(default=False)
     initiated_in_place = DateTimeProperty()
+    # rebuilt via the management command
     rebuilt_asynchronously = BooleanProperty(default=False)
 
     @property
@@ -747,6 +748,10 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
         # and so we don't know. Treating `None` as falsy allows calling
         # code to give `rebuild_has_died` the benefit of the doubt.
         return self.meta.build.rebuild_failed(self._id)
+
+    @property
+    def rebuild_awaiting_or_in_progress(self):
+        return self.meta.build.awaiting or (self.meta.build.is_rebuild_in_progress and not self.rebuild_failed)
 
 
 class RegistryDataSourceConfiguration(DataSourceConfiguration):

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -219,6 +219,9 @@ def resume_building_indicators(indicator_config_id, initiated_by=None):
     success = _('Your UCR table {} has finished rebuilding in {}').format(config.table_id, config.domain)
     failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
     with notify_someone(initiated_by, success_message=success, error_message=failure, send=True):
+        if not id_is_static(indicator_config_id):
+            config.meta.build.awaiting = False
+            config.save()
         resume_helper = DataSourceResumeHelper(config)
         adapter = get_indicator_adapter(config)
         adapter.log_table_build(

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -113,6 +113,7 @@ def rebuild_indicators(
         if not id_is_static(indicator_config_id):
             # Save the start time now in case anything goes wrong. This way we'll be
             # able to see if the rebuild started a long time ago without finishing.
+            config.meta.build.awaiting = False
             config.meta.build.initiated = datetime.utcnow()
             config.meta.build.finished = False
             config.meta.build.rebuilt_asynchronously = False
@@ -141,6 +142,7 @@ def rebuild_indicators_in_place(indicator_config_id, initiated_by=None, source=N
     with notify_someone(initiated_by, success_message=success, error_message=failure, send=True):
         adapter = get_indicator_adapter(config)
         if not id_is_static(indicator_config_id):
+            config.meta.build.awaiting = False
             config.meta.build.initiated_in_place = datetime.utcnow()
             config.meta.build.finished_in_place = False
             config.meta.build.rebuilt_asynchronously = False

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -17,7 +17,6 @@
           {% trans "Please note that this datasource is being rebuilt in place." %}
         {% endif %}
       </h4>
-      {% trans "If rebuilt again next rebuild will only start when the previous rebuild(s) finishes." %}
     </div>
   {% elif data_source.meta.build.awaiting %}
     <div class="alert alert-info">

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -20,7 +20,7 @@
     </div>
   {% elif data_source.meta.build.awaiting %}
     <div class="alert alert-info">
-      {% trans "Please note that this datasource is yet be picked for build / rebuild by CommCare HQ." %}
+      {% trans "Please note that this datasource is yet be built / rebuilt by CommCare HQ." %}
     </div>
   {% endif %}
   {% if data_source.get_id %}

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -153,7 +153,8 @@
           {% if not data_source.is_deactivated %}
             <li>
               <a
-                class="submit-dropdown-form"
+                class="submit-dropdown-form
+                {% if not data_source_rebuild_resumable %}btn disabled{% endif %}"
                 href=""
                 data-action="{% url 'resume_build' domain data_source.get_id %}"
               >

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -19,6 +19,10 @@
       </h4>
       {% trans "If rebuilt again next rebuild will only start when the previous rebuild(s) finishes." %}
     </div>
+  {% elif data_source.meta.build.awaiting %}
+    <div class="alert alert-info">
+      {% trans "Please note that this datasource is yet be picked for build / rebuild by CommCare HQ." %}
+    </div>
   {% endif %}
   {% if data_source.get_id %}
     <div class="btn-toolbar pull-right">

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -76,7 +76,7 @@
         </div>
       {% endif %}
       <div class="btn-group">
-        {% if data_source.disable_destructive_rebuild %}
+        {% if data_source.disable_destructive_rebuild or data_source.rebuild_awaiting_or_in_progress %}
           <div style="margin-right: 15px;">
             <button
               id="gtm-rebuild-ds-disabled"
@@ -89,13 +89,24 @@
                 {% trans 'Rebuild Data Source' %}
               {% endif %}
             </button>
-            {# janky: can't use a tooltip on a disabled button, so instead add a help icon and force extra space (above) so it's clear which button this is for. Todo: After bootstrap 4 upgrade there is a fix https://getbootstrap.com/docs/4.4/components/tooltips/#disabled-elements #}
-            <span
-              class="hq-help-template"
-              data-title="{% trans_html_attr "Rebuild Unavailable" %}"
-              data-content="{% trans_html_attr "Fully rebuilding has been disabled for this data source. Please use the in place rebuild if necessary." %}"
-              data-placement="left"
-            ></span>
+            {% if data_source.disable_destructive_rebuild %}
+              {# janky: can't use a tooltip on a disabled button, so instead add a help icon and force extra space (above) so it's clear which button this is for. Todo: After bootstrap 4 upgrade there is a fix https://getbootstrap.com/docs/4.4/components/tooltips/#disabled-elements #}
+              <span
+                class="hq-help-template"
+                data-title="{% trans_html_attr "Rebuild Unavailable" %}"
+                data-content="{% trans_html_attr "Fully rebuilding has been disabled for this data source. Please use the in place rebuild if necessary." %}"
+                data-placement="left"
+              >
+              </span>
+            {% elif data_source.rebuild_awaiting_or_in_progress %}
+              <span
+                class="hq-help-template"
+                data-title="{% trans_html_attr "Rebuild Unavailable" %}"
+                data-content="{% trans_html_attr "Rebuilding is not available until CommCare HQ finishes building / rebuilding." %}"
+                data-placement="left"
+              >
+              </span>
+            {% endif %}
           </div>
         {% else %}
           <div>
@@ -150,16 +161,24 @@
                 {% trans 'Resume Build' %}
               </a>
             </li>
-            <li>
-              <a
-                id="gtm-rebuild-in-place-btn"
-                class="submit-dropdown-form"
-                href=""
-                data-action="{% url 'build_in_place' domain data_source.get_id %}"
-              >
-                {% trans 'Rebuild Table in Place' %}
-              </a>
-            </li>
+            {% if data_source.rebuild_awaiting_or_in_progress %}
+              <li>
+                <a id="gtm-rebuild-in-place-disabled" class="btn disabled">
+                  {% trans 'Rebuild Table in Place' %}
+                </a>
+              </li>
+            {% else %}
+              <li>
+                <a
+                  id="gtm-rebuild-in-place-btn"
+                  class="submit-dropdown-form"
+                  href=""
+                  data-action="{% url 'build_in_place' domain data_source.get_id %}"
+                >
+                  {% trans 'Rebuild Table in Place' %}
+                </a>
+              </li>
+            {% endif %}
           {% endif %}
         </ul>
         <form method="post" class="hide" id="dropdown-form">

--- a/corehq/apps/userreports/templates/userreports/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/edit_data_source.html
@@ -77,7 +77,7 @@
       {% endif %}
       <div class="btn-group">
         {% if data_source.disable_destructive_rebuild or data_source.rebuild_awaiting_or_in_progress %}
-          <div style="margin-right: 15px;">
+          <div>
             <button
               id="gtm-rebuild-ds-disabled"
               class="btn btn-default"

--- a/corehq/apps/userreports/tests/test_tasks.py
+++ b/corehq/apps/userreports/tests/test_tasks.py
@@ -1,8 +1,16 @@
 from datetime import datetime
+from unittest.mock import Mock, call, patch
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
-from corehq.apps.userreports.tasks import time_in_range
+from corehq.apps.userreports.tasks import (
+    rebuild_indicators,
+    rebuild_indicators_in_place,
+    resume_building_indicators,
+    time_in_range,
+)
+from corehq.apps.userreports.tests.test_view import ConfigurableReportTestMixin
+from corehq.apps.userreports.util import get_ucr_datasource_config_by_id
 
 TEST_SETTINGS = {
     '*': [(0, 4), (12, 23)],
@@ -29,3 +37,122 @@ class TimeInRange(SimpleTestCase):
         for hour in range(12, 23):
             time = datetime(2018, 1, 22, hour)
             self.assertTrue(time_in_range(time, TEST_SETTINGS))
+
+
+class BaseTestRebuildIndicators(ConfigurableReportTestMixin, TestCase):
+    @classmethod
+    def tearDownClass(cls):
+        cls._delete_everything()
+        super().tearDownClass()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.data_source_config = cls._sample_data_source_config()
+        cls.data_source_config.save()
+
+
+class TestRebuildIndicators(BaseTestRebuildIndicators):
+    @patch('corehq.apps.userreports.tasks._report_ucr_rebuild_metrics')
+    @patch('corehq.apps.userreports.tasks._iteratively_build_table')
+    @patch('corehq.apps.userreports.tasks._get_rows_count_from_existing_table')
+    @patch('corehq.apps.userreports.tasks.get_indicator_adapter')
+    def test_rebuild_indicators(self, mock_get_indicator_adapter, mock_get_rows_count_from_existing_table,
+                                mock_iteratively_build_table, mock_report_ucr_rebuild_metrics):
+        mocked_adapter = Mock()
+        mock_get_indicator_adapter.return_value = mocked_adapter
+        self.data_source_config.meta.build.awaiting = True
+        self.data_source_config.meta.build.initiated = None
+        self.data_source_config.meta.build.finished = True
+        self.data_source_config.meta.build.rebuilt_asynchronously = True
+        self.data_source_config.save()
+
+        data_source_config = get_ucr_datasource_config_by_id(self.data_source_config.get_id)
+        self.assertTrue(data_source_config.meta.build.awaiting)
+        self.assertIsNone(data_source_config.meta.build.initiated)
+        self.assertTrue(data_source_config.meta.build.finished)
+        self.assertTrue(data_source_config.meta.build.rebuilt_asynchronously)
+
+        rebuild_indicators(self.data_source_config.get_id, source="test_rebuild_indicators")
+
+        # test calls
+        mock_get_indicator_adapter.assert_called_once()
+        mock_get_rows_count_from_existing_table.assert_called_once()
+        mocked_adapter.assert_has_calls([
+            call.rebuild_table(initiated_by=None, source="test_rebuild_indicators", skip_log=False, diffs=None)
+        ])
+        mock_iteratively_build_table.assert_called_once()
+        mock_report_ucr_rebuild_metrics.assert_called_once()
+
+        # test data source config updates
+        data_source_config = get_ucr_datasource_config_by_id(self.data_source_config.get_id)
+        self.assertFalse(data_source_config.meta.build.awaiting)
+        self.assertIsNotNone(data_source_config.meta.build.initiated)
+        self.assertFalse(data_source_config.meta.build.finished)
+        self.assertFalse(data_source_config.meta.build.rebuilt_asynchronously)
+
+
+class TestRebuildIndicatorsInPlace(BaseTestRebuildIndicators):
+    @patch('corehq.apps.userreports.tasks._report_ucr_rebuild_metrics')
+    @patch('corehq.apps.userreports.tasks._iteratively_build_table')
+    @patch('corehq.apps.userreports.tasks._get_rows_count_from_existing_table')
+    @patch('corehq.apps.userreports.tasks.get_indicator_adapter')
+    def test_rebuild_indicators_in_place(self, mock_get_indicator_adapter, mock_get_rows_count_from_existing_table,
+                                         mock_iteratively_build_table, mock_report_ucr_rebuild_metrics):
+        mocked_adapter = Mock()
+        mock_get_indicator_adapter.return_value = mocked_adapter
+        self.data_source_config.meta.build.awaiting = True
+        self.data_source_config.meta.build.initiated_in_place = None
+        self.data_source_config.meta.build.finished_in_place = True
+        self.data_source_config.meta.build.rebuilt_asynchronously = True
+        self.data_source_config.save()
+
+        data_source_config = get_ucr_datasource_config_by_id(self.data_source_config.get_id)
+        self.assertTrue(data_source_config.meta.build.awaiting)
+        self.assertIsNone(data_source_config.meta.build.initiated_in_place)
+        self.assertTrue(data_source_config.meta.build.finished_in_place)
+        self.assertTrue(data_source_config.meta.build.rebuilt_asynchronously)
+
+        rebuild_indicators_in_place(self.data_source_config.get_id, source="test_rebuild_indicators_in_place")
+
+        # test calls
+        mock_get_indicator_adapter.assert_called_once()
+        mock_get_rows_count_from_existing_table.assert_called_once()
+        mocked_adapter.assert_has_calls([
+            call.build_table(initiated_by=None, source="test_rebuild_indicators_in_place")
+        ])
+        mock_iteratively_build_table.assert_called_once()
+        mock_report_ucr_rebuild_metrics.assert_called_once()
+
+        # test data source config updates
+        data_source_config = get_ucr_datasource_config_by_id(self.data_source_config.get_id)
+        self.assertFalse(data_source_config.meta.build.awaiting)
+        self.assertIsNotNone(data_source_config.meta.build.initiated_in_place)
+        self.assertFalse(data_source_config.meta.build.finished_in_place)
+        self.assertFalse(data_source_config.meta.build.rebuilt_asynchronously)
+
+
+class TestResumeBuildingIndicators(BaseTestRebuildIndicators):
+    @patch('corehq.apps.userreports.tasks._iteratively_build_table')
+    @patch('corehq.apps.userreports.tasks.get_indicator_adapter')
+    def test_resume_building_indicators(self, mock_get_indicator_adapter, mock_iteratively_build_table):
+        mocked_adapter = Mock()
+        mock_get_indicator_adapter.return_value = mocked_adapter
+        self.data_source_config.meta.build.awaiting = True
+        self.data_source_config.save()
+
+        data_source_config = get_ucr_datasource_config_by_id(self.data_source_config.get_id)
+        self.assertTrue(data_source_config.meta.build.awaiting)
+
+        resume_building_indicators(self.data_source_config.get_id)
+
+        # test calls
+        mock_get_indicator_adapter.assert_called_once()
+        mocked_adapter.assert_has_calls([
+            call.log_table_build(initiated_by=None, source='resume_building_indicators')
+        ])
+        mock_iteratively_build_table.assert_called_once()
+
+        # test data source config updates
+        data_source_config = get_ucr_datasource_config_by_id(self.data_source_config.get_id)
+        self.assertFalse(data_source_config.meta.build.awaiting)

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -1,5 +1,5 @@
 import uuid
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from django.contrib.messages import get_messages
 from django.http import HttpRequest
@@ -27,8 +27,12 @@ from corehq.apps.userreports.models import (
     ReportConfiguration,
 )
 from corehq.apps.userreports.reports.view import ConfigurableReportView
-from corehq.apps.userreports.util import get_indicator_adapter
+from corehq.apps.userreports.util import (
+    get_indicator_adapter,
+    get_ucr_datasource_config_by_id,
+)
 from corehq.apps.userreports.views import (
+    _prep_data_source_for_rebuild,
     number_of_records_to_be_processed,
 )
 from corehq.apps.users.models import HQApiKey, HqPermissions, UserRole, WebUser
@@ -508,7 +512,8 @@ class TestDataSourceRebuild(ConfigurableReportTestMixin, TestCase):
         self.assertEqual(response.status_code, 404)
 
     @flag_enabled('USER_CONFIGURABLE_REPORTS')
-    def test_successful_rebuilt(self):
+    @patch('corehq.apps.userreports.views._prep_data_source_for_rebuild')
+    def test_successful_rebuilt(self, mock_prep_data_source_for_rebuild):
         response = self._send_data_source_rebuild_request()
         self.assertEqual(response.status_code, 302)
 
@@ -517,6 +522,8 @@ class TestDataSourceRebuild(ConfigurableReportTestMixin, TestCase):
             str(messages[0]),
             'Table "foo" is now being rebuilt. Data should start showing up soon'
         )
+
+        mock_prep_data_source_for_rebuild.assert_called_once()
 
     @flag_enabled('USER_CONFIGURABLE_REPORTS')
     @flag_enabled('RESTRICT_DATA_SOURCE_REBUILD')
@@ -549,6 +556,133 @@ class TestDataSourceRebuild(ConfigurableReportTestMixin, TestCase):
             str(messages[0]),
             'Table "foo" is now being rebuilt. Data should start showing up soon'
         )
+
+    @flag_enabled('USER_CONFIGURABLE_REPORTS')
+    def test_if_build_awaiting(self):
+        self.data_source_config.meta.build.awaiting = True
+        self.data_source_config.save()
+
+        response = self._send_data_source_rebuild_request()
+
+        self.assertEqual(response.status_code, 302)
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(
+            str(messages[0]),
+            'Rebuilding is not available until CommCare HQ finishes building / rebuilding.'
+        )
+
+        # reset for other tests
+        self.data_source_config.meta.build.awaiting = False
+        self.data_source_config.save()
+
+
+class TestPrepDataSourceForRebuild(ConfigurableReportTestMixin, TestCase):
+    def test_prep_data_source_for_rebuild_for_non_static(self):
+        data_source_config = self._sample_data_source_config()
+        data_source_config.is_deactivated = True
+        data_source_config.meta.build.awaiting = False
+        _prep_data_source_for_rebuild(data_source_config, is_static=False)
+
+        self.assertTrue(data_source_config.meta.build.awaiting)
+        self.assertFalse(data_source_config.is_deactivated)
+
+    def test_prep_data_source_for_rebuild_for_static(self):
+        data_source_config = self._sample_data_source_config()
+        data_source_config.is_deactivated = True
+        data_source_config.meta.build.awaiting = False
+        _prep_data_source_for_rebuild(data_source_config, is_static=True)
+
+        self.assertFalse(data_source_config.meta.build.awaiting)
+        self.assertFalse(data_source_config.is_deactivated)
+
+
+class TestBuildDataSourceInPlace(ConfigurableReportTestMixin, TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.data_source_config = cls._sample_data_source_config()
+        cls.data_source_config.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._delete_everything()
+        super().tearDownClass()
+
+    def _send_build_data_source_in_place_request(self):
+        path = reverse("build_in_place", args=(self.domain, self.data_source_config.get_id))
+        return self.client.post(path)
+
+    @flag_enabled('USER_CONFIGURABLE_REPORTS')
+    @patch('corehq.apps.userreports.views._report_ucr_rebuild_metrics')
+    @patch('corehq.apps.userreports.views.rebuild_indicators_in_place')
+    @patch('corehq.apps.userreports.views._prep_data_source_for_rebuild')
+    def test_successful_rebuilt(self, mock_prep_data_source_for_rebuild, mock_rebuild_indicators_in_place,
+                                mock_report_ucr_rebuild_metrics):
+        response = self._send_build_data_source_in_place_request()
+        self.assertEqual(response.status_code, 302)
+
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(
+            str(messages[0]),
+            'Table "foo" is now being rebuilt. Data should start showing up soon'
+        )
+
+        mock_prep_data_source_for_rebuild.assert_called_once()
+        mock_rebuild_indicators_in_place.assert_has_calls([
+            call.delay(self.data_source_config.get_id, '', source='edit_data_source_build_in_place',
+                       domain=self.domain)
+        ])
+        mock_report_ucr_rebuild_metrics.assert_called_once()
+
+    @flag_enabled('USER_CONFIGURABLE_REPORTS')
+    def test_if_build_awaiting(self):
+        self.data_source_config.meta.build.awaiting = True
+        self.data_source_config.save()
+
+        response = self._send_build_data_source_in_place_request()
+
+        self.assertEqual(response.status_code, 302)
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(
+            str(messages[0]),
+            'Rebuilding is not available until CommCare HQ finishes building / rebuilding.'
+        )
+
+        # reset for other tests
+        self.data_source_config.meta.build.awaiting = False
+        self.data_source_config.save()
+
+
+class TestResumeBuildingDataSource(ConfigurableReportTestMixin, TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.data_source_config = cls._sample_data_source_config()
+        cls.data_source_config.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._delete_everything()
+        super().tearDownClass()
+
+    def _send_resume_building_data_source_request(self):
+        path = reverse("resume_build", args=(self.domain, self.data_source_config.get_id))
+        return self.client.post(path)
+
+    @flag_enabled('USER_CONFIGURABLE_REPORTS')
+    @patch('corehq.apps.userreports.views.DataSourceResumeHelper')
+    @patch('corehq.apps.userreports.views.resume_building_indicators')
+    def test_awaiting_set(self, mock_resume_building_indicators, mock_helper):
+        self.data_source_config.meta.build.awaiting = False
+        self.data_source_config.save()
+
+        self._send_resume_building_data_source_request()
+
+        mock_resume_building_indicators.assert_has_calls([
+            call.delay(self.data_source_config.get_id, '')
+        ])
+        data_source_config = get_ucr_datasource_config_by_id(self.data_source_config.get_id)
+        self.assertTrue(data_source_config.meta.build.awaiting)
 
 
 class TestSubscribeToDataSource(TestCase):

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -289,6 +289,7 @@ class ConfigurableDataSourceEditForm(DocumentFormBase):
     def save(self, commit=False):
         self.instance.meta.build.finished = False
         self.instance.meta.build.initiated = None
+        self.instance.meta.build.awaiting = True
         instance = super(ConfigurableDataSourceEditForm, self).save(commit)
         self._report_edit_datasource_metrics()
         return instance

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1330,6 +1330,10 @@ def undelete_data_source(request, domain, config_id):
 def rebuild_data_source(request, domain, config_id):
     config, is_static = get_datasource_config_or_404(config_id, domain)
 
+    response = _redirect_response_if_build_awaiting(request, domain, config)
+    if response:
+        return response
+
     if not config.asynchronous and toggles.RESTRICT_DATA_SOURCE_REBUILD.enabled(domain):
         number_of_records = number_of_records_to_be_processed(datasource_configuration=config)
         if number_of_records and number_of_records > DATA_SOURCE_REBUILD_RESTRICTED_AT:
@@ -1355,6 +1359,17 @@ def rebuild_data_source(request, domain, config_id):
     return HttpResponseRedirect(reverse(
         EditDataSourceView.urlname, args=[domain, config._id]
     ))
+
+
+def _redirect_response_if_build_awaiting(request, domain, config):
+    if config.meta.build.awaiting:
+        messages.error(
+            request,
+            _('Rebuilding is not available until CommCare HQ finishes building / rebuilding.')
+        )
+        return HttpResponseRedirect(reverse(
+            EditDataSourceView.urlname, args=[domain, config.get_id]
+        ))
 
 
 def _prep_data_source_for_rebuild(data_source_config, is_static):
@@ -1477,6 +1492,11 @@ def resume_building_data_source(request, domain, config_id):
 @require_POST
 def build_data_source_in_place(request, domain, config_id):
     config, is_static = get_datasource_config_or_404(config_id, domain)
+
+    response = _redirect_response_if_build_awaiting(request, domain, config)
+    if response:
+        return response
+
     _prep_data_source_for_rebuild(config, is_static)
 
     messages.success(

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1268,6 +1268,8 @@ class EditDataSourceView(BaseEditDataSourceView):
         page_context = super().page_context
         adapter = get_indicator_adapter(self.config)
         page_context['data_source_table_exists'] = adapter.table_exists
+        if not self.config.is_deactivated:
+            page_context['data_source_rebuild_resumable'] = DataSourceResumeHelper(self.config).has_resume_info()
         return page_context
 
 

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1460,6 +1460,9 @@ def resume_building_data_source(request, domain, config_id):
             )
         )
     else:
+        if not is_static:
+            config.meta.build.awaiting = True
+            config.save()
         messages.success(
             request,
             _('Resuming rebuilding table "{}".').format(config.display_name)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1341,8 +1341,15 @@ def rebuild_data_source(request, domain, config_id):
                 EditDataSourceView.urlname, args=[domain, config_id]
             ))
 
+    save_config = False
+    if not id_is_static(config_id):
+        config.meta.build.awaiting = True
+        save_config = True
     if config.is_deactivated:
         config.is_deactivated = False
+        save_config = True
+
+    if save_config:
         config.save()
 
     messages.success(
@@ -1463,8 +1470,15 @@ def resume_building_data_source(request, domain, config_id):
 @require_POST
 def build_data_source_in_place(request, domain, config_id):
     config, is_static = get_datasource_config_or_404(config_id, domain)
+    save_config = False
+    if not id_is_static(config_id):
+        config.meta.build.awaiting = True
+        save_config = True
     if config.is_deactivated:
         config.is_deactivated = False
+        save_config = True
+
+    if save_config:
         config.save()
 
     messages.success(

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1209,7 +1209,7 @@ class BaseEditDataSourceView(BaseUserConfigReportsView):
                     config.display_name
                 ))
                 messages.success(request, _(
-                    'This data source will be picked for build / rebuild automatically by CommCare HQ.'
+                    'This data source will be built / rebuilt automatically by CommCare HQ.'
                 ))
                 if self.config_id is None:
                     return HttpResponseRedirect(reverse(

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1341,16 +1341,7 @@ def rebuild_data_source(request, domain, config_id):
                 EditDataSourceView.urlname, args=[domain, config_id]
             ))
 
-    save_config = False
-    if not id_is_static(config_id):
-        config.meta.build.awaiting = True
-        save_config = True
-    if config.is_deactivated:
-        config.is_deactivated = False
-        save_config = True
-
-    if save_config:
-        config.save()
+    _prep_data_source_for_rebuild(config, is_static)
 
     messages.success(
         request,
@@ -1364,6 +1355,19 @@ def rebuild_data_source(request, domain, config_id):
     return HttpResponseRedirect(reverse(
         EditDataSourceView.urlname, args=[domain, config._id]
     ))
+
+
+def _prep_data_source_for_rebuild(data_source_config, is_static):
+    save_config = False
+    if not is_static:
+        data_source_config.meta.build.awaiting = True
+        save_config = True
+    if data_source_config.is_deactivated:
+        data_source_config.is_deactivated = False
+        save_config = True
+
+    if save_config:
+        data_source_config.save()
 
 
 def _report_ucr_rebuild_metrics(domain, config, action):
@@ -1470,16 +1474,7 @@ def resume_building_data_source(request, domain, config_id):
 @require_POST
 def build_data_source_in_place(request, domain, config_id):
     config, is_static = get_datasource_config_or_404(config_id, domain)
-    save_config = False
-    if not id_is_static(config_id):
-        config.meta.build.awaiting = True
-        save_config = True
-    if config.is_deactivated:
-        config.is_deactivated = False
-        save_config = True
-
-    if save_config:
-        config.save()
+    _prep_data_source_for_rebuild(config, is_static)
 
     messages.success(
         request,


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
For a data source, if a build or rebuild is to happen (like for new or updated data sources) or is already in progress, avoid accepting a new rebuild request by disabling the "rebuild" and "build table in place" buttons.

Similarly, the "Resume Build" option is also now only available when there is a failed build to be resumed, otherwise it's disabled.

Here is what the user sees now:
In case of a rebuild request

![image](https://github.com/user-attachments/assets/45e0f7e6-4ef5-4f04-9a1c-8931fd8d3e54)

----- 

![image](https://github.com/user-attachments/assets/b9574300-d29c-4b95-8df0-47edccc9a9a3)

----
In case of a new data source yet to be built

![image](https://github.com/user-attachments/assets/cd91028d-6088-4ad8-ab05-eac3e0baeacc)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-4092

We already track build information for a data source and when a rebuild is in progress. Here, we extend that to also track if a data source is awaiting to be picked up for building/rebuilding.
Based on the state of different build information points and by checking with celery about the presence of the task, we disabled the rebuild button.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
USER_CONFIGURABLE_REPORTS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. Blast radius is limited to data source page only.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[Will take through QA.](https://dimagi.atlassian.net/browse/QA-7439)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
