### PR TITLE
Added Google Analytics New User Data

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/gtx.js
+++ b/corehq/apps/analytics/static/analytix/js/gtx.js
@@ -52,6 +52,7 @@ hqDefine('analytix/js/gtx', [
             userId: _get('userId', 'none'),
             isDimagi: _get('userIsDimagi', 'no', 'yes'),
             isCommCare: _get('userIsCommCareUser', 'no', 'yes'),
+            isNewUser: _get('isNewUser', 'false'),
             domain: _get('domain', 'none'),
             hqEnvironment: _get('hqInstance', 'none'),
             isTestDomain: _get('isTestDomain', 'none'),

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -887,7 +887,8 @@ def record_event(event_name, couch_user, event_properties=None):
     timestamp = unix_time_in_micros(datetime.utcnow())   # Dimagi KISSmetrics account uses UTC
 
     event_body = {
-        'client_id': couch_user._id,
+        'client_id': couch_user.userID,
+        'user_id': couch_user.userID,
         'timestamp_micros': timestamp,
         'events': [{
             'name': event_name,

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -887,6 +887,10 @@ def record_event(event_name, couch_user, event_properties=None):
     timestamp = unix_time_in_micros(datetime.utcnow())   # Dimagi KISSmetrics account uses UTC
 
     event_body = {
+        # The client_id is meant to represent a unique user/device pairing, but we don't have access to that
+        # from the backend. Using the user ID as a placeholder, but the important identifying information
+        # is making sure the user ID is assigned correctly, as that needs to match between the frontend
+        # and backend to trace metrics
         'client_id': couch_user.userID,
         'user_id': couch_user.userID,
         'timestamp_micros': timestamp,

--- a/corehq/apps/analytics/templates/analytics/initial/gtm.html
+++ b/corehq/apps/analytics/templates/analytics/initial/gtm.html
@@ -4,6 +4,7 @@
   {% initial_analytics_data 'gtm.userId' request.couch_user.userID %}
   {% initial_analytics_data 'gtm.userIsDimagi' request.couch_user.is_dimagi %}
   {% initial_analytics_data 'gtm.userIsCommCareUser' request.couch_user.is_commcare_user %}
+  {% initial_analytics_data 'gtm.isNewUser' request.couch_user|is_new_user %}
 {% endif %}
 {% if domain %}
   {% initial_analytics_data 'gtm.domain' domain %}

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -556,6 +556,13 @@ def view_pdb(element):
     return element
 
 
+@register.filter
+def is_new_user(user):
+    now = datetime.now()
+    one_week_ago = now - timedelta(days=7)
+    return True if user.created_on >= one_week_ago else False
+
+
 @register.tag
 def registerurl(parser, token):
     split_contents = token.split_contents()

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -76,6 +76,7 @@ def activate_new_user(
     username, password, created_by, created_via, first_name=None, last_name=None,
     is_domain_admin=False, domain=None, ip=None, atypical_user=False, commit=True
 ):
+    from corehq.apps.analytics.tasks import record_event
     now = datetime.utcnow()
 
     new_user = WebUser.create(
@@ -108,6 +109,11 @@ def activate_new_user(
     new_user.atypical_user = atypical_user
     if commit:
         new_user.save()
+
+    # Engagement time appears necessary for this event to show up within GA debug view
+    # (when 'debug_mode': '1' is also supplied)
+    # Leaving engagement time in as there doesn't seem a good reason to remove it
+    record_event('backend_new_user', new_user, {'engagement_time_msec': 1000})
 
     return new_user
 


### PR DESCRIPTION
## Technical Summary
Because new user creation can come from multiple different paths, and because relying on the `first_seen` data within google analytics can be flaky, we felt it was best to track new user creation from the backend. This PR sends the new `backend_new_user` event (perhaps we can standardize that events originating from the backend adopt this naming scheme?) and introduces the redundant `is_new_user` property. `is_new_user` is likely not necessarily, but will give us some flexibility when running google analytics queries, and serves as a safeguard in the event that the `backend_new_user` event does not occur (I had some concerns it could be 'sampled out' based on testing with even small numbers of events).

## Safety Assurance

### Safety story
This only touches analytics events, so doesn't really have a chance to disrupt other code. Adding the userID, specifically, is necessary for the analytics code to even work properly.

### Automated test coverage

No tests.

### QA Plan
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
