### PR TITLE
Removed nvd3 decorators

### DIFF
--- a/corehq/apps/app_execution/static/app_execution/js/workflow_charts.js
+++ b/corehq/apps/app_execution/static/app_execution/js/workflow_charts.js
@@ -4,6 +4,7 @@ hqDefine("app_execution/js/workflow_charts", [
     'moment/moment',
     'd3/d3.min',
     'nvd3/nv.d3.latest.min',  // version 1.1.10 has a bug that affects line charts with multiple series
+    'nvd3-1.8.6/build/nv.d3.css',
     'commcarehq',
 ], function (
     $, moment, d3, nv

--- a/corehq/apps/app_execution/templates/app_execution/workflow_list.html
+++ b/corehq/apps/app_execution/templates/app_execution/workflow_list.html
@@ -3,15 +3,6 @@
 {% load compress %}
 {% load i18n %}
 
-{% block stylesheets %}{{ block.super }}
-{% compress css %}
-    <link type="text/css"
-          rel="stylesheet"
-          media="all"
-          href="{% static 'nvd3-1.8.6/build/nv.d3.css' %}" />
-  {% endcompress %}
-{% endblock %}
-
 {% js_entry 'app_execution/js/workflow_charts' %}
 
 {% block page_content %}

--- a/corehq/apps/app_execution/templates/app_execution/workflow_log_list.html
+++ b/corehq/apps/app_execution/templates/app_execution/workflow_log_list.html
@@ -6,10 +6,6 @@
 {% block stylesheets %}{{ block.super }}
 {% compress css %}
     <link type="text/css"
-          rel="stylesheet"
-          media="all"
-          href="{% static 'nvd3-1.8.6/build/nv.d3.css' %}" />
-    <link type="text/css"
               rel="stylesheet"
               media="screen"
               href="{% static "@eonasdan/tempus-dominus/dist/css/tempus-dominus.min.css" %}" />

--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -47,34 +47,6 @@ def use_multiselect(view_func):
     return set_request_flag(view_func, 'use_multiselect')
 
 
-def use_nvd3(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to enable the inclusion of the nvd3 library at the base template
-    level. nvd3 is a library of charts for d3.
-
-    Example:
-
-    @use_nvd3
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-    return set_request_flag(view_func, 'use_nvd3')
-
-
-def use_nvd3_v3(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to enable the inclusion of the nvd3 library at the base template
-    level. nvd3 Version 3 is a library of charts for d3.
-
-    Example:
-
-    @use_nvd3
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-    return set_request_flag(view_func, 'use_nvd3_v3')
-
-
 def use_datatables(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable the inclusion of the datatables library at the base template

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/requirejs_config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/requirejs_config.js
@@ -82,10 +82,6 @@ requirejs.config({
             exports: "L",
         },
         "mapbox.js/dist/mapbox.uncompressed": { exports: "L" },
-        "nvd3/nv.d3.min": {
-            deps: ['d3/d3.min'],
-            exports: 'nv',
-        },
         "sentry_browser": { exports: "Sentry" },
     },
     wrapShim: true,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/requirejs_config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/requirejs_config.js
@@ -22,7 +22,6 @@ requirejs.config({
         "sentry_captureconsole": "sentry/js/sentry.captureconsole.7.28.0.min",
         "tempusDominus": "@eonasdan/tempus-dominus/dist/js/tempus-dominus.min",
         "underscore": "underscore/underscore",
-        "nvd3/nv.d3.latest.min": "nvd3-1.8.6/build/nv.d3.min",
         "stripe": "https://js.stripe.com/v2/?noext",
         "commcarehq": "hqwebapp/js/requirejs_webpack_fake",
     },
@@ -93,14 +92,6 @@ requirejs.config({
             exports: "L",
         },
         "mapbox.js/dist/mapbox.uncompressed": { exports: "L" },
-        "nvd3/nv.d3.min": {
-            deps: ['d3/d3.min'],
-            exports: 'nv',
-        },
-        "nvd3/nv.d3.latest.min": {
-            deps: ['d3/d3.min'],
-            exports: 'nv',
-        },
         "sentry_browser": { exports: "Sentry" },
     },
     wrapShim: true,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -73,7 +73,6 @@ function hqDefine(path, dependencies, moduleAccessor) {
                 'DOMPurify/dist/purify.min': 'DOMPurify',
                 'mocha/mocha': 'mocha',
                 'moment/moment': 'moment',
-                'nvd3/nv.d3.min': 'nv',
                 'crypto-js/crypto-js': 'CryptoJS',
                 'hqwebapp/js/lib/modernizr': 'Modernizr',
                 'sinon/pkg/sinon': 'sinon',

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -54,15 +54,6 @@
             href="{% static 'select2/dist/css/select2.min.css' %}" />
     {% endcompress %}
 
-    {% if request.use_nvd3 or request.use_nvd3_v3 %}
-      {% compress css %}
-        <link type="text/css"
-              rel="stylesheet"
-              media="all"
-              href="{% static 'nvd3/src/nv.d3.css' %}" />
-      {% endcompress %}
-    {% endif %}
-
     {% if request.use_daterangepicker and not use_bootstrap5 %}
       {% compress css %}
         <link type="text/css"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -373,23 +373,6 @@
       {% endcompress %}
     {% endif %}
 
-    {% if request.use_nvd3 and not use_js_bundler %}
-      {% compress js %}
-        <script src="{% static 'nvd3/lib/d3.v2.js' %}"></script>
-        <script src="{% static 'nvd3/lib/fisheye.js' %}"></script>
-        <script src="{% static 'd3/d3.min.js' %}"></script>
-        <script src="{% static 'nvd3/nv.d3.min.js' %}"></script>
-      {% endcompress %}
-    {% endif %}
-
-    {% if request.use_nvd3_v3 and not use_js_bundler %}
-      {% compress js %}
-        <script src="{% static 'nvd3/lib/d3.v3.js' %}"></script>
-        <script src="{% static 'd3/d3.min.js' %}"></script>
-        <script src="{% static 'nvd3/nv.d3.min.js' %}"></script>
-      {% endcompress %}
-    {% endif %}
-
     {% if request.use_datatables and not use_js_bundler %}
       {% if use_bootstrap5 %}
         {% compress js %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/requirejs_config.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -2,19 +2,27 @@
+@@ -2,18 +2,25 @@
  requirejs.config({
      baseUrl: '/static/',
      paths: {
@@ -26,11 +26,9 @@
          "sentry_captureconsole": "sentry/js/sentry.captureconsole.7.28.0.min",
 +        "tempusDominus": "@eonasdan/tempus-dominus/dist/js/tempus-dominus.min",
          "underscore": "underscore/underscore",
-+        "nvd3/nv.d3.latest.min": "nvd3-1.8.6/build/nv.d3.min",
          "stripe": "https://js.stripe.com/v2/?noext",
          "commcarehq": "hqwebapp/js/requirejs_webpack_fake",
-     },
-@@ -26,7 +34,6 @@
+@@ -26,7 +33,6 @@
          "ace-builds/src-min-noconflict/ext-searchbox": { deps: ["ace-builds/src-min-noconflict/ace"] },
          "At.js/dist/js/jquery.atwho": { deps: ['jquery', 'Caret.js/dist/jquery.caret'] },
          "backbone": { exports: "backbone" },
@@ -38,7 +36,7 @@
          "calendars/dist/js/jquery.calendars.picker": {
              deps: [
                  "calendars/dist/js/jquery.plugin",
-@@ -62,10 +69,14 @@
+@@ -62,10 +68,14 @@
              ],
          },
          "datatables.bootstrap": { deps: ['datatables'] },
@@ -54,18 +52,7 @@
          "hqwebapp/js/lib/modernizr": {
              exports: 'Modernizr',
          },
-@@ -86,6 +97,10 @@
-             deps: ['d3/d3.min'],
-             exports: 'nv',
-         },
-+        "nvd3/nv.d3.latest.min": {
-+            deps: ['d3/d3.min'],
-+            exports: 'nv',
-+        },
-         "sentry_browser": { exports: "Sentry" },
-     },
-     wrapShim: true,
-@@ -100,7 +115,7 @@
+@@ -96,7 +106,7 @@
          },
      },
  

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/aggregate_user_status.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/aggregate_user_status.js.diff.txt
@@ -8,6 +8,6 @@
      "nvd3/nv.d3.min",
 -    "hqwebapp/js/bootstrap3/main",
 +    "hqwebapp/js/bootstrap5/main",
+     'nvd3/src/nv.d3.css',
  ], function (
      $,
-     d3,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/project_health_dashboard.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/project_health_dashboard.js.diff.txt
@@ -6,7 +6,7 @@
      'jquery',
      'underscore',
      'd3/d3.min',
-@@ -119,7 +119,7 @@
+@@ -120,7 +120,7 @@
      // User Information PopOver, when clicked on username
      function setupPopovers() {
          // ajax popover: http://stackoverflow.com/a/14560039/8207

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -33,7 +33,6 @@ from corehq.apps.hqwebapp.decorators import (
     use_datatables,
     use_daterangepicker,
     use_jquery_ui,
-    use_nvd3,
 )
 from corehq.apps.reports.cache import request_cache
 from corehq.apps.reports.datatables import DataTablesHeader
@@ -836,7 +835,6 @@ class GenericReportView(object):
         """
         return []
 
-    @use_nvd3
     @use_jquery_ui
     @use_datatables
     @use_daterangepicker
@@ -851,7 +849,7 @@ class GenericReportView(object):
         class MyNewReport(GenericReport):
             ...
 
-            @use_nvd3
+            @use_jquery_ui
             def decorator_dispatcher(self, request, *args, **kwargs):
                 super(MyNewReport, self).decorator_dispatcher(request, *args, **kwargs)
 

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -28,7 +28,6 @@ from corehq.apps.es.aggregations import (
     FilterAggregation,
     NestedAggregation,
 )
-from corehq.apps.hqwebapp.decorators import use_nvd3
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
@@ -747,10 +746,6 @@ class AggregateUserStatusReport(ProjectReport, ProjectReportParametersMixin):
     ]
     exportable = False
     emailable = False
-
-    @use_nvd3
-    def decorator_dispatcher(self, request, *args, **kwargs):
-        super(AggregateUserStatusReport, self).decorator_dispatcher(request, *args, **kwargs)
 
     @property
     @memoized

--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -16,7 +16,6 @@ from corehq.apps.data_analytics.models import MALTRow
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.groups import GroupES
 from corehq.apps.es.users import UserES
-from corehq.apps.hqwebapp.decorators import use_nvd3
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.filters.select import SelectApplicationFilter
 from corehq.apps.reports.standard import ProjectReport
@@ -285,10 +284,6 @@ class ProjectHealthDashboard(ProjectReport):
         if self.is_rendered_as_email:
             self.report_template_path = "reports/project_health/bootstrap3/project_health_email.html"
         return super(ProjectHealthDashboard, self).template_report
-
-    @use_nvd3
-    def decorator_dispatcher(self, request, *args, **kwargs):
-        super(ProjectHealthDashboard, self).decorator_dispatcher(request, *args, **kwargs)
 
     @property
     def selected_app_id(self):

--- a/corehq/apps/reports/static/reports/js/bootstrap3/aggregate_user_status.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/aggregate_user_status.js
@@ -3,6 +3,7 @@ hqDefine("reports/js/bootstrap3/aggregate_user_status", [
     "d3/d3.min",
     "nvd3/nv.d3.min",
     "hqwebapp/js/bootstrap3/main",
+    'nvd3/src/nv.d3.css',
 ], function (
     $,
     d3,

--- a/corehq/apps/reports/static/reports/js/bootstrap3/project_health_dashboard.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/project_health_dashboard.js
@@ -4,6 +4,7 @@ hqDefine("reports/js/bootstrap3/project_health_dashboard", [
     'd3/d3.min',
     'moment/moment',
     'nvd3/nv.d3.min',
+    'nvd3/src/nv.d3.css',
 ], function (
     $,
     _,

--- a/corehq/apps/reports/static/reports/js/bootstrap5/aggregate_user_status.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/aggregate_user_status.js
@@ -3,6 +3,7 @@ hqDefine("reports/js/bootstrap5/aggregate_user_status", [
     "d3/d3.min",
     "nvd3/nv.d3.min",
     "hqwebapp/js/bootstrap5/main",
+    'nvd3/src/nv.d3.css',
 ], function (
     $,
     d3,

--- a/corehq/apps/reports/static/reports/js/bootstrap5/project_health_dashboard.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/project_health_dashboard.js
@@ -4,6 +4,7 @@ hqDefine("reports/js/bootstrap5/project_health_dashboard", [
     'd3/d3.min',
     'moment/moment',
     'nvd3/nv.d3.min',
+    'nvd3/src/nv.d3.css',
 ], function (
     $,
     _,

--- a/corehq/apps/reports/static/reports/js/charts/multibar_chart.js
+++ b/corehq/apps/reports/static/reports/js/charts/multibar_chart.js
@@ -2,6 +2,7 @@ hqDefine('reports/js/charts/multibar_chart', [
     'jquery',
     'd3/d3.min',
     'nvd3/nv.d3.min',
+    'nvd3/src/nv.d3.css',
 ], function (
     $,
     d3,

--- a/corehq/apps/reports/static/reports/js/charts/pie_chart.js
+++ b/corehq/apps/reports/static/reports/js/charts/pie_chart.js
@@ -2,6 +2,7 @@ hqDefine("reports/js/charts/pie_chart", [
     'jquery',
     'd3/d3.min',
     'nvd3/nv.d3.min',
+    'nvd3/src/nv.d3.css',
 ], function (
     $,
     d3,

--- a/corehq/apps/reports_core/static/reports_core/js/charts.js
+++ b/corehq/apps/reports_core/static/reports_core/js/charts.js
@@ -4,6 +4,7 @@ hqDefine('reports_core/js/charts', [
     'underscore',
     'd3/d3.min',
     'nvd3/nv.d3.min',
+    'nvd3/src/nv.d3.css',
 ], function (
     $,
     _,

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -34,7 +34,6 @@ from corehq.apps.hqwebapp.decorators import (
     use_datatables,
     use_daterangepicker,
     use_jquery_ui,
-    use_nvd3,
 )
 from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.apps.reports.datatables import DataTablesHeader
@@ -164,7 +163,6 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     @use_daterangepicker
     @use_jquery_ui
     @use_datatables
-    @use_nvd3
     @track_domain_request(calculated_prop='cp_n_viewed_ucr_reports')
     def dispatch(self, request, *args, **kwargs):
         if self.should_redirect_to_paywall(request):

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -65,7 +65,6 @@ from corehq.apps.hqwebapp.decorators import (
     use_daterangepicker,
     use_jquery_ui,
     use_multiselect,
-    use_nvd3,
 )
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
@@ -523,7 +522,6 @@ class ConfigureReport(ReportBuilderView):
 
     @use_jquery_ui
     @use_datatables
-    @use_nvd3
     @use_multiselect
     def dispatch(self, request, *args, **kwargs):
         if self.existing_report:

--- a/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
@@ -4,6 +4,7 @@ hqDefine("scheduling/js/dashboard",[
     'hqwebapp/js/initial_page_data',
     'd3/d3.min',
     'nvd3/nv.d3.min',
+    'nvd3/src/nv.d3.css',
     'commcarehq',
 ], function ($, ko, initialPageData, d3, nv) {
     var dashboardUrl = initialPageData.reverse("messaging_dashboard");

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -37,7 +37,6 @@ from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.decorators import (
     use_datatables,
     use_jquery_ui,
-    use_nvd3,
     use_timepicker,
 )
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
@@ -112,10 +111,6 @@ class MessagingDashboardView(BaseMessagingSectionView):
     urlname = 'messaging_dashboard'
     page_title = gettext_lazy("Dashboard")
     template_name = 'scheduling/dashboard.html'
-
-    @use_nvd3
-    def dispatch(self, *args, **kwargs):
-        return super(MessagingDashboardView, self).dispatch(*args, **kwargs)
 
     def get_messaging_history_errors_url(self, messaging_history_url):
         url_param_tuples = [


### PR DESCRIPTION
## Technical Summary
Now that all pages that depend on NVD3 are on webpack, and [CSS loading is available](https://github.com/dimagi/commcare-hq/pull/35703), we don't need the python decorators anymore.

## Safety Assurance

### Safety story
I deployed this PR to staging and tested that the messaging dashboard and project performance report still render fine, including verifying that they load the CSS file. I didn't test the other pages that use NVD3, I figure the changes are similar enough.

I'm not planning to merge this until the deploy freeze goes into place after tomorrow's prod deploy.

### Automated test coverage

Not really.

### QA Plan

Not requesting QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
