### PR TITLE
Refresh django user in save signal

### DIFF
--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -84,7 +84,6 @@ class SsoBackend(ModelBackend):
         if not is_new_user and not web_user.is_active:
             web_user.is_active = True
             web_user.save()
-            user.refresh_from_db()
             request.sso_new_user_messages['success'].append(
                 _("User account for {} has been re-activated.").format(web_user.username)
             )

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1587,6 +1587,8 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         else:
             couch_user = cls.from_django_user(django_user)
             if couch_user:
+                # ensure we sync from an up to date django user
+                django_user.refresh_from_db()
                 couch_user.sync_from_django_user(django_user)
 
                 try:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Without this, we risk unexpected behavior/values for fields shared between both the couch user and django user. This builds off of https://github.com/dimagi/commcare-hq/pull/35228, but puts the refresh logic into the couch user save signal handling itself to ensure the caller doesn't need to think about if the django user is stale or not.

I reverted the change made in that PR as this change solves the same problem on a deeper level.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I could create a test demonstrating that sending a stale django user to the couch user save signal will result in unexpected behavior in the couch user field. Before applying my change, the test that I added fails with:
```
FAILED corehq/apps/users/tests/test_signals.py::TestDjangoUserPostSaveSignal::test_signal_can_handle_stale_django_user - AssertionError: 'test@example.com' != ''  
```

From a performance perspective, this code is only executed when the django user is saved independent of a couch user save. For example, `login` updates the django user's last_logged_in field, which triggers a genuine save to be synced back to the couch user. Given that the couch user is our primary data model, and the django user is used for authentication purposes, most of the time we are saving the couch user first. This means the `DO_NOT_SAVE_COUCH_USER` attribute will be added to the django user when saving it, and the code added here to refresh from the db won't be run.


### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
