### PR TITLE
use HX-Redirect to take the user to the case session view

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/start_session.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/start_session.html
@@ -1,7 +1,0 @@
-{% load i18n %}
-
-<p x-init="window.location.href='{{ session_view_url }}'">
-  {% blocktrans %}
-    Starting a new data cleaning session for {{ case_type }}...
-  {% endblocktrans %}
-</p>


### PR DESCRIPTION
## Technical Summary
use HX-Redirect to take the user to the case session view instead of calling `window.location.href` in an `alpine` `x-init`.
thanks @jingcheng16 :) 

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change, no production workflow affected

### Automated test coverage
not this one

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
