### PR TITLE
`ConnectionSettings.used_by()` support for KYC Integration

### DIFF
--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -263,14 +263,15 @@ class ConnectionSettings(models.Model):
         this instance. Used for informing users, and determining whether
         the instance can be deleted.
         """
+        # TODO: Check OpenmrsImporters (when OpenmrsImporters use ConnectionSettings)
 
         kinds = set()
         if self.sqldatasetmap_set.exists():
             kinds.add(_('DHIS2 DataSet Maps'))
         if self.repeaters.exists():
             kinds.add(_('Data Forwarding'))
-
-        # TODO: Check OpenmrsImporters (when OpenmrsImporters use ConnectionSettings)
+        if self.kycconfig_set.exists():
+            kinds.add(_('KYC Integration'))
 
         return kinds
 


### PR DESCRIPTION
## Product Description

When a KYC Integration has been configured for a project, the Connection Settings that the integration uses will show that it is in use, and will prevent the user from unintentionally deleting those settings.

Unused Connection Settings:
![image](https://github.com/user-attachments/assets/30b01426-de4d-4df9-98de-da9fc3a2ab81)

Used by KYC Integration:
![image](https://github.com/user-attachments/assets/1a1932ca-d0f2-475a-ac8b-f4e1ac686f82)


## Technical Summary

Jira: [SC-4127](https://dimagi.atlassian.net/browse/SC-4127)
Spec: [Mobile Worker KYC integration](https://docs.google.com/document/d/1Aco77WDhARfc_I8zWZFoA8SccZGN9WVW8Mv3KpUtGig/edit?pli=1&tab=t.0#heading=h.ub6jhy1pn2ul)

## Feature Flag

TBD

## Safety Assurance

### Safety Story

Tested locally

### Automated test coverage

Includes tests

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-4127]: https://dimagi.atlassian.net/browse/SC-4127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ