### PR TITLE
Revert "Bump codecov/codecov-action from 4 to 5"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
       env:
         TOKEN: ${{ secrets.CODECOV_TOKEN }}
       if: env.TOKEN != ''
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml


### PR DESCRIPTION
Reverts dimagi/commcare-hq#35560

This is presumably causing test failures like this one: https://github.com/dimagi/commcare-hq/actions/runs/13272564222/job/37055215672