### PR TITLE
Better tailor text when saving user properties

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -470,6 +470,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
         };
 
         var caseTransaction = function (data, caseConfig, hasPrivilege) {
+            data.title = gettext("Save Questions to Case Properties");
             var self = baseTransaction(caseTransactionMapping, caseConfig.saveButton, 'Form Level', data, caseConfig, hasPrivilege);
 
             self.case_type(self.case_type() || caseConfig.caseType);
@@ -494,6 +495,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
 
 
         var usercaseTransaction = function (data, caseConfig) {
+            data.title = gettext("Save Questions to User Properties");
             var self = baseTransaction(usercaseTransactionMapping, caseConfig.saveUsercaseButton, 'User Case Management', data, caseConfig, true);
 
             self.case_type = function () {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -1,4 +1,3 @@
-"use strict";
 hqDefine('app_manager/js/forms/case_config_ui', function () {
     $(function () {
         var caseConfigUtils = hqImport('app_manager/js/case_config_utils'),
@@ -6,7 +5,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             addOnsPrivileges = initialPageData.get('add_ons_privileges'),
             privileges = hqImport('hqwebapp/js/privileges'),
             toggles = hqImport("hqwebapp/js/toggles");
-        var action_names = ["open_case", "update_case", "close_case", "case_preload",
+        var actionNames = ["open_case", "update_case", "close_case", "case_preload",
             // Usercase actions are managed in the User Properties tab.
             "usercase_update", "usercase_preload",
         ];
@@ -23,8 +22,8 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             self.home = params.home;
             self.actions = (function (a) {
                 var actions = {};
-                _(action_names).each(function (action_name) {
-                    actions[action_name] = a[action_name];
+                _(actionNames).each(function (actionName) {
+                    actions[actionName] = a[actionName];
                 });
                 actions.subcases = a.subcases;
                 return actions;
@@ -60,7 +59,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                     var actions = JSON.stringify(_(self.actions).extend(
                         HQFormActions.from_case_transaction(self.caseConfigViewModel.case_transaction), {
                             subcases: subcases,
-                        }
+                        },
                     ));
 
                     self.saveButton.ajax({
@@ -72,8 +71,8 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                         },
                         dataType: 'json',
                         success: function (data) {
-                            var app_manager = hqImport('app_manager/js/app_manager');
-                            app_manager.updateDOM(data.update);
+                            var appManager = hqImport('app_manager/js/app_manager');
+                            appManager.updateDOM(data.update);
                             self.requires(requires);
                             self.setPropertiesMap(data.propertiesMap);
 
@@ -91,7 +90,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 unsavedMessage: gettext("You have unchanged user properties settings"),
                 save: function () {
                     var actions = JSON.stringify(_(self.actions).extend(
-                        HQFormActions.from_usercase_transaction(self.caseConfigViewModel.usercase_transaction)
+                        HQFormActions.from_usercase_transaction(self.caseConfigViewModel.usercase_transaction),
                     ));
                     self.saveUsercaseButton.ajax({
                         type: 'post',
@@ -101,8 +100,8 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                         },
                         dataType: 'json',
                         success: function (data) {
-                            var app_manager = hqImport('app_manager/js/app_manager');
-                            app_manager.updateDOM(data.update);
+                            var appManager = hqImport('app_manager/js/app_manager');
+                            appManager.updateDOM(data.update);
                             self.setUsercasePropertiesMap(data.setUsercasePropertiesMap);
                         },
                     });
@@ -218,14 +217,14 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 return moduleCaseType.case_type;
             }));
             self.getCaseTypeLabel = function (caseType) {
-                var module_names = [],
+                var moduleNames = [],
                     label;
                 for (var i = 0; i < self.moduleCaseTypes.length; i++) {
                     if (self.moduleCaseTypes[i].case_type === caseType) {
-                        module_names.push(self.moduleCaseTypes[i].module_name);
+                        moduleNames.push(self.moduleCaseTypes[i].module_name);
                     }
                 }
-                label = module_names.join(', ');
+                label = moduleNames.join(', ');
                 if (caseType === self.caseConfig.caseType) {
                     label = '*' + label;
                 }
@@ -236,24 +235,27 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             self.subcases = ko.observableArray(
                 _(caseConfig.actions.subcases).map(function (subcase) {
                     return HQOpenSubCaseAction.to_case_transaction(subcase, caseConfig);
-                })
+                }),
             );
             self.addSubCase = function () {
-                if (!addOnsPrivileges.subcases) return;
+                if (!addOnsPrivileges.subcases) {
+                    return;
+                }
                 self.subcases.push(HQOpenSubCaseAction.to_case_transaction({}, caseConfig));
             };
             self.removeSubCase = function (subcase) {
-                if (!addOnsPrivileges.subcases) return;
+                if (!addOnsPrivileges.subcases) {
+                    return;
+                }
                 self.subcases.remove(subcase);
             };
 
             self.actionType = ko.observable((function () {
-                var opens_case = self.case_transaction.condition.type() !== 'never';
-                var requires_case = self.caseConfig.requires() === 'case';
-                var has_subcases = self.subcases().length;
-                if (requires_case) {
+                var opensCase = self.case_transaction.condition.type() !== 'never';
+                var requiresCase = self.caseConfig.requires() === 'case';
+                if (requiresCase) {
                     return 'update';
-                } else if (opens_case) {
+                } else if (opensCase) {
                     return 'open';
                 }
                 return 'update';
@@ -363,7 +365,9 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             }, self);
 
             self.addProperty = function () {
-                if (!self.hasPrivilege) return;
+                if (!self.hasPrivilege) {
+                    return;
+                }
                 var property = caseProperty.wrap({
                     path: '',
                     key: '',
@@ -377,7 +381,9 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             };
 
             self.removeProperty = function (property) {
-                if (!self.hasPrivilege) return;
+                if (!self.hasPrivilege) {
+                    return;
+                }
                 hqImport('analytix/js/google').track.event('Case Management', analyticsAction, 'Save Properties (remove)');
                 self.case_properties.remove(property);
                 self.visible_case_properties.remove(property);
@@ -388,7 +394,9 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             };
 
             self.switchSaveOnlyIfEdited = function (property, event) {
-                if (!self.hasPrivilege) return;
+                if (!self.hasPrivilege) {
+                    return;
+                }
                 var checked = event.target.checked;
                 if (checked) {
                     hqImport('analytix/js/google').track.event('Case Management', analyticsAction, 'Checked "Save only if edited"');
@@ -405,7 +413,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 var count = {};
                 _(self.case_properties()).each(function (p) {
                     var key = p.key();
-                    if (!count.hasOwnProperty(key)) {
+                    if (!_.has(count, key)) {
                         count[key] = 0;
                     }
                     return count[key] += 1;
@@ -433,24 +441,24 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             };
 
             self.setRequired = function (required) {
-                var delete_me = [];
-                _(self.case_properties()).each(function (case_property) {
-                    var key = case_property.key();
+                var deleteMe = [];
+                _(self.case_properties()).each(function (caseProperty) {
+                    var key = caseProperty.key();
                     if (_(required).contains(key)) {
-                        case_property.required(true);
+                        caseProperty.required(true);
                         required.splice(required.indexOf(key), 1);
                     } else {
-                        if (case_property.required()) {
-                            case_property.required(false);
-                            if (!case_property.path()) {
-                                delete_me.push(case_property);
+                        if (caseProperty.required()) {
+                            caseProperty.required(false);
+                            if (!caseProperty.path()) {
+                                deleteMe.push(caseProperty);
                             }
                         }
 
                     }
                 });
-                _(delete_me).each(function (case_property) {
-                    self.case_properties.remove(case_property);
+                _(deleteMe).each(function (caseProperty) {
+                    self.case_properties.remove(caseProperty);
                 });
                 _(required).each(function (key) {
                     self.case_properties.splice(0, 0, caseProperty.wrap({
@@ -510,9 +518,9 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             mapping: {
                 include: ['key', 'path', 'required', 'save_only_if_edited'],
             },
-            wrap: function (data, case_transaction) {
+            wrap: function (data, caseTransaction) {
                 var self = ko.mapping.fromJS(data, caseProperty.mapping);
-                self.case_transaction = case_transaction;
+                self.case_transaction = caseTransaction;
                 self.caseType = ko.computed(function () {
                     return self.case_transaction.case_type();
                 });
@@ -548,8 +556,8 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
 
         var caseProperty = {
             mapping: casePropertyBase.mapping,
-            wrap: function (data, case_transaction) {
-                var self = casePropertyBase.wrap(data, case_transaction);
+            wrap: function (data, caseTransaction) {
+                var self = casePropertyBase.wrap(data, caseTransaction);
                 self.defaultKey = ko.computed(function () {
                     var path = self.path() || '';
                     var value = path.split('/');
@@ -557,22 +565,22 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                     return value;
                 });
                 self.repeat_context = function () {
-                    return case_transaction.caseConfig.get_repeat_context(self.path());
+                    return caseTransaction.caseConfig.get_repeat_context(self.path());
                 };
                 self.validate = ko.computed(function () {
                     if (self.path() || self.key()) {
-                        if (case_transaction.propertyCounts()[self.key()] > 1) {
+                        if (caseTransaction.propertyCounts()[self.key()] > 1) {
                             return gettext("Property updated by two questions");
-                        } else if (case_transaction.caseConfig.reserved_words.indexOf(self.key()) !== -1) {
+                        } else if (caseTransaction.caseConfig.reserved_words.indexOf(self.key()) !== -1) {
                             return '<strong>' + self.key() + '</strong> is a reserved word';
-                        } else if (self.repeat_context() && self.repeat_context() !== case_transaction.repeat_context()) {
+                        } else if (self.repeat_context() && self.repeat_context() !== caseTransaction.repeat_context()) {
                             return gettext('Inside the wrong repeat!');
                         } else if (_.difference(
                             _.initial(self.key().split(/\//)),
-                            case_transaction.caseConfig.valid_index_names
+                            caseTransaction.caseConfig.valid_index_names,
                         ).length) {
                             return gettext('Property uses unrecognized prefix <strong>' +
-                                self.key().replace(/\/[^\/]*$/, '') + '</strong>');
+                                self.key().replace(/\/[^/]*$/, '') + '</strong>');
                         }
                     }
                     return null;
@@ -636,7 +644,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             },
             to_case_transaction: function (o, caseConfig) {
                 var self = HQFormActions.normalize(o);
-                var required_properties = (caseConfig.requires() === 'none' &&
+                var requiredProperties = (caseConfig.requires() === 'none' &&
                     caseConfig.actions.open_case.condition.type !== "never" &&
                     !o.update_case.update.name) ? [{
                         key: 'name',
@@ -644,20 +652,20 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                         required: true,
                         save_only_if_edited: self.open_case.name_update.update_mode === 'edit',
                     }] : [];
-                var case_properties = caseConfigUtils.propertyDictToArray(
-                    required_properties,
+                var caseProperties = caseConfigUtils.propertyDictToArray(
+                    requiredProperties,
                     self.update_case.update,
-                    caseConfig
+                    caseConfig,
                 );
-                var case_preload = caseConfigUtils.preloadDictToArray(
+                var casePreload = caseConfigUtils.preloadDictToArray(
                     self.case_preload.preload,
-                    caseConfig
+                    caseConfig,
                 );
                 var x = caseTransaction({
                     case_type: null, // will get overridden by the default
                     reference_id: null, // not used in normal case config
-                    case_properties: case_properties,
-                    case_preload: case_preload,
+                    case_properties: caseProperties,
+                    case_preload: casePreload,
                     condition: self.open_case.condition,
                     close_condition: self.close_case.condition,
                     suggestedProperties: function () {
@@ -680,60 +688,60 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 });
                 return x;
             },
-            from_case_transaction: function (case_transaction) {
-                var o = ko.mapping.toJS(case_transaction, caseTransactionMapping(case_transaction));
+            from_case_transaction: function (caseTransaction) {
+                var o = ko.mapping.toJS(caseTransaction, caseTransactionMapping(caseTransaction));
                 var x = caseConfigUtils.propertyArrayToDict(['name'], o.case_properties);
-                var case_properties = x[0],
-                    open_name_update = x[1].name;
-                var case_preload = caseConfigUtils.preloadArrayToDict(o.case_preload);
-                var open_condition = o.condition;
-                var close_condition = o.close_condition;
-                var update_condition = DEFAULT_CONDITION_ALWAYS;
-                var actionType = case_transaction.caseConfig.caseConfigViewModel.actionType();
+                var caseProperties = x[0],
+                    openNameUpdate = x[1].name;
+                var casePreload = caseConfigUtils.preloadArrayToDict(o.case_preload);
+                var openCondition = o.condition;
+                var closeCondition = o.close_condition;
+                var updateCondition = DEFAULT_CONDITION_ALWAYS;
+                var actionType = caseTransaction.caseConfig.caseConfigViewModel.actionType();
 
                 if (actionType === 'open') {
-                    if (open_condition.type === 'never') {
-                        open_condition.type = 'always';
+                    if (openCondition.type === 'never') {
+                        openCondition.type = 'always';
                     }
                 } else {
-                    open_condition.type = 'never';
+                    openCondition.type = 'never';
 
                 }
 
-                update_condition.type = 'always';
+                updateCondition.type = 'always';
 
                 return {
                     open_case: {
-                        condition: cleanCondition(open_condition),
-                        name_update: open_name_update,
+                        condition: cleanCondition(openCondition),
+                        name_update: openNameUpdate,
                     },
                     update_case: {
-                        update: case_properties,
-                        condition: cleanCondition(update_condition),
+                        update: caseProperties,
+                        condition: cleanCondition(updateCondition),
                     },
                     case_preload: {
-                        preload: case_preload,
-                        condition: cleanCondition(update_condition),
+                        preload: casePreload,
+                        condition: cleanCondition(updateCondition),
                     },
                     close_case: {
-                        condition: cleanCondition(close_condition),
+                        condition: cleanCondition(closeCondition),
                     },
                 };
             },
             to_usercase_transaction: function (o, caseConfig) {
                 var self = HQFormActions.normalize(o);
-                var case_properties = caseConfigUtils.propertyDictToArray(
+                var caseProperties = caseConfigUtils.propertyDictToArray(
                     [], // usercase has no required properties; it has already been created with everything it needs
                     self.usercase_update.update,
-                    caseConfig
+                    caseConfig,
                 );
-                var case_preload = caseConfigUtils.preloadDictToArray(
+                var casePreload = caseConfigUtils.preloadDictToArray(
                     self.usercase_preload.preload,
-                    caseConfig
+                    caseConfig,
                 );
                 return usercaseTransaction({
-                    case_properties: case_properties,
-                    case_preload: case_preload,
+                    case_properties: caseProperties,
+                    case_preload: casePreload,
                     case_type: 'commcare-user', // will get overridden by the default. Set here to check deprecated status for saved properties on initial page load
                     allow: {
                         repeats: function () {
@@ -752,18 +760,18 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                     },
                 }, caseConfig);
             },
-            from_usercase_transaction: function (usercase_transaction) {
-                var o = ko.mapping.toJS(usercase_transaction, usercaseTransactionMapping(usercase_transaction));
+            from_usercase_transaction: function (usercaseTransaction) {
+                var o = ko.mapping.toJS(usercaseTransaction, usercaseTransactionMapping(usercaseTransaction));
                 var x = caseConfigUtils.propertyArrayToDict([], o.case_properties);
-                var case_properties = x[0];
-                var case_preload = caseConfigUtils.preloadArrayToDict(o.case_preload);
+                var caseProperties = x[0];
+                var casePreload = caseConfigUtils.preloadArrayToDict(o.case_preload);
                 return {
                     usercase_update: {
-                        update: case_properties,
+                        update: caseProperties,
                         condition: cleanCondition(DEFAULT_CONDITION_ALWAYS), // usercase_update action is always active
                     },
                     usercase_preload: {
-                        preload: case_preload,
+                        preload: casePreload,
                     },
                 };
             },
@@ -784,7 +792,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             },
             to_case_transaction: function (o, caseConfig) {
                 var self = HQOpenSubCaseAction.normalize(o);
-                var case_properties = caseConfigUtils.propertyDictToArray([{
+                var caseProperties = caseConfigUtils.propertyDictToArray([{
                     path: self.name_update.question_path,
                     key: 'name',
                     required: true,
@@ -795,7 +803,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 return caseTransaction({
                     case_type: self.case_type,
                     reference_id: self.reference_id,
-                    case_properties: case_properties,
+                    case_properties: caseProperties,
                     condition: self.condition,
                     close_condition: self.close_condition,
                     relationship: self.relationship,
@@ -825,20 +833,20 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                     },
                 }, caseConfig, addOnsPrivileges.subcases);
             },
-            from_case_transaction: function (case_transaction) {
-                var o = ko.mapping.toJS(case_transaction, caseTransactionMapping(case_transaction));
+            from_case_transaction: function (caseTransaction) {
+                var o = ko.mapping.toJS(caseTransaction, caseTransactionMapping(caseTransaction));
                 var x = caseConfigUtils.propertyArrayToDict(['name'], o.case_properties);
-                var case_properties = x[0],
-                    open_subcase_update_name = x[1].name;
+                var caseProperties = x[0],
+                    openSubcaseUpdateName = x[1].name;
 
                 return {
-                    name_update: open_subcase_update_name,
+                    name_update: openSubcaseUpdateName,
                     case_type: o.case_type,
-                    case_properties: case_properties,
+                    case_properties: caseProperties,
                     reference_id: o.reference_id,
                     condition: cleanCondition(o.condition),
                     close_condition: cleanCondition(o.close_condition),
-                    repeat_context: case_transaction.repeat_context(),
+                    repeat_context: caseTransaction.repeat_context(),
                 };
             },
         };

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -200,7 +200,7 @@
         </div>
       </div>
       <i class="fa fa-arrow-right"></i><i class="fa fa-save"></i>
-      {% trans "Save Questions to Case Properties" %}
+      <!-- ko text: title --><!-- /ko -->
     </h4>
   </div>
   <div class="panel-body">
@@ -338,7 +338,7 @@
     <!-- ko if: !case_properties().length && !$parent.hasPrivilege -->
       <p>
         {% blocktrans %}
-          You no longer have permission to save case properties.
+          You no longer have permission to save this section.
         {% endblocktrans %}
       </p>
     <!-- /ko -->


### PR DESCRIPTION
## Product Description
Minor copy update.

Before: "Save questions to case properties"
<img width="807" alt="Screenshot 2025-02-04 at 2 38 03 PM" src="https://github.com/user-attachments/assets/f80d77df-e208-4854-8149-ce6f92c60269" />


After: "Save questions to user properties"
<img width="814" alt="Screenshot 2025-02-04 at 2 38 17 PM" src="https://github.com/user-attachments/assets/0318dd9b-d764-46d0-899b-35130f8530c9" />


## Safety Assurance

### Safety story
Minor text change. Tested locally.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
