### PR TITLE
App manager js dependencies: jquery/knockout/underscore only

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/filter.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/filter.js
@@ -1,3 +1,8 @@
+hqDefine("app_manager/js/details/filter", [
+    "knockout",
+], function (
+    ko,
+) {
 /**
  * Model for the case list filter, which has a button to
  * "Add Filter" when there's no filter, and when clicked
@@ -6,7 +11,6 @@
  * @param filterText Initial text of the filter
  * @param saveButton Save button for case list config
  */
-hqDefine("app_manager/js/details/filter", function () {
     return function (filterText, saveButton) {
         var self = {};
         self.filterText = ko.observable(typeof filterText === "string" && filterText.length > 0 ? filterText : "");

--- a/corehq/apps/app_manager/static/app_manager/js/details/fixture_select.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/fixture_select.js
@@ -1,7 +1,11 @@
 /**
  * Model for Lookup Table Case Selection in case list configuration.
  */
-hqDefine("app_manager/js/details/fixture_select", function () {
+hqDefine("app_manager/js/details/fixture_select", [
+    "knockout",
+], function (
+    ko,
+) {
     return function (init) {
         var self = {};
         self.active = ko.observable(init.active);

--- a/corehq/apps/app_manager/static/app_manager/js/forms/custom_instances.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/custom_instances.js
@@ -1,7 +1,8 @@
-"use strict";
-hqDefine('app_manager/js/forms/custom_instances', function () {
-    'use strict';
-
+hqDefine("app_manager/js/forms/custom_instances", [
+    "knockout",
+], function (
+    ko,
+) {
     var customInstance = function (instanceId, instancePath) {
         var self = {};
         self.instanceId = ko.observable(instanceId || '');

--- a/corehq/apps/app_manager/static/app_manager/js/modules/case_list_setting.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/case_list_setting.js
@@ -1,4 +1,10 @@
-hqDefine("app_manager/js/modules/case_list_setting", function () {
+hqDefine("app_manager/js/modules/case_list_setting", [
+    'jquery',
+    'underscore',
+], function (
+    $,
+    _
+) {
     function getLabel(slug) { return $('.case-list-setting-label[data-slug="' + slug + '"]'); }
     function getShow(slug) { return $('.case-list-setting-show[data-slug="' + slug + '"]'); }
     function getMedia(slug) { return $('.case-list-setting-media[data-slug="' + slug + '"]'); }

--- a/corehq/apps/app_manager/static/app_manager/js/modules/shadow_module_settings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/shadow_module_settings.js
@@ -1,4 +1,10 @@
-hqDefine('app_manager/js/modules/shadow_module_settings', function () {
+hqDefine('app_manager/js/modules/shadow_module_settings', [
+    'knockout',
+    'underscore',
+], function (
+    ko,
+    _,
+) {
     const module = {
 
         /**

--- a/corehq/apps/app_manager/static/app_manager/js/section_changer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/section_changer.js
@@ -32,7 +32,11 @@
 
  *  When the user shows or hides a section, that preference is stored in localStorage.
  */
-hqDefine("app_manager/js/section_changer", function () {
+hqDefine("app_manager/js/section_changer", [
+    'jquery',
+], function (
+    $
+) {
     // Determine key for localStorage
     // page is something like "module-view"
     // section is something like "logic"


### PR DESCRIPTION
## Technical Summary
This adds explicit dependencies to a set of app manager js files.

This was an automated change - I ran a script that searched files for usage of `$`, `ko`, `_`, and `hqImport` and updated the `hqDefine` calls accordingly. 

## Safety Assurance

### Safety story
This PR only includes files that only depend on one or more of jquery, underscore, and knockout, since those are guaranteed to be available before any HQ js is loaded, which makes this a safe change.

### Automated test coverage

`test_requirejs_disallows_hqimport` verifies that js files that specify their dependencies in `hqDefine` don't include any `hqImport` statements. The linter verifies that no additional undefined variables (globals) are present.

### QA Plan

Not requesting QA/

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
