### PR TITLE
fix value error if there is an issue with initializing domain

### DIFF
--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -170,7 +170,7 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
                 'first_domain_for_user': is_new_user,
                 'error': str(error),
             })
-            new_domain.delete()
+            new_domain.delete(leave_tombstone=True)
             raise ErrorInitializingDomain(f"Subscription setup failed for '{name}'")
 
         if settings.IS_SAAS_ENVIRONMENT:


### PR DESCRIPTION
## Technical Summary
the `delete` function will always throw a `ValueError` (unless in `UNIT_TESTING` mode) due to
https://github.com/dimagi/commcare-hq/blob/12afbba03603ba172ebfc449531dbfc2647690a7/corehq/apps/domain/models.py#L785-L787

as a result the following exception (which the UI knows how to handle properly) is never raised

## Safety Assurance

### Safety story
safe change, also tested locally

### Automated test coverage
no

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
