### PR TITLE
flag_enabled on method takes precedence over class decorator

### DIFF
--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -177,7 +177,7 @@ def disable_overpatch(patch_obj):
         def decorate_callable(func):
             key = getkey(patch)
             if any(key == getkey(p) for p in getattr(func, "patchings", [])):
-                # do not decorate if already patched for this oneshot
+                # do not decorate if already patched
                 return func
             return real_decorate_callable(func)
 

--- a/corehq/util/tests/test_utils.py
+++ b/corehq/util/tests/test_utils.py
@@ -106,7 +106,7 @@ class TestFlagEnabled(TestCase):
         with flag_enabled("ASYNC_RESTORE"):
             assert ASYNC_RESTORE.enabled(...)
             assert ASYNC_RESTORE.enabled_for_request(...)
-            
+
     @flag_enabled("USER_CONFIGURABLE_REPORTS")
     def test_multiple_flags_enabled_at_different_levels(self):
         from corehq.toggles import ASYNC_RESTORE, USER_CONFIGURABLE_REPORTS

--- a/corehq/util/tests/test_utils.py
+++ b/corehq/util/tests/test_utils.py
@@ -2,7 +2,12 @@ from unittest import TestCase
 
 from testil import eq
 
-from ..test_utils import disable_quickcache, generate_cases
+from ..test_utils import (
+    disable_quickcache,
+    flag_disabled,
+    flag_enabled,
+    generate_cases,
+)
 
 
 def test_disable_quickcache():
@@ -81,3 +86,23 @@ def check_case(Test):
         test = getattr(test_case, name, None)
         assert test is not None, (name, dir(test_case))
         eq(test(), str(arg))
+
+
+@flag_enabled("ASYNC_RESTORE")  # random flag chosen for testing
+class TestFlagEnabled(TestCase):
+
+    def test_flag_is_enabled(self):
+        from corehq.toggles import ASYNC_RESTORE
+        assert ASYNC_RESTORE.enabled(...)
+        assert ASYNC_RESTORE.enabled_for_request(...)
+
+    @flag_disabled("ASYNC_RESTORE")
+    def test_flag_disabled_in_class_where_it_is_enabled(self):
+        from corehq.toggles import ASYNC_RESTORE
+        assert not ASYNC_RESTORE.enabled(...)
+        assert not ASYNC_RESTORE.enabled_for_request(...)
+
+        # context manager should be effective
+        with flag_enabled("ASYNC_RESTORE"):
+            assert ASYNC_RESTORE.enabled(...)
+            assert ASYNC_RESTORE.enabled_for_request(...)

--- a/corehq/util/tests/test_utils.py
+++ b/corehq/util/tests/test_utils.py
@@ -106,3 +106,9 @@ class TestFlagEnabled(TestCase):
         with flag_enabled("ASYNC_RESTORE"):
             assert ASYNC_RESTORE.enabled(...)
             assert ASYNC_RESTORE.enabled_for_request(...)
+            
+    @flag_enabled("USER_CONFIGURABLE_REPORTS")
+    def test_multiple_flags_enabled_at_different_levels(self):
+        from corehq.toggles import ASYNC_RESTORE, USER_CONFIGURABLE_REPORTS
+        assert ASYNC_RESTORE.enabled(...)
+        assert USER_CONFIGURABLE_REPORTS.enabled(...)


### PR DESCRIPTION
Inspired by and could be applied to https://github.com/dimagi/commcare-hq/pull/35781

## Safety Assurance

### Safety story

Affects tests only.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations, although it may cause tests to fail if they have been written to depend on this behavior.
