### PR TITLE
Typos

### DIFF
--- a/corehq/apps/es/README.rst
+++ b/corehq/apps/es/README.rst
@@ -567,7 +567,7 @@ provides the following functionality:
 Tombstone
 ---------
 
-The concept of Tombstone in the ES mulitplexer is there to be placeholder for
+The concept of Tombstone in the ES multiplexer is there to be placeholder for
 the docs that get deleted on the primary index prior to that document being
 indexed on the secondary index. It means that whenever an adapter is multiplexed
 and a document is deleted, then the secondary index will receive a tombstone

--- a/corehq/motech/fhir/tests/test_fhir_views.py
+++ b/corehq/motech/fhir/tests/test_fhir_views.py
@@ -209,7 +209,7 @@ class TestFHIRSearchView(BaseFHIRViewTest):
 
     @flag_enabled('FHIR_INTEGRATION')
     def test_no_resource_provided(self):
-        url = reverse("fhir_search_mulitple_types", args=[DOMAIN, FHIR_VERSION]) + f"?_id={PERSON_CASE_ID}"
+        url = reverse("fhir_search_multiple_types", args=[DOMAIN, FHIR_VERSION]) + f"?_id={PERSON_CASE_ID}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(

--- a/corehq/motech/fhir/urls.py
+++ b/corehq/motech/fhir/urls.py
@@ -6,9 +6,13 @@ from corehq.motech.fhir.views import (
 )
 
 urlpatterns = [
-    url(r'^fhir/(?P<fhir_version_name>\w+)/(?P<resource_type>\w+)/$', search_view, name="fhir_search"),
-    url(r'^fhir/(?P<fhir_version_name>\w+)/$', search_view,
+    url(r'^fhir/(?P<fhir_version_name>\w+)/$',
+        view=search_view,
         name="fhir_search_multiple_types"),
-    url(r'^fhir/(?P<fhir_version_name>\w+)/(?P<resource_type>\w+)/(?P<resource_id>[\w\-]+)/$', get_view,
+    url(r'^fhir/(?P<fhir_version_name>\w+)/(?P<resource_type>\w+)/$',
+        view=search_view,
+        name="fhir_search"),
+    url(r'^fhir/(?P<fhir_version_name>\w+)/(?P<resource_type>\w+)/(?P<resource_id>[\w\-]+)/$',
+        view=get_view,
         name="fhir_get_view"),
 ]

--- a/corehq/motech/fhir/urls.py
+++ b/corehq/motech/fhir/urls.py
@@ -8,7 +8,7 @@ from corehq.motech.fhir.views import (
 urlpatterns = [
     url(r'^fhir/(?P<fhir_version_name>\w+)/(?P<resource_type>\w+)/$', search_view, name="fhir_search"),
     url(r'^fhir/(?P<fhir_version_name>\w+)/$', search_view,
-        name="fhir_search_mulitple_types"),
+        name="fhir_search_multiple_types"),
     url(r'^fhir/(?P<fhir_version_name>\w+)/(?P<resource_type>\w+)/(?P<resource_id>[\w\-]+)/$', get_view,
         name="fhir_get_view"),
 ]


### PR DESCRIPTION
## Technical Summary

Tiny. Fixes two typos and adds some linebreaks. The linebreaks make the diff more confusing, so :blowfish: :tropical_fish: :fish: 

## Safety Assurance

### Safety story

The only code change is to rename a view URL. It is only used in one place.

### Automated test coverage

N/A

### QA Plan

Not planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
