### PR TITLE
Multi Case Type Filter for Microplanning Map

### DIFF
--- a/corehq/apps/geospatial/reports.py
+++ b/corehq/apps/geospatial/reports.py
@@ -47,13 +47,6 @@ from .utils import (
 
 
 class BaseCaseMapReport(ProjectReport, CaseListMixin, XpathCaseSearchFilterMixin):
-    fields = [
-        'corehq.apps.reports.standard.cases.filters.XPathCaseSearchFilter',
-        'corehq.apps.reports.filters.case_list.CaseListFilter',
-        'corehq.apps.reports.filters.select.CaseTypeFilter',
-        'corehq.apps.reports.filters.select.SelectOpenCloseFilter',
-    ]
-
     section_name = gettext_noop("Data")
 
     dispatcher = CaseManagementMapDispatcher
@@ -99,6 +92,13 @@ class BaseCaseMapReport(ProjectReport, CaseListMixin, XpathCaseSearchFilterMixin
 class CaseManagementMap(BaseCaseMapReport):
     name = gettext_noop("Microplanning Map")
     slug = "microplanning_map"
+
+    fields = [
+        'corehq.apps.reports.standard.cases.filters.XPathCaseSearchFilter',
+        'corehq.apps.reports.filters.case_list.CaseListFilter',
+        'corehq.apps.reports.filters.select.MultiCaseTypeFilter',
+        'corehq.apps.reports.filters.select.SelectOpenCloseFilter',
+    ]
 
     base_template = "geospatial/case_management_base.html"
     report_template_path = "geospatial/case_management.html"
@@ -153,6 +153,13 @@ class CaseManagementMap(BaseCaseMapReport):
 class CaseGroupingReport(BaseCaseMapReport):
     name = gettext_noop('Case Clustering Map')
     slug = 'case_clustering_map'
+
+    fields = [
+        'corehq.apps.reports.standard.cases.filters.XPathCaseSearchFilter',
+        'corehq.apps.reports.filters.case_list.CaseListFilter',
+        'corehq.apps.reports.filters.select.CaseTypeFilter',
+        'corehq.apps.reports.filters.select.SelectOpenCloseFilter',
+    ]
 
     base_template = 'geospatial/case_grouping_map_base.html'
     report_template_path = 'geospatial/case_grouping_map.html'


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The user will now be able to select multiple case types for filtering on the Microplanning Map page:
![multi-case-types](https://github.com/user-attachments/assets/17ad9a7a-6895-40db-9097-0147d9f01ef4)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-4185).
Link to tech spec [here](https://docs.google.com/document/d/13hses-6dLPqjEa6ChDmXSMIUK0VRNOdbkY7Zxr7MMt4/edit?tab=t.0#heading=h.tm6qgkpea0z1).

This PR introduces a very small change where the `CaseTypeFilter` class for the Microplanning Map report has been swapped out for the `MultiCaseTypeFilter` class. It should be noted that the latter is not being implemented in this PR and is already available within the codebase.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`MICROPLANNING`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing done

This is a very small UI change that simply swaps out the current single case type filter for a multi-case type filter.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
