### PR TITLE
Added is_admin_report to remaining accounting reports

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -487,6 +487,7 @@ class InvoiceInterfaceBase(GenericTabularReport):
     dispatcher = AccountingAdminInterfaceDispatcher
     exportable = True
     export_format_override = Format.CSV
+    is_admin_report = True
 
     def filter_by_subscription(self, subscription):
         self.subscription = subscription
@@ -1212,6 +1213,7 @@ class PaymentRecordInterface(GenericTabularReport):
     base_template = 'accounting/report_filter_actions.html'
     asynchronous = True
     exportable = True
+    is_admin_report = True
 
     fields = [
         'corehq.apps.accounting.interface.DateCreatedFilter',
@@ -1303,6 +1305,7 @@ class SubscriptionAdjustmentInterface(GenericTabularReport):
     base_template = 'accounting/report_filter_actions.html'
     asynchronous = True
     exportable = True
+    is_admin_report = True
 
     fields = [
         'corehq.apps.accounting.interface.DomainFilter',
@@ -1373,6 +1376,7 @@ class CreditAdjustmentInterface(GenericTabularReport):
     base_template = 'accounting/report_filter_actions.html'
     asynchronous = True
     exportable = True
+    is_admin_report = True
 
     fields = [
         'corehq.apps.accounting.interface.NameFilter',


### PR DESCRIPTION
## Technical Summary
See https://github.com/dimagi/commcare-hq/pull/35637

This time I went through all of the direct subclasses of `GenericTabularReport` in `interface.py` so hopefully this is the last PR.

## Safety Assurance

### Safety story
Minor configuration change to some admin reports.

### Automated test coverage

no

### QA Plan

QA will verify, we're discussing this on [QA-7353](https://dimagi.atlassian.net/browse/QA-7353).

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[QA-7353]: https://dimagi.atlassian.net/browse/QA-7353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ