### PR TITLE
fix active tab in mainmenu for B5 pages

### DIFF
--- a/corehq/tabs/templates/tabs/bootstrap5/menu_main.html
+++ b/corehq/tabs/templates/tabs/bootstrap5/menu_main.html
@@ -6,7 +6,7 @@
   {% for tab in tabs %}
     {% cache 500 header_tab tab.frag_value %}
       {% with tab.filtered_dropdown_items as items %}
-        <li class="nav-item mainmenu-tab{% if items %} dropdown{% endif %}" {# mainmenu-tab is old class #}
+        <li class="nav-item mainmenu-tab{% if items %} dropdown{% endif %} {% if tab.is_active_tab %} active{% endif %}"
             id="{{ tab.class_name }}"
           {% if ANALYTICS_IDS.GOOGLE_ANALYTICS_API_ID and tab.ga_tracker %}
             data-category="{{ tab.ga_tracker.category }}"
@@ -16,7 +16,7 @@
             {% endif %}
           {% endif %}
         >
-          <a class="nav-link{% if tab.is_active_tab %} active{% endif %}{% if items %} dropdown-toggle{% endif %}"
+          <a class="nav-link{% if items %} dropdown-toggle{% endif %}"
              {% if tab.is_active_tab %}aria-current="page"{% endif %}
              {% if items %}role="button" data-bs-toggle="dropdown" aria-expanded="false"{% endif %}
              href="{% if items %}#{% else %}{{ tab.url }}{% endif %}">


### PR DESCRIPTION
## Technical Summary
In bootstrap 5 pages, the "active" tab is not being highlighted in the main navigation bar if a page is a child of that tab.

for instance, if the "data" tab is active, it should look like this:
![Screenshot 2025-02-13 at 10 39 32 PM](https://github.com/user-attachments/assets/3d94ae81-e967-40a4-a6fb-42ed27f1c05e)

This fixes the issue by moving the "active" css class to the correct location.

## Safety Assurance

### Safety story
fixes a ui issue. very safe change

### Automated test coverage
N/A

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
leaving un checked due to bootstrap 5 diffs
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
