### PR TITLE
Remove --noinput option in `delete_domain` command

### DIFF
--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -12,13 +12,6 @@ class Command(BaseCommand):
         parser.add_argument(
             'domain_name',
         )
-        parser.add_argument(
-            '--noinput',
-            action='store_true',
-            dest='noinput',
-            default=False,
-            help='Skip important confirmation warnings.',
-        )
 
     def handle(self, domain_name, **options):
         domain_objs = list(iter_all_domains_and_deleted_domains_with_name(domain_name))
@@ -28,18 +21,17 @@ class Command(BaseCommand):
         if len(domain_objs) > 1:
             print("FYI: There are multiple domain objects for this domain"
                   "and they will all be soft-deleted.")
-        if not options['noinput']:
-            confirm = input(textwrap.dedent(
-                f"""
-                Are you sure you want to delete the domain "{domain_name}" and all of it's data?
-                This operation is not reversible and all forms and cases will be PERMANENTLY deleted.
+        confirm = input(textwrap.dedent(
+            f"""
+            Are you sure you want to delete the domain "{domain_name}" and all of it's data?
+            This operation is not reversible and all forms and cases will be PERMANENTLY deleted.
 
-                Type the domain's name again to continue, or anything else to cancel:
-                """
-            ))
-            if confirm != domain_name:
-                print("\n\t\tDomain deletion cancelled.")
-                return
+            Type the domain's name again to continue, or anything else to cancel:
+            """
+        ))
+        if confirm != domain_name:
+            print("\n\t\tDomain deletion cancelled.")
+            return
         print(f"Soft-Deleting domain {domain_name} "
               "(i.e. switching its type to Domain-Deleted, "
               "which will prevent anyone from reusing that domain)")


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This command is too dangerous to allow running without confirmation.

Updated [docs](https://dimagi.atlassian.net/wiki/spaces/saas/pages/2146607022/SaaS+Genie+Chores) that previously referenced this option too.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just removes an option
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
