### PR TITLE
Exclude RepeatRecords from domain dumps

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -197,14 +197,9 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('case_importer.CaseUploadFileMeta', SimpleFilter('caseuploadrecord__domain')),
     FilteredModelIteratorBuilder('case_importer.CaseUploadFormRecord', SimpleFilter('case_upload_record__domain')),
     FilteredModelIteratorBuilder('case_importer.CaseUploadRecord', SimpleFilter('domain')),
-    # Repeat Records might foreign key to deleted repeaters, override default manager to include deleted repeaters
-    FilteredModelIteratorBuilder('repeaters.Repeater', SimpleFilter('domain'), use_all_objects=True),
+    FilteredModelIteratorBuilder('repeaters.Repeater', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('motech.ConnectionSettings', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('motech.RequestLog', SimpleFilter('domain')),
-    # NH (2021-01-08): Including RepeatRecord because we dump (Couch)
-    # RepeatRecord, but this does not seem like a good idea.
-    FilteredModelIteratorBuilder('repeaters.RepeatRecord', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('repeaters.RepeatRecordAttempt', SimpleFilter('repeat_record__domain')),
     FilteredModelIteratorBuilder('saved_reports.ScheduledReportLog', SimpleFilter('domain')),
     UnfilteredModelIteratorBuilder('saved_reports.ScheduledReportsCheckpoint'),
     FilteredModelIteratorBuilder('translations.SMSTranslations', SimpleFilter('domain')),

--- a/corehq/apps/dump_reload/tests/test_dump_models.py
+++ b/corehq/apps/dump_reload/tests/test_dump_models.py
@@ -95,6 +95,10 @@ IGNORE_MODELS = {
     "registry.RegistryGrant",
     "registry.RegistryInvitation",
 
+    # RepeatRecords are just queue tokens. RequestLog records what is sent.
+    'repeaters.RepeatRecord',
+    'repeaters.RepeatRecordAttempt',
+
     "sessions.Session",
     "sites.Site",
     "tastypie.ApiAccess",  # not tagged by domain


### PR DESCRIPTION
## Technical Summary

It seems odd that we should include RepeatRecord in domain dumps:
1. We include RequestLog in domain dumps, and that provides a history of API interactions
2. RepeatRecord is a queue token, used for scheduling tasks. We don't dump the Celery message queue, because that would make no sense. For the same reason, I don't think we should dump repeat records.
3. The repeat records table can get *big*.

## Safety Assurance

### Automated test coverage

Covered by tests

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
