### PR TITLE
Only set CheckboxInputField for BooleanFields

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -952,7 +952,7 @@ class PrivacySecurityForm(forms.Form):
             excluded_fields.append('secure_sessions_timeout')
 
         for field in self.fields.values():
-            if not isinstance(field.widget, BootstrapCheckboxInput):
+            if isinstance(field, BooleanField):
                 field.widget = BootstrapCheckboxInput()
 
         fields = [hqcrispy.CheckboxField(field_name)

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -952,7 +952,8 @@ class PrivacySecurityForm(forms.Form):
             excluded_fields.append('secure_sessions_timeout')
 
         for field in self.fields.values():
-            if isinstance(field, BooleanField):
+            has_custom_input = isinstance(field.widget, BootstrapCheckboxInput)
+            if isinstance(field, BooleanField) and not has_custom_input:
                 field.widget = BootstrapCheckboxInput()
 
         fields = [hqcrispy.CheckboxField(field_name)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-16481

Followup to https://github.com/dimagi/commcare-hq/pull/35550.

There is a non-boolean field input on this page that was impacted by all field widget's being set to a checkbox input, which made validation fail for this form any time a change was attempted, and therefore no changes could be made.

The field that is a non-boolean field is behind a feature flag, but still impacts form validation even when in a domain where the flag is not enabled.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
