### PR TITLE
Add placeholder Editable Record for ElasticTable's record_class

### DIFF
--- a/corehq/apps/data_cleaning/records.py
+++ b/corehq/apps/data_cleaning/records.py
@@ -1,0 +1,11 @@
+from corehq.apps.hqwebapp.tables.elasticsearch.records import CaseSearchElasticRecord
+
+
+class EditableCaseSearchElasticRecord(CaseSearchElasticRecord):
+
+    def __init__(self, record, request, **kwargs):
+        super().__init__(record, request, **kwargs)
+        self.session = kwargs.pop('session')
+
+    def __getitem__(self, item):
+        return super().__getitem__(item)

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -2,13 +2,13 @@ from django.utils.translation import gettext_lazy
 from django_tables2 import columns, tables
 
 from corehq.apps.data_cleaning.columns import DataCleaningHtmxColumn
-from corehq.apps.hqwebapp.tables.elasticsearch.records import CaseSearchElasticRecord
+from corehq.apps.data_cleaning.records import EditableCaseSearchElasticRecord
 from corehq.apps.hqwebapp.tables.elasticsearch.tables import ElasticTable
 from corehq.apps.hqwebapp.tables.htmx import BaseHtmxTable
 
 
 class CleanCaseTable(BaseHtmxTable, ElasticTable):
-    record_class = CaseSearchElasticRecord
+    record_class = EditableCaseSearchElasticRecord
 
     class Meta(BaseHtmxTable.Meta):
         pass

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -48,6 +48,9 @@ class CleanCasesTableView(BaseDataCleaningTableView):
     def get_table_kwargs(self):
         return {
             'extra_columns': self.table_class.get_columns_from_session(self.session),
+            'record_kwargs': {
+                'session': self.session,
+            },
         }
 
     def get_queryset(self):

--- a/corehq/apps/hqwebapp/tables/elasticsearch/records.py
+++ b/corehq/apps/hqwebapp/tables/elasticsearch/records.py
@@ -11,7 +11,7 @@ from corehq.util.timezones.utils import get_timezone
 
 class BaseElasticRecord(ABC):
 
-    def __init__(self, record, request):
+    def __init__(self, record, request, **kwargs):
         self.record = record
         self.request = request
 
@@ -63,12 +63,12 @@ class CaseSearchElasticRecord(BaseElasticRecord):
     verbose_name = gettext_lazy("case")
     verbose_name_plural = gettext_lazy("cases")
 
-    def __init__(self, record, request):
+    def __init__(self, record, request, **kwargs):
         record = SafeCaseDisplay(
             wrap_case_search_hit(record),
             get_timezone(request, request.domain)
         )
-        super().__init__(record, request)
+        super().__init__(record, request, **kwargs)
 
     def __getitem__(self, item):
         return self.record.get(item)


### PR DESCRIPTION
## Technical Summary
This creates the placeholder class `EditableCaseSearchElasticRecord`, which will be able to access a `BulkEditSession` instance and return the context needed for `DataCleaningHtmxColumn` to render the edited state for a given column, its data type, and inline edit widget.
This is just a placeholder for future work (coming in a later PR). The big update is allowing the `ElasticTable`'s `record_class` to receive an optional set of `kwargs`.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe. touches no production workflows.

### Automated test coverage
Yes, the base classes are tested.

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
