### PR TITLE
Make email validator case-insensitive

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/validators.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/validators.ko.js
@@ -1,16 +1,17 @@
 hqDefine("hqwebapp/js/bootstrap3/validators.ko", [
     'jquery',
     'knockout',
+    'hqwebapp/js/constants',
     'knockout-validation/dist/knockout.validation.min', // needed for ko.validation
 ], function (
     $,
     ko,
+    constants,
 ) {
     ko.validation.rules['emailRFC2822'] = {
         validator: function (val) {
             if (val === undefined || val.length === 0) {return true;}  // do separate validation for required
-            // eslint-disable-next-line no-control-regex
-            var re = /(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
+            var re = constants.EMAIL_VALIDATION_REGEX;
             return re.test(val || '') && val.indexOf(' ') < 0;
         },
         message: gettext("Not a valid email"),

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/validators.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/validators.ko.js
@@ -9,7 +9,7 @@ hqDefine("hqwebapp/js/bootstrap3/validators.ko", [
     ko.validation.rules['emailRFC2822'] = {
         validator: function (val) {
             if (val === undefined || val.length === 0) {return true;}  // do separate validation for required
-            var re = /(?:[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
+            var re = /(?:[A-Za-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
             return re.test(val || '') && val.indexOf(' ') < 0;
         },
         message: gettext("Not a valid email"),

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/validators.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/validators.ko.js
@@ -9,7 +9,8 @@ hqDefine("hqwebapp/js/bootstrap3/validators.ko", [
     ko.validation.rules['emailRFC2822'] = {
         validator: function (val) {
             if (val === undefined || val.length === 0) {return true;}  // do separate validation for required
-            var re = /(?:[A-Za-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
+            // eslint-disable-next-line no-control-regex
+            var re = /(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
             return re.test(val || '') && val.indexOf(' ') < 0;
         },
         message: gettext("Not a valid email"),

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/validators.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/validators.ko.js
@@ -16,7 +16,7 @@ hqDefine("hqwebapp/js/bootstrap5/validators.ko", [
     ko.validation.rules['emailRFC2822'] = {
         validator: function (val) {
             if (val === undefined || val.length === 0) {return true;}  // do separate validation for required
-            var re = /(?:[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
+            var re = /(?:[A-Za-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
             return re.test(val || '') && val.indexOf(' ') < 0;
         },
         message: gettext("Not a valid email"),

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/validators.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/validators.ko.js
@@ -1,10 +1,12 @@
 hqDefine("hqwebapp/js/bootstrap5/validators.ko", [
     'jquery',
     'knockout',
+    'hqwebapp/js/constants',
     'knockout-validation/dist/knockout.validation.min', // needed for ko.validation
 ], function (
     $,
     ko,
+    constants,
 ) {
     ko.validation.init({
         errorMessageClass: 'invalid-feedback',
@@ -16,8 +18,7 @@ hqDefine("hqwebapp/js/bootstrap5/validators.ko", [
     ko.validation.rules['emailRFC2822'] = {
         validator: function (val) {
             if (val === undefined || val.length === 0) {return true;}  // do separate validation for required
-            // eslint-disable-next-line no-control-regex
-            var re = /(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
+            var re = constants.EMAIL_VALIDATION_REGEX;
             return re.test(val || '') && val.indexOf(' ') < 0;
         },
         message: gettext("Not a valid email"),

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/validators.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/validators.ko.js
@@ -16,7 +16,8 @@ hqDefine("hqwebapp/js/bootstrap5/validators.ko", [
     ko.validation.rules['emailRFC2822'] = {
         validator: function (val) {
             if (val === undefined || val.length === 0) {return true;}  // do separate validation for required
-            var re = /(?:[A-Za-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
+            // eslint-disable-next-line no-control-regex
+            var re = /(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/;
             return re.test(val || '') && val.indexOf(' ') < 0;
         },
         message: gettext("Not a valid email"),

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/constants.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/constants.js
@@ -1,0 +1,6 @@
+hqDefine("hqwebapp/js/constants", [], function () {
+    return {
+        // eslint-disable-next-line no-control-regex
+        EMAIL_VALIDATION_REGEX: /(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/,
+    };
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/bootstrap3/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/bootstrap3/main.js
@@ -1,6 +1,7 @@
 import hqMocha from "mocha/js/main";
 
 import "hqwebapp/spec/assert_properties_spec";
+import "hqwebapp/spec/email_validator_spec";
 import "hqwebapp/spec/bootstrap3/inactivity_spec";
 import "hqwebapp/spec/urllib_spec";
 import "hqwebapp/spec/bootstrap3/widgets_spec";

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/bootstrap5/main.js
@@ -1,6 +1,7 @@
 import hqMocha from "mocha/js/main";
 
 import "hqwebapp/spec/assert_properties_spec";
+import "hqwebapp/spec/email_validator_spec";
 import "hqwebapp/spec/bootstrap5/inactivity_spec";
 import "hqwebapp/spec/urllib_spec";
 import "hqwebapp/spec/bootstrap5/widgets_spec";

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/email_validator_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/email_validator_spec.js
@@ -1,0 +1,83 @@
+/* eslint-env mocha */
+hqDefine("hqwebapp/spec/email_validator_spec", [
+    'hqwebapp/js/constants',
+], function (
+    constants,
+) {
+    describe('email_validator', function () {
+        const re = constants.EMAIL_VALIDATION_REGEX;
+        const testEmail = email => re.test(email);
+
+        it('should allow simple email addresses', function () {
+            assert.ok(testEmail('simple@example.com'));
+        });
+
+        it('should allow capital letters in the local part', function () {
+            assert.ok(testEmail('Capital@example.com'));
+            assert.ok(testEmail('VERYCAPITAL@example.com'));
+        });
+
+        it('should allow capital letters in the domain part', function () {
+            assert.ok(testEmail('email@Example.com'));
+            assert.ok(testEmail('email@EXAMPLE.COM'));
+        });
+
+        it('should allow digits in the local part', function () {
+            assert.ok(testEmail('email123@example.com'));
+        });
+
+        it('should allow specified special characters in the local part', function () {
+            assert.ok(testEmail('.\x01!#$%&"\'*+/=?^_`{|}~-@example.com'));
+        });
+
+        it('should allow subdomains', function () {
+            assert.ok(testEmail('email@subdomain.example.com'));
+        });
+
+        it('should allow hyphens in domain names', function () {
+            assert.ok(testEmail('email@ex-ample.com'));
+        });
+
+        it('should allow IP addresses in brackets as the domain', function () {
+            assert.ok(testEmail('whosaidthiswasok@[127.0.0.1]'));
+        });
+
+        it('should reject missing @ symbol', function () {
+            assert.notOk(testEmail('notanemail'));
+        });
+
+        it('should reject missing local part', function () {
+            assert.notOk(testEmail('@example.com'));
+        });
+
+        it('should reject missing top-level domain', function () {
+            assert.notOk(testEmail('nothing@toseehere'));
+            assert.notOk(testEmail('noteven@toseehere.'));
+        });
+
+        it('should reject invalid characters in the domain part', function () {
+            const emails = [
+                // allowed in local part but not domain
+                'me@ex\x01ample.com',
+                'me@ex!ample.com',
+                'me@ex#ample.com',
+                'me@ex$ample.com',
+                'me@ex%ample.com',
+                'me@ex&ample.com',
+                'me@ex"ample.com',
+                'me@ex\'ample.com',
+                'me@ex*ample.com',
+                'me@ex+ample.com',
+                'me@ex/ample.com',
+                'me@ex=ample.com',
+                'me@ex?ample.com',
+                'me@ex^ample.com',
+                'me@ex_ample.com',
+                'me@ex`ample.com',
+                'me@ex{ample}.com',
+                'me@ex|ample.com',
+            ];
+            emails.forEach(email => assert.notOk(testEmail(email)));
+        });
+    });
+});

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/validators.ko.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/validators.ko.js.diff.txt
@@ -5,10 +5,10 @@
 +hqDefine("hqwebapp/js/bootstrap5/validators.ko", [
      'jquery',
      'knockout',
-     'knockout-validation/dist/knockout.validation.min', // needed for ko.validation
-@@ -6,6 +6,13 @@
-     $,
+     'hqwebapp/js/constants',
+@@ -8,6 +8,13 @@
      ko,
+     constants,
  ) {
 +    ko.validation.init({
 +        errorMessageClass: 'invalid-feedback',
@@ -20,7 +20,7 @@
      ko.validation.rules['emailRFC2822'] = {
          validator: function (val) {
              if (val === undefined || val.length === 0) {return true;}  // do separate validation for required
-@@ -19,52 +26,71 @@
+@@ -21,52 +28,71 @@
  
      /**
       * Use this handler to show bootstrap validation states on a form input when

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/spec/main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/spec/main.js.diff.txt
@@ -1,9 +1,9 @@
 --- 
 +++ 
-@@ -1,8 +1,8 @@
- import hqMocha from "mocha/js/main";
+@@ -2,8 +2,8 @@
  
  import "hqwebapp/spec/assert_properties_spec";
+ import "hqwebapp/spec/email_validator_spec";
 -import "hqwebapp/spec/bootstrap3/inactivity_spec";
 +import "hqwebapp/spec/bootstrap5/inactivity_spec";
  import "hqwebapp/spec/urllib_spec";

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -601,7 +601,7 @@ class AdminInvitesUserForm(SelectUserLocationForm):
         )
 
     def clean_email(self):
-        email = self.cleaned_data['email'].strip()
+        email = self.cleaned_data['email'].strip().lower()
 
         from corehq.apps.registration.validation import AdminInvitesUserFormValidator
         error = AdminInvitesUserFormValidator.validate_email(self.domain, email, bool(self.invite))


### PR DESCRIPTION
## Product Description
Addresses the issue of capital letters in an email address potentially causing a validation error when inviting a web user. Previously, any email address typed with the name portion ending in a capital letter or the domain portion containing any capital letters would be marked invalid, e.g.
![image](https://github.com/user-attachments/assets/ece53fa1-cb16-45c2-b651-1d2fcc1e4b81)

![image](https://github.com/user-attachments/assets/ccec7234-93b6-4942-a0ce-88efe8e3fdf3)

Both of which are now valid.

## Technical Summary
[SAAS-15628](https://dimagi.atlassian.net/browse/SAAS-15628)
Updates the regular expression for email in `validators.ko` to allow capital letters. Also lowercases the email address as part of the web user invitation form's `clean_email`, which while not required here because of the `AdminInvitesUserFormValidator`, makes it consistent with other `clean_email` methods.

## Safety Assurance

### Safety story
This is a small change to make email addresses validation more accurate and not block the entry of some valid email addresses. I think the risks are quite low.

### Automated test coverage
We don't have tests for this monster of a regular expression.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-15628]: https://dimagi.atlassian.net/browse/SAAS-15628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ