### PR TITLE
Coderabbit/config updates

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,7 +13,7 @@ reviews:
     path_instructions:
         - path: "**/*.js"
           instructions: >-
-            - Review the JavaScript code against the Google JavaScript style guide and point out any mismatches
+            - Review the JavaScript code against the [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) and point out any mismatches
             - Also follow [this guide](https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/code-review.rst)
         - path: "**/*.py"
           instructions: >-

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,6 @@ reviews:
     high_level_summary: false
     review_status: false
     poem: false
-    collapse_walkthrough: true
     changed_files_summary: false
     abort_on_close: true
     instructions: >-

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,7 +18,7 @@ reviews:
         - path: "**/*.py"
           instructions: >-
             - Review the code following best practises and standards
-    path_filters: ["**/*.js", "**/*.py", "**/*.md", "**/*.rst"]
+    path_filters: ["**/*.js", "**/*.py", "**/*.md", "**/*.rst", "**/*.html"]
     auto_review:
         enabled: false
         auto_incremental_review: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,13 +1,25 @@
 language: en-US
 early_access: true
 reviews:
-  high_level_summary: false
-  review_status: false
-  poem: false
-  collapse_walkthrough: true
-  changed_files_summary: false
-  abort_on_close: true
-  auto_review:
-    enabled: false
-    auto_incremental_review: false
-    drafts: false
+    high_level_summary: false
+    review_status: false
+    poem: false
+    collapse_walkthrough: true
+    changed_files_summary: false
+    abort_on_close: true
+    instructions: >-
+        - Consider the [code review](https://github.com/dimagi/open-source/blob/master/docs/code_review.md) and [contributing](https://github.com/dimagi/commcare-hq/blob/master/CONTRIBUTING.rst)
+        guides when doing a review.
+        - Follow the [project standards and best practices](https://github.com/dimagi/commcare-hq/blob/master/STANDARDS.rst) guide.
+    path_instructions:
+        - path: "**/*.js"
+          instructions: >-
+            - Review the JavaScript code against the Google JavaScript style guide and point out any mismatches
+            - Follow [this guide](https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/code-review.rst)
+        - path: "**/*.py"
+          instructions: >-
+            - Review the code following best practises and standards
+    auto_review:
+        enabled: false
+        auto_incremental_review: false
+        drafts: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,4 +10,4 @@ reviews:
   auto_review:
     enabled: false
     auto_incremental_review: false
-    drafts: true
+    drafts: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,12 +9,12 @@ reviews:
     instructions: >-
         - Consider the [code review](https://github.com/dimagi/open-source/blob/master/docs/code_review.md) and [contributing](https://github.com/dimagi/commcare-hq/blob/master/CONTRIBUTING.rst)
         guides when doing a review.
-        - Follow the [project standards and best practices](https://github.com/dimagi/commcare-hq/blob/master/STANDARDS.rst) guide.
+        - Also follow the [project standards and best practices](https://github.com/dimagi/commcare-hq/blob/master/STANDARDS.rst) guide.
     path_instructions:
         - path: "**/*.js"
           instructions: >-
             - Review the JavaScript code against the Google JavaScript style guide and point out any mismatches
-            - Follow [this guide](https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/code-review.rst)
+            - Also follow [this guide](https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/code-review.rst)
         - path: "**/*.py"
           instructions: >-
             - Review the code following best practises and standards

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,6 +18,7 @@ reviews:
         - path: "**/*.py"
           instructions: >-
             - Review the code following best practises and standards
+    path_filters: ["**/*.js", "**/*.py", "**/*.md", "**/*.rst"]
     auto_review:
         enabled: false
         auto_incremental_review: false


### PR DESCRIPTION
Makes some updates to the coderabbit configuration file.

I'm not 100% sure if we can simply give it links like I did in the instructions and assume it will load the content as context, but that's what I want to test out.

I'm also trying to tell it to only review certain files, as seen in the `path_filters` config. I thought it's probably best to tell it what we want it to review rather than what we don't want to reduce unintentional noise. Maybe we can flip it.