### PR TITLE
Remove load_appcues_template_app

### DIFF
--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -89,12 +89,6 @@ def update_linked_app_and_notify_task(domain, app_id, master_app_id, user_id, em
     update_linked_app_and_notify(domain, app_id, master_app_id, user_id, email)
 
 
-@task
-def load_appcues_template_app(domain, username, app_slug):
-    from corehq.apps.app_manager.views.apps import load_app_from_slug
-    load_app_from_slug(domain, username, app_slug)
-
-
 @task(queue='background_queue', ignore_result=True)
 def analyse_new_app_build(domain, new_build_id):
     new_build = get_app(domain, new_build_id)

--- a/corehq/apps/registration/templates/registration/partials/register_new_user/submit_info.html
+++ b/corehq/apps/registration/templates/registration/partials/register_new_user/submit_info.html
@@ -13,9 +13,6 @@
   <p class="timeout-message" data-bind="visible: showSecondTimeout">
     <i class="fa fa-check"></i> {% trans "Created new user..." %}
   </p>
-  <p class="timeout-message" data-bind="visible: showFirstTimeout">
-    <i class="fa fa-check"></i> {% trans "Created sample applications..." %}
-  </p>
   <p class="timeout-message" data-bind="visible: showThirdTimeout">
     <i class="fa fa-check"></i> {% trans "Updated reports..." %}
   </p>

--- a/corehq/apps/registration/templates/registration/partials/register_new_user/submit_info.html
+++ b/corehq/apps/registration/templates/registration/partials/register_new_user/submit_info.html
@@ -22,7 +22,8 @@
   <hr data-bind="visible: showFirstTimeout" />
   <p>
     {% blocktrans %}
-      Thank you for choosing <strong>CommCare</strong>. <i class="fa fa-heart"></i>
+      Thank you for choosing <strong>CommCare</strong>.
+      <i class="fa fa-heart"></i>
     {% endblocktrans %}
   </p>
 </div>

--- a/corehq/apps/registration/templates/registration/partials/register_new_user/submit_info.html
+++ b/corehq/apps/registration/templates/registration/partials/register_new_user/submit_info.html
@@ -10,8 +10,11 @@
       Please wait a moment&mdash;almost there!
     {% endblocktrans %}
   </p>
-  <p class="timeout-message" data-bind="visible: showSecondTimeout">
+  <p class="timeout-message" data-bind="visible: showFirstTimeout">
     <i class="fa fa-check"></i> {% trans "Created new user..." %}
+  </p>
+  <p class="timeout-message" data-bind="visible: showSecondTimeout">
+    <i class="fa fa-check"></i> {% trans "Prepared project space..." %}
   </p>
   <p class="timeout-message" data-bind="visible: showThirdTimeout">
     <i class="fa fa-check"></i> {% trans "Updated reports..." %}


### PR DESCRIPTION
## Product Description
Removes the automatic creation of these 3 template apps for new accounts in SaaS environments:
![image](https://github.com/user-attachments/assets/42502d59-fd08-49f4-8b18-7b4cb662c31d)

This will be paired with a removal of the Appcues workflow that highlights these template apps:
![image](https://github.com/user-attachments/assets/f86cfe75-3110-40eb-be62-d9263d6d0e23)

This should also have the effect of allowing the new account activation email to send more quickly, since it is not waiting on template apps to be built.

## Technical Summary
[SAAS-16570](https://dimagi.atlassian.net/browse/SAAS-16570)
Removes `load_appcues_template_app` and its usage when creating a new account. The code to load a template app generally is retained in [app_from_template](https://github.com/dimagi/commcare-hq/blob/498409c1ca4ab8f7da6ba41c8a54e8f8cdc71322/corehq/apps/app_manager/views/apps.py#L511) and `load_app_from_slug`, which it calls.

## Safety Assurance

### Safety story
This is a straightforward change and has been tested on staging to see that template apps are not created when a new account is registered.

### Automated test coverage
None here.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16570]: https://dimagi.atlassian.net/browse/SAAS-16570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ