### PR TITLE
Add ids and classes to identify elements

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/persistent_menu.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/persistent_menu.html
@@ -14,7 +14,8 @@
       aria-expanded="true"
       aria-controls="persistent-menu-container">
       <i class="fa fs-3 fa-chevron-right"></i>
-      <span class="position-absolute"
+      <!-- persistent-menu-toggle is used by google analytics. -->
+      <span id="persistent-menu-toggle" class="position-absolute"
         style="width: 60px; height: 60px;">
       </span>
     </button>
@@ -44,7 +45,8 @@
       <i class="fa <%- iconClass %> persistent-menu-image align-self-start flex-shrink-0" aria-hidden="true"></i>
     <% } %>
     <div class="mx-3 flex-grow-1">
-      <a class="d-block d-lg-none stretched-link text-reset <%= isActive ? 'fw-bold' : '' %>" href="#"
+      <!-- persistent-menu-link is used by google analytics. -->
+      <a class="persistent-menu-link d-block d-lg-none stretched-link text-reset <%= isActive ? 'fw-bold' : '' %>" href="#"
          data-bs-toggle="offcanvas" data-bs-target="#persistent-menu-container">
         <%- displayText %>
       </a>
@@ -52,7 +54,7 @@
       Duplicate of the <a> tag above with the toggle attributes removed. They are only needed on small screens
       and interfere with other modals on large screens.
       -->
-      <a class="d-none d-lg-block stretched-link text-reset <%= isActive ? 'fw-bold' : '' %>" href="#">
+      <a class="persistent-menu-link d-none d-lg-block stretched-link text-reset <%= isActive ? 'fw-bold' : '' %>" href="#">
         <%- displayText %>
       </a>
     </div>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/persistent_menu.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/persistent_menu.html
@@ -14,8 +14,7 @@
       aria-expanded="true"
       aria-controls="persistent-menu-container">
       <i class="fa fs-3 fa-chevron-right"></i>
-      <!-- persistent-menu-toggle is used by google analytics. -->
-      <span id="persistent-menu-toggle" class="position-absolute"
+      <span id="gtm-persistent-menu-toggle" class="position-absolute"
         style="width: 60px; height: 60px;">
       </span>
     </button>
@@ -45,8 +44,7 @@
       <i class="fa <%- iconClass %> persistent-menu-image align-self-start flex-shrink-0" aria-hidden="true"></i>
     <% } %>
     <div class="mx-3 flex-grow-1">
-      <!-- persistent-menu-link is used by google analytics. -->
-      <a class="persistent-menu-link d-block d-lg-none stretched-link text-reset <%= isActive ? 'fw-bold' : '' %>" href="#"
+      <a class="gtm-persistent-menu-link d-block d-lg-none stretched-link text-reset <%= isActive ? 'fw-bold' : '' %>" href="#"
          data-bs-toggle="offcanvas" data-bs-target="#persistent-menu-container">
         <%- displayText %>
       </a>
@@ -54,7 +52,7 @@
       Duplicate of the <a> tag above with the toggle attributes removed. They are only needed on small screens
       and interfere with other modals on large screens.
       -->
-      <a class="persistent-menu-link d-none d-lg-block stretched-link text-reset <%= isActive ? 'fw-bold' : '' %>" href="#">
+      <a class="gtm-persistent-menu-link d-none d-lg-block stretched-link text-reset <%= isActive ? 'fw-bold' : '' %>" href="#">
         <%- displayText %>
       </a>
     </div>


### PR DESCRIPTION
## Product Description

It is easier to identify clicks on specific html tags in google analytics if the elements have unique ids or classes.
In the case of the toggle you can either click on the button or its icon. So both targets need to be identifiable.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-5149

## Feature Flag

[persistent_menu_setting](https://www.commcarehq.org/hq/flags/edit/persistent_menu_setting/)

## Safety Assurance

This only add non-functional code. Persistent menu still behaves the same locally and on staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
