### PR TITLE
Fix standard_hq_report

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/standard_hq_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/standard_hq_report.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,14 +1,16 @@
+@@ -1,15 +1,17 @@
  /*
      This file also controls basic logic and event handling for report pages.
  */
@@ -10,6 +10,7 @@
      'underscore',
 +    'bootstrap5',
      'hqwebapp/js/initial_page_data',
+     'reports/js/util',
 -    'reports/js/bootstrap3/hq_report',
 +    'reports/js/bootstrap5/hq_report',
  ], function (
@@ -17,9 +18,9 @@
      _,
 +    bootstrap,
      initialPageData,
+     util,
      hqReportModule,
- ) {
-@@ -50,7 +52,7 @@
+@@ -56,7 +58,7 @@
          var reportOptions = initialPageData.get('js_options') || {};
          if (reportOptions.slug && reportOptions.async) {
              let promise = $.Deferred();
@@ -28,7 +29,7 @@
                  var asyncHQReport = asyncHQReportModule({
                      standardReport: getStandard(),
                  });
-@@ -69,13 +71,19 @@
+@@ -75,13 +77,19 @@
      asyncReport = getAsync();
  
      $(function () {

--- a/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
@@ -5,11 +5,13 @@ hqDefine("reports/js/bootstrap3/standard_hq_report", [
     'jquery',
     'underscore',
     'hqwebapp/js/initial_page_data',
+    'reports/js/util',
     'reports/js/bootstrap3/hq_report',
 ], function (
     $,
     _,
     initialPageData,
+    util,
     hqReportModule,
 ) {
     var standardReport = undefined,
@@ -20,25 +22,29 @@ hqDefine("reports/js/bootstrap3/standard_hq_report", [
             return standardReport;
         }
 
-        if (typeof standardHQReport !== 'undefined') {
-            // Custom reports
-            standardReport = standardHQReport;
-        } else {
-            // Standard reports
-            var reportOptions = _.extend({}, initialPageData.get('js_options'), {
-                emailSuccessMessage: gettext('Report successfully emailed'),
-                emailErrorMessage: gettext('An error occurred emailing your report. Please try again.'),
-            });
-            if (initialPageData.get('startdate')) {
-                reportOptions.datespan = {
-                    startdate: initialPageData.get('startdate'),
-                    enddate: initialPageData.get('enddate'),
-                };
-            }
-            var standardHQReport = hqReportModule.hqReport(reportOptions);
-            standardHQReport.init();
-            standardReport = standardHQReport;
+        var reportOptions = _.extend({}, initialPageData.get('js_options'), {
+            emailSuccessMessage: gettext('Report successfully emailed'),
+            emailErrorMessage: gettext('An error occurred emailing your report. Please try again.'),
+        });
+
+        if (initialPageData.get('override_report_render_url')) {
+            reportOptions.getReportRenderUrl = function (renderType) {
+                var params = util.urlSerialize($('#paramSelectorForm'), ['format']);
+                return window.location.pathname + "?format=" + renderType + "&" + params;
+            };
         }
+
+        if (initialPageData.get('startdate')) {
+            reportOptions.datespan = {
+                startdate: initialPageData.get('startdate'),
+                enddate: initialPageData.get('enddate'),
+            };
+        }
+
+        var standardHQReport = hqReportModule.hqReport(reportOptions);
+        standardHQReport.init();
+        standardReport = standardHQReport;
+
         return standardReport;
     };
 

--- a/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
@@ -6,12 +6,14 @@ hqDefine("reports/js/bootstrap5/standard_hq_report", [
     'underscore',
     'bootstrap5',
     'hqwebapp/js/initial_page_data',
+    'reports/js/util',
     'reports/js/bootstrap5/hq_report',
 ], function (
     $,
     _,
     bootstrap,
     initialPageData,
+    util,
     hqReportModule,
 ) {
     var standardReport = undefined,
@@ -22,25 +24,29 @@ hqDefine("reports/js/bootstrap5/standard_hq_report", [
             return standardReport;
         }
 
-        if (typeof standardHQReport !== 'undefined') {
-            // Custom reports
-            standardReport = standardHQReport;
-        } else {
-            // Standard reports
-            var reportOptions = _.extend({}, initialPageData.get('js_options'), {
-                emailSuccessMessage: gettext('Report successfully emailed'),
-                emailErrorMessage: gettext('An error occurred emailing your report. Please try again.'),
-            });
-            if (initialPageData.get('startdate')) {
-                reportOptions.datespan = {
-                    startdate: initialPageData.get('startdate'),
-                    enddate: initialPageData.get('enddate'),
-                };
-            }
-            var standardHQReport = hqReportModule.hqReport(reportOptions);
-            standardHQReport.init();
-            standardReport = standardHQReport;
+        var reportOptions = _.extend({}, initialPageData.get('js_options'), {
+            emailSuccessMessage: gettext('Report successfully emailed'),
+            emailErrorMessage: gettext('An error occurred emailing your report. Please try again.'),
+        });
+
+        if (initialPageData.get('override_report_render_url')) {
+            reportOptions.getReportRenderUrl = function (renderType) {
+                var params = util.urlSerialize($('#paramSelectorForm'), ['format']);
+                return window.location.pathname + "?format=" + renderType + "&" + params;
+            };
         }
+
+        if (initialPageData.get('startdate')) {
+            reportOptions.datespan = {
+                startdate: initialPageData.get('startdate'),
+                enddate: initialPageData.get('enddate'),
+            };
+        }
+
+        var standardHQReport = hqReportModule.hqReport(reportOptions);
+        standardHQReport.init();
+        standardReport = standardHQReport;
+
         return standardReport;
     };
 

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -149,7 +149,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     prefix = slug
     emailable = False
     is_exportable = True
-    exportable_all = True
+    exportable_all = False
     show_filters = True
 
     _domain = None

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -147,7 +147,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     template_name = 'userreports/configurable_report.html'
     slug = "configurable"
     prefix = slug
-    emailable = True
+    emailable = False
     is_exportable = True
     exportable_all = True
     show_filters = True
@@ -372,11 +372,9 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             "slug": self.slug,
             "subReportSlug": self.sub_slug,
             "type": self.type,
-            #"filterSet": self.filter_set,       # TODO: has this ever mattered?
-            #"needsFilters": self.needs_filters, # TODO: has this ever mattered?
             "isExportable": self.is_exportable,
-            #"isExportAll": self.exportable_all, # TODO: is this being ignored by HTML?
-            #"isEmailable": self.emailable,      # TODO: is this being ignored by HTML?
+            "isExportAll": self.exportable_all,
+            "isEmailable": self.emailable,
             "emailDefaultSubject": self.title,
         }
 

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -346,6 +346,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
         context = {
             'report': self,
             'report_table': {'default_rows': 25},
+            'js_options': self.js_options,
             'filter_context': self.filter_context,
             'url': self.url,
             'method': 'POST',
@@ -363,6 +364,22 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
         if self.request.couch_user.is_staff and hasattr(self.data_source, 'data_source'):
             context['queries'] = self.data_source.data_source.get_query_strings()
         return context
+
+    @property
+    def js_options(self):
+        return {
+            "domain": self.domain,
+            #"url_root": self.url_root,         # TODO: has this ever mattered?
+            "slug": self.slug,
+            "subReportSlug": self.sub_slug,
+            "type": self.type,
+            #"filterSet": self.filter_set,       # TODO: has this ever mattered?
+            #"needsFilters": self.needs_filters, # TODO: has this ever mattered?
+            "isExportable": self.is_exportable,
+            #"isExportAll": self.exportable_all, # TODO: is this being ignored by HTML?
+            #"isEmailable": self.emailable,      # TODO: is this being ignored by HTML?
+            "emailDefaultSubject": self.title,
+        }
 
     def pop_report_builder_context_data(self):
         """

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -369,7 +369,6 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     def js_options(self):
         return {
             "domain": self.domain,
-            #"url_root": self.url_root,         # TODO: has this ever mattered?
             "slug": self.slug,
             "subReportSlug": self.sub_slug,
             "type": self.type,

--- a/corehq/apps/userreports/static/userreports/js/configurable_report.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_report.js
@@ -6,7 +6,7 @@ hqDefine("userreports/js/configurable_report", [
     'hqwebapp/js/initial_page_data',
     'reports/js/bootstrap3/hq_report',
     'reports/js/bootstrap3/report_config_models',
-    'reports/js/util',
+    'reports/js/bootstrap3/standard_hq_report',
     'userreports/js/report_analytix',
     'userreports/js/base',
     'commcarehq',
@@ -18,17 +18,14 @@ hqDefine("userreports/js/configurable_report", [
     initialPageData,
     hqReport,
     reportConfigModels,
-    util,
+    standardHQReportModule,
     analytics,
 ) {
-    var getStandardHQReport = function (isFirstLoad) {
-        if (!initialPageData.get("standardHQReport")) {
-            return undefined;
-        }
+    $(function () {
+        standardHQReportModule.getStandardHQReport();
 
-        var $editReportButton = $("#edit-report-link");
-
-        if (initialPageData.get("created_by_builder") && !isFirstLoad) {
+        // Set up analytics
+        if (initialPageData.get("created_by_builder")) {
             var $applyFiltersButton = $("#apply-filters"),
                 builderType = initialPageData.get("builder_report_type"),
                 reportType = initialPageData.get("type");
@@ -37,48 +34,15 @@ hqDefine("userreports/js/configurable_report", [
                 analytics.track.event("View Report Builder Report", label);
             });
             analytics.track.event("Loaded Report Builder Report");
-            $editReportButton.click(function () {
+            $("#edit-report-link").click(function () {
                 kissmetrics.track.event("RBv2 - Click Edit Report");
             });
         }
 
+        // More analytics
         _.each(initialPageData.get("report_builder_events"), function (e) {
             analytics.track.event.apply(this, e);
         });
-
-        var urlSerialize = util.urlSerialize;
-        var reportOptions = {
-            domain: initialPageData.get('domain'),
-            urlRoot: initialPageData.get('url_root'),
-            slug: initialPageData.get('slug'),
-            subReportSlug: initialPageData.get('sub_slug'),
-            type: initialPageData.get('type'),
-            filterSet: initialPageData.get('filter_set'),
-            needsFilters: initialPageData.get('needs_filters'),
-            isExportable: initialPageData.get('is_exportable'),
-            isExportAll: initialPageData.get('is_export_all'),
-            isEmailable: initialPageData.get('is_emailable'),
-            emailDefaultSubject: initialPageData.get('title'),
-            emailSuccessMessage: gettext('Report successfully emailed'),
-            emailErrorMessage: gettext('An error occurred emailing you report. Please try again.'),
-            getReportRenderUrl: function (renderType) {
-                var params = urlSerialize($('#paramSelectorForm'), ['format']);
-                return window.location.pathname + "?format=" + renderType + "&" + params;
-            },
-        };
-        if (initialPageData.get('startdate')) {
-            reportOptions.datespan = {
-                startdate: initialPageData.get('startdate'),
-                enddate: initialPageData.get('enddate'),
-            };
-        }
-        var standardHQReport = hqReport.hqReport(reportOptions);
-        standardHQReport.init();
-        return standardHQReport;
-    };
-
-    $(function () {
-        getStandardHQReport(true);
 
         // Bind the ReportConfigsViewModel to the save button.
         var defaultConfig = initialPageData.get("default_config");
@@ -120,7 +84,5 @@ hqDefine("userreports/js/configurable_report", [
         }
     });
 
-    return {
-        getStandardHQReport: getStandardHQReport,
-    };
+    return 1;
 });

--- a/corehq/apps/userreports/static/userreports/js/configurable_report.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_report.js
@@ -83,6 +83,4 @@ hqDefine("userreports/js/configurable_report", [
             );
         }
     });
-
-    return 1;
 });

--- a/corehq/apps/userreports/templates/userreports/configurable_report.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_report.html
@@ -12,7 +12,6 @@
 
 {% block page_actions %}
   {% registerurl 'add_report_config' domain %}
-  {% initial_page_data 'standardHQReport' True %}
   {% initial_page_data 'builder_report_type' report.spec.report_meta.builder_report_type %}
   {% initial_page_data 'report_builder_events' report_builder_events %}
   {% initial_page_data 'default_config' default_config %}
@@ -24,17 +23,9 @@
     {% initial_page_data 'startdate' datespan.startdate|date:"Y-m-d" %}
     {% initial_page_data 'enddate' datespan.enddate|date:"Y-m-d" %}
   {% endif %}
-  {% initial_page_data 'domain' domain %}
-  {% initial_page_data 'url_root' report.url_root %}
-  {% initial_page_data 'slug' report.slug %}
-  {% initial_page_data 'sub_slug' report.sub_slug %}
   {% initial_page_data 'type' report.type %}
-  {% initial_page_data 'filter_set' report.filter_set %}
-  {% initial_page_data 'needs_filters' report.needs_filters %}
-  {% initial_page_data 'is_exportable' report.is_exportable %}
-  {% initial_page_data 'is_export_all' report.is_export_all %}
-  {% initial_page_data 'is_emailable' report.is_emailable %}
-  {% initial_page_data 'title' report.title %}
+  {% initial_page_data 'js_options' js_options %}
+  {% initial_page_data 'override_report_render_url' True %}
 
   {% if has_report_builder_trial %}
     <a class="btn btn-primary" href="{% url 'report_builder_paywall_pricing' domain %}">


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SAAS-16512

Fixes a bug where UCRs could not be saved as saved reports.

## Technical Summary
Introduced in https://github.com/dimagi/commcare-hq/pull/35599, specifically the removal of the block [here](https://github.com/dimagi/commcare-hq/pull/35599/files#diff-c140afd2d0403854fb9c2d60bda41f8409d03f856c2c46cd080e7aafefcc397dL36-L38) that handled UCRs by calling out to the UCR version of `getStandardReport`.

`getStandardReport` was split into a UCR version and a standard reports version many years ago, because UCRs were migrated to requirejs and standard reports were not. Now that all reports are on webpack, this PR merges the two sets of logic back into one. The UCR version included some UCR-specific analytics code that's staying in the UCR module.

This means updating UCRs to use one big `js_options` object for report options, the way standard reports do, instead of passing the report options as individual pieces of data. Because `js_options` is built in python, this highlighted that several of these options have never done anything in UCRs. Additional context on this...

Standard reports all derive from `GenericReportView`, which sets up a `report` object in the context [here](https://github.com/dimagi/commcare-hq/blob/bba4cfffc632c956628539be42669e18fe41cebe/corehq/apps/reports/generic.py#L536).

In UCRs, the `report` in the context is the view itself (see [here](https://github.com/dimagi/commcare-hq/blob/bba4cfffc632c956628539be42669e18fe41cebe/corehq/apps/userreports/reports/view.py#L347)), which has some inconsistencies with `GenericReportView`.

Expressions like `report.filter_set`, which don't exist in the UCR view class, were previously failing silently when they got called during template rendering and are now removed. This also made it apparent that although UCRs have `emailable` set to True, the initial page data incorrectly referenced `report.is_emailable` and therefore the functionality wasn't working. I started to implement emailability for UCRs, since clearly that was the original intention, but I backed out after realizing that it would be more involved than expected.

This PR does, however, turn on the export all functionality, which was similarly previously broken but now should work because `isExportAll` is now based on the [real](https://github.com/dimagi/commcare-hq/blob/bba4cfffc632c956628539be42669e18fe41cebe/corehq/apps/userreports/reports/view.py#L152) `exportable_all` view attribute, instead of `is_export_all` which exists in the context of standard reports (see [here](https://github.com/dimagi/commcare-hq/blob/bba4cfffc632c956628539be42669e18fe41cebe/corehq/apps/reports/generic.py#L556)) but doesn't exist in UCRs.

This PR has made me much less fond of renames [like this](https://github.com/dimagi/commcare-hq/blob/bba4cfffc632c956628539be42669e18fe41cebe/corehq/apps/reports/generic.py#L555-L556) where the name changes but the meaning does not. Not that I was fond of them in the first place.

## Feature Flag
UCRs

## Safety Assurance

### Safety story
I'm testing on staging. I'm leaning towards requesting QA to make sure I didn't break any other basic reports interaction in either standard reports or UCRs.

I've tested the inddex reports on staging.

### Automated test coverage

No

### QA Plan

https://dimagi.atlassian.net/browse/QA-7456

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
