### PR TITLE
Create admin page to check status of emails

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/email_status.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email_status.html
@@ -1,17 +1,27 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load i18n %}
 
 {% block page_content %}
   <p>{% trans "Check the status of an email" %}</p>
-  <form class="form-inline" method="GET" action="">
-    <input
-      name="q"
-      type="text"
-      class="form-control"
-      placeholder="you@example.com"
-    />
-    <input class="btn btn-primary" type="submit" />
-  </form>
+  <div class="">
+    <form method="GET" action="">
+      <div class="row">
+        <div class="col-sm-4">
+          <input
+            name="q"
+            type="text"
+            class="form-control"
+            placeholder="you@example.com"
+          />
+        </div>
+        <div class="col-sm-4">
+          <button class="btn btn-primary" type="submit">
+            {% trans "Check Status" %}
+          </button>
+        </div>
+      </div>
+    </form>
+  </div>
   {% if statuses %}
     <hr />
     <h1>{% blocktrans %}Email status for {{ email }}{% endblocktrans %}</h1>

--- a/corehq/apps/hqadmin/templates/hqadmin/email_status.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email_status.html
@@ -3,25 +3,23 @@
 
 {% block page_content %}
   <p>{% trans "Check the status of an email" %}</p>
-  <div class="">
-    <form method="GET" action="">
-      <div class="row">
-        <div class="col-sm-4">
-          <input
-            name="q"
-            type="text"
-            class="form-control"
-            placeholder="you@example.com"
-          />
-        </div>
-        <div class="col-sm-4">
-          <button class="btn btn-primary" type="submit">
-            {% trans "Check Status" %}
-          </button>
-        </div>
+  <form method="GET" action="">
+    <div class="row">
+      <div class="col-sm-4">
+        <input
+          name="q"
+          type="text"
+          class="form-control"
+          placeholder="you@example.com"
+        />
       </div>
-    </form>
-  </div>
+      <div class="col-sm-4">
+        <button class="btn btn-primary" type="submit">
+          {% trans "Check Status" %}
+        </button>
+      </div>
+    </div>
+  </form>
   {% if statuses %}
     <hr />
     <h1>{% blocktrans %}Email status for {{ email }}{% endblocktrans %}</h1>

--- a/corehq/apps/hqadmin/templates/hqadmin/email_status.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email_status.html
@@ -1,0 +1,39 @@
+{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% load i18n %}
+
+{% block page_content %}
+  <p>{% trans "Check the status of an email" %}</p>
+  <form class="form-inline" method="GET" action="">
+    <input
+      name="q"
+      type="text"
+      class="form-control"
+      placeholder="you@example.com"
+    />
+    <input class="btn btn-primary" type="submit" />
+  </form>
+  {% if statuses %}
+    <hr />
+    <h1>{% blocktrans %}Email status for {{ email }}{% endblocktrans %}</h1>
+    <p>
+      See documentation on
+      <a
+        href="https://dimagi.atlassian.net/wiki/spaces/saas/pages/2146610035/Handling+SES+Email+Bounces"
+        >SES Email Bounces</a
+      >
+      for more information.
+    </p>
+    <table class="table table-striped table-bordered">
+      <tr>
+        <th class="col-sm-4">{% trans "Type" %}</th>
+        <th class="col-sm-4">{% trans "Status" %}</th>
+      </tr>
+      {% for type, status in statuses.items %}
+        <tr>
+          <td>{{ type }}</td>
+          <td>{{ status }}</td>
+        </tr>
+      {% endfor %}
+    </table>
+  {% endif %}
+{% endblock %}

--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -28,6 +28,7 @@ from corehq.apps.hqadmin.views.users import (
     SuperuserManagement,
     OffboardingUserList,
     WebUserDataView,
+    email_status,
     superuser_table,
     web_user_lookup,
 )
@@ -48,6 +49,7 @@ urlpatterns = [
     url(r'^get_offboarding_list/$', OffboardingUserList.as_view(), name=OffboardingUserList.urlname),
     url(r'^superuser_table.csv$', superuser_table, name='superuser_table'),
     url(r'^tombstone_management/$', TombstoneManagement.as_view(), name=TombstoneManagement.urlname),
+    url(r'^email_status/$', email_status, name='email_status'),
     url(r'^create_tombstone/$', create_tombstone, name='create_tombstone'),
     url(r'^phone/restore/$', AdminRestoreView.as_view(), name="admin_restore"),
     url(r'^phone/restore/(?P<app_id>[\w-]+)/$', AdminRestoreView.as_view(), name='app_aware_admin_restore'),

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -35,6 +35,7 @@ from two_factor.utils import default_device
 from casexml.apps.phone.xml import SYNC_XMLNS
 from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
 from corehq.apps.hqadmin.utils import unset_password
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from couchexport.models import Format
 from couchforms.openrosa_response import RESPONSE_XMLNS
 from dimagi.utils.django.email import send_HTML_email
@@ -724,6 +725,7 @@ class OffboardingUserList(UserAdministration):
         return self.get(request, *args, **kwargs)
 
 
+@use_bootstrap5
 @require_superuser
 def email_status(request):
     template = "hqadmin/email_status.html"

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -723,6 +723,7 @@ class OffboardingUserList(UserAdministration):
 
         return self.get(request, *args, **kwargs)
 
+
 @require_superuser
 def email_status(request):
     template = "hqadmin/email_status.html"

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -2617,6 +2617,9 @@ class AdminTab(UITab):
                 {'title': _('Manage deleted domains'),
                  'url': reverse('tombstone_management'),
                  'icon': 'fa fa-minus-circle'},
+                {'title': _('Check email status'),
+                 'url': reverse('email_status'),
+                 'icon': 'fa fa-envelope-circle-check'},
             ]
             admin_operations = [
                 {'title': _('CommCare Builds'),

--- a/corehq/util/bounced_email_utils.py
+++ b/corehq/util/bounced_email_utils.py
@@ -15,8 +15,10 @@ from corehq.util.models import (
 def _get_blocked_emails(emails):
     return [email for email in emails if BLOCKED_EMAIL_DOMAIN_RECIPIENTS.enabled(email)]
 
+
 def _get_badly_formatted_emails(emails):
     return [email for email in emails if BouncedEmail.is_bad_email_format(email)]
+
 
 def _get_bounced_emails(emails):
     bounced_emails = set(BouncedEmail.objects.filter(email__in=emails).values_list('email', flat=True))
@@ -30,6 +32,7 @@ def _get_bounced_emails(emails):
     bounced_emails.update(transient_emails)
     return bounced_emails
 
+
 def _get_permanently_bounced_emails(bounced_emails):
     """
     For the given emails, find any records of these emails being bounced
@@ -40,12 +43,13 @@ def _get_permanently_bounced_emails(bounced_emails):
     # These are emails that were marked as Suppressed or Undetermined
     # by SNS metadata, meaning they definitely hard bounced
     permanent_bounces = set(
-        PermanentBounceMeta.objects.filter(sub_type__in=[
-            BounceSubType.UNDETERMINED, BounceSubType.SUPPRESSED
-        ], bounced_email__email__in=bounced_emails).values_list(
-            'bounced_email__email', flat=True)
+        PermanentBounceMeta.objects.filter(
+            sub_type__in=[BounceSubType.UNDETERMINED, BounceSubType.SUPPRESSED],
+            bounced_email__email__in=bounced_emails,
+        ).values_list('bounced_email__email', flat=True)
     )
     return permanent_bounces
+
 
 def _get_complaint_bounced_emails(emails):
     # These are definite complaints against us
@@ -55,6 +59,7 @@ def _get_complaint_bounced_emails(emails):
         )
     )
 
+
 def _get_legacy_bounced_emails(emails):
     # see note surrounding LEGACY_BOUNCE_MANAGER_DATE above
     return set(
@@ -63,6 +68,7 @@ def _get_legacy_bounced_emails(emails):
             created__lte=LEGACY_BOUNCE_MANAGER_DATE,
         ).values_list('email', flat=True)
     )
+
 
 def _get_emails_over_limit(bounced_emails):
     return [email for email in bounced_emails if BouncedEmail.is_email_over_limits(email)]
@@ -91,5 +97,3 @@ def get_email_statuses(emails):
         }
         statuses_by_email[email] = statuses_for_email
     return statuses_by_email
-
-

--- a/corehq/util/bounced_email_utils.py
+++ b/corehq/util/bounced_email_utils.py
@@ -1,0 +1,95 @@
+from collections import defaultdict
+
+from corehq.toggles import BLOCKED_EMAIL_DOMAIN_RECIPIENTS
+from corehq.util.email_event_utils import get_emails_to_never_bounce
+from corehq.util.models import (
+    LEGACY_BOUNCE_MANAGER_DATE,
+    BouncedEmail,
+    BounceSubType,
+    ComplaintBounceMeta,
+    PermanentBounceMeta,
+    TransientBounceEmail,
+)
+
+
+def _get_blocked_emails(emails):
+    return [email for email in emails if BLOCKED_EMAIL_DOMAIN_RECIPIENTS.enabled(email)]
+
+def _get_badly_formatted_emails(emails):
+    return [email for email in emails if BouncedEmail.is_bad_email_format(email)]
+
+def _get_bounced_emails(emails):
+    bounced_emails = set(BouncedEmail.objects.filter(email__in=emails).values_list('email', flat=True))
+    transient_emails = set(
+        TransientBounceEmail.get_active_query()
+        .filter(
+            email__in=emails,
+        )
+        .values_list('email', flat=True)
+    )
+    bounced_emails.update(transient_emails)
+    return bounced_emails
+
+def _get_permanently_bounced_emails(bounced_emails):
+    """
+    For the given emails, find any records of these emails being bounced
+    and if so, check if they are permanently bounced.
+    TODO: can we just check if there are any Permanent Bounces for the given emails?
+    """
+
+    # These are emails that were marked as Suppressed or Undetermined
+    # by SNS metadata, meaning they definitely hard bounced
+    permanent_bounces = set(
+        PermanentBounceMeta.objects.filter(sub_type__in=[
+            BounceSubType.UNDETERMINED, BounceSubType.SUPPRESSED
+        ], bounced_email__email__in=bounced_emails).values_list(
+            'bounced_email__email', flat=True)
+    )
+    return permanent_bounces
+
+def _get_complaint_bounced_emails(emails):
+    # These are definite complaints against us
+    return set(
+        ComplaintBounceMeta.objects.filter(bounced_email__email__in=emails).values_list(
+            'bounced_email__email', flat=True
+        )
+    )
+
+def _get_legacy_bounced_emails(emails):
+    # see note surrounding LEGACY_BOUNCE_MANAGER_DATE above
+    return set(
+        BouncedEmail.objects.filter(
+            email__in=emails,
+            created__lte=LEGACY_BOUNCE_MANAGER_DATE,
+        ).values_list('email', flat=True)
+    )
+
+def _get_emails_over_limit(bounced_emails):
+    return [email for email in bounced_emails if BouncedEmail.is_email_over_limits(email)]
+
+
+def get_email_statuses(emails):
+    statuses_by_email = defaultdict(dict)
+
+    blocked_emails = _get_blocked_emails(emails)
+    badly_formatted_emails = _get_badly_formatted_emails(emails)
+    bounced_emails = _get_bounced_emails(emails)
+    permanently_bounced_emails = _get_permanently_bounced_emails(bounced_emails)
+    complaint_bounced_emails = _get_complaint_bounced_emails(bounced_emails)
+    legacy_bounced_emails = _get_legacy_bounced_emails(emails)
+    emails_over_limit = _get_emails_over_limit(emails)
+    whitelisted_emails = set(get_emails_to_never_bounce()).union(set(emails))
+    for email in emails:
+        statuses_for_email = {
+            'blocked': email in blocked_emails,
+            'invalid_format': email in badly_formatted_emails,
+            'permanently_bounced': email in permanently_bounced_emails,
+            'complaint_bounced': email in complaint_bounced_emails,
+            'legacy_bounced': email in legacy_bounced_emails,
+            'over_limits': email in emails_over_limit,
+            'whitelisted': email in whitelisted_emails,
+        }
+        statuses_by_email[email] = statuses_for_email
+    return statuses_by_email
+
+


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
![image](https://github.com/user-attachments/assets/038aec20-63e4-4a60-9374-d0b42670f550)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
@AmitPhulera mentioned this idea and I'm reminded of it every time support asks a developer to check if an email is blocked. It would have been nice to reuse the same logic that is used when running the management command `check_bounced_email`, which effectively calls `BouncedEmail.get_hard_bounced_emails`, but there was a lot going on there and I was a bit hesitant to make changes to it since it is used in production code as well.

While not the DRYest addition to our codebase, I think it is a net positive as is.

A reasonable next iteration on this would be to allow unblocking an email from this UI, but I figured this is a good enough start and didn't want to sink too much time into it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just a change to the HQ admin page. The least safe part of this is the idea of taking action based on this information, but I've tried to keep the logic the same for how it does in `BouncedEmail.get_hard_bounced_emails`. 
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
