### PR TITLE
Fixed missing banner due to project missing from request

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -188,6 +188,7 @@ def _ensure_request_project(request):
     project = getattr(request, 'project', None)
     if not project and hasattr(request, 'domain'):
         _store_project_on_request(request, request.domain)
+        project = request.project
     return project
 
 


### PR DESCRIPTION
## Product Description
Project alerts banners aren't displaying on web apps.

https://dimagi.atlassian.net/browse/SAAS-16681

## Technical Summary
This was reproducible locally. Alerts are generated by the [commcare_alerts tag](https://github.com/dimagi/commcare-hq/blob/8a3e7f9f9b235ba987e844297eb61a3bf21320fc/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py#L404-L417). `load_alerts_for_domain` was coming up as `None` for web apps.

The [FormplayerMain](https://github.com/dimagi/commcare-hq/blob/8a3e7f9f9b235ba987e844297eb61a3bf21320fc/corehq/apps/cloudcare/views.py#L97-L108) view doesn't use `login_and_domain_required` or inherit from a view that uses `LoginAndDomainMixin`. Views that do one of those two things end up calling `load_domain` [here](https://github.com/dimagi/commcare-hq/blob/8a3e7f9f9b235ba987e844297eb61a3bf21320fc/corehq/apps/domain/decorators.py#L88) which calls [_store_project_on_request](https://github.com/dimagi/commcare-hq/blob/8a3e7f9f9b235ba987e844297eb61a3bf21320fc/corehq/apps/domain/decorators.py#L73) and ensures that the `project` attr on the request object is populated. FormplayerMain does its permission checking in [require_cloudcare_access_ex](https://github.com/dimagi/commcare-hq/blob/8a3e7f9f9b235ba987e844297eb61a3bf21320fc/corehq/apps/cloudcare/decorators.py#L14-L47) which looks at the couch user on the request but generally doesn't call `login_and_domain_required`.

The code path to populate` project` for requests that don't already have it appears to be just broken, which is odd, but maybe not that odd, given that the vast majority of views in HQ are either decorated with `@login_and_domain_required` or use `LoginAndDomainMixin`, so they have `request.project` populated and perhaps this code path isn't hit often.

## Safety Assurance

### Safety story
The change itself is pretty innocuous and the scope is limited. `domain.decorators` is a core file, but `_ensure_request_project` is only called by `user_can_access_domain_specific_pages`, which is only called in the `commcarehq_alerts` template tag.

### Automated test coverage

There are a bunch of related tests in [test_auth.py](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/domain/tests/test_auth.py) but they seem to all patch `_ensure_request_project`.

### QA Plan

Not requesting QA.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
