### PR TITLE
[B5] Update core report modules to ESM format and fix datatables imports for bootstrap 5

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/base.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/base.js.diff.txt
@@ -1,23 +1,83 @@
 --- 
 +++ 
-@@ -1,8 +1,8 @@
+@@ -1,45 +1,41 @@
 -hqDefine("reports/js/bootstrap3/base", [
-+hqDefine("reports/js/bootstrap5/base", [
-     'jquery',
-     'hqwebapp/js/initial_page_data',
+-    'jquery',
+-    'hqwebapp/js/initial_page_data',
 -    'reports/js/filters/bootstrap3/main',
 -    'reports/js/bootstrap3/report_config_models',
-+    'reports/js/filters/bootstrap5/main',
-+    'reports/js/bootstrap5/report_config_models',
-     'reports/js/bootstrap3/tabular',
-     'commcarehq',
- ], function (
-@@ -36,7 +36,7 @@
-             reportConfigsView.setConfigBeingViewed(reportConfigModels.reportConfig(defaultConfig));
-         }
+-    'reports/js/bootstrap3/tabular',
+-    'commcarehq',
+-], function (
+-    $,
+-    initialPageData,
+-    filtersMain,
+-    reportConfigModels
+-) {
+-    $(function () {
+-        filtersMain.init();
++import 'commcarehq';
+ 
+-        var defaultConfig = initialPageData.get('default_config') || {};
+-        if (initialPageData.get('has_datespan')) {
+-            defaultConfig.date_range = 'last7';
+-        } else {
+-            defaultConfig.date_range = null;
+-        }
+-        defaultConfig.has_ucr_datespan = false;
+-        defaultConfig.datespan_filters = [];
+-        defaultConfig.datespan_slug = null;
++import $ from 'jquery';
+ 
+-        var $savedReports = $("#savedReports");
+-        if ($savedReports.length) {
+-            var reportConfigsView = reportConfigModels.reportConfigsViewModel({
+-                    filterForm: $("#reportFilters"),
+-                    items: initialPageData.get('report_configs'),
+-                    defaultItem: defaultConfig,
+-                    saveUrl: initialPageData.reverse("add_report_config"),
+-                });
+-            $savedReports.koApplyBindings(reportConfigsView);
+-            reportConfigsView.setConfigBeingViewed(reportConfigModels.reportConfig(defaultConfig));
+-        }
++import initialPageData from 'hqwebapp/js/initial_page_data';
++import filtersMain from 'reports/js/filters/bootstrap5/main';
++import reportConfigModels from 'reports/js/bootstrap5/report_config_models';
  
 -        $('#email-enabled').tooltip({
-+        $('#email-enabled').tooltip({  /* todo B5: plugin:tooltip */
-             placement: 'right',
-             html: true,
-             title: gettext("You can email a saved version<br />of this report."),
+-            placement: 'right',
+-            html: true,
+-            title: gettext("You can email a saved version<br />of this report."),
++import 'reports/js/bootstrap3/tabular';
++
++$(function () {
++    filtersMain.init();
++
++    var defaultConfig = initialPageData.get('default_config') || {};
++    if (initialPageData.get('has_datespan')) {
++        defaultConfig.date_range = 'last7';
++    } else {
++        defaultConfig.date_range = null;
++    }
++    defaultConfig.has_ucr_datespan = false;
++    defaultConfig.datespan_filters = [];
++    defaultConfig.datespan_slug = null;
++
++    var $savedReports = $("#savedReports");
++    if ($savedReports.length) {
++        var reportConfigsView = reportConfigModels.reportConfigsViewModel({
++            filterForm: $("#reportFilters"),
++            items: initialPageData.get('report_configs'),
++            defaultItem: defaultConfig,
++            saveUrl: initialPageData.reverse("add_report_config"),
+         });
++        $savedReports.koApplyBindings(reportConfigsView);
++        reportConfigsView.setConfigBeingViewed(reportConfigModels.reportConfig(defaultConfig));
++    }
++
++    $('#email-enabled').tooltip({  /* todo B5: plugin:tooltip */
++        placement: 'right',
++        html: true,
++        title: gettext("You can email a saved version<br />of this report."),
+     });
+ });

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
@@ -1,17 +1,676 @@
 --- 
 +++ 
-@@ -1,4 +1,4 @@
+@@ -1,340 +1,338 @@
 -hqDefine("reports/js/bootstrap3/datatables_config", [
-+hqDefine("reports/js/bootstrap5/datatables_config", [
-     'jquery',
-     'underscore',
-     'analytix/js/google',
-@@ -87,7 +87,7 @@
-             });
-             function applyBootstrapMagic() {
-                 $('[data-datatable-tooltip]').each(function () {
+-    'jquery',
+-    'underscore',
+-    'analytix/js/google',
+-    'datatables.bootstrap',
+-    'datatables.fixedColumns',
+-], function (
+-    $,
+-    _,
+-    googleAnalytics
+-) {
+-    var HQReportDataTables = function (options) {
+-        var self = {};
+-        self.dataTableElem = options.dataTableElem || '.datatable';
+-        self.paginationType = options.paginationType || 'bs_normal';
+-        self.forcePageSize = options.forcePageSize || false;
+-        self.defaultRows = options.defaultRows || 10;
+-        self.startAtRowNum = options.startAtRowNum || 0;
+-        self.showAllRowsOption = options.showAllRowsOption || false;
+-        self.aoColumns = options.aoColumns;
+-        self.autoWidth = (options.autoWidth !== undefined) ? options.autoWidth : true;
+-        self.defaultSort = (options.defaultSort !== undefined) ? options.defaultSort : true;
+-        self.customSort = options.customSort || null;
+-        self.ajaxParams = options.ajaxParams || {};
+-        self.ajaxSource = options.ajaxSource;
+-        self.ajaxMethod = options.ajaxMethod || 'GET';
+-        self.loadingText = options.loadingText || "<i class='fa fa-spin fa-spinner'></i> " + gettext("Loading");
+-        self.loadingTemplateSelector = options.loadingTemplateSelector;
+-        if (self.loadingTemplateSelector !== undefined) {
+-            var loadingTemplate = _.template($(self.loadingTemplateSelector).html() || self.loadingText);
+-            self.loadingText = loadingTemplate({});
++import $ from 'jquery';
++import _ from 'underscore';
++import googleAnalytics from 'analytix/js/google';
++
++import 'datatables.bootstrap';
++import 'datatables.fixedColumns';
++
++
++var HQReportDataTables = function (options) {
++    var self = {};
++    self.dataTableElem = options.dataTableElem || '.datatable';
++    self.paginationType = options.paginationType || 'bs_normal';
++    self.forcePageSize = options.forcePageSize || false;
++    self.defaultRows = options.defaultRows || 10;
++    self.startAtRowNum = options.startAtRowNum || 0;
++    self.showAllRowsOption = options.showAllRowsOption || false;
++    self.aoColumns = options.aoColumns;
++    self.autoWidth = (options.autoWidth !== undefined) ? options.autoWidth : true;
++    self.defaultSort = (options.defaultSort !== undefined) ? options.defaultSort : true;
++    self.customSort = options.customSort || null;
++    self.ajaxParams = options.ajaxParams || {};
++    self.ajaxSource = options.ajaxSource;
++    self.ajaxMethod = options.ajaxMethod || 'GET';
++    self.loadingText = options.loadingText || "<i class='fa fa-spin fa-spinner'></i> " + gettext("Loading");
++    self.loadingTemplateSelector = options.loadingTemplateSelector;
++    if (self.loadingTemplateSelector !== undefined) {
++        var loadingTemplate = _.template($(self.loadingTemplateSelector).html() || self.loadingText);
++        self.loadingText = loadingTemplate({});
++    }
++    self.emptyText = options.emptyText || gettext("No data available to display. " +
++                                                  "Please try changing your filters.");
++    self.errorText = options.errorText || "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
++                     gettext("There was an error with your query, it has been logged, please try another query.");
++    self.badRequestErrorText = options.badRequestErrorText || options.errorText ||
++                               "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
++                               gettext("Your search query is invalid, please adjust the formatting and try again.");
++    self.fixColumns = !!(options.fixColumns);
++    self.fixColsNumLeft = options.fixColsNumLeft || 1;
++    self.fixColsWidth = options.fixColsWidth || 100;
++    self.show_pagination = (options.show_pagination === undefined) ? true : options.bPaginate;
++    self.aaSorting = options.aaSorting || null;
++    // a list of functions to call back to after ajax.
++    // see user configurable charts for an example usage
++    self.successCallbacks = options.successCallbacks;
++    self.errorCallbacks = options.errorCallbacks;
++    self.includeFilter = options.includeFilter || false;
++    self.datatable = null;
++    self.rendered = false;
++
++    self.render_footer_row = (function () {
++        var $dataTableElem = $(self.dataTableElem);
++        return function (id, row) {
++            if ($dataTableElem.find('tfoot').length === 0) {
++                var $row = $dataTableElem.find('#' + id);
++                if ($row.length === 0) {
++                    $row = $('<tfoot />');
++                    $dataTableElem.append($row);
++                }
++                $row.html('');
++                for (var i = 0; i < row.length; i++) {
++                    $row.append('<td>' + row[i] + '</td>');
++                }
++            }
++        };
++    })();
++
++    self.render = function () {
++        if (self.rendered) {
++            $(self.dataTableElem).each(function () {
++                if ($.fn.dataTable.versionCheck) {
++                    // $.fn.dataTable.versionCheck does not exist prior to 1.10
++                    $(this).DataTable().ajax.reload();
++                } else {
++                    $(this).dataTable().fnReloadAjax();
++                }
++            });
++            return;
+         }
+-        self.emptyText = options.emptyText || gettext("No data available to display. " +
+-                                                      "Please try changing your filters.");
+-        self.errorText = options.errorText || "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
+-                         gettext("There was an error with your query, it has been logged, please try another query.");
+-        self.badRequestErrorText = options.badRequestErrorText || options.errorText ||
+-                                   "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
+-                                   gettext("Your search query is invalid, please adjust the formatting and try again.");
+-        self.fixColumns = !!(options.fixColumns);
+-        self.fixColsNumLeft = options.fixColsNumLeft || 1;
+-        self.fixColsWidth = options.fixColsWidth || 100;
+-        self.show_pagination = (options.show_pagination === undefined) ? true : options.bPaginate;
+-        self.aaSorting = options.aaSorting || null;
+-        // a list of functions to call back to after ajax.
+-        // see user configurable charts for an example usage
+-        self.successCallbacks = options.successCallbacks;
+-        self.errorCallbacks = options.errorCallbacks;
+-        self.includeFilter = options.includeFilter || false;
+-        self.datatable = null;
+-        self.rendered = false;
+-
+-        self.render_footer_row = (function () {
+-            var $dataTableElem = $(self.dataTableElem);
+-            return function (id, row) {
+-                if ($dataTableElem.find('tfoot').length === 0) {
+-                    var $row = $dataTableElem.find('#' + id);
+-                    if ($row.length === 0) {
+-                        $row = $('<tfoot />');
+-                        $dataTableElem.append($row);
+-                    }
+-                    $row.html('');
+-                    for (var i = 0; i < row.length; i++) {
+-                        $row.append('<td>' + row[i] + '</td>');
+-                    }
+-                }
+-            };
+-        })();
+-
+-        self.render = function () {
+-            if (self.rendered) {
+-                $(self.dataTableElem).each(function () {
+-                    if ($.fn.dataTable.versionCheck) {
+-                        // $.fn.dataTable.versionCheck does not exist prior to 1.10
+-                        $(this).DataTable().ajax.reload();
+-                    } else {
+-                        $(this).dataTable().fnReloadAjax();
+-                    }
+-                });
+-                return;
+-            }
+-
+-            self.rendered = true;
+-
+-            $('[data-datatable-highlight-closest]').each(function () {
+-                $(this).closest($(this).attr('data-datatable-highlight-closest')).addClass('active');
+-            });
+-            function applyBootstrapMagic() {
+-                $('[data-datatable-tooltip]').each(function () {
 -                    $(this).tooltip({
-+                    $(this).tooltip({  /* todo B5: plugin:tooltip */
-                         placement: $(this).attr('data-datatable-tooltip'),
-                         title: $(this).attr('data-datatable-tooltip-text'),
-                     });
+-                        placement: $(this).attr('data-datatable-tooltip'),
+-                        title: $(this).attr('data-datatable-tooltip-text'),
+-                    });
+-                });
+-            }
+-            applyBootstrapMagic();
+-
+-            var dataTablesDom = "frt<'row dataTables_control'<'col-sm-5'il><'col-sm-7 text-right'p>>";
+-            $(self.dataTableElem).each(function () {
+-                var params = {
+-                    sDom: dataTablesDom,
+-                    bPaginate: self.show_pagination,
+-                    sPaginationType: self.paginationType,
+-                    iDisplayLength: self.defaultRows,
+-                    bAutoWidth: self.autoWidth,
+-                    sScrollX: "100%",
+-                    bSort: self.defaultSort,
+-                    bFilter: self.includeFilter,
+-                };
+-                if (self.aaSorting !== null || self.customSort !== null) {
+-                    params.aaSorting = self.aaSorting || self.customSort;
+-                }
+-
+-                if (self.ajaxSource) {
+-                    params.bServerSide = true;
+-                    params.bProcessing = true;
+-                    params.sAjaxSource = {
+-                        url: self.ajaxSource,
+-                        method: self.ajaxMethod,
+-                    };
+-                    params.bFilter = $(this).data('filter') || false;
+-                    self.fmtParams = function (defParams) {
+-                        var ajaxParams = $.isFunction(self.ajaxParams) ? self.ajaxParams() : self.ajaxParams;
+-                        for (var p in ajaxParams) {
+-                            if (_.has(ajaxParams, p)) {
+-                                var currentParam = ajaxParams[p];
+-                                if (_.isObject(currentParam.value)) {
+-                                    for (var j = 0; j < currentParam.value.length; j++) {
+-                                        defParams.push({
+-                                            name: currentParam.name,
+-                                            value: currentParam.value[j],
+-                                        });
+-                                    }
+-                                } else {
+-                                    defParams.push(currentParam);
+-                                }
+-                            }
+-                        }
+-                        return defParams;
+-                    };
+-                    params.fnServerData = function (sSource, aoData, fnCallback, oSettings) {
+-                        var customCallback = function (data) {
+-                            if (data.warning) {
+-                                throw new Error(data.warning);
+-                            }
+-                            var result = fnCallback(data); // this must be called first because datatables clears the tfoot of the table
+-                            var i;
+-                            if ('total_row' in data) {
+-                                self.render_footer_row('ajax_total_row', data['total_row']);
+-                            }
+-                            if ('statistics_rows' in data) {
+-                                for (i = 0; i < data.statistics_rows.length; i++) {
+-                                    self.render_footer_row('ajax_stat_row-' + i, data.statistics_rows[i]);
+-                                }
+-                            }
+-                            applyBootstrapMagic();
+-                            if (self.successCallbacks) {
+-                                for (i = 0; i < self.successCallbacks.length; i++) {
+-                                    self.successCallbacks[i](data);
+-                                }
+-                            }
+-                            return result;
+-                        };
+-                        oSettings.jqXHR = $.ajax({
+-                            "url": sSource.url,
+-                            "method": sSource.method,
+-                            "data": self.fmtParams(aoData),
+-                            "success": customCallback,
+-                            "error": function (jqXHR, textStatus, errorThrown) {
+-                                $(".dataTables_processing").hide();
+-                                if (jqXHR.status === 400) {
+-                                    var errorMessage = self.badRequestErrorText;
+-                                    if (jqXHR.responseText) {
+-                                        errorMessage = "<p><span class='label label-danger'>" + gettext("Sorry!") + "</span> " + jqXHR.responseText + "</p>";
+-                                    }
+-                                    $(".dataTables_empty").html(errorMessage);
+-                                } else {
+-                                    $(".dataTables_empty").html(self.errorText);
+-                                }
+-                                $(".dataTables_empty").show();
+-                                if (self.errorCallbacks) {
+-                                    for (var i = 0; i < self.errorCallbacks.length; i++) {
+-                                        self.errorCallbacks[i](jqXHR, textStatus, errorThrown);
+-                                    }
+-                                }
+-                            },
+-                        });
+-                    };
+-                }
+-                params.oLanguage = {
+-                    sProcessing: self.loadingText,
+-                    sLoadingRecords: self.loadingText,
+-                    sZeroRecords: self.emptyText,
+-                };
+-
+-                params.fnDrawCallback = function (a,b,c) {
+-                    /* be able to set fnDrawCallback from outside here later */
+-                    if (self.fnDrawCallback) {
+-                        self.fnDrawCallback(a,b,c);
+-                    }
+-                };
+-
+-                if (self.aoColumns) {
+-                    params.aoColumns = self.aoColumns;
+-                }
+-
+-                if (self.forcePageSize) {
+-                    // limit the page size option to just the default size
+-                    params.lengthMenu = [self.defaultRows];
+-                }
+-                var datatable = $(this).dataTable(params);
+-                if (!self.datatable) {
+-                    self.datatable = datatable;
+-                }
+-
+-                if (self.fixColumns) {
+-                    new $.fn.dataTable.FixedColumns(datatable, {
+-                        iLeftColumns: self.fixColsNumLeft,
+-                        iLeftWidth: self.fixColsWidth,
+-                    });
+-                }
+-
+-                // This fixes a display bug in some browsers where the pagination
+-                // overlaps the footer when resizing from 10 to 100 or 10 to 50 rows
+-                // (perhaps other lengths are affected...unknown). This makes sure
+-                // that columns are redrawn on the first hit of a new length,
+-                // as fnAdjustColumnSizing fixes the issue and it remains fixed
+-                // without intervention afterward.
+-                self._lengthsSeen = [];
+-                datatable.on('length.dt', function (e, settings, length) {
+-                    if (self._lengthsSeen.indexOf(length) < 0) {
+-                        datatable.fnAdjustColumnSizing();
+-                        self._lengthsSeen.push(length);
+-                    }
+-                });
+-
+-                var $dataTablesFilter = $(".dataTables_filter");
+-                if ($dataTablesFilter && $("#extra-filter-info")) {
+-                    if ($dataTablesFilter.length > 1) {
+-                        $($dataTablesFilter.first()).remove();
+-                        $dataTablesFilter = $($dataTablesFilter.last());
+-                    }
+-                    $("#extra-filter-info").html($dataTablesFilter);
+-                    $dataTablesFilter.addClass("form-search");
+-                    var $inputField = $dataTablesFilter.find("input"),
+-                        $inputLabel = $dataTablesFilter.find("label");
+-
+-                    $dataTablesFilter.append($inputField);
+-                    $inputField.attr("id", "dataTables-filter-box");
+-                    $inputField.addClass("search-query").addClass('form-control');
+-                    $inputField.attr("placeholder", "Search...");
+-
+-                    $inputLabel.attr("for", "dataTables-filter-box");
+-                    $inputLabel.html($('<i />').addClass("icon-search"));
+-                }
+-
+-                var $dataTablesLength = $(self.dataTableElem).parents('.dataTables_wrapper').find(".dataTables_length"),
+-                    $dataTablesInfo = $(self.dataTableElem).parents('.dataTables_wrapper').find(".dataTables_info");
+-                if ($dataTablesLength && $dataTablesInfo) {
+-                    var $selectField = $dataTablesLength.find("select"),
+-                        $selectLabel = $dataTablesLength.find("label");
+-
+-                    $dataTablesLength.append($selectField);
+-                    $selectLabel.remove();
+-                    $selectField.children().append(" per page");
+-                    if (self.showAllRowsOption) {
+-                        $selectField.append($('<option value="-1" />').text("All Rows"));
+-                    }
+-                    $selectField.addClass('form-control');
+-                    $selectField.on("change", function () {
+-                        var selectedValue = $selectField.find('option:selected').val();
+-                        googleAnalytics.track.event("Reports", "Changed number of items shown", selectedValue);
+-                    });
+-                }
+-                $(".dataTables_length select").change(function () {
+-                    $(self.dataTableElem).trigger('hqreport.tabular.lengthChange', $(this).val());
++
++        self.rendered = true;
++
++        $('[data-datatable-highlight-closest]').each(function () {
++            $(this).closest($(this).attr('data-datatable-highlight-closest')).addClass('active');
++        });
++        function applyBootstrapMagic() {
++            $('[data-datatable-tooltip]').each(function () {
++                $(this).tooltip({  /* todo B5: plugin:tooltip */
++                    placement: $(this).attr('data-datatable-tooltip'),
++                    title: $(this).attr('data-datatable-tooltip-text'),
+                 });
+             });
+-        };  // end of self.render
+-
+-        return self;
+-    };
+-
+-    $.extend($.fn.dataTableExt.oStdClasses, {
+-        "sSortAsc": "header headerSortAsc",
+-        "sSortDesc": "header headerSortDesc",
+-        "sSortable": "header headerSort",
+-    });
+-
+-    // For sorting rows
+-
+-    function sortSpecial(a, b, asc, convert) {
+-        var x = convert(a);
+-        var y = convert(b);
+-
+-        // sort nulls at end regardless of current sort direction
+-        if (x === null && y === null) {
+-            return 0;
+         }
+-        if (x === null) {
+-            return 1;
++        applyBootstrapMagic();
++
++        var dataTablesDom = "frt<'row dataTables_control'<'col-sm-5'il><'col-sm-7 text-right'p>>";
++        $(self.dataTableElem).each(function () {
++            var params = {
++                sDom: dataTablesDom,
++                bPaginate: self.show_pagination,
++                sPaginationType: self.paginationType,
++                iDisplayLength: self.defaultRows,
++                bAutoWidth: self.autoWidth,
++                sScrollX: "100%",
++                bSort: self.defaultSort,
++                bFilter: self.includeFilter,
++            };
++            if (self.aaSorting !== null || self.customSort !== null) {
++                params.aaSorting = self.aaSorting || self.customSort;
++            }
++
++            if (self.ajaxSource) {
++                params.bServerSide = true;
++                params.bProcessing = true;
++                params.sAjaxSource = {
++                    url: self.ajaxSource,
++                    method: self.ajaxMethod,
++                };
++                params.bFilter = $(this).data('filter') || false;
++                self.fmtParams = function (defParams) {
++                    var ajaxParams = $.isFunction(self.ajaxParams) ? self.ajaxParams() : self.ajaxParams;
++                    for (var p in ajaxParams) {
++                        if (_.has(ajaxParams, p)) {
++                            var currentParam = ajaxParams[p];
++                            if (_.isObject(currentParam.value)) {
++                                for (var j = 0; j < currentParam.value.length; j++) {
++                                    defParams.push({
++                                        name: currentParam.name,
++                                        value: currentParam.value[j],
++                                    });
++                                }
++                            } else {
++                                defParams.push(currentParam);
++                            }
++                        }
++                    }
++                    return defParams;
++                };
++                params.fnServerData = function (sSource, aoData, fnCallback, oSettings) {
++                    var customCallback = function (data) {
++                        if (data.warning) {
++                            throw new Error(data.warning);
++                        }
++                        var result = fnCallback(data); // this must be called first because datatables clears the tfoot of the table
++                        var i;
++                        if ('total_row' in data) {
++                            self.render_footer_row('ajax_total_row', data['total_row']);
++                        }
++                        if ('statistics_rows' in data) {
++                            for (i = 0; i < data.statistics_rows.length; i++) {
++                                self.render_footer_row('ajax_stat_row-' + i, data.statistics_rows[i]);
++                            }
++                        }
++                        applyBootstrapMagic();
++                        if (self.successCallbacks) {
++                            for (i = 0; i < self.successCallbacks.length; i++) {
++                                self.successCallbacks[i](data);
++                            }
++                        }
++                        return result;
++                    };
++                    oSettings.jqXHR = $.ajax({
++                        "url": sSource.url,
++                        "method": sSource.method,
++                        "data": self.fmtParams(aoData),
++                        "success": customCallback,
++                        "error": function (jqXHR, textStatus, errorThrown) {
++                            $(".dataTables_processing").hide();
++                            if (jqXHR.status === 400) {
++                                var errorMessage = self.badRequestErrorText;
++                                if (jqXHR.responseText) {
++                                    errorMessage = "<p><span class='label label-danger'>" + gettext("Sorry!") + "</span> " + jqXHR.responseText + "</p>";
++                                }
++                                $(".dataTables_empty").html(errorMessage);
++                            } else {
++                                $(".dataTables_empty").html(self.errorText);
++                            }
++                            $(".dataTables_empty").show();
++                            if (self.errorCallbacks) {
++                                for (var i = 0; i < self.errorCallbacks.length; i++) {
++                                    self.errorCallbacks[i](jqXHR, textStatus, errorThrown);
++                                }
++                            }
++                        },
++                    });
++                };
++            }
++            params.oLanguage = {
++                sProcessing: self.loadingText,
++                sLoadingRecords: self.loadingText,
++                sZeroRecords: self.emptyText,
++            };
++
++            params.fnDrawCallback = function (a,b,c) {
++                /* be able to set fnDrawCallback from outside here later */
++                if (self.fnDrawCallback) {
++                    self.fnDrawCallback(a,b,c);
++                }
++            };
++
++            if (self.aoColumns) {
++                params.aoColumns = self.aoColumns;
++            }
++
++            if (self.forcePageSize) {
++                // limit the page size option to just the default size
++                params.lengthMenu = [self.defaultRows];
++            }
++            var datatable = $(this).dataTable(params);
++            if (!self.datatable) {
++                self.datatable = datatable;
++            }
++
++            if (self.fixColumns) {
++                new $.fn.dataTable.FixedColumns(datatable, {
++                    iLeftColumns: self.fixColsNumLeft,
++                    iLeftWidth: self.fixColsWidth,
++                });
++            }
++
++            // This fixes a display bug in some browsers where the pagination
++            // overlaps the footer when resizing from 10 to 100 or 10 to 50 rows
++            // (perhaps other lengths are affected...unknown). This makes sure
++            // that columns are redrawn on the first hit of a new length,
++            // as fnAdjustColumnSizing fixes the issue and it remains fixed
++            // without intervention afterward.
++            self._lengthsSeen = [];
++            datatable.on('length.dt', function (e, settings, length) {
++                if (self._lengthsSeen.indexOf(length) < 0) {
++                    datatable.fnAdjustColumnSizing();
++                    self._lengthsSeen.push(length);
++                }
++            });
++
++            var $dataTablesFilter = $(".dataTables_filter");
++            if ($dataTablesFilter && $("#extra-filter-info")) {
++                if ($dataTablesFilter.length > 1) {
++                    $($dataTablesFilter.first()).remove();
++                    $dataTablesFilter = $($dataTablesFilter.last());
++                }
++                $("#extra-filter-info").html($dataTablesFilter);
++                $dataTablesFilter.addClass("form-search");
++                var $inputField = $dataTablesFilter.find("input"),
++                    $inputLabel = $dataTablesFilter.find("label");
++
++                $dataTablesFilter.append($inputField);
++                $inputField.attr("id", "dataTables-filter-box");
++                $inputField.addClass("search-query").addClass('form-control');
++                $inputField.attr("placeholder", "Search...");
++
++                $inputLabel.attr("for", "dataTables-filter-box");
++                $inputLabel.html($('<i />').addClass("icon-search"));
++            }
++
++            var $dataTablesLength = $(self.dataTableElem).parents('.dataTables_wrapper').find(".dataTables_length"),
++                $dataTablesInfo = $(self.dataTableElem).parents('.dataTables_wrapper').find(".dataTables_info");
++            if ($dataTablesLength && $dataTablesInfo) {
++                var $selectField = $dataTablesLength.find("select"),
++                    $selectLabel = $dataTablesLength.find("label");
++
++                $dataTablesLength.append($selectField);
++                $selectLabel.remove();
++                $selectField.children().append(" per page");
++                if (self.showAllRowsOption) {
++                    $selectField.append($('<option value="-1" />').text("All Rows"));
++                }
++                $selectField.addClass('form-control');
++                $selectField.on("change", function () {
++                    var selectedValue = $selectField.find('option:selected').val();
++                    googleAnalytics.track.event("Reports", "Changed number of items shown", selectedValue);
++                });
++            }
++            $(".dataTables_length select").change(function () {
++                $(self.dataTableElem).trigger('hqreport.tabular.lengthChange', $(this).val());
++            });
++        });
++    };  // end of self.render
++
++    return self;
++};
++
++$.extend($.fn.dataTableExt.oStdClasses, {
++    "sSortAsc": "header headerSortAsc",
++    "sSortDesc": "header headerSortDesc",
++    "sSortable": "header headerSort",
++});
++
++// For sorting rows
++
++function sortSpecial(a, b, asc, convert) {
++    var x = convert(a);
++    var y = convert(b);
++
++    // sort nulls at end regardless of current sort direction
++    if (x === null && y === null) {
++        return 0;
++    }
++    if (x === null) {
++        return 1;
++    }
++    if (y === null) {
++        return -1;
++    }
++
++    return (asc ? 1 : -1) * ((x < y) ? -1 : ((x > y) ?  1 : 0));
++}
++
++function convertNum(k) {
++    var m = k.match(/title="*([-+.0-9eE]+)/);
++    if (m !== null) {
++        m = +m[1];
++        if (isNaN(m)) {
++            m = null;
+         }
+-        if (y === null) {
+-            return -1;
+-        }
+-
+-        return (asc ? 1 : -1) * ((x < y) ? -1 : ((x > y) ?  1 : 0));
+-    }
+-
+-    function convertNum(k) {
+-        var m = k.match(/title="*([-+.0-9eE]+)/);
+-        if (m !== null) {
+-            m = +m[1];
+-            if (isNaN(m)) {
+-                m = null;
+-            }
+-        }
+-        return m;
+-    }
+-
+-    function convertDate(k) {
+-        var m = k.match(/title="*(.+)"/);
+-        if (m[1] === "None") {
+-            return null;
+-        }
+-        return new Date(m[1]);
+-    }
+-
+-    $.fn.dataTableExt.oSort['title-numeric-asc'] = function (a, b) { return sortSpecial(a, b, true, convertNum); };
+-
+-    $.fn.dataTableExt.oSort['title-numeric-desc'] = function (a, b) { return sortSpecial(a, b, false, convertNum); };
+-
+-    $.fn.dataTableExt.oSort['title-date-asc']  = function (a,b) { return sortSpecial(a, b, true, convertDate); };
+-
+-    $.fn.dataTableExt.oSort['title-date-desc']  = function (a,b) { return sortSpecial(a, b, false, convertDate); };
+-
+-    return {
+-        HQReportDataTables: function (options) { return new HQReportDataTables(options); },
+-    };
+-});
++    }
++    return m;
++}
++
++function convertDate(k) {
++    var m = k.match(/title="*(.+)"/);
++    if (m[1] === "None") {
++        return null;
++    }
++    return new Date(m[1]);
++}
++
++$.fn.dataTableExt.oSort['title-numeric-asc'] = function (a, b) { return sortSpecial(a, b, true, convertNum); };
++
++$.fn.dataTableExt.oSort['title-numeric-desc'] = function (a, b) { return sortSpecial(a, b, false, convertNum); };
++
++$.fn.dataTableExt.oSort['title-date-asc']  = function (a,b) { return sortSpecial(a, b, true, convertDate); };
++
++$.fn.dataTableExt.oSort['title-date-desc']  = function (a,b) { return sortSpecial(a, b, false, convertDate); };
++
++export default {
++    HQReportDataTables: function (options) {
++        return new HQReportDataTables(options);
++    },
++};

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/tabular.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/tabular.js.diff.txt
@@ -1,37 +1,200 @@
 --- 
 +++ 
-@@ -1,18 +1,18 @@
+@@ -1,105 +1,100 @@
 -hqDefine("reports/js/bootstrap3/tabular", [
-+hqDefine("reports/js/bootstrap5/tabular", [
-     'jquery',
-     'underscore',
-     'hqwebapp/js/initial_page_data',
+-    'jquery',
+-    'underscore',
+-    'hqwebapp/js/initial_page_data',
 -    'reports/js/bootstrap3/datatables_config',
 -    'reports/js/bootstrap3/standard_hq_report',
-+    'reports/js/bootstrap5/datatables_config',
-+    'reports/js/bootstrap5/standard_hq_report',
-     'reports/js/datepicker',
+-    'reports/js/datepicker',
++import 'commcarehq';
  
-     // Page-specific scripts
+-    // Page-specific scripts
 -    'data_interfaces/js/bootstrap3/case_management',
-+    'data_interfaces/js/bootstrap5/case_management',
-     'data_interfaces/js/archive_forms',
-     'reports/js/inspect_data',
+-    'data_interfaces/js/archive_forms',
+-    'reports/js/inspect_data',
 -    'reports/js/bootstrap3/project_health_dashboard',
 -    'reports/js/bootstrap3/aggregate_user_status',
 -    'reports/js/bootstrap3/application_status',
-+    'reports/js/bootstrap5/project_health_dashboard',
-+    'reports/js/bootstrap5/aggregate_user_status',
-+    'reports/js/bootstrap5/application_status',
-     'reports/js/user_history',
-     'reports/js/case_activity',
- ], function (
-@@ -70,7 +70,7 @@
-             reportTables.render();
+-    'reports/js/user_history',
+-    'reports/js/case_activity',
+-], function (
+-    $,
+-    _,
+-    initialPageData,
+-    datatablesConfig,
+-    standardHQReportModule
+-) {
+-    function renderPage(slug, tableOptions) {
+-        if (tableOptions && tableOptions.datatables) {
+-            var tableConfig = tableOptions,
+-                options = {
+-                    dataTableElem: '#report_table_' + slug,
+-                    forcePageSize: tableConfig.force_page_size,
+-                    defaultRows: tableConfig.default_rows,
+-                    startAtRowNum: tableConfig.start_at_row,
+-                    showAllRowsOption: tableConfig.show_all_rows,
+-                    loadingTemplateSelector: '#js-template-loading-report',
+-                    autoWidth: tableConfig.headers.auto_width,
+-                };
+-            if (!tableConfig.sortable) {
+-                options.defaultSort = false;
+-            }
+-            if (tableConfig.headers.render_aoColumns) {
+-                options.aoColumns = tableConfig.headers.render_aoColumns;
+-            }
+-            if (tableConfig.headers.custom_sort) {
+-                options.customSort = tableConfig.headers.custom_sort;
+-            }
+-            if (tableConfig.pagination.hide) {
+-                options.show_pagination = false;
+-            }
+-            if (tableConfig.pagination.is_on) {
+-                _.extend(options, {
+-                    ajaxSource: tableConfig.pagination.source,
+-                    ajaxParams: tableConfig.pagination.params,
+-                });
+-            }
+-            if (tableConfig.bad_request_error_text) {
+-                options.badRequestErrorText = "<span class='label label-important'>" + gettext("Sorry!") + "</span>" + tableConfig.bad_request_error_text;
+-            }
+-            if (tableConfig.left_col.is_fixed) {
+-                _.extend(options, {
+-                    fixColumns: true,
+-                    fixColsNumLeft: tableConfig.left_col.fixed.num,
+-                    fixColsWidth: tableConfig.left_col.fixed.width,
+-                });
+-            }
+-            var reportTables = datatablesConfig.HQReportDataTables(options);
+-            var standardHQReport = standardHQReportModule.getStandardHQReport();
+-            if (typeof standardHQReport !== 'undefined') {
+-                standardHQReport.handleTabularReportCookies(reportTables);
+-            }
+-            reportTables.render();
++import $ from 'jquery';
++import _ from 'underscore';
++import initialPageData from 'hqwebapp/js/initial_page_data';
++import datatablesConfig from 'reports/js/bootstrap5/datatables_config';
++import standardHQReportModule from 'reports/js/bootstrap5/standard_hq_report';
++
++import 'reports/js/datepicker';
++
++import 'data_interfaces/js/bootstrap5/case_management';
++import 'data_interfaces/js/archive_forms';
++import 'reports/js/inspect_data';
++import 'reports/js/bootstrap5/project_health_dashboard';
++import 'reports/js/bootstrap5/aggregate_user_status';
++import 'reports/js/bootstrap5/application_status';
++import 'reports/js/user_history';
++import 'reports/js/case_activity';
++
++
++function renderPage(slug, tableOptions) {
++    if (tableOptions && tableOptions.datatables) {
++        var tableConfig = tableOptions,
++            options = {
++                dataTableElem: '#report_table_' + slug,
++                forcePageSize: tableConfig.force_page_size,
++                defaultRows: tableConfig.default_rows,
++                startAtRowNum: tableConfig.start_at_row,
++                showAllRowsOption: tableConfig.show_all_rows,
++                loadingTemplateSelector: '#js-template-loading-report',
++                autoWidth: tableConfig.headers.auto_width,
++            };
++        if (!tableConfig.sortable) {
++            options.defaultSort = false;
          }
- 
+-
 -        $('.header-popover').popover({
-+        $('.header-popover').popover({  /* todo B5: plugin:popover */
-             trigger: 'hover',
-             placement: 'bottom',
-             container: 'body',
+-            trigger: 'hover',
+-            placement: 'bottom',
+-            container: 'body',
+-        });
++        if (tableConfig.headers.render_aoColumns) {
++            options.aoColumns = tableConfig.headers.render_aoColumns;
++        }
++        if (tableConfig.headers.custom_sort) {
++            options.customSort = tableConfig.headers.custom_sort;
++        }
++        if (tableConfig.pagination.hide) {
++            options.show_pagination = false;
++        }
++        if (tableConfig.pagination.is_on) {
++            _.extend(options, {
++                ajaxSource: tableConfig.pagination.source,
++                ajaxParams: tableConfig.pagination.params,
++            });
++        }
++        if (tableConfig.bad_request_error_text) {
++            options.badRequestErrorText = "<span class='label label-important'>" + gettext("Sorry!") + "</span>" + tableConfig.bad_request_error_text;
++        }
++        if (tableConfig.left_col.is_fixed) {
++            _.extend(options, {
++                fixColumns: true,
++                fixColsNumLeft: tableConfig.left_col.fixed.num,
++                fixColsWidth: tableConfig.left_col.fixed.width,
++            });
++        }
++        var reportTables = datatablesConfig.HQReportDataTables(options);
++        var standardHQReport = standardHQReportModule.getStandardHQReport();
++        if (typeof standardHQReport !== 'undefined') {
++            standardHQReport.handleTabularReportCookies(reportTables);
++        }
++        reportTables.render();
+     }
+ 
+-    // Handle async reports
+-    $(document).on('ajaxSuccess', function (e, xhr, ajaxOptions, data) {
+-        if (!data || !data.slug) {
+-            // This file is imported by inddex/main, which then gets this event handler, which it doesn't need,
+-            // and which errors sometimes (presumably because there are ajax requests happening that aren't the
+-            // same as what this handler expects). Checking for data.slug is pretty innocuous and fixes the issue.
+-            return;
+-        }
+-        var jsOptions = initialPageData.get("js_options");
+-        if (jsOptions && ajaxOptions.url.indexOf(jsOptions.asyncUrl) === -1) {
+-            return;
+-        }
+-        renderPage(data.slug, data.report_table_js_options);
++    $('.header-popover').popover({  /* todo B5: plugin:popover */
++        trigger: 'hover',
++        placement: 'bottom',
++        container: 'body',
+     });
++}
+ 
+-    // Handle sync reports
+-    $(function () {
+-        if (initialPageData.get("report_table_js_options")) {
+-            renderPage(initialPageData.get("js_options").slug, initialPageData.get("report_table_js_options"));
+-        }
+-    });
++// Handle async reports
++$(document).on('ajaxSuccess', function (e, xhr, ajaxOptions, data) {
++    if (!data || !data.slug) {
++        // This file is imported by inddex/main, which then gets this event handler, which it doesn't need,
++        // and which errors sometimes (presumably because there are ajax requests happening that aren't the
++        // same as what this handler expects). Checking for data.slug is pretty innocuous and fixes the issue.
++        return;
++    }
++    var jsOptions = initialPageData.get("js_options");
++    if (jsOptions && ajaxOptions.url.indexOf(jsOptions.asyncUrl) === -1) {
++        return;
++    }
++    renderPage(data.slug, data.report_table_js_options);
++});
+ 
+-    return {
+-        renderPage: renderPage,
+-    };
++// Handle sync reports
++$(function () {
++    if (initialPageData.get("report_table_js_options")) {
++        renderPage(initialPageData.get("js_options").slug, initialPageData.get("report_table_js_options"));
++    }
+ });
++
++export default {
++    renderPage: renderPage,
++};

--- a/corehq/apps/reports/static/reports/js/bootstrap5/base.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/base.js
@@ -1,45 +1,41 @@
-hqDefine("reports/js/bootstrap5/base", [
-    'jquery',
-    'hqwebapp/js/initial_page_data',
-    'reports/js/filters/bootstrap5/main',
-    'reports/js/bootstrap5/report_config_models',
-    'reports/js/bootstrap3/tabular',
-    'commcarehq',
-], function (
-    $,
-    initialPageData,
-    filtersMain,
-    reportConfigModels
-) {
-    $(function () {
-        filtersMain.init();
+import 'commcarehq';
 
-        var defaultConfig = initialPageData.get('default_config') || {};
-        if (initialPageData.get('has_datespan')) {
-            defaultConfig.date_range = 'last7';
-        } else {
-            defaultConfig.date_range = null;
-        }
-        defaultConfig.has_ucr_datespan = false;
-        defaultConfig.datespan_filters = [];
-        defaultConfig.datespan_slug = null;
+import $ from 'jquery';
 
-        var $savedReports = $("#savedReports");
-        if ($savedReports.length) {
-            var reportConfigsView = reportConfigModels.reportConfigsViewModel({
-                    filterForm: $("#reportFilters"),
-                    items: initialPageData.get('report_configs'),
-                    defaultItem: defaultConfig,
-                    saveUrl: initialPageData.reverse("add_report_config"),
-                });
-            $savedReports.koApplyBindings(reportConfigsView);
-            reportConfigsView.setConfigBeingViewed(reportConfigModels.reportConfig(defaultConfig));
-        }
+import initialPageData from 'hqwebapp/js/initial_page_data';
+import filtersMain from 'reports/js/filters/bootstrap5/main';
+import reportConfigModels from 'reports/js/bootstrap5/report_config_models';
 
-        $('#email-enabled').tooltip({  /* todo B5: plugin:tooltip */
-            placement: 'right',
-            html: true,
-            title: gettext("You can email a saved version<br />of this report."),
+import 'reports/js/bootstrap3/tabular';
+
+$(function () {
+    filtersMain.init();
+
+    var defaultConfig = initialPageData.get('default_config') || {};
+    if (initialPageData.get('has_datespan')) {
+        defaultConfig.date_range = 'last7';
+    } else {
+        defaultConfig.date_range = null;
+    }
+    defaultConfig.has_ucr_datespan = false;
+    defaultConfig.datespan_filters = [];
+    defaultConfig.datespan_slug = null;
+
+    var $savedReports = $("#savedReports");
+    if ($savedReports.length) {
+        var reportConfigsView = reportConfigModels.reportConfigsViewModel({
+            filterForm: $("#reportFilters"),
+            items: initialPageData.get('report_configs'),
+            defaultItem: defaultConfig,
+            saveUrl: initialPageData.reverse("add_report_config"),
         });
+        $savedReports.koApplyBindings(reportConfigsView);
+        reportConfigsView.setConfigBeingViewed(reportConfigModels.reportConfig(defaultConfig));
+    }
+
+    $('#email-enabled').tooltip({  /* todo B5: plugin:tooltip */
+        placement: 'right',
+        html: true,
+        title: gettext("You can email a saved version<br />of this report."),
     });
 });

--- a/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
@@ -1,340 +1,338 @@
-hqDefine("reports/js/bootstrap5/datatables_config", [
-    'jquery',
-    'underscore',
-    'analytix/js/google',
-    'datatables.bootstrap',
-    'datatables.fixedColumns',
-], function (
-    $,
-    _,
-    googleAnalytics
-) {
-    var HQReportDataTables = function (options) {
-        var self = {};
-        self.dataTableElem = options.dataTableElem || '.datatable';
-        self.paginationType = options.paginationType || 'bs_normal';
-        self.forcePageSize = options.forcePageSize || false;
-        self.defaultRows = options.defaultRows || 10;
-        self.startAtRowNum = options.startAtRowNum || 0;
-        self.showAllRowsOption = options.showAllRowsOption || false;
-        self.aoColumns = options.aoColumns;
-        self.autoWidth = (options.autoWidth !== undefined) ? options.autoWidth : true;
-        self.defaultSort = (options.defaultSort !== undefined) ? options.defaultSort : true;
-        self.customSort = options.customSort || null;
-        self.ajaxParams = options.ajaxParams || {};
-        self.ajaxSource = options.ajaxSource;
-        self.ajaxMethod = options.ajaxMethod || 'GET';
-        self.loadingText = options.loadingText || "<i class='fa fa-spin fa-spinner'></i> " + gettext("Loading");
-        self.loadingTemplateSelector = options.loadingTemplateSelector;
-        if (self.loadingTemplateSelector !== undefined) {
-            var loadingTemplate = _.template($(self.loadingTemplateSelector).html() || self.loadingText);
-            self.loadingText = loadingTemplate({});
-        }
-        self.emptyText = options.emptyText || gettext("No data available to display. " +
-                                                      "Please try changing your filters.");
-        self.errorText = options.errorText || "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
-                         gettext("There was an error with your query, it has been logged, please try another query.");
-        self.badRequestErrorText = options.badRequestErrorText || options.errorText ||
-                                   "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
-                                   gettext("Your search query is invalid, please adjust the formatting and try again.");
-        self.fixColumns = !!(options.fixColumns);
-        self.fixColsNumLeft = options.fixColsNumLeft || 1;
-        self.fixColsWidth = options.fixColsWidth || 100;
-        self.show_pagination = (options.show_pagination === undefined) ? true : options.bPaginate;
-        self.aaSorting = options.aaSorting || null;
-        // a list of functions to call back to after ajax.
-        // see user configurable charts for an example usage
-        self.successCallbacks = options.successCallbacks;
-        self.errorCallbacks = options.errorCallbacks;
-        self.includeFilter = options.includeFilter || false;
-        self.datatable = null;
-        self.rendered = false;
+import $ from 'jquery';
+import _ from 'underscore';
+import googleAnalytics from 'analytix/js/google';
 
-        self.render_footer_row = (function () {
-            var $dataTableElem = $(self.dataTableElem);
-            return function (id, row) {
-                if ($dataTableElem.find('tfoot').length === 0) {
-                    var $row = $dataTableElem.find('#' + id);
-                    if ($row.length === 0) {
-                        $row = $('<tfoot />');
-                        $dataTableElem.append($row);
-                    }
-                    $row.html('');
-                    for (var i = 0; i < row.length; i++) {
-                        $row.append('<td>' + row[i] + '</td>');
-                    }
+import 'datatables.bootstrap';
+import 'datatables.fixedColumns';
+
+
+var HQReportDataTables = function (options) {
+    var self = {};
+    self.dataTableElem = options.dataTableElem || '.datatable';
+    self.paginationType = options.paginationType || 'bs_normal';
+    self.forcePageSize = options.forcePageSize || false;
+    self.defaultRows = options.defaultRows || 10;
+    self.startAtRowNum = options.startAtRowNum || 0;
+    self.showAllRowsOption = options.showAllRowsOption || false;
+    self.aoColumns = options.aoColumns;
+    self.autoWidth = (options.autoWidth !== undefined) ? options.autoWidth : true;
+    self.defaultSort = (options.defaultSort !== undefined) ? options.defaultSort : true;
+    self.customSort = options.customSort || null;
+    self.ajaxParams = options.ajaxParams || {};
+    self.ajaxSource = options.ajaxSource;
+    self.ajaxMethod = options.ajaxMethod || 'GET';
+    self.loadingText = options.loadingText || "<i class='fa fa-spin fa-spinner'></i> " + gettext("Loading");
+    self.loadingTemplateSelector = options.loadingTemplateSelector;
+    if (self.loadingTemplateSelector !== undefined) {
+        var loadingTemplate = _.template($(self.loadingTemplateSelector).html() || self.loadingText);
+        self.loadingText = loadingTemplate({});
+    }
+    self.emptyText = options.emptyText || gettext("No data available to display. " +
+                                                  "Please try changing your filters.");
+    self.errorText = options.errorText || "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
+                     gettext("There was an error with your query, it has been logged, please try another query.");
+    self.badRequestErrorText = options.badRequestErrorText || options.errorText ||
+                               "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
+                               gettext("Your search query is invalid, please adjust the formatting and try again.");
+    self.fixColumns = !!(options.fixColumns);
+    self.fixColsNumLeft = options.fixColsNumLeft || 1;
+    self.fixColsWidth = options.fixColsWidth || 100;
+    self.show_pagination = (options.show_pagination === undefined) ? true : options.bPaginate;
+    self.aaSorting = options.aaSorting || null;
+    // a list of functions to call back to after ajax.
+    // see user configurable charts for an example usage
+    self.successCallbacks = options.successCallbacks;
+    self.errorCallbacks = options.errorCallbacks;
+    self.includeFilter = options.includeFilter || false;
+    self.datatable = null;
+    self.rendered = false;
+
+    self.render_footer_row = (function () {
+        var $dataTableElem = $(self.dataTableElem);
+        return function (id, row) {
+            if ($dataTableElem.find('tfoot').length === 0) {
+                var $row = $dataTableElem.find('#' + id);
+                if ($row.length === 0) {
+                    $row = $('<tfoot />');
+                    $dataTableElem.append($row);
                 }
-            };
-        })();
-
-        self.render = function () {
-            if (self.rendered) {
-                $(self.dataTableElem).each(function () {
-                    if ($.fn.dataTable.versionCheck) {
-                        // $.fn.dataTable.versionCheck does not exist prior to 1.10
-                        $(this).DataTable().ajax.reload();
-                    } else {
-                        $(this).dataTable().fnReloadAjax();
-                    }
-                });
-                return;
+                $row.html('');
+                for (var i = 0; i < row.length; i++) {
+                    $row.append('<td>' + row[i] + '</td>');
+                }
             }
+        };
+    })();
 
-            self.rendered = true;
-
-            $('[data-datatable-highlight-closest]').each(function () {
-                $(this).closest($(this).attr('data-datatable-highlight-closest')).addClass('active');
-            });
-            function applyBootstrapMagic() {
-                $('[data-datatable-tooltip]').each(function () {
-                    $(this).tooltip({  /* todo B5: plugin:tooltip */
-                        placement: $(this).attr('data-datatable-tooltip'),
-                        title: $(this).attr('data-datatable-tooltip-text'),
-                    });
-                });
-            }
-            applyBootstrapMagic();
-
-            var dataTablesDom = "frt<'row dataTables_control'<'col-sm-5'il><'col-sm-7 text-right'p>>";
+    self.render = function () {
+        if (self.rendered) {
             $(self.dataTableElem).each(function () {
-                var params = {
-                    sDom: dataTablesDom,
-                    bPaginate: self.show_pagination,
-                    sPaginationType: self.paginationType,
-                    iDisplayLength: self.defaultRows,
-                    bAutoWidth: self.autoWidth,
-                    sScrollX: "100%",
-                    bSort: self.defaultSort,
-                    bFilter: self.includeFilter,
-                };
-                if (self.aaSorting !== null || self.customSort !== null) {
-                    params.aaSorting = self.aaSorting || self.customSort;
+                if ($.fn.dataTable.versionCheck) {
+                    // $.fn.dataTable.versionCheck does not exist prior to 1.10
+                    $(this).DataTable().ajax.reload();
+                } else {
+                    $(this).dataTable().fnReloadAjax();
                 }
+            });
+            return;
+        }
 
-                if (self.ajaxSource) {
-                    params.bServerSide = true;
-                    params.bProcessing = true;
-                    params.sAjaxSource = {
-                        url: self.ajaxSource,
-                        method: self.ajaxMethod,
-                    };
-                    params.bFilter = $(this).data('filter') || false;
-                    self.fmtParams = function (defParams) {
-                        var ajaxParams = $.isFunction(self.ajaxParams) ? self.ajaxParams() : self.ajaxParams;
-                        for (var p in ajaxParams) {
-                            if (_.has(ajaxParams, p)) {
-                                var currentParam = ajaxParams[p];
-                                if (_.isObject(currentParam.value)) {
-                                    for (var j = 0; j < currentParam.value.length; j++) {
-                                        defParams.push({
-                                            name: currentParam.name,
-                                            value: currentParam.value[j],
-                                        });
-                                    }
-                                } else {
-                                    defParams.push(currentParam);
+        self.rendered = true;
+
+        $('[data-datatable-highlight-closest]').each(function () {
+            $(this).closest($(this).attr('data-datatable-highlight-closest')).addClass('active');
+        });
+        function applyBootstrapMagic() {
+            $('[data-datatable-tooltip]').each(function () {
+                $(this).tooltip({  /* todo B5: plugin:tooltip */
+                    placement: $(this).attr('data-datatable-tooltip'),
+                    title: $(this).attr('data-datatable-tooltip-text'),
+                });
+            });
+        }
+        applyBootstrapMagic();
+
+        var dataTablesDom = "frt<'row dataTables_control'<'col-sm-5'il><'col-sm-7 text-right'p>>";
+        $(self.dataTableElem).each(function () {
+            var params = {
+                sDom: dataTablesDom,
+                bPaginate: self.show_pagination,
+                sPaginationType: self.paginationType,
+                iDisplayLength: self.defaultRows,
+                bAutoWidth: self.autoWidth,
+                sScrollX: "100%",
+                bSort: self.defaultSort,
+                bFilter: self.includeFilter,
+            };
+            if (self.aaSorting !== null || self.customSort !== null) {
+                params.aaSorting = self.aaSorting || self.customSort;
+            }
+
+            if (self.ajaxSource) {
+                params.bServerSide = true;
+                params.bProcessing = true;
+                params.sAjaxSource = {
+                    url: self.ajaxSource,
+                    method: self.ajaxMethod,
+                };
+                params.bFilter = $(this).data('filter') || false;
+                self.fmtParams = function (defParams) {
+                    var ajaxParams = $.isFunction(self.ajaxParams) ? self.ajaxParams() : self.ajaxParams;
+                    for (var p in ajaxParams) {
+                        if (_.has(ajaxParams, p)) {
+                            var currentParam = ajaxParams[p];
+                            if (_.isObject(currentParam.value)) {
+                                for (var j = 0; j < currentParam.value.length; j++) {
+                                    defParams.push({
+                                        name: currentParam.name,
+                                        value: currentParam.value[j],
+                                    });
                                 }
+                            } else {
+                                defParams.push(currentParam);
                             }
                         }
-                        return defParams;
-                    };
-                    params.fnServerData = function (sSource, aoData, fnCallback, oSettings) {
-                        var customCallback = function (data) {
-                            if (data.warning) {
-                                throw new Error(data.warning);
-                            }
-                            var result = fnCallback(data); // this must be called first because datatables clears the tfoot of the table
-                            var i;
-                            if ('total_row' in data) {
-                                self.render_footer_row('ajax_total_row', data['total_row']);
-                            }
-                            if ('statistics_rows' in data) {
-                                for (i = 0; i < data.statistics_rows.length; i++) {
-                                    self.render_footer_row('ajax_stat_row-' + i, data.statistics_rows[i]);
-                                }
-                            }
-                            applyBootstrapMagic();
-                            if (self.successCallbacks) {
-                                for (i = 0; i < self.successCallbacks.length; i++) {
-                                    self.successCallbacks[i](data);
-                                }
-                            }
-                            return result;
-                        };
-                        oSettings.jqXHR = $.ajax({
-                            "url": sSource.url,
-                            "method": sSource.method,
-                            "data": self.fmtParams(aoData),
-                            "success": customCallback,
-                            "error": function (jqXHR, textStatus, errorThrown) {
-                                $(".dataTables_processing").hide();
-                                if (jqXHR.status === 400) {
-                                    var errorMessage = self.badRequestErrorText;
-                                    if (jqXHR.responseText) {
-                                        errorMessage = "<p><span class='label label-danger'>" + gettext("Sorry!") + "</span> " + jqXHR.responseText + "</p>";
-                                    }
-                                    $(".dataTables_empty").html(errorMessage);
-                                } else {
-                                    $(".dataTables_empty").html(self.errorText);
-                                }
-                                $(".dataTables_empty").show();
-                                if (self.errorCallbacks) {
-                                    for (var i = 0; i < self.errorCallbacks.length; i++) {
-                                        self.errorCallbacks[i](jqXHR, textStatus, errorThrown);
-                                    }
-                                }
-                            },
-                        });
-                    };
-                }
-                params.oLanguage = {
-                    sProcessing: self.loadingText,
-                    sLoadingRecords: self.loadingText,
-                    sZeroRecords: self.emptyText,
+                    }
+                    return defParams;
                 };
-
-                params.fnDrawCallback = function (a,b,c) {
-                    /* be able to set fnDrawCallback from outside here later */
-                    if (self.fnDrawCallback) {
-                        self.fnDrawCallback(a,b,c);
-                    }
+                params.fnServerData = function (sSource, aoData, fnCallback, oSettings) {
+                    var customCallback = function (data) {
+                        if (data.warning) {
+                            throw new Error(data.warning);
+                        }
+                        var result = fnCallback(data); // this must be called first because datatables clears the tfoot of the table
+                        var i;
+                        if ('total_row' in data) {
+                            self.render_footer_row('ajax_total_row', data['total_row']);
+                        }
+                        if ('statistics_rows' in data) {
+                            for (i = 0; i < data.statistics_rows.length; i++) {
+                                self.render_footer_row('ajax_stat_row-' + i, data.statistics_rows[i]);
+                            }
+                        }
+                        applyBootstrapMagic();
+                        if (self.successCallbacks) {
+                            for (i = 0; i < self.successCallbacks.length; i++) {
+                                self.successCallbacks[i](data);
+                            }
+                        }
+                        return result;
+                    };
+                    oSettings.jqXHR = $.ajax({
+                        "url": sSource.url,
+                        "method": sSource.method,
+                        "data": self.fmtParams(aoData),
+                        "success": customCallback,
+                        "error": function (jqXHR, textStatus, errorThrown) {
+                            $(".dataTables_processing").hide();
+                            if (jqXHR.status === 400) {
+                                var errorMessage = self.badRequestErrorText;
+                                if (jqXHR.responseText) {
+                                    errorMessage = "<p><span class='label label-danger'>" + gettext("Sorry!") + "</span> " + jqXHR.responseText + "</p>";
+                                }
+                                $(".dataTables_empty").html(errorMessage);
+                            } else {
+                                $(".dataTables_empty").html(self.errorText);
+                            }
+                            $(".dataTables_empty").show();
+                            if (self.errorCallbacks) {
+                                for (var i = 0; i < self.errorCallbacks.length; i++) {
+                                    self.errorCallbacks[i](jqXHR, textStatus, errorThrown);
+                                }
+                            }
+                        },
+                    });
                 };
-
-                if (self.aoColumns) {
-                    params.aoColumns = self.aoColumns;
-                }
-
-                if (self.forcePageSize) {
-                    // limit the page size option to just the default size
-                    params.lengthMenu = [self.defaultRows];
-                }
-                var datatable = $(this).dataTable(params);
-                if (!self.datatable) {
-                    self.datatable = datatable;
-                }
-
-                if (self.fixColumns) {
-                    new $.fn.dataTable.FixedColumns(datatable, {
-                        iLeftColumns: self.fixColsNumLeft,
-                        iLeftWidth: self.fixColsWidth,
-                    });
-                }
-
-                // This fixes a display bug in some browsers where the pagination
-                // overlaps the footer when resizing from 10 to 100 or 10 to 50 rows
-                // (perhaps other lengths are affected...unknown). This makes sure
-                // that columns are redrawn on the first hit of a new length,
-                // as fnAdjustColumnSizing fixes the issue and it remains fixed
-                // without intervention afterward.
-                self._lengthsSeen = [];
-                datatable.on('length.dt', function (e, settings, length) {
-                    if (self._lengthsSeen.indexOf(length) < 0) {
-                        datatable.fnAdjustColumnSizing();
-                        self._lengthsSeen.push(length);
-                    }
-                });
-
-                var $dataTablesFilter = $(".dataTables_filter");
-                if ($dataTablesFilter && $("#extra-filter-info")) {
-                    if ($dataTablesFilter.length > 1) {
-                        $($dataTablesFilter.first()).remove();
-                        $dataTablesFilter = $($dataTablesFilter.last());
-                    }
-                    $("#extra-filter-info").html($dataTablesFilter);
-                    $dataTablesFilter.addClass("form-search");
-                    var $inputField = $dataTablesFilter.find("input"),
-                        $inputLabel = $dataTablesFilter.find("label");
-
-                    $dataTablesFilter.append($inputField);
-                    $inputField.attr("id", "dataTables-filter-box");
-                    $inputField.addClass("search-query").addClass('form-control');
-                    $inputField.attr("placeholder", "Search...");
-
-                    $inputLabel.attr("for", "dataTables-filter-box");
-                    $inputLabel.html($('<i />').addClass("icon-search"));
-                }
-
-                var $dataTablesLength = $(self.dataTableElem).parents('.dataTables_wrapper').find(".dataTables_length"),
-                    $dataTablesInfo = $(self.dataTableElem).parents('.dataTables_wrapper').find(".dataTables_info");
-                if ($dataTablesLength && $dataTablesInfo) {
-                    var $selectField = $dataTablesLength.find("select"),
-                        $selectLabel = $dataTablesLength.find("label");
-
-                    $dataTablesLength.append($selectField);
-                    $selectLabel.remove();
-                    $selectField.children().append(" per page");
-                    if (self.showAllRowsOption) {
-                        $selectField.append($('<option value="-1" />').text("All Rows"));
-                    }
-                    $selectField.addClass('form-control');
-                    $selectField.on("change", function () {
-                        var selectedValue = $selectField.find('option:selected').val();
-                        googleAnalytics.track.event("Reports", "Changed number of items shown", selectedValue);
-                    });
-                }
-                $(".dataTables_length select").change(function () {
-                    $(self.dataTableElem).trigger('hqreport.tabular.lengthChange', $(this).val());
-                });
-            });
-        };  // end of self.render
-
-        return self;
-    };
-
-    $.extend($.fn.dataTableExt.oStdClasses, {
-        "sSortAsc": "header headerSortAsc",
-        "sSortDesc": "header headerSortDesc",
-        "sSortable": "header headerSort",
-    });
-
-    // For sorting rows
-
-    function sortSpecial(a, b, asc, convert) {
-        var x = convert(a);
-        var y = convert(b);
-
-        // sort nulls at end regardless of current sort direction
-        if (x === null && y === null) {
-            return 0;
-        }
-        if (x === null) {
-            return 1;
-        }
-        if (y === null) {
-            return -1;
-        }
-
-        return (asc ? 1 : -1) * ((x < y) ? -1 : ((x > y) ?  1 : 0));
-    }
-
-    function convertNum(k) {
-        var m = k.match(/title="*([-+.0-9eE]+)/);
-        if (m !== null) {
-            m = +m[1];
-            if (isNaN(m)) {
-                m = null;
             }
-        }
-        return m;
-    }
+            params.oLanguage = {
+                sProcessing: self.loadingText,
+                sLoadingRecords: self.loadingText,
+                sZeroRecords: self.emptyText,
+            };
 
-    function convertDate(k) {
-        var m = k.match(/title="*(.+)"/);
-        if (m[1] === "None") {
-            return null;
-        }
-        return new Date(m[1]);
-    }
+            params.fnDrawCallback = function (a,b,c) {
+                /* be able to set fnDrawCallback from outside here later */
+                if (self.fnDrawCallback) {
+                    self.fnDrawCallback(a,b,c);
+                }
+            };
 
-    $.fn.dataTableExt.oSort['title-numeric-asc'] = function (a, b) { return sortSpecial(a, b, true, convertNum); };
+            if (self.aoColumns) {
+                params.aoColumns = self.aoColumns;
+            }
 
-    $.fn.dataTableExt.oSort['title-numeric-desc'] = function (a, b) { return sortSpecial(a, b, false, convertNum); };
+            if (self.forcePageSize) {
+                // limit the page size option to just the default size
+                params.lengthMenu = [self.defaultRows];
+            }
+            var datatable = $(this).dataTable(params);
+            if (!self.datatable) {
+                self.datatable = datatable;
+            }
 
-    $.fn.dataTableExt.oSort['title-date-asc']  = function (a,b) { return sortSpecial(a, b, true, convertDate); };
+            if (self.fixColumns) {
+                new $.fn.dataTable.FixedColumns(datatable, {
+                    iLeftColumns: self.fixColsNumLeft,
+                    iLeftWidth: self.fixColsWidth,
+                });
+            }
 
-    $.fn.dataTableExt.oSort['title-date-desc']  = function (a,b) { return sortSpecial(a, b, false, convertDate); };
+            // This fixes a display bug in some browsers where the pagination
+            // overlaps the footer when resizing from 10 to 100 or 10 to 50 rows
+            // (perhaps other lengths are affected...unknown). This makes sure
+            // that columns are redrawn on the first hit of a new length,
+            // as fnAdjustColumnSizing fixes the issue and it remains fixed
+            // without intervention afterward.
+            self._lengthsSeen = [];
+            datatable.on('length.dt', function (e, settings, length) {
+                if (self._lengthsSeen.indexOf(length) < 0) {
+                    datatable.fnAdjustColumnSizing();
+                    self._lengthsSeen.push(length);
+                }
+            });
 
-    return {
-        HQReportDataTables: function (options) { return new HQReportDataTables(options); },
-    };
+            var $dataTablesFilter = $(".dataTables_filter");
+            if ($dataTablesFilter && $("#extra-filter-info")) {
+                if ($dataTablesFilter.length > 1) {
+                    $($dataTablesFilter.first()).remove();
+                    $dataTablesFilter = $($dataTablesFilter.last());
+                }
+                $("#extra-filter-info").html($dataTablesFilter);
+                $dataTablesFilter.addClass("form-search");
+                var $inputField = $dataTablesFilter.find("input"),
+                    $inputLabel = $dataTablesFilter.find("label");
+
+                $dataTablesFilter.append($inputField);
+                $inputField.attr("id", "dataTables-filter-box");
+                $inputField.addClass("search-query").addClass('form-control');
+                $inputField.attr("placeholder", "Search...");
+
+                $inputLabel.attr("for", "dataTables-filter-box");
+                $inputLabel.html($('<i />').addClass("icon-search"));
+            }
+
+            var $dataTablesLength = $(self.dataTableElem).parents('.dataTables_wrapper').find(".dataTables_length"),
+                $dataTablesInfo = $(self.dataTableElem).parents('.dataTables_wrapper').find(".dataTables_info");
+            if ($dataTablesLength && $dataTablesInfo) {
+                var $selectField = $dataTablesLength.find("select"),
+                    $selectLabel = $dataTablesLength.find("label");
+
+                $dataTablesLength.append($selectField);
+                $selectLabel.remove();
+                $selectField.children().append(" per page");
+                if (self.showAllRowsOption) {
+                    $selectField.append($('<option value="-1" />').text("All Rows"));
+                }
+                $selectField.addClass('form-control');
+                $selectField.on("change", function () {
+                    var selectedValue = $selectField.find('option:selected').val();
+                    googleAnalytics.track.event("Reports", "Changed number of items shown", selectedValue);
+                });
+            }
+            $(".dataTables_length select").change(function () {
+                $(self.dataTableElem).trigger('hqreport.tabular.lengthChange', $(this).val());
+            });
+        });
+    };  // end of self.render
+
+    return self;
+};
+
+$.extend($.fn.dataTableExt.oStdClasses, {
+    "sSortAsc": "header headerSortAsc",
+    "sSortDesc": "header headerSortDesc",
+    "sSortable": "header headerSort",
 });
+
+// For sorting rows
+
+function sortSpecial(a, b, asc, convert) {
+    var x = convert(a);
+    var y = convert(b);
+
+    // sort nulls at end regardless of current sort direction
+    if (x === null && y === null) {
+        return 0;
+    }
+    if (x === null) {
+        return 1;
+    }
+    if (y === null) {
+        return -1;
+    }
+
+    return (asc ? 1 : -1) * ((x < y) ? -1 : ((x > y) ?  1 : 0));
+}
+
+function convertNum(k) {
+    var m = k.match(/title="*([-+.0-9eE]+)/);
+    if (m !== null) {
+        m = +m[1];
+        if (isNaN(m)) {
+            m = null;
+        }
+    }
+    return m;
+}
+
+function convertDate(k) {
+    var m = k.match(/title="*(.+)"/);
+    if (m[1] === "None") {
+        return null;
+    }
+    return new Date(m[1]);
+}
+
+$.fn.dataTableExt.oSort['title-numeric-asc'] = function (a, b) { return sortSpecial(a, b, true, convertNum); };
+
+$.fn.dataTableExt.oSort['title-numeric-desc'] = function (a, b) { return sortSpecial(a, b, false, convertNum); };
+
+$.fn.dataTableExt.oSort['title-date-asc']  = function (a,b) { return sortSpecial(a, b, true, convertDate); };
+
+$.fn.dataTableExt.oSort['title-date-desc']  = function (a,b) { return sortSpecial(a, b, false, convertDate); };
+
+export const datatablesConfig = {
+    HQReportDataTables: function (options) {
+        return new HQReportDataTables(options);
+    },
+};

--- a/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
@@ -331,7 +331,7 @@ $.fn.dataTableExt.oSort['title-date-asc']  = function (a,b) { return sortSpecial
 
 $.fn.dataTableExt.oSort['title-date-desc']  = function (a,b) { return sortSpecial(a, b, false, convertDate); };
 
-export const datatablesConfig = {
+export default {
     HQReportDataTables: function (options) {
         return new HQReportDataTables(options);
     },

--- a/corehq/apps/reports/static/reports/js/bootstrap5/tabular.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/tabular.js
@@ -1,105 +1,100 @@
-hqDefine("reports/js/bootstrap5/tabular", [
-    'jquery',
-    'underscore',
-    'hqwebapp/js/initial_page_data',
-    'reports/js/bootstrap5/datatables_config',
-    'reports/js/bootstrap5/standard_hq_report',
-    'reports/js/datepicker',
+import 'commcarehq';
 
-    // Page-specific scripts
-    'data_interfaces/js/bootstrap5/case_management',
-    'data_interfaces/js/archive_forms',
-    'reports/js/inspect_data',
-    'reports/js/bootstrap5/project_health_dashboard',
-    'reports/js/bootstrap5/aggregate_user_status',
-    'reports/js/bootstrap5/application_status',
-    'reports/js/user_history',
-    'reports/js/case_activity',
-], function (
-    $,
-    _,
-    initialPageData,
-    datatablesConfig,
-    standardHQReportModule
-) {
-    function renderPage(slug, tableOptions) {
-        if (tableOptions && tableOptions.datatables) {
-            var tableConfig = tableOptions,
-                options = {
-                    dataTableElem: '#report_table_' + slug,
-                    forcePageSize: tableConfig.force_page_size,
-                    defaultRows: tableConfig.default_rows,
-                    startAtRowNum: tableConfig.start_at_row,
-                    showAllRowsOption: tableConfig.show_all_rows,
-                    loadingTemplateSelector: '#js-template-loading-report',
-                    autoWidth: tableConfig.headers.auto_width,
-                };
-            if (!tableConfig.sortable) {
-                options.defaultSort = false;
-            }
-            if (tableConfig.headers.render_aoColumns) {
-                options.aoColumns = tableConfig.headers.render_aoColumns;
-            }
-            if (tableConfig.headers.custom_sort) {
-                options.customSort = tableConfig.headers.custom_sort;
-            }
-            if (tableConfig.pagination.hide) {
-                options.show_pagination = false;
-            }
-            if (tableConfig.pagination.is_on) {
-                _.extend(options, {
-                    ajaxSource: tableConfig.pagination.source,
-                    ajaxParams: tableConfig.pagination.params,
-                });
-            }
-            if (tableConfig.bad_request_error_text) {
-                options.badRequestErrorText = "<span class='label label-important'>" + gettext("Sorry!") + "</span>" + tableConfig.bad_request_error_text;
-            }
-            if (tableConfig.left_col.is_fixed) {
-                _.extend(options, {
-                    fixColumns: true,
-                    fixColsNumLeft: tableConfig.left_col.fixed.num,
-                    fixColsWidth: tableConfig.left_col.fixed.width,
-                });
-            }
-            var reportTables = datatablesConfig.HQReportDataTables(options);
-            var standardHQReport = standardHQReportModule.getStandardHQReport();
-            if (typeof standardHQReport !== 'undefined') {
-                standardHQReport.handleTabularReportCookies(reportTables);
-            }
-            reportTables.render();
+import $ from 'jquery';
+import _ from 'underscore';
+import initialPageData from 'hqwebapp/js/initial_page_data';
+import datatablesConfig from 'reports/js/bootstrap5/datatables_config';
+import standardHQReportModule from 'reports/js/bootstrap5/standard_hq_report';
+
+import 'reports/js/datepicker';
+
+import 'data_interfaces/js/bootstrap5/case_management';
+import 'data_interfaces/js/archive_forms';
+import 'reports/js/inspect_data';
+import 'reports/js/bootstrap5/project_health_dashboard';
+import 'reports/js/bootstrap5/aggregate_user_status';
+import 'reports/js/bootstrap5/application_status';
+import 'reports/js/user_history';
+import 'reports/js/case_activity';
+
+
+function renderPage(slug, tableOptions) {
+    if (tableOptions && tableOptions.datatables) {
+        var tableConfig = tableOptions,
+            options = {
+                dataTableElem: '#report_table_' + slug,
+                forcePageSize: tableConfig.force_page_size,
+                defaultRows: tableConfig.default_rows,
+                startAtRowNum: tableConfig.start_at_row,
+                showAllRowsOption: tableConfig.show_all_rows,
+                loadingTemplateSelector: '#js-template-loading-report',
+                autoWidth: tableConfig.headers.auto_width,
+            };
+        if (!tableConfig.sortable) {
+            options.defaultSort = false;
         }
-
-        $('.header-popover').popover({  /* todo B5: plugin:popover */
-            trigger: 'hover',
-            placement: 'bottom',
-            container: 'body',
-        });
+        if (tableConfig.headers.render_aoColumns) {
+            options.aoColumns = tableConfig.headers.render_aoColumns;
+        }
+        if (tableConfig.headers.custom_sort) {
+            options.customSort = tableConfig.headers.custom_sort;
+        }
+        if (tableConfig.pagination.hide) {
+            options.show_pagination = false;
+        }
+        if (tableConfig.pagination.is_on) {
+            _.extend(options, {
+                ajaxSource: tableConfig.pagination.source,
+                ajaxParams: tableConfig.pagination.params,
+            });
+        }
+        if (tableConfig.bad_request_error_text) {
+            options.badRequestErrorText = "<span class='label label-important'>" + gettext("Sorry!") + "</span>" + tableConfig.bad_request_error_text;
+        }
+        if (tableConfig.left_col.is_fixed) {
+            _.extend(options, {
+                fixColumns: true,
+                fixColsNumLeft: tableConfig.left_col.fixed.num,
+                fixColsWidth: tableConfig.left_col.fixed.width,
+            });
+        }
+        var reportTables = datatablesConfig.HQReportDataTables(options);
+        var standardHQReport = standardHQReportModule.getStandardHQReport();
+        if (typeof standardHQReport !== 'undefined') {
+            standardHQReport.handleTabularReportCookies(reportTables);
+        }
+        reportTables.render();
     }
 
-    // Handle async reports
-    $(document).on('ajaxSuccess', function (e, xhr, ajaxOptions, data) {
-        if (!data || !data.slug) {
-            // This file is imported by inddex/main, which then gets this event handler, which it doesn't need,
-            // and which errors sometimes (presumably because there are ajax requests happening that aren't the
-            // same as what this handler expects). Checking for data.slug is pretty innocuous and fixes the issue.
-            return;
-        }
-        var jsOptions = initialPageData.get("js_options");
-        if (jsOptions && ajaxOptions.url.indexOf(jsOptions.asyncUrl) === -1) {
-            return;
-        }
-        renderPage(data.slug, data.report_table_js_options);
+    $('.header-popover').popover({  /* todo B5: plugin:popover */
+        trigger: 'hover',
+        placement: 'bottom',
+        container: 'body',
     });
+}
 
-    // Handle sync reports
-    $(function () {
-        if (initialPageData.get("report_table_js_options")) {
-            renderPage(initialPageData.get("js_options").slug, initialPageData.get("report_table_js_options"));
-        }
-    });
-
-    return {
-        renderPage: renderPage,
-    };
+// Handle async reports
+$(document).on('ajaxSuccess', function (e, xhr, ajaxOptions, data) {
+    if (!data || !data.slug) {
+        // This file is imported by inddex/main, which then gets this event handler, which it doesn't need,
+        // and which errors sometimes (presumably because there are ajax requests happening that aren't the
+        // same as what this handler expects). Checking for data.slug is pretty innocuous and fixes the issue.
+        return;
+    }
+    var jsOptions = initialPageData.get("js_options");
+    if (jsOptions && ajaxOptions.url.indexOf(jsOptions.asyncUrl) === -1) {
+        return;
+    }
+    renderPage(data.slug, data.report_table_js_options);
 });
+
+// Handle sync reports
+$(function () {
+    if (initialPageData.get("report_table_js_options")) {
+        renderPage(initialPageData.get("js_options").slug, initialPageData.get("report_table_js_options"));
+    }
+});
+
+export default {
+    renderPage: renderPage,
+};


### PR DESCRIPTION
## Technical Summary
Updates `base.js`, `tabular.js` and `datatables_config.js` to ESM format

## Safety Assurance

### Safety story
Safe change. Not used by any production pages (no bootstrap 5 reports yet)

### Automated test coverage
N/A

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
unchecking due to bootstrap 5 diffs. late reverts can cause issues.
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
