### PR TITLE
Revert "Revert "TableauConnectedApp, TransifexOrganization, and OpenmrsImporter models: AES CBC encryption Migration ""

### DIFF
--- a/corehq/apps/reports/migrations/0021_tableauconnectedapp_use_aes_cbc_encryption.py
+++ b/corehq/apps/reports/migrations/0021_tableauconnectedapp_use_aes_cbc_encryption.py
@@ -1,4 +1,4 @@
-from django.db import migrations
+from django.db import migrations, models
 from django.db.migrations import RunPython
 
 from corehq.motech.const import ALGO_AES, ALGO_AES_CBC
@@ -51,6 +51,11 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.AlterField(
+            model_name='tableauconnectedapp',
+            name='encrypted_secret_value',
+            field=models.CharField(max_length=128),
+        ),
         RunPython(migrate_tableau_connected_app_secret_value,
                   reverse_code=revert_tableau_connected_app_secret_value),
     ]

--- a/corehq/apps/reports/migrations/0021_tableauconnectedapp_use_aes_cbc_encryption.py
+++ b/corehq/apps/reports/migrations/0021_tableauconnectedapp_use_aes_cbc_encryption.py
@@ -1,12 +1,11 @@
 from django.db import migrations, models
 from django.db.migrations import RunPython
 
-from corehq.motech.const import ALGO_AES, ALGO_AES_CBC
+from corehq.motech.const import ALGO_AES_CBC
 from corehq.util.django_migrations import skip_on_fresh_install
 from corehq.motech.utils import (
     reencrypt_ecb_to_cbc_mode,
     reencrypt_cbc_to_ecb_mode,
-    b64_aes_cbc_encrypt,
 )
 
 
@@ -20,13 +19,8 @@ def migrate_tableau_connected_app_secret_value(apps, schema_editor):
 
     for connected_app in connected_apps_to_update:
         encrypted_secret_value = connected_app.encrypted_secret_value
-        if encrypted_secret_value.startswith(f'${ALGO_AES}$'):
-            connected_app.encrypted_secret_value = reencrypt_ecb_to_cbc_mode(
-                encrypted_secret_value, f'${ALGO_AES}$'
-            )
-        else:
-            ciphertext = b64_aes_cbc_encrypt(encrypted_secret_value)
-            connected_app.encrypted_secret_value = f'${ALGO_AES_CBC}${ciphertext}'
+        connected_app.encrypted_secret_value = reencrypt_ecb_to_cbc_mode(
+            encrypted_secret_value)
         connected_app.save()
 
 

--- a/corehq/apps/reports/migrations/0021_tableauconnectedapp_use_aes_cbc_encryption.py
+++ b/corehq/apps/reports/migrations/0021_tableauconnectedapp_use_aes_cbc_encryption.py
@@ -1,0 +1,56 @@
+from django.db import migrations
+from django.db.migrations import RunPython
+
+from corehq.motech.const import ALGO_AES, ALGO_AES_CBC
+from corehq.util.django_migrations import skip_on_fresh_install
+from corehq.motech.utils import (
+    reencrypt_ecb_to_cbc_mode,
+    reencrypt_cbc_to_ecb_mode,
+    b64_aes_cbc_encrypt,
+)
+
+
+@skip_on_fresh_install
+def migrate_tableau_connected_app_secret_value(apps, schema_editor):
+    TableauConnectedApp = apps.get_model('reports', 'TableauConnectedApp')
+
+    connected_apps_to_update = TableauConnectedApp.objects.exclude(
+        encrypted_secret_value__startswith=f'${ALGO_AES_CBC}$'
+    ).exclude(encrypted_secret_value=None).exclude(encrypted_secret_value='')
+
+    for connected_app in connected_apps_to_update:
+        encrypted_secret_value = connected_app.encrypted_secret_value
+        if encrypted_secret_value.startswith(f'${ALGO_AES}$'):
+            connected_app.encrypted_secret_value = reencrypt_ecb_to_cbc_mode(
+                encrypted_secret_value, f'${ALGO_AES}$'
+            )
+        else:
+            ciphertext = b64_aes_cbc_encrypt(encrypted_secret_value)
+            connected_app.encrypted_secret_value = f'${ALGO_AES_CBC}${ciphertext}'
+        connected_app.save()
+
+
+def revert_tableau_connected_app_secret_value(apps, schema_editor):
+    TableauConnectedApp = apps.get_model('reports', 'TableauConnectedApp')
+
+    connected_apps_to_revert = TableauConnectedApp.objects.filter(
+        encrypted_secret_value__startswith=f'${ALGO_AES_CBC}$'
+    )
+
+    for connected_app in connected_apps_to_revert:
+        connected_app.encrypted_secret_value = reencrypt_cbc_to_ecb_mode(
+            connected_app.encrypted_secret_value, f'${ALGO_AES_CBC}$'
+        )
+        connected_app.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('reports', '0020_tableauserver_get_reports_using_role'),
+    ]
+
+    operations = [
+        RunPython(migrate_tableau_connected_app_secret_value,
+                  reverse_code=revert_tableau_connected_app_secret_value),
+    ]

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -200,7 +200,7 @@ class TableauVisualization(models.Model):
 class TableauConnectedApp(models.Model):
     app_client_id = models.CharField(max_length=64)
     secret_id = models.CharField(max_length=64)
-    encrypted_secret_value = models.CharField(max_length=64)
+    encrypted_secret_value = models.CharField(max_length=128)
     server = models.OneToOneField(TableauServer, on_delete=models.CASCADE)
 
     def __str__(self):

--- a/corehq/apps/translations/migrations/0010_transifex_organization_api_token_encryption.py
+++ b/corehq/apps/translations/migrations/0010_transifex_organization_api_token_encryption.py
@@ -1,0 +1,50 @@
+from django.db import migrations
+from django.db.migrations import RunPython
+
+from corehq.util.django_migrations import skip_on_fresh_install
+from corehq.motech.const import ALGO_AES_CBC
+from corehq.motech.utils import (
+    reencrypt_ecb_to_cbc_mode,
+    reencrypt_cbc_to_ecb_mode,
+    AesEcbDecryptionError
+)
+
+
+@skip_on_fresh_install
+def reencrypt_api_tokens(apps, schema_editor):
+    TransifexOrganization = apps.get_model('translations', 'TransifexOrganization')
+
+    transifex_orgs_to_update = TransifexOrganization.objects.exclude(
+        api_token__startswith=f'${ALGO_AES_CBC}$'
+    ).exclude(api_token=None).exclude(api_token='')
+
+    for org in transifex_orgs_to_update:
+        try:
+            org.api_token = reencrypt_ecb_to_cbc_mode(org.api_token)
+        except AesEcbDecryptionError:
+            org.api_token = ''
+        org.save()
+
+
+def reversion_api_tokens(apps, schema_editor):
+    TransifexOrganization = apps.get_model('translations', 'TransifexOrganization')
+
+    transifex_orgs_to_update = TransifexOrganization.objects.filter(
+        api_token__startswith=f'${ALGO_AES_CBC}$'
+    )
+
+    for org in transifex_orgs_to_update:
+        org.api_token = reencrypt_cbc_to_ecb_mode(org.api_token,
+                                                f'${ALGO_AES_CBC}$')
+        org.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('translations', '0009_auto_20200924_1753'),
+    ]
+
+    operations = [
+        RunPython(reencrypt_api_tokens, reverse_code=reversion_api_tokens),
+    ]

--- a/corehq/motech/migrations/0018_openmrsimporter_use_aes_cbc_encryption.py
+++ b/corehq/motech/migrations/0018_openmrsimporter_use_aes_cbc_encryption.py
@@ -1,0 +1,54 @@
+from django.db import migrations
+from django.db.migrations import RunPython
+
+from corehq.dbaccessors.couchapps.all_docs import get_doc_ids_by_class
+from corehq.motech.const import ALGO_AES_CBC
+from corehq.util.couch import DocUpdate, iter_update
+from corehq.util.django_migrations import skip_on_fresh_install
+from corehq.util.log import with_progress_bar
+from corehq.motech.openmrs.models import OpenmrsImporter
+from corehq.motech.utils import (
+    reencrypt_ecb_to_cbc_mode,
+    reencrypt_cbc_to_ecb_mode,
+)
+
+
+@skip_on_fresh_install
+def reencrypt_openmrsimporters_passwords(apps, schema_editor):
+    app_ids = get_doc_ids_by_class(OpenmrsImporter)
+    iter_update(OpenmrsImporter.get_db(), _reencrypt_password, with_progress_bar(app_ids))
+
+
+def _reencrypt_password(app_doc):
+    original_password = app_doc['password']
+    if original_password.startswith(f'${ALGO_AES_CBC}$'):
+        return DocUpdate(app_doc)
+    else:
+        app_doc['password'] = reencrypt_ecb_to_cbc_mode(original_password)
+    return DocUpdate(app_doc)
+
+
+def revert_reencrypt_openmrsimporters_passwords(apps, schema_editor):
+    app_ids = get_doc_ids_by_class(OpenmrsImporter)
+    iter_update(OpenmrsImporter.get_db(), _revert_reencrypt_password,
+                with_progress_bar(app_ids))
+
+
+def _revert_reencrypt_password(app_doc):
+    original_password = app_doc['password']
+    if original_password.startswith(f'${ALGO_AES_CBC}$'):
+        encrypted_password = reencrypt_cbc_to_ecb_mode(original_password, f'${ALGO_AES_CBC}$')
+        app_doc['password'] = encrypted_password.split('$', 2)[2]
+    return DocUpdate(app_doc)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('motech', '0017_connectionsettings_use_aes_cbc_encryption'),
+    ]
+
+    operations = [
+        RunPython(reencrypt_openmrsimporters_passwords,
+                  revert_reencrypt_openmrsimporters_passwords),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -729,6 +729,7 @@ motech
  0015_requestlog_duration
  0016_connectionsettings_include_client_id_and_more
  0017_connectionsettings_use_aes_cbc_encryption
+ 0018_openmrsimporter_use_aes_cbc_encryption
 notifications
  0001_squashed_0003_auto_20160504_2049 (3 squashed migrations)
  0002_auto_20160505_2058
@@ -874,6 +875,7 @@ reports
  0018_alter_tableauuser_role
  0019_tableauvisualization_location_safe
  0020_tableauserver_get_reports_using_role
+ 0021_tableauconnectedapp_use_aes_cbc_encryption
 saved_reports
  0001_initial
  0002_scheduledreportlog
@@ -1174,6 +1176,7 @@ translations
  0007_populate_smstranslations
  0008_remove_couch_id
  0009_auto_20200924_1753
+ 0010_transifex_organization_api_token_encryption
 two_factor
  (no migrations)
 user_importer


### PR DESCRIPTION
Reverts dimagi/commcare-hq#35725

This reintroduces the changes in the original PR https://github.com/dimagi/commcare-hq/pull/35666 and fixes a bug where the `encrypted_secret_value` field in `TableauConnectedApp` had an insufficient max_char limit.