### PR TITLE
Functionality for creating new session or resuming/restarting an existing session

### DIFF
--- a/corehq/apps/data_cleaning/forms/setup.py
+++ b/corehq/apps/data_cleaning/forms/setup.py
@@ -2,6 +2,7 @@ import json
 
 from crispy_forms import bootstrap as twbscrispy, layout as crispy
 from django import forms
+from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy, gettext as _
 
 from corehq.apps.hqwebapp import crispy as hqcrispy
@@ -43,6 +44,61 @@ class SelectCaseTypeForm(forms.Form):
         case_type = self.cleaned_data['case_type']
         if not self.cleaned_data['case_type']:
             raise forms.ValidationError(_("Please select a case type to continue."))
+        if case_type not in self.allowed_case_types:
+            raise forms.ValidationError(_("'{}' is not a valid case type").format(case_type))
+        return case_type
+
+
+class ResumeOrRestartCaseSessionForm(forms.Form):
+    case_type = forms.CharField(
+        label=gettext_lazy("Case Type"),
+        required=False,
+    )
+    next_step = forms.ChoiceField(
+        label=gettext_lazy("Next Step"),
+        required=False,
+        widget=forms.RadioSelect,
+        choices=(
+            ('resume', gettext_lazy("Resume the session.")),
+            ('new', gettext_lazy("Start a new session and delete the existing session.")),
+        ),
+    )
+
+    def __init__(self, domain, container_id, cancel_url, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.allowed_case_types = sorted(get_case_types_for_domain(domain))
+        self.helper = hqcrispy.HQFormHelper()
+        self.helper.form_tag = False
+        self.helper.layout = crispy.Layout(
+            crispy.HTML(render_to_string(
+                'data_cleaning/partials/forms/active_session_exists.html', {}
+            )),
+            crispy.Field(
+                'case_type',
+                readonly="",
+                css_class="form-control-plaintext",
+            ),
+            'next_step',
+            hqcrispy.FormActions(
+                twbscrispy.StrictButton(
+                    _("Start Session"),
+                    type="submit",
+                    css_class="btn btn-primary",
+                ),
+                twbscrispy.StrictButton(
+                    _("Go Back"),
+                    type="button",
+                    css_class="btn btn-outline-primary",
+                    hx_get=cancel_url,
+                    hx_target=f"#{container_id}",
+                    hx_disabled_elt='this',
+                ),
+                css_class="mb-0"
+            ),
+        )
+
+    def clean_case_type(self):
+        case_type = self.cleaned_data['case_type']
         if case_type not in self.allowed_case_types:
             raise forms.ValidationError(_("'{}' is not a valid case type").format(case_type))
         return case_type

--- a/corehq/apps/data_cleaning/forms/setup.py
+++ b/corehq/apps/data_cleaning/forms/setup.py
@@ -15,10 +15,10 @@ class SelectCaseTypeForm(forms.Form):
     )
 
     def __init__(self, domain, *args, **kwargs):
-        self.domain = domain
         super().__init__(*args, **kwargs)
+        self.allowed_case_types = sorted(get_case_types_for_domain(domain))
         self.fields['case_type'].choices = [(None, None)] + [
-            (c, c) for c in sorted(get_case_types_for_domain(self.domain))
+            (c, c) for c in self.allowed_case_types
         ]
         self.helper = hqcrispy.HQFormHelper()
         self.helper.form_tag = False
@@ -43,4 +43,6 @@ class SelectCaseTypeForm(forms.Form):
         case_type = self.cleaned_data['case_type']
         if not self.cleaned_data['case_type']:
             raise forms.ValidationError(_("Please select a case type to continue."))
+        if case_type not in self.allowed_case_types:
+            raise forms.ValidationError(_("'{}' is not a valid case type").format(case_type))
         return case_type

--- a/corehq/apps/data_cleaning/forms/setup.py
+++ b/corehq/apps/data_cleaning/forms/setup.py
@@ -25,7 +25,6 @@ class SelectCaseTypeForm(forms.Form):
         self.helper.layout = crispy.Layout(
             crispy.Field(
                 'case_type',
-                css_class="d-none",
                 x_select2=json.dumps({
                     "placeholder": _("Select a Case Type"),
                 }),

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -292,7 +292,7 @@ class BulkEditColumn(models.Model):
             'opened_on': _("Opened On"),
             'opened_by_username': _("Created By"),
             'modified_on': _("Last Modified On"),
-            'status': _("Status"),
+            '@status': _("Status"),
         }
         return known_labels.get(prop_id, prop_id)
 
@@ -307,7 +307,7 @@ class BulkEditColumn(models.Model):
         default_properties = {
             BulkEditSessionType.CASE: (
                 'name', 'owner_name', 'opened_on', 'opened_by_username',
-                'modified_on', 'status',
+                'modified_on', '@status',
             ),
         }.get(session.session_type)
 

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -72,6 +72,13 @@ class BulkEditSession(models.Model):
         return case_session
 
     @classmethod
+    def restart_case_session(cls, user, domain_name, case_type):
+        previous_session = cls.get_active_case_session(user, domain_name, case_type)
+        previous_session.delete()
+        new_session = cls.new_case_session(user, domain_name, case_type)
+        return new_session
+
+    @classmethod
     def new_form_session(cls, user, domain_name, xmlns):
         raise NotImplementedError("Form data cleaning sessions are not yet supported!")
 

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -3,8 +3,9 @@ import uuid
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.utils.translation import gettext_lazy
+from django.utils.translation import gettext_lazy, gettext as _
 
+from corehq.apps.case_search.const import METADATA_IN_REPORTS
 from corehq.apps.data_cleaning.exceptions import UnsupportedActionException
 
 
@@ -35,6 +36,44 @@ class BulkEditSession(models.Model):
 
     class Meta:
         ordering = ["-created_on"]
+
+    @classmethod
+    def get_active_case_session(cls, user, domain_name, case_type):
+        return cls._get_active_session(user, domain_name, case_type, BulkEditSessionType.CASE)
+
+    @classmethod
+    def get_active_form_session(cls, user, domain_name, xmlns):
+        return cls._get_active_session(user, domain_name, xmlns, BulkEditSessionType.FORM)
+
+    @classmethod
+    def _get_active_session(cls, user, domain_name, identifier, session_type):
+        try:
+            return cls.objects.get(
+                user=user,
+                domain=domain_name,
+                identifier=identifier,
+                session_type=session_type,
+                committed_on=None,
+                completed_on=None,
+            )
+        except cls.DoesNotExist:
+            return None
+
+    @classmethod
+    def new_case_session(cls, user, domain_name, case_type):
+        case_session = cls.objects.create(
+            user=user,
+            domain=domain_name,
+            identifier=case_type,
+            session_type=BulkEditSessionType.CASE,
+        )
+        BulkEditPinnedFilter.create_default_filters(case_session)
+        BulkEditColumn.create_default_columns(case_session)
+        return case_session
+
+    @classmethod
+    def new_form_session(cls, user, domain_name, xmlns):
+        raise NotImplementedError("Form data cleaning sessions are not yet supported!")
 
 
 class DataType:
@@ -185,6 +224,10 @@ class PinnedFilterType:
         (CASE_STATUS, CASE_STATUS),
     )
 
+    DEFAULT_FOR_CASE = (
+        CASE_OWNERS, CASE_STATUS
+    )
+
 
 class BulkEditPinnedFilter(models.Model):
     session = models.ForeignKey(BulkEditSession, related_name="pinned_filters", on_delete=models.CASCADE)
@@ -202,6 +245,22 @@ class BulkEditPinnedFilter(models.Model):
     class Meta:
         ordering = ["index"]
 
+    @classmethod
+    def create_default_filters(cls, session):
+        default_types = {
+            BulkEditSessionType.CASE: PinnedFilterType.DEFAULT_FOR_CASE,
+        }.get(session.session_type)
+
+        if not default_types:
+            raise NotImplementedError(f"{session.session_type} default pinned filters not yet supported")
+
+        for index, filter_type in enumerate(default_types):
+            cls.objects.create(
+                session=session,
+                index=index,
+                filter_type=filter_type,
+            )
+
 
 class BulkEditColumn(models.Model):
     session = models.ForeignKey(BulkEditSession, related_name="columns", on_delete=models.CASCADE)
@@ -217,6 +276,45 @@ class BulkEditColumn(models.Model):
 
     class Meta:
         ordering = ["index"]
+
+    @staticmethod
+    def get_default_label(prop_id):
+        known_labels = {
+            'name': _("Name"),
+            'owner_name': _('Owner'),
+            'opened_on': _("Opened On"),
+            'opened_by_username': _("Created By"),
+            'modified_on': _("Last Modified On"),
+            'status': _("Status"),
+        }
+        return known_labels.get(prop_id, prop_id)
+
+    @staticmethod
+    def is_system_property(prop_id):
+        return prop_id in set(METADATA_IN_REPORTS).difference({
+            'name', 'case_name', 'external_id',
+        })
+
+    @classmethod
+    def create_default_columns(cls, session):
+        default_properties = {
+            BulkEditSessionType.CASE: (
+                'name', 'owner_name', 'opened_on', 'opened_by_username',
+                'modified_on', 'status',
+            ),
+        }.get(session.session_type)
+
+        if not default_properties:
+            raise NotImplementedError(f"{session.session_type} default columns not yet supported")
+
+        for index, prop_id in enumerate(default_properties):
+            cls.objects.create(
+                session=session,
+                index=index,
+                prop_id=prop_id,
+                label=cls.get_default_label(prop_id),
+                is_system=cls.is_system_property(prop_id),
+            )
 
 
 class BulkEditRecord(models.Model):

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/forms/active_session_exists.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/forms/active_session_exists.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+
+<div class="alert alert-info">
+  {% blocktrans %}
+    An active data cleaning session already exists for this case type.
+    Please decide how you would like to proceed.
+  {% endblocktrans %}
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/forms/next_action_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/forms/next_action_form.html
@@ -8,6 +8,7 @@
   <form
     hx-post="{{ request.path_info }}"
     hx-target="#{{ container_id }}"
+    hx-disabled-elt="find button"
     hq-hx-action="{{ next_action }}"
   >
     {% crispy form %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/start_session.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/start_session.html
@@ -1,7 +1,0 @@
-{% load i18n %}
-
-<p x-init="window.location.href='{{ session_view_url }}'">
-  {% blocktrans %}
-    Starting a new data cleaning session for {{ case_type }}...
-  {% endblocktrans %}
-</p>

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -83,3 +83,9 @@ class BulkEditSessionTest(TestCase):
             self.django_user, self.domain_name, self.case_type
         )
         self.assertIsNone(active_session)
+
+    def test_restart_case_session(self):
+        old_session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        old_session_id = old_session.session_id
+        new_session = BulkEditSession.restart_case_session(self.django_user, self.domain_name, self.case_type)
+        self.assertNotEqual(old_session_id, new_session.session_id)

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -1,0 +1,85 @@
+import datetime
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from corehq.apps.data_cleaning.models import BulkEditSession, BulkEditSessionType
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import WebUser
+
+
+class BulkEditSessionTest(TestCase):
+    domain_name = 'dc-session-test'
+    username = 'someone@cleandata.org'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = create_domain(cls.domain_name)
+        cls.addClassCleanup(cls.domain.delete)
+
+        cls.web_user = WebUser.create(
+            cls.domain.name, 'b@vaultwax.com', 'testpwd', None, None
+        )
+        cls.django_user = User.objects.get(username=cls.web_user.username)
+        cls.addClassCleanup(cls.web_user.delete, cls.domain.name, deleted_by=None)
+
+        cls.case_type = 'child'
+        cls.form_xmlns = 'http://openrosa.org/formdesigner/2423EFB5-2E8C-4B8F-9DA0-23FFFD4391AF'
+
+    def test_has_no_active_case_session(self):
+        active_session = BulkEditSession.get_active_case_session(
+            self.django_user, self.domain_name, self.case_type
+        )
+        self.assertIsNone(active_session)
+
+    def test_has_no_active_form_session(self):
+        active_session = BulkEditSession.get_active_form_session(
+            self.django_user, self.domain_name, self.form_xmlns
+        )
+        self.assertIsNone(active_session)
+
+    def test_new_case_session(self):
+        new_session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        self.assertEqual(new_session.session_type, BulkEditSessionType.CASE)
+        self.assertEqual(new_session.columns.count(), 6)
+        self.assertEqual(new_session.column_filters.count(), 0)
+        self.assertEqual(new_session.pinned_filters.count(), 2)
+        self.assertEqual(new_session.records.count(), 0)
+        self.assertEqual(new_session.changes.count(), 0)
+
+    def test_has_active_case_session(self):
+        BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        active_session = BulkEditSession.get_active_case_session(
+            self.django_user, self.domain_name, self.case_type
+        )
+        self.assertIsNotNone(active_session)
+        self.assertEqual(active_session.user, self.django_user)
+        self.assertEqual(active_session.domain, self.domain_name)
+        self.assertEqual(active_session.identifier, self.case_type)
+
+    def test_has_no_active_case_session_other_type(self):
+        BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        active_session = BulkEditSession.get_active_case_session(
+            self.django_user, self.domain_name, 'other'
+        )
+        self.assertIsNone(active_session)
+
+    def test_has_no_active_case_session_after_committed(self):
+        case_session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        case_session.committed_on = datetime.datetime.now()
+        case_session.save()
+        active_session = BulkEditSession.get_active_case_session(
+            self.django_user, self.domain_name, self.case_type
+        )
+        self.assertIsNone(active_session)
+
+    def test_has_no_active_case_session_after_completed(self):
+        case_session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        case_session.committed_on = datetime.datetime.now()
+        case_session.completed_on = datetime.datetime.now()
+        case_session.save()
+        active_session = BulkEditSession.get_active_case_session(
+            self.django_user, self.domain_name, self.case_type
+        )
+        self.assertIsNone(active_session)

--- a/corehq/apps/data_cleaning/views/setup.py
+++ b/corehq/apps/data_cleaning/views/setup.py
@@ -5,7 +5,10 @@ from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
 from corehq import toggles
-from corehq.apps.data_cleaning.forms.setup import SelectCaseTypeForm
+from corehq.apps.data_cleaning.forms.setup import (
+    SelectCaseTypeForm,
+    ResumeOrRestartCaseSessionForm,
+)
 from corehq.apps.data_cleaning.models import BulkEditSession
 from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.domain.views import DomainViewMixin
@@ -20,12 +23,13 @@ from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 class SetupCaseSessionFormView(HqHtmxActionMixin, LoginAndDomainMixin, DomainViewMixin, TemplateView):
     urlname = "data_cleaning_select_case_type_form"
     template_name = "data_cleaning/partials/forms/next_action_form.html"
+    container_id = "setup-case-session"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update({
             "form": kwargs.pop('form', SelectCaseTypeForm(self.domain)),
-            "container_id": "setup-case-session",
+            "container_id": self.container_id,
             "next_action": kwargs.pop('next_action', 'validate_session'),
         })
         return context
@@ -44,6 +48,34 @@ class SetupCaseSessionFormView(HqHtmxActionMixin, LoginAndDomainMixin, DomainVie
                     request.user, self.domain, case_type
                 )
                 return self.render_session_redirect(new_session)
+            form = ResumeOrRestartCaseSessionForm(
+                self.domain, self.container_id, request.path_info, {
+                    'case_type': case_type,
+                    'next_step': 'resume',
+                },
+            )
+            next_action = 'resume_or_restart'
+        return self.get(request, form=form, next_action=next_action, *args, **kwargs)
+
+    @hq_hx_action('post')
+    def resume_or_restart(self, request, *args, **kwargs):
+        form = ResumeOrRestartCaseSessionForm(
+            self.domain, self.container_id, request.path_info, request.POST
+        )
+        next_action = 'resume_or_restart'
+        if form.is_valid():
+            case_type = form.cleaned_data['case_type']
+            next_step = form.cleaned_data['next_step']
+            get_session = {
+                'resume': lambda: BulkEditSession.get_active_case_session(
+                    request.user, self.domain, case_type
+                ),
+                'new': lambda: BulkEditSession.restart_case_session(
+                    request.user, self.domain, case_type
+                ),
+            }[next_step]
+            if get_session:
+                return self.render_session_redirect(get_session())
         return self.get(request, form=form, next_action=next_action, *args, **kwargs)
 
     def render_session_redirect(self, session):


### PR DESCRIPTION
## Technical Summary
- adds utility to check if an existing case bulk edit session exists
- adds utility to check if an existing form bulk edit session exists
- adds utility to create a new case bulk editing session, including default columns and pinned filters
- adds utility to restart a case session (delete old session and start a new one)
- adds tests

new UI additions:
![Screenshot 2025-02-21 at 2 52 41 PM](https://github.com/user-attachments/assets/8349b98a-f41c-404d-b3a2-1d2719bcd865)
![Screenshot 2025-02-21 at 2 52 50 PM](https://github.com/user-attachments/assets/00b89405-4ad9-42f1-939a-2eb39f87e9fb)


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change, does not affect production workflows

### Automated test coverage
yes

### QA Plan
Not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
