### PR TITLE
Update "Number of overdue repeat records" metric

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1011,8 +1011,13 @@ class RepeatRecordManager(models.Manager):
     def count_overdue(self, threshold=timedelta(minutes=10)):
         return self.filter(
             next_check__isnull=False,
-            next_check__lt=datetime.utcnow() - threshold
-        ).count()
+            next_check__lt=datetime.utcnow() - threshold,
+            # `check_repeaters()` updates the `next_check` value of
+            # repeat records of paused repeaters, but `process_repeaters()`
+            # does not. Exclude the repeat records of paused repeaters
+            # for domains using `process_repeaters()`.
+            repeater__is_paused=False,
+        ).select_related('repeater').count()
 
     @staticmethod
     def count_all_ready():

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -551,7 +551,7 @@ class RepeaterLock:
 metrics_gauge_task(
     'commcare.repeaters.overdue',
     RepeatRecord.objects.count_overdue,
-    run_every=crontab(),  # every minute
+    run_every=crontab(minute='*/5'),  # every five minutes
     multiprocess_mode=MPM_MAX
 )
 

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -725,6 +725,20 @@ class TestRepeatRecordManager(RepeaterTestCase):
         overdue = RepeatRecord.objects.count_overdue()
         self.assertEqual(overdue, 3)
 
+        with self.pause_repeater():
+            overdue = RepeatRecord.objects.count_overdue()
+            self.assertEqual(overdue, 0)
+
+    @contextmanager
+    def pause_repeater(self):
+        try:
+            self.repeater.is_paused = True
+            self.repeater.save()
+            yield
+        finally:
+            self.repeater.is_paused = False
+            self.repeater.save()
+
     iter_partition = RepeatRecord.objects.iter_partition
 
     def test_one_partition(self):


### PR DESCRIPTION
## Technical Summary

Update "Number of overdue repeat records" metric for repeat records processed by `process_repeaters()`.

![image](https://github.com/user-attachments/assets/137938f7-8dec-4716-a01c-2101f93f0e28)

The 'commcare.repeaters.overdue' metric uses `RepeatRecord.next_check` to identify overdue repeat records. Under `process_repeaters()`, `RepeatRecord.next_check` is unused, but it's still a reasonable indicator of when a repeat record is overdue, if we exclude the repeat records of paused repeaters.

## Safety Assurance

### Safety story

This query is significantly slower on Production (almost 10s, compared to less than 1s). To mitigate this, this change runs it every 5 minutes instead of every minute. For the repeat records queue, that seems a reasonable compromise.

### Automated test coverage

Tests included.

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
