### PR TITLE
Data cleaning: a save button

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -83,6 +83,19 @@ class BulkEditSession(models.Model):
     def new_form_session(cls, user, domain_name, xmlns):
         raise NotImplementedError("Form data cleaning sessions are not yet supported!")
 
+    @classmethod
+    def get_committed_sessions(cls, user, domain_name):
+        return cls.objects.filter(user=user, domain=domain_name, committed_on__isnull=False)
+
+    @property
+    def status(self):
+        if self.committed_on:
+            if self.completed_on:
+                return "complete"
+            else:
+                return "in progress"
+        return "pending"
+
 
 class DataType:
     TEXT = 'text'

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -30,8 +30,11 @@ class CaseCleaningTasksTable(BaseHtmxTable, tables.Table):
     status = columns.Column(
         verbose_name=gettext_lazy("Status"),
     )
-    time = columns.Column(
-        verbose_name=gettext_lazy("Time"),
+    committed_on = columns.Column(
+        verbose_name=gettext_lazy("Committed On"),
+    )
+    completed_on = columns.Column(
+        verbose_name=gettext_lazy("Completed On"),
     )
     case_type = columns.Column(
         verbose_name=gettext_lazy("Case Type"),

--- a/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_session.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_session.html
@@ -2,17 +2,24 @@
 {% load hq_shared_tags %}
 {% load django_tables2 %}
 {% load i18n %}
-
 {% js_entry "data_cleaning/js/clean_cases_session" %}
 
 {% block content %}
   {% breadcrumbs current_page section current_page.parents %}
   <div class="d-flex align-items-center m-3">
-    <h1 class="fs-3 pe-3 py-3 m-0">
-      {{ current_page.page_name }}
-    </h1>
+    <h1 class="fs-3 pe-3 py-3 m-0">{{ current_page.page_name }}</h1>
     <div>
       {% include "data_cleaning/partials/button_bar.html" %}
+      <form
+        method="POST"
+        action="{% url "save_case_session" domain session_id %}"
+        class="float-end mx-3"
+      >
+        {% csrf_token %}
+        <button type="submit" class="btn btn-success">
+          <i class="fa fa-hippo"></i> Save
+        </button>
+      </form>
     </div>
   </div>
   <div

--- a/corehq/apps/data_cleaning/urls.py
+++ b/corehq/apps/data_cleaning/urls.py
@@ -3,6 +3,7 @@ from django.urls import re_path as url
 from corehq.apps.data_cleaning.views.main import (
     CleanCasesMainView,
     CleanCasesSessionView,
+    save_case_session,
 )
 from corehq.apps.data_cleaning.views.tables import (
     CleanCasesTableView,
@@ -20,4 +21,5 @@ urlpatterns = [
         name=CleanCasesSessionView.urlname),
     url(r'^cases/(?P<session_id>[\w\-]+)/table/$', CleanCasesTableView.as_view(),
         name=CleanCasesTableView.urlname),
+    url(r'^cases/save/(?P<session_id>[\w\-]+)/$', save_case_session, name='save_case_session'),
 ]

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from memoized import memoized
 
 from django.contrib import messages
-from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -98,4 +97,4 @@ def save_case_session(request, domain, session_id):
     session.save()
     commit_data_cleaning.delay(session_id)
     messages.success(request, _("Session saved."))
-    return HttpResponseRedirect(reverse(CleanCasesMainView.urlname, args=(domain,)))
+    return redirect(reverse(CleanCasesMainView.urlname, args=(domain,)))

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -59,11 +59,10 @@ class CaseCleaningTasksTableView(BaseDataCleaningTableView):
     table_class = CaseCleaningTasksTable
 
     def get_queryset(self):
-        return [
-            {
-                "status": "test",
-                "time": "no time",
-                "case_type": "placeholder",
-                "details": "foo",
-            }
-        ]
+        return [{
+            "status": session.status,
+            "committed_on": session.committed_on,
+            "completed_on": session.completed_on,
+            "case_type": session.identifier,
+            "details": session.result,
+        } for session in BulkEditSession.get_committed_sessions(self.request.user, self.domain)]


### PR DESCRIPTION
## Product Description
This PR adds the barest-boned possible UI for saving a session and kicking off the save task. I don't expect it to live long, I just want to be able to click a button so I can stop creating new sessions in the django shell. PRing this now in the hope of avoiding conflicts in `data_cleaning.models`

This is the ugly save button:
![Screenshot 2025-02-25 at 8 44 33 PM](https://github.com/user-attachments/assets/e8922c6c-17ac-4d04-a6e8-686b3af4eb7d)

This is the table of tasks, which is now populated with real sessions though I haven't put any thought yet into the data displayed:
![Screenshot 2025-02-25 at 8 44 45 PM](https://github.com/user-attachments/assets/986cdf0a-eeed-4f3b-9608-5f50c5707b4c)

## Feature Flag
DATA_CLEANING_CASES

## Safety Assurance

### Safety story
UI changes that are under a flag for a feature still in development.

### Automated test coverage

I didn't add any. I could be persuaded to add them for the `status` and `get_committed_sessions` functions pretty easily, though I expect status might change.

### QA Plan

No.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
