### PR TITLE
App manager js dependencies: hqwebapp

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
@@ -9,7 +9,6 @@ hqDefine("app_manager/js/case_config_utils", [
     toggles,
     initialPageData,
 ) {
-"use strict";
     return {
         getQuestions: function (questions, filter, excludeHidden, includeRepeat, excludeTrigger) {
             // filter can be "all", or any of "select1", "select", or "input" separated by spaces
@@ -144,8 +143,8 @@ hqDefine("app_manager/js/case_config_utils", [
             return _.object(
                 _.map(
                     _.filter(preloadArray, function (i) { return (i.key || i.path); }),
-                    function (i) { return [i.path, i.key]; }
-                )
+                    function (i) { return [i.path, i.key]; },
+                ),
             );
         },
     };

--- a/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
@@ -1,5 +1,15 @@
+hqDefine("app_manager/js/case_config_utils", [
+    "jquery",
+    "underscore",
+    "hqwebapp/js/toggles",
+    "hqwebapp/js/initial_page_data",
+], function (
+    $,
+    _,
+    toggles,
+    initialPageData,
+) {
 "use strict";
-hqDefine('app_manager/js/case_config_utils', function () {
     return {
         getQuestions: function (questions, filter, excludeHidden, includeRepeat, excludeTrigger) {
             // filter can be "all", or any of "select1", "select", or "input" separated by spaces
@@ -16,7 +26,7 @@ hqDefine('app_manager/js/case_config_utils', function () {
             if (!excludeTrigger) {
                 filter.push('trigger');
             }
-            var allowAttachments = hqImport('hqwebapp/js/toggles').toggleEnabled('MM_CASE_PROPERTIES');
+            var allowAttachments = toggles.toggleEnabled('MM_CASE_PROPERTIES');
             for (i = 0; i < questions.length; i += 1) {
                 q = questions[i];
                 if (filter[0] === "all" || filter.indexOf(q.tag) !== -1) {
@@ -55,8 +65,7 @@ hqDefine('app_manager/js/case_config_utils', function () {
         },
         // This function depends on initial page data, so it should be called within a document ready handler
         initRefreshQuestions: function (questionsObservable) {
-            var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
-                formUniqueId = initialPageData.get("form_unique_id");
+            const formUniqueId = initialPageData.get("form_unique_id");
             if (formUniqueId) {
                 var currentAppUrl = initialPageData.reverse("current_app_version"),
                     oldVersion = initialPageData.get("app_subset").version;

--- a/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
@@ -1,7 +1,15 @@
 "use strict";
-hqDefine('app_manager/js/custom_assertions', function () {
-    var initialPageData = hqImport("hqwebapp/js/initial_page_data");
-
+hqDefine('app_manager/js/custom_assertions', [
+    'jquery',
+    'knockout',
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/toggles',
+], function (
+    $,
+    ko,
+    initialPageData,
+    toggles
+) {
     var customAssertion = function (test, text) {
         var self = {};
         self.test = ko.observable(test || '');
@@ -55,7 +63,7 @@ hqDefine('app_manager/js/custom_assertions', function () {
     };
 
     $(function () {
-        if (hqImport('hqwebapp/js/toggles').toggleEnabled('CUSTOM_ASSERTIONS')) {
+        if (toggles.toggleEnabled('CUSTOM_ASSERTIONS')) {
             var assertions = customAssertions().wrap({
                 'customAssertions': initialPageData.get('custom_assertions'),
             });

--- a/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
@@ -1,4 +1,3 @@
-"use strict";
 hqDefine('app_manager/js/custom_assertions', [
     'jquery',
     'knockout',
@@ -8,7 +7,7 @@ hqDefine('app_manager/js/custom_assertions', [
     $,
     ko,
     initialPageData,
-    toggles
+    toggles,
 ) {
     var customAssertion = function (test, text) {
         var self = {};
@@ -47,7 +46,7 @@ hqDefine('app_manager/js/custom_assertions', [
         self.addAssertion = function (assertion) {
             assertion = assertion || {test: null, text: null};
             self.customAssertions.push(
-                customAssertion(assertion.test, assertion.text)
+                customAssertion(assertion.test, assertion.text),
             );
         };
 

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -1,7 +1,18 @@
+hqDefine("app_manager/js/details/case_claim", [
+    "jquery",
+    "knockout",
+    "underscore",
+    "hqwebapp/js/initial_page_data",
+    "hqwebapp/js/assert_properties",
+], function (
+    $,
+    ko,
+    _,
+    initialPageData,
+    assertProperties,
+) {
 "use strict";
-hqDefine("app_manager/js/details/case_claim", function () {
-    var initialPageData = hqImport('hqwebapp/js/initial_page_data'),
-        generateSemiRandomId = function () {
+    var generateSemiRandomId = function () {
             // https://stackoverflow.com/a/2117523
             return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, function (c) {
                 return (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16);
@@ -207,7 +218,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
         'search_on_clear',
     ];
     var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
-        hqImport("hqwebapp/js/assert_properties").assertRequired(options, searchConfigKeys);
+        assertProperties.assertRequired(options, searchConfigKeys);
 
         options.search_label = options.search_label[lang] || "";
         options.search_again_label = options.search_again_label[lang] || "";

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -11,7 +11,6 @@ hqDefine("app_manager/js/details/case_claim", [
     initialPageData,
     assertProperties,
 ) {
-"use strict";
     var generateSemiRandomId = function () {
             // https://stackoverflow.com/a/2117523
             return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, function (c) {
@@ -163,7 +162,7 @@ hqDefine("app_manager/js/details/case_claim", [
                         "value": p.id,
                         "name": p.name,
                     };
-                }
+                },
             );
         });
         self.itemset = itemsetModel(options.itemsetOptions, saveButton);
@@ -375,7 +374,7 @@ hqDefine("app_manager/js/details/case_claim", [
         });
 
         self.search_properties = ko.observableArray(
-            wrappedSearchProperties.length > 0 ? wrappedSearchProperties : [searchPropertyModel({}, saveButton)]
+            wrappedSearchProperties.length > 0 ? wrappedSearchProperties : [searchPropertyModel({}, saveButton)],
         );
 
         self.search_properties.subscribe(function (newProperties) {
@@ -407,7 +406,7 @@ hqDefine("app_manager/js/details/case_claim", [
             return _.map(
                 _.filter(
                     self.search_properties(),
-                    function (p) { return p.name().length > 0;}  // Skip properties where name is blank
+                    function (p) { return p.name().length > 0;},  // Skip properties where name is blank
                 ),
                 function (p) {
                     var ifSupportsValidation = function (val) {
@@ -432,7 +431,7 @@ hqDefine("app_manager/js/details/case_claim", [
                         is_group: p.isGroup,
                         group_key: p.groupKey,
                     };
-                }
+                },
             );
         };
 
@@ -446,9 +445,9 @@ hqDefine("app_manager/js/details/case_claim", [
             return _.map(
                 _.filter(
                     self.default_properties(),
-                    function (p) { return p.property().length > 0; }  // Skip properties where property is blank
+                    function (p) { return p.property().length > 0; },  // Skip properties where property is blank
                 ),
-                function (prop) { return ko.mapping.toJS(prop); }
+                function (prop) { return ko.mapping.toJS(prop); },
             );
         };
 
@@ -463,9 +462,9 @@ hqDefine("app_manager/js/details/case_claim", [
                 _.filter(
                     self.custom_sort_properties(),
                     // Skip properties where property is blank
-                    function (p) { return p.property_name().length > 0; }
+                    function (p) { return p.property_name().length > 0; },
                 ),
-                function (prop) { return ko.mapping.toJS(prop); }
+                function (prop) { return ko.mapping.toJS(prop); },
             );
         };
 
@@ -492,7 +491,7 @@ hqDefine("app_manager/js/details/case_claim", [
                 commonProperties,
                 function (p) {
                     return p.name();
-                }
+                },
             );
         });
 

--- a/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
@@ -25,7 +25,7 @@ hqDefine("app_manager/js/details/detail_tab_nodeset", [
         self.dropdownOptions = [{name: gettext("Data Tab: Custom Expression"), value: ""}].concat(
             _.map(options.caseTypes, function (t) {
                 return {name: gettext("Data Tab: Child Cases: ") + t, value: t};
-            })
+            }),
         );
 
         self.showXpath = ko.computed(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
@@ -1,10 +1,20 @@
+hqDefine("app_manager/js/details/detail_tab_nodeset", [
+    "jquery",
+    "knockout",
+    "underscore",
+    "hqwebapp/js/bootstrap3/main",
+], function (
+    $,
+    ko,
+    _,
+    main,
+) {
 /**
  * This provides the UI for a case detail tab's nodeset.
  *
  * It contains a dropdown where to select the type of data,
  * currently either a child case type or a custom xpath expression.
  */
-hqDefine('app_manager/js/details/detail_tab_nodeset', function () {
     return function (options) {
         var self = {};
 
@@ -27,7 +37,7 @@ hqDefine('app_manager/js/details/detail_tab_nodeset', function () {
         self.ui = $(_.template($("#module-case-detail-tab-nodeset-template").text())());
         self.ui.koApplyBindings(self);
 
-        hqImport("hqwebapp/js/bootstrap3/main").eventize(self);
+        main.eventize(self);
         self.nodeset.subscribe(function () {
             self.fire('change');
         });

--- a/corehq/apps/app_manager/static/app_manager/js/details/parent_select.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/parent_select.js
@@ -15,7 +15,15 @@
  * first case. This first case will just be available to forms.
  * This is used for deduplication workflows.
  */
-hqDefine("app_manager/js/details/parent_select", function () {
+hqDefine("app_manager/js/details/parent_select", [
+    'knockout',
+    'underscore',
+    'hqwebapp/js/toggles',
+], function (
+    ko,
+    _,
+    toggles
+) {
     return function (init) {
         var self = {};
         var defaultModule = _(init.parentModules).findWhere({
@@ -26,7 +34,7 @@ hqDefine("app_manager/js/details/parent_select", function () {
         self.parentModules = ko.observable(init.parentModules);
         self.lang = ko.observable(init.lang);
         self.langs = ko.observable(init.langs);
-        self.enableOtherOption = hqImport('hqwebapp/js/toggles').toggleEnabled('NON_PARENT_MENU_SELECTION');
+        self.enableOtherOption = toggles.toggleEnabled('NON_PARENT_MENU_SELECTION');
 
         self.selectOptions = [
             {id: 'none', text: gettext('None')},

--- a/corehq/apps/app_manager/static/app_manager/js/details/parent_select.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/parent_select.js
@@ -22,7 +22,7 @@ hqDefine("app_manager/js/details/parent_select", [
 ], function (
     ko,
     _,
-    toggles
+    toggles,
 ) {
     return function (init) {
         var self = {};
@@ -42,7 +42,7 @@ hqDefine("app_manager/js/details/parent_select", [
         ];
         if (self.enableOtherOption) {
             self.selectOptions.push(
-                {id: 'other', text: gettext('Other')}
+                {id: 'other', text: gettext('Other')},
             );
         }
         var selectMode = init.active ? (init.relationship === 'parent' ? 'parent' : 'other') : 'none';

--- a/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
@@ -25,7 +25,7 @@ hqDefine("app_manager/js/forms/copy_form_to_app", [
         self.modules = ko.observableArray(
             _.map(modules, function (mod) {
                 return module(mod["module_id"], mod["name"], mod["is_current"]);
-            })
+            }),
         );
         var currentModule = _.find(self.modules(), function (mod) {
             return mod.isCurrent;
@@ -39,7 +39,7 @@ hqDefine("app_manager/js/forms/copy_form_to_app", [
         self.apps = ko.observableArray(
             _.map(appsModules, function (app) {
                 return application(app["app_id"], app["name"], app["is_current"], app["modules"]);
-            })
+            }),
         );
         var currentApp = _.find(self.apps(), function (app) {
             return app.isCurrent;
@@ -56,7 +56,7 @@ hqDefine("app_manager/js/forms/copy_form_to_app", [
     $(function () {
         var $appModuleSelection = $("#app-module-selection");
         var viewModel = appsModulesModel(
-            initialPageData.get("apps_modules")
+            initialPageData.get("apps_modules"),
         );
         if ($appModuleSelection.length) {
             $appModuleSelection.koApplyBindings(viewModel);

--- a/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
@@ -1,7 +1,14 @@
-"use strict";
-hqDefine("app_manager/js/forms/copy_form_to_app", function () {
-    "use strict";
-
+hqDefine("app_manager/js/forms/copy_form_to_app", [
+    "jquery",
+    "knockout",
+    "underscore",
+    "hqwebapp/js/initial_page_data",
+], function (
+    $,
+    ko,
+    _,
+    initialPageData,
+) {
     var module = function (moduleId, moduleName, isCurrentModule) {
         var self = {};
         self.id = moduleId;
@@ -49,7 +56,7 @@ hqDefine("app_manager/js/forms/copy_form_to_app", function () {
     $(function () {
         var $appModuleSelection = $("#app-module-selection");
         var viewModel = appsModulesModel(
-            hqImport("hqwebapp/js/initial_page_data").get("apps_modules")
+            initialPageData.get("apps_modules")
         );
         if ($appModuleSelection.length) {
             $appModuleSelection.koApplyBindings(viewModel);

--- a/corehq/apps/app_manager/static/app_manager/js/releases/language_profiles.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/language_profiles.js
@@ -1,4 +1,14 @@
-hqDefine('app_manager/js/releases/language_profiles', function () {
+hqDefine("app_manager/js/releases/language_profiles", [
+    "jquery",
+    "knockout",
+    "underscore",
+    "hqwebapp/js/bootstrap3/main",
+], function (
+    $,
+    ko,
+    _,
+    main,
+) {
     var _p = {};
     _p.profileUrl = 'profiles/';
 
@@ -24,7 +34,7 @@ hqDefine('app_manager/js/releases/language_profiles', function () {
         self.app_langs = appLangs;
         self.enable_practice_users = enablePracticeUsers;
         self.practice_users = [{'id': '', 'text': ''}].concat(practiceUsers);
-        self.saveButton = hqImport("hqwebapp/js/bootstrap3/main").initSaveButton({
+        self.saveButton = main.initSaveButton({
             unsavedMessage: gettext("You have unsaved changes to your application profiles"),
             save: function () {
                 var postProfiles = [];

--- a/corehq/apps/app_manager/static/app_manager/js/releases/update_prompt.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/update_prompt.js
@@ -1,9 +1,15 @@
-hqDefine('app_manager/js/releases/update_prompt', function () {
+hqDefine("app_manager/js/releases/update_prompt", [
+    "jquery",
+    "hqwebapp/js/bootstrap3/main",
+], function (
+    $,
+    main,
+) {
     function updatePromptModel(form) {
         var self = {};
         var url = form[0].action,
             method = form[0].method;
-        self.saveButton = hqImport("hqwebapp/js/bootstrap3/main").initSaveButton({
+        self.saveButton = main.initSaveButton({
             unsavedMessage: gettext("You have unsaved changes to your prompt setting"),
             save: function () {
                 self.saveButton.ajax({

--- a/corehq/apps/app_manager/static/app_manager/js/settings/translations.js
+++ b/corehq/apps/app_manager/static/app_manager/js/settings/translations.js
@@ -1,6 +1,14 @@
-hqDefine("app_manager/js/settings/translations", function () {
+hqDefine("app_manager/js/settings/translations", [
+    "jquery",
+    "knockout",
+    "hqwebapp/js/assert_properties",
+], function (
+    $,
+    ko,
+    assertProperties,
+) {
     var appTranslationsModel = function (options) {
-        hqImport("hqwebapp/js/assert_properties").assertRequired(options, ['baseUrl', 'format', 'lang', 'skipBlacklisted']);
+        assertProperties.assertRequired(options, ['baseUrl', 'format', 'lang', 'skipBlacklisted']);
         var self = {};
 
         self.file = ko.observable();


### PR DESCRIPTION
## Technical Summary
Sibling to https://github.com/dimagi/commcare-hq/pull/35693, more changes made by that same script.

## Safety Assurance

### Safety story
This PR only contains modules that only depend on jquery/knockout/underscore and common hqwebapp modules from either [core_libraries.html](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/templates/hqwebapp/includes/core_libraries.html) or [this set of js files in hqwebapp/base.html](https://github.com/dimagi/commcare-hq/blob/d9e337a03097060943c30951f7c6088ae2a4e1d1/corehq/apps/hqwebapp/templates/hqwebapp/base.html#L341-L365). Those are all included before any page-specific javascript, which gets added in [these two blocks](https://github.com/dimagi/commcare-hq/blob/d9e337a03097060943c30951f7c6088ae2a4e1d1/corehq/apps/hqwebapp/templates/hqwebapp/base.html#L461-L463) way at the bottom of `hqwebapp/base.html`.

### Automated test coverage

`test_requirejs_disallows_hqimport` verifies that js files that specify their dependencies in `hqDefine` don't include any `hqImport` statements. The linter verifies that no additional undefined variables (globals) are present.

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
