### PR TITLE
Moved custom_assertions.js into base template instead of partial

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
@@ -63,10 +63,13 @@ hqDefine('app_manager/js/custom_assertions', [
 
     $(function () {
         if (toggles.toggleEnabled('CUSTOM_ASSERTIONS')) {
-            var assertions = customAssertions().wrap({
-                'customAssertions': initialPageData.get('custom_assertions'),
-            });
-            $('#custom-assertions').koApplyBindings(assertions);
+            const $container = $('#custom-assertions');
+            if ($container.length) {
+                var assertions = customAssertions().wrap({
+                    'customAssertions': initialPageData.get('custom_assertions'),
+                });
+                $container.koApplyBindings(assertions);
+            }
         }
     });
 

--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -71,6 +71,7 @@
     <script src="{% static 'app_manager/js/managed_app.js' %}"></script>
     <script src="{% static 'hqwebapp/js/bootstrap3/rollout_modal.js' %}"></script>
     <script src="{% static 'app_manager/js/section_changer.js' %}"></script>
+    <script src="{% static 'app_manager/js/custom_assertions.js' %}"></script>
   {% endcompress %}
 {% endblock %}
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/custom_assertions.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/custom_assertions.html
@@ -1,7 +1,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 {% initial_page_data 'custom_assertions' custom_assertions %}
-<script src="{% static 'app_manager/js/custom_assertions.js' %}"></script>
 <label class="control-label col-sm-2">
   {% trans "Custom Assertions" %}
   <span class="hq-help-template"


### PR DESCRIPTION
## Product Description
Fixes a js error in app manager for projects using custom assertions. From cursory testing, this doesn't appear to break anything *else* on the page, since by the time the error is hit, at least most and maybe all of the other js has loaded.

## Technical Summary
Introduced in https://github.com/dimagi/commcare-hq/commit/a4ec28cf70eb493863c585c559ebee2e05a833a2

Because this script was included in a partial, it ends up in the content block [here](https://github.com/dimagi/commcare-hq/blob/a3442a0eccb132c557ed61c325ffe747a6dbda04/corehq/apps/hqwebapp/templates/hqwebapp/base.html#L186). But the toggles library isn't included until way down [here](https://github.com/dimagi/commcare-hq/blob/a3442a0eccb132c557ed61c325ffe747a6dbda04/corehq/apps/hqwebapp/templates/hqwebapp/base.html#L358).

Previously, this didn't matter because the `hqImport` for toggles was in a document ready callback, but the breaking change causes it to get imported at the time that `custom_assertions.js` is loaded.

## Feature Flag
Custom assertions

## Safety Assurance

### Safety story
Code review is sufficient safety check.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
