### PR TITLE
fix padding around dismissable alerts in bootstrap 5 pages

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/alert_user.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/alert_user.js
@@ -27,7 +27,7 @@ function (
         var self = {
             "message": ko.observable(message),
             "alert_class": ko.observable(
-                "alert alert-dismissible message-alert"
+                "alert alert-dismissible message-alert mt-3 mb-2"
             ),
         };
         if (tags) {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/alert_user.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/alert_user.js.diff.txt
@@ -23,7 +23,7 @@
              "message": ko.observable(message),
              "alert_class": ko.observable(
 -                "alert fade in message-alert"
-+                "alert alert-dismissible message-alert"
++                "alert alert-dismissible message-alert mt-3 mb-2"
              ),
          };
          if (tags) {


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
Fixes padding around dismissable alerts on bootstrap 5 pages

from this:
![Screenshot 2025-01-20 at 5 39 28 PM](https://github.com/user-attachments/assets/0b93d6f3-143f-4c14-b0f3-2454b2ee38bd)

to this:
![Screenshot 2025-01-20 at 5 39 11 PM](https://github.com/user-attachments/assets/9614f192-19fa-4400-9b74-8288801799b0)



## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
very safe change. just adds some bootstrap 5 utility classes

### Automated test coverage
bootstrap 5 diffs

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
unchecked due to bootstrap 5 diffs causing problems with reverts in past
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
