### PR TITLE
Fixed an index error with the enterprise domains report

### DIFF
--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -230,7 +230,7 @@ class DomainResource(ODataEnterpriseReportResource):
     REPORT_SLUG = EnterpriseReport.DOMAINS
 
     def dehydrate(self, bundle):
-        bundle.data['domain'] = bundle.obj[6]
+        bundle.data['domain'] = bundle.obj[9]
         bundle.data['created_on'] = self.convert_datetime(bundle.obj[0])
         bundle.data['num_apps'] = bundle.obj[1]
         bundle.data['num_mobile_users'] = bundle.obj[2]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
This is a fix in response to https://dimagi.atlassian.net/browse/SAAS-16537.
Recently, the domains report was updated to include some data that was previously available in the OData Feeds report, which shifted the domain field down several fields. Unfortunately, I did not update the API to reference that new index, and the old index contained an integer, rather than a string, which led to a mismatch due to the expected schema. 

## Safety Assurance

### Safety story
Verified locally that I could import the domains report into PowerBI successfully.

### Automated test coverage

This should have a test covering it, but I think the effort to create a framework to test reports is probably outside the scope of this ticket when a client is currently blocked by this. The API pulls from the domains enterprise report, so the straight-forward way to test this would be to construct a full enterprise report. Unfortunately, that requires creating a billing account, domain + subscription, web users, and setting up the elasticsearch indexes just to get a report that returns data for an empty domain. If we wanted to look at a realistic domains report, we'd also need to create exports etc. Long-term, I think we could create fake generators for all this data, but right now I don't think should attempt that.

### QA Plan
No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
