### PR TITLE
[B5] have email report form support usage with bootstrap 5 pages

### DIFF
--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -13,6 +13,7 @@ from crispy_forms.bootstrap import StrictButton
 import langcodes
 from corehq.apps.hqwebapp.crispy import FormActions, HQFormHelper, LinkButton
 from corehq.apps.hqwebapp.fields import MultiEmailField
+from corehq.apps.hqwebapp.utils.bootstrap import get_bootstrap_version, BOOTSTRAP_5
 from corehq.apps.hqwebapp.widgets import SelectToggle
 from corehq.apps.reports.models import TableauServer, TableauVisualization
 from corehq.apps.saved_reports.models import (
@@ -243,6 +244,12 @@ class EmailReportForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        if get_bootstrap_version() == BOOTSTRAP_5:
+            self._setup_bootstrap5()
+        else:
+            self._setup_bootstrap3()
+
+    def _setup_bootstrap3(self):
         self.helper = HQFormHelper()
         self.helper.field_class = "col-xs-10"
         self.helper.layout = crispy.Layout(
@@ -250,18 +257,38 @@ class EmailReportForm(forms.Form):
                 crispy.Field('subject', data_bind="value: subject"),
                 crispy.Field('send_to_owner', data_bind="checked: send_to_owner"),
                 crispy.Field('recipient_emails', css_id='email-report-recipient_emails',
-                    data_bind="selectedOptions: recipient_emails"),
+                             data_bind="selectedOptions: recipient_emails"),
                 crispy.Field('notes', data_bind="value: notes"),
                 css_class='modal-body'
             ),
             FormActions(
                 crispy.Div(
                     crispy.Button('close', _('Close'), css_class='btn btn-default cancel-button',
-                        data_bind='click: resetModal', data_dismiss='modal'),
+                                  data_bind='click: resetModal', data_dismiss='modal'),
                     crispy.Submit('submit_btn', _('Send Email'), css_class="btn btn-primary send-button",
-                        data_bind='click: sendEmail', data_loading_text=_('Sending...')),
+                                  data_bind='click: sendEmail', data_loading_text=_('Sending...')),
                     css_class='pull-right',
                 )
+            )
+        )
+
+    def _setup_bootstrap5(self):
+        self.helper = FormHelper()
+        self.helper.layout = crispy.Layout(
+            crispy.Div(
+                crispy.Field('subject', data_bind="value: subject"),
+                crispy.Field('send_to_owner', data_bind="checked: send_to_owner"),
+                crispy.Field('recipient_emails', css_id='email-report-recipient_emails',
+                             data_bind="selectedOptions: recipient_emails"),
+                crispy.Field('notes', data_bind="value: notes"),
+                css_class='modal-body'
+            ),
+            crispy.Div(
+                crispy.Button('close', _('Close'), css_class='btn btn-outline-primary cancel-button',
+                              data_bind='click: resetModal', data_bs_dismiss='modal'),
+                crispy.Submit('submit_btn', _('Send Email'), css_class="btn btn-primary send-button",
+                              data_bind='click: sendEmail', data_loading_text=_('Sending...')),
+                css_class='modal-footer',
             )
         )
 


### PR DESCRIPTION
## Technical Summary
In Bootstrap 5, we switch to vertical form labels (versus horizontal labels) in places with restricted horizontal space. Since this crispy form is used by both bootstrap 3 and (soon) bootstrap 5 reports, we need a way to support both states. Additionally some `data-` tags, like `data-dismiss` change in bootstrap 5 to `data-bs-dismiss`

![Screenshot 2025-01-20 at 5 45 17 PM](https://github.com/user-attachments/assets/1af35a80-c4f1-4ef9-9591-18b97faa1837)


## Safety Assurance

### Safety story
Very safe change. Has already been a part of QA efforts on staging

### Automated test coverage
N/A

### QA Plan
Not needed, but it already has been a part of successful QA efforts on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
