### PR TITLE
Dockerfile_incl build: don't crash on a missing git repository

### DIFF
--- a/settingshelper.py
+++ b/settingshelper.py
@@ -280,7 +280,7 @@ def get_git_commit(base_dir):
     try:
         out = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=base_dir)
         return out.strip().decode('ascii')
-    except OSError:
+    except (OSError, subprocess.CalledProcessError):
         pass
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Pure development infrastructure change, doesn't have any effect on the end user.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://github.com/dimagi/commcare-hq/tree/master/docker#running-services-and-hq-in-docker
provides instructions how to run both the HQ and services in Docker.

As reported in #32971 , the `$ docker build -f Dockerfile_incl -t commcarehq_incl .` build is currently broken. It fails with

```
[...]
Step 20/20 : RUN python manage.py collectstatic --noinput
 ---> Running in ddc87140d441
fatal: not a git repository (or any of the parent directories): .git
Traceback (most recent call last):
  File "/vendor/manage.py", line 172, in <module>
    main()
  File "/vendor/manage.py", line 50, in main
    execute_from_command_line(sys.argv)
  File "/vendor/lib/python3.9/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/vendor/lib/python3.9/site-packages/django/core/management/__init__.py", line 382, in execute
    settings.INSTALLED_APPS
  File "/vendor/lib/python3.9/site-packages/django/conf/__init__.py", line 102, in __getattr__
    self._setup(name)
  File "/vendor/lib/python3.9/site-packages/django/conf/__init__.py", line 89, in _setup
    self._wrapped = Settings(settings_module)
  File "/vendor/lib/python3.9/site-packages/django/conf/__init__.py", line 217, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/vendor/settings.py", line 2094, in <module>
    COMMCARE_RELEASE = helper.get_release_name(BASE_DIR, SERVER_ENVIRONMENT)
  File "/vendor/settingshelper.py", line 276, in get_release_name
    return get_git_commit(base_dir) or 'unknown'
  File "/vendor/settingshelper.py", line 281, in get_git_commit
    out = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=base_dir)
  File "/usr/local/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/local/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'rev-parse', 'HEAD']' returned non-zero exit status 128.
The command '/bin/sh -c python manage.py collectstatic --noinput' returned a non-zero code: 1
```

Having followed back the path of the unhandled exception I assume that `get_git_commit()` in `settingshelper.py` obviously wants to catch exceptions of this kind, but has not been properly tested in scenarios when the git repo is actually not available and misses the type of exceptions actually thrown by `subprocess.check_output()`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I followed the instructions in https://github.com/dimagi/commcare-hq/tree/master/docker#running-services-and-hq-in-docker and encountered the error reported in #32971 .

With the change included in this PR the Docker image build finishes successfully.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

Test all application setup scenarios where the `settingshelper.py` script is called.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
