### PR TITLE
Removed redundant script tag

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/repeat_records.html
@@ -1,10 +1,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% block js %}
-  <script src="{% static "case/js/repeat_records.js" %}"></script>
-{% endblock js %}
-
 <table class="table table-striped table-hover">
   <thead>
     <tr>


### PR DESCRIPTION
## Technical Summary
Missed this in a previous webpack migration.

This file is only included [here](https://github.com/dimagi/commcare-hq/blob/dfa8cc3cc2dadda4a92aca720750516903b10180/corehq/apps/reports/templates/reports/reportdata/bootstrap3/case_data.html#L138-L142) in `case_data.html`, which [uses case_details.js as an entry point](https://github.com/dimagi/commcare-hq/blob/dfa8cc3cc2dadda4a92aca720750516903b10180/corehq/apps/reports/templates/reports/reportdata/bootstrap3/case_data.html#L11), which already includes this script [here](https://github.com/dimagi/commcare-hq/blob/dfa8cc3cc2dadda4a92aca720750516903b10180/corehq/apps/reports/static/reports/js/bootstrap3/case_details.js#L13).

My guess is that cases that are attached to repeat records are throwing a js error, but that the page still behaves correctly, because the script is already included.

## Safety Assurance

### Safety story
Code review is a sufficient safety check for this change.

### Automated test coverage

no

### QA Plan

not requesting QA


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
