### PR TITLE
Excluded analytix/js/cta_forms from requirejs build

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/yaml/bootstrap3/requirejs.yml
+++ b/corehq/apps/hqwebapp/static/hqwebapp/yaml/bootstrap3/requirejs.yml
@@ -13,6 +13,7 @@ paths:
   sentry_browser: "empty:"
   sentry_captureconsole: "empty:"
   stripe: "empty:"
+  analytix/js/cta_forms: "empty:"
 modules:
   # These two modules are referenced in hqwebapp/base.html, not in a requirejs_main tag,
   # so they won't get picked up by build_requirejs.py and instead need to be specified here

--- a/corehq/apps/hqwebapp/static/hqwebapp/yaml/bootstrap5/requirejs.yml
+++ b/corehq/apps/hqwebapp/static/hqwebapp/yaml/bootstrap5/requirejs.yml
@@ -13,6 +13,7 @@ paths:
   sentry_browser: "empty:"
   sentry_captureconsole: "empty:"
   stripe: "empty:"
+  analytix/js/cta_forms: "empty:"
   "tempusDominus": "empty:"
 modules:
   # These two modules are referenced in hqwebapp/base.html, not in a requirejs_main tag,


### PR DESCRIPTION
## Technical Summary
This is followup for https://github.com/dimagi/commcare-hq/pull/35729

The `import` statement added to cta_forms.js [here](https://github.com/dimagi/commcare-hq/pull/35729/files#diff-209e8e85abf322d467e18459b6336ac3af8654f39b60fab5cd5698425194d7d0R133) breaks requirejs's parser. That file, as part of analytics, is in the `base_main` bundle, even though it's only needed on pre-login pages where the demo button is displayed.

This PR tells requirejs to ignore that file when bundling. There's probably some minor performance implication to this, but we only have ~10 pages left on requirejs, so I'm not concerned.

## Safety Assurance

### Safety story
This change primarily affects the deploy process. I've deployed to staging and tested that the signup workflow with the telephone widget still works properly, and I've smoke tested that the "Current Subscription" page (one of the few remaining requirejs pages) loads without doing anything wonky.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
