### PR TITLE
Stripe Upgrade

### DIFF
--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -4,7 +4,7 @@ from django.core import mail
 from unittest import mock
 from django_prbac.models import Role
 import stripe
-from stripe.stripe_object import StripeObject
+from stripe import StripeObject
 
 from dimagi.utils.dates import add_months_to_date
 

--- a/corehq/apps/accounting/tests/test_stripe_payment.py
+++ b/corehq/apps/accounting/tests/test_stripe_payment.py
@@ -3,7 +3,7 @@ from django.test.client import RequestFactory
 
 import stripe
 from unittest.mock import patch
-from stripe.stripe_object import StripeObject
+from stripe import StripeObject
 
 from corehq.apps.accounting.models import (
     BillingAccount,

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -65,6 +65,9 @@ WHITELIST = [
     # warnings that should not be ignored
     # note: override_action "default" causes warning to be printed on stderr
     ("django.db.backends.postgresql.base", "unable to create a connection", RuntimeWarning, "default"),
+    # This is an internal stripe-python warning that is not actionable as of now
+    # It might get resolved in the future, but for now, it is not actionable
+    ("stripe", "For internal stripe-python use only. The public interface will be removed in a future version"),
 ]
 
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -762,7 +762,7 @@ stack-data==0.1.4
     # via ipython
 stone==3.3.1
     # via dropbox
-stripe==7.2.0
+stripe==8.11.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -762,7 +762,7 @@ stack-data==0.1.4
     # via ipython
 stone==3.3.1
     # via dropbox
-stripe==9.12.0
+stripe==10.12.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -762,7 +762,7 @@ stack-data==0.1.4
     # via ipython
 stone==3.3.1
     # via dropbox
-stripe==8.11.0
+stripe==9.12.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -762,7 +762,7 @@ stack-data==0.1.4
     # via ipython
 stone==3.3.1
     # via dropbox
-stripe==10.12.0
+stripe==11.4.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -640,7 +640,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==9.12.0
+stripe==10.12.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -640,7 +640,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==8.11.0
+stripe==9.12.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -640,7 +640,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==7.2.0
+stripe==8.11.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -640,7 +640,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==10.12.0
+stripe==11.4.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -625,7 +625,7 @@ stack-data==0.1.4
     # via ipython
 stone==3.3.1
     # via dropbox
-stripe==8.11.0
+stripe==9.12.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -625,7 +625,7 @@ stack-data==0.1.4
     # via ipython
 stone==3.3.1
     # via dropbox
-stripe==7.2.0
+stripe==8.11.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -625,7 +625,7 @@ stack-data==0.1.4
     # via ipython
 stone==3.3.1
     # via dropbox
-stripe==10.12.0
+stripe==11.4.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -625,7 +625,7 @@ stack-data==0.1.4
     # via ipython
 stone==3.3.1
     # via dropbox
-stripe==9.12.0
+stripe==10.12.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -584,7 +584,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==9.12.0
+stripe==10.12.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -584,7 +584,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==8.11.0
+stripe==9.12.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -584,7 +584,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==10.12.0
+stripe==11.4.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -584,7 +584,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==7.2.0
+stripe==8.11.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -640,7 +640,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==9.12.0
+stripe==10.12.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -640,7 +640,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==8.11.0
+stripe==9.12.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -640,7 +640,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==7.2.0
+stripe==8.11.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -640,7 +640,7 @@ sqlparse==0.5.0
     # via django
 stone==3.3.1
     # via dropbox
-stripe==10.12.0
+stripe==11.4.0
     # via -r base-requirements.in
 suds-py3==1.4.5.0
     # via -r base-requirements.in


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Upgrades stripe to latest available version i.e 11.4.
Starting from version 8, Stripe has introduced a new way to interact with Stripe SDK using a service based pattern. See [this](https://github.com/stripe/stripe-python/wiki/Migration-guide-for-v8-(StripeClient)) but Stripe also supports the existing pattern. 
I tried to do this upgrade version by version to and deal with any failures that come along the way. Luckily the only change that we needed to do was [fd9797b](https://github.com/dimagi/commcare-hq/pull/35635/commits/fd9797b83445091b851c8c38b4078b301ddd74d4) 
Usage of Stripe library in HQ has a very good coverage(thanks to @jingcheng16) I am fairly confident that if tests pass then we should be good to go. Since this library deals with a critical system of HQ, I have additionally requested QA on this.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A
## Safety Assurance
Has good test coverage and once through QA should be pretty safe to merge.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Changes are covered by tests.
### QA Plan
https://dimagi.atlassian.net/browse/QA-7404
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
