### PR TITLE
Sanitise Microplanning Road Network Algorithm Param Data

### DIFF
--- a/corehq/apps/geospatial/routing_solvers/pulp.py
+++ b/corehq/apps/geospatial/routing_solvers/pulp.py
@@ -68,7 +68,10 @@ class RadialDistanceSolver(DisbursementAlgorithmSolverInterface):
     def solve(self, config, print_solution=False):
         parameters = self.get_parameters(config)
 
-        distance_costs, duration_costs = self.calculate_distance_matrix(config)
+        try:
+            distance_costs, duration_costs = self.calculate_distance_matrix(config)
+        except ValueError as e:
+            raise ValueError('Some user and/or case locations are invalid') from e
 
         if not distance_costs:
             return self.solution_results(

--- a/corehq/apps/geospatial/routing_solvers/pulp.py
+++ b/corehq/apps/geospatial/routing_solvers/pulp.py
@@ -191,7 +191,7 @@ class RoadNetworkSolver(RadialDistanceSolver):
             raise Exception("This is more than Mapbox matrix API limit (25)")
 
         coordinates = ';'.join([
-            f'{loc["lon"]},{loc["lat"]}'
+            f'{float(loc["lon"])},{float(loc["lat"])}'
             for loc in self.user_locations + self.case_locations]
         )
         sources_count = len(self.user_locations)

--- a/corehq/apps/geospatial/tests/test_pulp.py
+++ b/corehq/apps/geospatial/tests/test_pulp.py
@@ -10,6 +10,10 @@ from corehq.apps.geospatial.models import GeoConfig
 class TestRadialDistanceSolver(SimpleTestCase):
     # Tests the correctness of the code, not the optimumness of the solution
 
+    def setUp(self):
+        super().setUp()
+        self.solver = RadialDistanceSolver(self._problem_data)
+
     @property
     def _problem_data(self):
         return {
@@ -31,11 +35,10 @@ class TestRadialDistanceSolver(SimpleTestCase):
 
     def test_basic(self):
         config = GeoConfig()
-        solver = RadialDistanceSolver(self._problem_data)
-        params = solver.get_parameters(config=config)
+        params = self.solver.get_parameters(config=config)
 
         self.assertEqual(
-            solver.solve(config), {
+            self.solver.solve(config), {
                 'assigned': {
                     'New York': ['New Hampshire', 'Newark', 'NY2'],
                     'Los Angeles': ['Phoenix', 'LA2', 'LA3', 'Dallas', 'Jackson']
@@ -44,11 +47,10 @@ class TestRadialDistanceSolver(SimpleTestCase):
 
     def test_with_max_criteria(self):
         config = GeoConfig(max_cases_per_user=4)
-        solver = RadialDistanceSolver(self._problem_data)
-        params = solver.get_parameters(config=config)
+        params = self.solver.get_parameters(config=config)
 
         self.assertEqual(
-            solver.solve(config), {
+            self.solver.solve(config), {
                 'assigned': {
                     'New York': ['New Hampshire', 'Newark', 'NY2', 'Dallas'],
                     'Los Angeles': ['Phoenix', 'LA2', 'LA3', 'Jackson']
@@ -58,8 +60,7 @@ class TestRadialDistanceSolver(SimpleTestCase):
     def test_more_cases_than_is_assignable(self):
         # If max_cases_per_user * n_users < n_cases, that would result in an infeasible solution.
         config = GeoConfig(max_cases_per_user=2)
-        solver = RadialDistanceSolver(self._problem_data)
-        params = solver.get_parameters(config=config)
+        params = self.solver.get_parameters(config=config)
 
         expected_results = {
             'assigned': [],
@@ -67,20 +68,19 @@ class TestRadialDistanceSolver(SimpleTestCase):
             'parameters': params.__dict__,
         }
         self.assertEqual(
-            solver.solve(config), expected_results
+            self.solver.solve(config), expected_results
         )
 
     def test_too_few_cases_for_minimum_criteria(self):
         config = GeoConfig(min_cases_per_user=5)
-        solver = RadialDistanceSolver(self._problem_data)
-        params = solver.get_parameters(config=config)
+        params = self.solver.get_parameters(config=config)
 
         expected_results = {
             'assigned': [],
             'unassigned': self._problem_data['cases'],
             'parameters': params.__dict__,
         }
-        self.assertEqual(solver.solve(config), expected_results)
+        self.assertEqual(self.solver.solve(config), expected_results)
 
     def test_no_cases_is_infeasible_solution(self):
         problem_data = self._problem_data
@@ -110,8 +110,7 @@ class TestRadialDistanceSolver(SimpleTestCase):
 
     def test_cases_too_far_distance(self):
         config = GeoConfig(max_case_distance=1)
-        solver = RadialDistanceSolver(self._problem_data)
-        params = solver.get_parameters(config=config)
+        params = self.solver.get_parameters(config=config)
 
         expected_results = {
             'assigned': {'New York': [], 'Los Angeles': []},
@@ -119,16 +118,16 @@ class TestRadialDistanceSolver(SimpleTestCase):
             'parameters': params.__dict__,
         }
         self.assertEqual(
-            solver.solve(config), expected_results
+            self.solver.solve(config), expected_results
         )
 
     def test_massive_distance_disburses_normally(self):
         # This test just shows that, given a big enough radius from the user, the results will look
         # the same as if there was no radius at all
-        results_from_normal = RadialDistanceSolver(self._problem_data).solve(GeoConfig())
+        results_from_normal = self.solver.solve(GeoConfig())
         results_from_normal['parameters'] = {}  # don't care about params
 
-        results_massive_max_distance = RadialDistanceSolver(self._problem_data).solve(
+        results_massive_max_distance = self.solver.solve(
             GeoConfig(max_case_distance=10000)
         )
         results_massive_max_distance['parameters'] = {}
@@ -138,8 +137,8 @@ class TestRadialDistanceSolver(SimpleTestCase):
         )
 
     def test_radial_solver_does_not_take_travel_time_into_account(self):
-        results_from_normal = RadialDistanceSolver(self._problem_data).solve(GeoConfig())
-        results_with_travel_time = RadialDistanceSolver(self._problem_data).solve(
+        results_from_normal = self.solver.solve(GeoConfig())
+        results_with_travel_time = self.solver.solve(
             GeoConfig(max_case_travel_time=5)
         )
         self.assertEqual(

--- a/corehq/apps/geospatial/tests/test_pulp.py
+++ b/corehq/apps/geospatial/tests/test_pulp.py
@@ -1,7 +1,8 @@
 from django.test import SimpleTestCase
 
 from corehq.apps.geospatial.routing_solvers.pulp import (
-    RadialDistanceSolver
+    RadialDistanceSolver,
+    RoadNetworkSolver
 )
 from corehq.apps.geospatial.models import GeoConfig
 
@@ -144,3 +145,32 @@ class TestRadialDistanceSolver(SimpleTestCase):
         self.assertEqual(
             results_from_normal, results_with_travel_time
         )
+
+    def test_incorrect_data(self):
+        config = GeoConfig()
+        problem_data = self._problem_data
+        problem_data['cases'] = [
+            {'id': 'Wrong', 'lat': 'incorrect-data', 'lon': 21.20},
+        ]
+        with self.assertRaises(ValueError):
+            RadialDistanceSolver(problem_data).calculate_distance_matrix(config)
+
+
+class TestRoadNetworkSolver(SimpleTestCase):
+
+    @property
+    def _problem_data(self):
+        return {
+            "users": [
+                {"id": "New York", "lon": -73.9750671, "lat": 40.7638143},
+            ],
+            "cases": [
+                {"id": "New Hampshire", "lon": -71.572395, "lat": 43.193851},
+                {"id": "Phoenix", "lon": 'incorrect-data', "lat": 33.870416},
+            ],
+        }
+
+    def test_incorrect_data(self):
+        config = GeoConfig()
+        with self.assertRaises(ValueError):
+            RoadNetworkSolver(self._problem_data).calculate_distance_matrix(config)

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -59,6 +59,7 @@ from .utils import (
     create_case_with_gps_property,
     get_flag_assigned_cases_config,
     get_geo_case_property,
+    get_geo_config,
     get_geo_user_property,
     get_lat_lon_from_dict,
     set_case_gps_property,
@@ -86,7 +87,7 @@ class CaseDisbursementAlgorithm(BaseDomainView):
     urlname = "case_disbursement"
 
     def post(self, request, domain, *args, **kwargs):
-        config = GeoConfig.objects.get(domain=domain)
+        config = get_geo_config(domain)
         request_json = json.loads(request.body.decode('utf-8'))
 
         solver_class = config.disbursement_solver


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-4246).

The `RoadNetworkSolver` class concatenates a string of user and case coordinates when calculating the distance matrix, which then gets sent off to the Mapbox API. These coordinates are passed in from an endpoint, and if a user were to invoke this endpoint directly they could potentially pass in whatever values they want for the user and case coordinates. This leads to creating a coordinate string that can be vulnerable to SQL injection.

It should be noted this does not directly affect the CommCare HQ DB since the coordinate string is simply sent off to the Mapbox API. Still, it is better to ensure this data is sanitised to prevent any potential unforeseen consequences.

In additon to the above, this PR also makes a small change to safely fetch the `GeoConfig` instance for a domain. Previously, if a config did not exist for a domain then a exception would be thrown. This can happen if a domain has not changed any Microplanning settings yet.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`MICROPLANNING`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing done
- Unit tests exist

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests exist to verify that an exception is correctly thrown when invalid param data is passed into the disbursement solver.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
