### PR TITLE
Ensure KYC Config Exists for KYC Verification Report

### DIFF
--- a/corehq/apps/integration/kyc/views.py
+++ b/corehq/apps/integration/kyc/views.py
@@ -158,6 +158,22 @@ class KycVerificationReportView(BaseDomainView):
     page_title = _('KYC Report')
 
     @property
+    def page_context(self):
+        context = super().page_context
+        context.update({
+            'domain_has_config': self.domain_has_config,
+        })
+        return context
+
+    @property
+    def domain_has_config(self):
+        try:
+            KycConfig.objects.get(domain=self.domain)
+        except KycConfig.DoesNotExist:
+            return False
+        return True
+
+    @property
     def page_url(self):
         return reverse(self.urlname, args=[self.domain])
 

--- a/corehq/apps/integration/templates/kyc/kyc_verify_report.html
+++ b/corehq/apps/integration/templates/kyc/kyc_verify_report.html
@@ -12,8 +12,8 @@
       <div class="alert alert-warning">
         <i class="fa-valid-alert-icon fa fa-warning"></i>
         {% blocktrans %}
-          This domain does not have a saved KYC configuration, which is required to view this report.
-          Please create a configuration first.
+          This domain does not have a saved KYC configuration, which is required
+          to view this report. Please create a configuration first.
         {% endblocktrans %}
         <a href="{% url 'kyc_configuration' domain %}">
           {% blocktrans %}

--- a/corehq/apps/integration/templates/kyc/kyc_verify_report.html
+++ b/corehq/apps/integration/templates/kyc/kyc_verify_report.html
@@ -8,32 +8,48 @@
   <div>
     <h1 class="py-3 m-0">{% trans "KYC Report" %}</h1>
     <div id="verify-alert"></div>
-    <p>
-      <button
-        id="verify-selected-btn"
-        class="btn btn-primary"
-        type="button"
-        hx-post="{% url 'kyc_verify_table' request.domain %}"
-        hx-swap="innerHTML"
-        hx-target="#verify-alert"
-        hq-hx-action="verify_rows"
-        hx-vals='{
-                "selected_ids": [],
-                "verify_all": true
-            }'
-      >
-        <span> {% trans "Verify All" %} </span>
-        <span class="d-none"> {% trans "Verify Selected" %} </span>
-      </button>
-    </p>
-    <div
-      hx-trigger="load"
-      hx-get="{% url 'kyc_verify_table' domain %}{% querystring %}"
-    >
-      <div class="htmx-indicator">
-        <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading..." %}
+    {% if not domain_has_config %}
+      <div class="alert alert-warning">
+        <i class="fa-valid-alert-icon fa fa-warning"></i>
+        {% blocktrans %}
+          This domain does not have a saved KYC configuration, which is required to view this report.
+          Please create a configuration first.
+        {% endblocktrans %}
+        <a href="{% url 'kyc_configuration' domain %}">
+          {% blocktrans %}
+            Navigate there.
+          {% endblocktrans %}
+        </a>
       </div>
-    </div>
+    {% else %}
+      <p>
+        <button
+          id="verify-selected-btn"
+          class="btn btn-primary"
+          type="button"
+          hx-post="{% url 'kyc_verify_table' request.domain %}"
+          hx-swap="innerHTML"
+          hx-target="#verify-alert"
+          hq-hx-action="verify_rows"
+          hx-vals='{
+                  "selected_ids": [],
+                  "verify_all": true
+              }'
+        >
+          <span> {% trans "Verify All" %} </span>
+          <span class="d-none"> {% trans "Verify Selected" %} </span>
+        </button>
+      </p>
+
+      <div
+        hx-trigger="load"
+        hx-get="{% url 'kyc_verify_table' domain %}{% querystring %}"
+      >
+        <div class="htmx-indicator">
+          <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading..." %}
+        </div>
+      </div>
+    {% endif %}
   </div>
 {% endblock %}
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
If the domain has not yet saved a KYC config, then the KYC verification page will look as follows:
![Screenshot from 2025-02-26 10-53-38](https://github.com/user-attachments/assets/4eddd643-3ee7-498d-bad0-782db1a9b047)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-4334).

This PR addresses an exception that happens when a user tries to navigate to the KYC verification page without having saved a KYC configuration first. Specifically, the exception occurs because a `.get()` query is done to fetch the KYC config instance for a specific domain. Since this assumes that the instance exists when the query is run, an exception is thrown when it doesn't.

The above is addressed by simply adding a check to the KYC verification page base view to check for a valid config for the domain. If it doesn't exist, then the report isn't loaded and instead, a warning is given to the user to create a config first.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`KYC_VERIFICATION`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Unit tests exist

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

A unit test has been added to ensure that the `domain_has_config` property holds the correct value.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
