### PR TITLE
Return real user status instead of always Active

### DIFF
--- a/corehq/apps/users/bulk_download.py
+++ b/corehq/apps/users/bulk_download.py
@@ -193,7 +193,7 @@ def make_web_user_dict(user, location_cache, domain):
         'email': user.email,
         'role': role_name,
         'location_code': location_codes,
-        'status': gettext('Active User'),
+        'status': gettext('Active User') if user.is_active else gettext('Inactive User'),
         'last_access_date (read only)': domain_membership.last_accessed,
         'last_login (read only)': user.last_login,
         'remove': '',

--- a/corehq/apps/users/tests/test_bulk_download.py
+++ b/corehq/apps/users/tests/test_bulk_download.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+from corehq.apps.domain.shortcuts import create_domain
+
+from ..models import WebUser
+from ..bulk_download import make_web_user_dict
+
+
+class TestBulkDownload(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = create_domain("test")
+        cls.addClassCleanup(cls.domain.delete)
+
+    def test_make_web_user_dict_with_inactive_user(self):
+        user = WebUser.create("test", 'username', 'password', None, None)
+        self.addCleanup(user.delete, "test", deleted_by=None)
+        assert user.is_active
+        user.is_active = False
+
+        data = make_web_user_dict(user, {}, "test")
+        assert data["status"] == "Inactive User"


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-16692

## Safety Assurance

### Safety story

Tiny bugfix.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations