### PR TITLE
Geoconfig and API settings models: AES CBC encryption read and write

### DIFF
--- a/corehq/apps/geospatial/const.py
+++ b/corehq/apps/geospatial/const.py
@@ -2,6 +2,7 @@
 GPS_POINT_CASE_PROPERTY = 'gps_point'
 
 ALGO_AES = 'aes'
+ALGO_AES_CBC = 'aes-cbc'
 
 # Max number of cases per geohash
 MAX_GEOHASH_DOC_COUNT = 1_000

--- a/corehq/apps/geospatial/const.py
+++ b/corehq/apps/geospatial/const.py
@@ -1,9 +1,6 @@
 
 GPS_POINT_CASE_PROPERTY = 'gps_point'
 
-ALGO_AES = 'aes'
-ALGO_AES_CBC = 'aes-cbc'
-
 # Max number of cases per geohash
 MAX_GEOHASH_DOC_COUNT = 1_000
 

--- a/corehq/apps/geospatial/models.py
+++ b/corehq/apps/geospatial/models.py
@@ -5,13 +5,12 @@ from django.core.exceptions import ValidationError
 
 from corehq.apps.geospatial.const import (
     GPS_POINT_CASE_PROPERTY,
-    ALGO_AES,
-    ALGO_AES_CBC,
     TRAVEL_MODE_WALKING,
     TRAVEL_MODE_CYCLING,
     TRAVEL_MODE_DRIVING,
 )
 from corehq.apps.geospatial.routing_solvers import pulp
+from corehq.motech.const import ALGO_AES, ALGO_AES_CBC
 from corehq.motech.utils import (
     b64_aes_decrypt,
     b64_aes_cbc_decrypt,

--- a/corehq/apps/geospatial/models.py
+++ b/corehq/apps/geospatial/models.py
@@ -6,12 +6,17 @@ from django.core.exceptions import ValidationError
 from corehq.apps.geospatial.const import (
     GPS_POINT_CASE_PROPERTY,
     ALGO_AES,
+    ALGO_AES_CBC,
     TRAVEL_MODE_WALKING,
     TRAVEL_MODE_CYCLING,
     TRAVEL_MODE_DRIVING,
 )
 from corehq.apps.geospatial.routing_solvers import pulp
-from corehq.motech.utils import b64_aes_encrypt, b64_aes_decrypt
+from corehq.motech.utils import (
+    b64_aes_decrypt,
+    b64_aes_cbc_decrypt,
+    b64_aes_cbc_encrypt,
+)
 
 
 class GeoPolygon(models.Model):
@@ -112,9 +117,13 @@ class GeoConfig(models.Model):
 
     @property
     def plaintext_api_token(self):
-        if self.api_token and self.api_token.startswith(f'${ALGO_AES}$'):
-            ciphertext = self.api_token.split('$', 2)[2]
-            return b64_aes_decrypt(ciphertext)
+        if self.api_token:
+            if self.api_token.startswith(f'${ALGO_AES}$'):  # This will be deleted after migration to cbc is done
+                ciphertext = self.api_token.split('$', 2)[2]
+                return b64_aes_decrypt(ciphertext)
+            elif self.api_token.startswith(f'${ALGO_AES_CBC}$'):
+                ciphertext = self.api_token.split('$', 2)[2]
+                return b64_aes_cbc_decrypt(ciphertext)
         return self.api_token
 
     @plaintext_api_token.setter
@@ -124,9 +133,9 @@ class GeoConfig(models.Model):
         else:
             assert isinstance(value, str), "Only string values allowed for api token"
 
-            if value and not value.startswith(f'${ALGO_AES}$'):
-                ciphertext = b64_aes_encrypt(value)
-                self.api_token = f'${ALGO_AES}${ciphertext}'
+            if value and not value.startswith(f'${ALGO_AES_CBC}$'):
+                ciphertext = b64_aes_cbc_encrypt(value)
+                self.api_token = f'${ALGO_AES_CBC}${ciphertext}'
             else:
                 raise Exception("Unexpected value set for plaintext api token")
 

--- a/corehq/apps/geospatial/tests/test_models.py
+++ b/corehq/apps/geospatial/tests/test_models.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 from django.test import TestCase
 
-from ..const import GPS_POINT_CASE_PROPERTY, ALGO_AES
+from ..const import GPS_POINT_CASE_PROPERTY, ALGO_AES_CBC
 from ..models import GeoConfig
 from ..utils import get_geo_case_property
 
@@ -25,7 +25,7 @@ class TestGeoConfig(TestCase):
         with self.get_geo_config() as config:
             config.plaintext_api_token = '1234'
             self.assertEqual(config.plaintext_api_token, '1234')
-            self.assertTrue(config.api_token.startswith(f"${ALGO_AES}$"))
+            self.assertTrue(config.api_token.startswith(f"${ALGO_AES_CBC}$"))
 
             config.plaintext_api_token = None
             self.assertEqual(config.plaintext_api_token, None)
@@ -48,7 +48,7 @@ class TestGeoConfig(TestCase):
     def test_geo_config_api_token_cannot_start_with_encryption_str(self):
         with self.assertRaises(Exception) as context:
             with self.get_geo_config() as config:
-                config.plaintext_api_token = f"${ALGO_AES}$1234"
+                config.plaintext_api_token = f"${ALGO_AES_CBC}$1234"
 
         self.assertEqual(str(context.exception), "Unexpected value set for plaintext api token")
 

--- a/corehq/apps/geospatial/tests/test_models.py
+++ b/corehq/apps/geospatial/tests/test_models.py
@@ -2,9 +2,10 @@ from contextlib import contextmanager
 
 from django.test import TestCase
 
-from ..const import GPS_POINT_CASE_PROPERTY, ALGO_AES_CBC
+from ..const import GPS_POINT_CASE_PROPERTY
 from ..models import GeoConfig
 from ..utils import get_geo_case_property
+from corehq.motech.const import ALGO_AES_CBC
 
 
 class TestGeoConfig(TestCase):

--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -165,8 +165,9 @@ class ConnectionSettings(models.Model):
     def last_token(self) -> Optional[dict]:
         if self.last_token_aes:
             if self.last_token_aes.startswith(f'${ALGO_AES_CBC}$'):
-                ciphertext = self.client_secret.split('$', 2)[2]
-                return b64_aes_cbc_decrypt(ciphertext)
+                ciphertext = self.last_token_aes.split('$', 2)[2]
+                plaintext = b64_aes_cbc_decrypt(ciphertext)
+                return json.loads(plaintext)
             else:
                 # This will be deleted after migration to cbc is done
                 plaintext = b64_aes_decrypt(self.last_token_aes)
@@ -180,7 +181,7 @@ class ConnectionSettings(models.Model):
         else:
             plaintext = json.dumps(token)
             ciphertext = b64_aes_cbc_encrypt(plaintext)
-            self.last_token_aes_cbc = f'${ALGO_AES_CBC}${ciphertext}'
+            self.last_token_aes = f'${ALGO_AES_CBC}${ciphertext}'
 
     @property
     def notify_addresses(self):

--- a/corehq/motech/tests/test_auth.py
+++ b/corehq/motech/tests/test_auth.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from corehq.motech.auth import BasicAuthManager
-from corehq.motech.const import ALGO_AES, BASIC_AUTH
+from corehq.motech.const import ALGO_AES_CBC, BASIC_AUTH
 from corehq.motech.models import ConnectionSettings
 
 
@@ -30,4 +30,4 @@ class ConnectionSettingsAuthManagerTests(TestCase):
         self.assertEqual(auth_manager.username, self.username)
         self.assertEqual(auth_manager.password, self.password)
         self.assertNotEqual(auth_manager.password, self.connx.password)
-        self.assertTrue(self.connx.password.startswith(f'${ALGO_AES}$'))
+        self.assertTrue(self.connx.password.startswith(f'${ALGO_AES_CBC}$'))

--- a/corehq/motech/tests/test_models.py
+++ b/corehq/motech/tests/test_models.py
@@ -15,6 +15,7 @@ from corehq.motech.models import (
     RequestLogEntry,
 )
 from corehq.motech.requests import get_basic_requests
+from corehq.motech.utils import b64_aes_encrypt
 from corehq.util import as_json_text, as_text
 
 TEST_API_URL = 'http://example.com:9080/api/'
@@ -163,6 +164,11 @@ class ConnectionSettingsPropertiesTests(SimpleTestCase):
         cs.plaintext_client_secret = PASSWORD_PLACEHOLDER
         self.assertEqual(cs.client_secret, '')
 
+    def test_last_token_setter_none(self):
+        cs = ConnectionSettings()
+        cs.last_token = None
+        self.assertEqual(cs.last_token_aes, '')
+
     def test_password_setter(self):
         cs = ConnectionSettings()
         cs.plaintext_password = 'secret'
@@ -172,6 +178,12 @@ class ConnectionSettingsPropertiesTests(SimpleTestCase):
         cs = ConnectionSettings()
         cs.plaintext_client_secret = 'secret'
         self.assertTrue(cs.client_secret.startswith(f'${ALGO_AES_CBC}$'))
+
+    def test_last_token_setter(self):
+        cs = ConnectionSettings()
+        token = {'key': 'value'}
+        cs.last_token = token
+        self.assertTrue(cs.last_token_aes.startswith(f'${ALGO_AES_CBC}$'))
 
     def test_password_getter_decrypts(self):
         cs = ConnectionSettings()
@@ -183,6 +195,19 @@ class ConnectionSettingsPropertiesTests(SimpleTestCase):
         cs.plaintext_client_secret = 'secret'
         self.assertEqual(cs.plaintext_client_secret, 'secret')
 
+    def test_last_token_getter_decrypts_cbc(self):
+        cs = ConnectionSettings()
+        token = {'key': 'value'}
+        cs.last_token = token
+        self.assertEqual(cs.last_token, token)
+
+    def test_last_token_getter_decrypts_ecb(self):
+        cs = ConnectionSettings()
+        token = {'key': 'value'}
+        plaintext = json.dumps(token)
+        cs.last_token_aes = b64_aes_encrypt(plaintext)
+        self.assertEqual(cs.last_token, token)
+
     def test_password_getter_returns(self):
         cs = ConnectionSettings()
         cs.password = 'secret'
@@ -192,6 +217,11 @@ class ConnectionSettingsPropertiesTests(SimpleTestCase):
         cs = ConnectionSettings()
         cs.client_secret = 'secret'
         self.assertEqual(cs.plaintext_client_secret, 'secret')
+
+    def test_last_token_getter_returns(self):
+        cs = ConnectionSettings()
+        cs.last_token_aes = ''
+        self.assertIsNone(cs.last_token)
 
 
 class NotifyAddressesTests(SimpleTestCase):

--- a/corehq/motech/tests/test_models.py
+++ b/corehq/motech/tests/test_models.py
@@ -8,7 +8,7 @@ import requests
 from unittest.mock import ANY, Mock, patch
 
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import pp_json
-from corehq.motech.const import ALGO_AES, PASSWORD_PLACEHOLDER
+from corehq.motech.const import ALGO_AES_CBC, PASSWORD_PLACEHOLDER
 from corehq.motech.models import (
     ConnectionSettings,
     RequestLog,
@@ -166,12 +166,12 @@ class ConnectionSettingsPropertiesTests(SimpleTestCase):
     def test_password_setter(self):
         cs = ConnectionSettings()
         cs.plaintext_password = 'secret'
-        self.assertTrue(cs.password.startswith(f'${ALGO_AES}$'))
+        self.assertTrue(cs.password.startswith(f'${ALGO_AES_CBC}$'))
 
     def test_client_secret_setter(self):
         cs = ConnectionSettings()
         cs.plaintext_client_secret = 'secret'
-        self.assertTrue(cs.client_secret.startswith(f'${ALGO_AES}$'))
+        self.assertTrue(cs.client_secret.startswith(f'${ALGO_AES_CBC}$'))
 
     def test_password_getter_decrypts(self):
         cs = ConnectionSettings()

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -132,6 +132,10 @@ def b64_aes_cbc_decrypt(message):
     return plaintext_bytes.decode('utf8')
 
 
+class AesEcbDecryptionError(Exception):
+    pass
+
+
 # Only needed for migration from ECB to CBC mode.
 def reencrypt_ecb_to_cbc_mode(encrypted_text, existing_prefix=None):
     """
@@ -144,8 +148,11 @@ def reencrypt_ecb_to_cbc_mode(encrypted_text, existing_prefix=None):
         ciphertext = encrypted_text[len(existing_prefix):]
     else:
         ciphertext = encrypted_text
-
-    new_ciphertext = b64_aes_cbc_encrypt(b64_aes_decrypt(ciphertext))
+    try:
+        plaintext = b64_aes_decrypt(ciphertext)
+    except UnicodeDecodeError:
+        raise AesEcbDecryptionError("Failed to decrypt the AES-ECB-encrypted text.")
+    new_ciphertext = b64_aes_cbc_encrypt(plaintext)
     return f'${ALGO_AES_CBC}${new_ciphertext}'
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
N/A

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Continuation of the work initiated by [this PR](https://github.com/dimagi/commcare-hq/pull/35403) 
[Jira Ticket
](https://dimagi.atlassian.net/browse/USH-5180)

Introduces a solution for these code scan alerts:
https://github.com/dimagi/commcare-hq/security/code-scanning/295
https://github.com/dimagi/commcare-hq/security/code-scanning/296

This PR updates `GeoConfig`'s `api_token`, and `ConnectionSettings`'s `password`, `client_secret`, and `last_token_aes`. The model continues supporting reads for both AES ECB and AES CBC encryption while writes only with CBC encryption.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested. This change will not affect any existing data and existing data will be read the same way.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There exists tests that the encryption and decryption with CBC results in the expected plaintext.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
There is no migration in this PR. But there is a follow up PR that does a migration related to the changes in this PR.
[Related migration
](https://github.com/dimagi/commcare-hq/pull/35641)
<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
This PR will start writing data with AES CBC encryption while also adding support to read AES CBC encrypted data. If this PR is reverted, the data encrypted with CBC will fail to be decrypted. To rollback this PR, data written with AES CBC encryption will need to be reencrypted with EBC.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
