### PR TITLE
[B5} update ChangeButtonState utility to support the 'reset' option

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
@@ -84,6 +84,9 @@ hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
     };
 
     $.fn.changeButtonState = function (state) {
+        if (!$(this).data('reset-text')) {
+            $(this).data('reset-text', $(this).text());
+        }
         $(this).text($(this).data(state + '-text'));
         return this;
     };

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
@@ -40,7 +40,7 @@
      $.fn.hqHelp = function (opts) {
          var self = this;
          self.each(function (i) {
-@@ -85,22 +73,19 @@
+@@ -85,22 +73,22 @@
              if (opts) {
                  options = _.extend(options, opts);
              }
@@ -65,6 +65,9 @@
 +    };
 +
 +    $.fn.changeButtonState = function (state) {
++        if (!$(this).data('reset-text')) {
++            $(this).data('reset-text', $(this).text());
++        }
 +        $(this).text($(this).data(state + '-text'));
 +        return this;
      };


### PR DESCRIPTION
## Technical Summary
The original `button()` state change utility from Bootstrap 3 allowed for a "reset" option to be passed in which would change the button state back to what it was prior to any other state change. This implements that behavior, which is needed by reports.

## Safety Assurance

### Safety story
Very safe small change

### Automated test coverage
N/A...diffs only

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
unchecked due to diffs
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
