### PR TITLE
Remove Save and Favorites buttons from remaining accounting admin pages

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -114,6 +114,7 @@ def invoice_cost_cell(invoice):
 class AddItemInterface(GenericTabularReport):
     base_template = 'accounting/partials/add_new_item_button.html'
     exportable = True
+    is_admin_report = True
 
     item_name = None
     new_item_view = None
@@ -143,7 +144,6 @@ class AccountingInterface(AddItemInterface):
     slug = "accounts"
     dispatcher = AccountingAdminInterfaceDispatcher
     hide_filters = False
-    is_admin_report = True
     item_name = "Billing Account"
 
     fields = [


### PR DESCRIPTION
## Product Description
This change should cause the "Save" and "Favorites" buttons to be removed from all of the accounting admin pages. They were previously removed from only a subset of pages.

## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/35581/

QA pointed out that the change (removing the "Save" and "Favorites" buttons) was only affecting some accounting reports, and it turns out I should have added the flag to the superclass. `AddItemInterface` is also used by `IdentityProviderInterface` in the sso app, which should be fine since that's also within accounting admin.

## Safety Assurance

### Safety story
Minor UI change to internal admin pages.

### Automated test coverage

Not of this change.

### QA Plan

No formal ticket, but QA will verify this, we're discussing on [QA-7353](https://dimagi.atlassian.net/browse/QA-7353?focusedCommentId=361670).

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[QA-7353]: https://dimagi.atlassian.net/browse/QA-7353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ