### PR TITLE
Replaced inline edit's postSave callback with event on document

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -3,6 +3,15 @@ hqDefine("app_manager/js/app_view", function () {
     $(function () {
         var initialPageData = hqImport("hqwebapp/js/initial_page_data");
 
+        // App name
+        $(document).on("inline-edit-save", function (e, data) {
+            if (_.has(data.update, '.variable-app_name')) {
+                var appManager = hqImport('app_manager/js/app_manager');
+                appManager.updatePageTitle(data.update['.variable-app_name']);
+                appManager.updateDOM(data.update);
+            }
+        });
+
         // Settings
         var $settingsContainer = $('#commcare-settings');
         if ($settingsContainer.length) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -77,6 +77,15 @@ hqDefine("app_manager/js/forms/form_view", function () {
     }
 
     $(function () {
+        // Form name
+        $(document).on("inline-edit-save", function (e, data) {
+            if (_.has(data.update, '.variable-form_name')) {
+                var appManager = hqImport('app_manager/js/app_manager');
+                appManager.updatePageTitle(data.update['.variable-form_name']);
+                appManager.updateDOM(data.update);
+            }
+        });
+
         // Validation for build
         var setupValidation = hqImport('app_manager/js/app_manager').setupValidation;
         setupValidation(initialPageData.reverse("validate_form_for_build"));

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -1,5 +1,14 @@
 hqDefine("app_manager/js/modules/module_view", function () {
     $(function () {
+        // Module name
+        $(document).on("inline-edit-save", function (e, data) {
+            if (_.has(data.update, '.variable-module_name')) {
+                var appManager = hqImport('app_manager/js/app_manager');
+                appManager.updatePageTitle(data.update['.variable-module_name']);
+                appManager.updateDOM(data.update);
+            }
+        });
+
         $('.case-type-dropdown').select2();
         $('.overwrite-danger').on("click", function () {
             hqImport('analytix/js/kissmetrix').track.event("Overwrite Case Lists/Case Details");

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -40,7 +40,6 @@
         containerClass: 'h3 app-title',
         url: '{% url "edit_app_attr" domain app.id 'name' %}',
         placeholder: '{% trans "Untitled App"|escapejs %}',
-        postSave: function(data) { var appManager = hqImport('app_manager/js/app_manager'); appManager.updatePageTitle(data.update['.variable-app_name']); return appManager.updateDOM(data.update); },
         rows: 1,
         saveValueName: 'name',
         nodeName: 'input',

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -83,15 +83,15 @@
   </div>
 
   <div class="appmanager-edit-title">
-    {% with postSave="function(data) { var appManager = hqImport('app_manager/js/app_manager'); appManager.updatePageTitle(data.update['.variable-form_name']); return appManager.updateDOM(data.update);}" disallow_edit=request.couch_user.can_edit_apps|yesno:"false,true" %}
+    {% with disallow_edit=request.couch_user.can_edit_apps|yesno:"false,true" %}
       {% if form.get_action_type == 'open' %}
-        {% inline_edit_trans form.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fcc fcc-app-createform' postSave=postSave disallow_edit=disallow_edit %}
+        {% inline_edit_trans form.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fcc fcc-app-createform' disallow_edit=disallow_edit %}
       {% elif form.requires_case %}
-        {% inline_edit_trans form.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fcc fcc-app-updateform' postSave=postSave disallow_edit=disallow_edit %}
+        {% inline_edit_trans form.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fcc fcc-app-updateform' disallow_edit=disallow_edit %}
       {% elif form.form_type == 'shadow_form' %}
-        {% inline_edit_trans form.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa-regular fa-moon' postSave=postSave disallow_edit=disallow_edit %}
+        {% inline_edit_trans form.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa-regular fa-moon' disallow_edit=disallow_edit %}
       {% else %}
-        {% inline_edit_trans form.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa-regular fa-file' postSave=postSave disallow_edit=disallow_edit %}
+        {% inline_edit_trans form.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa-regular fa-file' disallow_edit=disallow_edit %}
       {% endif %}
     {% endwith %}
   </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_heading.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_heading.html
@@ -6,19 +6,19 @@
   {% include 'app_manager/partials/app_summary_button.html' %}
 </div>
 <div class="appmanager-edit-title">
-  {% with postSave="function(data) { var appManager = hqImport('app_manager/js/app_manager'); appManager.updatePageTitle(data.update['.variable-module_name']); return appManager.updateDOM(data.update);}" disallow_edit=request.couch_user.can_edit_apps|yesno:"false,true"%}
+  {% with disallow_edit=request.couch_user.can_edit_apps|yesno:"false,true"%}
     {% if module.is_training_module %}
-      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa fa-book' postSave=postSave disallow_edit=disallow_edit %}
+      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa fa-book' disallow_edit=disallow_edit %}
     {% elif module.module_type == "shadow" %}
-      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa-regular fa-folder-open' postSave=postSave disallow_edit=disallow_edit %}
+      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa-regular fa-folder-open' disallow_edit=disallow_edit %}
     {% elif module.module_type == "report" %}
-      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa-regular fa-chart-bar' postSave=postSave disallow_edit=disallow_edit %}
+      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa-regular fa-chart-bar' disallow_edit=disallow_edit %}
     {% elif module.module_type == "advanced" %}
-      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa fa-flask' postSave=postSave disallow_edit=disallow_edit %}
+      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa fa-flask' disallow_edit=disallow_edit %}
     {% elif module.is_surveys %}
-      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa fa-folder-open' postSave=postSave disallow_edit=disallow_edit %}
+      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa fa-folder-open' disallow_edit=disallow_edit %}
     {% else %}
-      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa fa-bars' postSave=postSave disallow_edit=disallow_edit %}
+      {% inline_edit_trans module.name langs edit_name_url saveValueName='name' containerClass='h3' iconClass='fa fa-bars' disallow_edit=disallow_edit %}
     {% endif %}
   {% endwith %}
 </div>

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -155,7 +155,7 @@ def input_trans(name, langs=None, input_name='name', input_id=None, data_bind=No
 
 
 @register.simple_tag
-def inline_edit_trans(name, langs=None, url='', saveValueName='', postSave='',
+def inline_edit_trans(name, langs=None, url='', saveValueName='',
         containerClass='', iconClass='', readOnlyClass='', disallow_edit='false'):
     options = _get_dynamic_input_trans_options(name, EscapeMethod.JS, langs=langs, allow_blank=False)
     options.update({
@@ -164,7 +164,6 @@ def inline_edit_trans(name, langs=None, url='', saveValueName='', postSave='',
         'containerClass': containerClass,
         'iconClass': iconClass,
         'readOnlyClass': readOnlyClass,
-        'postSave': postSave,
         'disallow_edit': disallow_edit
     })
 
@@ -180,7 +179,6 @@ def inline_edit_trans(name, langs=None, url='', saveValueName='', postSave='',
             containerClass: '{containerClass}',
             iconClass: '{iconClass}',
             readOnlyClass: '{readOnlyClass}',
-            postSave: {postSave},
             disallow_edit: {disallow_edit},
         "></inline-edit>
     '''

--- a/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
+++ b/corehq/apps/app_manager/tests/templatetags/test_xforms_extras.py
@@ -169,7 +169,6 @@ class TestInlineEditTransFilter(SimpleTestCase):
         langs=['en'],
         url='test-url',
         saveValueName='saveValue',
-        postSave='postSave',
         containerClass='containerClass',
         iconClass='iconClass',
         readOnlyClass='readOnlyClass',
@@ -180,7 +179,6 @@ class TestInlineEditTransFilter(SimpleTestCase):
             langs,
             url,
             saveValueName,
-            postSave,
             containerClass,
             iconClass,
             readOnlyClass,
@@ -213,7 +211,6 @@ class TestInlineEditTransFilter(SimpleTestCase):
             langs=['en'],
             url='test-url',
             saveValueName='saveValue',
-            postSave='postSave',
             containerClass='containerClass',
             iconClass='iconClass',
             readOnlyClass='readOnlyClass',
@@ -227,7 +224,6 @@ class TestInlineEditTransFilter(SimpleTestCase):
         self.assertEqual(params['containerClass'], "'containerClass'")
         self.assertEqual(params['iconClass'], "'iconClass'")
         self.assertEqual(params['readOnlyClass'], "'readOnlyClass'")
-        self.assertEqual(params['postSave'], 'postSave')
         self.assertEqual(params['disallow_edit'], 'false')
 
     def test_primary_language(self):

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/inline_edit.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/inline_edit.js
@@ -117,7 +117,13 @@ hqDefine('hqwebapp/js/components/inline_edit', [
                             self.isSaving(false);
                             self.hasError(false);
                             self.serverValue = self.readOnlyValue;
+
+                            // Allow callers to attach logic that will fire after save.
+                            // This code has access to the knockout object, but not the HTML element.
+                            // Calling code typically has access to the HTML element, but not the knockout object.
+                            // So, use the document as a global message bus, which everyone has access to. Gross.
                             $(document).trigger("inline-edit-save", data);
+
                             $(window).off("beforeunload", self.beforeUnload);
                         },
                         error: function (response) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/inline_edit.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/inline_edit.js
@@ -72,7 +72,6 @@ hqDefine('hqwebapp/js/components/inline_edit', [
             self.saveValueName = params.saveValueName || 'value';
             self.hasError = ko.observable(false);
             self.isSaving = ko.observable(false);
-            self.postSave = params.postSave;
 
             // On edit, set editing mode, which controls visibility of inner components
             self.edit = function () {
@@ -118,9 +117,7 @@ hqDefine('hqwebapp/js/components/inline_edit', [
                             self.isSaving(false);
                             self.hasError(false);
                             self.serverValue = self.readOnlyValue;
-                            if (self.postSave) {
-                                self.postSave(data);
-                            }
+                            $(document).trigger("inline-edit-save", data);
                             $(window).off("beforeunload", self.beforeUnload);
                         },
                         error: function (response) {


### PR DESCRIPTION
## Technical Summary
Similar to https://github.com/dimagi/commcare-hq/pull/35814, this gets rid of the remaining `hqImport` calls in HTML bindings, which are all usages of the inline edit knockout component, as part of migrating app manager to webpack.

This is the third attempt. The first one was to use [eventize](https://github.com/dimagi/commcare-hq/blob/22b3c418ffef3e4b1c8039d23aa16e995ccbfd99/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js#L20) on the knockout component, and the second was to use jQuery events on the inline edit DOM element. Neither of these worked, because at the time the event is triggered, the code has access to the knockout component object but not the DOM element, whereas the code attaching the listener has access to the DOM but not to the knockout component object. So instead I'm passing an event that's triggered on the document, which both pieces of code have access to. I'm not proud of this.

## Safety Assurance

### Safety story
Tested locally. Fairly small change.

### Automated test coverage

no

### QA Plan

Not requesting QA.


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
