### PR TITLE
Bump jsonobject to 2.3.1

### DIFF
--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -57,7 +57,7 @@ iso8601
 Jinja2
 jsonfield
 jsonobject-couchdbkit
-jsonobject>=2.3.0
+jsonobject>=2.3.1
 # jsonpath-ng with support for "wherenot" operator, and building documents
 # Upgrade when changes merged upstream
 jsonpath-ng @ https://github.com/kaapstorm/python-jsonpath-rw/raw/wherenot+find_or_create/wheel/jsonpath_ng-1.5.2.2-py3-none-any.whl

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -57,7 +57,7 @@ iso8601
 Jinja2
 jsonfield
 jsonobject-couchdbkit
-jsonobject>=2.0.0
+jsonobject>=2.3.0
 # jsonpath-ng with support for "wherenot" operator, and building documents
 # Upgrade when changes merged upstream
 jsonpath-ng @ https://github.com/kaapstorm/python-jsonpath-rw/raw/wherenot+find_or_create/wheel/jsonpath_ng-1.5.2.2-py3-none-any.whl

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -340,7 +340,7 @@ jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==2.3.0
+jsonobject==2.3.1
     # via
     #   -r base-requirements.in
     #   git-build-branch

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -340,7 +340,7 @@ jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==2.0.0
+jsonobject==2.3.0
     # via
     #   -r base-requirements.in
     #   git-build-branch
@@ -628,7 +628,6 @@ six==1.16.0
     #   eulxml
     #   fixture
     #   isodate
-    #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng
     #   mando

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -287,7 +287,7 @@ jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==2.3.0
+jsonobject==2.3.1
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -287,7 +287,7 @@ jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==2.0.0
+jsonobject==2.3.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit
@@ -513,7 +513,6 @@ six==1.16.0
     #   dropbox
     #   ethiopian-date-converter
     #   eulxml
-    #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng
     #   pyjwkest

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -289,7 +289,7 @@ jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==2.0.0
+jsonobject==2.3.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit
@@ -524,7 +524,6 @@ six==1.16.0
     #   ethiopian-date-converter
     #   eulxml
     #   isodate
-    #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng
     #   pyjwkest

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -289,7 +289,7 @@ jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==2.3.0
+jsonobject==2.3.1
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -271,7 +271,7 @@ jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==2.0.0
+jsonobject==2.3.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit
@@ -485,7 +485,6 @@ six==1.16.0
     #   ethiopian-date-converter
     #   eulxml
     #   isodate
-    #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng
     #   pyjwkest

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -271,7 +271,7 @@ jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==2.3.0
+jsonobject==2.3.1
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -291,7 +291,7 @@ jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==2.0.0
+jsonobject==2.3.0
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit
@@ -535,7 +535,6 @@ six==1.16.0
     #   ethiopian-date-converter
     #   eulxml
     #   isodate
-    #   jsonobject
     #   jsonobject-couchdbkit
     #   jsonpath-ng
     #   mando

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -291,7 +291,7 @@ jsonfield==3.1.0
     # via
     #   -r base-requirements.in
     #   django-prbac
-jsonobject==2.3.0
+jsonobject==2.3.1
     # via
     #   -r base-requirements.in
     #   jsonobject-couchdbkit


### PR DESCRIPTION
Prepare for Python 3.13

One nice feature of jsonobject 2.3.x is that manylinux wheels for all supported versions of Python (3.9 - 3.13) are now hosted on PyPI, which means it is not necessary to build the C extensions when installing on Linux (all of our hosted HQ instances).

## Safety Assurance

### Safety story

`jsonobject` is used widely throughout the HQ codebase, and is accordingly well covered by tests. The changes since the previous release add support for new Python versions (3.11, 3.12, and 3.13) and updated a build dependency (Cython) of jsonobject.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations