### PR TITLE
B5: fix spacing in forms

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_forms.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_forms.scss
@@ -9,6 +9,7 @@
 :not(.field-label) + .field-control,
 .row > .field-control:first-child {
   @extend .offset-sm-4, .offset-md-3, .offset-lg-2;
+  flex-shrink: initial;
 }
 
 .row > div > .form-check:first-child,
@@ -51,6 +52,10 @@ legend {
   border-bottom-right-radius: $border-radius;
   padding: $spacer 0;
   margin: 0 0 $spacer 0;
+
+  .field-control:first-child {
+    padding-left: ($grid-gutter-width - $spacer) / 2;
+  }
 
   > * {
     flex-shrink: initial;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/forms._forms.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/forms._forms.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,356 +1,20 @@
+@@ -1,356 +1,21 @@
 -// FORM ACTIONS from TWBS 2
 -// ------------
 -
@@ -39,6 +39,7 @@
 +:not(.field-label) + .field-control,
 +.row > .field-control:first-child {
 +  @extend .offset-sm-4, .offset-md-3, .offset-lg-2;
++  flex-shrink: initial;
  }
  
 -legend .subtext {
@@ -368,7 +369,7 @@
  }
  
  .form-hide-actions .form-actions {
-@@ -361,21 +25,38 @@
+@@ -361,21 +26,42 @@
    .validationMessage {
      display: block;
      padding-top: 8px;
@@ -409,6 +410,10 @@
 +  border-bottom-right-radius: $border-radius;
 +  padding: $spacer 0;
 +  margin: 0 0 $spacer 0;
++
++  .field-control:first-child {
++    padding-left: ($grid-gutter-width - $spacer) / 2;
++  }
 +
 +  > * {
 +    flex-shrink: initial;


### PR DESCRIPTION
## Technical Summary
I've been very bothered by a couple things in our bootstrap 5 forms....

First, the misalignment of the buttons in Form Actions is driving me absolutely mental.

Here is what it looks like before the fix:
![Screenshot 2025-02-20 at 10 19 26 PM](https://github.com/user-attachments/assets/17240608-b488-4cb0-b7c0-74e432cfddf9)

here's what it looks like after the fix:
![Screenshot 2025-02-20 at 10 19 36 PM](https://github.com/user-attachments/assets/4a881185-2e95-4a75-9f42-16ef10ebdde1)

Don't see it? let me help you...

Before:
![Screenshot 2025-02-20 at 10 21 57 PM](https://github.com/user-attachments/assets/8ec3ee8a-2508-40c2-ae2c-388ca8e3f90e)

After:
![Screenshot 2025-02-20 at 10 22 16 PM](https://github.com/user-attachments/assets/26ac4164-a18e-49df-89cf-7c7080e98705)

Didn't see it without the ruler? Count your blessings. Also, maybe don't do design...

Additionally, I fixed some issues with label-less `field-control`s feeling very wide. It's invisible, until it isn't and your page is scrolling sideways.

Before:
![Screenshot 2025-02-20 at 10 00 28 PM](https://github.com/user-attachments/assets/30d7c755-909a-48ad-a5cd-4d4a086a1562)

After:
![Screenshot 2025-02-20 at 10 25 19 PM](https://github.com/user-attachments/assets/86dc79fd-20ff-400a-9cac-22feab5f58f8)


## Safety Assurance

### Safety story
style updates only

### Automated test coverage
N/A

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
