### PR TITLE
Safe mapping

### DIFF
--- a/corehq/apps/integration/kyc/forms.py
+++ b/corehq/apps/integration/kyc/forms.py
@@ -45,7 +45,7 @@ class KycConfigureForm(forms.ModelForm):
     api_field_to_user_data_map = JsonField(
         label=_('API Field to User Data Map'),
         required=True,
-        expected_type=list,
+        expected_type=dict,
     )
     connection_settings = forms.ModelChoiceField(
         label=_('Connection Settings'),

--- a/corehq/apps/integration/kyc/models.py
+++ b/corehq/apps/integration/kyc/models.py
@@ -34,7 +34,7 @@ class KycConfig(models.Model):
     domain = models.CharField(max_length=126, db_index=True)
     user_data_store = models.CharField(max_length=25, choices=UserDataStore.CHOICES)
     other_case_type = models.CharField(max_length=126, null=True)
-    api_field_to_user_data_map = jsonfield.JSONField(default=list)
+    api_field_to_user_data_map = jsonfield.JSONField(default=dict)
     provider = models.CharField(
         max_length=25,
         choices=KycProviders.choices,

--- a/corehq/apps/integration/kyc/services.py
+++ b/corehq/apps/integration/kyc/services.py
@@ -143,20 +143,20 @@ def get_user_data_for_api(source, config):
     }
     source_data = _get_source_data(source, config)
     user_data_for_api = {}
-    for mapping in config.api_field_to_user_data_map:
-        if mapping['mapsTo'] in source_data:
+    for api_field, user_data_property in config.api_field_to_user_data_map.items():
+        if user_data_property in source_data:
             # Fetch value from usercase / custom user data by default
-            value = source_data[mapping['mapsTo']]
+            value = source_data[user_data_property]
         elif (
             isinstance(source, CommCareUser)
-            and mapping['mapsTo'] in safe_commcare_user_properties
+            and user_data_property in safe_commcare_user_properties
         ):
             # Fall back to CommCareUser
-            value = getattr(source, mapping['mapsTo'])
+            value = getattr(source, user_data_property)
         else:
             # Conservative approach to skip the API field if data is not available for the user
             continue
-        user_data_for_api[mapping['fieldName']] = value
+        user_data_for_api[api_field] = value
     return user_data_for_api
 
 

--- a/corehq/apps/integration/kyc/services.py
+++ b/corehq/apps/integration/kyc/services.py
@@ -10,6 +10,7 @@ import jsonschema
 
 from corehq.apps.hqcase.utils import update_case
 from corehq.apps.integration.kyc.models import UserDataStore
+from corehq.apps.users.models import CommCareUser
 
 
 class UserCaseNotFound(Exception):
@@ -129,17 +130,33 @@ def get_user_data_for_api(source, config):
         Returns a dictionary of user data for the API.
         ``source`` is a CommCareUser or a CommCareCase.
     """
+    # CommCareUser properties that could map to API fields
+    safe_commcare_user_properties = {
+        'first_name',
+        'last_name',
+        'full_name',
+        'name',
+        'email',
+        'username',  # For CommCareUsers this is an email address
+        'phone_number',
+        'default_phone_number',
+    }
     source_data = _get_source_data(source, config)
     user_data_for_api = {}
     for mapping in config.api_field_to_user_data_map:
-        try:
-            if mapping['source'] == 'standard':
-                user_data_for_api[mapping['fieldName']] = getattr(source, mapping['mapsTo'])
-            else:
-                user_data_for_api[mapping['fieldName']] = source_data[mapping['mapsTo']]
-        except (AttributeError, KeyError):
+        if mapping['mapsTo'] in source_data:
+            # Fetch value from usercase / custom user data by default
+            value = source_data[mapping['mapsTo']]
+        elif (
+            isinstance(source, CommCareUser)
+            and mapping['mapsTo'] in safe_commcare_user_properties
+        ):
+            # Fall back to CommCareUser
+            value = getattr(source, mapping['mapsTo'])
+        else:
             # Conservative approach to skip the API field if data is not available for the user
             continue
+        user_data_for_api[mapping['fieldName']] = value
     return user_data_for_api
 
 

--- a/corehq/apps/integration/kyc/tests/test_services.py
+++ b/corehq/apps/integration/kyc/tests/test_services.py
@@ -167,6 +167,17 @@ class TestGetUserDataForAPI(TestCase):
         result = get_user_data_for_api(self.user, self.config)
         self.assertEqual(result, {'first_name': 'abc', 'nationality': 'Indian'})
 
+    def test_unsafe_custom_user_data_store(self):
+        self.config.api_field_to_user_data_map = [
+            {
+                "fieldName": "first_name",
+                "mapsTo": "password",
+                "source": "standard"
+            }
+        ]
+        result = get_user_data_for_api(self.user, self.config)
+        self.assertEqual(result, {})
+
     def test_custom_user_data_store_with_no_data(self):
         result = get_user_data_for_api(self.user, self.config)
         self.assertEqual(result, {'first_name': 'abc'})

--- a/corehq/apps/integration/kyc/tests/test_services.py
+++ b/corehq/apps/integration/kyc/tests/test_services.py
@@ -135,7 +135,11 @@ class TestGetUserDataForAPI(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.user = CommCareUser.create(self.domain, 'test-kyc', '123', None, None, first_name='abc')
+        self.user = CommCareUser.create(
+            self.domain, 'test-kyc', '123',
+            None, None,
+            first_name='abc',
+        )
         self.config = KycConfig.objects.create(
             domain=self.domain,
             user_data_store=UserDataStore.CUSTOM_USER_DATA,
@@ -149,18 +153,11 @@ class TestGetUserDataForAPI(TestCase):
         super().tearDown()
 
     def _sample_api_field_to_user_data_map(self):
-        return [
-            {
-                "fieldName": "first_name",
-                "mapsTo": "first_name",
-                "source": "standard"
-            },
-            {
-                "fieldName": "nationality",
-                "mapsTo": "nationality",
-                "source": "custom"
-            }
-        ]
+        return {
+            # API Field : User data
+            "first_name": "first_name",
+            "nationality": "nationality",
+        }
 
     def test_custom_user_data_store(self):
         self.user.get_user_data(self.domain).update({'nationality': 'Indian'})
@@ -168,13 +165,10 @@ class TestGetUserDataForAPI(TestCase):
         self.assertEqual(result, {'first_name': 'abc', 'nationality': 'Indian'})
 
     def test_unsafe_custom_user_data_store(self):
-        self.config.api_field_to_user_data_map = [
-            {
-                "fieldName": "first_name",
-                "mapsTo": "password",
-                "source": "standard"
-            }
-        ]
+        self.config.api_field_to_user_data_map = {
+            # API field : Custom user data / CommCareUser property
+            "first_name": "password",
+        }
         result = get_user_data_for_api(self.user, self.config)
         self.assertEqual(result, {})
 
@@ -207,7 +201,6 @@ class TestGetUserDataForAPI(TestCase):
     def test_custom_case_data_store(self):
         self.config.user_data_store = UserDataStore.OTHER_CASE_TYPE
         self.config.other_case_type = 'other-case'
-        self.config.api_field_to_user_data_map[0]['source'] = 'custom'
         self.config.save()
         case = create_case(
             self.domain,
@@ -232,7 +225,7 @@ class TestGetUserDataForAPI(TestCase):
 
     def test_incorrect_mapping_standard_field(self):
         api_field_to_user_data_map = self._sample_api_field_to_user_data_map()
-        api_field_to_user_data_map[0]['mapsTo'] = 'wrong-standard_field'
+        api_field_to_user_data_map['first_name'] = 'wrong-standard_field'
         self.config.api_field_to_user_data_map = api_field_to_user_data_map
         self.config.save()
 

--- a/corehq/apps/integration/kyc/tests/test_views.py
+++ b/corehq/apps/integration/kyc/tests/test_views.py
@@ -105,53 +105,18 @@ class TestKycVerificationTableView(BaseTestKycView):
         )
         cls.addClassCleanup(conn_settings.delete)
 
-        cls.kyc_mapping = [
-            {
-                'fieldName': 'first_name',
-                'mapsTo': 'first_name',
-                'source': 'standard',
-            },
-            {
-                'fieldName': 'last_name',
-                'mapsTo': 'last_name',
-                'source': 'standard'
-            },
-            {
-                'fieldName': 'email',
-                'mapsTo': 'email',
-                'source': 'standard'
-            },
-            {
-                'fieldName': 'phone_number',
-                'mapsTo': 'phone_number',
-                'source': 'custom',
-            },
-            {
-                'fieldName': 'national_id_number',
-                'mapsTo': 'national_id_number',
-                'source': 'custom',
-            },
-            {
-                'fieldName': 'street_address',
-                'mapsTo': 'street_address',
-                'source': 'custom',
-            },
-            {
-                'fieldName': 'city',
-                'mapsTo': 'city',
-                'source': 'custom',
-            },
-            {
-                'fieldName': 'post_code',
-                'mapsTo': 'post_code',
-                'source': 'custom',
-            },
-            {
-                'fieldName': 'country',
-                'mapsTo': 'country',
-                'source': 'custom',
-            },
-        ]
+        cls.kyc_mapping = {
+            # API field: User data
+            'first_name': 'first_name',
+            'last_name': 'last_name',
+            'email': 'email',
+            'phone_number': 'phone_number',
+            'national_id_number': 'national_id_number',
+            'street_address': 'street_address',
+            'city': 'city',
+            'post_code': 'post_code',
+            'country': 'country',
+        }
         cls.kyc_config = KycConfig.objects.create(
             domain=cls.domain,
             user_data_store=UserDataStore.CUSTOM_USER_DATA,
@@ -266,23 +231,11 @@ class TestKycVerificationTableView(BaseTestKycView):
     def test_response_data_cases(self):
         self.kyc_config.user_data_store = UserDataStore.OTHER_CASE_TYPE
         self.kyc_config.other_case_type = 'other-case'
-        self.kyc_config.api_field_to_user_data_map[0:3] = [
-            {
-                'fieldName': 'first_name',
-                'mapsTo': 'first_name',
-                'source': 'custom'
-            },
-            {
-                'fieldName': 'last_name',
-                'mapsTo': 'last_name',
-                'source': 'custom'
-            },
-            {
-                'fieldName': 'email',
-                'mapsTo': 'email',
-                'source': 'custom'
-            }
-        ]
+        self.kyc_config.api_field_to_user_data_map.update({
+            'first_name': 'first_name',
+            'last_name': 'last_name',
+            'email': 'email',
+        })
         self.kyc_config.save()
 
         response = self._make_request()

--- a/corehq/apps/integration/kyc/tests/test_views.py
+++ b/corehq/apps/integration/kyc/tests/test_views.py
@@ -244,6 +244,7 @@ class TestKycVerificationTableView(BaseTestKycView):
                     'has_invalid_data': True,
                     'first_name': 'Jane',
                     'last_name': 'Doe',
+                    'phone_number': None,
                     'email': '',
                 })
             else:


### PR DESCRIPTION
## Technical Summary

I noticed that with the current way we do mapping, it is possible to expose user secrets. With this change, I realised that maybe we could drop the "source" property in mappings, and got back to using a dictionary. Curious to hear your thoughts.

## Feature Flag

KYC_INTEGRATIONS

## Safety Assurance

### Safety story

Local testing

### Automated test coverage

Tests included

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
