### PR TITLE
Handle endpoint duration on payload error

### DIFF
--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -239,15 +239,11 @@ def retry_process_datasource_repeat_record(repeat_record_id, domain):
 def _process_repeat_record(repeat_record):
 
     def endpoint_duration(timer_):
-        try:
-            return next(
-                sub.duration
-                for sub in timer_.to_list(exclude_root=True)
-                if sub.name == ENDPOINT_TIMER
-            )
-        except StopIteration:
-            # If there was a payload error, we won't have sent to an endpoint
-            return None
+        return next((
+            sub.duration
+            for sub in timer_.to_list(exclude_root=True)
+            if sub.name == ENDPOINT_TIMER
+        ), None)  # If there was a payload error, we won't have sent to an endpoint
 
     request_duration = action = None
     with TimingContext('process_repeat_record') as timer:

--- a/corehq/motech/repeaters/tests/test_tasks.py
+++ b/corehq/motech/repeaters/tests/test_tasks.py
@@ -181,6 +181,25 @@ class TestProcessRepeatRecord(TestCase):
         self.assertEqual(self.mock_fire.call_count, 1)
         self.assertEqual(self.mock_postpone_by.call_count, 0)
 
+    def test_payload_error_metrics(self):
+        with (
+            patch('corehq.motech.repeaters.tasks.metrics_histogram') as mock_metrics,
+            patch('corehq.motech.repeaters.tasks.logging') as mock_logging,
+        ):
+            repeater = FormRepeater.objects.create(
+                domain=self.domain,
+                connection_settings=self.conn_settings,
+            )
+            repeat_record = RepeatRecord(
+                domain=self.domain,
+                payload_id='does-not-exist',
+                registered_at=datetime.utcnow(),
+                repeater_id=repeater.repeater_id,
+            )
+            _process_repeat_record(repeat_record)
+            mock_logging.exception.assert_not_called()
+            mock_metrics.assert_called_once()
+
     def test_paused_and_deleted_repeater_does_not_fire_or_postpone(self):
         paused_and_deleted_repeater = Repeater.objects.create(
             domain=self.domain,


### PR DESCRIPTION
## Technical Summary

If an error occurs while getting a payload, then it will not be sent, and there won't be an endpoint timer.

This small change handles that scenario gracefully.

## Safety Assurance

### Safety story

Tested locally.

### Automated test coverage

Test included.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
