### PR TITLE
Updated js docs

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1001,15 +1001,12 @@ class MultipleSelectionForm(forms.Form):
             return super(MyView, self).dispatch(request, *args, **kwargs)
 
         # javascript
-        hqDefine("app/js/module", function() {
-            // Multiselect widget
-            $(function () {
-                var multiselect_utils = hqImport('hqwebapp/js/multiselect_utils');
-                multiselect_utils.createFullMultiselectWidget('id_of_multiselect_field', {
-                    selectableHeaderTitle: gettext("Available Things"),
-                    selectedHeaderTitle: gettext("Things Selected"),
-                    searchItemTitle: gettext("Search Things..."),
-                });
+        import multiselectUtils from "hqwebapp/js/multiselect_utils";
+        $(function () {
+            multiselectUtils.createFullMultiselectWidget('id_of_multiselect_field', {
+                selectableHeaderTitle: gettext("Available Things"),
+                selectedHeaderTitle: gettext("Things Selected"),
+                searchItemTitle: gettext("Search Things..."),
             });
         });
     """

--- a/docs/js-guide/amd-to-esm.rst
+++ b/docs/js-guide/amd-to-esm.rst
@@ -115,6 +115,13 @@ Key Points
     a problem, check ``requirejs_config.js``, because there might have been an alias defined there that hasn't
     been added to ``webpack.common.js``.
 
+Automation
+~~~~~~~~~~
+
+As a first step, you can run the `hqdefine_to_esm <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/management/commands/hqdefine_to_esm.py>`__
+management command, which will rewrite the file in place, replacing the ``hqDefine`` call with a series of
+``import`` statements.
+
 
 Example Structural Change
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/js-guide/dependencies.rst
+++ b/docs/js-guide/dependencies.rst
@@ -402,8 +402,8 @@ un-migrated files. At the time of writing:
 
     $ ./scripts/codechecks/hqDefine.sh
 
-    97%	(1209/1254) of HTML files are free of inline scripts
-    94%	(553/594) of non-ESM JS files use hqDefine
-    75%	(443/594) of non-ESM JS files specify their dependencies
-    93%	(1162/1254) of HTML files are free of script tags
-    1%	(3/597) of JS files use ESM format
+    97%     (1264/1306) of HTML files are free of inline scripts
+    96%     (550/576) of non-ESM JS files use hqDefine
+    87%     (500/576) of non-ESM JS files specify their dependencies
+    98%     (1270/1306) of HTML files are free of script tags
+    5%      (30/606) of JS files use ESM format

--- a/docs/js-guide/integration-patterns.rst
+++ b/docs/js-guide/integration-patterns.rst
@@ -25,16 +25,14 @@ The data can be a template variable or a constant.
    {% initial_page_data 'defaultRows' report_table.default_rows|default:10 %}
    {% initial_page_data 'tableOptions' table_options %}
 
-Your JavaScript can then include
-``<script src="{% static 'hqwebapp/js/initial_page_data.js' %}"></script>``
+Your JavaScript can then ``import initialPageData from 'hqwebapp/js/initial_page_data';``
 and access this data using the same names as in the Django template:
 
 ::
 
-   var get = hqImport('hqwebapp/js/initial_page_data').get,
-       renderReportTables = get('renderReportTables'),
-       defaultRows = get('defaultRows'),
-       tableOptions = get('tableOptions');
+   const renderReportTables = initialPageData.get('renderReportTables'),
+       defaultRows = initialPageData.get('defaultRows'),
+       tableOptions = initialPageData.get('tableOptions');
 
 When your JavaScript data is a complex object, it’s generally cleaner to
 build it in your view than to pass a lot of variables through the Django
@@ -150,9 +148,9 @@ in js
 
 ::
 
-   var initial_page_data = hqImport('hqwebapp/js/initial_page_data');
+   import initialPageData from 'hqwebapp/js/initial_page_data';
 
-   $.get(initial_page_data.reverse('all_widget_info')).done(function () {...});
+   $.get(initialPageData.reverse('all_widget_info')).done(function () {...});
 
 As in this example, prefer inlining the call to
 ``initial_page_data.reverse`` over assigning its return value to a
@@ -172,9 +170,9 @@ in js
 
 ::
 
-   var initial_page_data = hqImport('hqwebapp/js/initial_page_data');
+   import initialPageData from 'hqwebapp/js/initial_page_data';
    var widgetId = 'xxxx';
-   $.get(initial_page_data.reverse('more_widget_info', widgetId)).done(function () {...});
+   $.get(initialPageData.reverse('more_widget_info', widgetId)).done(function () {...});
 
 ``registerurl`` is essentially a special case of initial page data, and
 it gets messy when used in partials in the same way as initial page


### PR DESCRIPTION
## Technical Summary
This makes a couple minor updates to the js docs:
* Reference the new script to convert AMD modules to ESM
* Updates some examples to use EMS syntax. We're not quite ready to remove all AMD references from docs, bu tthat day is coming.
* Update the migration stats, because why not?

## Safety Assurance

### Safety story
docs only

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
