### PR TITLE
Handle missing request.domain

### DIFF
--- a/corehq/apps/analytics/templates/analytics/initial/gtm.html
+++ b/corehq/apps/analytics/templates/analytics/initial/gtm.html
@@ -6,8 +6,10 @@
   {% initial_analytics_data 'gtm.userIsCommCareUser' request.couch_user.is_commcare_user %}
   {% initial_analytics_data 'gtm.isNewUser' request.couch_user|is_new_user %}
 {% endif %}
-{% if domain or request.domain %}
-  {% initial_analytics_data 'gtm.domain' domain|default:request.domain %}
+{% if request.domain %}
+  {% initial_analytics_data 'gtm.domain' request.domain %}
+{% elif domain %}
+  {% initial_analytics_data 'gtm.domain' domain %}
 {% endif %}
 {% if ANALYTICS_CONFIG.HQ_INSTANCE %}
   {% initial_analytics_data 'gtm.hqInstance' ANALYTICS_CONFIG.HQ_INSTANCE %}


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-16519

[Jenny's comment](https://github.com/dimagi/commcare-hq/pull/35720#discussion_r1941594416):

> The original code breaks the raw_doc page, where domain is the string "Unknown" (see [here](https://github.com/dimagi/commcare-hq/blob/4385ccd1b66464b8c70951634d0b1885317d94f5/corehq/apps/hqwebapp/doc_lookup.py#L166-L171)) and the request doesn't have a domain attribute.

> Sample error message: Failed lookup for key [domain] in <WSGIRequest: GET '/hq/admin/raw_doc/?id=c9cbe65cc318b403ea60ebafe6000826'> I don't know why django is accessing request.domain at all, since domain is present, but maybe the expression passed to default gets evaluated regardless of whether or not it's ultimately used.



## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not planning QA. Tested locally that it fix the raw data page issue.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
