### PR TITLE
move CSRF input field into body

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -47,10 +47,6 @@
 
     {% block stylesheets %}{% endblock stylesheets %}
 
-    {% block csrf_token_block %}
-      <input id="csrfTokenContainer" type="hidden" value="{{ csrf_token }}">
-    {% endblock %}
-
     {% compress css %}
       <link type="text/css"
             rel="stylesheet"
@@ -167,6 +163,11 @@
     {% endblock %}
   </head>
   <body>
+
+    {% block csrf_token_block %}
+      <input id="csrfTokenContainer" type="hidden" value="{{ csrf_token }}">
+    {% endblock %}
+
     {# for setting up page-wide backgrounds #}
     {% block background_content %}{% endblock %}
 


### PR DESCRIPTION

## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
It is invalid HTML to have an `<input />` tag in the `<head>`, and forces the browser to move all the tags (including stylesheets) following this input tag from the `<head>` into the `<body>`. bad things could happen in less forgiving browsers or in the future.

## Safety Assurance

### Safety story
very safe change. makes code better

### Automated test coverage
N/A

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
