### PR TITLE
Upgraded pyyaml from 6.0 to 6.0.2

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -87,7 +87,7 @@ pyphonetics
 python-magic
 pytz
 pyjwt
-PyYAML
+PyYAML>=6.0.2
 hl7apy
 pyzxcvbn
 qrcode

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -612,7 +612,7 @@ pytz==2024.1
     #   -r base-requirements.in
     #   babel
     #   celery
-pyyaml==6.0
+pyyaml==6.0.2
     # via
     #   -r base-requirements.in
     #   git-build-branch

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -511,7 +511,7 @@ pytz==2024.1
     #   -r base-requirements.in
     #   babel
     #   celery
-pyyaml==6.0
+pyyaml==6.0.2
     # via
     #   -r base-requirements.in
     #   myst-parser

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -520,7 +520,7 @@ pytz==2024.1
     #   -r base-requirements.in
     #   celery
     #   flower
-pyyaml==6.0
+pyyaml==6.0.2
     # via -r base-requirements.in
 pyzxcvbn==0.8.0
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -483,7 +483,7 @@ pytz==2024.1
     # via
     #   -r base-requirements.in
     #   celery
-pyyaml==6.0
+pyyaml==6.0.2
     # via -r base-requirements.in
 pyzxcvbn==0.8.0
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -528,7 +528,7 @@ pytz==2024.1
     # via
     #   -r base-requirements.in
     #   celery
-pyyaml==6.0
+pyyaml==6.0.2
     # via -r base-requirements.in
 pyzxcvbn==0.8.0
     # via -r base-requirements.in


### PR DESCRIPTION
## Technical Summary
Needed for python 3.13 support.

Changes to the library are minimal: https://github.com/yaml/pyyaml/blob/main/CHANGES

## Safety Assurance

### Safety story
Very minor-looking library upgrade. The only place I found this used is in git-build-branch, so I ran rebuildstaging as a test and that went fine.

### Automated test coverage

If it's jut used in git-build-branch, I don't think so.

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
