### PR TITLE
Merge repeat records

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -475,6 +475,7 @@ DOMAIN_DELETE_OPERATIONS = [
         'FHIRImportResourceProperty',
     ]),
     ModelDeletion('repeaters', 'Repeater', 'domain', manager='all_objects'),
+    ModelDeletion('repeaters', 'DataSourceUpdateLog', 'domain'),
     ModelDeletion('motech', 'ConnectionSettings', 'domain', manager='all_objects'),
     ModelDeletion('couchforms', 'UnfinishedSubmissionStub', 'domain'),
     ModelDeletion('couchforms', 'UnfinishedArchiveStub', 'domain'),

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -205,6 +205,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     # RepeatRecord, but this does not seem like a good idea.
     FilteredModelIteratorBuilder('repeaters.RepeatRecord', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('repeaters.RepeatRecordAttempt', SimpleFilter('repeat_record__domain')),
+    FilteredModelIteratorBuilder('repeaters.DataSourceUpdateLog', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('saved_reports.ScheduledReportLog', SimpleFilter('domain')),
     UnfilteredModelIteratorBuilder('saved_reports.ScheduledReportsCheckpoint'),
     FilteredModelIteratorBuilder('translations.SMSTranslations', SimpleFilter('domain')),

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -151,12 +151,7 @@ class DataSourceConfigurationTest(SimpleTestCase):
         sample_doc, expected_indicators = get_sample_doc_and_indicators(fake_time_now)
         [results] = self.config.get_all_values(sample_doc)
         for result in results:
-            try:
-                self.assertEqual(expected_indicators[result.column.id], result.value)
-            except AssertionError:
-                # todo: this is a hack due to the fact that type conversion currently happens
-                # in the database layer. this should eventually be fixed.
-                self.assertEqual(str(expected_indicators[result.column.id]), result.value)
+            self.assertEqual(expected_indicators[result.column.id], result.value)
 
     def test_configured_filter_auto_date_convert(self):
         source = self.config.to_json()

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -9,7 +9,7 @@ from django.test import SimpleTestCase, TestCase
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from pillow_retry.models import PillowError
-from corehq.motech.repeaters.models import RepeatRecord
+
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.userreports.data_source_providers import (
     DynamicDataSourceProvider,
@@ -46,6 +46,8 @@ from corehq.form_processor.signals import sql_case_post_save
 from corehq.motech.repeaters.models import (
     ConnectionSettings,
     DataSourceRepeater,
+    DataSourceUpdateLog,
+    RepeatRecord,
 )
 from corehq.motech.repeaters.tests.test_repeater import BaseRepeaterTest
 from corehq.pillows.case import get_case_pillow
@@ -440,7 +442,6 @@ class IndicatorPillowTest(BaseRepeaterTest):
     @mock.patch('corehq.motech.repeaters.signals.create_repeat_records')
     @mock.patch('corehq.apps.userreports.specs.datetime')
     def test_datasource_change_triggers_change_signal(self, datetime_mock, create_repeat_records_mock):
-        from corehq.apps.userreports.util import DataSourceUpdateLog
         data_source_id = self.config._id
         num_repeaters = 2
         self._setup_data_source_subscription(self.config.domain, data_source_id, num_repeaters=num_repeaters)
@@ -458,7 +459,7 @@ class IndicatorPillowTest(BaseRepeaterTest):
         update_log = call_args[1]
         self.assertEqual(update_log.domain, self.domain)
         self.assertEqual(update_log.data_source_id, self.config._id)
-        self.assertEqual(update_log.doc_id, sample_doc["_id"])
+        self.assertEqual(update_log.doc_ids, [sample_doc["_id"]])
 
     @mock.patch('corehq.apps.userreports.specs.datetime')
     def test_rebuild_indicators(self, datetime_mock):

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -2,8 +2,6 @@ import collections
 import hashlib
 import logging
 import re
-from dataclasses import dataclass
-from typing import Any, Optional
 
 from couchdbkit import ResourceNotFound
 from django_prbac.utils import has_privilege
@@ -31,18 +29,6 @@ from corehq.util.metrics.load_counters import ucr_load_counter
 
 UCR_TABLE_PREFIX = 'ucr_'
 LEGACY_UCR_TABLE_PREFIX = 'config_report_'
-
-
-@dataclass
-class DataSourceUpdateLog:
-    domain: str
-    data_source_id: str
-    doc_id: str
-    rows: Optional[list[dict[str, Any]]] = None
-
-    @property
-    def get_id(self):
-        return self.doc_id
 
 
 def localize(value, lang):
@@ -94,6 +80,7 @@ def has_report_builder_trial(request):
 
 def can_edit_report(request, report):
     from corehq.apps.userreports.models import is_data_registry_report
+
     return (
         _can_edit_report(request, report)
         and not is_linked_report(report)
@@ -175,11 +162,15 @@ def get_configurable_and_static_reports_for_data_source(domain, data_source_id):
 
 def get_configurable_and_static_reports(domain):
     from corehq.apps.userreports.models import StaticReportConfiguration
+
     return get_existing_reports(domain) + StaticReportConfiguration.by_domain(domain)
 
 
 def get_existing_reports(domain):
-    from corehq.apps.userreports.dbaccessors import get_report_and_registry_report_configs_for_domain
+    from corehq.apps.userreports.dbaccessors import (
+        get_report_and_registry_report_configs_for_domain,
+    )
+
     existing_reports = get_report_and_registry_report_configs_for_domain(domain)
     return [
         report for report in existing_reports
@@ -210,6 +201,7 @@ def get_indicator_adapter(config, raise_errors=False, load_source="unknown"):
         IndicatorSqlAdapter,
         MultiDBSqlAdapter,
     )
+
     requires_mirroring = config.mirrored_engine_ids
     if requires_mirroring and ENABLE_UCR_MIRRORS.enabled(config.domain):
         adapter_cls = ErrorRaisingMultiDBAdapter if raise_errors else MultiDBSqlAdapter
@@ -321,6 +313,7 @@ def add_tabbed_text(text):
 
 def get_report_config_or_not_found(domain, config_id):
     from corehq.apps.userreports.models import ReportConfiguration
+
     try:
         doc = ReportConfiguration.get_db().get(config_id)
         config = wrap_report_config_by_type(doc)
@@ -339,6 +332,7 @@ def get_ucr_datasource_config_by_id(indicator_config_id, allow_deleted=False):
         StaticDataSourceConfiguration,
         id_is_static,
     )
+
     if id_is_static(indicator_config_id):
         return StaticDataSourceConfiguration.by_id(indicator_config_id)
     else:
@@ -351,6 +345,7 @@ def _wrap_data_source_by_doc_type(doc, allow_deleted=False):
         DataSourceConfiguration,
         RegistryDataSourceConfiguration,
     )
+
     if is_deleted(doc) and not allow_deleted:
         raise DataSourceConfigurationNotFoundError()
 
@@ -366,6 +361,7 @@ def wrap_report_config_by_type(config, allow_deleted=False):
         RegistryReportConfiguration,
         ReportConfiguration,
     )
+
     if is_deleted(config) and not allow_deleted:
         raise ReportConfigurationNotFoundError()
 
@@ -392,8 +388,12 @@ def get_domain_for_ucr_table_name(table_name):
 
 
 def register_data_source_row_change(domain, data_source_id, doc_ids):
-    from corehq.motech.repeaters.models import DataSourceRepeater
+    from corehq.motech.repeaters.models import (
+        DataSourceRepeater,
+        DataSourceUpdateLog,
+    )
     from corehq.motech.repeaters.signals import ucr_data_source_updated
+
     try:
         if not (
             toggles.SUPERSET_ANALYTICS.enabled(domain)
@@ -401,16 +401,15 @@ def register_data_source_row_change(domain, data_source_id, doc_ids):
         ):
             return
 
-        for doc_id in doc_ids:
-            update_log = DataSourceUpdateLog(
-                domain,
-                data_source_id=data_source_id,
-                doc_id=doc_id,
-                # We don't need to set `rows` here. We will determine
-                # them at send time. See DataSourceRepeater.payload_doc()
-                rows=None,
-            )
-            ucr_data_source_updated.send_robust(sender=None, update_log=update_log)
+        update_log = DataSourceUpdateLog.objects.create(
+            domain=domain,
+            data_source_id=data_source_id,
+            doc_ids=doc_ids,
+            # We don't need to set `rows` here. We will determine
+            # them at send time. See DataSourceRepeater.payload_doc()
+            rows=None,
+        )
+        ucr_data_source_updated.send_robust(sender=None, update_log=update_log)
 
     except Exception as e:
         logging.exception(str(e))

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -404,7 +404,7 @@ def register_data_source_row_change(domain, data_source_id, doc_ids):
         update_log = DataSourceUpdateLog.objects.create(
             domain=domain,
             data_source_id=data_source_id,
-            doc_ids=doc_ids,
+            doc_ids=list(doc_ids),
             # We don't need to set `rows` here. We will determine
             # them at send time. See DataSourceRepeater.payload_doc()
             rows=None,

--- a/corehq/motech/repeaters/migrations/0018_datasourceupdatelog.py
+++ b/corehq/motech/repeaters/migrations/0018_datasourceupdatelog.py
@@ -1,0 +1,38 @@
+import corehq.sql_db.fields
+from django.db import migrations, models
+import jsonfield.fields
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("repeaters", "0017_add_indexes"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DataSourceUpdateLog",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        db_column="id_",
+                        default=uuid.uuid4,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "domain",
+                    corehq.sql_db.fields.CharIdField(db_index=True, max_length=126),
+                ),
+                ("data_source_id", models.UUIDField()),
+                ("doc_ids", jsonfield.fields.JSONField(default=list)),
+                (
+                    "rows",
+                    jsonfield.fields.JSONField(blank=True, default=list, null=True),
+                ),
+            ],
+        ),
+    ]

--- a/corehq/motech/repeaters/migrations/0018_datasourceupdatelog.py
+++ b/corehq/motech/repeaters/migrations/0018_datasourceupdatelog.py
@@ -1,7 +1,15 @@
-import corehq.sql_db.fields
-from django.db import migrations, models
-import jsonfield.fields
 import uuid
+
+from django.db import migrations, models
+
+import jsonfield.fields
+from architect.commands import partition
+
+import corehq.sql_db.fields
+
+
+def add_partitions(apps, schema_editor):
+    partition.run({'module': 'corehq.motech.repeaters.models'})
 
 
 class Migration(migrations.Migration):
@@ -33,6 +41,11 @@ class Migration(migrations.Migration):
                     "rows",
                     jsonfield.fields.JSONField(blank=True, default=list, null=True),
                 ),
+                ("timestamp", models.DateTimeField(auto_now_add=True)),
             ],
+            options={
+                "db_table": "repeaters_datasourceupdatelog",
+            },
         ),
+        migrations.RunPython(add_partitions),
     ]

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -618,6 +618,10 @@ class Repeater(RepeaterSuperProxy):
         """
         return self._repeater_type
 
+    @property
+    def can_merge_records(self):
+        return hasattr(self, 'merge_records')
+
 
 class FormRepeater(Repeater):
 
@@ -722,6 +726,46 @@ class CaseRepeater(Repeater):
         })
         return headers
 
+    # TODO: Test
+    def merge_records(self):
+        """
+        ``CaseRepeater`` and ``UpdateCaseRepeater`` forward a case as it
+        is at the time of sending (not as it is at the time that the
+        repeat record was registered). This method merges repeat records
+        to send each case only once and cancel any duplicate repeat
+        records for the same case.
+        """
+        # Get only the payload IDs to be sent
+        payload_ids = {
+            record.payload_id
+            for record in self.repeat_records_ready[:self.num_workers]
+        }
+        payload_records = (
+            self.repeat_records_ready
+            .filter(payload_id__in=payload_ids)
+        )
+        if len(payload_records) == len(payload_ids):
+            # There are no duplicates
+            return
+
+        records_by_payload_id = defaultdict(list)
+        for record in payload_records:
+            records_by_payload_id[record.payload_id].append(record)
+
+        for payload_id, records in records_by_payload_id.items():
+            if len(records) > 1:
+                new_record = RepeatRecord(
+                    repeater_id=self.id,
+                    domain=self.domain,
+                    registered_at=records[0].registered_at,
+                    next_check=records[0].next_check,
+                    payload_id=payload_id,
+                )
+                new_record.save()
+                for old_record in records:
+                    old_record.cancel()
+                    old_record.save()
+
 
 class CreateCaseRepeater(CaseRepeater):
     class Meta:
@@ -732,6 +776,11 @@ class CreateCaseRepeater(CaseRepeater):
     def allowed_to_forward(self, payload):
         # assume if there's exactly 1 xform_id that modified the case it's being created
         return super().allowed_to_forward(payload) and len(payload.xform_ids) == 1
+
+    @property
+    def can_merge_records(self):
+        # CreateCaseRepeater will not have duplicate repeat records
+        return False
 
 
 class UpdateCaseRepeater(CaseRepeater):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -73,6 +73,7 @@ from datetime import datetime, timedelta
 from http import HTTPStatus
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
+import architect
 from django.conf import settings
 from django.db import models, router
 from django.db.models.base import Deferred
@@ -922,12 +923,19 @@ def get_all_repeater_types():
     return dict(REPEATER_CLASS_MAP)
 
 
+@architect.install('partition', type='range', subtype='date', constraint='month', column='timestamp')
 class DataSourceUpdateLog(models.Model):
     id = models.UUIDField(primary_key=True, db_column="id_", default=uuid.uuid4)
     domain = CharIdField(max_length=126, db_index=True)
     data_source_id = models.UUIDField()
     doc_ids = JSONField(default=list)
     rows = JSONField(default=list, blank=True, null=True)
+    timestamp = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'repeaters_datasourceupdatelog'
+
+    MAX_AGE = timedelta(days=93)
 
     @property
     def get_id(self):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -959,7 +959,6 @@ class DataSourceRepeater(Repeater):
             domain=self.domain
         )
         datasource_adapter = get_indicator_adapter(config, load_source='repeat_record')
-        # TODO: Test
         if self.SEP in repeat_record.payload_id:
             rows = [
                 row
@@ -986,7 +985,6 @@ class DataSourceRepeater(Repeater):
             domain=domain, options={"data_source_id": data_source_id}
         ).exists()
 
-    # TODO: Test
     def merge_records(self):
         """
         Merges updates to the same data source.

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -726,7 +726,6 @@ class CaseRepeater(Repeater):
         })
         return headers
 
-    # TODO: Test
     def merge_records(self):
         """
         ``CaseRepeater`` and ``UpdateCaseRepeater`` forward a case as it

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -726,6 +726,7 @@ class CaseRepeater(Repeater):
         })
         return headers
 
+    # TODO: Test
     def merge_records(self):
         """
         ``CaseRepeater`` and ``UpdateCaseRepeater`` forward a case as it

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -755,6 +755,8 @@ class DataSourcePayloadGenerator(BasePayloadGenerator):
         Returns the request body to be forwarded to CommCare Analytics
         for ``payload_doc``, which is a ``DataSourceUpdateLog``.
         """
+        if payload_doc is None:
+            return None
         data = {
             "data": payload_doc.rows,
             "data_source_id": payload_doc.data_source_id.hex,

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -757,7 +757,8 @@ class DataSourcePayloadGenerator(BasePayloadGenerator):
         """
         data = {
             "data": payload_doc.rows,
-            "data_source_id": payload_doc.data_source_id,
-            "doc_id": payload_doc.doc_id,
+            "data_source_id": payload_doc.data_source_id.hex,
+            "doc_id": payload_doc.get_id,
+            "doc_ids": payload_doc.doc_ids,
         }
         return json.dumps(data, cls=CommCareJSONEncoder)

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -106,9 +106,9 @@ def fire_synchronous_case_repeaters(sender, case, **kwargs):
     _create_repeat_records(DataRegistryCaseUpdateRepeater, case, fire_synchronously=True)
 
 
-def create_data_source_updated_repeat_record(sender, **kwargs):
+def create_data_source_updated_repeat_record(sender, update_log, **kwargs):
     """Creates a transaction log for the datasource that changed"""
-    create_repeat_records(DataSourceRepeater, kwargs["update_log"])
+    create_repeat_records(DataSourceRepeater, update_log)
 
 
 successful_form_received.connect(create_form_repeat_records)

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -77,6 +77,7 @@ from datetime import datetime, timedelta
 from inspect import cleandoc
 
 from django.conf import settings
+from django.db import connection
 
 from celery import chord
 from celery.schedules import crontab
@@ -113,6 +114,7 @@ from .const import (
     State,
 )
 from .models import (
+    DataSourceUpdateLog,
     Repeater,
     RepeatRecord,
     domain_can_forward,
@@ -556,6 +558,18 @@ class RepeaterLock:
         if self.token:
             lock.local.token = self.token
         return lock
+
+
+@periodic_task(
+    run_every=crontab(hour='5', minute='0', day_of_month='1'),
+    queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'),
+)
+def purge_old_datasourceupdatelogs():
+    table_name_format = f'{DataSourceUpdateLog.Meta.db_table}_y%Ym%m'
+    max_age = datetime.utcnow() - DataSourceUpdateLog.MAX_AGE
+    table_name = (max_age - timedelta(days=1)).strftime(table_name_format)
+    with connection.cursor() as cursor:
+        cursor.execute(f'DROP TABLE IF EXISTS {table_name}')
 
 
 metrics_gauge_task(

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -362,7 +362,7 @@ def process_repeater(repeater, lock_token):
     """
     Initiates a Celery task to process a repeater.
     """
-    if hasattr(repeater, 'merge_records'):
+    if repeater.can_merge_records:
         _merge_records_and_process_repeater.delay(repeater.repeater_id, lock_token)
     else:
         _process_repeater(repeater, lock_token)

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -362,7 +362,7 @@ def process_repeater(repeater, lock_token):
     """
     Initiates a Celery task to process a repeater.
     """
-    if repeater.can_merge_records:
+    if hasattr(repeater, 'merge_records'):
         _merge_records_and_process_repeater.delay(repeater.repeater_id, lock_token)
     else:
         _process_repeater(repeater, lock_token)

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1357,11 +1357,11 @@ class DataSourceRepeaterTest(BaseRepeaterTest):
     def _assert_payload_equal(self, payload, doc_id, expected_indicators):
         # assert payload == {
         #     'data_source_id': self.data_source._id,
-        #     'doc_id': doc_id,
+        #     'doc_ids': doc_ids,
         #     'data': expected_indicators,
         # }
         # ^^^ kinda like this, but accommodates the value of "estimate":
-        assert set(payload.keys()) == {'data_source_id', 'doc_id', 'data'}
+        assert set(payload.keys()) == {'data_source_id', 'doc_id', 'doc_ids', 'data'}
         assert payload['data_source_id'] == self.data_source._id
         assert payload['doc_id'] == doc_id
         for i, data in enumerate(payload['data']):

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1274,64 +1274,74 @@ class DataSourceRepeaterTest(BaseRepeaterTest):
 
     def setUp(self):
         super().setUp()
-        self.config = get_sample_data_source()
-        self.config.save()
-        self.addCleanup(self.config.delete)
-        self.adapter = get_indicator_adapter(self.config)
+        self.data_source = get_sample_data_source()
+        self.data_source.save()
+        self.addCleanup(self.data_source.delete)
+        self.adapter = get_indicator_adapter(self.data_source)
         self.adapter.build_table()
         self.addCleanup(self.adapter.drop_table)
-        self.fake_time_now = datetime(2015, 4, 24, 12, 30, 8, 24886)
-        self.pillow = _get_pillow([self.config], processor_chunk_size=100)
+        self.pillow = _get_pillow([self.data_source], processor_chunk_size=100)
 
         self.connx = ConnectionSettings.objects.create(
             domain=self.domain,
             url="case-repeater-url",
         )
-        self.data_source_id = self.config._id
         self.repeater = DataSourceRepeater(
             domain=self.domain,
             connection_settings_id=self.connx.id,
-            data_source_id=self.data_source_id,
+            data_source_id=self.data_source._id,
         )
         self.repeater.save()
 
     def test_datasource_is_subscribed_to(self):
-        self.assertTrue(self.repeater.datasource_is_subscribed_to(self.domain, self.data_source_id))
-        self.assertFalse(self.repeater.datasource_is_subscribed_to("malicious-domain", self.data_source_id))
+        assert self.repeater.datasource_is_subscribed_to(
+            self.domain,
+            self.data_source._id,
+        )
+        assert not self.repeater.datasource_is_subscribed_to(
+            "malicious-domain",
+            self.data_source._id,
+        )
 
     @flag_enabled('SUPERSET_ANALYTICS')
     def test_payload_format(self):
-        sample_doc, expected_indicators = self._create_log_and_repeat_record()
-        later = datetime.utcnow() + timedelta(hours=50)
-        repeat_record = RepeatRecord.objects.filter(domain=self.domain, next_check__lt=later).first()
-        json_payload = self.repeater.get_payload(repeat_record)
-        payload = json.loads(json_payload)
+        doc_id, expected_indicators = self._create_log_and_repeat_record()
+        repeat_record = self.repeater.repeat_records_ready.first()
+        payload_str = repeat_record.get_payload()
+        payload = json.loads(payload_str)
 
-        # Clean expected_indicators:
-        # expected_indicators includes 'repeat_iteration'
-        del expected_indicators['repeat_iteration']
-        # Decimal expected indicator is not rounded, and will not match
-        del expected_indicators['estimate']
-        del payload['data'][0]['estimate']
-
-        self.assertEqual(payload, {
-            'data_source_id': self.data_source_id,
-            'doc_id': sample_doc['_id'],
-            'data': [expected_indicators]
-        })
+        # assert payload == {
+        #     'data_source_id': self.data_source._id,
+        #     'doc_id': doc_id,
+        #     'data': [expected_indicators],
+        # }
+        # ^^^ kinda like this, but accommodates the value of "estimate":
+        assert set(payload.keys()) == {'data_source_id', 'doc_id', 'data'}
+        assert payload['data_source_id'] == self.data_source._id
+        assert payload['doc_id'] == doc_id
+        assert len(payload['data']) == 1
+        for key, value in payload['data'][0].items():
+            if key == 'estimate':
+                # '2.3000000000000000' == '2.2999999999...1893310546875'
+                assert float(value) == float(expected_indicators[key])
+            else:
+                assert value == expected_indicators[key]
 
     def _create_log_and_repeat_record(self):
         from corehq.apps.userreports.tests.test_pillow import _save_sql_case
+
         with patch('corehq.apps.userreports.specs.datetime') as datetime_mock:
-            datetime_mock.utcnow.return_value = self.fake_time_now
-            sample_doc, expected_indicators = get_sample_doc_and_indicators(self.fake_time_now)
+            fake_time_now = datetime(2015, 4, 24, 12, 30, 8, 24886)
+            datetime_mock.utcnow.return_value = fake_time_now
+            sample_doc, expected_indicators = get_sample_doc_and_indicators(fake_time_now)
             since = self.pillow.get_change_feed().get_latest_offsets()
             _save_sql_case(sample_doc)
             self.pillow.process_changes(since=since, forever=False)
+
         # Serialize and deserialize to get objects as strings
         json_indicators = json.dumps(expected_indicators, cls=CommCareJSONEncoder)
         expected_indicators = json.loads(json_indicators)
-        return sample_doc, expected_indicators
+        return sample_doc['_id'], expected_indicators
 
 
 class TestSetBackoff(TestCase):

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1309,7 +1309,7 @@ class DataSourceRepeaterTest(BaseRepeaterTest):
         repeat_record = self.repeater.repeat_records_ready.first()
         payload_str = repeat_record.get_payload()
         payload = json.loads(payload_str)
-        self._assert_payload_equal(payload, doc_id, [expected_indicators])
+        self._assert_payload_equal(payload, [doc_id], [expected_indicators])
 
     @flag_enabled('SUPERSET_ANALYTICS')
     def test_merged_payload_doc(self):
@@ -1327,7 +1327,7 @@ class DataSourceRepeaterTest(BaseRepeaterTest):
 
         self._assert_payload_equal(
             payload,
-            f"{doc_id_1},{doc_id_2}",
+            [doc_id_1, doc_id_2],
             [expected_indicators_1, expected_indicators_2],
         )
 
@@ -1354,7 +1354,7 @@ class DataSourceRepeaterTest(BaseRepeaterTest):
         expected_indicators = json.loads(json_indicators)
         return sample_doc['_id'], expected_indicators
 
-    def _assert_payload_equal(self, payload, doc_id, expected_indicators):
+    def _assert_payload_equal(self, payload, doc_ids, expected_indicators):
         # assert payload == {
         #     'data_source_id': self.data_source._id,
         #     'doc_ids': doc_ids,
@@ -1363,8 +1363,10 @@ class DataSourceRepeaterTest(BaseRepeaterTest):
         # ^^^ kinda like this, but accommodates the value of "estimate":
         assert set(payload.keys()) == {'data_source_id', 'doc_id', 'doc_ids', 'data'}
         assert payload['data_source_id'] == self.data_source._id
-        assert payload['doc_id'] == doc_id
-        for i, data in enumerate(payload['data']):
+        assert sorted(payload['doc_ids']) == sorted(doc_ids)
+        payload_data = sorted(payload['data'], key=lambda x: x['doc_id'])
+        expected_indicators = sorted(expected_indicators, key=lambda x: x['doc_id'])
+        for i, data in enumerate(payload_data):
             for key, value in data.items():
                 if key == 'estimate':
                     # '2.3000000000000000' == '2.2999999999...1893310546875'

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -587,7 +587,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
             case_type="planet",
         ).as_text()
         CaseFactory(self.domain).post_case_blocks([white_listed_case])
-        assert len(self.repeat_records(self.domain).all()) == 1
+        self.assertEqual(1, len(self.repeat_records(self.domain).all()))
 
         non_white_listed_case = CaseBlock(
             case_id="b_case_id",
@@ -595,7 +595,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
             case_type="cat",
         ).as_text()
         CaseFactory(self.domain).post_case_blocks([non_white_listed_case])
-        assert len(self.repeat_records(self.domain).all()) == 1
+        self.assertEqual(1, len(self.repeat_records(self.domain).all()))
 
     def test_black_listed_user_cases_do_not_forward(self):
         self.repeater.black_listed_users = ['black_listed_user']
@@ -618,7 +618,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         )
         self.post_xml(xform_xml, self.domain)
 
-        assert len(self.repeat_records(self.domain).all()) == 0
+        self.assertEqual(0, len(self.repeat_records(self.domain).all()))
 
         # case-creations by normal users should be forwarded
         normal_user_case = CaseBlock(
@@ -636,7 +636,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         )
         self.post_xml(xform_xml, self.domain)
 
-        assert len(self.repeat_records(self.domain).all()) == 1
+        self.assertEqual(1, len(self.repeat_records(self.domain).all()))
 
         # case-updates by black-listed users shouldn't be forwarded
         black_listed_user_case = CaseBlock(
@@ -652,7 +652,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
             black_listed_user_case,
         )
         self.post_xml(xform_xml, self.domain)
-        assert len(self.repeat_records(self.domain).all()) == 1
+        self.assertEqual(1, len(self.repeat_records(self.domain).all()))
 
         # case-updates by normal users should be forwarded
         normal_user_case = CaseBlock(
@@ -668,50 +668,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
             normal_user_case,
         )
         self.post_xml(xform_xml, self.domain)
-        assert len(self.repeat_records(self.domain).all()) == 2
-
-    def test_merge_records(self):
-        factory = CaseFactory(self.domain)
-        factory.post_case_blocks([
-            CaseBlock(
-                case_id='(134340) Pluto',
-                create=True,
-                case_name='Pluto',
-                case_type='planet',
-                date_opened='1930-02-18',
-            ).as_text(),
-        ])
-        factory.post_case_blocks([
-            CaseBlock(
-                case_id='(134340) Pluto I',
-                create=True,
-                case_name='Charon',
-                case_type='moon',
-                date_opened='1978-06-22',
-            ).as_text(),
-        ])
-        factory.post_case_blocks([
-            CaseBlock(
-                case_id='(134340) Pluto',
-                update={
-                    'case_type': 'dwarf_planet'
-                },
-                date_modified='2006-08-24',
-            ).as_text(),
-        ])
-        repeat_records = self.repeater.repeat_records_ready.all()
-        assert [r.payload_id for r in repeat_records] == [
-            '(134340) Pluto',
-            '(134340) Pluto I',
-            '(134340) Pluto',
-        ]
-        self.repeater.merge_records()
-
-        repeat_records = self.repeater.repeat_records_ready.all()
-        assert [r.payload_id for r in repeat_records] == [
-            '(134340) Pluto',
-            '(134340) Pluto I',
-        ]
+        self.assertEqual(2, len(self.repeat_records(self.domain).all()))
 
 
 class RepeaterFailureTest(BaseRepeaterTest):

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -587,7 +587,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
             case_type="planet",
         ).as_text()
         CaseFactory(self.domain).post_case_blocks([white_listed_case])
-        self.assertEqual(1, len(self.repeat_records(self.domain).all()))
+        assert len(self.repeat_records(self.domain).all()) == 1
 
         non_white_listed_case = CaseBlock(
             case_id="b_case_id",
@@ -595,7 +595,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
             case_type="cat",
         ).as_text()
         CaseFactory(self.domain).post_case_blocks([non_white_listed_case])
-        self.assertEqual(1, len(self.repeat_records(self.domain).all()))
+        assert len(self.repeat_records(self.domain).all()) == 1
 
     def test_black_listed_user_cases_do_not_forward(self):
         self.repeater.black_listed_users = ['black_listed_user']
@@ -618,7 +618,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         )
         self.post_xml(xform_xml, self.domain)
 
-        self.assertEqual(0, len(self.repeat_records(self.domain).all()))
+        assert len(self.repeat_records(self.domain).all()) == 0
 
         # case-creations by normal users should be forwarded
         normal_user_case = CaseBlock(
@@ -636,7 +636,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         )
         self.post_xml(xform_xml, self.domain)
 
-        self.assertEqual(1, len(self.repeat_records(self.domain).all()))
+        assert len(self.repeat_records(self.domain).all()) == 1
 
         # case-updates by black-listed users shouldn't be forwarded
         black_listed_user_case = CaseBlock(
@@ -652,7 +652,7 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
             black_listed_user_case,
         )
         self.post_xml(xform_xml, self.domain)
-        self.assertEqual(1, len(self.repeat_records(self.domain).all()))
+        assert len(self.repeat_records(self.domain).all()) == 1
 
         # case-updates by normal users should be forwarded
         normal_user_case = CaseBlock(
@@ -668,7 +668,50 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
             normal_user_case,
         )
         self.post_xml(xform_xml, self.domain)
-        self.assertEqual(2, len(self.repeat_records(self.domain).all()))
+        assert len(self.repeat_records(self.domain).all()) == 2
+
+    def test_merge_records(self):
+        factory = CaseFactory(self.domain)
+        factory.post_case_blocks([
+            CaseBlock(
+                case_id='(134340) Pluto',
+                create=True,
+                case_name='Pluto',
+                case_type='planet',
+                date_opened='1930-02-18',
+            ).as_text(),
+        ])
+        factory.post_case_blocks([
+            CaseBlock(
+                case_id='(134340) Pluto I',
+                create=True,
+                case_name='Charon',
+                case_type='moon',
+                date_opened='1978-06-22',
+            ).as_text(),
+        ])
+        factory.post_case_blocks([
+            CaseBlock(
+                case_id='(134340) Pluto',
+                update={
+                    'case_type': 'dwarf_planet'
+                },
+                date_modified='2006-08-24',
+            ).as_text(),
+        ])
+        repeat_records = self.repeater.repeat_records_ready.all()
+        assert [r.payload_id for r in repeat_records] == [
+            '(134340) Pluto',
+            '(134340) Pluto I',
+            '(134340) Pluto',
+        ]
+        self.repeater.merge_records()
+
+        repeat_records = self.repeater.repeat_records_ready.all()
+        assert [r.payload_id for r in repeat_records] == [
+            '(134340) Pluto',
+            '(134340) Pluto I',
+        ]
 
 
 class RepeaterFailureTest(BaseRepeaterTest):

--- a/migrations.lock
+++ b/migrations.lock
@@ -847,6 +847,7 @@ repeaters
  0015_drop_receiverwrapper_couchdb
  0016_repeater_max_workers
  0017_add_indexes
+ 0018_datasourceupdatelog
 reports
  0001_initial
  0002_auto_20171121_1803


### PR DESCRIPTION
## Technical Summary

Context: [SC-3872](https://dimagi.atlassian.net/browse/SC-3872)
Corresponding `commcare-analytics` PR: https://github.com/dimagi/commcare-analytics/pull/108

This change reduces the load on CommCare Analytics by merging payloads for the same data source. So instead of having up to 6 separate updates for the same table, this change results in just one update.

## Feature Flag

SUPERSET_ANALYTICS + PROCESS_REPEATERS

## Safety Assurance

### Safety story

* Tested merged payloads locally.
* The PROCESS_REPEATERS flag must be enabled for this code to be called. This flag is not yet used for any production domains.

### Automated test coverage

Includes tests

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3872]: https://dimagi.atlassian.net/browse/SC-3872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ