### PR TITLE
Remove Cases with GPS Data (Microplanning)

### DIFF
--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -399,6 +399,12 @@ class GetPaginatedCases(CaseListMixin):
         case_data = []
         for case_obj in cases:
             lat, lon = get_lat_lon_from_dict(case_obj.case_json, location_prop_name)
+
+            # There might be a few moments where GPS data is saved for a case but the ES index hasn't
+            # updated yet, and so will still show as missing data in the ES query. For these instances,
+            #  we can simply filter them out here.
+            if show_cases_with_missing_gps_data_only and (lat or lon):
+                continue
             case_data.append(
                 {
                     'id': case_obj.case_id,


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-4269).

This PR introduces a very small change where an extra conditional is added to the endpoint that retrieves cases without GPS data for the "Manage GPS Data" page for the Microplanning feature. Previously, there existed a scenario where GPS data might have been added for a case and, upon refreshing the page, that case would still appear when the "Missing GPS Data" filter was applied.

This happened because the GPS data is being saved/retrieved from the DB, whilst the query to find cases with missing GPS data is done in ES. If the ES index hasn't had a chance to update yet, then there might be a few moments in which a case has GPS data but still pops up as having missing GPS data.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`MICROPLANNING`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing done
- Behind feature flag
- Very small change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests do exist.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
