### PR TITLE
Added icons to 'Edit Data' section of menu

### DIFF
--- a/corehq/apps/case_importer/base.py
+++ b/corehq/apps/case_importer/base.py
@@ -21,6 +21,7 @@ class ImportCases(DataInterface):
     name = gettext_lazy("Import Cases from Excel")
     slug = "import_cases"
     report_template_path = "case_importer/import_cases.html"
+    icon = 'far fa-file-excel'
     hide_filters = True
     asynchronous = False
 

--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -46,6 +46,7 @@ class CaseReassignmentInterface(CaseListMixin, BulkDataInterface):
     name = gettext_noop("Reassign Cases")
     slug = "reassign_cases"
     report_template_path = 'data_interfaces/interfaces/bootstrap3/case_management.html'
+    icon = 'fas fa-people-arrows'
     action = "reassign"
     action_text = gettext_lazy("Reassign")
 
@@ -170,6 +171,7 @@ class CaseCopyInterface(CaseReassignmentInterface):
     name = gettext_noop("Copy Cases")
     slug = "copy_cases"
     report_template_path = 'data_interfaces/interfaces/bootstrap3/case_management.html'
+    icon = 'fas fa-copy'
     action = "copy"
     action_text = gettext_lazy("Copy")
 
@@ -293,6 +295,7 @@ class BulkFormManagementInterface(SubmitHistoryMixin, DataInterface, ProjectRepo
     name = gettext_noop("Manage Forms")
     slug = "bulk_archive_forms"
     report_template_path = 'data_interfaces/interfaces/bootstrap3/archive_forms.html'
+    icon = 'far fa-file-alt'
 
     def __init__(self, request, **kwargs):
         super(BulkFormManagementInterface, self).__init__(request, **kwargs)

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/navs.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/navs.less
@@ -21,6 +21,10 @@
     > a:hover {
       background-color: #dbdbdb;
     }
+    a > i {
+      display: inline-block;
+      width: 16px;
+    }
   }
   &.nav li.active {
     > a, > a:link, > a:visited, > a:hover {

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_nav.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_nav.scss
@@ -21,6 +21,10 @@
     > a:hover {
       background-color: #dbdbdb;
     }
+    a > i {
+      display: inline-block;
+      width: 16px;
+    }
   }
   &.nav li {
     > a.active,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/navs._nav.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/navs._nav.style.diff.txt
@@ -9,7 +9,7 @@
    padding: 0;
    padding-bottom: 20px;
  }
-@@ -16,15 +16,18 @@
+@@ -16,7 +16,7 @@
    &.nav > li {
      a {
        padding: 3px 20px;
@@ -18,6 +18,8 @@
      }
      > a:hover {
        background-color: #dbdbdb;
+@@ -26,9 +26,12 @@
+       width: 16px;
      }
    }
 -  &.nav li.active {
@@ -32,7 +34,7 @@
        color: #ffffff;
      }
    }
-@@ -36,7 +39,7 @@
+@@ -40,7 +43,7 @@
      margin: 8px 10px;
      overflow: hidden;
      background-color: white;
@@ -41,7 +43,7 @@
    }
    .nav-input {
      padding: 3px 20px;
-@@ -54,6 +57,7 @@
+@@ -58,6 +61,7 @@
  .nav-main-icon {
    font-size: 1.7em;
    line-height: 0.7em;
@@ -49,7 +51,7 @@
  }
  
  .text-hq-nav-header {
-@@ -68,7 +72,7 @@
+@@ -72,7 +76,7 @@
  }
  
  .nav > li > a {

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -954,6 +954,7 @@ class ProjectDataTab(UITab):
             automatic_update_rule_list_view = {
                 'title': _(AutomaticUpdateRuleListView.page_title),
                 'url': reverse(AutomaticUpdateRuleListView.urlname, args=[self.domain]),
+                'icon': 'fa-solid fa-cogs',
             }
             if edit_section:
                 edit_section[0][1].append(automatic_update_rule_list_view)
@@ -967,6 +968,7 @@ class ProjectDataTab(UITab):
             deduplication_list_view = {
                 'title': _(DeduplicationRuleListView.page_title),
                 'url': reverse(DeduplicationRuleListView.urlname, args=[self.domain]),
+                'icon': 'fa-solid fa-network-wired',
             }
             edit_section[0][1].append(deduplication_list_view)
 
@@ -977,6 +979,7 @@ class ProjectDataTab(UITab):
             clean_cases_view = {
                 'title': _(CleanCasesMainView.page_title),
                 'url': reverse(CleanCasesMainView.urlname, args=[self.domain]),
+                'icon': 'fa-solid fa-shower',
             }
             edit_section[0][1].append(clean_cases_view)
 


### PR DESCRIPTION
## Product Description
It's getting long.

<img width="219" alt="Screenshot 2025-02-25 at 12 21 08 PM" src="https://github.com/user-attachments/assets/7e0356d3-9781-4e0c-9b56-e78282e608d3" />

## Safety Assurance

### Safety story
Not risky code.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
