### PR TITLE
Add correct error handling for page data nodes

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -603,15 +603,15 @@ def html_attr(value):
     return conditional_escape(value)
 
 
-def _create_page_data(parser, token, node_slug):
-    split_contents = token.split_contents()
+def _create_page_data(parser, original_token, node_slug):
+    split_contents = original_token.split_contents()
     tag = split_contents[0]
     name = parse_literal(split_contents[1], parser, tag)
     value = parser.compile_filter(split_contents[2])
 
     class FakeNode(template.Node):
-        # must mock token or error handling code will fail and not reveal real error
-        token = Token(TokenType.TEXT, '', (0, 0), 0)
+        token = original_token
+        origin = parser.origin
 
         def render(self, context):
             resolved = value.resolve(context)


### PR DESCRIPTION
## Technical Summary
While debugging the [domain analytics issue](https://github.com/dimagi/commcare-hq/pull/35720#discussion_r1941594416), I noticed that the error wasn't being displayed properly in my local environment. Rather than correctly point to the missing domain property, I was instead seeing an error about `origin`:
<img width="467" alt="image" src="https://github.com/user-attachments/assets/ac08731e-506d-4d91-8c61-0746f0050580" />


I was able to add in an origin property to mimic what was being done in the [Django source](https://github.com/django/django/blob/4a3ad9eebbc16ce80b348644b557c84ecc741be7/django/template/base.py#L549)

However, I then realized that it would always attribute the error as occuring on the first line for unrelated code, due to incorrect `position`  and `lineno` variables. The previous code cited the need to mock the `token`, but I believe that was due to the absence of a token causing errors. I think we should be using the real token, in order to get fully correct error information.

Once fixed, the error output aligns with normal Django expectations:
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/8a0bf45c-15a9-4fc7-9d78-0669e78728de" />

## Feature Flag
No feature flag

## Safety Assurance

### Safety story
Verified this locally. I believe the reason we needed to fake the token was due to `render_annotated`'s behavior when `DEBUG` is on. From the [Django Node code](https://github.com/django/django/blob/4a3ad9eebbc16ce80b348644b557c84ecc741be7/django/template/base.py#L969-L975), there is no exception processing unless `context.template.engine.debug` is `True`. Given that production does not run in debug mode, this change should only affect local machines.

### Automated test coverage

No tests

### QA Plan
No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
