### PR TITLE
Don't keep processing when backoff is set

### DIFF
--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -492,6 +492,7 @@ def update_repeater(repeat_record_states, repeater_id, lock_token, more):
                 'commcare.repeaters.process_repeaters.repeater_backoff',
                 tags={'domain': repeater.domain},
             )
+            more = False
             repeater.set_backoff()
     finally:
         lock = RepeaterLock(repeater_id, lock_token)

--- a/corehq/motech/repeaters/tests/test_tasks.py
+++ b/corehq/motech/repeaters/tests/test_tasks.py
@@ -314,16 +314,26 @@ class TestUpdateRepeater(SimpleTestCase):
         mock_repeater.set_backoff.assert_not_called()
         mock_repeater.reset_backoff.assert_called_once()
 
+    @patch('corehq.motech.repeaters.tasks.process_repeater')
     @patch('corehq.motech.repeaters.tasks.RepeaterLock')
     @patch('corehq.motech.repeaters.tasks.Repeater.objects.get')
-    def test_update_repeater_sets_backoff_on_failure(self, mock_get_repeater, __):
+    def test_update_repeater_backs_off_on_failure(
+        self,
+        mock_get_repeater,
+        mock_get_repeater_lock,
+        mock_process_repeater,
+    ):
         repeat_record_states = [State.Fail, State.Empty, None]
         mock_repeater = MagicMock()
         mock_get_repeater.return_value = mock_repeater
-        update_repeater(repeat_record_states, 1, 'token', False)
+        mock_lock = MagicMock()
+        mock_get_repeater_lock.return_value = mock_lock
+        update_repeater(repeat_record_states, 1, 'token', True)
 
         mock_repeater.set_backoff.assert_called_once()
         mock_repeater.reset_backoff.assert_not_called()
+        mock_process_repeater.assert_not_called()
+        mock_lock.release.assert_called_once()
 
     @patch('corehq.motech.repeaters.tasks.RepeaterLock')
     @patch('corehq.motech.repeaters.tasks.Repeater.objects.get')


### PR DESCRIPTION
## Technical Summary

I missed something: Currently `update_repeater()` will keep processing payloads, even when it is set to back off. This is a one-line change (and an updated test) to fix that.

## Feature Flag
`PROCESS_REPEATERS`

## Safety Assurance

### Safety story

This feature is not yet deployed.

### Automated test coverage

Includes test

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
