### PR TITLE
Fix broken links due to ga parameter

### DIFF
--- a/corehq/apps/analytics/templates/analytics/forms/bootstrap3/hubspot_cta_form.html
+++ b/corehq/apps/analytics/templates/analytics/forms/bootstrap3/hubspot_cta_form.html
@@ -4,9 +4,9 @@
   {% csrf_token %}
   <div class="modal-body">
     <!-- ko if: showErrorMessage -->
-      <div class="alert alert-warning">
-        <p data-bind="text: errorMessage"></p>
-      </div>
+    <div class="alert alert-warning">
+      <p data-bind="text: errorMessage"></p>
+    </div>
     <!-- /ko -->
     <div class="row">
       <div class="col-sm-6">
@@ -15,10 +15,12 @@
             {% trans "First name" %}<span class="asteriskField">*</span>
           </label>
           <div class="controls">
-            <input type="text"
-                   name="firstname"
-                   data-bind="textInput: firstname"
-                   class="form-control">
+            <input
+              type="text"
+              name="firstname"
+              data-bind="textInput: firstname"
+              class="form-control"
+            />
           </div>
         </div>
       </div>
@@ -28,10 +30,12 @@
             {% trans "Last name" %}<span class="asteriskField">*</span>
           </label>
           <div class="controls">
-            <input type="text"
-                   name="lastname"
-                   data-bind="textInput: lastname"
-                   class="form-control">
+            <input
+              type="text"
+              name="lastname"
+              data-bind="textInput: lastname"
+              class="form-control"
+            />
           </div>
         </div>
       </div>
@@ -41,89 +45,104 @@
         {% trans "Organization" %}<span class="asteriskField">*</span>
       </label>
       <div class="controls">
-        <input type="text"
-               name="company"
-               data-bind="textInput: company"
-               class="form-control">
+        <input
+          type="text"
+          name="company"
+          data-bind="textInput: company"
+          class="form-control"
+        />
       </div>
     </div>
     <div class="form-group">
       <label class="control-label">
-        {% trans "Professional email address" %}<span class="asteriskField">*</span>
+        {% trans "Professional email address" %}<span class="asteriskField"
+          >*</span
+        >
       </label>
       <div class="controls">
-        <input type="email"
-               name="email"
-               data-bind="textInput: email"
-               class="form-control">
+        <input
+          type="email"
+          name="email"
+          data-bind="textInput: email"
+          class="form-control"
+        />
       </div>
     </div>
-    <div class="form-group"
-         data-bind="visible: showContactMethod">
+    <div class="form-group" data-bind="visible: showContactMethod">
       <label class="control-label">
-          {% trans "How should we contact you?" %}<span class="asteriskField">*</span>
+        {% trans "How should we contact you?" %}<span class="asteriskField"
+          >*</span
+        >
       </label>
       <div class="controls">
-        <select name="preferred_method_of_contact"
-                data-bind="value: preferred_method_of_contact"
-                class="select form-control">
+        <select
+          name="preferred_method_of_contact"
+          data-bind="value: preferred_method_of_contact"
+          class="select form-control"
+        >
           <option value="">{% trans "Please Select" %}</option>
           <option value="Phone">{% trans "Phone" %}</option>
           <option value="Skype">{% trans "Skype" %}</option>
           <!-- ko if: useWhatsApp -->
-            <option value="WhatsApp">{% trans "WhatsApp" %}</option>
+          <option value="WhatsApp">{% trans "WhatsApp" %}</option>
           <!-- /ko -->
           <!-- ko if: useGoogleHangouts -->
-            <option value="Google hangouts">{% trans "Google hangouts" %}</option>
+          <option value="Google hangouts">{% trans "Google hangouts" %}</option>
           <!-- /ko -->
         </select>
       </div>
     </div>
-    <div class="form-group"
-         data-bind="visible: showPhoneNumber">
+    <div class="form-group" data-bind="visible: showPhoneNumber">
       <label class="control-label">
-          {% trans "Preferred phone number" %}<span class="asteriskField">*</span>
+        {% trans "Preferred phone number" %}<span class="asteriskField">*</span>
       </label>
       <div class="controls">
-        <input type="text"
-               name="phone"
-               data-bind="textInput: phone"
-               class="form-control">
+        <input
+          type="text"
+          name="phone"
+          data-bind="textInput: phone"
+          class="form-control"
+        />
       </div>
     </div>
-    <div class="form-group"
-         data-bind="visible: showSkype">
+    <div class="form-group" data-bind="visible: showSkype">
       <label class="control-label">
-          {% trans "Skype username" %}<span class="asteriskField">*</span>
+        {% trans "Skype username" %}<span class="asteriskField">*</span>
       </label>
       <div class="controls">
-        <input type="text"
-               name="skype__c"
-               data-bind="textInput: skype__c"
-               class="form-control">
+        <input
+          type="text"
+          name="skype__c"
+          data-bind="textInput: skype__c"
+          class="form-control"
+        />
       </div>
     </div>
-    <div class="form-group"
-         data-bind="visible: showWhatsApp">
+    <div class="form-group" data-bind="visible: showWhatsApp">
       <label class="control-label">
-          {% trans "Preferred WhatsApp number" %}<span class="asteriskField">*</span>
+        {% trans "Preferred WhatsApp number" %}<span class="asteriskField"
+          >*</span
+        >
       </label>
       <div class="controls">
-        <input type="text"
-               name="preferred_whatsapp_number"
-               data-bind="textInput: preferred_whatsapp_number"
-               class="form-control">
+        <input
+          type="text"
+          name="preferred_whatsapp_number"
+          data-bind="textInput: preferred_whatsapp_number"
+          class="form-control"
+        />
       </div>
     </div>
-    <div class="form-group"
-         data-bind="visible: showPreferredLanguage">
+    <div class="form-group" data-bind="visible: showPreferredLanguage">
       <label class="control-label">
         {% trans "Preferred Language" %}<span class="asteriskField">*</span>
       </label>
       <div class="controls">
-        <select name="language__c"
-                data-bind="value: language__c"
-                class="form-control">
+        <select
+          name="language__c"
+          data-bind="value: language__c"
+          class="form-control"
+        >
           <option value="">{% trans "Please Select" %}</option>
           <option value="English">{% trans "English" %}</option>
           <option value="French">{% trans "French" %}</option>
@@ -133,14 +152,21 @@
     </div>
     {% blocktrans %}
       By clicking this button, you agree to Dimagi's
-      <a href="http://www.dimagi.com/terms-of-service/" target="_blank">Terms of Service</a> and
-      <a href="http://www.dimagi.com/terms-privacy/" target="_blank">Privacy Policy</a>.
+      <a href="http://www.dimagi.com/terms-of-service/" target="_blank"
+        >Terms of Service</a
+      >
+      and
+      <a href="http://www.dimagi.com/terms-privacy/" target="_blank"
+        >Privacy Policy</a
+      >.
     {% endblocktrans %}
   </div>
   <div class="modal-footer">
-    <button class="btn btn btn-primary"
-            data-bind="click: submitForm, disable: isSubmitDisabled"
-            type="button">
+    <button
+      class="btn btn btn-primary"
+      data-bind="click: submitForm, disable: isSubmitDisabled"
+      type="button"
+    >
       <!-- ko text: nextButtonText --><!-- /ko -->
     </button>
   </div>

--- a/corehq/apps/analytics/templates/analytics/forms/bootstrap3/hubspot_cta_form.html
+++ b/corehq/apps/analytics/templates/analytics/forms/bootstrap3/hubspot_cta_form.html
@@ -134,7 +134,7 @@
     {% blocktrans %}
       By clicking this button, you agree to Dimagi's
       <a href="http://www.dimagi.com/terms/latest/tos/" target="_blank">Terms of Service</a> and
-      <a href="http://www.dimagi.com/terms/latest/privacy/" target="_blank">Privacy Policy</a>.
+      <a href="http://www.dimagi.com/terms-privacy/" target="_blank">Privacy Policy</a>.
     {% endblocktrans %}
   </div>
   <div class="modal-footer">

--- a/corehq/apps/analytics/templates/analytics/forms/bootstrap3/hubspot_cta_form.html
+++ b/corehq/apps/analytics/templates/analytics/forms/bootstrap3/hubspot_cta_form.html
@@ -133,7 +133,7 @@
     </div>
     {% blocktrans %}
       By clicking this button, you agree to Dimagi's
-      <a href="http://www.dimagi.com/terms/latest/tos/" target="_blank">Terms of Service</a> and
+      <a href="http://www.dimagi.com/terms-of-service/" target="_blank">Terms of Service</a> and
       <a href="http://www.dimagi.com/terms-privacy/" target="_blank">Privacy Policy</a>.
     {% endblocktrans %}
   </div>

--- a/corehq/apps/analytics/templates/analytics/forms/bootstrap5/hubspot_cta_form.html
+++ b/corehq/apps/analytics/templates/analytics/forms/bootstrap5/hubspot_cta_form.html
@@ -112,7 +112,7 @@
     {% blocktrans %}
       By clicking this button, you agree to Dimagi's
       <a href="http://www.dimagi.com/terms/latest/tos/" target="_blank">Terms of Service</a> and
-      <a href="http://www.dimagi.com/terms/latest/privacy/" target="_blank">Privacy Policy</a>.
+      <a href="http://www.dimagi.com/terms-privacy/" target="_blank">Privacy Policy</a>.
     {% endblocktrans %}
   </div>
   <div class="modal-footer">

--- a/corehq/apps/analytics/templates/analytics/forms/bootstrap5/hubspot_cta_form.html
+++ b/corehq/apps/analytics/templates/analytics/forms/bootstrap5/hubspot_cta_form.html
@@ -4,105 +4,124 @@
   {% csrf_token %}
   <div class="modal-body">
     <!-- ko if: showErrorMessage -->
-      <div class="alert alert-warning">
-        <p data-bind="text: errorMessage"></p>
-      </div>
+    <div class="alert alert-warning">
+      <p data-bind="text: errorMessage"></p>
+    </div>
     <!-- /ko -->
     <div class="row mb-3">
       <div class="col-sm-6">
         <label class="form-label">
           {% trans "First name" %}<span class="asteriskField">*</span>
         </label>
-        <input type="text"
-               name="firstname"
-               data-bind="textInput: firstname"
-               class="form-control">
+        <input
+          type="text"
+          name="firstname"
+          data-bind="textInput: firstname"
+          class="form-control"
+        />
       </div>
       <div class="col-sm-6">
         <label class="form-label">
           {% trans "Last name" %}<span class="asteriskField">*</span>
         </label>
-        <input type="text"
-               name="lastname"
-               data-bind="textInput: lastname"
-               class="form-control">
+        <input
+          type="text"
+          name="lastname"
+          data-bind="textInput: lastname"
+          class="form-control"
+        />
       </div>
     </div>
     <div class="mb-3">
       <label class="form-label">
         {% trans "Organization" %}<span class="asteriskField">*</span>
       </label>
-      <input type="text"
-             name="company"
-             data-bind="textInput: company"
-             class="form-control">
+      <input
+        type="text"
+        name="company"
+        data-bind="textInput: company"
+        class="form-control"
+      />
     </div>
     <div class="mb-3">
       <label class="form-label">
-        {% trans "Professional email address" %}<span class="asteriskField">*</span>
+        {% trans "Professional email address" %}<span class="asteriskField"
+          >*</span
+        >
       </label>
-      <input type="email"
-             name="email"
-             data-bind="textInput: email"
-             class="form-control">
+      <input
+        type="email"
+        name="email"
+        data-bind="textInput: email"
+        class="form-control"
+      />
     </div>
-    <div class="mb-3"
-         data-bind="visible: showContactMethod">
+    <div class="mb-3" data-bind="visible: showContactMethod">
       <label class="form-label">
-          {% trans "How should we contact you?" %}<span class="asteriskField">*</span>
+        {% trans "How should we contact you?" %}<span class="asteriskField"
+          >*</span
+        >
       </label>
-      <select name="preferred_method_of_contact"
-              data-bind="value: preferred_method_of_contact"
-              class="form-select">
+      <select
+        name="preferred_method_of_contact"
+        data-bind="value: preferred_method_of_contact"
+        class="form-select"
+      >
         <option value="">{% trans "Please Select" %}</option>
         <option value="Phone">{% trans "Phone" %}</option>
         <option value="Skype">{% trans "Skype" %}</option>
         <!-- ko if: useWhatsApp -->
-          <option value="WhatsApp">{% trans "WhatsApp" %}</option>
+        <option value="WhatsApp">{% trans "WhatsApp" %}</option>
         <!-- /ko -->
         <!-- ko if: useGoogleHangouts -->
-          <option value="Google hangouts">{% trans "Google hangouts" %}</option>
+        <option value="Google hangouts">{% trans "Google hangouts" %}</option>
         <!-- /ko -->
       </select>
     </div>
-    <div class="mb-3"
-         data-bind="visible: showPhoneNumber">
+    <div class="mb-3" data-bind="visible: showPhoneNumber">
       <label class="form-label">
-          {% trans "Preferred phone number" %}<span class="asteriskField">*</span>
+        {% trans "Preferred phone number" %}<span class="asteriskField">*</span>
       </label>
-      <input type="text"
-             name="phone"
-             data-bind="textInput: phone"
-             class="form-control">
+      <input
+        type="text"
+        name="phone"
+        data-bind="textInput: phone"
+        class="form-control"
+      />
     </div>
-    <div class="mb-3"
-         data-bind="visible: showSkype">
+    <div class="mb-3" data-bind="visible: showSkype">
       <label class="form-label">
-          {% trans "Skype username" %}<span class="asteriskField">*</span>
+        {% trans "Skype username" %}<span class="asteriskField">*</span>
       </label>
-      <input type="text"
-             name="skype__c"
-             data-bind="textInput: skype__c"
-             class="form-control">
+      <input
+        type="text"
+        name="skype__c"
+        data-bind="textInput: skype__c"
+        class="form-control"
+      />
     </div>
-    <div class="mb-3"
-         data-bind="visible: showWhatsApp">
+    <div class="mb-3" data-bind="visible: showWhatsApp">
       <label class="form-label">
-          {% trans "Preferred WhatsApp number" %}<span class="asteriskField">*</span>
+        {% trans "Preferred WhatsApp number" %}<span class="asteriskField"
+          >*</span
+        >
       </label>
-      <input type="text"
-             name="preferred_whatsapp_number"
-             data-bind="textInput: preferred_whatsapp_number"
-             class="form-control">
+      <input
+        type="text"
+        name="preferred_whatsapp_number"
+        data-bind="textInput: preferred_whatsapp_number"
+        class="form-control"
+      />
     </div>
-    <div class="mb-3"
-         data-bind="visible: showPreferredLanguage">
+    <div class="mb-3" data-bind="visible: showPreferredLanguage">
       <label class="form-label">
         {% trans "Preferred Language" %}<span class="asteriskField">*</span>
       </label>
-      <select name="language__c"
-              data-bind="value: language__c"
-              class="form-select">
+      <select
+        name="language__c"
+        data-bind="value: language__c"
+        class="form-select"
+      >
         <option value="">{% trans "Please Select" %}</option>
         <option value="English">{% trans "English" %}</option>
         <option value="French">{% trans "French" %}</option>
@@ -111,14 +130,21 @@
     </div>
     {% blocktrans %}
       By clicking this button, you agree to Dimagi's
-      <a href="http://www.dimagi.com/terms/terms-of-service/" target="_blank">Terms of Service</a> and
-      <a href="http://www.dimagi.com/terms-privacy/" target="_blank">Privacy Policy</a>.
+      <a href="http://www.dimagi.com/terms/terms-of-service/" target="_blank"
+        >Terms of Service</a
+      >
+      and
+      <a href="http://www.dimagi.com/terms-privacy/" target="_blank"
+        >Privacy Policy</a
+      >.
     {% endblocktrans %}
   </div>
   <div class="modal-footer">
-    <button class="btn btn btn-primary"
-            data-bind="click: submitForm, disable: isSubmitDisabled"
-            type="button">
+    <button
+      class="btn btn btn-primary"
+      data-bind="click: submitForm, disable: isSubmitDisabled"
+      type="button"
+    >
       <!-- ko text: nextButtonText --><!-- /ko -->
     </button>
   </div>

--- a/corehq/apps/analytics/templates/analytics/forms/bootstrap5/hubspot_cta_form.html
+++ b/corehq/apps/analytics/templates/analytics/forms/bootstrap5/hubspot_cta_form.html
@@ -111,7 +111,7 @@
     </div>
     {% blocktrans %}
       By clicking this button, you agree to Dimagi's
-      <a href="http://www.dimagi.com/terms/latest/tos/" target="_blank">Terms of Service</a> and
+      <a href="http://www.dimagi.com/terms/terms-of-service/" target="_blank">Terms of Service</a> and
       <a href="http://www.dimagi.com/terms-privacy/" target="_blank">Privacy Policy</a>.
     {% endblocktrans %}
   </div>

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -874,7 +874,7 @@ class PrivacySecurityForm(forms.Form):
             "and CommCare system administrators will also have direct access "
             "to data infrastructure strictly for the purposes of system administration "
             "as outlined in our "
-            '<a href="https://www.dimagi.com/terms/latest/privacy/">Privacy Policy</a>.'
+            '<a href="https://www.dimagi.com/terms-privacy/">Privacy Policy</a>.'
         )
     )
     secure_submissions = BooleanField(

--- a/corehq/apps/domain/templates/domain/activate_transfer_domain.html
+++ b/corehq/apps/domain/templates/domain/activate_transfer_domain.html
@@ -13,7 +13,7 @@
           <p class="lead">
             {% blocktrans with domain=transfer.domain%}
               By clicking "accept" below you acknowledge that you accept full ownership of this project space ("{{ domain }}").
-              You agree to be bound by the terms of Dimagi's <a href="https://www.dimagi.com/terms/latest/privacy/">Terms of Service and Business Agreement</a>.
+              You agree to be bound by the terms of Dimagi's <a href="https://www.dimagi.com/terms-privacy/">Terms of Service and Business Agreement</a>.
               By accepting this agreement, your are acknowledging you have permission and authority to accept these terms. A Dimagi representative will notify you when the transfer is complete.
             {% endblocktrans %}
           </p>

--- a/corehq/apps/domain/templates/domain/activate_transfer_domain.html
+++ b/corehq/apps/domain/templates/domain/activate_transfer_domain.html
@@ -11,21 +11,36 @@
       <div class="col-lg-8 col-sm-12">
         {% if transfer %}
           <p class="lead">
-            {% blocktrans with domain=transfer.domain%}
-              By clicking "accept" below you acknowledge that you accept full ownership of this project space ("{{ domain }}").
-              You agree to be bound by the terms of Dimagi's <a href="https://www.dimagi.com/terms-privacy/">Terms of Service and Business Agreement</a>.
-              By accepting this agreement, your are acknowledging you have permission and authority to accept these terms. A Dimagi representative will notify you when the transfer is complete.
+            {% blocktrans with domain=transfer.domain %}
+              By clicking "accept" below you acknowledge that you accept full
+              ownership of this project space ("{{ domain }}"). You agree to be
+              bound by the terms of Dimagi's
+              <a href="https://www.dimagi.com/terms-privacy/"
+                >Terms of Service and Business Agreement</a
+              >. By accepting this agreement, your are acknowledging you have
+              permission and authority to accept these terms. A Dimagi
+              representative will notify you when the transfer is complete.
             {% endblocktrans %}
           </p>
           <div class="row">
             <div class="col-lg-2">
-              <form action="{{ transfer.activate_url }}" method="POST">{% csrf_token %}
-                <input type="submit" value="{% trans "Accept" %}" class="btn btn-primary"/>
+              <form action="{{ transfer.activate_url }}" method="POST">
+                {% csrf_token %}
+                <input
+                  type="submit"
+                  value="{% trans "Accept" %}"
+                  class="btn btn-primary"
+                />
               </form>
             </div>
             <div class="col-lg-2">
-              <form action="{{ transfer.deactivate_url }}" method="POST">{% csrf_token %}
-                <input type="submit" value="{% trans "Decline" %}" class="btn btn-outline-danger"/>
+              <form action="{{ transfer.deactivate_url }}" method="POST">
+                {% csrf_token %}
+                <input
+                  type="submit"
+                  value="{% trans "Decline" %}"
+                  class="btn btn-outline-danger"
+                />
               </form>
             </div>
           </div>

--- a/corehq/apps/domain/templates/domain/admin/feature_previews.html
+++ b/corehq/apps/domain/templates/domain/admin/feature_previews.html
@@ -3,20 +3,16 @@
 {% load hq_shared_tags %}
 
 {% block page_content %}
-  <p class="lead">
-    {% trans "Feature Previews" %}
-  </p>
+  <p class="lead">{% trans "Feature Previews" %}</p>
   <div class="row">
     <div class="col-lg-6">
       <p class="help-block">
-        <strong>
-          {% trans "What are Feature Previews?" %}
-        </strong>
-        <br/>
+        <strong> {% trans "What are Feature Previews?" %} </strong>
+        <br />
         {% blocktrans %}
           Before we invest in making certain product features generally
-          available, we release them as Feature Previews to learn the
-          following two things from usage data and qualitative feedback.
+          available, we release them as Feature Previews to learn the following
+          two things from usage data and qualitative feedback.
         {% endblocktrans %}
       </p>
       <ul>
@@ -24,10 +20,10 @@
           <p class="help-block">
             {% blocktrans %}
               <strong>Perceived Value:</strong>
-              The biggest risk in product development is to
-              build something that offers little value to our users. As such,
-              we make Feature Previews generally available only if they have
-              high perceived value.
+              The biggest risk in product development is to build something that
+              offers little value to our users. As such, we make Feature
+              Previews generally available only if they have high perceived
+              value.
             {% endblocktrans %}
           </p>
         </li>
@@ -35,21 +31,21 @@
           <p class="help-block">
             {% blocktrans %}
               <strong>User Experience:</strong>
-              Even if a feature has high perceived value,
-              it is important that the user experience of the feature is
-              optimized such that our users actually receive the value.
-              As such, we make high value Feature Previews generally
-              available after we optimize the user experience.
+              Even if a feature has high perceived value, it is important that
+              the user experience of the feature is optimized such that our
+              users actually receive the value. As such, we make high value
+              Feature Previews generally available after we optimize the user
+              experience.
             {% endblocktrans %}
           </p>
         </li>
       </ul>
       <p class="help-block">
         {% blocktrans %}
-          Feature Previews are in active product development, therefore
-          should not be used for business critical workflows. We encourage
-          you to use Feature Previews and provide us feedback, however
-          please note that Feature Previews:
+          Feature Previews are in active product development, therefore should
+          not be used for business critical workflows. We encourage you to use
+          Feature Previews and provide us feedback, however please note that
+          Feature Previews:
         {% endblocktrans %}
       </p>
       <ul>
@@ -79,9 +75,12 @@
             {% blocktrans %}
               Are not subject to any warranties on current and future
               availability. Please refer to our
-              <a href="http://www.dimagi.com/terms/terms-of-service/"
-                 target="_blank">terms</a> to
-              learn more.
+              <a
+                href="http://www.dimagi.com/terms/terms-of-service/"
+                target="_blank"
+                >terms</a
+              >
+              to learn more.
             {% endblocktrans %}
           </p>
         </li>
@@ -95,11 +94,11 @@
         <p class="mb-0">
           {% blocktrans %}
             The feature flags <strong>Control Mapping in Case List</strong>,
-            <strong>Custom Calculations in Case List</strong>, <strong>Custom
-            Single and Multiple Answer Questions</strong>, and <strong>Icons in
-            Case List</strong> are now add-ons for individual apps. To turn
-            them on, go to the application's settings and choose the
-            <strong>Add-Ons</strong> tab.
+            <strong>Custom Calculations in Case List</strong>,
+            <strong>Custom Single and Multiple Answer Questions</strong>, and
+            <strong>Icons in Case List</strong> are now add-ons for individual
+            apps. To turn them on, go to the application's settings and choose
+            the <strong>Add-Ons</strong> tab.
           {% endblocktrans %}
         </p>
       </div>
@@ -110,28 +109,36 @@
     <div class="col-md-10">
       <form action="" method="post">
         {% csrf_token %}
-        <button type="submit" class="btn btn-primary">{% trans "Update previews" %}</button>
+        <button type="submit" class="btn btn-primary">
+          {% trans "Update previews" %}
+        </button>
         <table class="table table-striped">
           <thead>
-          <th class="col-md-3">{% trans "Feature Name" %}</th>
-          <th>{% trans "Description" %}</th>
-          <th>{% trans "Enable" %}</th>
+            <th class="col-md-3">{% trans "Feature Name" %}</th>
+            <th>{% trans "Description" %}</th>
+            <th>{% trans "Enable" %}</th>
           </thead>
           <tbody>
-          {% for feature, enabled in features %}
-            <tr>
-              <td>{{ feature.label }}</td>
-              <td>
-                {{ feature.description }}<br/>
-                {% if feature.help_link %}
-                  <a href="{{ feature.help_link }}" target="_blank">{% trans "More information" %}</a>
-                {% endif %}
-              </td>
-              <td>
-                <input type="checkbox" name="{{ feature.slug }}" {% if enabled %}checked{% endif %}/>
-              </td>
-            </tr>
-          {% endfor %}
+            {% for feature, enabled in features %}
+              <tr>
+                <td>{{ feature.label }}</td>
+                <td>
+                  {{ feature.description }}<br />
+                  {% if feature.help_link %}
+                    <a href="{{ feature.help_link }}" target="_blank"
+                      >{% trans "More information" %}</a
+                    >
+                  {% endif %}
+                </td>
+                <td>
+                  <input
+                    type="checkbox"
+                    name="{{ feature.slug }}"
+                    {% if enabled %}checked{% endif %}
+                  />
+                </td>
+              </tr>
+            {% endfor %}
           </tbody>
         </table>
       </form>

--- a/corehq/apps/domain/templates/domain/admin/feature_previews.html
+++ b/corehq/apps/domain/templates/domain/admin/feature_previews.html
@@ -79,7 +79,7 @@
             {% blocktrans %}
               Are not subject to any warranties on current and future
               availability. Please refer to our
-              <a href="http://www.dimagi.com/terms/latest/tos/"
+              <a href="http://www.dimagi.com/terms/terms-of-service/"
                  target="_blank">terms</a> to
               learn more.
             {% endblocktrans %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -2,7 +2,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 {% load menu_tags %}
-
 {% js_entry_b3 'accounting/js/pricing_table' %}
 
 {% block form_content %}
@@ -26,11 +25,14 @@
   </p>
 
   <section id="plans" class="ko-template">
-
     <p class="switch-label text-center">
       {% trans "Pay Monthly" %}
       <label class="switch">
-        <input type="checkbox" id="pricing-toggle" data-bind="{checked: oShowAnnualPricing}">
+        <input
+          type="checkbox"
+          id="pricing-toggle"
+          data-bind="{checked: oShowAnnualPricing}"
+        />
         <span class="slider round slider-blue slider-blue-on"></span>
       </label>
       {% trans "Pay Annually" %}
@@ -42,11 +44,12 @@
       {% endblocktrans %}
     </p>
 
-    <p class="refund-text text-center"
-       data-bind="css: oRefundCss">
+    <p class="refund-text text-center" data-bind="css: oRefundCss">
       <i class="fa fa-check"></i>
-      <a href="https://dimagi.com/terms/terms-of-service/"
-         class="check-icon blue">
+      <a
+        href="https://dimagi.com/terms/terms-of-service/"
+        class="check-icon blue"
+      >
         {% trans '90 day refund policy' %}
       </a>
     </p>
@@ -54,22 +57,26 @@
     <div class="select-plan-row">
       <!-- ko foreach: oPlanOptions -->
       <div class="select-plan-col">
-        <a href="#"
-           class="tile"
-           data-bind="css: oCssClass, click: selectPlan">
+        <a href="#" class="tile" data-bind="css: oCssClass, click: selectPlan">
           <h3 data-bind="text: oName"></h3>
-          <p class="pricing-type"
-             data-bind="text: oPricingTypeText, css: oPricingTypeCssClass"></p>
+          <p
+            class="pricing-type"
+            data-bind="text: oPricingTypeText, css: oPricingTypeCssClass"
+          ></p>
 
           <p class="plan-price" data-bind="text: oDisplayPrice"></p>
           <p class="plan-monthly-label">
             {% trans "monthly" %}
-            <span data-bind="visible: oDisplayDiscountNotice">({% trans 'discounted' %})</span>
+            <span data-bind="visible: oDisplayDiscountNotice"
+              >({% trans 'discounted' %})</span
+            >
           </p>
           <p class="plan-desc" data-bind="text: oDescription"></p>
 
-          <p class="plan-downgrade-notice text-warning"
-             data-bind="visible: oShowDowngradeNotice">
+          <p
+            class="plan-downgrade-notice text-warning"
+            data-bind="visible: oShowDowngradeNotice"
+          >
             <i class="fa fa-warning"></i>
             {% blocktrans %}
               This plan will be downgrading to
@@ -78,8 +85,10 @@
             {% endblocktrans %}
           </p>
 
-          <p class="plan-downgrade-notice text-warning"
-             data-bind="visible: oShowPausedNotice">
+          <p
+            class="plan-downgrade-notice text-warning"
+            data-bind="visible: oShowPausedNotice"
+          >
             <i class="fa fa-warning"></i>
             {% blocktrans %}
               This plan will be pausing on<br />
@@ -87,13 +96,11 @@
             {% endblocktrans %}
           </p>
 
-          <div class="btn btn-current"
-               data-bind="visible: oIsCurrentPlan">
+          <div class="btn btn-current" data-bind="visible: oIsCurrentPlan">
             {% trans "Current Plan" %}
           </div>
 
-          <div class="btn btn-select"
-               data-bind="visible: !oIsCurrentPlan()">
+          <div class="btn btn-select" data-bind="visible: !oIsCurrentPlan()">
             {% trans "Select Plan" %}
           </div>
         </a>
@@ -101,10 +108,14 @@
       <!-- /ko -->
     </div>
 
-    <div data-bind="visible: !oIsCurrentPlanCommunity() && !oIsNextPlanPaused() && !oIsCurrentPlanPaused()">
-      <a href="#"
-         class="tile tile-paused"
-         data-bind="click: selectPausedPlan, css: oPausedCss">
+    <div
+      data-bind="visible: !oIsCurrentPlanCommunity() && !oIsNextPlanPaused() && !oIsCurrentPlanPaused()"
+    >
+      <a
+        href="#"
+        class="tile tile-paused"
+        data-bind="click: selectPausedPlan, css: oPausedCss"
+      >
         <h4 class="text-center">
           {% blocktrans %}
             Pause Subscription
@@ -118,8 +129,8 @@
         <ul>
           <li>
             {% blocktrans %}
-              You will lose access to your project space, but you will be
-              able to re-subscribe anytime in the future.
+              You will lose access to your project space, but you will be able
+              to re-subscribe anytime in the future.
             {% endblocktrans %}
           </li>
           <li>
@@ -131,8 +142,10 @@
       </a>
     </div>
 
-    <div class="alert {% if can_domain_unpause %}alert-info{% else %}alert-danger{% endif %} text-center"
-         data-bind="visible: oIsCurrentPlanPaused">
+    <div
+      class="alert {% if can_domain_unpause %}alert-info{% else %}alert-danger{% endif %} text-center"
+      data-bind="visible: oIsCurrentPlanPaused"
+    >
       <p class="lead">
         {% if can_domain_unpause %}
           <i class="fa-regular fa-circle-pause"></i>
@@ -146,39 +159,45 @@
             Your subscription is currently paused because you have
             <a href="{{ url_statements }}">past-due invoices</a>.
           {% endblocktrans %}
-            <br />
+          <br />
           {% blocktrans %}
-            You will not be allowed to un-pause your project until
-            these invoices are paid.
+            You will not be allowed to un-pause your project until these
+            invoices are paid.
           {% endblocktrans %}
         {% endif %}
       </p>
     </div>
 
-    <div class="alert alert-warning text-center"
-         data-bind="visible: oIsNextPlanPaused">
+    <div
+      class="alert alert-warning text-center"
+      data-bind="visible: oIsNextPlanPaused"
+    >
       <i class="fa fa-warning"></i>
       {% blocktrans %}
         Your subscription will be pausing on
-        <span data-bind="text: oStartDateAfterMinimumSubscription"></span> unless
-        you select a different plan above.
+        <span data-bind="text: oStartDateAfterMinimumSubscription"></span>
+        unless you select a different plan above.
       {% endblocktrans %}
     </div>
 
-    <div class="alert alert-warning text-center"
-         style="margin-top: 20px;"
-         data-bind="visible: oIsNextPlanDowngrade">
+    <div
+      class="alert alert-warning text-center"
+      style="margin-top: 20px;"
+      data-bind="visible: oIsNextPlanDowngrade"
+    >
       <i class="fa fa-warning"></i>
       {% blocktrans %}
         Your subscription will be downgrading to
         <span data-bind="text: oNextSubscription"></span> on
-        <span data-bind="text: oStartDateAfterMinimumSubscription"></span> unless
-        you select a different plan above.
+        <span data-bind="text: oStartDateAfterMinimumSubscription"></span>
+        unless you select a different plan above.
       {% endblocktrans %}
     </div>
 
-    <div class="community-plan-notice alert alert-info text-center"
-         data-bind="visible: oIsCurrentPlanCommunity">
+    <div
+      class="community-plan-notice alert alert-info text-center"
+      data-bind="visible: oIsCurrentPlanCommunity"
+    >
       <p class="lead">
         {% blocktrans %}
           You are currently on the FREE CommCare Community plan.
@@ -192,52 +211,67 @@
       {% else %}
         action="{% url 'confirm_selected_plan' domain %}"
       {% endif %}
-        class="form"
-        id="select-plan-form"
-        method="post"
-        data-bind="visible: oShowNext"
-        style="display: none;"
-        action="{% url 'confirm_selected_plan' domain %}">
+      class="form"
+      id="select-plan-form"
+      method="post"
+      data-bind="visible: oShowNext"
+      style="display: none;"
+      action="{% url 'confirm_selected_plan' domain %}"
+    >
       {% csrf_token %}
       {% if is_renewal %}
-        <input type="hidden" name="from_plan_page" value="true">
+        <input type="hidden" name="from_plan_page" value="true" />
       {% endif %}
 
       {% if can_domain_unpause %}
-        <input type="hidden" name="plan_edition" data-bind="value: oSelectedPlan">
+        <input
+          type="hidden"
+          name="plan_edition"
+          data-bind="value: oSelectedPlan"
+        />
         <div class="text-center plan-next">
-          <button type="submit"
-                  class="btn btn-primary btn-lg"
-                  data-bind="click: openMinimumSubscriptionModal, disable: oIsSubmitDisabled">
+          <button
+            type="submit"
+            class="btn btn-primary btn-lg"
+            data-bind="click: openMinimumSubscriptionModal, disable: oIsSubmitDisabled"
+          >
             {% trans 'Next' %}
           </button>
         </div>
       {% else %}
         <div class="text-center plan-next">
-          <button type="button"
-                  class="btn btn-primary btn-lg"
-                  disabled="disabled">
+          <button
+            type="button"
+            class="btn btn-primary btn-lg"
+            disabled="disabled"
+          >
             {% trans 'Next' %}
           </button>
         </div>
       {% endif %}
     </form>
 
-    <form action="{% url 'annual_plan_request_quote' domain %}"
-          data-bind="visible: !oShowNext()">
+    <form
+      action="{% url 'annual_plan_request_quote' domain %}"
+      data-bind="visible: !oShowNext()"
+    >
       {% csrf_token %}
-      <input type="hidden" name="plan_edition" data-bind="value: oSelectedPlan">
+      <input
+        type="hidden"
+        name="plan_edition"
+        data-bind="value: oSelectedPlan"
+      />
       <div class="text-center plan-next">
         <button class="btn btn-primary btn-lg" data-bind="click: contactSales">
           {% trans 'Talk to Sales' %}
         </button>
       </div>
     </form>
-
   </section>
 {% endblock %}
 
-{% block modals %}{{ block.super }}
+{% block modals %}
+  {{ block.super }}
   <div class="modal fade" id="modal-minimum-subscription">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -248,12 +282,18 @@
           </button>
           <h4 class="modal-title">Downgrading?</h4>
         </div>
-        <div class="modal-body">
-          <br><br>
-        </div>
+        <div class="modal-body"><br /><br /></div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary" data-dismiss="modal">{% trans "Dismiss" %}</button>
-          <button type="button" class="btn btn-danger" data-bind="click: submitDowngradeForm">{% trans "Continue" %}</button>
+          <button type="button" class="btn btn-primary" data-dismiss="modal">
+            {% trans "Dismiss" %}
+          </button>
+          <button
+            type="button"
+            class="btn btn-danger"
+            data-bind="click: submitDowngradeForm"
+          >
+            {% trans "Continue" %}
+          </button>
         </div>
       </div>
     </div>

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -45,7 +45,7 @@
     <p class="refund-text text-center"
        data-bind="css: oRefundCss">
       <i class="fa fa-check"></i>
-      <a href="https://dimagi.com/terms/latest/tos/"
+      <a href="https://dimagi.com/terms/terms-of-service/"
          class="check-icon blue">
         {% trans '90 day refund policy' %}
       </a>

--- a/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
@@ -2,7 +2,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 {% load menu_tags %}
-
 {% js_entry 'accounting/js/pricing_table' %}
 
 {% block form_content %}
@@ -26,11 +25,15 @@
   </p>
 
   <section id="plans" class="ko-template">
-
     <p class="switch-label text-center">
       {% trans "Pay Monthly" %}
       <label class="switch">
-        <input type="checkbox" id="pricing-toggle" data-bind="{checked: oShowAnnualPricing}">  {# todo B5: css-checkbox #}
+        <input
+          type="checkbox"
+          id="pricing-toggle"
+          data-bind="{checked: oShowAnnualPricing}"
+        />
+        {# todo B5: css-checkbox #}
         <span class="slider round slider-blue slider-blue-on"></span>
       </label>
       {% trans "Pay Annually" %}
@@ -38,15 +41,16 @@
 
     <p class="text-center">
       {% blocktrans %}
-        Save close to 20% when you pay annually.  {# todo B5: css-close #}
+        Save close to 20% when you pay annually. {# todo B5: css-close #}
       {% endblocktrans %}
     </p>
 
-    <p class="refund-text text-center"
-       data-bind="css: oRefundCss">
+    <p class="refund-text text-center" data-bind="css: oRefundCss">
       <i class="fa fa-check"></i>
-      <a href="https://dimagi.com/terms/terms-of-service/"
-         class="check-icon blue">
+      <a
+        href="https://dimagi.com/terms/terms-of-service/"
+        class="check-icon blue"
+      >
         {% trans '90 day refund policy' %}
       </a>
     </p>
@@ -54,22 +58,26 @@
     <div class="select-plan-row">
       <!-- ko foreach: oPlanOptions -->
       <div class="select-plan-col">
-        <a href="#"
-           class="tile"
-           data-bind="css: oCssClass, click: selectPlan">
+        <a href="#" class="tile" data-bind="css: oCssClass, click: selectPlan">
           <h3 data-bind="text: oName"></h3>
-          <p class="pricing-type"
-             data-bind="text: oPricingTypeText, css: oPricingTypeCssClass"></p>
+          <p
+            class="pricing-type"
+            data-bind="text: oPricingTypeText, css: oPricingTypeCssClass"
+          ></p>
 
           <p class="plan-price" data-bind="text: oDisplayPrice"></p>
           <p class="plan-monthly-label">
             {% trans "monthly" %}
-            <span data-bind="visible: oDisplayDiscountNotice">({% trans 'discounted' %})</span>
+            <span data-bind="visible: oDisplayDiscountNotice"
+              >({% trans 'discounted' %})</span
+            >
           </p>
           <p class="plan-desc" data-bind="text: oDescription"></p>
 
-          <p class="plan-downgrade-notice text-warning"
-             data-bind="visible: oShowDowngradeNotice">
+          <p
+            class="plan-downgrade-notice text-warning"
+            data-bind="visible: oShowDowngradeNotice"
+          >
             <i class="fa fa-warning"></i>
             {% blocktrans %}
               This plan will be downgrading to
@@ -78,8 +86,10 @@
             {% endblocktrans %}
           </p>
 
-          <p class="plan-downgrade-notice text-warning"
-             data-bind="visible: oShowPausedNotice">
+          <p
+            class="plan-downgrade-notice text-warning"
+            data-bind="visible: oShowPausedNotice"
+          >
             <i class="fa fa-warning"></i>
             {% blocktrans %}
               This plan will be pausing on<br />
@@ -87,13 +97,11 @@
             {% endblocktrans %}
           </p>
 
-          <div class="btn btn-current"
-               data-bind="visible: oIsCurrentPlan">
+          <div class="btn btn-current" data-bind="visible: oIsCurrentPlan">
             {% trans "Current Plan" %}
           </div>
 
-          <div class="btn btn-select"
-               data-bind="visible: !oIsCurrentPlan()">
+          <div class="btn btn-select" data-bind="visible: !oIsCurrentPlan()">
             {% trans "Select Plan" %}
           </div>
         </a>
@@ -101,10 +109,14 @@
       <!-- /ko -->
     </div>
 
-    <div data-bind="visible: !oIsCurrentPlanCommunity() && !oIsNextPlanPaused() && !oIsCurrentPlanPaused()">
-      <a href="#"
-         class="tile tile-paused"
-         data-bind="click: selectPausedPlan, css: oPausedCss">
+    <div
+      data-bind="visible: !oIsCurrentPlanCommunity() && !oIsNextPlanPaused() && !oIsCurrentPlanPaused()"
+    >
+      <a
+        href="#"
+        class="tile tile-paused"
+        data-bind="click: selectPausedPlan, css: oPausedCss"
+      >
         <h4 class="text-center">
           {% blocktrans %}
             Pause Subscription
@@ -118,8 +130,8 @@
         <ul>
           <li>
             {% blocktrans %}
-              You will lose access to your project space, but you will be
-              able to re-subscribe anytime in the future.
+              You will lose access to your project space, but you will be able
+              to re-subscribe anytime in the future.
             {% endblocktrans %}
           </li>
           <li>
@@ -131,8 +143,10 @@
       </a>
     </div>
 
-    <div class="alert {% if can_domain_unpause %}alert-info{% else %}alert-danger{% endif %} text-center"
-         data-bind="visible: oIsCurrentPlanPaused">
+    <div
+      class="alert {% if can_domain_unpause %}alert-info{% else %}alert-danger{% endif %} text-center"
+      data-bind="visible: oIsCurrentPlanPaused"
+    >
       <p class="lead">
         {% if can_domain_unpause %}
           <i class="fa-regular fa-circle-pause"></i>
@@ -146,39 +160,46 @@
             Your subscription is currently paused because you have
             <a href="{{ url_statements }}">past-due invoices</a>.
           {% endblocktrans %}
-            <br />
+          <br />
           {% blocktrans %}
-            You will not be allowed to un-pause your project until
-            these invoices are paid.
+            You will not be allowed to un-pause your project until these
+            invoices are paid.
           {% endblocktrans %}
         {% endif %}
       </p>
     </div>
 
-    <div class="alert alert-warning text-center"
-         data-bind="visible: oIsNextPlanPaused">
+    <div
+      class="alert alert-warning text-center"
+      data-bind="visible: oIsNextPlanPaused"
+    >
       <i class="fa fa-warning"></i>
       {% blocktrans %}
         Your subscription will be pausing on
-        <span data-bind="text: oStartDateAfterMinimumSubscription"></span> unless
-        you select a different plan above.
+        <span data-bind="text: oStartDateAfterMinimumSubscription"></span>
+        unless you select a different plan above.
       {% endblocktrans %}
     </div>
 
-    <div class="alert alert-warning text-center"
-         style="margin-top: 20px;"  {# todo B5: inline-style #}
-         data-bind="visible: oIsNextPlanDowngrade">
+    <div
+      class="alert alert-warning text-center"
+      style="margin-top: 20px;"
+      {# todo B5: inline-style #}
+      data-bind="visible: oIsNextPlanDowngrade"
+    >
       <i class="fa fa-warning"></i>
       {% blocktrans %}
         Your subscription will be downgrading to
         <span data-bind="text: oNextSubscription"></span> on
-        <span data-bind="text: oStartDateAfterMinimumSubscription"></span> unless
-        you select a different plan above.
+        <span data-bind="text: oStartDateAfterMinimumSubscription"></span>
+        unless you select a different plan above.
       {% endblocktrans %}
     </div>
 
-    <div class="community-plan-notice alert alert-info text-center"
-         data-bind="visible: oIsCurrentPlanCommunity">
+    <div
+      class="community-plan-notice alert alert-info text-center"
+      data-bind="visible: oIsCurrentPlanCommunity"
+    >
       <p class="lead">
         {% blocktrans %}
           You are currently on the FREE CommCare Community plan.
@@ -192,68 +213,91 @@
       {% else %}
         action="{% url 'confirm_selected_plan' domain %}"
       {% endif %}
-        class="form"
-        id="select-plan-form"
-        method="post"
-        data-bind="visible: oShowNext"
-        style="display: none;"  {# todo B5: inline-style #}
-        action="{% url 'confirm_selected_plan' domain %}">
+      class="form"
+      id="select-plan-form"
+      method="post"
+      data-bind="visible: oShowNext"
+      style="display: none;"
+      {# todo B5: inline-style #}
+      action="{% url 'confirm_selected_plan' domain %}"
+    >
       {% csrf_token %}
       {% if is_renewal %}
-        <input type="hidden" name="from_plan_page" value="true">
+        <input type="hidden" name="from_plan_page" value="true" />
       {% endif %}
 
       {% if can_domain_unpause %}
-        <input type="hidden" name="plan_edition" data-bind="value: oSelectedPlan">
+        <input
+          type="hidden"
+          name="plan_edition"
+          data-bind="value: oSelectedPlan"
+        />
         <div class="text-center plan-next">
-          <button type="submit"
-                  class="btn btn-primary btn-lg"
-                  data-bind="click: openMinimumSubscriptionModal, disable: oIsSubmitDisabled">
+          <button
+            type="submit"
+            class="btn btn-primary btn-lg"
+            data-bind="click: openMinimumSubscriptionModal, disable: oIsSubmitDisabled"
+          >
             {% trans 'Next' %}
           </button>
         </div>
       {% else %}
         <div class="text-center plan-next">
-          <button type="button"
-                  class="btn btn-primary btn-lg"
-                  disabled="disabled">
+          <button
+            type="button"
+            class="btn btn-primary btn-lg"
+            disabled="disabled"
+          >
             {% trans 'Next' %}
           </button>
         </div>
       {% endif %}
     </form>
 
-    <form action="{% url 'annual_plan_request_quote' domain %}"
-          data-bind="visible: !oShowNext()">
+    <form
+      action="{% url 'annual_plan_request_quote' domain %}"
+      data-bind="visible: !oShowNext()"
+    >
       {% csrf_token %}
-      <input type="hidden" name="plan_edition" data-bind="value: oSelectedPlan">
+      <input
+        type="hidden"
+        name="plan_edition"
+        data-bind="value: oSelectedPlan"
+      />
       <div class="text-center plan-next">
         <button class="btn btn-primary btn-lg" data-bind="click: contactSales">
           {% trans 'Talk to Sales' %}
         </button>
       </div>
     </form>
-
   </section>
 {% endblock %}
 
-{% block modals %}{{ block.super }}
+{% block modals %}
+  {{ block.super }}
   <div class="modal fade" id="modal-minimum-subscription">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="btn-close" data-bs-dismiss="modal">  {# todo B5: css-close #}
+          <button type="button" class="btn-close" data-bs-dismiss="modal">
+            {# todo B5: css-close #}
             <span aria-hidden="true">&times;</span>
             <span class="sr-only">{% trans "Close" %}</span>
           </button>
           <h4 class="modal-title">Downgrading?</h4>
         </div>
-        <div class="modal-body">
-          <br><br>
-        </div>
+        <div class="modal-body"><br /><br /></div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">{% trans "Dismiss" %}</button>
-          <button type="button" class="btn btn-outline-danger" data-bind="click: submitDowngradeForm">{% trans "Continue" %}</button>
+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">
+            {% trans "Dismiss" %}
+          </button>
+          <button
+            type="button"
+            class="btn btn-outline-danger"
+            data-bind="click: submitDowngradeForm"
+          >
+            {% trans "Continue" %}
+          </button>
         </div>
       </div>
     </div>

--- a/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
@@ -45,7 +45,7 @@
     <p class="refund-text text-center"
        data-bind="css: oRefundCss">
       <i class="fa fa-check"></i>
-      <a href="https://dimagi.com/terms/latest/tos/"
+      <a href="https://dimagi.com/terms/terms-of-service/"
          class="check-icon blue">
         {% trans '90 day refund policy' %}
       </a>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/modal_eula.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/modal_eula.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="modal fade" id="eulaModal" style="z-index: 2147483548;">
-  <!-- This is ridiculous, needed for Appcues -->
+  <!-- The z-index above is ridiculous, needed for Appcues -->
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/modal_eula.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/modal_eula.html
@@ -1,39 +1,50 @@
 {% load i18n %}
-<div class="modal fade" id="eulaModal" style="z-index: 2147483548;"><!-- This is ridiculous, needed for Appcues -->
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title">{% trans "CommCare HQ Terms" %}</h4>
-            </div>
-            <div class="modal-body">
-                {% blocktrans %}
-                    On May 25, 2018 our new
-                    <a href="http://www.dimagi.com/terms-privacy/" target="_blank">
-                            Privacy Policy, Terms of Service, Business Agreement, and Acceptable Use Policy
-                    </a>
-                    (collectively, "Terms") went into effect. We made these updates to clarify our terms and address
-                    some new privacy laws in Europe. The spirit of our previous terms remains unchanged and,
-                    as always, you are the owner of your data.
-                    <a href="https://confluence.dimagi.com/display/commcarepublic/CommCare+Notices" target="_blank">Click here</a> to learn more.
+<div class="modal fade" id="eulaModal" style="z-index: 2147483548;">
+  <!-- This is ridiculous, needed for Appcues -->
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">{% trans "CommCare HQ Terms" %}</h4>
+      </div>
+      <div class="modal-body">
+        {% blocktrans %}
+          On May 25, 2018 our new
+          <a href="http://www.dimagi.com/terms-privacy/" target="_blank">
+            Privacy Policy, Terms of Service, Business Agreement, and Acceptable
+            Use Policy
+          </a>
+          (collectively, "Terms") went into effect. We made these updates to
+          clarify our terms and address some new privacy laws in Europe. The
+          spirit of our previous terms remains unchanged and, as always, you are
+          the owner of your data.
+          <a
+            href="https://confluence.dimagi.com/display/commcarepublic/CommCare+Notices"
+            target="_blank"
+            >Click here</a
+          >
+          to learn more.
 
-                    <br><br>
+          <br /><br />
 
-                    Click on the 'I Agree' button to let us know that you agree to our new Terms. If you do not
-                    agree to our new Terms, you may choose to stop using our services. Before doing so, however,
-                    please get in touch with us at <a href="mailto:{{ PRIVACY_EMAIL }}">{{ PRIVACY_EMAIL }}</a>.
-                    We're here to answer any questions you have. Again, our updates are intended to reflect the
-                    spirit of our previous terms.
+          Click on the 'I Agree' button to let us know that you agree to our new
+          Terms. If you do not agree to our new Terms, you may choose to stop
+          using our services. Before doing so, however, please get in touch with
+          us at <a href="mailto:{{ PRIVACY_EMAIL }}">{{ PRIVACY_EMAIL }}</a>.
+          We're here to answer any questions you have. Again, our updates are
+          intended to reflect the spirit of our previous terms.
 
-                    <br><br>
+          <br /><br />
 
-                    Thank you,
-                    <br><br>
-                    - The Dimagi Team
-                {% endblocktrans %}
-            </div>
-            <div class="modal-footer">
-                <button id="eula-agree" type="submit" class="btn btn-primary">{% trans 'I Agree' %}</button>
-            </div>
-        </div>
+          Thank you,
+          <br /><br />
+          - The Dimagi Team
+        {% endblocktrans %}
+      </div>
+      <div class="modal-footer">
+        <button id="eula-agree" type="submit" class="btn btn-primary">
+          {% trans 'I Agree' %}
+        </button>
+      </div>
     </div>
+  </div>
 </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/modal_eula.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/modal_eula.html
@@ -8,7 +8,7 @@
             <div class="modal-body">
                 {% blocktrans %}
                     On May 25, 2018 our new
-                    <a href="http://www.dimagi.com/terms/latest/privacy/" target="_blank">
+                    <a href="http://www.dimagi.com/terms-privacy/" target="_blank">
                             Privacy Policy, Terms of Service, Business Agreement, and Acceptable Use Policy
                     </a>
                     (collectively, "Terms") went into effect. We made these updates to clarify our terms and address

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/modal_eula.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/modal_eula.html
@@ -1,39 +1,50 @@
 {% load i18n %}
-<div class="modal fade" id="eulaModal" style="z-index: 2147483548;"><!-- This is ridiculous, needed for Appcues -->
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title">{% trans "CommCare HQ Terms" %}</h4>
-            </div>
-            <div class="modal-body">
-                {% blocktrans %}
-                    On May 25, 2018 our new
-                    <a href="http://www.dimagi.com/terms-privacy/" target="_blank">
-                            Privacy Policy, Terms of Service, Business Agreement, and Acceptable Use Policy
-                    </a>
-                    (collectively, "Terms") went into effect. We made these updates to clarify our terms and address
-                    some new privacy laws in Europe. The spirit of our previous terms remains unchanged and,
-                    as always, you are the owner of your data.
-                    <a href="https://confluence.dimagi.com/display/commcarepublic/CommCare+Notices" target="_blank">Click here</a> to learn more.
+<div class="modal fade" id="eulaModal" style="z-index: 2147483548;">
+  <!-- This is ridiculous, needed for Appcues -->
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">{% trans "CommCare HQ Terms" %}</h4>
+      </div>
+      <div class="modal-body">
+        {% blocktrans %}
+          On May 25, 2018 our new
+          <a href="http://www.dimagi.com/terms-privacy/" target="_blank">
+            Privacy Policy, Terms of Service, Business Agreement, and Acceptable
+            Use Policy
+          </a>
+          (collectively, "Terms") went into effect. We made these updates to
+          clarify our terms and address some new privacy laws in Europe. The
+          spirit of our previous terms remains unchanged and, as always, you are
+          the owner of your data.
+          <a
+            href="https://confluence.dimagi.com/display/commcarepublic/CommCare+Notices"
+            target="_blank"
+            >Click here</a
+          >
+          to learn more.
 
-                    <br><br>
+          <br /><br />
 
-                    Click on the 'I Agree' button to let us know that you agree to our new Terms. If you do not
-                    agree to our new Terms, you may choose to stop using our services. Before doing so, however,
-                    please get in touch with us at <a href="mailto:{{ PRIVACY_EMAIL }}">{{ PRIVACY_EMAIL }}</a>.
-                    We're here to answer any questions you have. Again, our updates are intended to reflect the
-                    spirit of our previous terms.
+          Click on the 'I Agree' button to let us know that you agree to our new
+          Terms. If you do not agree to our new Terms, you may choose to stop
+          using our services. Before doing so, however, please get in touch with
+          us at <a href="mailto:{{ PRIVACY_EMAIL }}">{{ PRIVACY_EMAIL }}</a>.
+          We're here to answer any questions you have. Again, our updates are
+          intended to reflect the spirit of our previous terms.
 
-                    <br><br>
+          <br /><br />
 
-                    Thank you,
-                    <br><br>
-                    - The Dimagi Team
-                {% endblocktrans %}
-            </div>
-            <div class="modal-footer">
-                <button id="eula-agree" type="submit" class="btn btn-primary">{% trans 'I Agree' %}</button>
-            </div>
-        </div>
+          Thank you,
+          <br /><br />
+          - The Dimagi Team
+        {% endblocktrans %}
+      </div>
+      <div class="modal-footer">
+        <button id="eula-agree" type="submit" class="btn btn-primary">
+          {% trans 'I Agree' %}
+        </button>
+      </div>
     </div>
+  </div>
 </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/modal_eula.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/modal_eula.html
@@ -8,7 +8,7 @@
             <div class="modal-body">
                 {% blocktrans %}
                     On May 25, 2018 our new
-                    <a href="http://www.dimagi.com/terms/latest/privacy/" target="_blank">
+                    <a href="http://www.dimagi.com/terms-privacy/" target="_blank">
                             Privacy Policy, Terms of Service, Business Agreement, and Acceptable Use Policy
                     </a>
                     (collectively, "Terms") went into effect. We made these updates to clarify our terms and address

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/analytics/forms/hubspot_cta_form.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/analytics/forms/hubspot_cta_form.html.diff.txt
@@ -8,9 +8,9 @@
    {% csrf_token %}
    <div class="modal-body">
      <!-- ko if: showErrorMessage -->
-@@ -8,128 +8,106 @@
-         <p data-bind="text: errorMessage"></p>
-       </div>
+@@ -8,151 +8,129 @@
+       <p data-bind="text: errorMessage"></p>
+     </div>
      <!-- /ko -->
 -    <div class="row">
 +    <div class="row mb-3">
@@ -20,19 +20,23 @@
 -            {% trans "First name" %}<span class="asteriskField">*</span>
 -          </label>
 -          <div class="controls">
--            <input type="text"
--                   name="firstname"
--                   data-bind="textInput: firstname"
--                   class="form-control">
+-            <input
+-              type="text"
+-              name="firstname"
+-              data-bind="textInput: firstname"
+-              class="form-control"
+-            />
 -          </div>
 -        </div>
 +        <label class="form-label">
 +          {% trans "First name" %}<span class="asteriskField">*</span>
 +        </label>
-+        <input type="text"
-+               name="firstname"
-+               data-bind="textInput: firstname"
-+               class="form-control">
++        <input
++          type="text"
++          name="firstname"
++          data-bind="textInput: firstname"
++          class="form-control"
++        />
        </div>
        <div class="col-sm-6">
 -        <div class="form-group">
@@ -40,10 +44,12 @@
 -            {% trans "Last name" %}<span class="asteriskField">*</span>
 -          </label>
 -          <div class="controls">
--            <input type="text"
--                   name="lastname"
--                   data-bind="textInput: lastname"
--                   class="form-control">
+-            <input
+-              type="text"
+-              name="lastname"
+-              data-bind="textInput: lastname"
+-              class="form-control"
+-            />
 -          </div>
 -        </div>
 -      </div>
@@ -56,12 +62,14 @@
 +        <label class="form-label">
 +          {% trans "Last name" %}<span class="asteriskField">*</span>
 +        </label>
-         <input type="text"
--               name="company"
--               data-bind="textInput: company"
-+               name="lastname"
-+               data-bind="textInput: lastname"
-                class="form-control">
+         <input
+           type="text"
+-          name="company"
+-          data-bind="textInput: company"
++          name="lastname"
++          data-bind="textInput: lastname"
+           class="form-control"
+         />
        </div>
      </div>
 -    <div class="form-group">
@@ -70,136 +78,163 @@
 +      <label class="form-label">
 +        {% trans "Organization" %}<span class="asteriskField">*</span>
 +      </label>
-+      <input type="text"
-+             name="company"
-+             data-bind="textInput: company"
-+             class="form-control">
++      <input
++        type="text"
++        name="company"
++        data-bind="textInput: company"
++        class="form-control"
++      />
 +    </div>
 +    <div class="mb-3">
 +      <label class="form-label">
-         {% trans "Professional email address" %}<span class="asteriskField">*</span>
+         {% trans "Professional email address" %}<span class="asteriskField"
+           >*</span
+         >
        </label>
 -      <div class="controls">
--        <input type="email"
--               name="email"
--               data-bind="textInput: email"
--               class="form-control">
+-        <input
+-          type="email"
+-          name="email"
+-          data-bind="textInput: email"
+-          class="form-control"
+-        />
 -      </div>
-+      <input type="email"
-+             name="email"
-+             data-bind="textInput: email"
-+             class="form-control">
++      <input
++        type="email"
++        name="email"
++        data-bind="textInput: email"
++        class="form-control"
++      />
      </div>
--    <div class="form-group"
-+    <div class="mb-3"
-          data-bind="visible: showContactMethod">
+-    <div class="form-group" data-bind="visible: showContactMethod">
 -      <label class="control-label">
++    <div class="mb-3" data-bind="visible: showContactMethod">
 +      <label class="form-label">
-           {% trans "How should we contact you?" %}<span class="asteriskField">*</span>
+         {% trans "How should we contact you?" %}<span class="asteriskField"
+           >*</span
+         >
        </label>
 -      <div class="controls">
--        <select name="preferred_method_of_contact"
--                data-bind="value: preferred_method_of_contact"
--                class="select form-control">
+-        <select
+-          name="preferred_method_of_contact"
+-          data-bind="value: preferred_method_of_contact"
+-          class="select form-control"
+-        >
 -          <option value="">{% trans "Please Select" %}</option>
 -          <option value="Phone">{% trans "Phone" %}</option>
 -          <option value="Skype">{% trans "Skype" %}</option>
 -          <!-- ko if: useWhatsApp -->
--            <option value="WhatsApp">{% trans "WhatsApp" %}</option>
+-          <option value="WhatsApp">{% trans "WhatsApp" %}</option>
 -          <!-- /ko -->
 -          <!-- ko if: useGoogleHangouts -->
--            <option value="Google hangouts">{% trans "Google hangouts" %}</option>
+-          <option value="Google hangouts">{% trans "Google hangouts" %}</option>
 -          <!-- /ko -->
 -        </select>
 -      </div>
-+      <select name="preferred_method_of_contact"
-+              data-bind="value: preferred_method_of_contact"
-+              class="form-select">
++      <select
++        name="preferred_method_of_contact"
++        data-bind="value: preferred_method_of_contact"
++        class="form-select"
++      >
 +        <option value="">{% trans "Please Select" %}</option>
 +        <option value="Phone">{% trans "Phone" %}</option>
 +        <option value="Skype">{% trans "Skype" %}</option>
 +        <!-- ko if: useWhatsApp -->
-+          <option value="WhatsApp">{% trans "WhatsApp" %}</option>
++        <option value="WhatsApp">{% trans "WhatsApp" %}</option>
 +        <!-- /ko -->
 +        <!-- ko if: useGoogleHangouts -->
-+          <option value="Google hangouts">{% trans "Google hangouts" %}</option>
++        <option value="Google hangouts">{% trans "Google hangouts" %}</option>
 +        <!-- /ko -->
 +      </select>
      </div>
--    <div class="form-group"
-+    <div class="mb-3"
-          data-bind="visible: showPhoneNumber">
+-    <div class="form-group" data-bind="visible: showPhoneNumber">
 -      <label class="control-label">
++    <div class="mb-3" data-bind="visible: showPhoneNumber">
 +      <label class="form-label">
-           {% trans "Preferred phone number" %}<span class="asteriskField">*</span>
+         {% trans "Preferred phone number" %}<span class="asteriskField">*</span>
        </label>
 -      <div class="controls">
--        <input type="text"
--               name="phone"
--               data-bind="textInput: phone"
--               class="form-control">
+-        <input
+-          type="text"
+-          name="phone"
+-          data-bind="textInput: phone"
+-          class="form-control"
+-        />
 -      </div>
-+      <input type="text"
-+             name="phone"
-+             data-bind="textInput: phone"
-+             class="form-control">
++      <input
++        type="text"
++        name="phone"
++        data-bind="textInput: phone"
++        class="form-control"
++      />
      </div>
--    <div class="form-group"
-+    <div class="mb-3"
-          data-bind="visible: showSkype">
+-    <div class="form-group" data-bind="visible: showSkype">
 -      <label class="control-label">
++    <div class="mb-3" data-bind="visible: showSkype">
 +      <label class="form-label">
-           {% trans "Skype username" %}<span class="asteriskField">*</span>
+         {% trans "Skype username" %}<span class="asteriskField">*</span>
        </label>
 -      <div class="controls">
--        <input type="text"
--               name="skype__c"
--               data-bind="textInput: skype__c"
--               class="form-control">
+-        <input
+-          type="text"
+-          name="skype__c"
+-          data-bind="textInput: skype__c"
+-          class="form-control"
+-        />
 -      </div>
-+      <input type="text"
-+             name="skype__c"
-+             data-bind="textInput: skype__c"
-+             class="form-control">
++      <input
++        type="text"
++        name="skype__c"
++        data-bind="textInput: skype__c"
++        class="form-control"
++      />
      </div>
--    <div class="form-group"
-+    <div class="mb-3"
-          data-bind="visible: showWhatsApp">
+-    <div class="form-group" data-bind="visible: showWhatsApp">
 -      <label class="control-label">
++    <div class="mb-3" data-bind="visible: showWhatsApp">
 +      <label class="form-label">
-           {% trans "Preferred WhatsApp number" %}<span class="asteriskField">*</span>
+         {% trans "Preferred WhatsApp number" %}<span class="asteriskField"
+           >*</span
+         >
        </label>
 -      <div class="controls">
--        <input type="text"
--               name="preferred_whatsapp_number"
--               data-bind="textInput: preferred_whatsapp_number"
--               class="form-control">
+-        <input
+-          type="text"
+-          name="preferred_whatsapp_number"
+-          data-bind="textInput: preferred_whatsapp_number"
+-          class="form-control"
+-        />
 -      </div>
-+      <input type="text"
-+             name="preferred_whatsapp_number"
-+             data-bind="textInput: preferred_whatsapp_number"
-+             class="form-control">
++      <input
++        type="text"
++        name="preferred_whatsapp_number"
++        data-bind="textInput: preferred_whatsapp_number"
++        class="form-control"
++      />
      </div>
--    <div class="form-group"
-+    <div class="mb-3"
-          data-bind="visible: showPreferredLanguage">
+-    <div class="form-group" data-bind="visible: showPreferredLanguage">
 -      <label class="control-label">
++    <div class="mb-3" data-bind="visible: showPreferredLanguage">
 +      <label class="form-label">
          {% trans "Preferred Language" %}<span class="asteriskField">*</span>
        </label>
 -      <div class="controls">
--        <select name="language__c"
--                data-bind="value: language__c"
--                class="form-control">
+-        <select
+-          name="language__c"
+-          data-bind="value: language__c"
+-          class="form-control"
+-        >
 -          <option value="">{% trans "Please Select" %}</option>
 -          <option value="English">{% trans "English" %}</option>
 -          <option value="French">{% trans "French" %}</option>
 -          <option value="Spanish">{% trans "Spanish" %}</option>
 -        </select>
 -      </div>
-+      <select name="language__c"
-+              data-bind="value: language__c"
-+              class="form-select">
++      <select
++        name="language__c"
++        data-bind="value: language__c"
++        class="form-select"
++      >
 +        <option value="">{% trans "Please Select" %}</option>
 +        <option value="English">{% trans "English" %}</option>
 +        <option value="French">{% trans "French" %}</option>
@@ -208,3 +243,8 @@
      </div>
      {% blocktrans %}
        By clicking this button, you agree to Dimagi's
+-      <a href="http://www.dimagi.com/terms-of-service/" target="_blank"
++      <a href="http://www.dimagi.com/terms/terms-of-service/" target="_blank"
+         >Terms of Service</a
+       >
+       and

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/select_plan.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/select_plan.html.diff.txt
@@ -1,70 +1,71 @@
 --- 
 +++ 
-@@ -1,9 +1,9 @@
+@@ -1,8 +1,8 @@
 -{% extends "domain/bootstrap3/base_change_plan.html" %}
 +{% extends "domain/bootstrap5/base_change_plan.html" %}
  {% load hq_shared_tags %}
  {% load i18n %}
  {% load menu_tags %}
- 
 -{% js_entry_b3 'accounting/js/pricing_table' %}
 +{% js_entry 'accounting/js/pricing_table' %}
  
  {% block form_content %}
    {% initial_page_data 'editions' editions %}
-@@ -30,7 +30,7 @@
-     <p class="switch-label text-center">
-       {% trans "Pay Monthly" %}
-       <label class="switch">
--        <input type="checkbox" id="pricing-toggle" data-bind="{checked: oShowAnnualPricing}">
-+        <input type="checkbox" id="pricing-toggle" data-bind="{checked: oShowAnnualPricing}">  {# todo B5: css-checkbox #}
+@@ -33,6 +33,7 @@
+           id="pricing-toggle"
+           data-bind="{checked: oShowAnnualPricing}"
+         />
++        {# todo B5: css-checkbox #}
          <span class="slider round slider-blue slider-blue-on"></span>
        </label>
        {% trans "Pay Annually" %}
-@@ -38,7 +38,7 @@
+@@ -40,7 +41,7 @@
  
      <p class="text-center">
        {% blocktrans %}
 -        Save close to 20% when you pay annually.
-+        Save close to 20% when you pay annually.  {# todo B5: css-close #}
++        Save close to 20% when you pay annually. {# todo B5: css-close #}
        {% endblocktrans %}
      </p>
  
-@@ -166,7 +166,7 @@
-     </div>
- 
-     <div class="alert alert-warning text-center"
--         style="margin-top: 20px;"
-+         style="margin-top: 20px;"  {# todo B5: inline-style #}
-          data-bind="visible: oIsNextPlanDowngrade">
+@@ -183,6 +184,7 @@
+     <div
+       class="alert alert-warning text-center"
+       style="margin-top: 20px;"
++      {# todo B5: inline-style #}
+       data-bind="visible: oIsNextPlanDowngrade"
+     >
        <i class="fa fa-warning"></i>
-       {% blocktrans %}
-@@ -196,7 +196,7 @@
-         id="select-plan-form"
-         method="post"
-         data-bind="visible: oShowNext"
--        style="display: none;"
-+        style="display: none;"  {# todo B5: inline-style #}
-         action="{% url 'confirm_selected_plan' domain %}">
+@@ -216,6 +218,7 @@
+       method="post"
+       data-bind="visible: oShowNext"
+       style="display: none;"
++      {# todo B5: inline-style #}
+       action="{% url 'confirm_selected_plan' domain %}"
+     >
        {% csrf_token %}
-       {% if is_renewal %}
-@@ -242,7 +242,7 @@
+@@ -276,7 +279,8 @@
      <div class="modal-dialog">
        <div class="modal-content">
          <div class="modal-header">
 -          <button type="button" class="close" data-dismiss="modal">
-+          <button type="button" class="btn-close" data-bs-dismiss="modal">  {# todo B5: css-close #}
++          <button type="button" class="btn-close" data-bs-dismiss="modal">
++            {# todo B5: css-close #}
              <span aria-hidden="true">&times;</span>
              <span class="sr-only">{% trans "Close" %}</span>
            </button>
-@@ -252,8 +252,8 @@
-           <br><br>
+@@ -284,12 +288,12 @@
          </div>
+         <div class="modal-body"><br /><br /></div>
          <div class="modal-footer">
--          <button type="button" class="btn btn-primary" data-dismiss="modal">{% trans "Dismiss" %}</button>
--          <button type="button" class="btn btn-danger" data-bind="click: submitDowngradeForm">{% trans "Continue" %}</button>
-+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">{% trans "Dismiss" %}</button>
-+          <button type="button" class="btn btn-outline-danger" data-bind="click: submitDowngradeForm">{% trans "Continue" %}</button>
-         </div>
-       </div>
-     </div>
+-          <button type="button" class="btn btn-primary" data-dismiss="modal">
++          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">
+             {% trans "Dismiss" %}
+           </button>
+           <button
+             type="button"
+-            class="btn btn-danger"
++            class="btn btn-outline-danger"
+             data-bind="click: submitDowngradeForm"
+           >
+             {% trans "Continue" %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/modal_eula.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/modal_eula.html.diff.txt
@@ -1,0 +1,10 @@
+--- 
++++ 
+@@ -1,6 +1,6 @@
+ {% load i18n %}
+ <div class="modal fade" id="eulaModal" style="z-index: 2147483548;">
+-  <!-- The z-index above is ridiculous, needed for Appcues -->
++  <!-- This is ridiculous, needed for Appcues -->
+   <div class="modal-dialog modal-lg">
+     <div class="modal-content">
+       <div class="modal-header">

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -68,7 +68,7 @@ class RegisterWebUserForm(forms.Form):
                target="_blank">Privacy Policy</a>,
             <a href="http://www.dimagi.com/terms/terms-of-service/"
                target="_blank">Terms of Service</a>,
-            <a href="http://www.dimagi.com/terms/latest/ba/"
+            <a href="http://www.dimagi.com/terms-ba/"
                target="_blank">Business Agreement</a>, and
             <a href="http://www.dimagi.com/terms-aup/"
                target="_blank">Acceptable Use Policy</a>.

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -64,7 +64,7 @@ class RegisterWebUserForm(forms.Form):
         required=False,
         label=mark_safe(_(
             """I have read and agree to Dimagi's
-            <a href="http://www.dimagi.com/terms/latest/privacy/"
+            <a href="http://www.dimagi.com/terms-privacy/"
                target="_blank">Privacy Policy</a>,
             <a href="http://www.dimagi.com/terms/latest/tos/"
                target="_blank">Terms of Service</a>,

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -70,7 +70,7 @@ class RegisterWebUserForm(forms.Form):
                target="_blank">Terms of Service</a>,
             <a href="http://www.dimagi.com/terms/latest/ba/"
                target="_blank">Business Agreement</a>, and
-            <a href="http://www.dimagi.com/terms/latest/aup/"
+            <a href="http://www.dimagi.com/terms-aup/"
                target="_blank">Acceptable Use Policy</a>.
             """)))
     atypical_user = forms.BooleanField(required=False, widget=forms.HiddenInput())

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -66,7 +66,7 @@ class RegisterWebUserForm(forms.Form):
             """I have read and agree to Dimagi's
             <a href="http://www.dimagi.com/terms-privacy/"
                target="_blank">Privacy Policy</a>,
-            <a href="http://www.dimagi.com/terms/latest/tos/"
+            <a href="http://www.dimagi.com/terms/terms-of-service/"
                target="_blank">Terms of Service</a>,
             <a href="http://www.dimagi.com/terms/latest/ba/"
                target="_blank">Business Agreement</a>, and

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -338,7 +338,7 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
             "Allow Dimagi to collect usage information to improve CommCare. "
             "You can learn more about the information we collect and the ways "
             "we use it in our "
-            '<a href="http://www.dimagi.com/terms/latest/privacy/">privacy policy</a>'
+            '<a href="http://www.dimagi.com/terms-privacy/">privacy policy</a>'
         ),
     )
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-16518

Summary of the issue: https://docs.google.com/document/d/1VsJMDeW6hrF70wJ0WdCmPF5Cz1cz9wk0TQO8a1zXOks/edit?tab=t.0#heading=h.609dr5lptgfa

TLDR: 
The redirection broken due to the google analytics parameter added to the url.

Instead of using:
https://dimagi.com/terms/latest/privacy/
https://dimagi.com/terms/latest/tos/
https://dimagi.com/terms/latest/aup/
https://dimagi.com/terms/latest/ba/

We will replace them directly in the codebase with their redirected versions:
https://dimagi.com/terms-privacy/
https://dimagi.com/terms-of-service/
https://dimagi.com/terms-aup/
https://dimagi.com/terms-ba/

🐠 Review by commit

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Only update urls.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
