### PR TITLE
Add 'Organization or Company' to signup form and use for BillingContactInfo

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -84,7 +84,7 @@ class RegisterWebUserForm(forms.Form):
         if settings.ENFORCE_SSO_LOGIN and self.is_sso:
             self.fields['password'].required = False
 
-        additional_fields = []
+        saas_fields = []
         if settings.IS_SAAS_ENVIRONMENT:
             company_name = hqcrispy.InlineField(
                 'company_name',
@@ -120,7 +120,7 @@ class RegisterWebUserForm(forms.Form):
                               "}",
                 ),
             ]
-            additional_fields = [company_name, *persona_fields]
+            saas_fields = [company_name, *persona_fields]
 
         self.helper = FormHelper()
         self.helper.form_tag = False
@@ -210,7 +210,7 @@ class RegisterWebUserForm(forms.Form):
                                   "   validator: projectName "
                                   "}",
                     ),
-                    crispy.Div(*additional_fields),
+                    crispy.Div(*saas_fields),
                     hqcrispy.InlineField(
                         'eula_confirmed',
                         css_class="input-lg",

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -60,7 +60,7 @@ class RegisterWebUserForm(forms.Form):
         label=_("Please Specify"),
     )
     project_name = forms.CharField(label=_("Project Name"))
-    company_name = forms.CharField(label=_("Organization or Company"), max_length=50)
+    company_name = forms.CharField(label=_("Organization or Company"), required=False, max_length=50)
     eula_confirmed = forms.BooleanField(
         required=False,
         label=mark_safe(_(
@@ -84,8 +84,17 @@ class RegisterWebUserForm(forms.Form):
         if settings.ENFORCE_SSO_LOGIN and self.is_sso:
             self.fields['password'].required = False
 
-        persona_fields = []
+        additional_fields = []
         if settings.IS_SAAS_ENVIRONMENT:
+            company_name = hqcrispy.InlineField(
+                'company_name',
+                css_class="input-lg",
+                data_bind="value: companyName, "
+                          "valueUpdate: 'keyup', "
+                          "koValidationStateFeedback: { "
+                          "   validator: companyName "
+                          "}",
+            )
             persona_fields = [
                 crispy.Div(
                     hqcrispy.RadioSelect(
@@ -111,6 +120,7 @@ class RegisterWebUserForm(forms.Form):
                               "}",
                 ),
             ]
+            additional_fields = [company_name, *persona_fields]
 
         self.helper = FormHelper()
         self.helper.form_tag = False
@@ -200,16 +210,7 @@ class RegisterWebUserForm(forms.Form):
                                   "   validator: projectName "
                                   "}",
                     ),
-                    hqcrispy.InlineField(
-                        'company_name',
-                        css_class="input-lg",
-                        data_bind="value: companyName, "
-                                  "valueUpdate: 'keyup', "
-                                  "koValidationStateFeedback: { "
-                                  "   validator: companyName "
-                                  "}",
-                    ),
-                    crispy.Div(*persona_fields),
+                    crispy.Div(*additional_fields),
                     hqcrispy.InlineField(
                         'eula_confirmed',
                         css_class="input-lg",

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -60,8 +60,12 @@ class RegisterWebUserForm(forms.Form):
         required=False,
         label=_("Please Specify"),
     )
+    company_name = forms.CharField(
+        required=False,
+        label=_("Organization or Company"),
+        max_length=50,
+    )
     project_name = forms.CharField(label=_("Project Name"))
-    company_name = forms.CharField(label=_("Organization or Company"), required=False, max_length=50)
     eula_confirmed = forms.BooleanField(
         required=False,
         label=mark_safe(_(
@@ -87,15 +91,6 @@ class RegisterWebUserForm(forms.Form):
 
         saas_fields = []
         if settings.IS_SAAS_ENVIRONMENT:
-            company_name = hqcrispy.InlineField(
-                'company_name',
-                css_class="input-lg",
-                data_bind="value: companyName, "
-                          "valueUpdate: 'keyup', "
-                          "koValidationStateFeedback: { "
-                          "   validator: companyName "
-                          "}",
-            )
             persona_fields = [
                 crispy.Div(
                     hqcrispy.RadioSelect(
@@ -121,7 +116,21 @@ class RegisterWebUserForm(forms.Form):
                               "}",
                 ),
             ]
-            saas_fields = [company_name, *persona_fields]
+            saas_fields = [
+                *persona_fields,
+                crispy.Div(
+                    hqcrispy.InlineField(
+                        'company_name',
+                        css_class="input-lg",
+                        data_bind="value: companyName, "
+                                  "valueUpdate: 'keyup', "
+                                  "koValidationStateFeedback: { "
+                                  "   validator: companyName "
+                                  "}",
+                    ),
+                    data_bind="visible: isPersonaChoiceProfessional, ",
+                ),
+            ]
 
         self.helper = FormHelper()
         self.helper.form_tag = False

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -60,6 +60,7 @@ class RegisterWebUserForm(forms.Form):
         label=_("Please Specify"),
     )
     project_name = forms.CharField(label=_("Project Name"))
+    company_name = forms.CharField(label=_("Organization or Company"), max_length=50)
     eula_confirmed = forms.BooleanField(
         required=False,
         label=mark_safe(_(
@@ -197,6 +198,15 @@ class RegisterWebUserForm(forms.Form):
                                   "valueUpdate: 'keyup', "
                                   "koValidationStateFeedback: { "
                                   "   validator: projectName "
+                                  "}",
+                    ),
+                    hqcrispy.InlineField(
+                        'company_name',
+                        css_class="input-lg",
+                        data_bind="value: companyName, "
+                                  "valueUpdate: 'keyup', "
+                                  "koValidationStateFeedback: { "
+                                  "   validator: companyName "
                                   "}",
                     ),
                     crispy.Div(*persona_fields),

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -52,6 +52,7 @@ class RegisterWebUserForm(forms.Form):
             ("Improve Delivery", _("Improve delivery of services")),
             ("Research", _("Collect data for a research project")),
             ("IT", _("Build a technology solution for my team/clients")),
+            ("Personal", _("Explore data collection for personal use")),
             ("Other", _("Other")),
         )
     )

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -230,6 +230,10 @@ hqDefine('registration/js/new_user.ko', [
         self.isPersonaChoiceOtherNeeded = ko.computed(function () {
             return self.eulaConfirmed() && self.isPersonaChoiceOther() && !self.personaOther();
         });
+        self.isPersonaChoiceProfessional = ko.computed(function () {
+            return self.isPersonaChoiceChosen()
+                && !(self.isPersonaChoiceOther() || self.personaChoice() === 'Personal');
+        });
         self.isPersonaValid = ko.computed(function () {
             if (!self.hasPersonaFields) {
                 return true;

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -192,19 +192,6 @@ hqDefine('registration/js/new_user.ko', [
             }
         });
 
-        // For 'Organization or Company' Field
-        self.hasCompanyNameField = $(containerSelector).find("[name='company_name']").length;
-        self.companyName = ko.observable(defaults.company_name)
-            .extend({
-                required: {
-                    message: gettext("Please list your organization or 'N/A' if not applicable."),
-                    params: true,
-                },
-            });
-        self.isCompanyNameValid = ko.computed(function () {
-            return self.companyName.isValid() || !self.hasCompanyNameField;
-        });
-
         // For User Persona Field
         self.hasPersonaFields = $(containerSelector).find("[name='persona']").length;
         self.personaChoice = ko.observable();
@@ -242,6 +229,21 @@ hqDefine('registration/js/new_user.ko', [
                    && (!self.isPersonaChoiceOther() || self.isPersonaChoiceOtherPresent());
         });
 
+        // For 'Organization or Company' Field
+        self.hasCompanyNameField = $(containerSelector).find("[name='company_name']").length;
+        self.companyName = ko.observable(defaults.company_name)
+            .extend({
+                required: {
+                    message: gettext("Please list your organization or company name."),
+                    params: true,
+                },
+            });
+        self.requireCompanyName = ko.computed(function () {
+            return self.hasCompanyNameField && self.isPersonaChoiceProfessional();
+        });
+        self.isCompanyNameValid = ko.computed(function () {
+            return !self.requireCompanyName() || self.companyName.isValid();
+        });
 
         // ---------------------------------------------------------------------
         // Form Functionality
@@ -266,15 +268,15 @@ hqDefine('registration/js/new_user.ko', [
                 phone_number: module.getPhoneNumberFn() || self.phoneNumber(),
                 atypical_user: defaults.atypical_user,
             };
-            if (self.hasCompanyNameField) {
-                _.extend(data, {
-                    company_name: self.companyName(),
-                });
-            }
             if (self.hasPersonaFields) {
                 _.extend(data, {
                     persona: self.personaChoice(),
                     persona_other: self.isPersonaChoiceOther() ? self.personaOther() : '',
+                });
+            }
+            if (self.requireCompanyName()) {
+                _.extend(data, {
+                    company_name: self.companyName(),
                 });
             }
             return data;

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -185,6 +185,13 @@ hqDefine('registration/js/new_user.ko', [
                     params: true,
                 },
             });
+        self.companyName = ko.observable(defaults.company_name)
+            .extend({
+                required: {
+                    message: gettext("Please list your organization or 'N/A' if not applicable."),
+                    params: true,
+                },
+            });
         self.eulaConfirmed = ko.observable(defaults.eula_confirmed || false);
         self.eulaConfirmed.subscribe(function (isConfirmed) {
             if (isConfirmed && self.projectName() === undefined) {
@@ -245,6 +252,7 @@ hqDefine('registration/js/new_user.ko', [
                 email: self.email(),
                 password: password,
                 project_name: self.projectName(),
+                company_name: self.companyName(),
                 eula_confirmed: self.eulaConfirmed(),
                 phone_number: module.getPhoneNumberFn() || self.phoneNumber(),
                 atypical_user: defaults.atypical_user,
@@ -290,6 +298,7 @@ hqDefine('registration/js/new_user.ko', [
         self.isStepTwoValid = ko.computed(function () {
             return self.projectName() !== undefined
                 && self.projectName.isValid()
+                && self.companyName.isValid()
                 && self.isPersonaValid()
                 && self.eulaConfirmed();
         });

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -185,6 +185,15 @@ hqDefine('registration/js/new_user.ko', [
                     params: true,
                 },
             });
+        self.eulaConfirmed = ko.observable(defaults.eula_confirmed || false);
+        self.eulaConfirmed.subscribe(function (isConfirmed) {
+            if (isConfirmed && self.projectName() === undefined) {
+                self.projectName('');
+            }
+        });
+
+        // For 'Organization or Company' Field
+        self.hasCompanyNameField = $(containerSelector).find("[name='company_name']").length;
         self.companyName = ko.observable(defaults.company_name)
             .extend({
                 required: {
@@ -192,11 +201,8 @@ hqDefine('registration/js/new_user.ko', [
                     params: true,
                 },
             });
-        self.eulaConfirmed = ko.observable(defaults.eula_confirmed || false);
-        self.eulaConfirmed.subscribe(function (isConfirmed) {
-            if (isConfirmed && self.projectName() === undefined) {
-                self.projectName('');
-            }
+        self.isCompanyNameValid = ko.computed(function () {
+            return self.companyName.isValid() || !self.hasCompanyNameField;
         });
 
         // For User Persona Field
@@ -252,11 +258,15 @@ hqDefine('registration/js/new_user.ko', [
                 email: self.email(),
                 password: password,
                 project_name: self.projectName(),
-                company_name: self.companyName(),
                 eula_confirmed: self.eulaConfirmed(),
                 phone_number: module.getPhoneNumberFn() || self.phoneNumber(),
                 atypical_user: defaults.atypical_user,
             };
+            if (self.hasCompanyNameField) {
+                _.extend(data, {
+                    company_name: self.companyName(),
+                });
+            }
             if (self.hasPersonaFields) {
                 _.extend(data, {
                     persona: self.personaChoice(),
@@ -298,7 +308,7 @@ hqDefine('registration/js/new_user.ko', [
         self.isStepTwoValid = ko.computed(function () {
             return self.projectName() !== undefined
                 && self.projectName.isValid()
-                && self.companyName.isValid()
+                && self.isCompanyNameValid()
                 && self.isPersonaValid()
                 && self.eulaConfirmed();
         });

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -157,7 +157,7 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
 
     if not settings.ENTERPRISE_MODE:
         try:
-            _setup_subscription(new_domain.name, current_user, company_name=company_name)
+            _setup_subscription(new_domain.name, current_user, company_name)
         except Exception as error:
             # any error thrown in this process will cause the transaction.atomic() block that
             # the subscription setup is wrapped in to fail and any SQL changes related to the subscription

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -118,7 +118,7 @@ def activate_new_user(
     return new_user
 
 
-def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=False):
+def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=False, company_name=None):
     now = datetime.utcnow()
     current_user = CouchUser.from_django_user(request.user, strict=True)
 
@@ -157,7 +157,7 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
 
     if not settings.ENTERPRISE_MODE:
         try:
-            _setup_subscription(new_domain.name, current_user)
+            _setup_subscription(new_domain.name, current_user, company_name=company_name)
         except Exception as error:
             # any error thrown in this process will cause the transaction.atomic() block that
             # the subscription setup is wrapped in to fail and any SQL changes related to the subscription
@@ -228,7 +228,7 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
     return new_domain.name
 
 
-def _setup_subscription(domain_name, user):
+def _setup_subscription(domain_name, user, company_name):
     with transaction.atomic():
         ensure_community_or_paused_subscription(
             domain_name, date.today(), SubscriptionAdjustmentMethod.USER,
@@ -237,7 +237,7 @@ def _setup_subscription(domain_name, user):
 
     # add user's email as contact email for billing account for the domain
     account = BillingAccount.get_account_by_domain(domain_name)
-    billing_contact, _ = BillingContactInfo.objects.get_or_create(account=account)
+    billing_contact, _ = BillingContactInfo.objects.get_or_create(account=account, company_name=company_name)
     billing_contact.email_list = [user.email]
     billing_contact.save()
 

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -182,6 +182,7 @@ class ProcessRegistrationView(JSONResponseMixin, View):
                     self.request,
                     reg_form.cleaned_data['project_name'],
                     is_new_user=True,
+                    company_name=reg_form.cleaned_data['company_name'],
                 )
             except NameUnavailableException:
                 # technically, the form should never reach this as names are


### PR DESCRIPTION
## Product Description
In SaaS environments only:
Adds "Explore data collection for personal use" option to existing "I will be using CommCare primarily to..." persona dropdown:
<img width="477" alt="image" src="https://github.com/user-attachments/assets/49d36e80-1e56-4f3f-9394-ed3ca665a56a" />


Adds 'Organization or Company' field to new account signup screen when someone selects anything other than "personal" or "Other" in the persona dropdown:
<img width="477" alt="image" src="https://github.com/user-attachments/assets/e9571c56-562a-447b-bbcf-923c5455f7a5" />



## Technical Summary
[SAAS-16648](https://dimagi.atlassian.net/browse/SAAS-16648)
This new form field is required when shown and will populate the `BillingContactInfo` field `company_name` (shown as "Company / Organization" on the Billing Info screen), as discussed in design doc linked in ticket.

## Safety Assurance

### Safety story
This adds a simple textfield to the new account form with basic "required" validation much like other fields on the form. The new `company_name` kwarg is made optional in `request_new_domain` so as not to break any existing use of these functions. Even if no company name is provided by the form, the field is set `null=True` on the model so a passed in `None` is acceptable.

Manually tested that the new "Organization or Company" form field:
 - validates correctly when visible and saves to the billing contact info
 - does not submit data when not visible (even if previously entered)
 - is not visible and does not submit data when `IS_SAAS_ENVIRONMENT` is False

### Automated test coverage
We don't have automated tests for this particular form and it's not likely to add them in the planned timeframe.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16648]: https://dimagi.atlassian.net/browse/SAAS-16648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ