### PR TITLE
Fix bug syncing mobile UCRs

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -182,6 +182,8 @@ class ReportDataCache(object):
         Args:
             subset (list[ReportConfig]): Subset of reports to fetch. If None, fetch all reports.
         """
+        if subset == []:
+            return
         subset_ids = {config.report_id for config in subset} if subset is not None else None
         report_ids = [
             config.report_id for config in self.report_configs

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -182,14 +182,12 @@ class ReportDataCache(object):
         Args:
             subset (list[ReportConfig]): Subset of reports to fetch. If None, fetch all reports.
         """
-        if subset == []:
-            return
-        subset_ids = {config.report_id for config in subset} if subset is not None else None
-        report_ids = [
-            config.report_id for config in self.report_configs
-            if config.report_id not in self.reports and (subset is None or config.report_id in subset_ids)
-        ]
-        self.reports.update(_get_report_configs(report_ids, self.domain))
+        to_load = {config.report_id for config in self.report_configs} - set(self.reports)
+        if subset is not None:
+            to_load = to_load.intersection({config.report_id for config in subset})
+        if to_load:
+            reports = get_report_configs(to_load, self.domain)
+            self.reports.update({report._id: report for report in reports})
 
     def get_report_and_datasource(self, report_id):
         if not self.reports:
@@ -600,11 +598,6 @@ def _get_filters_elem(defer_filters, filter_options_by_field, couch_user):
             filter_elem.append(option_elem)
         filters_elem.append(filter_elem)
     return filters_elem
-
-
-def _get_report_configs(report_ids, domain):
-    reports = get_report_configs(report_ids, domain)
-    return {report._id: report for report in reports}
 
 
 class MockTotalRowCalculator(object):

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -182,7 +182,7 @@ class ReportDataCache(object):
         Args:
             subset (list[ReportConfig]): Subset of reports to fetch. If None, fetch all reports.
         """
-        subset_ids = {config.report_id for config in subset} if subset else None
+        subset_ids = {config.report_id for config in subset} if subset is not None else None
         report_ids = [
             config.report_id for config in self.report_configs
             if config.report_id not in self.reports and (subset is None or config.report_id in subset_ids)

--- a/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
+++ b/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
@@ -219,4 +219,4 @@ class TestReportDataCache(SimpleTestCase):
 
     def test_load_reports_none(self, _get_report_configs):
         self.cache.load_reports([])
-        _get_report_configs.assert_called_once_with([], self.domain)
+        _get_report_configs.assert_not_called()

--- a/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
+++ b/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
@@ -194,3 +194,29 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
 
     def test_get_oldest_sync_time_excluded(self):
         self._test_get_oldest_sync_time(datetime.utcnow(), ['c'], {'b'}, datetime(2018, 9, 11, 6, 35, 20))
+
+
+@patch('corehq.apps.app_manager.fixtures.mobile_ucr._get_report_configs')
+class TestReportDataCache(SimpleTestCase):
+    def setUp(self):
+        self.domain = 'TestReportDataCache'
+        self.cache = ReportDataCache(self.domain, [
+            Mock(report_id='a'),
+            Mock(report_id='b'),
+            Mock(report_id='c'),
+        ])
+
+    def test_load_reports_all(self, _get_report_configs):
+        self.cache.load_reports()
+        _get_report_configs.assert_called_once_with(['a', 'b', 'c'], self.domain)
+
+    def test_load_reports_some(self, _get_report_configs):
+        self.cache.load_reports([
+            Mock(report_id='b'),
+            Mock(report_id='c'),
+        ])
+        _get_report_configs.assert_called_once_with(['b', 'c'], self.domain)
+
+    def test_load_reports_none(self, _get_report_configs):
+        self.cache.load_reports([])
+        _get_report_configs.assert_called_once_with([], self.domain)

--- a/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
+++ b/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
@@ -196,7 +196,7 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
         self._test_get_oldest_sync_time(datetime.utcnow(), ['c'], {'b'}, datetime(2018, 9, 11, 6, 35, 20))
 
 
-@patch('corehq.apps.app_manager.fixtures.mobile_ucr._get_report_configs')
+@patch('corehq.apps.app_manager.fixtures.mobile_ucr.get_report_configs')
 class TestReportDataCache(SimpleTestCase):
     def setUp(self):
         self.domain = 'TestReportDataCache'
@@ -206,17 +206,17 @@ class TestReportDataCache(SimpleTestCase):
             Mock(report_id='c'),
         ])
 
-    def test_load_reports_all(self, _get_report_configs):
+    def test_load_reports_all(self, get_report_configs):
         self.cache.load_reports()
-        _get_report_configs.assert_called_once_with(['a', 'b', 'c'], self.domain)
+        get_report_configs.assert_called_once_with({'a', 'b', 'c'}, self.domain)
 
-    def test_load_reports_some(self, _get_report_configs):
+    def test_load_reports_some(self, get_report_configs):
         self.cache.load_reports([
             Mock(report_id='b'),
             Mock(report_id='c'),
         ])
-        _get_report_configs.assert_called_once_with(['b', 'c'], self.domain)
+        get_report_configs.assert_called_once_with({'b', 'c'}, self.domain)
 
-    def test_load_reports_none(self, _get_report_configs):
+    def test_load_reports_none(self, get_report_configs):
         self.cache.load_reports([])
-        _get_report_configs.assert_not_called()
+        get_report_configs.assert_not_called()


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.sentry.io/issues/6251250913/events/31ac70aa3a32436aa73e51170c1e9db9/?project=136860
https://dimagi.atlassian.net/browse/SUPPORT-23213


In this line:
```
if config.report_id not in self.reports and (subset is None or config.report_id in subset_ids)
```
`subset_ids` was `None` when `subset` was provided but equal to `[]`.  This happened because one place checked `subset is None` and the other checked only for truthiness (`if subset`).

## Feature Flag


## Safety Assurance


### Safety story
Automated testing seems fine

### Automated test coverage
Added in this PR

### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
