### PR TITLE
Add Case List Optimizations

### DIFF
--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -103,3 +103,12 @@ MOBILE_UCR_V1_FIXTURE_PATTERN = r'<.*src="jr://fixture/commcare:reports.*>'
 MOBILE_UCR_V1_REFERENCES_PATTERN = r"<.*instance\('reports'\)/reports/.*>"
 MOBILE_UCR_V1_ALL_REFERENCES = f"{MOBILE_UCR_V1_FIXTURE_PATTERN}|{MOBILE_UCR_V1_REFERENCES_PATTERN}"
 MOBILE_UCR_V1_CASE_LIST_REFERENCES_PATTERN = r"instance\('commcare:reports'\)/reports/report\[@id='.*'\]/rows/row"
+
+FORMATS_SUPPORTING_CASE_LIST_OPTIMIZATIONS = [
+    'address',
+    'date',
+    'markdown',
+    'phone',
+    'plain',
+    'enum'
+]

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -311,7 +311,7 @@ class FormattedDetailColumn(object):
             # since case list optimizations are only available for versions higher than the
             # ones needed for multi sort, it's safe to assume that case list optimizations
             # should only be added only when multi sort is enabled
-            if self.app.supports_case_list_optimizations:
+            if self.app.supports_case_list_optimizations and self.column.supports_optimizations:
                 self._set_case_list_optimizations(field, self.column.optimization)
             yield field
         elif (self.sort_xpath_function and self.detail.display == 'short'

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -112,7 +112,7 @@ class FormattedDetailColumn(object):
         self.entries_helper = entries_helper
 
     def has_sort_node_for_nodeset_column(self):
-        return self.parent_tab_nodeset and self.detail.sort_nodeset_columns_for_detail()
+        return self.parent_tab_nodeset and self.detail.sort_nodeset_columns_for_long_detail()
 
     @property
     def locale_id(self):

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -263,3 +263,10 @@ class CommCareFeatureSupportMixin(object):
         return (
             self._require_minimum_version('2.54')
         )
+
+    @property
+    def supports_case_list_optimizations(self):
+        return (
+            toggles.CASE_LIST_OPTIMIZATIONS.enabled(self.domain)
+            and self._require_minimum_version('2.56')
+        )

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -70,6 +70,7 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
     get_usercase_properties,
 )
 from corehq.apps.app_manager.commcare_settings import check_condition
+from corehq.apps.app_manager.const import FORMATS_SUPPORTING_CASE_LIST_OPTIMIZATIONS
 from corehq.apps.app_manager.dbaccessors import (
     domain_has_apps,
     get_app,
@@ -1921,11 +1922,17 @@ class DetailColumn(IndexedSchema):
             for item in to_ret.enum:
                 for lang, path in item.value.items():
                     item.value[lang] = interpolate_media_path(path)
+
+        if to_ret.optimization and not to_ret.supports_optimizations:
+            to_ret.optimization = None
         return to_ret
 
     @property
     def invisible(self):
         return self.format == 'invisible'
+
+    def supports_optimizations(self):
+        return self.format in FORMATS_SUPPORTING_CASE_LIST_OPTIMIZATIONS
 
 
 class SortElement(IndexedSchema):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2577,6 +2577,7 @@ class Module(ModuleBase, ModuleDetailsMixin):
     search_config = SchemaProperty(CaseSearch)
     display_style = StringProperty(default='list')
     lazy_load_case_list_fields = BooleanProperty(default=False)
+    show_case_list_optimization_options = BooleanProperty(default=False)
 
     @classmethod
     def new_module(cls, name, lang):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1860,6 +1860,7 @@ class DetailColumn(IndexedSchema):
     field = StringProperty()
     useXpathExpression = BooleanProperty(default=False)
     format = StringProperty(exclude_if_none=True)
+    optimization = StringProperty(exclude_if_none=True)
 
     # Only applies to custom case list tile. grid_x and grid_y are zero-based values
     # representing the starting row and column.

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2068,7 +2068,7 @@ class Detail(IndexedSchema, CaseListLookupMixin):
         for column in self.columns:
             column.rename_lang(old_lang, new_lang)
 
-    def sort_nodeset_columns_for_detail(self):
+    def sort_nodeset_columns_for_long_detail(self):
         return (
             self.display == "long"
             and any(tab for tab in self.get_tabs() if tab.has_nodeset)

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -81,6 +81,27 @@ hqDefine("app_manager/js/details/column", function () {
         });
         self.tileColumnStart = ko.observable(self.original.grid_x + 1 || 1); // converts from 0 to 1-based for UI
         self.tileColumnOptions = _.range(1, self.tileColumnMax());
+
+        let optimizationOptions = [
+            {
+                value: "",
+                label: "",
+            },
+            {
+                value: "cache",
+                label: gettext('Cache'),
+            },
+            {
+                value: "lazy_load",
+                label: gettext('Lazy Load'),
+            },
+            {
+                value: "cache_and_lazy_load",
+                label: gettext('Cache & Lazy Load'),
+            },
+        ];
+        self.optimizationSelectElement = uiElementSelect.new(optimizationOptions).val(self.original.optimization || "");
+        self.$optimizationSelectElement = $('<div/>').append(self.optimizationSelectElement.ui);
         self.tileWidth = ko.observable(self.original.width || self.tileRowMax() - 1);
         self.tileWidthOptions = ko.computed(function () {
             return _.range(1, self.tileColumnMax() + 1 - (self.tileColumnStart() || 1));
@@ -351,6 +372,7 @@ hqDefine("app_manager/js/details/column", function () {
             'nodeset_extra',
             'relevant',
             'format',
+            'optimizationSelectElement',
             'date_extra',
             'enum_extra',
             'action_form_extra',
@@ -471,6 +493,7 @@ hqDefine("app_manager/js/details/column", function () {
             column.field = self.field.val();
             column.header[self.lang] = self.header.val();
             column.format = self.format.val();
+            column.optimization = self.optimizationSelectElement.val();
             column.date_format = self.date_extra.val();
             column.enum = self.enum_extra.getItems();
             column.endpoint_action_id = self.action_form_extra.val() === "-1" ? null : self.action_form_extra.val();

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -265,6 +265,17 @@ hqDefine("app_manager/js/details/column", function () {
         }
 
         self.format = uiElementSelect.new(menuOptions).val(self.original.format || null);
+        self.supportsOptimizations = ko.observable(false);
+        self.optimizationsSupported = function () {
+            return (
+                self.format.val() &&
+                initialPageData.get('formats_supporting_case_list_optimizations').includes(self.format.val())
+            );
+        };
+        self.setSupportOptimizations = function () {
+            self.supportsOptimizations(self.optimizationsSupported());
+        };
+        self.setSupportOptimizations();
 
         (function () {
             const o = {
@@ -408,6 +419,7 @@ hqDefine("app_manager/js/details/column", function () {
             }
 
             self.coordinatesVisible(!_.contains(['address', 'address-popup', 'invisible'], self.format.val()));
+            self.setSupportOptimizations();
             // Prevent self from running on page load before init
             if (self.format.ui.parent().length > 0) {
                 self.date_extra.ui.detach();
@@ -493,7 +505,7 @@ hqDefine("app_manager/js/details/column", function () {
             column.field = self.field.val();
             column.header[self.lang] = self.header.val();
             column.format = self.format.val();
-            column.optimization = self.optimizationSelectElement.val();
+            column.optimization = self.supportsOptimizations() ? self.optimizationSelectElement.val() : null;
             column.date_format = self.date_extra.val();
             column.enum = self.enum_extra.getItems();
             column.endpoint_action_id = self.action_form_extra.val() === "-1" ? null : self.action_form_extra.val();

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -270,15 +270,13 @@ hqDefine("app_manager/js/details/column", function () {
 
         self.format = uiElementSelect.new(menuOptions).val(self.original.format || null);
         self.supportsOptimizations = ko.observable(false);
-        self.optimizationsSupported = function () {
-            return (
+        self.setSupportOptimizations = function () {
+            let optimizationsSupported = (
                 screen.showCaseListOptimizations &&
                 self.format.val() &&
                 initialPageData.get('formats_supporting_case_list_optimizations').includes(self.format.val())
             );
-        };
-        self.setSupportOptimizations = function () {
-            self.supportsOptimizations(self.optimizationsSupported());
+            self.supportsOptimizations(optimizationsSupported);
         };
         self.setSupportOptimizations();
 

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -510,10 +510,7 @@ hqDefine("app_manager/js/details/column", function () {
             column.field = self.field.val();
             column.header[self.lang] = self.header.val();
             column.format = self.format.val();
-            // fetch val by searching the select element instead of directly from optimizationSelectElement since
-            // the event binding to fire change on optimizationSelectElement with change on select, gets lost
-            // when the element is hidden and then revealed again based on format.
-            column.optimization = self.supportsOptimizations() ? self.optimizationSelectElement.ui.find("select").val() : null;
+            column.optimization = self.supportsOptimizations() ? self.optimizationSelectElement.val() : null;
             column.date_format = self.date_extra.val();
             column.enum = self.enum_extra.getItems();
             column.endpoint_action_id = self.action_form_extra.val() === "-1" ? null : self.action_form_extra.val();

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -100,8 +100,12 @@ hqDefine("app_manager/js/details/column", function () {
                 label: gettext('Cache & Lazy Load'),
             },
         ];
-        self.optimizationSelectElement = uiElementSelect.new(optimizationOptions).val(self.original.optimization || "");
-        self.$optimizationSelectElement = $('<div/>').append(self.optimizationSelectElement.ui);
+        if (screen.showCaseListOptimizations) {
+            self.optimizationSelectElement = uiElementSelect.new(
+                optimizationOptions,
+            ).val(self.original.optimization || "");
+            self.$optimizationSelectElement = $('<div/>').append(self.optimizationSelectElement.ui);
+        }
         self.tileWidth = ko.observable(self.original.width || self.tileRowMax() - 1);
         self.tileWidthOptions = ko.computed(function () {
             return _.range(1, self.tileColumnMax() + 1 - (self.tileColumnStart() || 1));
@@ -268,6 +272,7 @@ hqDefine("app_manager/js/details/column", function () {
         self.supportsOptimizations = ko.observable(false);
         self.optimizationsSupported = function () {
             return (
+                screen.showCaseListOptimizations &&
                 self.format.val() &&
                 initialPageData.get('formats_supporting_case_list_optimizations').includes(self.format.val())
             );
@@ -383,7 +388,6 @@ hqDefine("app_manager/js/details/column", function () {
             'nodeset_extra',
             'relevant',
             'format',
-            'optimizationSelectElement',
             'date_extra',
             'enum_extra',
             'action_form_extra',
@@ -395,6 +399,9 @@ hqDefine("app_manager/js/details/column", function () {
         ], function (element) {
             self[element].on('change', fireChange);
         });
+        if (self.optimizationSelectElement) {
+            self.optimizationSelectElement.on('change', fireChange);
+        }
         self.case_tile_field.subscribe(fireChange);
         self.tileRowStart.subscribe(fireChange);
         self.tileColumnStart.subscribe(fireChange);

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -505,7 +505,10 @@ hqDefine("app_manager/js/details/column", function () {
             column.field = self.field.val();
             column.header[self.lang] = self.header.val();
             column.format = self.format.val();
-            column.optimization = self.supportsOptimizations() ? self.optimizationSelectElement.val() : null;
+            // fetch val by searching the select element instead of directly from optimizationSelectElement since
+            // the event binding to fire change on optimizationSelectElement with change on select, gets lost
+            // when the element is hidden and then revealed again based on format.
+            column.optimization = self.supportsOptimizations() ? self.optimizationSelectElement.ui.find("select").val() : null;
             column.date_format = self.date_extra.val();
             column.enum = self.enum_extra.getItems();
             column.endpoint_action_id = self.action_form_extra.val() === "-1" ? null : self.action_form_extra.val();

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -85,7 +85,7 @@ hqDefine("app_manager/js/details/column", function () {
         let optimizationOptions = [
             {
                 value: "",
-                label: "",
+                label: "---",
             },
             {
                 value: "cache",

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -110,7 +110,7 @@ hqDefine("app_manager/js/details/screen", function () {
         });
         self.showCaseListOptimizations = (
             self.columnKey === 'short' &&
-            hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_OPTIMIZATIONS') &&
+            initialPageData.get('app_supports_case_list_optimizations') &&
             initialPageData.get('show_case_list_optimization_options')
         );
         self.persistCaseContext = ko.observable(detail.persist_case_context || false);

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -14,7 +14,8 @@
 hqDefine("app_manager/js/details/screen", function () {
     const Utils = hqImport('app_manager/js/details/utils'),
         ColumnModel = hqImport("app_manager/js/details/column"),
-        uiMapList = hqImport("hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list");
+        uiMapList = hqImport("hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list"),
+        initialPageData = hqImport('hqwebapp/js/initial_page_data');
 
     const getPropertyTitle = function (property) {
         // Strip "<prefix>:" before converting to title case.
@@ -109,7 +110,8 @@ hqDefine("app_manager/js/details/screen", function () {
         });
         self.showCaseListOptimizations = (
             self.columnKey === 'short' &&
-            hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_OPTIMIZATIONS')
+            hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_OPTIMIZATIONS') &&
+            initialPageData.get('show_case_list_optimization_options')
         );
         self.persistCaseContext = ko.observable(detail.persist_case_context || false);
         self.persistentCaseContextXML = ko.observable(detail.persistent_case_context_xml || 'case_name');

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -107,6 +107,10 @@ hqDefine("app_manager/js/details/screen", function () {
             const caseTileTemplate = self.caseTileTemplate() && self.caseTileTemplate() !== "custom";
             return caseTileTemplate && featureFlag;
         });
+        self.showCaseListOptimizations = (
+            self.columnKey === 'short' &&
+            hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_OPTIMIZATIONS')
+        );
         self.persistCaseContext = ko.observable(detail.persist_case_context || false);
         self.persistentCaseContextXML = ko.observable(detail.persistent_case_context_xml || 'case_name');
 

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -173,9 +173,9 @@ hqDefine("app_manager/js/modules/module_view", function () {
             });
         }
 
-        var showCaseListOptimizationsElement = $('#show_case_list_optimization_options');
-        if (showCaseListOptimizationsElement.length > 0) {
-            showCaseListOptimizationsElement.koApplyBindings({
+        var $showCaseListOptimizationsElement = $('#show_case_list_optimization_options');
+        if ($showCaseListOptimizationsElement.length) {
+            $showCaseListOptimizationsElement.koApplyBindings({
                 show_case_list_optimization_options: ko.observable(
                     initialPageData.get('show_case_list_optimization_options'),
                 ),

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -173,6 +173,15 @@ hqDefine("app_manager/js/modules/module_view", function () {
             });
         }
 
+        var showCaseListOptimizationsElement = $('#show_case_list_optimization_options');
+        if (showCaseListOptimizationsElement.length > 0) {
+            showCaseListOptimizationsElement.koApplyBindings({
+                show_case_list_optimization_options: ko.observable(
+                    initialPageData.get('show_case_list_optimization_options'),
+                ),
+            });
+        }
+
 
         // Registration in case list
         if ($('#case-list-form').length) {

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -105,7 +105,7 @@ class DetailContributor(SectionContributor):
                 if detail.custom_xml:
                     elements.append(self._get_custom_xml_detail(module, detail, detail_type))
                 else:
-                    if detail.sort_nodeset_columns_for_detail():
+                    if detail.sort_nodeset_columns_for_long_detail():
                         # list of DetailColumnInfo named tuples
                         detail_column_infos = get_detail_column_infos_for_tabs_with_sorting(detail)
                     else:

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -130,6 +130,8 @@ class DetailContributor(SectionContributor):
                         )
                         if d:
                             elements.append(d)
+                            if self.app.supports_case_list_optimizations:
+                                _add_detail_optimizations(module_detail=detail, detail_xml_object=d)
 
                     # add the persist case context if needed and if
                     # case tiles are present and have their own persistent block
@@ -590,6 +592,28 @@ class DetailsHelper(object):
             detail_type=detail_type,
         )
         return detail_id if detail_id in self.active_details else None
+
+
+def _add_detail_optimizations(module_detail, detail_xml_object):
+    """
+    Add optimizations on detail based on optimizations added on columns under the detail.
+    We set any optimization on the detail that is preset on any of the column.
+
+    This is needed by CommCare app to maintain consistency with features that already use these optimizations
+    via different settings/feature flags, which should get deprecated by this feature.
+    """
+    column_optimizations = [
+        column.optimization if column.supports_optimizations else None
+        for column in module_detail.get_columns()
+    ]
+    if 'cache_and_lazy_load' in column_optimizations:
+        detail_xml_object.cache_enabled = True
+        detail_xml_object.lazy_loading = True
+    else:
+        if 'cache' in column_optimizations:
+            detail_xml_object.cache_enabled = True
+        if 'lazy_load' in column_optimizations:
+            detail_xml_object.lazy_loading = True
 
 
 def get_nodeset_sort_elements(detail):

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -866,6 +866,8 @@ class Field(OrderedXmlObject):
 
     sort = StringField('@sort')
     print_id = StringField('@print-id')
+    lazy_loading = BooleanField('@lazy_loading', required=False)
+    cache_enabled = BooleanField('@cache_enabled', required=False)
     style = NodeField('style', Style)
     header = NodeField('header', Header)
     template = NodeField('template', Template)

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -938,6 +938,7 @@ class Detail(OrderedXmlObject, IdNode):
     ROOT_NAME = 'detail'
 
     lazy_loading = BooleanField('@lazy_loading')
+    cache_enabled = BooleanField('@cache_enabled', required=False)
 
     ORDER = ('title', 'lookup', 'no_items_text', 'details', 'fields')
 

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -69,6 +69,7 @@
   {% initial_page_data 'case_list_form_not_allowed_reasons' case_list_form_not_allowed_reasons %}
   {% initial_page_data 'case_type' module.case_type %}
   {% initial_page_data 'lazy_load_case_list_fields' module.lazy_load_case_list_fields %}
+  {% initial_page_data 'show_case_list_optimization_options' module.show_case_list_optimization_options %}
   {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}
   {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}
   {% initial_page_data 'parent_case_modules' parent_case_modules %}

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -70,6 +70,7 @@
   {% initial_page_data 'case_type' module.case_type %}
   {% initial_page_data 'lazy_load_case_list_fields' module.lazy_load_case_list_fields %}
   {% initial_page_data 'show_case_list_optimization_options' module.show_case_list_optimization_options %}
+  {% initial_page_data 'formats_supporting_case_list_optimizations' formats_supporting_case_list_optimizations %}
   {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}
   {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}
   {% initial_page_data 'parent_case_modules' parent_case_modules %}

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -70,6 +70,7 @@
   {% initial_page_data 'case_type' module.case_type %}
   {% initial_page_data 'lazy_load_case_list_fields' module.lazy_load_case_list_fields %}
   {% initial_page_data 'show_case_list_optimization_options' module.show_case_list_optimization_options %}
+  {% initial_page_data 'app_supports_case_list_optimizations' app.supports_case_list_optimizations %}
   {% initial_page_data 'formats_supporting_case_list_optimizations' formats_supporting_case_list_optimizations %}
   {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}
   {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
@@ -18,13 +18,13 @@
         <!-- ko ifnot: showCaseTileMappingColumn() -->
         <th class="col-sm-2">{% trans "Format" %}</th>
         <!-- /ko -->
-        <!-- ko if: showCaseListOptimizations -->
-        <th class="col-sm-2">{% trans "Optimize" %}</th>
-        <!-- /ko -->
         <!-- ko if: showCaseTileConfigColumns() -->
         <th class="col-sm-1">{% trans "Row/Column" %}</th>
         <th class="col-sm-1">{% trans "Width/Height" %}</th>
         <th class="col-sm-1">{% trans "Style" %}</th>
+        <!-- /ko -->
+        <!-- ko if: showCaseListOptimizations -->
+        <th class="col-sm-2">{% trans "Optimize" %}</th>
         <!-- /ko -->
         <th class="col-sm-1"></th>
       </tr>
@@ -87,18 +87,6 @@
                               'col-sm-2': !$parent.showCaseTileMappingColumn(),
                           }"
         ></td>
-        <!-- ko if: $parent.showCaseListOptimizations -->
-        <!-- ko if: supportsOptimizations -->
-        <td data-bind="jqueryElement: $optimizationSelectElement"></td>
-        <!-- /ko -->
-        <!-- ko ifnot: supportsOptimizations -->
-        <td>
-          <select class="form-control" disabled>
-            <option>{% trans "N/A" %}</option>
-          </select>
-        </td>
-        <!-- /ko -->
-        <!-- /ko -->
         <!-- ko if: $parent.showCaseTileConfigColumns() -->
         <td class="col-sm-1">
           <select
@@ -170,6 +158,18 @@
             data-bind="value: case_tile_field, options: $parent.caseTileFieldsForTemplate, visible: !$data.isTab"
           ></select>
         </td>
+        <!-- /ko -->
+        <!-- ko if: $parent.showCaseListOptimizations -->
+        <!-- ko if: supportsOptimizations -->
+        <td data-bind="jqueryElement: $optimizationSelectElement"></td>
+        <!-- /ko -->
+        <!-- ko ifnot: supportsOptimizations -->
+        <td>
+          <select class="form-control" disabled>
+            <option>{% trans "N/A" %}</option>
+          </select>
+        </td>
+        <!-- /ko -->
         <!-- /ko -->
         <td class="col-sm-1 text-center">
           <i

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
@@ -88,7 +88,16 @@
                           }"
         ></td>
         <!-- ko if: $parent.showCaseListOptimizations -->
+        <!-- ko if: supportsOptimizations -->
         <td data-bind="jqueryElement: $optimizationSelectElement"></td>
+        <!-- /ko -->
+        <!-- ko ifnot: supportsOptimizations -->
+        <td>
+          <select class="form-control" disabled>
+            <option>{% trans "N/A" %}</option>
+          </select>
+        </td>
+        <!-- /ko -->
         <!-- /ko -->
         <!-- ko if: $parent.showCaseTileConfigColumns() -->
         <td class="col-sm-1">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
@@ -160,16 +160,14 @@
         </td>
         <!-- /ko -->
         <!-- ko if: $parent.showCaseListOptimizations -->
-        <!-- ko if: supportsOptimizations -->
-        <td data-bind="jqueryElement: $optimizationSelectElement"></td>
-        <!-- /ko -->
-        <!-- ko ifnot: supportsOptimizations -->
-        <td>
+        <td
+          data-bind="jqueryElement: $optimizationSelectElement, visible: supportsOptimizations"
+        ></td>
+        <td data-bind="hidden: supportsOptimizations">
           <select class="form-control" disabled>
             <option>{% trans "N/A" %}</option>
           </select>
         </td>
-        <!-- /ko -->
         <!-- /ko -->
         <td class="col-sm-1 text-center">
           <i

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
@@ -18,6 +18,9 @@
         <!-- ko ifnot: showCaseTileMappingColumn() -->
         <th class="col-sm-2">{% trans "Format" %}</th>
         <!-- /ko -->
+        <!-- ko if: showCaseListOptimizations -->
+        <th class="col-sm-2">{% trans "Optimize" %}</th>
+        <!-- /ko -->
         <!-- ko if: showCaseTileConfigColumns() -->
         <th class="col-sm-1">{% trans "Row/Column" %}</th>
         <th class="col-sm-1">{% trans "Width/Height" %}</th>
@@ -84,6 +87,9 @@
                               'col-sm-2': !$parent.showCaseTileMappingColumn(),
                           }"
         ></td>
+        <!-- ko if: $parent.showCaseListOptimizations -->
+        <td data-bind="jqueryElement: $optimizationSelectElement"></td>
+        <!-- /ko -->
         <!-- ko if: $parent.showCaseTileConfigColumns() -->
         <td class="col-sm-1">
           <select

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -267,6 +267,22 @@
               </div>
             {% endif %}
 
+            {% if request|toggle_enabled:'CASE_LIST_OPTIMIZATIONS' and not module.is_surveys %}
+              <div class="form-group">
+                <label class="control-label {% css_label_class %}">
+                  {% trans "Show Case List Optimizations" %}
+                  <span class="hq-help-template"
+                        data-title="{% trans "Case List Optimizations" %}"
+                        data-content="{% blocktrans %}Set caching and lazy loading for case list columns for better performance. Once saved, reload this page to reveal/hide relevant column on case list. {% endblocktrans %}"
+                  ></span>
+                </label>
+                <div id="show_case_list_optimization_options" class="{% css_field_class %} commcare-feature" data-since-version="2.56">
+                  <input id="show_case_list_optimization_options-input" type="checkbox" data-bind="checked: show_case_list_optimization_options" />
+                  <input type="hidden" name="show_case_list_optimization_options" data-bind="value: show_case_list_optimization_options"/>
+                </div>
+              </div>
+            {% endif %}
+
             {% if request|toggle_enabled:'USH_EMPTY_CASE_LIST_TEXT' %}
             <div class="form-group">
               <label for="no_items_text" class="{% css_label_class %} control-label">

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -9,6 +9,7 @@ from corehq.apps.app_manager.models import (
     CaseSearchAgainLabel,
     CaseSearchLabel,
     CaseSearchProperty,
+    DetailColumn,
     GraphConfiguration,
     GraphSeries,
     ReportAppConfig,
@@ -303,3 +304,177 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
         )
         module.assign_references()
         self.assertXmlHasXpath(factory.app.create_suite(), "./entry/post")
+
+    def test_case_list_optimizations_without_feature_flag(self):
+        factory = AppFactory(build_version='2.56.0')
+        module, form = factory.new_basic_module('m0', 'case')
+
+        module.case_details.short.columns = [
+            DetailColumn(
+                header={'en': 'CachedProperty'},
+                model='case',
+                field="prop1",
+                optimization='cache',
+            )
+        ]
+
+        suite = factory.app.create_suite()
+
+        cached_property_template = """
+        <partial>
+          <field>
+            <header>
+              <text>
+                <locale id="m0.case_short.case_prop1_1.header"/>
+              </text>
+            </header>
+            <template>
+              <text>
+                <xpath function="prop1"/>
+              </text>
+            </template>
+          </field>
+        </partial>
+        """
+
+        self.assertXmlPartialEqual(
+            cached_property_template,
+            suite,
+            './detail[@id="m0_case_short"]/field[1]'
+        )
+
+    @flag_enabled('CASE_LIST_OPTIMIZATIONS')
+    def test_case_list_optimizations_without_necessary_build_version(self):
+        factory = AppFactory(build_version='2.55.0')
+        module, form = factory.new_basic_module('m0', 'case')
+
+        module.case_details.short.columns = [
+            DetailColumn(
+                header={'en': 'CachedProperty'},
+                model='case',
+                field="prop1",
+                optimization='cache',
+            )
+        ]
+
+        suite = factory.app.create_suite()
+
+        cached_property_template = """
+        <partial>
+          <field>
+            <header>
+              <text>
+                <locale id="m0.case_short.case_prop1_1.header"/>
+              </text>
+            </header>
+            <template>
+              <text>
+                <xpath function="prop1"/>
+              </text>
+            </template>
+          </field>
+        </partial>
+        """
+
+        self.assertXmlPartialEqual(
+            cached_property_template,
+            suite,
+            './detail[@id="m0_case_short"]/field[1]'
+        )
+
+    @flag_enabled('CASE_LIST_OPTIMIZATIONS')
+    def test_case_list_optimizations(self):
+        factory = AppFactory(build_version='2.56.0')
+        module, form = factory.new_basic_module('m0', 'case')
+
+        module.case_details.short.columns = [
+            DetailColumn(
+                header={'en': 'CachedProperty'},
+                model='case',
+                field="prop1",
+                optimization='cache',
+            ),
+            DetailColumn(
+                header={'en': 'lazyLoadedProperty'},
+                model='case',
+                field="prop2",
+                optimization='lazy_load',
+            ),
+            DetailColumn(
+                header={'en': 'Cached&LazyLoadedProperty'},
+                model='case',
+                field="prop3",
+                optimization='cache_and_lazy_load',
+            ),
+        ]
+
+        suite = factory.app.create_suite()
+
+        cached_property_template = """
+        <partial>
+          <field cache_enabled="true">
+            <header>
+              <text>
+                <locale id="m0.case_short.case_prop1_1.header"/>
+              </text>
+            </header>
+            <template>
+              <text>
+                <xpath function="prop1"/>
+              </text>
+            </template>
+          </field>
+        </partial>
+        """
+
+        self.assertXmlPartialEqual(
+            cached_property_template,
+            suite,
+            './detail[@id="m0_case_short"]/field[1]'
+        )
+
+        lazy_loaded_property_template = """
+        <partial>
+          <field lazy_loading="true">
+            <header>
+              <text>
+                <locale id="m0.case_short.case_prop2_2.header"/>
+              </text>
+            </header>
+            <template>
+              <text>
+                <xpath function="prop2"/>
+              </text>
+            </template>
+          </field>
+        </partial>
+        """
+
+        self.assertXmlPartialEqual(
+            lazy_loaded_property_template,
+            suite,
+            './detail[@id="m0_case_short"]/field[2]'
+        )
+
+        cached_and_lazy_loaded_property_template = """
+        <partial>
+          <field cache_enabled="true" lazy_loading="true">
+            <header>
+              <text>
+                <locale id="m0.case_short.case_prop3_3.header"/>
+              </text>
+            </header>
+            <template>
+              <text>
+                <xpath function="prop3"/>
+              </text>
+            </template>
+          </field>
+        </partial>
+        """
+
+        self.assertXmlPartialEqual(
+            cached_and_lazy_loaded_property_template,
+            suite,
+            './detail[@id="m0_case_short"]/field[3]'
+        )

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -343,6 +343,9 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
             './detail[@id="m0_case_short"]/field[1]'
         )
 
+        # No optimizations added on detail as well
+        self.assertIn('<detail id="m0_case_short">', str(suite))
+
     @flag_enabled('CASE_LIST_OPTIMIZATIONS')
     def test_case_list_optimizations_without_necessary_build_version(self):
         factory = AppFactory(build_version='2.55.0')
@@ -381,6 +384,9 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
             suite,
             './detail[@id="m0_case_short"]/field[1]'
         )
+
+        # No optimizations added on detail as well
+        self.assertIn('<detail id="m0_case_short">', str(suite))
 
     @flag_enabled('CASE_LIST_OPTIMIZATIONS')
     def test_case_list_optimizations(self):
@@ -478,3 +484,6 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
             suite,
             './detail[@id="m0_case_short"]/field[3]'
         )
+
+        # Optimizations added on detail as well
+        self.assertIn('<detail id="m0_case_short" cache_enabled="true" lazy_loading="true">', str(suite))

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -718,6 +718,7 @@ class TestViewGeneric(ViewsBase):
         'langs', 'details', 'None', 'CUSTOM_LOGO_URL', 'hq', 'selected_form', 'slug', 'env', 'False', 'id',
         'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'EULA_COMPLIANCE', 'sentry',
         'case_list_form_not_allowed_reasons', 'child_module_enabled', 'block', 'IS_ANALYTICS_ENVIRONMENT',
+        'formats_supporting_case_list_optimizations',
     }
 
     expected_keys_form = {

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -685,6 +685,7 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
         "case_list_session_endpoint_id": None,
         'custom_assertions': None,
         'lazy_load_case_list_fields': None,
+        'show_case_list_optimization_options': None,
     }
 
     if attr not in attributes:
@@ -842,6 +843,11 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
 
     if should_edit('lazy_load_case_list_fields'):
         module["lazy_load_case_list_fields"] = request.POST.get("lazy_load_case_list_fields") == 'true'
+
+    if should_edit('show_case_list_optimization_options') and app.supports_case_list_optimizations:
+        module["show_case_list_optimization_options"] = request.POST.get(
+            "show_case_list_optimization_options"
+        ) == 'true'
 
     if should_edit('custom_assertions'):
         module.custom_assertions = validate_custom_assertions(

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -32,6 +32,7 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
 )
 from corehq.apps.app_manager.const import (
     CASE_LIST_FILTER_LOCATIONS_FIXTURE,
+    FORMATS_SUPPORTING_CASE_LIST_OPTIMIZATIONS,
     MOBILE_UCR_VERSION_1,
     REGISTRY_WORKFLOW_LOAD_CASE,
     REGISTRY_WORKFLOW_SMART_LINK,
@@ -161,6 +162,7 @@ def get_module_view_context(request, app, module, lang=None):
             {'test': assertion.test, 'text': assertion.text.get(lang)}
             for assertion in module.custom_assertions
         ],
+        'formats_supporting_case_list_optimizations': FORMATS_SUPPORTING_CASE_LIST_OPTIMIZATIONS,
     }
     module_brief = {
         'id': module.id,

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1376,6 +1376,16 @@ CACHE_AND_INDEX = StaticToggle(
     help_link='https://confluence.dimagi.com/pages/viewpage.action?pageId=41484944',
 )
 
+
+CASE_LIST_OPTIMIZATIONS = StaticToggle(
+    'case_list_optimizations',
+    'Enable options to cache and lazy load case list columns',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN],
+    # ToDo: Add help link when available
+    # help_link=''
+)
+
 CUSTOM_PROPERTIES = StaticToggle(
     'custom_properties',
     'Allow users to add arbitrary custom properties to their application',

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1382,8 +1382,7 @@ CASE_LIST_OPTIMIZATIONS = StaticToggle(
     'Enable options to cache and lazy load case list columns',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
-    # ToDo: Add help link when available
-    # help_link=''
+    help_link='https://dimagi.atlassian.net/wiki/spaces/GS/pages/2939519055/Feature+Usage+Guide+Case+List+Caching+and+Lazy+Loading+in+CommCare',  # noqa: E501
 )
 
 CUSTOM_PROPERTIES = StaticToggle(


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This PR adds optimization options (Caching and Lazy loading) to be set for case list columns that support optimization (based on the format for the column). This setting is then used by CommCare app to provide better performance for heavier case lists.
This change is behind a new feature flag and would deprecate the existing "Cache and Index" feature flag eventually.

Once the feature flag is enabled and the app is configured to be on required commcare version (>2.56),
for each menu, 
the user can mark a setting to show optimization options. This is added to make the user decision explicit to add optimizations.

Under Settings tab for a module, in "Advanced" settings:
![image](https://github.com/user-attachments/assets/60e97843-eb3d-4b32-84fd-f6e3562506d9)

---
with help text
![image](https://github.com/user-attachments/assets/f608d4da-80db-402f-8ad9-ecc9d06ef1ba)

Once set, the user can see the optimizations options for columns in case list and `N/A` where not applicable (depending on the format chosen).

![image](https://github.com/user-attachments/assets/4e3dc6b1-2e41-4e9c-85b8-c420a6e57dc5)


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-4060

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`CASE_LIST_OPTIMIZATIONS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and limited the impact of code changes to only when feature flag is enabled.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests for new changes.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi.atlassian.net/browse/QA-7470

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
