### PR TITLE
Add placeholder views for data cleaning tool

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/cases.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/cases.html
@@ -13,7 +13,7 @@
   </div>
   <div
     class="mx-3"
-    hx-get="{% url "data_cleaning_cases_table" domain %}{% querystring %}"
+    hx-get="{% url "data_cleaning_cases_table" domain session_id %}{% querystring %}"
     hx-trigger="load"
   >
     <div class="htmx-indicator">

--- a/corehq/apps/data_cleaning/templates/data_cleaning/cases.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/cases.html
@@ -6,17 +6,18 @@
 {% js_entry "hqwebapp/js/htmx_and_alpine" %}
 
 {% block content %}
-  <div class="container p-5">
-    <h1 class="py-3 m-0">
+  <div class="d-flex align-items-center m-3">
+    <h1 class="fs-3 pe-3 py-3 m-0">
       {% trans "Case Data Cleaning Test View" %}
     </h1>
-    <div
-      hx-trigger="load"
-      hx-get="{% url "data_cleaning_cases_table" domain %}{% querystring %}"
-    >
-      <div class="htmx-indicator">
-        <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading..." %}
-      </div>
+  </div>
+  <div
+    class="mx-3"
+    hx-get="{% url "data_cleaning_cases_table" domain %}{% querystring %}"
+    hx-trigger="load"
+  >
+    <div class="htmx-indicator">
+      <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading..." %}
     </div>
   </div>
 {% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/cases.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/cases.html
@@ -6,9 +6,10 @@
 {% js_entry "hqwebapp/js/htmx_and_alpine" %}
 
 {% block content %}
+  {% breadcrumbs current_page section current_page.parents %}
   <div class="d-flex align-items-center m-3">
     <h1 class="fs-3 pe-3 py-3 m-0">
-      {% trans "Case Data Cleaning Test View" %}
+      {{ current_page.page_name }}
     </h1>
   </div>
   <div

--- a/corehq/apps/data_cleaning/templates/data_cleaning/select_case_type.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/select_case_type.html
@@ -1,0 +1,13 @@
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
+{% load hq_shared_tags %}
+{% load django_tables2 %}
+{% load i18n %}
+
+{% block page_content %}
+  <p>
+    Placeholder for selecting case type.
+  </p>
+  <p>
+    <a class="btn btn-primary" href="{% url "data_cleaning_cases_session" domain session_id %}">Next</a>
+  </p>
+{% endblock %}

--- a/corehq/apps/data_cleaning/tests/test_views.py
+++ b/corehq/apps/data_cleaning/tests/test_views.py
@@ -1,0 +1,100 @@
+import uuid
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from corehq.apps.data_cleaning.views import (
+    CleanCasesMainView,
+    CleanCasesSessionView,
+    CleanCasesTableView,
+)
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import WebUser
+from corehq.util.test_utils import flag_enabled
+
+
+class CleanCasesViewAccessTest(TestCase):
+    domain_name = 'clean-data-view-test'
+    other_domain_name = 'no-access-view-test'
+    password = 'Passw0rd!'
+
+    @classmethod
+    def make_user(cls, email, domain_obj):
+        user = WebUser.create(
+            domain=domain_obj.name,
+            username=email,
+            password=cls.password,
+            created_by=None,
+            created_via=None
+        )
+        user.save()
+        return user
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain_name)
+        cls.other_domain_obj = create_domain(cls.other_domain_name)
+
+        cls.user_in_domain = cls.make_user(
+            'domain_member@datacleaning.org',
+            cls.domain_obj,
+        )
+        cls.user_outside_of_domain = cls.make_user(
+            'outsider@nope.org',
+            cls.other_domain_obj,
+        )
+        cls.client = Client()
+        cls.fake_session_id = uuid.uuid4()
+        cls.main_view_url = reverse(CleanCasesMainView.urlname, args=[cls.domain_name])
+        cls.session_view_url = reverse(CleanCasesSessionView.urlname, args=[cls.domain_name, cls.fake_session_id])
+        cls.table_view_url = reverse(CleanCasesTableView.urlname, args=[cls.domain_name, cls.fake_session_id])
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user_in_domain.delete(cls.domain_name, deleted_by=None)
+        cls.user_outside_of_domain.delete(cls.other_domain_obj, deleted_by=None)
+        cls.domain_obj.delete()
+        cls.other_domain_obj.delete()
+        super().tearDownClass()
+
+    def test_has_no_access_without_login(self):
+        response_main = self.client.get(self.main_view_url)
+        response_session = self.client.get(self.session_view_url)
+        response_table = self.client.get(self.table_view_url)
+        self.assertEqual(response_main.status_code, 404)
+        self.assertEqual(response_session.status_code, 404)
+        self.assertEqual(response_table.status_code, 404)
+
+    def test_has_no_access_without_flag(self):
+        self.client.login(username=self.user_in_domain.username, password=self.password)
+        response_main = self.client.get(self.main_view_url)
+        response_session = self.client.get(self.session_view_url)
+        response_table = self.client.get(self.table_view_url)
+        self.assertEqual(response_main.status_code, 404)
+        self.assertEqual(response_session.status_code, 404)
+        self.assertEqual(response_table.status_code, 404)
+
+    @flag_enabled('DATA_CLEANING_CASES')
+    def test_has_access_with_flag(self):
+        """
+        Todo: update the access tests to include project privilege
+        and user permissions/roles once specifics are decided.
+        """
+        self.client.login(username=self.user_in_domain.username, password=self.password)
+        response_main = self.client.get(self.main_view_url)
+        response_session = self.client.get(self.session_view_url)
+        response_table = self.client.get(self.table_view_url)
+        self.assertEqual(response_main.status_code, 200)
+        self.assertEqual(response_session.status_code, 200)
+        self.assertEqual(response_table.status_code, 200)
+
+    @flag_enabled('DATA_CLEANING_CASES')
+    def test_has_no_access_with_other_domain(self):
+        self.client.login(username=self.user_outside_of_domain.username, password=self.password)
+        response_main = self.client.get(self.main_view_url)
+        response_session = self.client.get(self.session_view_url)
+        response_table = self.client.get(self.table_view_url)
+        self.assertEqual(response_main.status_code, 404)
+        self.assertEqual(response_session.status_code, 404)
+        self.assertEqual(response_table.status_code, 404)

--- a/corehq/apps/data_cleaning/tests/test_views.py
+++ b/corehq/apps/data_cleaning/tests/test_views.py
@@ -9,10 +9,13 @@ from corehq.apps.data_cleaning.views import (
     CleanCasesTableView,
 )
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.es.case_search import case_search_adapter
+from corehq.apps.es.tests.utils import es_test
 from corehq.apps.users.models import WebUser
 from corehq.util.test_utils import flag_enabled
 
 
+@es_test(requires=[case_search_adapter])
 class CleanCasesViewAccessTest(TestCase):
     domain_name = 'clean-data-view-test'
     other_domain_name = 'no-access-view-test'

--- a/corehq/apps/data_cleaning/urls.py
+++ b/corehq/apps/data_cleaning/urls.py
@@ -2,10 +2,14 @@ from django.urls import re_path as url
 
 from corehq.apps.data_cleaning.views import (
     CleanCasesMainView,
+    CleanCasesSessionView,
     CleanCasesTableView,
 )
 
 urlpatterns = [
     url(r'^cases/$', CleanCasesMainView.as_view(), name=CleanCasesMainView.urlname),
-    url(r'^cases/table/$', CleanCasesTableView.as_view(), name=CleanCasesTableView.urlname),
+    url(r'^cases/(?P<session_id>[\w\-]+)/$', CleanCasesSessionView.as_view(),
+        name=CleanCasesSessionView.urlname),
+    url(r'^cases/(?P<session_id>[\w\-]+)/table/$', CleanCasesTableView.as_view(),
+        name=CleanCasesTableView.urlname),
 ]

--- a/corehq/apps/data_cleaning/views.py
+++ b/corehq/apps/data_cleaning/views.py
@@ -1,19 +1,22 @@
 from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy
 
 from corehq import toggles
 from corehq.apps.data_cleaning.tables import CleanCaseTable
 from corehq.apps.domain.decorators import LoginAndDomainMixin
-from corehq.apps.domain.views import BaseDomainView, DomainViewMixin
+from corehq.apps.domain.views import DomainViewMixin
 from corehq.apps.es import CaseSearchES
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.tables.pagination import SelectablePaginatedTableView
+from corehq.apps.settings.views import BaseProjectDataView
 
 
 @method_decorator([
     use_bootstrap5,
     toggles.DATA_CLEANING_CASES.required_decorator(),
 ], name='dispatch')
-class CleanCasesMainView(BaseDomainView):
+class CleanCasesMainView(BaseProjectDataView):
+    page_title = gettext_lazy("Clean Case Data")
     urlname = "data_cleaning_cases"
     template_name = "data_cleaning/cases.html"
 
@@ -22,7 +25,10 @@ class CleanCasesMainView(BaseDomainView):
         return ""
 
 
-@method_decorator(toggles.DATA_CLEANING_CASES.required_decorator(), name='dispatch')
+@method_decorator([
+    use_bootstrap5,
+    toggles.DATA_CLEANING_CASES.required_decorator(),
+], name='dispatch')
 class CleanCasesTableView(LoginAndDomainMixin, DomainViewMixin, SelectablePaginatedTableView):
     urlname = "data_cleaning_cases_table"
     table_class = CleanCaseTable

--- a/corehq/apps/data_cleaning/views.py
+++ b/corehq/apps/data_cleaning/views.py
@@ -3,7 +3,7 @@ from memoized import memoized
 
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.translation import gettext_lazy
+from django.utils.translation import gettext_lazy, gettext as _
 
 from corehq import toggles
 from corehq.apps.data_cleaning.tables import CleanCaseTable
@@ -36,6 +36,7 @@ class CleanCasesMainView(BaseProjectDataView):
     toggles.DATA_CLEANING_CASES.required_decorator(),
 ], name='dispatch')
 class CleanCasesSessionView(BaseProjectDataView):
+    page_title = gettext_lazy("Clean Case Type")
     urlname = "data_cleaning_cases_session"
     template_name = "data_cleaning/cases.html"
 
@@ -44,10 +45,26 @@ class CleanCasesSessionView(BaseProjectDataView):
         return self.kwargs['session_id']
 
     @property
+    def case_type(self):
+        # todo: obtain from session
+        return "placeholder"
+
+    @property
+    def page_name(self):
+        return _('Case Type "{case_type}"').format(case_type=self.case_type)
+
+    @property
     @memoized
     def page_url(self):
         if self.urlname:
             return reverse(self.urlname, args=(self.domain, self.session_id,))
+
+    @property
+    def parent_pages(self):
+        return [{
+            'title': CleanCasesMainView.page_title,
+            'url': reverse(CleanCasesMainView.urlname, args=(self.domain,)),
+        }]
 
     @property
     def page_context(self):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -462,6 +462,7 @@ class ProjectDataTab(UITab):
         '/a/{domain}/data_dictionary/',
         '/a/{domain}/importer/',
         '/a/{domain}/case/',
+        '/a/{domain}/clean/',
         '/a/{domain}/microplanning/',
         '/a/{domain}/kyc/'
     )
@@ -972,7 +973,21 @@ class ProjectDataTab(UITab):
             }
             edit_section[0][1].append(deduplication_list_view)
 
+        if self._can_view_case_data_cleaning:
+            from corehq.apps.data_cleaning.views import (
+                CleanCasesMainView,
+            )
+            clean_cases_view = {
+                'title': _(CleanCasesMainView.page_title),
+                'url': reverse(CleanCasesMainView.urlname, args=[self.domain]),
+            }
+            edit_section[0][1].append(clean_cases_view)
+
         return edit_section
+
+    @property
+    def _can_view_case_data_cleaning(self):
+        return toggles.DATA_CLEANING_CASES.enabled_for_request(self._request)
 
     def _get_explore_data_views(self):
         explore_data_views = []


### PR DESCRIPTION
## Technical Summary
This PR 
- adds data cleaning view to the "data" tab under "edit data" (all under feature flag)
- updates the template for this view to be a placeholder where we will eventually add the select case type form and completed tasks table.
- introduces another placeholder view for the data cleaning "session" (model in separate PR)
- updates the table view to expect a session (forthcoming)
- updates the template for the data cleaning session view to be full-width and include breadcumbs
- adds access tests!

https://dimagi.atlassian.net/browse/SAAS-15754
![Screenshot 2025-02-17 at 10 18 30 PM](https://github.com/user-attachments/assets/80592857-2b55-4db7-81a4-391618dfc3aa)
![Screenshot 2025-02-17 at 10 18 45 PM](https://github.com/user-attachments/assets/7c06cccb-1242-4802-95c8-e3f70cae0a1d)



## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe changes all behind feature flags. tests added to ensure access is behind feature flag and login

### Automated test coverage
Yes

### QA Plan
Not needed at this stage

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
