### PR TITLE
Update FHIR documentation URLs

### DIFF
--- a/corehq/motech/fhir/bundle.py
+++ b/corehq/motech/fhir/bundle.py
@@ -2,7 +2,7 @@
 Tools for FHIR Bundles
 
 For more information about Bundles, including examples, see the
-`FHIR reference <https://www.hl7.org/fhir/bundle.html>`_.
+`FHIR reference <https://hl7.org/fhir/R4/bundle.html>`_.
 
 """
 from typing import Generator, Optional

--- a/corehq/motech/fhir/const.py
+++ b/corehq/motech/fhir/const.py
@@ -15,7 +15,7 @@ OWNER_TYPE_CHOICES = [
     (OWNER_TYPE_USER, _('User')),
 ]
 
-# See https://www.hl7.org/fhir/valueset-bundle-type.html
+# See https://hl7.org/fhir/R4/valueset-bundle-type.html
 FHIR_BUNDLE_TYPES = {
     'document',
     'message',
@@ -35,7 +35,7 @@ FHIR_BUNDLE_TYPES = {
 XMLNS_FHIR = 'http://commcarehq.org/x/fhir/engine-read'
 
 # The URI to identify CommCare as the system responsible for allocating
-# case IDs. See https://www.hl7.org/fhir/datatypes.html#Identifier
+# case IDs. See https://hl7.org/fhir/R4/datatypes.html#Identifier
 SYSTEM_URI_CASE_ID = 'http://commcarehq.org/x/fhir/case-id'
 
 FHIR_DATA_TYPE_LIST_OF_STRING = 'fhir_list_of_string'

--- a/corehq/motech/fhir/tasks.py
+++ b/corehq/motech/fhir/tasks.py
@@ -177,7 +177,7 @@ def claim_service_request(requests, service_request, case_id, attempt=0):
     """
     Uses `ETag`_ to prevent a race condition.
 
-    .. _ETag: https://www.hl7.org/fhir/http.html#concurrency
+    .. _ETag: https://hl7.org/fhir/R4/http.html#concurrency
     """
     endpoint = f"ServiceRequest/{service_request['id']}"
     response = requests.get(endpoint, raise_for_status=True)

--- a/docs/fhir/fhir_import_config.rst
+++ b/docs/fhir/fhir_import_config.rst
@@ -110,7 +110,7 @@ some of the imported values before overwriting existing values on the
 case. It is wise to confirm with the delivery team how to treat case
 properties that can be edited.
 
-.. _Patient search parameters: https://www.hl7.org/fhir/patient.html#search
+.. _Patient search parameters: https://hl7.org/fhir/R4/patient.html#search
 
 
 Configuring related resources

--- a/docs/fhir/fhir_repeater.rst
+++ b/docs/fhir/fhir_repeater.rst
@@ -211,4 +211,4 @@ Testing as the app is built catches problems early, and increases
 confidence in the app and the integration.
 
 
-.. _fhir-ref: https://www.hl7.org/fhir/
+.. _fhir-ref: https://hl7.org/fhir/R4/

--- a/docs/fhir/index.rst
+++ b/docs/fhir/index.rst
@@ -93,8 +93,8 @@ to become more familiar with JSONPath.
 
 
 .. _JSONPath: https://goessner.net/articles/JsonPath/
-.. _FHIR Patient: https://www.hl7.org/fhir/patient.html#resource
-.. _HumanName: https://www.hl7.org/fhir/datatypes.html#HumanName
+.. _FHIR Patient: https://hl7.org/fhir/R4/patient.html#resource
+.. _HumanName: https://hl7.org/fhir/R4/datatypes.html#HumanName
 .. _JSONPath expression syntax: https://goessner.net/articles/JsonPath/index.html#e2
 .. _JSONPath Online Evaluator: https://jsonpath.com/
 .. _Postman REST Client: https://www.postman.com/product/rest-client/


### PR DESCRIPTION
## Technical Summary

This is a documentation-only change. URLs for HL7 FHIR R4 have changed since our documentation for FHIR integration was written. This change updates those URLs.

## Feature Flag

FHIR INTEGRATION

## Safety Assurance

### Safety story

Documentation only

### Automated test coverage

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
