### PR TITLE
Show technical details to superusers only

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -209,10 +209,14 @@ def swallow_programming_errors(fn):
             messages.error(
                 request,
                 _('There was a problem processing your request. '
-                  'If you have recently modified your report data source please try again in a few minutes.'
-                  '<br><br>Technical details:<br>{}'.format(e)),
-                extra_tags='html',
+                  'If you have recently modified your report data source please try again in a few minutes.'),
             )
+            if request.couch_user.is_superuser:
+                messages.error(
+                    request,
+                    _('Technical details:<br>{}').format(e),
+                    extra_tags='html'
+                )
             return HttpResponseRedirect(reverse('configurable_reports_home', args=[domain]))
     return decorated
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
As a follow up to [this](https://github.com/dimagi/commcare-hq/pull/35679) PR, we will now show technical details with failed query to superusers only and show only the relevant message to the user,
So when previewing a data source that fails to load, the second block of error message is only visible to superusers, others only see the first message.

![image](https://github.com/user-attachments/assets/9e0c54c7-4993-4fb8-b214-cba61f41d8f4)


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-4091

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_CONFIGURABLE_REPORTS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
