### PR TITLE
Resolve Unassign Case Exception for Microplanning

### DIFF
--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -1057,7 +1057,7 @@ hqDefine('geospatial/js/models', [
 
         self.assignUserToCases = function () {
             let selectedUser;
-            if (self.mapModel.caseGroupsIndex[self.selectedUserId()]) {
+            if (self.selectedUserId()) {
                 selectedUser = self.mapModel.caseGroupsIndex[self.selectedUserId()].item;
             }
             for (const caseItem of self.caseDataPage()) {

--- a/corehq/apps/geospatial/static/geospatial/js/models.js
+++ b/corehq/apps/geospatial/static/geospatial/js/models.js
@@ -1056,17 +1056,20 @@ hqDefine('geospatial/js/models', [
         };
 
         self.assignUserToCases = function () {
-            const selectedUser = self.mapModel.caseGroupsIndex[self.selectedUserId()].item;
+            let selectedUser;
+            if (self.mapModel.caseGroupsIndex[self.selectedUserId()]) {
+                selectedUser = self.mapModel.caseGroupsIndex[self.selectedUserId()].item;
+            }
             for (const caseItem of self.caseDataPage()) {
                 if (!caseItem.isSelected()) {
                     continue;
                 }
 
                 caseItem.assignedUsername(
-                    (selectedUser) ? selectedUser.name : emptyColStr
+                    (selectedUser) ? selectedUser.name : emptyColStr,
                 );
                 caseItem.assignedUserPrimaryLocName(
-                    (selectedUser) ? selectedUser.customData.primary_loc_name : emptyColStr
+                    (selectedUser) ? selectedUser.customData.primary_loc_name : emptyColStr,
                 );
                 caseItem.assignedUserId = self.selectedUserId();
                 caseItem.isSelected(false);


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This PR introduces a small change that stops a JS exception from happening when trying to unassign a case in the review assignment popup for the Microplanning Map page. This exception happens because the code is trying to find a selected user. When doing an unassignment, there is no selected user and so an exception occurrs.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`MICROPLANNING`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
