### PR TITLE
fix select2 alpine directive bug when HTMX swaps the same form back into the DOM

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js
@@ -39,10 +39,10 @@ Alpine.directive('select2', (el, { expression }, { cleanup }) => {
 document.body.addEventListener('htmx:afterSettle', (event) => {
     /**
      * This fixes a bug for forms using x-select2 after submitting, validating, and swapping back into
-     * the DOMusing HTMX.
+     * the DOM using HTMX.
      *
      * Without this fix, you will get the **visible** <select> stacked on top of the select2, and no
-     * validation classes are passed to it.
+     * validation classes are passed to the select2.
      */
     event.target.querySelectorAll('[x-select2]').forEach((el) => {
         const activeSelect2 = $(el).data('select2');

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js
@@ -2,24 +2,58 @@ import $ from 'jquery';
 import 'select2/dist/js/select2.full.min';
 import Alpine from 'alpinejs';
 
-Alpine.directive('select2', (el, { expression }) => {
-    /*
-        To use, add x-select2 to your select element.
-        <select x-select2>
 
-        This is especially useful in crispy forms for a choice field:
-        self.helper.layout = crispy.Layout(
-            ...
-            crispy.Field(
-                'choice_field',
-                x_select2=json.dumps({
-                    "placeholder: "foo",
-                    ...
-                }),
-            ),
-            ...
-        )
+Alpine.directive('select2', (el, { expression }, { cleanup }) => {
+    /**
+     * To use, add x-select2 to your select element.
+     *
+     *      <select x-select2></select>
+     *          or
+     *      <select x=select2="{{ options|JSON }}"></select>
+     *
+     * This is especially useful in crispy forms for a choice field:
+     *
+     * self.helper.layout = crispy.Layout(
+     *     ...
+     *     crispy.Field(
+     *         'choice_field',
+     *         x_select2=json.dumps({
+     *             "placeholder: "foo",
+     *             ...
+     *         }),
+     *     ),
+     *     ...
+     * )
      */
     const options = (expression) ? JSON.parse(expression) : {};
     $(el).select2(options);
+
+    cleanup(() => {
+        if ($(el).data('select2')) {
+            $(el).select2('destroy');
+            $(el).off('select2:select');
+        }
+    });
+});
+
+document.body.addEventListener('htmx:afterSettle', (event) => {
+    /**
+     * This fixes a bug for forms using x-select2 after submitting, validating, and swapping back into
+     * the DOMusing HTMX.
+     *
+     * Without this fix, you will get the **visible** <select> stacked on top of the select2, and no
+     * validation classes are passed to it.
+     */
+    event.target.querySelectorAll('[x-select2]').forEach((el) => {
+        const activeSelect2 = $(el).data('select2');
+        if (activeSelect2) {
+            $(el).addClass('select2-hidden-accessible');
+            const validationClasses = ['is-valid', 'is-invalid'];
+            validationClasses.forEach((validationClass) => {
+                if ($(el).hasClass(validationClass)) {
+                    activeSelect2.$container.addClass(validationClass);
+                }
+            });
+        }
+    });
 });


### PR DESCRIPTION
## Technical Summary
fixes this really delightful error state:
![Screenshot 2025-02-20 at 11 39 03 PM](https://github.com/user-attachments/assets/c937366d-8b1b-4172-93e1-072fa3c7641e)

## Safety Assurance

### Safety story
just fixing an alpine directive that's only being used in the case data cleaning feature right now

### Automated test coverage
no

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
