### PR TITLE
App manager js dependencies: low risk modules

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/add_ons.js
+++ b/corehq/apps/app_manager/static/app_manager/js/add_ons.js
@@ -1,8 +1,17 @@
 "use strict";
-hqDefine("app_manager/js/add_ons", function () {
-    var sectionChanger = hqImport("app_manager/js/section_changer"),
-        initialPageData = hqImport("hqwebapp/js/initial_page_data");
-
+hqDefine("app_manager/js/add_ons", [
+    'jquery',
+    'underscore',
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/bootstrap3/main',
+    'app_manager/js/section_changer',
+], function (
+    $,
+    _,
+    initialPageData,
+    hqMain,
+    sectionChanger
+) {
     function EditAddOns(addOns, layout, saveUrl) {
         var self = this;
 
@@ -12,7 +21,7 @@ hqDefine("app_manager/js/add_ons", function () {
                 collapse: sectionChanger.shouldCollapse("add-ons", s.slug, s.collapse),
             });
         });
-        self.saveButton = hqImport("hqwebapp/js/bootstrap3/main").initSaveButton({
+        self.saveButton = hqMain.initSaveButton({
             unsavedMessage: gettext("You have unsaved changes."),
             save: function () {
                 // Send server map of slug => enabled

--- a/corehq/apps/app_manager/static/app_manager/js/add_ons.js
+++ b/corehq/apps/app_manager/static/app_manager/js/add_ons.js
@@ -1,4 +1,3 @@
-"use strict";
 hqDefine("app_manager/js/add_ons", [
     'jquery',
     'underscore',
@@ -10,7 +9,7 @@ hqDefine("app_manager/js/add_ons", [
     _,
     initialPageData,
     hqMain,
-    sectionChanger
+    sectionChanger,
 ) {
     function EditAddOns(addOns, layout, saveUrl) {
         var self = this;
@@ -48,7 +47,7 @@ hqDefine("app_manager/js/add_ons", [
             $addOns.koApplyBindings(new EditAddOns(
                 initialPageData.get("add_ons"),
                 initialPageData.get("add_ons_layout"),
-                initialPageData.reverse("edit_add_ons")
+                initialPageData.reverse("edit_add_ons"),
             ));
             sectionChanger.attachToForm($addOns.find("form"));
         }

--- a/corehq/apps/app_manager/static/app_manager/js/details/graph_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/graph_config.js
@@ -36,7 +36,7 @@ hqDefine("app_manager/js/details/graph_config", [
             '<i class="fa fa-pencil"></i> ' +
             gettext('Edit Graph') +
             '</button>' +
-            '</div>'
+            '</div>',
         );
 
         self.ui = $editButtonDiv;
@@ -270,8 +270,7 @@ hqDefine("app_manager/js/details/graph_config", [
         self.values = original.values || {};
         // Make the value for the current language observable
         self.values[self.lang] = ko.observable(
-            self.values[self.lang] === undefined ? null :
-                ko.unwrap(self.values[self.lang])
+            self.values[self.lang] === undefined ? null : ko.unwrap(self.values[self.lang]),
         );
 
         /**
@@ -342,7 +341,7 @@ hqDefine("app_manager/js/details/graph_config", [
                     'lang': self.lang,
                     'langs': self.langs,
                 });
-            }
+            },
         ));
 
         self.configPropertyOptions = [
@@ -540,7 +539,7 @@ hqDefine("app_manager/js/details/graph_config", [
             })).concat([{
                 'text': 'custom',
                 'value': 'custom',
-            }])
+            }]),
         ));
 
         self.selectedSource = ko.observable(origOrDefault('selectedSource', self.sourceOptions()[0]));
@@ -579,7 +578,7 @@ hqDefine("app_manager/js/details/graph_config", [
 
         var seriesValidationWarning = gettext(
             "It is recommended that you leave this value blank. Future changes to your report's " +
-            "chart configuration will not be reflected here."
+            "chart configuration will not be reflected here.",
         );
         self.dataPathWarning = ko.computed(function () {
             if (!self.dataPathPlaceholder() || !self.dataPath()) {
@@ -632,7 +631,7 @@ hqDefine("app_manager/js/details/graph_config", [
                     'lang': self.lang,
                     'langs': self.langs,
                 });
-            }
+            },
         ));
         if (original.localeSpecificConfigurations && original.localeSpecificConfigurations.length !== 0) {
             self.localeSpecificConfigurations(_.map(original.localeSpecificConfigurations, function (o) {

--- a/corehq/apps/app_manager/static/app_manager/js/details/graph_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/graph_config.js
@@ -1,20 +1,31 @@
-/* global Clipboard */
-hqDefine('app_manager/js/details/graph_config', function () {
-    /**
-     * Create a view model that is bound to an "Edit graph" button. The ui property
-     * of this view model allows us to integrate the knockout elements with the
-     * jquery based part of the ui.
-     *
-     * @param moduleOptions
-     * A mapping of configuration options from the module. The following keys are required:
-     *      lang
-     *      langs
-     *      childCaseTypes
-     *      fixtures
-     * @param serverRepresentationOfGraph
-     * Object corresponding to a graph configuration saved in couch.
-     * @constructor
-     */
+/**
+ * Create a view model that is bound to an "Edit graph" button. The ui property
+ * of this view model allows us to integrate the knockout elements with the
+ * jquery based part of the ui.
+ *
+ * @param moduleOptions
+ * A mapping of configuration options from the module. The following keys are required:
+ *      lang
+ *      langs
+ *      childCaseTypes
+ *      fixtures
+ * @param serverRepresentationOfGraph
+ * Object corresponding to a graph configuration saved in couch.
+ * @constructor
+ */
+hqDefine("app_manager/js/details/graph_config", [
+    "jquery",
+    "knockout",
+    "underscore",
+    "hqwebapp/js/bootstrap3/main",
+    "clipboard/dist/clipboard",
+], function (
+    $,
+    ko,
+    _,
+    main,
+    Clipboard,
+) {
     var graphConfigurationUiElement = function (moduleOptions, serverRepresentationOfGraph) {
         var self = {};
         moduleOptions = moduleOptions || {};
@@ -61,7 +72,7 @@ hqDefine('app_manager/js/details/graph_config', function () {
         };
 
         self.ui.koApplyBindings(self);
-        hqImport("hqwebapp/js/bootstrap3/main").eventize(self);
+        main.eventize(self);
 
         /**
          * Return an object representing this graph configuration that is suitable

--- a/corehq/apps/app_manager/static/app_manager/js/details/utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/utils.js
@@ -1,12 +1,22 @@
-'use strict';
-/* globals DOMPurify */
 /**
  * Contains a few UI utilities for the Display Properties
  * section of case list/detail configuration.
  *
  * Depends on `add_ons` being available in initial page data
  */
-hqDefine("app_manager/js/details/utils", function () {
+hqDefine("app_manager/js/details/utils", [
+    "jquery",
+    "underscore",
+    "DOMPurify/dist/purify.min",
+    "hqwebapp/js/toggles",
+    "hqwebapp/js/initial_page_data",
+], function (
+    $,
+    _,
+    DOMPurify,
+    toggles,
+    initialPageData,
+) {
     var module = {};
 
     module.fieldFormatWarningMessage = gettext("Must begin with a letter and contain only letters, numbers, '-', and '_'");
@@ -44,21 +54,21 @@ hqDefine("app_manager/js/details/utils", function () {
             label: gettext('Markdown'),
         }];
 
-        if (hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_MAP')) {
+        if (toggles.toggleEnabled('CASE_LIST_MAP')) {
             formats.push({
                 value: "address-popup",
                 label: gettext('Address Popup (Web Apps only)'),
             });
         }
 
-        if (hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CLICKABLE_ICON')) {
+        if (toggles.toggleEnabled('CASE_LIST_CLICKABLE_ICON')) {
             formats.push({
                 value: "clickable-icon",
                 label: gettext('Clickable Icon (Web Apps only)'),
             });
         }
 
-        if (hqImport('hqwebapp/js/toggles').toggleEnabled('MM_CASE_PROPERTIES')) {
+        if (toggles.toggleEnabled('MM_CASE_PROPERTIES')) {
             formats.push({
                 value: "picture",
                 label: gettext('Picture'),
@@ -68,7 +78,7 @@ hqDefine("app_manager/js/details/utils", function () {
             });
         }
 
-        var addOns = hqImport("hqwebapp/js/initial_page_data").get("add_ons");
+        var addOns = initialPageData.get("add_ons");
         if (addOns.enum_image) {
             formats.push({
                 value: "enum-image",
@@ -88,7 +98,7 @@ hqDefine("app_manager/js/details/utils", function () {
             });
         }
 
-        if (hqImport('hqwebapp/js/toggles').toggleEnabled('VELLUM_CASE_MICRO_IMAGE')) {
+        if (toggles.toggleEnabled('VELLUM_CASE_MICRO_IMAGE')) {
             formats.push({
                 value: "image",
                 label: gettext('Image'),

--- a/corehq/apps/app_manager/static/app_manager/js/details/utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/utils.js
@@ -135,9 +135,7 @@ hqDefine("app_manager/js/details/utils", [
 
     module.isValidPropertyName = function (name) {
         var word = '[a-zA-Z][\\w_-]*';
-        var regex = new RegExp(
-            '^(' + word + ':)*(' + word + '\\/)*#?' + word + '$'
-        );
+        var regex = new RegExp('^(' + word + ':)*(' + word + '\\/)*#?' + word + '$');
         return regex.test(name);
     };
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
@@ -1,7 +1,12 @@
-"use strict";
-hqDefine('app_manager/js/forms/advanced/case_properties', function () {
-    var caseConfigUtils = hqImport('app_manager/js/case_config_utils');
-
+hqDefine("app_manager/js/forms/advanced/case_properties", [
+    "knockout",
+    "underscore",
+    "app_manager/js/case_config_utils",
+], function (
+    ko,
+    _,
+    caseConfigUtils,
+) {
     var casePropertyBase = {
         mapping: {
             include: ['key', 'path', 'required'],

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
@@ -65,7 +65,7 @@ hqDefine("app_manager/js/forms/advanced/case_properties", [
                 suggestedSaveProperties: ko.computed(function () {
                     return caseConfigUtils.filteredSuggestedProperties(
                         self.action.suggestedProperties(),
-                        self.action.case_properties()
+                        self.action.case_properties(),
                     );
                 }),
             };
@@ -114,7 +114,7 @@ hqDefine("app_manager/js/forms/advanced/case_properties", [
                 suggestedPreloadProperties: ko.computed(function () {
                     return caseConfigUtils.filteredSuggestedProperties(
                         self.action.suggestedProperties(),
-                        self.action.preload()
+                        self.action.preload(),
                     );
                 }),
             };


### PR DESCRIPTION
## Technical Summary
Sibling to https://github.com/dimagi/commcare-hq/pull/35693 and https://github.com/dimagi/commcare-hq/pull/35694, output from the same script.

## Safety Assurance

### Safety story
There are two main risks in adding dependencies to `hqDefine` calls in areas that don't use a js bundler (webpack or requirejs):
* Script tags for all of a module's dependencies need to be included before the module itself. This is because dependencies are now loaded when the module is loaded and `hqDefine` is called. In code that instead calls `hqImport`, those calls may be inside of a document ready handler or some other area that doesn't execute until later.
* Third-party libraries that depend on globals need to be configured [here](https://github.com/dimagi/commcare-hq/blob/5fe14801267a27d02a155896edf9171583f0cba9/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js#L65-L80)

The modules updated in this PR all have dependencies that are easy to reason about. See comments.

### Automated test coverage

`test_requirejs_disallows_hqimport` verifies that js files that specify their dependencies in `hqDefine` don't include any `hqImport` statements. The linter verifies that no additional undefined variables (globals) are present.

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change