### PR TITLE
Remove outdated docstring

### DIFF
--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -39,13 +39,6 @@ class SemanticVersionProperty(StringProperty):
 
 
 class CommCareBuild(BlobMixin, Document):
-    """
-    #python manage.py shell
-    #>>> from corehq.apps.builds.models import CommCareBuild
-    #>>> build = CommCareBuild.create_from_zip('/Users/droberts/Desktop/zip/7106.zip', '1.2.dev', 7106)
-
-    """
-
     build_number = IntegerProperty()
     version = SemanticVersionProperty()
     time = DateTimeProperty()


### PR DESCRIPTION


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
`CommCareBuild.create_from_zip` is removed in https://github.com/dimagi/commcare-hq/pull/32845
So remove the docstring as well

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe. Just remove docstring.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
