### PR TITLE
Add rate limiting for check_username_availability

### DIFF
--- a/corehq/apps/registration/rate_limiter.py
+++ b/corehq/apps/registration/rate_limiter.py
@@ -17,7 +17,7 @@ STATUS_BAD_REQUEST = 'bad_request'
 STATUS_ACCEPTED = 'accepted'
 
 
-@run_only_when(not settings.ENTERPRISE_MODE and not settings.UNIT_TESTING)
+@run_only_when(not settings.UNIT_TESTING)
 @silence_and_report_error("Exception raised in the check username availability rate limiter",
                           'commcare.registration.check_username_rate_limiter_errors')
 def rate_limit_check_username_availability():
@@ -48,9 +48,12 @@ def rate_limit_check_username_availability():
 def _get_session_and_ip():
     request = get_request()
     if request and request.session:
-        return request.session.session_key, get_ip(request)
+        session_id = request.session.session_key
+        ip_address = get_ip(request)
     else:
-        return None
+        session_id, ip_address = None, None
+
+    return session_id, ip_address
 
 
 def _check_for_exceeded_rate_limits(session, ip):

--- a/corehq/apps/registration/rate_limiter.py
+++ b/corehq/apps/registration/rate_limiter.py
@@ -1,0 +1,98 @@
+from django.conf import settings
+
+from dimagi.utils.web import get_ip
+
+from corehq.project_limits.rate_limiter import (
+    RateDefinition,
+    RateLimiter,
+    get_dynamic_rate_definition,
+)
+from corehq.util.decorators import run_only_when, silence_and_report_error
+from corehq.util.global_request import get_request
+from corehq.util.metrics import metrics_counter
+
+
+@run_only_when(not settings.ENTERPRISE_MODE and not settings.UNIT_TESTING)
+@silence_and_report_error("Exception raised in the check username availability rate limiter",
+                          'commcare.registration.check_username_rate_limiter_errors')
+def rate_limit_check_username_availability():
+    """
+    This holds attempts per IP OR per session below limits given by
+    check_username_rate_limiter_by_ip and check_username_rate_limiter_by_session, respectively.
+
+    Requests without both an IP and session ID are rejected.
+    """
+    _status_session_rate_limited = 'session_rate_limited'
+    _status_ip_rate_limited = 'ip_rate_limited'
+    _status_bad_request = 'bad_request'
+    _status_accepted = 'accepted'
+
+    def get_session_and_ip():
+        request = get_request()
+        if request and request.session:
+            return request.session.session_key, get_ip(request)
+        else:
+            return None
+
+    def _check_for_exceeded_rate_limits(session, ip):
+        session_window = (
+            check_username_rate_limiter_per_session
+            .get_window_of_first_exceeded_limit('session:{}'.format(session))
+        )
+        ip_window = check_username_rate_limiter_per_ip.get_window_of_first_exceeded_limit('ip:{}'.format(ip))
+
+        # ensure that no rate limit windows have been exceeded
+        # order of priority (session, ip)
+        if session_window is not None:
+            return _status_session_rate_limited, session_window
+        elif ip_window is not None:
+            return _status_ip_rate_limited, ip_window
+        else:
+            return _status_accepted, None
+
+    session_id, ip_address = get_session_and_ip()
+
+    if ip_address and session_id:
+        status, window = _check_for_exceeded_rate_limits(session_id, ip_address)
+        if status == _status_accepted:
+            check_username_rate_limiter_per_session.report_usage('session:{}'.format(session_id))
+            check_username_rate_limiter_per_ip.report_usage('ip:{}'.format(ip_address))
+
+    else:
+        window = None
+        status = _status_bad_request
+
+    metrics_counter('commcare.registration.check_username_attempts', 1, tags={
+        'status': status,
+        'window': window or 'none',
+    })
+    return status != _status_accepted
+
+
+check_username_rate_limiter_per_ip = RateLimiter(
+    feature_key='check_username_attempts_per_ip',
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
+        'check_username_attempts_per_ip',
+        default=RateDefinition(
+            per_week=5000,
+            per_day=2500,
+            per_hour=1000,
+            per_minute=200,
+            per_second=25,
+        )
+    ).get_rate_limits(scope),
+)
+
+check_username_rate_limiter_per_session = RateLimiter(
+    feature_key='check_username_attempts_per_session',
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
+        'check_username_attempts_per_session',
+        default=RateDefinition(
+            per_week=500,
+            per_day=250,
+            per_hour=100,
+            per_minute=20,
+            per_second=2.5,
+        )
+    ).get_rate_limits(scope),
+)

--- a/corehq/apps/registration/rate_limiter.py
+++ b/corehq/apps/registration/rate_limiter.py
@@ -11,6 +11,11 @@ from corehq.util.decorators import run_only_when, silence_and_report_error
 from corehq.util.global_request import get_request
 from corehq.util.metrics import metrics_counter
 
+STATUS_SESSION_RATE_LIMITED = 'session_rate_limited'
+STATUS_IP_RATE_LIMITED = 'ip_rate_limited'
+STATUS_BAD_REQUEST = 'bad_request'
+STATUS_ACCEPTED = 'accepted'
+
 
 @run_only_when(not settings.ENTERPRISE_MODE and not settings.UNIT_TESTING)
 @silence_and_report_error("Exception raised in the check username availability rate limiter",
@@ -22,51 +27,47 @@ def rate_limit_check_username_availability():
 
     Requests without both an IP and session ID are rejected.
     """
-    _status_session_rate_limited = 'session_rate_limited'
-    _status_ip_rate_limited = 'ip_rate_limited'
-    _status_bad_request = 'bad_request'
-    _status_accepted = 'accepted'
-
-    def get_session_and_ip():
-        request = get_request()
-        if request and request.session:
-            return request.session.session_key, get_ip(request)
-        else:
-            return None
-
-    def _check_for_exceeded_rate_limits(session, ip):
-        session_window = (
-            check_username_rate_limiter_per_session
-            .get_window_of_first_exceeded_limit('session:{}'.format(session))
-        )
-        ip_window = check_username_rate_limiter_per_ip.get_window_of_first_exceeded_limit('ip:{}'.format(ip))
-
-        # ensure that no rate limit windows have been exceeded
-        # order of priority (session, ip)
-        if session_window is not None:
-            return _status_session_rate_limited, session_window
-        elif ip_window is not None:
-            return _status_ip_rate_limited, ip_window
-        else:
-            return _status_accepted, None
-
-    session_id, ip_address = get_session_and_ip()
+    session_id, ip_address = _get_session_and_ip()
 
     if ip_address and session_id:
         status, window = _check_for_exceeded_rate_limits(session_id, ip_address)
-        if status == _status_accepted:
+        if status == STATUS_ACCEPTED:
             check_username_rate_limiter_per_session.report_usage('session:{}'.format(session_id))
             check_username_rate_limiter_per_ip.report_usage('ip:{}'.format(ip_address))
-
     else:
         window = None
-        status = _status_bad_request
+        status = STATUS_BAD_REQUEST
 
     metrics_counter('commcare.registration.check_username_attempts', 1, tags={
         'status': status,
         'window': window or 'none',
     })
-    return status != _status_accepted
+    return status != STATUS_ACCEPTED
+
+
+def _get_session_and_ip():
+    request = get_request()
+    if request and request.session:
+        return request.session.session_key, get_ip(request)
+    else:
+        return None
+
+
+def _check_for_exceeded_rate_limits(session, ip):
+    session_window = (
+        check_username_rate_limiter_per_session
+        .get_window_of_first_exceeded_limit('session:{}'.format(session))
+    )
+    ip_window = check_username_rate_limiter_per_ip.get_window_of_first_exceeded_limit('ip:{}'.format(ip))
+
+    # ensure that no rate limit windows have been exceeded
+    # order of priority (session, ip)
+    if session_window is not None:
+        return STATUS_SESSION_RATE_LIMITED, session_window
+    elif ip_window is not None:
+        return STATUS_IP_RATE_LIMITED, ip_window
+    else:
+        return STATUS_ACCEPTED, None
 
 
 check_username_rate_limiter_per_ip = RateLimiter(

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -38,7 +38,15 @@ from corehq.apps.registration.models import (
 from corehq.apps.registration.tasks import send_domain_registration_email
 from corehq.apps.users.models import CouchUser, WebUser
 from corehq.apps.users.role_utils import initialize_domain_with_default_roles
+from corehq.project_limits.rate_limiter import (
+    RateDefinition,
+    RateLimiter,
+    get_dynamic_rate_definition,
+)
 from corehq.toggles import USE_LOGO_IN_SYSTEM_EMAILS
+from corehq.util.decorators import run_only_when, silence_and_report_error
+from corehq.util.global_request import get_request
+from corehq.util.metrics import metrics_counter
 from corehq.util.soft_assert import soft_assert
 from corehq.util.view_utils import absolute_reverse
 
@@ -313,3 +321,89 @@ def send_mobile_experience_reminder(recipient, full_name, additional_email_conte
         logging.warning(
             "Can't send email, but the message was:\n%s" % message_plaintext)
         raise
+
+
+@run_only_when(not settings.ENTERPRISE_MODE and not settings.UNIT_TESTING)
+@silence_and_report_error("Exception raised in the check username availability rate limiter",
+                          'commcare.registration.check_username_rate_limiter_errors')
+def rate_limit_check_username_availability():
+    """
+    This holds attempts per IP OR per session below limits given by
+    check_username_rate_limiter_by_ip and check_username_rate_limiter_by_session, respectively.
+
+    Requests without both an IP and session ID are rejected.
+    """
+    _status_session_rate_limited = 'session_rate_limited'
+    _status_ip_rate_limited = 'ip_rate_limited'
+    _status_bad_request = 'bad_request'
+    _status_accepted = 'accepted'
+
+    def get_session_and_ip():
+        request = get_request()
+        if request and request.session:
+            return request.session.session_key, get_ip(request)
+        else:
+            return None
+
+    def _check_for_exceeded_rate_limits(session, ip):
+        session_window = (
+            check_username_rate_limiter_per_session
+            .get_window_of_first_exceeded_limit('session:{}'.format(session))
+        )
+        ip_window = check_username_rate_limiter_per_ip.get_window_of_first_exceeded_limit('ip:{}'.format(ip))
+
+        # ensure that no rate limit windows have been exceeded
+        # order of priority (session, ip)
+        if session_window is not None:
+            return _status_session_rate_limited, session_window
+        elif ip_window is not None:
+            return _status_ip_rate_limited, ip_window
+        else:
+            return _status_accepted, None
+
+    session_id, ip_address = get_session_and_ip()
+
+    if ip_address and session_id:
+        status, window = _check_for_exceeded_rate_limits(session_id, ip_address)
+        if status == _status_accepted:
+            check_username_rate_limiter_per_session.report_usage('session:{}'.format(session_id))
+            check_username_rate_limiter_per_ip.report_usage('ip:{}'.format(ip_address))
+
+    else:
+        window = None
+        status = _status_bad_request
+
+    metrics_counter('commcare.registration.check_username_attempts', 1, tags={
+        'status': status,
+        'window': window or 'none',
+    })
+    return status != _status_accepted
+
+
+check_username_rate_limiter_per_ip = RateLimiter(
+    feature_key='check_username_attempts_per_ip',
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
+        'check_username_attempts_per_ip',
+        default=RateDefinition(
+            per_week=5000,
+            per_day=2500,
+            per_hour=1000,
+            per_minute=200,
+            per_second=25,
+        )
+    ).get_rate_limits(scope),
+)
+
+check_username_rate_limiter_per_session = RateLimiter(
+    feature_key='check_username_attempts_per_session',
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
+        'check_username_attempts_per_session',
+        default=RateDefinition(
+            per_week=500,
+            per_day=250,
+            per_hour=100,
+            per_minute=20,
+            per_second=2.5,
+        )
+    ).get_rate_limits(scope),
+)

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -38,15 +38,7 @@ from corehq.apps.registration.models import (
 from corehq.apps.registration.tasks import send_domain_registration_email
 from corehq.apps.users.models import CouchUser, WebUser
 from corehq.apps.users.role_utils import initialize_domain_with_default_roles
-from corehq.project_limits.rate_limiter import (
-    RateDefinition,
-    RateLimiter,
-    get_dynamic_rate_definition,
-)
 from corehq.toggles import USE_LOGO_IN_SYSTEM_EMAILS
-from corehq.util.decorators import run_only_when, silence_and_report_error
-from corehq.util.global_request import get_request
-from corehq.util.metrics import metrics_counter
 from corehq.util.soft_assert import soft_assert
 from corehq.util.view_utils import absolute_reverse
 
@@ -321,89 +313,3 @@ def send_mobile_experience_reminder(recipient, full_name, additional_email_conte
         logging.warning(
             "Can't send email, but the message was:\n%s" % message_plaintext)
         raise
-
-
-@run_only_when(not settings.ENTERPRISE_MODE and not settings.UNIT_TESTING)
-@silence_and_report_error("Exception raised in the check username availability rate limiter",
-                          'commcare.registration.check_username_rate_limiter_errors')
-def rate_limit_check_username_availability():
-    """
-    This holds attempts per IP OR per session below limits given by
-    check_username_rate_limiter_by_ip and check_username_rate_limiter_by_session, respectively.
-
-    Requests without both an IP and session ID are rejected.
-    """
-    _status_session_rate_limited = 'session_rate_limited'
-    _status_ip_rate_limited = 'ip_rate_limited'
-    _status_bad_request = 'bad_request'
-    _status_accepted = 'accepted'
-
-    def get_session_and_ip():
-        request = get_request()
-        if request and request.session:
-            return request.session.session_key, get_ip(request)
-        else:
-            return None
-
-    def _check_for_exceeded_rate_limits(session, ip):
-        session_window = (
-            check_username_rate_limiter_per_session
-            .get_window_of_first_exceeded_limit('session:{}'.format(session))
-        )
-        ip_window = check_username_rate_limiter_per_ip.get_window_of_first_exceeded_limit('ip:{}'.format(ip))
-
-        # ensure that no rate limit windows have been exceeded
-        # order of priority (session, ip)
-        if session_window is not None:
-            return _status_session_rate_limited, session_window
-        elif ip_window is not None:
-            return _status_ip_rate_limited, ip_window
-        else:
-            return _status_accepted, None
-
-    session_id, ip_address = get_session_and_ip()
-
-    if ip_address and session_id:
-        status, window = _check_for_exceeded_rate_limits(session_id, ip_address)
-        if status == _status_accepted:
-            check_username_rate_limiter_per_session.report_usage('session:{}'.format(session_id))
-            check_username_rate_limiter_per_ip.report_usage('ip:{}'.format(ip_address))
-
-    else:
-        window = None
-        status = _status_bad_request
-
-    metrics_counter('commcare.registration.check_username_attempts', 1, tags={
-        'status': status,
-        'window': window or 'none',
-    })
-    return status != _status_accepted
-
-
-check_username_rate_limiter_per_ip = RateLimiter(
-    feature_key='check_username_attempts_per_ip',
-    get_rate_limits=lambda scope: get_dynamic_rate_definition(
-        'check_username_attempts_per_ip',
-        default=RateDefinition(
-            per_week=5000,
-            per_day=2500,
-            per_hour=1000,
-            per_minute=200,
-            per_second=25,
-        )
-    ).get_rate_limits(scope),
-)
-
-check_username_rate_limiter_per_session = RateLimiter(
-    feature_key='check_username_attempts_per_session',
-    get_rate_limits=lambda scope: get_dynamic_rate_definition(
-        'check_username_attempts_per_session',
-        default=RateDefinition(
-            per_week=500,
-            per_day=250,
-            per_hour=100,
-            per_minute=20,
-            per_second=2.5,
-        )
-    ).get_rate_limits(scope),
-)

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -49,10 +49,10 @@ from corehq.apps.registration.models import (
     RegistrationRequest,
     SelfSignupWorkflow,
 )
+from corehq.apps.registration.rate_limiter import rate_limit_check_username_availability
 from corehq.apps.registration.utils import (
     activate_new_user_via_reg_form,
     project_logo_emails_context,
-    rate_limit_check_username_availability,
     request_new_domain,
     send_domain_registration_email,
     send_mobile_experience_reminder,

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -216,7 +216,7 @@ class ProcessRegistrationView(JSONResponseMixin, View):
     def check_username_availability(self, data):
         if rate_limit_check_username_availability():
             return {
-                'isValid': None,
+                'isValid': False,
                 'message': _("Please try again."),
             }
 

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -52,6 +52,7 @@ from corehq.apps.registration.models import (
 from corehq.apps.registration.utils import (
     activate_new_user_via_reg_form,
     project_logo_emails_context,
+    rate_limit_check_username_availability,
     request_new_domain,
     send_domain_registration_email,
     send_mobile_experience_reminder,
@@ -213,6 +214,12 @@ class ProcessRegistrationView(JSONResponseMixin, View):
 
     @allow_remote_invocation
     def check_username_availability(self, data):
+        if rate_limit_check_username_availability():
+            return {
+                'isValid': None,
+                'message': _("Please try again."),
+            }
+
         email = data['email'].strip()
         duplicate = CouchUser.get_by_username(email)
         is_existing = User.objects.filter(username__iexact=email).count() > 0 or duplicate


### PR DESCRIPTION
## Product Description
Adds rate limiting when checking username availability prior to signup. Invisible under normal circumstances.

## Technical Summary
[SAAS-16420
](https://dimagi.atlassian.net/browse/SAAS-16420)
Based on [rate_limit_two_factor_setup](https://github.com/dimagi/commcare-hq/blob/8802076f90e2b0682dc27c312977179822740582/corehq/apps/hqwebapp/two_factor_gateways.py#L103), this adds a rate limiter for the `check_username_availability` endpoint that is based on both IP (more lax, since public IPs can sometimes be shared) and session ID (more strict). 

Specific rates here were chosen because they seemed "about right" for someone possibly typing and retyping an email address several times during signup, with the fastest per-session rate matching the [frontend rate limit](https://github.com/dimagi/commcare-hq/blob/8802076f90e2b0682dc27c312977179822740582/corehq/apps/registration/static/registration/js/new_user.ko.js#L83) on the signup form (a 400ms delay). Open to other thoughts here as well.

## Safety Assurance

### Safety story
Tested locally to see that IP and session ID get stored and checked against as expected for rate limiting, and that rate limits do seem to apply correctly when requests are quick enough.

### Automated test coverage
No automated tests here.

### QA Plan
Not currently planning QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
