### PR TITLE
Added BulkEditChange.edited_value

### DIFF
--- a/corehq/apps/data_cleaning/exceptions.py
+++ b/corehq/apps/data_cleaning/exceptions.py
@@ -1,0 +1,2 @@
+class UnsupportedActionException(Exception):
+    """Raised when an unknown action is encountered"""

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -277,8 +277,7 @@ class BulkEditChange(models.Model):
             return simple_transformations[self.action_type](old_value)
 
         if self.action_type == EditActionType.COPY_REPLACE:
-            old_value = case.get_case_property(self.copy_from_property)
-            return old_value.replace(self.find_string, self.replace_string)
+            return case.get_case_property(self.copy_from_property)
 
         if self.action_type == EditActionType.RESET:
             raise UnsupportedActionException(f"{EditActionType.RESET} is not applied by calling edited_value")

--- a/corehq/apps/data_cleaning/tests/test_models.py
+++ b/corehq/apps/data_cleaning/tests/test_models.py
@@ -22,7 +22,7 @@ class BulkEditChangeTest(TestCase):
                 'nearest_ocean': 'atlantic',
                 'town': 'Isabel Segunda',
                 'favorite_beach': 'Playa Bastimento',
-                'art': '  :)     ',
+                'art': '\n  :)   \n  \t',
                 'second_favorite_beach': 'no idea',
             },
         )

--- a/corehq/apps/data_cleaning/tests/test_models.py
+++ b/corehq/apps/data_cleaning/tests/test_models.py
@@ -1,0 +1,103 @@
+from django.test import TestCase
+
+from casexml.apps.case.mock import CaseFactory
+from corehq.apps.data_cleaning.models import (
+    BulkEditChange,
+    EditActionType,
+)
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
+
+
+class BulkEditChangeTest(TestCase):
+    domain = 'planet'
+    case_type = 'island'
+
+    def setUp(self):
+        factory = CaseFactory(domain=self.domain)
+        self.case = factory.create_case(
+            case_type=self.case_type,
+            owner_id='q123',
+            case_name='Vieques',
+            update={
+                'nearest_ocean': 'atlantic',
+                'town': 'Isabel Segunda',
+                'favorite_beach': 'Playa Bastimento',
+                'art': '  :)     ',
+                'second_favorite_beach': 'no idea',
+            },
+        )
+
+        super().setUp()
+
+    def tearDown(self):
+        FormProcessorTestUtils.delete_all_cases()
+        super().tearDown()
+
+    def test_replace(self):
+        change = BulkEditChange(
+            property='town',
+            action_type=EditActionType.REPLACE,
+            replace_string='Esperanza',
+        )
+        self.assertEqual(change.edited_value(self.case), 'Esperanza')
+
+    def test_find_replace(self):
+        change = BulkEditChange(
+            property='favorite_beach',
+            action_type=EditActionType.FIND_REPLACE,
+            find_string='Playa',
+            replace_string='Punta',
+        )
+        self.assertEqual(change.edited_value(self.case), 'Punta Bastimento')
+
+    def test_strip(self):
+        change = BulkEditChange(
+            property='art',
+            action_type=EditActionType.STRIP,
+        )
+        self.assertEqual(change.edited_value(self.case), ':)')
+
+    def test_copy_replace(self):
+        change = BulkEditChange(
+            property='nearest_ocean',
+            action_type=EditActionType.COPY_REPLACE,
+            copy_from_property='favorite_beach',
+            find_string='Bastimento',
+            replace_string='Yallis',
+        )
+        self.assertEqual(change.edited_value(self.case), 'Playa Yallis')
+
+    def test_title_case(self):
+        change = BulkEditChange(
+            property='nearest_ocean',
+            action_type=EditActionType.TITLE_CASE,
+        )
+        self.assertEqual(change.edited_value(self.case), 'Atlantic')
+
+    def test_upper_case(self):
+        change = BulkEditChange(
+            property='town',
+            action_type=EditActionType.UPPER_CASE,
+        )
+        self.assertEqual(change.edited_value(self.case), 'ISABEL SEGUNDA')
+
+    def test_lower_case(self):
+        change = BulkEditChange(
+            property='town',
+            action_type=EditActionType.LOWER_CASE,
+        )
+        self.assertEqual(change.edited_value(self.case), 'isabel segunda')
+
+    def test_make_empty(self):
+        change = BulkEditChange(
+            property='nearest_ocean',
+            action_type=EditActionType.MAKE_EMPTY,
+        )
+        self.assertEqual(change.edited_value(self.case), '')
+
+    def test_make_null(self):
+        change = BulkEditChange(
+            property='nearest_ocean',
+            action_type=EditActionType.MAKE_NULL,
+        )
+        self.assertEqual(change.edited_value(self.case), None)

--- a/corehq/apps/data_cleaning/tests/test_models.py
+++ b/corehq/apps/data_cleaning/tests/test_models.py
@@ -62,10 +62,8 @@ class BulkEditChangeTest(TestCase):
             property='nearest_ocean',
             action_type=EditActionType.COPY_REPLACE,
             copy_from_property='favorite_beach',
-            find_string='Bastimento',
-            replace_string='Yallis',
         )
-        self.assertEqual(change.edited_value(self.case), 'Playa Yallis')
+        self.assertEqual(change.edited_value(self.case), 'Playa Bastimento')
 
     def test_title_case(self):
         change = BulkEditChange(


### PR DESCRIPTION
## Technical Summary
Cherry-pick from the data cleaning backend branch.

Adds a BulkEditChange.edited_value to do the basic string transformations.

This does not handle the RESET action, that'll come later.

## Safety Assurance

### Safety story
Adds new code and tests, but nothing calls the new code.

### Automated test coverage
In PR.

### QA Plan
No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
