### PR TITLE
Support API key as password for excel feeds

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -157,7 +157,7 @@ def basic_or_api_key(realm=''):
         def wrapper(request, *args, **kwargs):
             username, password = get_username_and_password_from_request(request)
             if username and password:
-                request.check_for_password_as_api_key = True
+                request.check_for_api_key_as_password = True
                 user = authenticate(username=username, password=password, request=request)
                 if user is not None and user.is_active:
                     request.user = user
@@ -212,7 +212,7 @@ def formplayer_as_user_auth(view):
 class ApiKeyFallbackBackend(object):
 
     def authenticate(self, request, username, password):
-        if not getattr(request, 'check_for_password_as_api_key', False):
+        if not getattr(request, 'check_for_api_key_as_password', False):
             return None
 
         try:

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -429,10 +429,13 @@ def api_auth(*, allow_creds_in_data=True, oauth_scopes=None):
     )
 
 
-def api_auth_allow_key_as_password(*, allow_creds_in_data=True, oauth_scopes=None):
+def api_auth_allow_key_as_password_LIMITED_USE(*, allow_creds_in_data=True, oauth_scopes=None):
     """
     Intentionally does not support digest auth to allow using api key as password if desired.
     See determine_authtype_from_header for more details on how defaulting to BASIC drops DIGEST support
+    This decorator arose because our previous version of authenticating through API keys
+    (providing an authentication header) was not being respected by Excel. This decorator should be used
+    sparingly, as we do not want the widespread ability to circumvent normal BASIC authentication
     """
     return get_multi_auth_decorator(
         default=BASIC,

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -465,6 +465,11 @@ def get_auth_decorator_map(
         allow_creds_in_data=True,
         allow_api_key_as_password=False,
 ):
+    # Due to the high risk of our login flows, leaving a safety net here to guard against
+    # non-domain endpoints accepting API keys as passwords. We have no current use for this combination,
+    # but this check can be removed if we create new global endpoints that should support api keys as passwords
+    assert not (require_domain is False and allow_api_key_as_password), \
+        'only domain endpoints support API key authentication'
     # get a mapped set of decorators for different auth types with the specified parameters
     oauth_scopes = oauth_scopes or ['access_apis']
     decorator_function_kwargs = {

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -388,6 +388,8 @@ def get_multi_auth_decorator(
         @wraps(fn)
         def _inner(request, *args, **kwargs):
             authtype = determine_authtype_from_request(request, default=default)
+            assert not (authtype == DIGEST and allow_api_key_as_password), \
+                'api keys as passwords are not supported for digest auth'
             if authtype == FORMPLAYER and not allow_formplayer:
                 auth_logger.info(
                     "Request rejected reason=%s request=%s",

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -429,7 +429,7 @@ def api_auth(*, allow_creds_in_data=True, oauth_scopes=None):
     )
 
 
-def api_auth_no_digest(*, allow_creds_in_data=True, oauth_scopes=None, allow_api_key_as_password=False):
+def api_auth_allow_key_as_password(*, allow_creds_in_data=True, oauth_scopes=None):
     """
     Intentionally does not support digest auth to allow using api key as password if desired.
     See determine_authtype_from_header for more details on how defaulting to BASIC drops DIGEST support
@@ -438,7 +438,7 @@ def api_auth_no_digest(*, allow_creds_in_data=True, oauth_scopes=None, allow_api
         default=BASIC,
         oauth_scopes=oauth_scopes,
         allow_creds_in_data=allow_creds_in_data,
-        allow_api_key_as_password=allow_api_key_as_password,
+        allow_api_key_as_password=True,
     )
 
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -321,8 +321,13 @@ def login_or_basic_ex(allow_cc_users=False, allow_sessions=True, require_domain=
     )
 
 
-def login_or_basic_or_api_key_ex(allow_cc_users=False, allow_sessions=True):
-    return _login_or_challenge(basic_or_api_key(), allow_cc_users=allow_cc_users, allow_sessions=allow_sessions)
+def login_or_basic_or_api_key_ex(allow_cc_users=False, allow_sessions=True, require_domain=True):
+    return _login_or_challenge(
+        basic_or_api_key(),
+        allow_cc_users=allow_cc_users,
+        allow_sessions=allow_sessions,
+        require_domain=require_domain,
+    )
 
 
 def login_or_digest_ex(allow_cc_users=False, allow_sessions=True, require_domain=True):
@@ -450,12 +455,11 @@ def get_auth_decorator_map(
         'allow_sessions': allow_sessions,
     }
 
-    if allow_api_key_as_password:
-        copied_kwargs = decorator_function_kwargs.copy()
-        copied_kwargs.pop('require_domain')
-        basic_auth_fn = login_or_basic_or_api_key_ex(**copied_kwargs)
-    else:
-        basic_auth_fn = login_or_basic_ex(**decorator_function_kwargs)
+    basic_auth_fn = (
+        login_or_basic_or_api_key_ex(**decorator_function_kwargs)
+        if allow_api_key_as_password
+        else login_or_basic_ex(**decorator_function_kwargs)
+    )
 
     return {
         DIGEST: login_or_digest_ex(**decorator_function_kwargs),

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -419,10 +419,23 @@ def two_factor_exempt(view_func):
     return wraps(view_func)(wrapped_view)
 
 
-def api_auth(*, allow_creds_in_data=True, oauth_scopes=None, allow_api_key_as_password=False):
+def api_auth(*, allow_creds_in_data=True, oauth_scopes=None):
     """Allow any auth type basic, digest, session, apikey, or oauth"""
     return get_multi_auth_decorator(
         default=DIGEST,
+        oauth_scopes=oauth_scopes,
+        allow_creds_in_data=allow_creds_in_data,
+        allow_api_key_as_password=False,  # if supporting digest auth, you cannot use an api key as a password
+    )
+
+
+def api_auth_no_digest(*, allow_creds_in_data=True, oauth_scopes=None, allow_api_key_as_password=False):
+    """
+    Intentionally does not support digest auth to allow using api key as password if desired.
+    See determine_authtype_from_header for more details on how defaulting to BASIC drops DIGEST support
+    """
+    return get_multi_auth_decorator(
+        default=BASIC,
         oauth_scopes=oauth_scopes,
         allow_creds_in_data=allow_creds_in_data,
         allow_api_key_as_password=allow_api_key_as_password,

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -364,7 +364,9 @@ def login_or_oauth2_ex(allow_cc_users=False, allow_sessions=True, require_domain
     )
 
 
-def get_multi_auth_decorator(default, allow_formplayer=False, oauth_scopes=None, allow_creds_in_data=True):
+def get_multi_auth_decorator(
+    default, allow_formplayer=False, oauth_scopes=None, allow_creds_in_data=True, allow_api_key_as_password=False
+):
     """
     :param allow_formplayer: If True this will allow one additional auth mechanism which is used
          by Formplayer:
@@ -373,6 +375,7 @@ def get_multi_auth_decorator(default, allow_formplayer=False, oauth_scopes=None,
              formplayer can not use the session cookie to auth. To allow formplayer access to the
              endpoints we validate each formplayer request using a shared key. See the auth
              function for more details.
+    :param allow_api_key_as_password: If True, allows API Key to be used in BASIC auth
     """
     oauth_scopes = oauth_scopes or ['access_apis']
 
@@ -391,6 +394,7 @@ def get_multi_auth_decorator(default, allow_formplayer=False, oauth_scopes=None,
                 allow_cc_users=True,
                 oauth_scopes=oauth_scopes,
                 allow_creds_in_data=allow_creds_in_data,
+                allow_api_key_as_password=allow_api_key_as_password,
             )[authtype]
             return function_wrapper(fn)(request, *args, **kwargs)
         return _inner
@@ -410,12 +414,13 @@ def two_factor_exempt(view_func):
     return wraps(view_func)(wrapped_view)
 
 
-def api_auth(*, allow_creds_in_data=True, oauth_scopes=None):
+def api_auth(*, allow_creds_in_data=True, oauth_scopes=None, allow_api_key_as_password=False):
     """Allow any auth type basic, digest, session, apikey, or oauth"""
     return get_multi_auth_decorator(
         default=DIGEST,
         oauth_scopes=oauth_scopes,
         allow_creds_in_data=allow_creds_in_data,
+        allow_api_key_as_password=allow_api_key_as_password,
     )
 
 
@@ -435,6 +440,7 @@ def get_auth_decorator_map(
         allow_sessions=True,
         oauth_scopes=None,
         allow_creds_in_data=True,
+        allow_api_key_as_password=False,
 ):
     # get a mapped set of decorators for different auth types with the specified parameters
     oauth_scopes = oauth_scopes or ['access_apis']
@@ -443,9 +449,17 @@ def get_auth_decorator_map(
         'require_domain': require_domain,
         'allow_sessions': allow_sessions,
     }
+
+    if allow_api_key_as_password:
+        copied_kwargs = decorator_function_kwargs.copy()
+        copied_kwargs.pop('require_domain')
+        basic_auth_fn = login_or_basic_or_api_key_ex(**copied_kwargs)
+    else:
+        basic_auth_fn = login_or_basic_ex(**decorator_function_kwargs)
+
     return {
         DIGEST: login_or_digest_ex(**decorator_function_kwargs),
-        BASIC: login_or_basic_ex(**decorator_function_kwargs),
+        BASIC: basic_auth_fn,
         API_KEY: login_or_api_key_ex(allow_creds_in_data=allow_creds_in_data,
                                      **decorator_function_kwargs),
         OAUTH2: login_or_oauth2_ex(oauth_scopes=oauth_scopes, **decorator_function_kwargs),

--- a/corehq/apps/domain/tests/test_api_key_auth.py
+++ b/corehq/apps/domain/tests/test_api_key_auth.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 
 from corehq.apps.domain.auth import HQApiKeyAuthentication
-from corehq.apps.domain.decorators import api_auth, api_auth_allow_key_as_password
+from corehq.apps.domain.decorators import api_auth, api_auth_allow_key_as_password_LIMITED_USE
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import HQApiKey, WebUser
 
@@ -98,7 +98,7 @@ class ApiAuthNoDigestTests(TestCase):
 
     def call_api(self, request, allow_creds_in_data=False):
 
-        @api_auth_allow_key_as_password()
+        @api_auth_allow_key_as_password_LIMITED_USE()
         def api_view(request, domain):
             return HttpResponse()
 

--- a/corehq/apps/domain/tests/test_api_key_auth.py
+++ b/corehq/apps/domain/tests/test_api_key_auth.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 
 from corehq.apps.domain.auth import HQApiKeyAuthentication
-from corehq.apps.domain.decorators import api_auth, api_auth_no_digest
+from corehq.apps.domain.decorators import api_auth, api_auth_allow_key_as_password
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import HQApiKey, WebUser
 
@@ -96,9 +96,9 @@ class ApiAuthNoDigestTests(TestCase):
         cls.user = WebUser.create(cls.domain, USERNAME, 'password', None, None)
         cls.api_key = HQApiKey.objects.create(user=cls.user.get_django_user()).plaintext_key
 
-    def call_api(self, request, allow_creds_in_data=False, allow_api_key_as_password=False):
+    def call_api(self, request, allow_creds_in_data=False):
 
-        @api_auth_no_digest(allow_api_key_as_password=allow_api_key_as_password)
+        @api_auth_allow_key_as_password()
         def api_view(request, domain):
             return HttpResponse()
 
@@ -110,8 +110,5 @@ class ApiAuthNoDigestTests(TestCase):
         encoded_creds = base64.b64encode(f"{USERNAME}:{self.api_key}".encode('utf-8')).decode('utf-8')
         request.META['HTTP_AUTHORIZATION'] = f"basic {encoded_creds}"
 
-        res = self.call_api(request, allow_api_key_as_password=False)
-        self.assertEqual(res.status_code, 401)
-
-        res = self.call_api(request, allow_api_key_as_password=True)
+        res = self.call_api(request)
         self.assertEqual(res.status_code, 200)

--- a/corehq/apps/domain/tests/test_api_key_auth.py
+++ b/corehq/apps/domain/tests/test_api_key_auth.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 
 from corehq.apps.domain.auth import HQApiKeyAuthentication
-from corehq.apps.domain.decorators import api_auth
+from corehq.apps.domain.decorators import api_auth, api_auth_no_digest
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import HQApiKey, WebUser
 
@@ -55,9 +55,9 @@ class AuthenticationTestBase(TestCase):
         cls.user = WebUser.create(cls.domain, USERNAME, 'password', None, None)
         cls.api_key = HQApiKey.objects.create(user=cls.user.get_django_user()).plaintext_key
 
-    def call_api(self, request, allow_creds_in_data=False, allow_api_key_as_password=False):
+    def call_api(self, request, allow_creds_in_data=False):
 
-        @api_auth(allow_creds_in_data=allow_creds_in_data, allow_api_key_as_password=allow_api_key_as_password)
+        @api_auth(allow_creds_in_data=allow_creds_in_data)
         def api_view(request, domain):
             return HttpResponse()
 
@@ -82,6 +82,28 @@ class AuthenticationTestBase(TestCase):
 
         res = self.call_api(request, allow_creds_in_data=False)
         self.assertEqual(res.status_code, 401)
+
+
+class ApiAuthNoDigestTests(TestCase):
+    domain = 'api-key-no-digest-test'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.factory = RequestFactory()
+        domain_obj = create_domain(name=cls.domain)
+        cls.addClassCleanup(domain_obj.delete)
+        cls.user = WebUser.create(cls.domain, USERNAME, 'password', None, None)
+        cls.api_key = HQApiKey.objects.create(user=cls.user.get_django_user()).plaintext_key
+
+    def call_api(self, request, allow_creds_in_data=False, allow_api_key_as_password=False):
+
+        @api_auth_no_digest(allow_api_key_as_password=allow_api_key_as_password)
+        def api_view(request, domain):
+            return HttpResponse()
+
+        request.user = AnonymousUser()  # middleware normally does this
+        return api_view(request, self.domain)
 
     def test_credentials_with_basic_auth(self):
         request = self.factory.get('/myapi/')

--- a/corehq/apps/domain/tests/test_api_key_auth.py
+++ b/corehq/apps/domain/tests/test_api_key_auth.py
@@ -80,3 +80,10 @@ class AuthenticationTestBase(TestCase):
 
         res = self.call_api(request, allow_creds_in_data=False)
         self.assertEqual(res.status_code, 401)
+
+    def test_credentials_with_basic_auth(self):
+        request = self.factory.get('/myapi/')
+        request.META['HTTP_AUTHORIZATION'] = f"basic {USERNAME}:{self.api_key}"
+
+        res = self.call_api(request)
+        self.assertEqual(res.status_code, 401)

--- a/corehq/apps/domain/tests/test_auth.py
+++ b/corehq/apps/domain/tests/test_auth.py
@@ -195,7 +195,7 @@ class ApiKeyFallbackTests(TestCase):
             request.META['HTTP_X_FORWARDED_FOR'] = ip
 
         if can_use_api_key:
-            request.check_for_password_as_api_key = True
+            request.check_for_api_key_as_password = True
 
         return request
 

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -33,7 +33,7 @@ from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.api.resources.v0_5 import ODataCaseResource, ODataFormResource
 from corehq.apps.app_manager.fields import ApplicationDataRMIHelper
-from corehq.apps.domain.decorators import api_auth_no_digest, login_and_domain_required
+from corehq.apps.domain.decorators import api_auth_allow_key_as_password, login_and_domain_required
 from corehq.apps.domain.models import Domain
 from corehq.apps.export.const import (
     CASE_EXPORT,
@@ -806,7 +806,7 @@ def can_download_daily_saved_export(export, domain, couch_user):
 
 @location_safe
 @csrf_exempt
-@api_auth_no_digest(allow_api_key_as_password=True)
+@api_auth_allow_key_as_password()
 @require_GET
 def download_daily_saved_export(req, domain, export_instance_id):
     with CriticalSection(['export-last-accessed-{}'.format(export_instance_id)]):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -33,7 +33,7 @@ from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.api.resources.v0_5 import ODataCaseResource, ODataFormResource
 from corehq.apps.app_manager.fields import ApplicationDataRMIHelper
-from corehq.apps.domain.decorators import api_auth_allow_key_as_password, login_and_domain_required
+from corehq.apps.domain.decorators import api_auth_allow_key_as_password_LIMITED_USE, login_and_domain_required
 from corehq.apps.domain.models import Domain
 from corehq.apps.export.const import (
     CASE_EXPORT,
@@ -806,7 +806,7 @@ def can_download_daily_saved_export(export, domain, couch_user):
 
 @location_safe
 @csrf_exempt
-@api_auth_allow_key_as_password()
+@api_auth_allow_key_as_password_LIMITED_USE()
 @require_GET
 def download_daily_saved_export(req, domain, export_instance_id):
     with CriticalSection(['export-last-accessed-{}'.format(export_instance_id)]):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -806,7 +806,7 @@ def can_download_daily_saved_export(export, domain, couch_user):
 
 @location_safe
 @csrf_exempt
-@api_auth()
+@api_auth(allow_api_key_as_password=True)
 @require_GET
 def download_daily_saved_export(req, domain, export_instance_id):
     with CriticalSection(['export-last-accessed-{}'.format(export_instance_id)]):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -33,7 +33,7 @@ from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.api.resources.v0_5 import ODataCaseResource, ODataFormResource
 from corehq.apps.app_manager.fields import ApplicationDataRMIHelper
-from corehq.apps.domain.decorators import api_auth, login_and_domain_required
+from corehq.apps.domain.decorators import api_auth_no_digest, login_and_domain_required
 from corehq.apps.domain.models import Domain
 from corehq.apps.export.const import (
     CASE_EXPORT,
@@ -806,7 +806,7 @@ def can_download_daily_saved_export(export, domain, couch_user):
 
 @location_safe
 @csrf_exempt
-@api_auth(allow_api_key_as_password=True)
+@api_auth_no_digest(allow_api_key_as_password=True)
 @require_GET
 def download_daily_saved_export(req, domain, export_instance_id):
     with CriticalSection(['export-last-accessed-{}'.format(export_instance_id)]):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Adds support for 2FA/SSO users to configure their Excel dashboard feeds with basic auth, using the API key in place of the password.

We will need to update [these docs](https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957984/Tutorial+Create+an+Excel+Dashboard) to reflect this option for 2FA/SSO users.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-16493

We already have support for this in OData feeds (https://github.com/dimagi/commcare-hq/pull/24231), and this is attempting to achieve similar behavior for Excel dashboards. We've seen unreliable behavior with our Excel handles the `Authorization` header that holds the username and API key to the point where Excel will remove this header from the request entirely before sending it. This obviously results in a 401, and our users are left frustrated because they followed our documentation for setting up a data feed in Excel.

Honestly, my main concern is that we will start to use this on other endpoints, when in reality we should reserve this for exceptional use cases where it is our best, and possibly only option. The alternative in this case is to tell users to pass the credentials via URL parameters, but that seems even less ideal than what this PR does, and therefore I went with this approach.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added test to ensure a 401 is still raised when the `allow_api_key_as_password` is set to False, which is what it defaults to. It is only set to True on this one endpoint (at the moment).

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
~I think we ideally want to fast track this change, so I will test on staging with the help of those that have access to Excel, and see if QA is needed then.~

https://dimagi.atlassian.net/browse/QA-7440

QA passed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

Excel dashboard feeds are currently broken for 2FA/SSO users on newer versions of excel, and if we tell users to adopt a new format configuring feeds, and then revert it, that would put us in an even worse situation.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
