### PR TITLE
Reduce hqImport usage in app_manager

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -1,7 +1,30 @@
 'use strict';
-hqDefine('app_manager/js/app_manager', function () {
-    var initialPageData = hqImport("hqwebapp/js/initial_page_data");
-    var module = hqImport("hqwebapp/js/bootstrap3/main").eventize({});
+hqDefine('app_manager/js/app_manager', [
+    'jquery',
+    'knockout',
+    'underscore',
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/toggles',
+    'analytix/js/google',
+    'analytix/js/kissmetrix',
+    'hqwebapp/js/bootstrap3/alert_user',
+    'hqwebapp/js/bootstrap3/main',
+    'app_manager/js/menu',
+    'app_manager/js/section_changer',
+], function (
+    $,
+    ko,
+    _,
+    initialPageData,
+    toggles,
+    google,
+    kissmetrix,
+    alertUser,
+    hqMain,
+    appManagerMenu,
+    sectionChanger
+) {
+    var module = hqMain.eventize({});
     var _private = {};
     _private.appendedPageTitle = "";
     _private.prependedPageTitle = "";
@@ -73,7 +96,7 @@ hqDefine('app_manager/js/app_manager', function () {
         if (module.fetchAndShowFormValidation) {
             module.fetchAndShowFormValidation();
         }
-        hqImport("hqwebapp/js/bootstrap3/main").updateDOM(update);
+        hqMain.updateDOM(update);
     };
 
     module.setupValidation = function (validationUrl) {
@@ -191,11 +214,11 @@ hqDefine('app_manager/js/app_manager', function () {
                             $form.data('clicked', 'true');
                             $('.new-module-icon').removeClass().addClass("fa fa-refresh fa-spin");
                             if (dataType === "case") {
-                                hqImport('analytix/js/google').track.event("Added Case List Menu");
-                                hqImport('analytix/js/kissmetrix').track.event("Added Case List Menu");
+                                google.track.event("Added Case List Menu");
+                                kissmetrix.track.event("Added Case List Menu");
                             } else if (dataType === "survey") {
-                                hqImport('analytix/js/google').track.event("Added Surveys Menu");
-                                hqImport('analytix/js/kissmetrix').track.event("Added Surveys Menu");
+                                google.track.event("Added Surveys Menu");
+                                kissmetrix.track.event("Added Surveys Menu");
                             }
                             $form.submit();
                         }
@@ -236,7 +259,7 @@ hqDefine('app_manager/js/app_manager', function () {
      */
     var _initMenuItemSorting = function () {
         var MODULE_SELECTOR = ".appmanager-main-menu .module";
-        if (!hqImport('hqwebapp/js/toggles').toggleEnabled('LEGACY_CHILD_MODULES')) {
+        if (!toggles.toggleEnabled('LEGACY_CHILD_MODULES')) {
             nestChildModules();
             initChildModuleUpdateListener();
         }
@@ -394,13 +417,13 @@ hqDefine('app_manager/js/app_manager', function () {
                 method: 'POST',
                 data: data,
                 success: function () {
-                    hqImport('hqwebapp/js/bootstrap3/alert_user').alert_user(gettext("Moved successfully."), "success");
+                    alertUser.alert_user(gettext("Moved successfully."), "success");
                 },
                 error: function (xhr) {
-                    hqImport('hqwebapp/js/bootstrap3/alert_user').alert_user(xhr.responseJSON.error, "danger");
+                    alertUser.alert_user(xhr.responseJSON.error, "danger");
                 },
             });
-            hqImport("app_manager/js/menu").setPublishStatus(true);
+            appManagerMenu.setPublishStatus(true);
         }
 
     };
@@ -414,7 +437,7 @@ hqDefine('app_manager/js/app_manager', function () {
         $forms.each(function () {
             var $form = $(this),
                 $buttonHolder = $form.find('.save-button-holder'),
-                button = hqImport("hqwebapp/js/bootstrap3/main").initSaveButtonForm($form, {
+                button = hqMain.initSaveButtonForm($form, {
                     unsavedMessage: gettext("You have unsaved changes"),
                     success: function (data) {
                         var key;
@@ -433,7 +456,7 @@ hqDefine('app_manager/js/app_manager', function () {
                 });
             button.ui.appendTo($buttonHolder);
             $buttonHolder.data('button', button);
-            hqImport("app_manager/js/section_changer").attachToForm($form);
+            sectionChanger.attachToForm($form);
         });
     };
 

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
@@ -8,6 +8,10 @@ hqDefine('app_manager/js/app_manager_media', function () {
                 isDefaultLanguage: initialPageData.get('current_language') === initialPageData.get('default_language'),
             };
 
+        self.trackGoogleEvent = function() {
+            hqImport('analytix/js/google').track.event(...arguments);
+        };
+
         self.enabled = ko.observable(
             o.ref.use_default_media ? self.isDefaultLanguage : true
         );

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -142,6 +142,9 @@ hqDefine("app_manager/js/details/column", function () {
             self.field = uiElementInput.new(self.original.field);
         }
         self.field.setIcon(icon);
+        self.getFieldHtml = function (value) {
+            return hqImport('app_manager/js/details/utils').getFieldHtml(value);
+        };
 
         // Make it possible to observe changes to self.field
         // note self observableVal is read only!
@@ -201,6 +204,7 @@ hqDefine("app_manager/js/details/column", function () {
 
         self.saveAttempted = ko.observable(false);
         self.useXpathExpression = self.original.useXpathExpression;
+        self.warningText = hqImport('app_manager/js/details/utils').fieldFormatWarningMessage;
         self.showWarning = ko.computed(function () {
             if (self.useXpathExpression) {
                 return false;

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -59,6 +59,7 @@ hqDefine("app_manager/js/details/screen", function () {
         self.containsSearchConfiguration = options.containsSearchConfiguration;
         self.containsCustomXMLConfiguration = options.containsCustomXMLConfiguration;
         self.allowsTabs = options.allowsTabs;
+        self.allowsCustomXML = hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CUSTOM_XML');
 
         let baseCaseTileTemplateOptions = [[null, gettext("Don't Use Case Tiles")]];
         if (hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_TILE_CUSTOM')) {
@@ -334,8 +335,7 @@ hqDefine("app_manager/js/details/screen", function () {
             });
         };
         self.allowsEmptyColumns = options.allowsEmptyColumns;
-        self.persistentCaseTileFromModule = (
-            ko.observable(detail.persistent_case_tile_from_module || ""));
+        self.persistentCaseTileFromModule = ko.observable(detail.persistent_case_tile_from_module || "");
         self.fireChange = function () {
             self.fire('change');
         };

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -687,12 +687,16 @@ hqDefine("app_manager/js/details/screen", function () {
                 hasAutocomplete: true,
             });
         };
+
+        self.hasGraphing = hqImport('app_manager/js/app_manager').checkCommcareVersion("2.17");
         self.addGraph = function () {
             self.addItem({
                 hasAutocomplete: false,
                 format: 'graph',
             });
         };
+
+        self.hasXpathExpressions = hqImport("hqwebapp/js/initial_page_data").get("add_ons").calc_xpaths;
         self.addXpathExpression = function () {
             self.addItem({
                 hasAutocomplete: false,

--- a/corehq/apps/app_manager/static/app_manager/js/details/sort_rows.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/sort_rows.js
@@ -18,6 +18,7 @@ hqDefine("app_manager/js/details/sort_rows", function () {
         self.sortCalculation = ko.observable(typeof params.sortCalculation !== 'undefined' ? params.sortCalculation : "");
 
         self.showWarning = ko.observable(false);
+        self.warningText = hqImport('app_manager/js/details/utils').fieldFormatWarningMessage;
         self.hasValidPropertyName = function () {
             let name = self.selectField.val();
             // changes here should also be made in

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -38,6 +38,10 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             self.moduleCaseTypes = params.moduleCaseTypes;
             self.allowUsercase = params.allowUsercase;
 
+            self.trackGoogleEvent = function() {
+                hqImport('analytix/js/google').track.event(...arguments);
+            };
+
             self.setPropertiesMap = function (propertiesMap) {
                 self.propertiesMap = ko.mapping.fromJS(propertiesMap);
             };

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -6,6 +6,7 @@ hqDefine("app_manager/js/releases/releases", [
     "analytix/js/kissmetrix",
     "app_manager/js/download_async_modal",
     "hqwebapp/js/initial_page_data",
+    "app_manager/js/app_manager",
     "app_manager/js/menu",
 ], function (
     $,
@@ -15,6 +16,7 @@ hqDefine("app_manager/js/releases/releases", [
     kissmetrix,
     downloadAsyncModal,
     initialPageData,
+    appManager,
     menu,
 ) {
     function savedAppModel(appData, releasesMain) {
@@ -44,6 +46,9 @@ hqDefine("app_manager/js/releases/releases", [
         });
         self.app_code = ko.observable(null);
         self.failed_url_generation = ko.observable(false);
+        self.allowOfflineInstall = ko.observable(function () {
+            return appManager.versionGE(self.build_spec.version(), '2.13.0');
+        });
         self.build_profile = ko.observable('');
 
         self.base_url = function () {

--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -63,6 +63,7 @@
     <script src="{% static 'langcodes/js/langcodes.js' %}"></script>
     <script src="{% static 'jquery-textchange/jquery.textchange.js' %}"></script>
     <script src="{% static 'hqwebapp/js/select2_knockout_bindings.ko.js' %}"></script>
+    <script src="{% static 'app_manager/js/section_changer.js' %}"></script>
     <script src="{% static 'app_manager/js/app_manager_utils.js' %}"></script>
     <script src="{% static 'app_manager/js/preview_app.js' %}"></script>
     <script src="{% static 'app_manager/js/apps_base.js' %}"></script>
@@ -70,7 +71,6 @@
     <script src="{% static 'app_manager/js/app_manager.js' %}"></script><!-- depends on menu.js -->
     <script src="{% static 'app_manager/js/managed_app.js' %}"></script>
     <script src="{% static 'hqwebapp/js/bootstrap3/rollout_modal.js' %}"></script>
-    <script src="{% static 'app_manager/js/section_changer.js' %}"></script>
     <script src="{% static 'app_manager/js/custom_assertions.js' %}"></script>
   {% endcompress %}
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
@@ -135,7 +135,7 @@
                              value: actionType,
                              event: {
                                change: function() {
-                                 hqImport('analytix/js/google').track.event('Case Management', 'Form Level', 'Case Action');
+                                 $root.trackGoogleEvent('Case Management', 'Form Level', 'Case Action');
                                }
                              }"></select>
         </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
@@ -1,30 +1,26 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-<script type="text/html"
-        id="remove-subcase-modal-template">
+<script type="text/html" id="remove-subcase-modal-template">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
         <a href="#" class="close" data-dismiss="modal">×</a>
-        <h4 class="modal-title">
-          {% trans "Remove Child Case?" %}
-        </h4>
+        <h4 class="modal-title">{% trans "Remove Child Case?" %}</h4>
       </div>
       <div class="modal-body">
-        <p>
-          {% trans "Are you sure you want to remove this Child Case?" %}
-        </p>
+        <p>{% trans "Are you sure you want to remove this Child Case?" %}</p>
       </div>
       <div class="modal-footer">
-        <a href="#" class="btn btn-default"
-           data-dismiss="modal">
+        <a href="#" class="btn btn-default" data-dismiss="modal">
           {% trans "Cancel" %}
         </a>
-        <a class="btn btn-danger"
-           href="#"
-           data-bind="click: $parent.removeSubCase"
-           data-dismiss="modal">
+        <a
+          class="btn btn-danger"
+          href="#"
+          data-bind="click: $parent.removeSubCase"
+          data-dismiss="modal"
+        >
           {% trans "Remove Child Case" %}
         </a>
       </div>
@@ -32,28 +28,29 @@
   </div>
 </script>
 
-<script type="text/html"
-        id="case-config:case-transaction">
-
+<script type="text/html" id="case-config:case-transaction">
   {% if add_ons.conditional_form_actions %}
-    <div class="panel panel-appmanager"
-         data-bind="visible: allow.condition()">
-      <div class="panel-heading">
-        <h4 class="panel-title panel-title-nolink">
-          {% trans "Open Case Condition" %}
-        </h4>
-      </div>
-      <div class="panel-body">
-        <div data-bind="template: {
+  <div class="panel panel-appmanager" data-bind="visible: allow.condition()">
+    <div class="panel-heading">
+      <h4 class="panel-title panel-title-nolink">
+        {% trans "Open Case Condition" %}
+      </h4>
+    </div>
+    <div class="panel-body">
+      <div
+        data-bind="template: {
                           name: 'case-config:condition',
                           data: {condition: condition, config: $data}
-                        }"></div>
-      </div>
+                        }"
+      ></div>
     </div>
+  </div>
   {% endif %}
 
-  <div class="panel panel-appmanager case-properties wide-select2s"
-       data-bind="template: 'case-config:case-transaction:case-properties'"></div>
+  <div
+    class="panel panel-appmanager case-properties wide-select2s"
+    data-bind="template: 'case-config:case-transaction:case-properties'"
+  ></div>
 
   <div class="panel panel-appmanager">
     <div class="panel-heading">
@@ -63,52 +60,60 @@
     </div>
     <div class="panel-body">
       <label>
-        <input type="checkbox"
-               data-bind="checked: close_case,
-                          disable: !hasPrivilege"/>
+        <input
+          type="checkbox"
+          data-bind="checked: close_case,
+                          disable: !hasPrivilege"
+        />
         {% trans "Close this case when the form is complete" %}
       </label>
       {% if add_ons.conditional_form_actions %}
-        <div data-bind="template: {
+      <div
+        data-bind="template: {
                           name: 'case-config:condition',
                           data: {
                             condition: $data.close_condition,
                             config: $data
                           },
                           if: $data.close_condition
-                        }"></div>
+                        }"
+      ></div>
       {% endif %}
     </div>
   </div>
-
 </script>
 
 <div id="case-config-ko">
-
   <div data-bind="saveButton: saveButton"></div>
 
   <div data-bind="with: caseConfigViewModel">
-
     <div class="panel panel-appmanager">
       <div class="panel-heading">
-        <h4 class="panel-title panel-title-nolink">
-          {% trans "Cases" %}
-        </h4>
+        <h4 class="panel-title panel-title-nolink">{% trans "Cases" %}</h4>
       </div>
       <div class="panel-body">
         <div class="container-fluid">
           <p class="lead">
             {% blocktrans %}
               <span data-bind="visible: showLeadRegistration">
-                This is a <strong><i class="fcc fcc-app-createform"></i> Registration</strong> form.
-                Use the Registration form to add new cases to your <strong><i class="fa fa-bars"></i> Case List</strong>.
+                This is a
+                <strong
+                  ><i class="fcc fcc-app-createform"></i> Registration</strong
+                >
+                form. Use the Registration form to add new cases to your
+                <strong><i class="fa fa-bars"></i> Case List</strong>.
               </span>
               <span data-bind="visible: showLeadFollowup">
-                This is a <strong><i class="fcc fcc-app-updateform"></i> Followup</strong> form.
-                Use Followup forms to update cases in your <strong><i class="fa fa-bars"></i> Case List</strong>.
+                This is a
+                <strong><i class="fcc fcc-app-updateform"></i> Followup</strong>
+                form. Use Followup forms to update cases in your
+                <strong><i class="fa fa-bars"></i> Case List</strong>.
               </span>
               <br />
-              <span><strong>Cases</strong> give you a way to track patients, farms, and other entities over time.</span>
+              <span
+                ><strong>Cases</strong> give you a way to track patients, farms,
+                and other entities over time.</span
+              >
             {% endblocktrans %}
           </p>
 
@@ -120,9 +125,10 @@
           {% else %}
             {% trans "Followup: This form loads a case and may then update or close it" as updates_case %}
           {% endif %}
-          <select class="form-control"
-                  id="case-action-select"
-                  data-bind="optstr: [
+          <select
+            class="form-control"
+            id="case-action-select"
+            data-bind="optstr: [
                                {
                                  value: 'open',
                                  label: '{{ registers_case|escapejs }}'
@@ -137,7 +143,8 @@
                                change: function() {
                                  $root.trackGoogleEvent('Case Management', 'Form Level', 'Case Action');
                                }
-                             }"></select>
+                             }"
+          ></select>
         </div>
       </div>
     </div>
@@ -145,52 +152,68 @@
     {% if form.source %}
       <!--ko if: actionType() === 'update' -->
       {% if module_loads_registry_case %}
-      <div class="panel panel-appmanager">
-        <div class="panel-body">
-          <p>{% blocktrans trimmed %}Updating cases directly is not supported when using data registry search. Refer
-            to the <a href="https://confluence.dimagi.com/display/USH/Data+Registry#DataRegistry-Updatingcases" target="_blank">documentation</a>
-            for information on how to update cases from a data registry.
-          {% endblocktrans %}</p>
+        <div class="panel panel-appmanager">
+          <div class="panel-body">
+            <p>
+              {% blocktrans trimmed %}
+                Updating cases directly is not supported when using data
+                registry search. Refer to the
+                <a
+                  href="https://confluence.dimagi.com/display/USH/Data+Registry#DataRegistry-Updatingcases"
+                  target="_blank"
+                  >documentation</a
+                >
+                for information on how to update cases from a data registry.
+              {% endblocktrans %}
+            </p>
+          </div>
         </div>
-      </div>
       {% elif module_is_multi_select %}
-      <div class="panel panel-appmanager">
-        <div class="panel-body">
-          <p>{% blocktrans trimmed %}
-            Updating cases directly is not supported for multi-select menus.
-          {% endblocktrans %}</p>
+        <div class="panel panel-appmanager">
+          <div class="panel-body">
+            <p>
+              {% blocktrans trimmed %}
+                Updating cases directly is not supported for multi-select menus.
+              {% endblocktrans %}
+            </p>
+          </div>
         </div>
-      </div>
       {% else %}
-      <div data-bind="template: {
+        <div
+          data-bind="template: {
                         name: 'case-config:case-transaction',
                         data: case_transaction
-                      }"></div>
+                      }"
+        ></div>
       {% endif %}
       <!--/ko-->
       <!--ko if: actionType() === 'open' -->
-      <div data-bind="template: {
+      <div
+        data-bind="template: {
                         name: 'case-config:case-transaction',
                         data: case_transaction
-                      }"></div>
+                      }"
+      ></div>
       <!--/ko-->
       {% if add_ons.subcases %}
         {% if module_loads_registry_case or module_is_multi_select %}
-        {# only allow subcases updating a single case in the same domain #}
-        <!--ko if: actionType() === 'open'-->
+          {# only allow subcases updating a single case in the same domain #}
+          <!--ko if: actionType() === 'open'-->
         {% else %}
-        <!--ko if: actionType() !== 'none'-->
+          <!--ko if: actionType() !== 'none'-->
         {% endif %}
         <hr />
         <p class="lead">
           {% blocktrans %}
-            <strong>Child Cases</strong> let you open other types of Cases for use in other Case Lists.
+            <strong>Child Cases</strong> let you open other types of Cases for
+            use in other Case Lists.
           {% endblocktrans %}
         </p>
         <p>
           {% blocktrans %}
-            When possible, they'll be linked to the current Case so you'll always know where they came from.
-            A great use of Child Cases is for tracking a newborn separately from its mother.
+            When possible, they'll be linked to the current Case so you'll
+            always know where they came from. A great use of Child Cases is for
+            tracking a newborn separately from its mother.
           {% endblocktrans %}
         </p>
 
@@ -199,9 +222,10 @@
             <p>
               <i class="fa fa-info-circle"></i>
               {% blocktrans %}
-                <strong>Child Cases</strong> are not available in your subscription.
-                This feature is only available on our <strong>Pro</strong> plan or higher.
-                This configuration will remain un-editable until you upgrade.
+                <strong>Child Cases</strong> are not available in your
+                subscription. This feature is only available on our
+                <strong>Pro</strong> plan or higher. This configuration will
+                remain un-editable until you upgrade.
               {% endblocktrans %}
             </p>
             <p>
@@ -216,14 +240,18 @@
               <h4 class="panel-title panel-title-nolink form-inline">
                 <i class="fa fa-check"></i>
                 {% trans "This Form opens a Child Case in the Case List" %}:&nbsp;
-                <span data-bind="text: $parent.getCaseTypeLabel(case_type())"></span>
+                <span
+                  data-bind="text: $parent.getCaseTypeLabel(case_type())"
+                ></span>
               </h4>
             </div>
             <div class="panel-case-actions-actions">
               {% if add_ons_privileges.subcases %}
-                <a href="#"
-                   class="case-action-remove btn btn-purple"
-                   data-bind="openModal: 'remove-subcase-modal-template'">
+                <a
+                  href="#"
+                  class="case-action-remove btn btn-purple"
+                  data-bind="openModal: 'remove-subcase-modal-template'"
+                >
                   <i class="fa-regular fa-trash-can"></i>
                 </a>
               {% endif %}
@@ -237,25 +265,29 @@
                 </div>
                 <div class="panel-body form-inline">
                   {% trans "This Form opens a Child Case in the Case List" %}&nbsp;
-                  <span class="form-group"
-                        data-bind="css: {'has-warning': !case_type()}">
-                    <select class="form-control"
-                            {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
-                            data-bind="options: $parent.caseTypes,
+                  <span
+                    class="form-group"
+                    data-bind="css: {'has-warning': !case_type()}"
+                  >
+                    <select
+                      class="form-control"
+                      {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
+                      data-bind="options: $parent.caseTypes,
                                        optionsText: $parent.getCaseTypeLabel,
                                        value: case_type,
-                                       optionsCaption: 'Choose a Module...'"></select>
+                                       optionsCaption: 'Choose a Module...'"
+                    ></select>
                     <span class="help-block" data-bind="visible: !case_type()">
                       {% trans "Required" %}
                     </span>
                     {% if show_custom_ref %}
-                      <label>
-                        {% trans "Override reference id: " %}
-                      </label>
-                      <input type="text"
-                             {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
-                             class="form-control"
-                             data-bind="value: reference_id"/>
+                      <label> {% trans "Override reference id: " %} </label>
+                      <input
+                        type="text"
+                        {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
+                        class="form-control"
+                        data-bind="value: reference_id"
+                      />
                     {% endif %}
                   </span>
                 </div>
@@ -265,9 +297,7 @@
           </div>
         </div>
         {% if add_ons_privileges.subcases %}
-          <a href="#"
-             class="btn btn-default"
-             data-bind="click: addSubCase">
+          <a href="#" class="btn btn-default" data-bind="click: addSubCase">
             <i class="fa fa-plus"></i>
             {% trans "Add a Child Case to open a case for a different Case List..." %}
           </a>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -81,7 +81,7 @@
                        change: function(view, e) {
                          if (e.target.closest('#case-config-ko')) {
                            var action = e.target.closest('.case-preload') ? 'Load' : 'Save';
-                           hqImport('analytix/js/google').track.event('Case Management', 'Form Level', action + ' Property (add/edit)');
+                            $root.trackGoogleEvent('Case Management', 'Form Level', action + ' Property (add/edit)');
                          }
                        }
                      }"></select>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/add_property_button.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/add_property_button.html
@@ -12,19 +12,19 @@
     <ul class="dropdown-menu">
       <li data-bind="click: addProperty"><a>{% trans "Property" %}</a></li>
 
-      <!-- ko if: hqImport('app_manager/js/app_manager').checkCommcareVersion("2.17") -->
+      <!-- ko if: hasGraphing -->
       <li data-bind="click: addGraph"><a>{% trans "Graph" %}</a></li>
       <!-- /ko -->
-      <!-- ko ifnot: hqImport('app_manager/js/app_manager').checkCommcareVersion("2.17") -->
+      <!-- ko ifnot: hasGraphing -->
       <li class="disabled"><a>{% trans "Graph <small>(upgrade to 2.17 or greater)</small>" %}</a></li>
       <!-- /ko -->
 
-      <!-- ko if: hqImport("hqwebapp/js/initial_page_data").get("add_ons").calc_xpaths -->
+      <!-- ko if: hasXpathExpressions -->
       <li data-bind="click: addXpathExpression"><a>{% trans "Calculated Property" %}</a></li>
       <!-- /ko -->
     </ul>
   {% else %}
-    <!-- ko if: hqImport("hqwebapp/js/initial_page_data").get("add_ons").calc_xpaths -->
+    <!-- ko if: hasXpathExpressions -->
     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
       <span class="caret"></span>
     </button>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/add_property_button.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/add_property_button.html
@@ -16,11 +16,15 @@
       <li data-bind="click: addGraph"><a>{% trans "Graph" %}</a></li>
       <!-- /ko -->
       <!-- ko ifnot: hasGraphing -->
-      <li class="disabled"><a>{% trans "Graph <small>(upgrade to 2.17 or greater)</small>" %}</a></li>
+      <li class="disabled">
+        <a>{% trans "Graph <small>(upgrade to 2.17 or greater)</small>" %}</a>
+      </li>
       <!-- /ko -->
 
       <!-- ko if: hasXpathExpressions -->
-      <li data-bind="click: addXpathExpression"><a>{% trans "Calculated Property" %}</a></li>
+      <li data-bind="click: addXpathExpression">
+        <a>{% trans "Calculated Property" %}</a>
+      </li>
       <!-- /ko -->
     </ul>
   {% else %}
@@ -30,7 +34,9 @@
     </button>
     <ul class="dropdown-menu">
       <li data-bind="click: addProperty"><a>{% trans "Property" %}</a></li>
-      <li data-bind="click: addXpathExpression"><a>{% trans "Calculated Property" %}</a></li>
+      <li data-bind="click: addXpathExpression">
+        <a>{% trans "Calculated Property" %}</a>
+      </li>
     </ul>
     <!-- /ko -->
   {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
@@ -2,7 +2,6 @@
 {% load hq_shared_tags %}
 {% load app_manager_extras %}
 {% load xforms_extras %}
-
 {% include 'app_manager/partials/modules/case_list_missing_warning.html' %}
 
 <div data-bind="saveButton: shortScreen.saveButton"></div>
@@ -17,7 +16,10 @@
     <div class="panel-body">
       <div class="row">
         <div class="col-sm-6">
-          <textarea class="form-control vertical-resize" data-bind="value: xml"></textarea>
+          <textarea
+            class="form-control vertical-resize"
+            data-bind="value: xml"
+          ></textarea>
         </div>
       </div>
     </div>
@@ -29,7 +31,6 @@
 {% if module.module_type != "shadow" and module.module_type != "advanced" %}
   {% include 'app_manager/partials/modules/case_list_multi_select.html' %}
 {% endif %}
-
 
 <div class="panel panel-appmanager">
   <div class="panel-heading">
@@ -44,50 +45,71 @@
         <div data-bind="visible: !caseTileTemplate()">
           <div class="checkbox">
             <label>
-              <input type="checkbox" data-bind="checked: persistCaseContext">
+              <input type="checkbox" data-bind="checked: persistCaseContext" />
               {% trans "Show some information about the case at the top of the screen when filling out forms" %}
             </label>
           </div>
           <div class="form-inline" data-bind="visible: persistCaseContext">
-            <label>
-              {% trans "Case property to show" %}
-            </label>
-            <input class="form-control" type="text" data-bind="value: persistentCaseContextXML" placeholder="e.g. case_name" />
+            <label> {% trans "Case property to show" %} </label>
+            <input
+              class="form-control"
+              type="text"
+              data-bind="value: persistentCaseContextXML"
+              placeholder="e.g. case_name"
+            />
           </div>
         </div>
       {% endif %}
       {% if app.supports_grouped_case_tiles %}
-      <div data-bind="visible: caseTileTemplate()">
-        <div class="checkbox">
-          <label>
-            <input type="checkbox" data-bind="checked: caseTileGrouped">
-            {% trans "Show case tiles grouped by parent case" %}
-          </label>
-        </div>
-        <div class="form-horizontal" data-bind="visible: caseTileGrouped">
-          <div class="form-group">
-              <label for="id_case_tile_group_by" class="col-xs-6 col-sm-4 col-md-4 col-lg-2 control-label">
+        <div data-bind="visible: caseTileTemplate()">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" data-bind="checked: caseTileGrouped" />
+              {% trans "Show case tiles grouped by parent case" %}
+            </label>
+          </div>
+          <div class="form-horizontal" data-bind="visible: caseTileGrouped">
+            <div class="form-group">
+              <label
+                for="id_case_tile_group_by"
+                class="col-xs-6 col-sm-4 col-md-4 col-lg-2 control-label"
+              >
                 {% trans "Parent case index name" %}
               </label>
               <div class="col-xs-6 col-sm-2 col-md-2 col-lg-2 controls">
-                <input class="form-control" type="text" data-bind="value: caseTileGroupBy" id="id_case_tile_group_by" placeholder="e.g. parent" />
+                <input
+                  class="form-control"
+                  type="text"
+                  data-bind="value: caseTileGroupBy"
+                  id="id_case_tile_group_by"
+                  placeholder="e.g. parent"
+                />
               </div>
-          </div>
-          <div class="form-group">
-              <label for="id_case_tile_header_rows" class="col-xs-6 col-sm-4 col-md-4 col-lg-2 control-label">
+            </div>
+            <div class="form-group">
+              <label
+                for="id_case_tile_header_rows"
+                class="col-xs-6 col-sm-4 col-md-4 col-lg-2 control-label"
+              >
                 {% trans "Case tile header rows" %}
               </label>
               <div class="col-xs-6 col-sm-2 col-md-2 col-lg-2 controls">
-                <input class="form-control" type="text" data-bind="value: caseTileGroupHeaderRows" id="id_case_tile_header_rows" placeholder="e.g. 2" />
+                <input
+                  class="form-control"
+                  type="text"
+                  data-bind="value: caseTileGroupHeaderRows"
+                  id="id_case_tile_header_rows"
+                  placeholder="e.g. 2"
+                />
               </div>
+            </div>
           </div>
         </div>
-      </div>
       {% endif %}
       <div data-bind="visible: caseTileTemplate() || allowsCustomXML">
         <div class="checkbox">
           <label>
-            <input type="checkbox" data-bind="checked: persistTileOnForms">
+            <input type="checkbox" data-bind="checked: persistTileOnForms" />
             {% trans "Use this case list tile persistently in forms" %}
           </label>
         </div>
@@ -102,12 +124,16 @@
                   {% trans "Use persistent case tile from menu" %}
                 </label>
                 <div>
-                  <select name='persistent_case_tile_from_module' class='form-control' data-bind="value: persistentCaseTileFromModule">
-                    <option value>
-                      {% trans "Select Menu" %}
-                    </option>
+                  <select
+                    name="persistent_case_tile_from_module"
+                    class="form-control"
+                    data-bind="value: persistentCaseTileFromModule"
+                  >
+                    <option value>{% trans "Select Menu" %}</option>
                     {% for other_mod in available_modules %}
-                      <option value={{ other_mod.unique_id }}>{{ other_mod.name|html_trans:langs }}</option>
+                      <option value="{{ other_mod.unique_id }}">
+                        {{ other_mod.name|html_trans:langs }}
+                      </option>
                     {% endfor %}
                   </select>
                 </div>
@@ -117,16 +143,23 @@
         {% endwith %}
       {% endif %}
 
-      <div data-bind="visible: caseTileTemplate() || persistentCaseTileFromModule() || allowsCustomXML">
-        <div class="checkbox" data-bind="visible: persistTileOnForms() || persistentCaseTileFromModule">
+      <div
+        data-bind="visible: caseTileTemplate() || persistentCaseTileFromModule() || allowsCustomXML"
+      >
+        <div
+          class="checkbox"
+          data-bind="visible: persistTileOnForms() || persistentCaseTileFromModule"
+        >
           <label>
-            <input type="checkbox" data-bind="checked: enableTilePullDown">
-            <span data-bind="visible: persistTileOnForms() && !persistentCaseTileFromModule()">
-                        {% trans "Embed case details in case tile pull-down" %}
-                    </span>
+            <input type="checkbox" data-bind="checked: enableTilePullDown" />
+            <span
+              data-bind="visible: persistTileOnForms() && !persistentCaseTileFromModule()"
+            >
+              {% trans "Embed case details in case tile pull-down" %}
+            </span>
             <span data-bind="visible: persistentCaseTileFromModule()">
-                        {% trans "Embed case details in case tile pull-down from the menu" %}
-                    </span>
+              {% trans "Embed case details in case tile pull-down from the menu" %}
+            </span>
           </label>
         </div>
       </div>
@@ -136,7 +169,6 @@
     </div>
   </div>
 </div>
-
 
 {% if detail.type == 'case' %}
   <div class="panel panel-appmanager">
@@ -152,141 +184,151 @@
           <div class="ui-sortable">
             <table class="table table-condensed" data-bind="visible: showing">
               <thead>
-              <tr>
-                <th></th>
-                <th>
-                  {% trans "Sort Property" %}
-                  <span class="hq-help-template"
-                        data-title="{% trans "Sort Properties" %}"
-                        data-content=
-                          "{% blocktrans %}
-                                              Properties in this list determine how
-                                              cases are ordered in your case list. This
-                                              is useful if for example you want higher
-                                              priority cases to appear closer to the
-                                              top of the list. The case list will sort
-                                              by the first property, then the second,
-                                              etc.
-                                          {% endblocktrans %}" >
-                                </span>
-                </th>
-                <th>{% trans "Direction" %}</th>
-                {% if app.enable_case_list_sort_blanks %}
+                <tr>
+                  <th></th>
                   <th>
-                    {% trans "Display Blanks" %}
-                    <span class="hq-help-template"
-                          data-title="{% trans "Display Blanks" %}"
-                          data-content=
-                            "{% blocktrans %}
-                                                  Should cases that don't have a value for the sort property
-                                                  appear at the top or the bottom of the case list?
-                                              {% endblocktrans %}" >
-                                    </span>
+                    {% trans "Sort Property" %}
+                    <span
+                      class="hq-help-template"
+                      data-title="{% trans "Sort Properties" %}"
+                      data-content="{% blocktrans %}
+                        Properties in this list determine how cases are ordered
+                        in your case list. This is useful if for example you
+                        want higher priority cases to appear closer to the top
+                        of the list. The case list will sort by the first
+                        property, then the second, etc.
+                      {% endblocktrans %}"
+                    >
+                    </span>
                   </th>
-                {% endif %}
-                {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
-                  <th>{% trans "Sort Calculation" %}</th>
-                {% endif %}
-                <th>{% trans "Format" %}</th>
-                <th>
-                  {% trans "Display Text" %}
-                  <span class="hq-help-template"
-                        data-title="{% trans "Display Text" %}"
-                        data-content=
-                          "{% blocktrans %}
-                                              The 'Display Text' is used for properties that are only listed as
-                                              Sort Properties and not as Display Properties above. The text appears
-                                              in the 'Sort By' menu on the mobile to allow the user to change the
-                                              sort ordering. If the display text is left blank then the option
-                                              for that sort property will not appear in the 'Sort By' menu.
-                                          {% endblocktrans %}" >
-                                </span>
-                </th>
-                <th></th>
-              </tr>
+                  <th>{% trans "Direction" %}</th>
+                  {% if app.enable_case_list_sort_blanks %}
+                    <th>
+                      {% trans "Display Blanks" %}
+                      <span
+                        class="hq-help-template"
+                        data-title="{% trans "Display Blanks" %}"
+                        data-content="{% blocktrans %}
+                          Should cases that don't have a value for the sort
+                          property appear at the top or the bottom of the case
+                          list?
+                        {% endblocktrans %}"
+                      >
+                      </span>
+                    </th>
+                  {% endif %}
+                  {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
+                    <th>{% trans "Sort Calculation" %}</th>
+                  {% endif %}
+                  <th>{% trans "Format" %}</th>
+                  <th>
+                    {% trans "Display Text" %}
+                    <span
+                      class="hq-help-template"
+                      data-title="{% trans "Display Text" %}"
+                      data-content="{% blocktrans %}
+                        The 'Display Text' is used for properties that are only
+                        listed as Sort Properties and not as Display Properties
+                        above. The text appears in the 'Sort By' menu on the
+                        mobile to allow the user to change the sort ordering. If
+                        the display text is left blank then the option for that
+                        sort property will not appear in the 'Sort By' menu.
+                      {% endblocktrans %}"
+                    >
+                    </span>
+                  </th>
+                  <th></th>
+                </tr>
               </thead>
               <tbody data-bind="foreach: sortRows(), sortableList: sortRows">
-              <tr>
-                <td>
-                  <i class="grip fa-solid fa-up-down icon-blue"></i>
-                </td>
-                <td class="form-group col-sm-2" data-bind="css: {'has-error': showWarning}">
-                  <div data-bind="jqueryElement: selectField.ui"></div>
-                  <div data-bind="visible: showWarning">
-                                    <span class="help-block" data-bind="
-                                        text: warningText
-                                    "></span>
-                  </div>
-                </td>
-                <td>
-                  <select class="form-control" data-bind="value: direction">
-                    <option value="ascending"
-                            data-bind="text: ascendText">
-                    </option>
-                    <option value="descending"
-                            data-bind="text: descendText">
-                    </option>
-                  </select>
-                </td>
-
-                {% if app.enable_case_list_sort_blanks %}
+                <tr>
                   <td>
-                    <select class="form-control" data-bind="value: blanks">
-                      <option value="last">
-                        {% trans "Bottom of list" %}
-                      </option>
-                      <option value="first">
-                        {% trans "Top of list" %}
-                      </option>
+                    <i class="grip fa-solid fa-up-down icon-blue"></i>
+                  </td>
+                  <td
+                    class="form-group col-sm-2"
+                    data-bind="css: {'has-error': showWarning}"
+                  >
+                    <div data-bind="jqueryElement: selectField.ui"></div>
+                    <div data-bind="visible: showWarning">
+                      <span
+                        class="help-block"
+                        data-bind="
+                                        text: warningText
+                                    "
+                      ></span>
+                    </div>
+                  </td>
+                  <td>
+                    <select class="form-control" data-bind="value: direction">
+                      <option
+                        value="ascending"
+                        data-bind="text: ascendText"
+                      ></option>
+                      <option
+                        value="descending"
+                        data-bind="text: descendText"
+                      ></option>
                     </select>
                   </td>
-                {% endif %}
 
-                {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
+                  {% if app.enable_case_list_sort_blanks %}
+                    <td>
+                      <select class="form-control" data-bind="value: blanks">
+                        <option value="last">
+                          {% trans "Bottom of list" %}
+                        </option>
+                        <option value="first">{% trans "Top of list" %}</option>
+                      </select>
+                    </td>
+                  {% endif %}
+
+                  {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
+                    <td>
+                      <input
+                        class="form-control"
+                        type="text"
+                        data-bind="value: sortCalculation"
+                      />
+                    </td>
+                  {% endif %}
+
                   <td>
-                    <input class="form-control" type='text' data-bind='value: sortCalculation'/>
-                  </td>
-                {% endif %}
-
-
-                <td>
-                  <select class="form-control" data-bind="value: type">
-                    <option value="plain">
-                      {% trans "Plain" %}
-                    </option>
-                    <option value="date">
-                      {% trans "Date" %}
-                    </option>
-                    <option value="int">
-                      {% trans "Integer" %}
-                    </option>
-                    <option value="double">
-                      {% trans "Decimal" %}
-                    </option>
-                    <option value="distance">
-                      {% trans "Distance from current location" %}
-                    </option>
-                    {% if request|toggle_enabled:'CACHE_AND_INDEX' %}
-                      <option value="index">
-                        {% trans "Cache and Index" %}
+                    <select class="form-control" data-bind="value: type">
+                      <option value="plain">{% trans "Plain" %}</option>
+                      <option value="date">{% trans "Date" %}</option>
+                      <option value="int">{% trans "Integer" %}</option>
+                      <option value="double">{% trans "Decimal" %}</option>
+                      <option value="distance">
+                        {% trans "Distance from current location" %}
                       </option>
-                    {% endif %}
-                  </select>
-                </td>
-                <td>
-                  <input class="form-control" type='text' data-bind='value: display'/>
-                </td>
-                <td>
-                  <a data-bind="click: $root.sortRows.removeSortRow">
-                    <i class="fa fa-remove icon-blue"></i>
-                  </a>
-                </td>
-              </tr>
+                      {% if request|toggle_enabled:'CACHE_AND_INDEX' %}
+                        <option value="index">
+                          {% trans "Cache and Index" %}
+                        </option>
+                      {% endif %}
+                    </select>
+                  </td>
+                  <td>
+                    <input
+                      class="form-control"
+                      type="text"
+                      data-bind="value: display"
+                    />
+                  </td>
+                  <td>
+                    <a data-bind="click: $root.sortRows.removeSortRow">
+                      <i class="fa fa-remove icon-blue"></i>
+                    </a>
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>
           <div class="form-group">
-            <button class="btn btn-default btn-sm" data-bind="
+            <button
+              class="btn btn-default btn-sm"
+              data-bind="
                     click: function(data){data.addSortRow('', '', '', '', '', true, '');}"
             >
               <i class="fa fa-plus"></i>
@@ -300,51 +342,67 @@
 {% endif %}
 
 {% if detail.parent_select %}
-  <div data-bind="with: parentSelect, DetailScreenConfig_notifyShortScreenOnChange: $root">
-    <div class="panel panel-appmanager" data-bind="visible: moduleOptions().length">
+  <div
+    data-bind="with: parentSelect, DetailScreenConfig_notifyShortScreenOnChange: $root"
+  >
+    <div
+      class="panel panel-appmanager"
+      data-bind="visible: moduleOptions().length"
+    >
       <div class="panel-heading">
         <h4 class="panel-title panel-title-nolink">
           {% trans "Parent Child Selection" %}
         </h4>
       </div>
-        <div class="form-horizontal panel-body">
-          <div class="form-group">
-            <label class="control-label {% css_label_class %}">
-              {% trans "Select Parent First" %}
-            </label>
-            <div>
-              <select-toggle data-apply-bindings="false"
-                             params="options: selectOptions, value: selectMode"
-                             data-bind="visible: enableOtherOption">
-              </select-toggle>
-              <div class="{% css_field_class %} checkbox"
-                   data-bind="visible: !enableOtherOption">
-                <label>
-                  <input type="checkbox" data-bind="checked: active"/>
-                </label>
-              </div>
+      <div class="form-horizontal panel-body">
+        <div class="form-group">
+          <label class="control-label {% css_label_class %}">
+            {% trans "Select Parent First" %}
+          </label>
+          <div>
+            <select-toggle
+              data-apply-bindings="false"
+              params="options: selectOptions, value: selectMode"
+              data-bind="visible: enableOtherOption"
+            >
+            </select-toggle>
+            <div
+              class="{% css_field_class %} checkbox"
+              data-bind="visible: !enableOtherOption"
+            >
+              <label>
+                <input type="checkbox" data-bind="checked: active" />
+              </label>
             </div>
           </div>
-          <div class="form-group" data-bind="visible: active, css: {'has-error': hasError}">
-            <label class="control-label {% css_label_class %}">
-              {% trans "Use Case List from" %}
-            </label>
-            <div class="{% css_field_class %}">
-              <select class="form-control" data-bind="optstr: moduleOptions, value: moduleId"></select>
-              <div class="help-block" data-bind="visible: hasError">
-                {% blocktrans %}
-                  This menu could not be found. It may have been deleted. Please select a different menu.
-                {% endblocktrans %}
-              </div>
+        </div>
+        <div
+          class="form-group"
+          data-bind="visible: active, css: {'has-error': hasError}"
+        >
+          <label class="control-label {% css_label_class %}">
+            {% trans "Use Case List from" %}
+          </label>
+          <div class="{% css_field_class %}">
+            <select
+              class="form-control"
+              data-bind="optstr: moduleOptions, value: moduleId"
+            ></select>
+            <div class="help-block" data-bind="visible: hasError">
+              {% blocktrans %}
+                This menu could not be found. It may have been deleted. Please
+                select a different menu.
+              {% endblocktrans %}
             </div>
           </div>
+        </div>
         <div class="spacer"></div>
       </div>
     </div>
   </div>
 {% endif %}
 
-{% if request|toggle_enabled:"CASE_LIST_LOOKUP" or request|toggle_enabled:"BIOMETRIC_INTEGRATION"  %}
+{% if request|toggle_enabled:"CASE_LIST_LOOKUP" or request|toggle_enabled:"BIOMETRIC_INTEGRATION" %}
   {% include "app_manager/partials/modules/case_list_lookup.html" %}
 {% endif %}
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
@@ -84,7 +84,7 @@
         </div>
       </div>
       {% endif %}
-      <div data-bind="visible: caseTileTemplate() || hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CUSTOM_XML')">
+      <div data-bind="visible: caseTileTemplate() || allowsCustomXML">
         <div class="checkbox">
           <label>
             <input type="checkbox" data-bind="checked: persistTileOnForms">
@@ -117,7 +117,7 @@
         {% endwith %}
       {% endif %}
 
-      <div data-bind="visible: caseTileTemplate() || persistentCaseTileFromModule() || hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_CUSTOM_XML')">
+      <div data-bind="visible: caseTileTemplate() || persistentCaseTileFromModule() || allowsCustomXML">
         <div class="checkbox" data-bind="visible: persistTileOnForms() || persistentCaseTileFromModule">
           <label>
             <input type="checkbox" data-bind="checked: enableTilePullDown">
@@ -214,7 +214,7 @@
                   <div data-bind="jqueryElement: selectField.ui"></div>
                   <div data-bind="visible: showWarning">
                                     <span class="help-block" data-bind="
-                                        text: hqImport('app_manager/js/details/utils').fieldFormatWarningMessage
+                                        text: warningText
                                     "></span>
                   </div>
                 </td>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
@@ -4,127 +4,180 @@
 <div>
   <table class="table table-condensed">
     <thead data-bind="visible: columns().length > 0">
-    <tr tabindex="999" data-bind="paste: function (data) { pasteCallback(data, 0); }">
-      <th class="col-sm-1"></th>
-      <th class="col-sm-2">{% trans "Property" %}</th>
-      <th class="col-sm-2">{% trans "Display Text" %}</th>
-      <!-- ko if: showCaseTileMappingColumn() -->
+      <tr
+        tabindex="999"
+        data-bind="paste: function (data) { pasteCallback(data, 0); }"
+      >
+        <th class="col-sm-1"></th>
+        <th class="col-sm-2">{% trans "Property" %}</th>
+        <th class="col-sm-2">{% trans "Display Text" %}</th>
+        <!-- ko if: showCaseTileMappingColumn() -->
         <th class="col-sm-3">{% trans "Format" %}</th>
         <th class="col-sm-2">{% trans "Case Tile Mapping" %}</th>
-      <!--/ko-->
-      <!-- ko ifnot: showCaseTileMappingColumn() -->
+        <!--/ko-->
+        <!-- ko ifnot: showCaseTileMappingColumn() -->
         <th class="col-sm-2">{% trans "Format" %}</th>
-      <!-- /ko -->
-      <!-- ko if: showCaseTileConfigColumns() -->
+        <!-- /ko -->
+        <!-- ko if: showCaseTileConfigColumns() -->
         <th class="col-sm-1">{% trans "Row/Column" %}</th>
         <th class="col-sm-1">{% trans "Width/Height" %}</th>
         <th class="col-sm-1">{% trans "Style" %}</th>
-      <!-- /ko -->
-      <th class="col-sm-1"></th>
-    </tr>
+        <!-- /ko -->
+        <th class="col-sm-1"></th>
+      </tr>
     </thead>
-    <tbody data-bind="sortable: {
+    <tbody
+      data-bind="sortable: {
             data: columns,
             afterAdd: function (elem) { $(elem).hide().fadeIn() },
             beforeRemove: function (elem) { $(elem).fadeOut() }
         }"
       {# there must be no whitespace between <tbody> and <tr> #}
       {# the .hide().fadeIn() will fail badly on FireFox #}
-    ><tr data-bind="
+    >
+      <tr
+        data-bind="
                 css: {info: $data.isTab},
                 attr: {'data-order': _sortableOrder, 'tabindex': 1000 + $index()},
                 copy: function () { return copyCallback(); },
                 paste: function (data) { $parent.pasteCallback(data, $index() + 1); }
-            ">
-      <td class="text-center col-sm-1">
-        <span class="sort-disabled" data-bind="ifnot: grip"></span>
-        <i class="grip sortable-handle fa-solid fa-up-down" data-bind="
+            "
+      >
+        <td class="text-center col-sm-1">
+          <span class="sort-disabled" data-bind="ifnot: grip"></span>
+          <i
+            class="grip sortable-handle fa-solid fa-up-down"
+            data-bind="
                         if: grip,
                         event: {mousedown: function(){ $(':focus').blur(); }}
-                    "></i>
-      </td>
-      <!--ko if: !isTab -->
+                    "
+          ></i>
+        </td>
+        <!--ko if: !isTab -->
         <td class="col-sm-2" data-bind="css: {'has-error': showWarning}">
-          <div data-bind="html: $data.getFieldHtml(field.val()), visible: !field.edit"></div>
+          <div
+            data-bind="html: $data.getFieldHtml(field.val()), visible: !field.edit"
+          ></div>
           <div data-bind="jqueryElement: field.ui, visible: field.edit"></div>
           <!-- ko if: useXpathExpression -->
-            <div class="label label-default">{% trans "Calculated Property" %}&nbsp;(#<span data-bind="text: $index() + 1"></span>)</div>
+          <div class="label label-default">
+            {% trans "Calculated Property" %}&nbsp;(#<span
+              data-bind="text: $index() + 1"
+            ></span
+            >)
+          </div>
           <!-- /ko -->
           <div data-bind="visible: showWarning">
-            <span class="help-block" data-bind="
+            <span
+              class="help-block"
+              data-bind="
                 text: warningText
-            ">
+            "
+            >
             </span>
           </div>
         </td>
         <td data-bind="jqueryElement: header.ui"></td>
-        <td data-bind="jqueryElement: $format, css: {
+        <td
+          data-bind="jqueryElement: $format, css: {
                               'col-sm-3': $parent.showCaseTileMappingColumn(),
                               'col-sm-2': !$parent.showCaseTileMappingColumn(),
-                          }"></td>
+                          }"
+        ></td>
         <!-- ko if: $parent.showCaseTileConfigColumns() -->
-          <td class="col-sm-1">
-            <select class="form-control" data-bind="value: tileRowStart, options: tileRowOptions, visible: coordinatesVisible"></select>
-            <select class="form-control" data-bind="value: tileColumnStart, options: tileColumnOptions, visible: coordinatesVisible"></select>
-          </td>
-          <td class="col-sm-1">
-            <select class="form-control" data-bind="value: tileWidth, options: tileWidthOptions, visible: coordinatesVisible"></select>
-            <select class="form-control" data-bind="value: tileHeight, options: tileHeightOptions, visible: coordinatesVisible"></select>
-          </td>
-          <td class="col-sm-1">
-            <button class="btn btn-default" data-bind="click: openStyleModal, visible: coordinatesVisible">{% trans "Edit" %}</button>
-          </td>
+        <td class="col-sm-1">
+          <select
+            class="form-control"
+            data-bind="value: tileRowStart, options: tileRowOptions, visible: coordinatesVisible"
+          ></select>
+          <select
+            class="form-control"
+            data-bind="value: tileColumnStart, options: tileColumnOptions, visible: coordinatesVisible"
+          ></select>
+        </td>
+        <td class="col-sm-1">
+          <select
+            class="form-control"
+            data-bind="value: tileWidth, options: tileWidthOptions, visible: coordinatesVisible"
+          ></select>
+          <select
+            class="form-control"
+            data-bind="value: tileHeight, options: tileHeightOptions, visible: coordinatesVisible"
+          ></select>
+        </td>
+        <td class="col-sm-1">
+          <button
+            class="btn btn-default"
+            data-bind="click: openStyleModal, visible: coordinatesVisible"
+          >
+            {% trans "Edit" %}
+          </button>
+        </td>
         <!--/ko-->
-      <!--/ko-->
-      <!--ko if: isTab -->
+        <!--/ko-->
+        <!--ko if: isTab -->
         <!--ko if: $data.hasNodeset -->
-          <td class="col-sm-3" data-bind="jqueryElement: header.ui"></td>
-          <td class="col-sm-3 form-group">
-            <div data-bind="jqueryElement: relevant.ui"></div>
-          </td>
-          <td class="col-sm-3 form-group" data-bind="css: {'has-error': showWarning}">
+        <td class="col-sm-3" data-bind="jqueryElement: header.ui"></td>
+        <td class="col-sm-3 form-group">
+          <div data-bind="jqueryElement: relevant.ui"></div>
+        </td>
+        <td
+          class="col-sm-3 form-group"
+          data-bind="css: {'has-error': showWarning}"
+        >
           <div data-bind="jqueryElement: nodeset_extra.ui"></div>
-          <span class="help-block"
-                data-bind="text: gettext('Please enter an expression.'), visible: showWarning"></span>
-          </td>
+          <span
+            class="help-block"
+            data-bind="text: gettext('Please enter an expression.'), visible: showWarning"
+          ></span>
+        </td>
         <!--/ko-->
         <!--ko ifnot: $data.hasNodeset -->
-          <td class="col-sm-3" data-bind="jqueryElement: header.ui"></td>
-          <td class="col-sm-3 form-group">
-            <div data-bind="jqueryElement: relevant.ui"></div>
-          </td>
-          <td class="col-sm-3 form-group" data-bind="css: {'has-error': showWarning}"></td>
+        <td class="col-sm-3" data-bind="jqueryElement: header.ui"></td>
+        <td class="col-sm-3 form-group">
+          <div data-bind="jqueryElement: relevant.ui"></div>
+        </td>
+        <td
+          class="col-sm-3 form-group"
+          data-bind="css: {'has-error': showWarning}"
+        ></td>
         <!--/ko-->
         <!-- ko if: $parent.showCaseTileConfigColumns() -->
-          <td class="col-sm-1"></td>
-          <td class="col-sm-1"></td>
-          <td class="col-sm-1"></td>
+        <td class="col-sm-1"></td>
+        <td class="col-sm-1"></td>
+        <td class="col-sm-1"></td>
         <!--/ko-->
-      <!--/ko-->
-      <!-- ko if: $parent.showCaseTileMappingColumn() && $parent.caseTileFieldsForTemplate() -->
+        <!--/ko-->
+        <!-- ko if: $parent.showCaseTileMappingColumn() && $parent.caseTileFieldsForTemplate() -->
         <td class="col-sm-2">
-          <select class="form-control" data-bind="value: case_tile_field, options: $parent.caseTileFieldsForTemplate, visible: !$data.isTab"></select>
+          <select
+            class="form-control"
+            data-bind="value: case_tile_field, options: $parent.caseTileFieldsForTemplate, visible: !$data.isTab"
+          ></select>
         </td>
-      <!-- /ko -->
-      <td class="col-sm-1 text-center">
-        <i style="cursor: pointer;"
-           title="{% trans "Delete"|escapejs %}"
-           class="fa fa-remove"
-           data-bind="
+        <!-- /ko -->
+        <td class="col-sm-1 text-center">
+          <i
+            style="cursor: pointer;"
+            title="{% trans "Delete"|escapejs %}"
+            class="fa fa-remove"
+            data-bind="
                         visible: ($parent.columns().length > 1 || $parent.allowsEmptyColumns),
                         click: function(){screen.columns.remove($data);},
-                    "></i>
-      </td>
-      {# there must be no whitespace between <tbody> and <tr> #}
-      {# the .hide().fadeIn() will fail badly on FireFox #}
-    </tr></tbody>
+                    "
+          ></i>
+        </td>
+        {# there must be no whitespace between <tbody> and <tr> #}
+        {# the .hide().fadeIn() will fail badly on FireFox #}
+      </tr>
+    </tbody>
     <tbody data-bind="visible: columns().length > 0">
-    <tr>
-      <td></td>
-      <td colspan="4">
-        {% include "app_manager/partials/modules/add_property_button.html" %}
-      </td>
-    </tr>
+      <tr>
+        <td></td>
+        <td colspan="4">
+          {% include "app_manager/partials/modules/add_property_button.html" %}
+        </td>
+      </tr>
     </tbody>
   </table>
   <div data-bind="visible: columns().length == 0">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
@@ -45,14 +45,14 @@
       </td>
       <!--ko if: !isTab -->
         <td class="col-sm-2" data-bind="css: {'has-error': showWarning}">
-          <div data-bind="html: hqImport('app_manager/js/details/utils').getFieldHtml(field.val()), visible: !field.edit"></div>
+          <div data-bind="html: $data.getFieldHtml(field.val()), visible: !field.edit"></div>
           <div data-bind="jqueryElement: field.ui, visible: field.edit"></div>
           <!-- ko if: useXpathExpression -->
             <div class="label label-default">{% trans "Calculated Property" %}&nbsp;(#<span data-bind="text: $index() + 1"></span>)</div>
           <!-- /ko -->
           <div data-bind="visible: showWarning">
             <span class="help-block" data-bind="
-                text: hqImport('app_manager/js/details/utils').fieldFormatWarningMessage
+                text: warningText
             ">
             </span>
           </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
@@ -2,67 +2,85 @@
 {% load hq_shared_tags %}
 <div id="{{ qualifier|default_if_none:"" }}media_{{ type }}">
   <div class="form-group">
-    <label class="control-label col-sm-2" for="menu_{{ type }}_path">{% trans label %}</label>
-    <div class="col-sm-10 commcare-feature"
-         data-since-version="1.3">
+    <label class="control-label col-sm-2" for="menu_{{ type }}_path"
+      >{% trans label %}</label
+    >
+    <div class="col-sm-10 commcare-feature" data-since-version="1.3">
       {% if type == "image" %}
         {# must use "if" here instead of "visible" #}
         {# otherwise src will be "#" which makes an unneccessary request for the current page #}
         <a data-bind="if: isMediaMatched, attr: {href: url}" target="_blank">
           <img data-bind="attr: {src: thumbnailUrl}"
-          /></a>
+        /></a>
       {% elif type == "audio" %}
-        <a data-bind="visible: isMediaMatched, attr: {href: url}"
-           class="btn btn-default"
-           target="_blank">
+        <a
+          data-bind="visible: isMediaMatched, attr: {href: url}"
+          class="btn btn-default"
+          target="_blank"
+        >
           <i class="fa fa-volume-up"></i>
           {% trans "Preview" %}
         </a>
       {% endif %}
-      <button type="button" class="btn btn-default" data-toggle="modal" data-target="#{{ slug }}"
-              data-bind="attr: { 'data-hqmediapath': currentPath },
+      <button
+        type="button"
+        class="btn btn-default"
+        data-toggle="modal"
+        data-target="#{{ slug }}"
+        data-bind="attr: { 'data-hqmediapath': currentPath },
                                enable: enabled,
                                event: {
                                     mediaUploadComplete: uploadComplete,
                                     click: passToUploadController
-                               }">
+                               }"
+      >
         <i class="fa-solid fa-cloud-arrow-up"></i>
         <span data-bind="visible: isMediaMatched">{% trans 'Replace' %}</span>
         <span data-bind="visible: isMediaUnmatched">{% trans 'Upload' %}</span>
       </button>
-      <button type="button" class="btn btn-danger"
-              data-bind="
+      <button
+        type="button"
+        class="btn btn-danger"
+        data-bind="
                         visible: refHasPath,
                         enable: enabled,
                         event: {
                             click: removeMedia
                         }
-                    ">
+                    "
+      >
         <i class="fa fa-remove"></i>
       </button>
-      <button type="button" class="btn btn-default pull-right"
-              data-bind="
+      <button
+        type="button"
+        class="btn btn-default pull-right"
+        data-bind="
                         visible: showDefaultPath,
                         enable: enabled,
                         click: function () {
                             setCustomPath();
                             $root.trackGoogleEvent('App Builder', 'Click Show Path for a Form or Module', '{{ type }}');
-                        }">
+                        }"
+      >
         <i class="fa fa-cog"></i>
         {% trans 'Set Path' %}
       </button>
-      {% if app.langs|length > 1%}
+      {% if app.langs|length > 1 %}
         <div data-bind="visible: isDefaultLanguage">
           <label>
             {% blocktrans %}
               Use this {{ label }} for all languages
             {% endblocktrans %}:
-            <input type="checkbox" data-bind="enable: enabled, checked: languagesLinked" />
+            <input
+              type="checkbox"
+              data-bind="enable: enabled, checked: languagesLinked"
+            />
           </label>
         </div>
         <div data-bind="visible: languagesLinked() && !isDefaultLanguage">
           {% blocktrans %}
-            This {{ label }} is linked to the default language, and can only be modified there.
+            This {{ label }} is linked to the default language, and can only be
+            modified there.
           {% endblocktrans %}
         </div>
       {% endif %}
@@ -71,24 +89,35 @@
   <div class="form-group" data-bind="visible: showCustomPath">
     <label class="control-label col-sm-2">{% trans "Path" %}</label>
     <div class="col-sm-4">
-      <input type="text" class="form-control"
-             data-bind="value: customPath,
+      <input
+        type="text"
+        class="form-control"
+        data-bind="value: customPath,
                          enable: enabled,
-                         valueUpdate: 'textchange'" />
-      <input type="hidden" class="jr-resource-field"
-             name="{{ qualifier|default_if_none:"" }}media_{{ type }}"
-             data-bind="value: savedPath" />
-      <input type="hidden"
-             name="{{ qualifier|default_if_none:"" }}use_default_{{type}}_for_all"
-             data-bind="value: languagesLinked" />
+                         valueUpdate: 'textchange'"
+      />
+      <input
+        type="hidden"
+        class="jr-resource-field"
+        name="{{ qualifier|default_if_none:"" }}media_{{ type }}"
+        data-bind="value: savedPath"
+      />
+      <input
+        type="hidden"
+        name="{{ qualifier|default_if_none:"" }}use_default_{{ type }}_for_all"
+        data-bind="value: languagesLinked"
+      />
     </div>
     <div class="col-sm-1">
-      <button type="button" class="btn btn-default"
-              data-bind="
+      <button
+        type="button"
+        class="btn btn-default"
+        data-bind="
                         visible: showCustomPath,
                         enable: enabled,
                         event: { click: setDefaultPath }
-                    ">
+                    "
+      >
         <i class="fa fa-remove"></i>
         {% trans 'Use Default Path' %}
       </button>

--- a/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
@@ -46,7 +46,7 @@
                         enable: enabled,
                         click: function () {
                             setCustomPath();
-                            hqImport('analytix/js/google').track.event('App Builder', 'Click Show Path for a Form or Module', '{{ type }}');
+                            $root.trackGoogleEvent('App Builder', 'Click Show Path for a Form or Module', '{{ type }}');
                         }">
         <i class="fa fa-cog"></i>
         {% trans 'Set Path' %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_deploy_modal.html
@@ -124,13 +124,13 @@
                         </ul>
                       </div>
                       <div class="tab-pane" id="offline-install-tab">
-                        <div data-bind="ifnot: hqImport('app_manager/js/app_manager').versionGE(build_spec.version(), '2.13.0')">
+                        <div data-bind="ifnot: allowOfflineInstall()">
                           Upgrade to CommCare 2.13 to use this feature
                         </div>
                         <div data-bind="ifnot: allow_media_install">
                           Offline install is unavailable for Remote Apps.
                         </div>
-                        <div data-bind="if: hqImport('app_manager/js/app_manager').versionGE(build_spec.version(), '2.13.0') && allow_media_install()">
+                        <div data-bind="if: allowOfflineInstall() && allow_media_install()">
                           {% if build_profile_access and not app.is_remote_app and app.build_profiles %}
                             <div class="form-inline">
                               <label style="font-weight: normal">{% trans "Application Profile" %}:</label>


### PR DESCRIPTION
## Technical Summary
This is part of the webpack migration for app manager, which will eliminate `hqImport`.

Review by commit. The "real" changes are minor. I did some prettifying, and I've skimmed those commits to make sure prettify didn't do anything weird.

## Safety Assurance

### Safety story
Relatively minor changes. Risk is of js errors breaking app manager.

### Automated test coverage

not really

### QA Plan

Not requesting QA. I've tested these changes locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
