### PR TITLE
Reset backoff when user unpauses a repeater

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -501,6 +501,7 @@ class Repeater(RepeaterSuperProxy):
         Repeater.objects.filter(id=self.repeater_id).update(is_paused=True)
 
     def resume(self):
+        self.reset_backoff()
         self.is_paused = False
         Repeater.objects.filter(id=self.repeater_id).update(is_paused=False)
 

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1397,6 +1397,12 @@ class TestSetBackoff(TestCase):
             in_7_days.isoformat(timespec='seconds')
         )
 
+    def test_reset_on_resume(self):
+        self.repeater.set_backoff()
+        self.repeater.resume()
+        repeater = Repeater.objects.get(id=self.repeater.repeater_id)
+        assert repeater.next_attempt_at is None
+
 
 def fromisoformat(isoformat):
     """


### PR DESCRIPTION
## Technical Summary

This change allows users to reset a repeater's backoff by pausing and unpausing it.

## Feature Flag

PROCESS_REPEATERS

## Safety Assurance

### Safety story

Tested locally.

### Automated test coverage

Test included

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
