### PR TITLE
Update test runner documentation to use pytest

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -976,7 +976,7 @@ files from Vellum directly, do the following.
 To run the standard tests for CommCare HQ, run
 
 ```sh
-./manage.py test
+pytest
 ```
 
 These may not all pass in a local environment. It's often more practical, and
@@ -985,23 +985,18 @@ faster, to just run tests for the django app where you're working.
 To run a particular test or subset of tests:
 
 ```sh
-./manage.py test <test.module.path>[:<TestClass>[.<test_name>]]
+pytest <test/file/path.py>[::<TestClass>[::<test_name>]]
 
 # examples
-./manage.py test corehq.apps.app_manager
-./manage.py test corehq.apps.app_manager.tests.test_suite:SuiteTest
-./manage.py test corehq.apps.app_manager.tests.test_suite:SuiteTest.test_picture_format
-
-# alternate: file system path
-./manage.py test corehq/apps/app_manager
-./manage.py test corehq/apps/app_manager/tests/test_suite.py:SuiteTest
-./manage.py test corehq/apps/app_manager/tests/test_suite.py:SuiteTest.test_picture_format
+pytest corehq/apps/app_manager
+pytest corehq/apps/app_manager/tests/test_suite.py::SuiteTest
+pytest corehq/apps/app_manager/tests/test_suite.py::SuiteTest::test_printing
 ```
 
 To use the `pdb` debugger in tests, include the `s` flag:
 
 ```sh
-./manage.py test -s <test.module.path>[:<TestClass>[.<test_name>]]
+pytest -s <test/file/path.py>[::<TestClass>[::<test_name>]]
 ```
 
 If database tests are failing because of a `permission denied` error, give your
@@ -1029,13 +1024,13 @@ To avoid having to run the database setup for each test run you can specify the
 exists:
 
 ```sh
-REUSE_DB=1 ./manage.py test corehq.apps.app_manager
+REUSE_DB=1 pytest corehq/apps/app_manager
 ```
 
 Or, to drop the current test DB and create a fresh one
 
 ```sh
-./manage.py test corehq.apps.app_manager --reusedb=reset
+pytest corehq/apps/app_manager --reusedb=reset
 ```
 
 See `corehq.tests.pytest_plugins.reusedb` ([source](corehq/tests/pytest_plugins/reusedb.py))
@@ -1123,10 +1118,10 @@ See https://docs.pytest.org/en/stable/example/markers.html for more details.
 
 ```sh
 # only run tests that extend TestCase
-./manage.py test --db=only
+pytest --db=only
 
 # skip all tests that extend TestCase but run everything else
-./manage.py test --db=skip
+pytest --db=skip
 ```
 
 ### Running only failed tests

--- a/corehq/apps/builds/tests.py
+++ b/corehq/apps/builds/tests.py
@@ -1,16 +1,20 @@
+import pytest
+
 from corehq.apps.builds.utils import extract_build_info_from_filename
 
-# FIXME: does this do anything?
-# $ ./manage.py test -v corehq/apps/builds/tests.py
-# nosetests corehq/apps/builds/tests.py --verbosity=2
-#
-# ----------------------------------------------------------------------
-# Ran 0 tests in 0.000s
-#
-# OK
-__test__ = {
-    'extract_build_info_from_filename': extract_build_info_from_filename
-}
+
+def test_extract_build_info_from_filename():
+    info = extract_build_info_from_filename(
+        'attachment; filename=CommCare_CommCare_2.13_32703_artifacts.zip'
+    )
+    assert info == ('2.13', 32703)
+
+
+def test_extract_build_info_from_filename_error():
+    msg = r"Could not find filename like 'CommCare_CommCare_.+_artifacts.zip' in 'foo'"
+    with pytest.raises(ValueError, match=msg):
+        extract_build_info_from_filename('foo')
+
 
 # NOTE: Don't run the test below because GitHub rate-limits unauthenticated API
 # request _very_ fast.

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -50,8 +50,8 @@ LOCAL_LOGGING_CONFIG = {
             'handlers': ['null'],
             'level': 'WARNING',
         },
-        # The following configuration will print out all queries that are run through sqlalchemy on the command line
-        # Useful for UCR debugging
+        # The following configuration will print out all queries that are run
+        # through sqlalchemy on the command line. Useful for UCR debugging
         # 'sqlalchemy.engine': {
         #     'handlers': ['console'],
         #     'level': 'INFO',
@@ -171,6 +171,6 @@ if settingshelper.is_testing():
         },
     }
 
-### LOG FILES ###
+# LOG FILES
 DJANGO_LOG_FILE = "/tmp/commcare-hq.django.log"
 LOG_FILE = "/tmp/commcare-hq.log"

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -12,11 +12,6 @@ LOCAL_APPS = (
     'django_extensions',
 )
 
-# TEST_RUNNER is overridden in testsettings, which is the default settings
-# module for the test command (see manage.py); this has no effect by default.
-# Use ./manage.py test --settings=settings to use this setting.
-TEST_RUNNER = 'testrunner.DevTestRunner'
-
 SKIP_TESTS_REQUIRING_EXTRA_SETUP = True
 
 # touchforms must be running when this is false or not set

--- a/docs/test_coverage.rst
+++ b/docs/test_coverage.rst
@@ -18,7 +18,7 @@ First thing is to install the coverage.py library::
 Now you can run your tests through the coverage.py program::
 
 
-        $ coverage run manage.py test commtrack
+        $ coverage run `which pytest` commtrack
 
 
 This will create a binary `commcare-hq/.coverage` file (that is already


### PR DESCRIPTION
Missed during the [switch from pytest to nose](https://github.com/dimagi/commcare-hq/pull/34778).

### Safety story

Docs only.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations