### PR TITLE
Fix text overflow issue in button of Case Clustering Page

### DIFF
--- a/corehq/apps/geospatial/templates/geospatial/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/geospatial/case_grouping_map.html
@@ -4,47 +4,62 @@
 {% load hq_shared_tags %}
 
 {% block reportcontent %}
-{% include 'geospatial/partials/index_alert.html' %}
-<div class="row panel">
-  <div class="col col-md-2">
-    <span id="lock-groups-controls">
-      <div class="controls">
-        <button id="gtm-lock-case-grouping-btn" data-bind="visible: !groupsLocked(), click: toggleGroupLock" class="btn btn-default form-control">
-          <i class="fa fa-lock"></i>
-          {% trans "Lock Case Clustering Map for Me" %}
-        </button>
-        <button data-bind="visible: groupsLocked(), click: toggleGroupLock" class="btn btn-primary form-control">
-          <i class="fa fa-unlock"></i>
-          {% trans "Unlock Case Clustering Map for Me" %}
-        </button>
-      </div>
-    </span>
+  {% include 'geospatial/partials/index_alert.html' %}
+  <div class="row panel">
+    <div class="col col-md-2">
+      <span id="lock-groups-controls">
+        <div class="controls">
+          <button
+            id="gtm-lock-case-grouping-btn"
+            data-bind="visible: !groupsLocked(), click: toggleGroupLock"
+            class="btn btn-default form-control"
+          >
+            <i class="fa fa-lock"></i>
+            {% trans "Lock Case Clustering Map for Me" %}
+          </button>
+          <button
+            data-bind="visible: groupsLocked(), click: toggleGroupLock"
+            class="btn btn-primary form-control"
+          >
+            <i class="fa fa-unlock"></i>
+            {% trans "Unlock Case Clustering Map for Me" %}
+          </button>
+        </div>
+      </span>
+    </div>
+    <div class="col col-md-2">
+      <span id="export-controls">
+        <div class="controls">
+          <button
+            id="gtm-export-groups-btn"
+            class="btn btn-default form-control"
+            data-bind="click: downloadCSV, disable: !groupsReady()"
+          >
+            {% trans "Export Groups" %}
+          </button>
+        </div>
+      </span>
+    </div>
   </div>
-  <div class="col col-md-2">
-    <span id="export-controls">
-      <div class="controls">
-        <button id="gtm-export-groups-btn" class="btn btn-default form-control" data-bind="click: downloadCSV, disable: !groupsReady()">
-          {% trans "Export Groups" %}
-        </button>
-      </div>
-    </span>
-  </div>
-</div>
 
-{% include 'geospatial/partials/saved_polygon_filter.html' with uses_disbursement='false' %}
-<div id="case-grouping-map" style="height: 500px"></div>
+  {% include 'geospatial/partials/saved_polygon_filter.html' with uses_disbursement='false' %}
+  <div id="case-grouping-map" style="height: 500px"></div>
 
-<div class="panel-body-datatable">
+  <div class="panel-body-datatable">
     {% block reporttable %}
       {% if report.needs_filters %}
         {% include 'reports/partials/bootstrap3/description.html' %}
       {% else %}
-        <table id="report_table_{{ report.slug }}" class="table table-striped datatable" width="100%" {% if pagination.filter %} data-filter="true"{% endif %}>
-        </table>
+        <table
+          id="report_table_{{ report.slug }}"
+          class="table table-striped datatable"
+          width="100%"
+          {% if pagination.filter %}data-filter="true"{% endif %}
+        ></table>
       {% endif %}
     {% endblock reporttable %}
-</div>
-<div class="row">
+  </div>
+  <div class="row">
     <div class="col-sm-6" id="clusterStats">
       <table class="table table-striped table-bordered">
         <thead>
@@ -75,10 +90,15 @@
             </thead>
             <tbody data-bind="foreach: caseGroupsForTable">
               <tr>
-                <td data-bind="event: {mouseover: $parent.highlightGroup, mouseout: $parent.restoreMarkerOpacity}">
+                <td
+                  data-bind="event: {mouseover: $parent.highlightGroup, mouseout: $parent.restoreMarkerOpacity}"
+                >
                   <div class="checkbox">
                     <label>
-                      <input type="checkbox" data-bind="checked: $parent.visibleGroupIDs, checkedValue: groupId" />
+                      <input
+                        type="checkbox"
+                        data-bind="checked: $parent.visibleGroupIDs, checkedValue: groupId"
+                      />
                       <span data-bind="text: name"></span>
                       <span data-bind="style: {color: color}">■</span>
                     </label>
@@ -90,12 +110,18 @@
         </div>
         <div class="row">
           <div class="col col-md-6">
-            <button class="btn btn-default form-control" data-bind="click: showSelectedGroups(), disable: !groupsReady()">
+            <button
+              class="btn btn-default form-control"
+              data-bind="click: showSelectedGroups(), disable: !groupsReady()"
+            >
               {% trans "Show Only Selected Groups on Map" %}
             </button>
           </div>
           <div class="col col-md-6">
-            <button class="btn btn-default form-control" data-bind="click: showAllGroups(), disable: !groupsReady()">
+            <button
+              class="btn btn-default form-control"
+              data-bind="click: showAllGroups(), disable: !groupsReady()"
+            >
               {% trans "Show All Groups" %}
             </button>
           </div>
@@ -103,16 +129,16 @@
       </div>
     </div>
   </div>
-</div>
 
-<script type="text/html" id="select-case">
-  <div class="d-flex flex-row">
-    <label data-bind="attr: {for: selectCssId}, text: title"></label>
-    <select class="form-control" data-bind="attr: {id: selectCssId},
-        options: groupsOptions, optionsText: 'name', optionsValue: 'groupId', value: selectedGroup">
-    </select>
-  </div>
-  <div data-bind="html: $data.itemData.caseLink"></div>
-</script>
-
+  <script type="text/html" id="select-case">
+    <div class="d-flex flex-row">
+      <label data-bind="attr: {for: selectCssId}, text: title"></label>
+      <select
+        class="form-control"
+        data-bind="attr: {id: selectCssId},
+        options: groupsOptions, optionsText: 'name', optionsValue: 'groupId', value: selectedGroup"
+      ></select>
+    </div>
+    <div data-bind="html: $data.itemData.caseLink"></div>
+  </script>
 {% endblock %}

--- a/corehq/apps/geospatial/templates/geospatial/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/geospatial/case_grouping_map.html
@@ -15,14 +15,14 @@
             class="btn btn-default form-control"
           >
             <i class="fa fa-lock"></i>
-            {% trans "Lock Map for Me" %}
+            {% trans "Lock Map" %}
           </button>
           <button
             data-bind="visible: groupsLocked(), click: toggleGroupLock"
             class="btn btn-primary form-control"
           >
             <i class="fa fa-unlock"></i>
-            {% trans "Unlock Map for Me" %}
+            {% trans "Unlock Map" %}
           </button>
         </div>
       </span>

--- a/corehq/apps/geospatial/templates/geospatial/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/geospatial/case_grouping_map.html
@@ -9,11 +9,11 @@
   <div class="col col-md-2">
     <span id="lock-groups-controls">
       <div class="controls">
-        <button id="gtm-lock-case-grouping-btn" data-bind="visible: !groupsLocked(), click: toggleGroupLock" class="btn-default form-control">
+        <button id="gtm-lock-case-grouping-btn" data-bind="visible: !groupsLocked(), click: toggleGroupLock" class="btn btn-default form-control">
           <i class="fa fa-lock"></i>
           {% trans "Lock Case Clustering Map for Me" %}
         </button>
-        <button data-bind="visible: groupsLocked(), click: toggleGroupLock" class="btn-primary form-control">
+        <button data-bind="visible: groupsLocked(), click: toggleGroupLock" class="btn btn-primary form-control">
           <i class="fa fa-unlock"></i>
           {% trans "Unlock Case Clustering Map for Me" %}
         </button>
@@ -23,7 +23,7 @@
   <div class="col col-md-2">
     <span id="export-controls">
       <div class="controls">
-        <button id="gtm-export-groups-btn" class="btn-default form-control" data-bind="click: downloadCSV, disable: !groupsReady()">
+        <button id="gtm-export-groups-btn" class="btn btn-default form-control" data-bind="click: downloadCSV, disable: !groupsReady()">
           {% trans "Export Groups" %}
         </button>
       </div>
@@ -90,12 +90,12 @@
         </div>
         <div class="row">
           <div class="col col-md-6">
-            <button class="btn-default form-control" data-bind="click: showSelectedGroups(), disable: !groupsReady()">
+            <button class="btn btn-default form-control" data-bind="click: showSelectedGroups(), disable: !groupsReady()">
               {% trans "Show Only Selected Groups on Map" %}
             </button>
           </div>
           <div class="col col-md-6">
-            <button class="btn-default form-control" data-bind="click: showAllGroups(), disable: !groupsReady()">
+            <button class="btn btn-default form-control" data-bind="click: showAllGroups(), disable: !groupsReady()">
               {% trans "Show All Groups" %}
             </button>
           </div>

--- a/corehq/apps/geospatial/templates/geospatial/case_grouping_map.html
+++ b/corehq/apps/geospatial/templates/geospatial/case_grouping_map.html
@@ -6,7 +6,7 @@
 {% block reportcontent %}
   {% include 'geospatial/partials/index_alert.html' %}
   <div class="row panel">
-    <div class="col col-md-2">
+    <div class="col col-md-3 col-lg-2">
       <span id="lock-groups-controls">
         <div class="controls">
           <button
@@ -15,14 +15,14 @@
             class="btn btn-default form-control"
           >
             <i class="fa fa-lock"></i>
-            {% trans "Lock Case Clustering Map for Me" %}
+            {% trans "Lock Map for Me" %}
           </button>
           <button
             data-bind="visible: groupsLocked(), click: toggleGroupLock"
             class="btn btn-primary form-control"
           >
             <i class="fa fa-unlock"></i>
-            {% trans "Unlock Case Clustering Map for Me" %}
+            {% trans "Unlock Map for Me" %}
           </button>
         </div>
       </span>


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Minor UI change where a text overflow issue in a button of Case Grouping Page was fixed along with slight update of label for the button.

Before:
![image](https://github.com/user-attachments/assets/2d293918-de24-45a0-9c8a-4578ef1698a5)

After:
![image](https://github.com/user-attachments/assets/0d57d994-3f38-4b90-8707-df8aa25a01c1)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Ticket](https://dimagi.atlassian.net/browse/SC-4268)

The issue primarily occurred on Zoom in or relatively smaller resolutions because of insufficient button width as per the text.
Additionally,  the text was wrapped to a new line instead of a typical `no-wrap` followed in HQ

The fix addresses it 
- by setting the missing `btn` class to it and other buttons where they are missing.  
- It also sets appropriate column size so that text does not overflow for any device size/resolution.
- the label was updated from `Lock Case Clustering Map for Me` to `Lock Map` 


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Microplanning

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Minor UI change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
