### PR TITLE
"Retry Date" column for `process_repeaters()`

### DIFF
--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -215,8 +215,17 @@ class CaseDataView(BaseProjectReportSectionView):
             product_tuples.sort(key=lambda x: x[0])
             ledger_map[section] = product_tuples
 
+        process_repeaters_enabled = toggles.PROCESS_REPEATERS.enabled(
+            self.domain,
+            toggles.NAMESPACE_DOMAIN,
+        )
         repeat_records = [
-            RepeatRecordDisplay(record, timezone, date_format=DATE_FORMAT)
+            RepeatRecordDisplay(
+                record,
+                timezone,
+                date_format=DATE_FORMAT,
+                process_repeaters_enabled=process_repeaters_enabled,
+            )
             for record in RepeatRecord.objects.filter(domain=self.domain, payload_id=self.case_id)
         ]
 

--- a/corehq/motech/repeaters/tests/test_display.py
+++ b/corehq/motech/repeaters/tests/test_display.py
@@ -1,10 +1,13 @@
+from datetime import datetime
+
 from django.test import TestCase
 
 import pytz
 
 from corehq.motech.models import ConnectionSettings
+from corehq.util.test_utils import flag_enabled
 
-from ..const import RECORD_SUCCESS_STATE
+from ..const import State
 from ..models import FormRepeater
 from ..views.repeat_record_display import RepeatRecordDisplay
 from .test_models import make_repeat_record
@@ -27,21 +30,26 @@ class RepeaterTestCase(TestCase):
         self.date_format = "%Y-%m-%d %H:%M:%S"
 
     def test_record_display_sql(self):
-        with make_repeat_record(self.repeater, RECORD_SUCCESS_STATE) as record:
+        with make_repeat_record(self.repeater, State.Success) as record:
             response = ResponseDuck()
             record.add_success_attempt(response)
             last_checked = record.attempts[0].created_at
             self.last_checked_str = last_checked.strftime(self.date_format)
 
-            self._check_display(record)
+            display = RepeatRecordDisplay(record, pytz.UTC, date_format=self.date_format)
+            self.assertEqual(display.record_id, record.id)
+            self.assertEqual(display.last_checked, self.last_checked_str)
+            self.assertEqual(display.next_check, '---')
+            self.assertEqual(display.url, self.url)
+            self.assertEqual(display.state, '<span class="label label-success">Success</span>')
 
-    def _check_display(self, record):
-        display = RepeatRecordDisplay(record, pytz.UTC, date_format=self.date_format)
-        self.assertEqual(display.record_id, record.id)
-        self.assertEqual(display.last_checked, self.last_checked_str)
-        self.assertEqual(display.next_check, '---')
-        self.assertEqual(display.url, self.url)
-        self.assertEqual(display.state, '<span class="label label-success">Success</span>')
+    @flag_enabled('PROCESS_REPEATERS')
+    def test_record_display_process_repeaters(self):
+        jan_1 = datetime.strptime('2025-01-01 00:00:00', self.date_format)
+        self.repeater.next_attempt_at = jan_1
+        with make_repeat_record(self.repeater, State.Pending) as record:
+            display = RepeatRecordDisplay(record, pytz.UTC, date_format=self.date_format)
+            self.assertEqual(display.next_check, '2025-01-01 00:00:00')
 
 
 class ResponseDuck:

--- a/corehq/motech/repeaters/tests/test_display.py
+++ b/corehq/motech/repeaters/tests/test_display.py
@@ -5,7 +5,6 @@ from django.test import TestCase
 import pytz
 
 from corehq.motech.models import ConnectionSettings
-from corehq.util.test_utils import flag_enabled
 
 from ..const import State
 from ..models import FormRepeater
@@ -43,12 +42,16 @@ class RepeaterTestCase(TestCase):
             self.assertEqual(display.url, self.url)
             self.assertEqual(display.state, '<span class="label label-success">Success</span>')
 
-    @flag_enabled('PROCESS_REPEATERS')
     def test_record_display_process_repeaters(self):
         jan_1 = datetime.strptime('2025-01-01 00:00:00', self.date_format)
         self.repeater.next_attempt_at = jan_1
         with make_repeat_record(self.repeater, State.Pending) as record:
-            display = RepeatRecordDisplay(record, pytz.UTC, date_format=self.date_format)
+            display = RepeatRecordDisplay(
+                record,
+                pytz.UTC,
+                date_format=self.date_format,
+                process_repeaters_enabled=True,
+            )
             self.assertEqual(display.next_check, '2025-01-01 00:00:00')
 
 

--- a/corehq/motech/repeaters/tests/test_display.py
+++ b/corehq/motech/repeaters/tests/test_display.py
@@ -54,6 +54,12 @@ class RepeaterTestCase(TestCase):
             )
             self.assertEqual(display.next_check, '2025-01-01 00:00:00')
 
+    def test_record_display_repeater_paused(self):
+        self.repeater.is_paused = True
+        with make_repeat_record(self.repeater, State.Pending) as record:
+            display = RepeatRecordDisplay(record, pytz.UTC, date_format=self.date_format)
+            self.assertEqual(display.next_check, 'Paused')
+
 
 class ResponseDuck:
     status_code = 200

--- a/corehq/motech/repeaters/views/repeat_record_display.py
+++ b/corehq/motech/repeaters/views/repeat_record_display.py
@@ -1,7 +1,6 @@
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 
-from corehq import toggles
 from corehq.motech.repeaters.const import (
     RECORD_CANCELLED_STATE,
     RECORD_EMPTY_STATE,
@@ -16,10 +15,17 @@ MISSING_VALUE = '---'
 
 
 class RepeatRecordDisplay:
-    def __init__(self, record, timezone, date_format="%Y-%m-%d %H:%M"):
+    def __init__(
+            self,
+            record,
+            timezone,
+            date_format="%Y-%m-%d %H:%M",
+            process_repeaters_enabled=False,
+    ):
         self.record = record
         self.timezone = timezone
         self.date_format = date_format
+        self.process_repeaters_enabled = process_repeaters_enabled
 
     @property
     def record_id(self):
@@ -31,8 +37,7 @@ class RepeatRecordDisplay:
 
     @property
     def next_check(self):
-        domain, namespace = self.record.domain, toggles.NAMESPACE_DOMAIN
-        if toggles.PROCESS_REPEATERS.enabled(domain, namespace):
+        if self.process_repeaters_enabled:
             next_check_ = self.record.repeater.next_attempt_at
         else:
             next_check_ = self.record.next_check

--- a/corehq/motech/repeaters/views/repeat_record_display.py
+++ b/corehq/motech/repeaters/views/repeat_record_display.py
@@ -37,6 +37,8 @@ class RepeatRecordDisplay:
 
     @property
     def next_check(self):
+        if self.record.repeater.is_paused:
+            return _('Paused')
         if self.process_repeaters_enabled:
             next_check_ = self.record.repeater.next_attempt_at
         else:

--- a/corehq/motech/repeaters/views/repeat_record_display.py
+++ b/corehq/motech/repeaters/views/repeat_record_display.py
@@ -1,6 +1,7 @@
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 
+from corehq import toggles
 from corehq.motech.repeaters.const import (
     RECORD_CANCELLED_STATE,
     RECORD_EMPTY_STATE,
@@ -30,7 +31,12 @@ class RepeatRecordDisplay:
 
     @property
     def next_check(self):
-        return self._format_date(self.record.next_check)
+        domain, namespace = self.record.domain, toggles.NAMESPACE_DOMAIN
+        if toggles.PROCESS_REPEATERS.enabled(domain, namespace):
+            next_check_ = self.record.repeater.next_attempt_at
+        else:
+            next_check_ = self.record.next_check
+        return self._format_date(next_check_)
 
     @property
     def url(self):

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -66,6 +66,13 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
     # Keys match RepeatRecordStateFilter.options[*][0]
     _state_map = {s.name.upper(): s for s in State}
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.process_repeaters_enabled = toggles.PROCESS_REPEATERS.enabled(
+            self.domain,
+            toggles.NAMESPACE_DOMAIN,
+        )
+
     def _make_cancel_payload_button(self, record_id):
         return format_html('''
                 <a
@@ -187,7 +194,12 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         )
 
     def _make_row(self, record):
-        display = RepeatRecordDisplay(record, self.timezone, date_format='%b %d, %Y %H:%M:%S %Z')
+        display = RepeatRecordDisplay(
+            record,
+            self.timezone,
+            date_format='%b %d, %Y %H:%M:%S %Z',
+            process_repeaters_enabled=self.process_repeaters_enabled,
+        )
         checkbox = format_html(
             '<input type="checkbox" class="xform-checkbox" data-id="{}" name="xform_ids"/>',
             record.id)


### PR DESCRIPTION
## Technical Summary

Updates the "Retry Date" column in the Data Forwarding Report to support both `check_repeaters()` and the `process_repeaters()`. Also now shows "Paused" when the repeater is paused.

![image](https://github.com/user-attachments/assets/8ba56f4c-0827-4eb5-80cf-aa3e48bbe94c)

## Feature Flag

PROCESS_REPEATERS

## Safety Assurance

### Safety story

* Tested locally

### Automated test coverage

Tests included

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
