### PR TITLE
Clean up js errors in a few accounting reports

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/report_filter_actions.js
+++ b/corehq/apps/accounting/static/accounting/js/report_filter_actions.js
@@ -1,0 +1,3 @@
+import "reports/js/bootstrap3/base";
+import "accounting/js/widgets";
+import "commcarehq";

--- a/corehq/apps/accounting/templates/accounting/invoice_list.html
+++ b/corehq/apps/accounting/templates/accounting/invoice_list.html
@@ -2,14 +2,6 @@
 {% load compress %}
 {% load hq_shared_tags %}
 
-{% block js %}
-  {{ block.super }}
-  {% compress js %}
-    <script src="{% static 'hqwebapp/js/utils/email.js' %}"></script>
-    <script src="{% static 'accounting/js/widgets.js' %}"></script>
-  {% endcompress %}
-{% endblock %}
-
 {% block page_content %}
   {% for adjust_balance_form in adjust_balance_forms %}
     {% include 'accounting/partials/adjust_balance.html' %}

--- a/corehq/apps/accounting/templates/accounting/report_filter_actions.html
+++ b/corehq/apps/accounting/templates/accounting/report_filter_actions.html
@@ -1,5 +1,8 @@
 {% extends "reports/bootstrap3/base_template.html" %}
+{% load hq_shared_tags %}
 {% load i18n %}
+
+{% js_entry_b3 "accounting/js/report_filter_actions" %}
 
 {% block report_filter_actions %}
   <div id="savedReports" class="{{ report_filter_form_action_css_class }}">


### PR DESCRIPTION
## Technical Summary
I missed this when migrating reports to webpack. This template inherits from `reports/bootstrap3/base_template.html` and therefore was inheriting its `reports/js/bootstrap3/base` js entry, but these two scripts were included in script tags and therefore erroring out (because they call `hqDefine` which isn't defined in a webpack environment since the webpack build process [replaces](https://github.com/dimagi/commcare-hq/blob/dfa8cc3cc2dadda4a92aca720750516903b10180/webpack/webpack.common.js#L46-L56) `hqDefine` with `define` in js files that webpack controls).

I'm adding a js entry point that includes these two scripts (it imports `widgets` directly, and `widgets` [imports the email module](https://github.com/dimagi/commcare-hq/blob/dfa8cc3cc2dadda4a92aca720750516903b10180/corehq/apps/accounting/static/accounting/js/widgets.js#L6)) and also `reports/js/bootstrap3/base`.

So far as I can tell, this is causing js errors in these accounting reports but not any user-facing problems. That suggests that these dependencies may not be necessary for these reports. Nonetheless, I'm going to leave the dependencies there, as I'm not certain I've exhaustively tested all reports that use this code.

## Safety Assurance

### Safety story
Fixes errors on internal pages.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
