### PR TITLE
Fixed js access in advanced form case config

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
@@ -20,6 +20,12 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
 
         var CaseConfig = function (params) {
             var self = {};
+            self.title = gettext("Save Questions to Case Properties");
+
+            self.trackGoogleEvent = function() {
+                hqImport('analytix/js/google').track.event(...arguments);
+            };
+
             self.makePopover = function () {
                 $('.property-description').closest('.read-only').popover({
                     'trigger': 'hover',

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
@@ -1,4 +1,3 @@
-"use strict";
 hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
 
     $(function () {
@@ -22,7 +21,7 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
             var self = {};
             self.title = gettext("Save Questions to Case Properties");
 
-            self.trackGoogleEvent = function() {
+            self.trackGoogleEvent = function () {
                 hqImport('analytix/js/google').track.event(...arguments);
             };
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -200,7 +200,8 @@
         </div>
       </div>
       <i class="fa fa-arrow-right"></i><i class="fa fa-save"></i>
-      <!-- ko text: title --><!-- /ko -->
+      {# Location of title is different for regular and advanced forms #}
+      <!-- ko text: $data.title || $root.title --><!-- /ko -->
     </h4>
   </div>
   <div class="panel-body">


### PR DESCRIPTION
## Product Description
Fixes two bugs with the case property UI in advanced forms:
1. One introduced in https://github.com/dimagi/commcare-hq/pull/35733 and reported here: https://forum.dimagi.com/t/unable-to-view-case-managements-save-mapping/11600
2. One introduced in https://github.com/dimagi/commcare-hq/pull/35814, which has been merged but not yet deployed.

Both of these are happening because this template is shared by regular forms and advanced forms, which use different js, and I updated the regular js but not the advanced version.

## Feature Flag
Advanced modules

## Safety Assurance

### Safety story
Fixes existing bug. Tested locally.

### Automated test coverage

No.

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
