### PR TITLE
Reset backoff on pause instead of on resume

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -504,9 +504,9 @@ class Repeater(RepeaterSuperProxy):
     def pause(self):
         self.is_paused = True
         Repeater.objects.filter(id=self.repeater_id).update(is_paused=True)
+        self.reset_backoff()
 
     def resume(self):
-        self.reset_backoff()
         self.is_paused = False
         Repeater.objects.filter(id=self.repeater_id).update(is_paused=False)
 

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1397,9 +1397,9 @@ class TestSetBackoff(TestCase):
             in_7_days.isoformat(timespec='seconds')
         )
 
-    def test_reset_on_resume(self):
+    def test_reset_on_pause(self):
         self.repeater.set_backoff()
-        self.repeater.resume()
+        self.repeater.pause()
         repeater = Repeater.objects.get(id=self.repeater.repeater_id)
         assert repeater.next_attempt_at is None
 


### PR DESCRIPTION
## Technical Summary

Tiny. Seems more sensible to reset backoff on a repeater when it is paused instead of when it is resumed, so that `next_attempt_at` on a paused repeater isn't lying.

## Feature Flag

PROCESS_REPEATERS

## Safety Assurance

### Safety story

* Tiny change.
* Currently unused on Production.

### Automated test coverage

Test updated

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
