### PR TITLE
Add Bulk Edit Pinned Filter UIs (part one)

### DIFF
--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -1,0 +1,17 @@
+from corehq.apps.reports.filters.case_list import CaseListFilter
+
+
+class CaseOwnersPinnedFilter(CaseListFilter):
+    template = "data_cleaning/filters/pinned/multi_option.html"
+
+    @property
+    def filter_context(self):
+        context = super().filter_context
+        filter_help = [context.pop('filter_help_inline')]
+        search_help = context.pop('search_help_inline', None)
+        if search_help:
+            filter_help.append(search_help)
+        return {
+            'report_select2_config': context,
+            'filter_help': filter_help,
+        }

--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -1,9 +1,12 @@
+from django.utils.translation import gettext_lazy
+
 from corehq.apps.reports.filters.case_list import CaseListFilter
 from corehq.apps.reports.filters.select import SelectOpenCloseFilter
 
 
 class CaseOwnersPinnedFilter(CaseListFilter):
     template = "data_cleaning/filters/pinned/multi_option.html"
+    placeholder = gettext_lazy("Please add case owners to filter the list of cases.")
 
     @property
     def filter_context(self):

--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -1,4 +1,5 @@
 from corehq.apps.reports.filters.case_list import CaseListFilter
+from corehq.apps.reports.filters.select import SelectOpenCloseFilter
 
 
 class CaseOwnersPinnedFilter(CaseListFilter):
@@ -14,4 +15,14 @@ class CaseOwnersPinnedFilter(CaseListFilter):
         return {
             'report_select2_config': context,
             'filter_help': filter_help,
+        }
+
+
+class CaseStatusPinnedFilter(SelectOpenCloseFilter):
+    template = "data_cleaning/filters/pinned/single_option.html"
+
+    @property
+    def filter_context(self):
+        return {
+            'report_select2_config': super().filter_context,
         }

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -1,5 +1,6 @@
 import 'commcarehq';
 import 'hqwebapp/js/htmx_base';
+import 'hqwebapp/js/alpinejs/directives/report_select2';
 
 import Alpine from 'alpinejs';
 Alpine.start();

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/pinned/base.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/pinned/base.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+
+<div class="row mb-2">
+  <label for="{{ css_id }}" class="form-label col-2">{{ label }}</label>
+  <div class="col-10">
+    {% block filter_content %}
+    {% endblock %}
+  </div>
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/pinned/multi_option.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/pinned/multi_option.html
@@ -1,0 +1,19 @@
+{% extends 'data_cleaning/filters/pinned/base.html' %}
+{% load hq_shared_tags %}
+
+{% block filter_content %}
+  <div class="input-group">
+    <select
+      class="form-select"
+      name="{{ slug }}"
+      multiple
+      x-report-select2-multi="{% html_attr report_select2_config %}"
+    ></select>
+  </div>
+
+  {% for help in filter_help %}
+    <div class="help-block">
+      {{ help }}
+    </div>
+  {% endfor %}
+{% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/pinned/single_option.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/pinned/single_option.html
@@ -1,0 +1,17 @@
+{% extends 'data_cleaning/filters/pinned/base.html' %}
+{% load hq_shared_tags %}
+
+{% block filter_content %}
+  <div
+    x-data="{
+      selected: '{{ report_select2_config.select.selected|default:'' }}',
+    }"
+  >
+    <select
+      class="form-select"
+      name="{{ slug }}"
+      x-model="selected"
+      x-report-select2="{% html_attr report_select2_config %}"
+    ></select>
+  </div>
+{% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/pinned_filter_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/pinned_filter_form.html
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{{ filter_type }}
+{{ rendered_filter }}

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -7,6 +7,7 @@ from django.test import TestCase, RequestFactory
 from corehq.apps.data_cleaning.exceptions import UnsupportedFilterValueException
 from corehq.apps.data_cleaning.filters import (
     CaseOwnersPinnedFilter,
+    CaseStatusPinnedFilter,
 )
 from corehq.apps.data_cleaning.models import (
     BulkEditColumnFilter,
@@ -647,5 +648,30 @@ class TestReportFilterSubclasses(TestCase):
                 '.net/wiki/spaces/commcarepublic/pages/2215051298/Organization+Data'
                 '+Management"target="_blank">Learn more</a>.'
             ],
+        }
+        self.assertEqual(report_filter.filter_context, expected_context)
+
+    def test_case_status_report_filter_context(self):
+        report_filter = CaseStatusPinnedFilter(
+            self.request, self.domain_name, use_bootstrap5=True
+        )
+        expected_context = {
+            'report_select2_config': {
+                'select': {
+                    'options': [
+                        {'val': 'open', 'text': 'Only Open'},
+                        {'val': 'closed', 'text': 'Only Closed'},
+                    ],
+                    'default_text': 'Show All',
+                    'selected': '',
+                    'placeholder': '',
+                },
+                'pagination': {
+                    'enabled': False,
+                    'url': None,
+                    'handler': '',
+                    'action': None,
+                },
+            },
         }
         self.assertEqual(report_filter.filter_context, expected_context)

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -609,7 +609,7 @@ class TestReportFilterSubclasses(TestCase):
                 'target="_blank"> Filter Definitions</a>.',
             ],
         }
-        self.assertEqual(report_filter.filter_context, expected_context)
+        self.assertDictEqual(report_filter.filter_context, expected_context)
 
     @mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting
     def test_case_owners_report_filter_context_locations(self):
@@ -649,7 +649,7 @@ class TestReportFilterSubclasses(TestCase):
                 '+Management"target="_blank">Learn more</a>.'
             ],
         }
-        self.assertEqual(report_filter.filter_context, expected_context)
+        self.assertDictEqual(report_filter.filter_context, expected_context)
 
     def test_case_status_report_filter_context(self):
         report_filter = CaseStatusPinnedFilter(
@@ -674,4 +674,4 @@ class TestReportFilterSubclasses(TestCase):
                 },
             },
         }
-        self.assertEqual(report_filter.filter_context, expected_context)
+        self.assertDictEqual(report_filter.filter_context, expected_context)

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -1,13 +1,20 @@
 import pytest
 from testil import eq
-from django.test import TestCase
+from unittest import mock
+
+from django.test import TestCase, RequestFactory
 
 from corehq.apps.data_cleaning.exceptions import UnsupportedFilterValueException
+from corehq.apps.data_cleaning.filters import (
+    CaseOwnersPinnedFilter,
+)
 from corehq.apps.data_cleaning.models import (
     BulkEditColumnFilter,
     DataType,
     FilterMatchType,
 )
+from corehq.apps.domain.models import Domain
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es import CaseSearchES
 from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.es.tests.utils import (
@@ -15,6 +22,7 @@ from corehq.apps.es.tests.utils import (
     es_test,
 )
 from corehq.apps.hqwebapp.tests.tables.generator import get_case_blocks
+from corehq.apps.users.models import WebUser
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
 
@@ -545,3 +553,99 @@ class BulkEditColumnFilterXpathTest(TestCase):
                     column_filter.get_xpath_expression(),
                     msg=f"{match_type} for {data_type} should not return an xpath expression"
                 )
+
+
+class TestReportFilterSubclasses(TestCase):
+    domain_name = 'report-filter-pinned-test'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = create_domain(cls.domain_name)
+        cls.addClassCleanup(cls.domain.delete)
+
+        cls.web_user = WebUser.create(
+            cls.domain.name, 'tester@datacleaning.org', 'testpwd', None, None
+        )
+        cls.addClassCleanup(cls.web_user.delete, cls.domain.name, deleted_by=None)
+
+    def setUp(self):
+        super().setUp()
+        self.request = RequestFactory().get('/cases/')
+        self.request.domain = self.domain_name
+        self.request.can_access_all_locations = True
+        self.request.couch_user = self.web_user
+        self.request.project = self.domain
+
+    def test_case_owners_report_filter_context(self):
+        report_filter = CaseOwnersPinnedFilter(
+            self.request, self.domain_name, use_bootstrap5=True
+        )
+        expected_context = {
+            'report_select2_config': {
+                'select': {
+                    'options': [
+                        {'val': 't__0', 'text': '[Active Mobile Workers]'}
+                    ],
+                    'default_text': 'Filter by...',
+                    'selected': [
+                        {'id': 'project_data', 'text': '[Project Data]'},
+                    ],
+                    'placeholder': 'Add case owners to filter this report.',
+                },
+                'pagination': {
+                    'enabled': False,
+                    'url': None,
+                    'handler': '',
+                    'action': None,
+                },
+                'endpoint': '/a/report-filter-pinned-test/reports/filters/case_list_options/',
+            },
+            'filter_help': [
+                '<i class="fa fa-info-circle"></i> See <a href="'
+                'https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/'
+                '2215051298/Organization+Data+Management#Search-for-Locations" '
+                'target="_blank"> Filter Definitions</a>.',
+            ],
+        }
+        self.assertEqual(report_filter.filter_context, expected_context)
+
+    @mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting
+    def test_case_owners_report_filter_context_locations(self):
+        report_filter = CaseOwnersPinnedFilter(
+            self.request, self.domain_name, use_bootstrap5=True
+        )
+        expected_context = {
+            'report_select2_config': {
+                'select': {
+                    'options': [
+                        {'val': 't__0', 'text': '[Active Mobile Workers]'}
+                    ],
+                    'default_text': 'Filter by...',
+                    'selected': [
+                        {'id': 'project_data', 'text': '[Project Data]'},
+                    ],
+                    'placeholder': 'Add case owners to filter this report.',
+                },
+                'pagination': {
+                    'enabled': False,
+                    'url': None,
+                    'handler': '',
+                    'action': None,
+                },
+                'endpoint': '/a/report-filter-pinned-test/reports/filters/case_list_options/',
+            },
+            'filter_help': [
+                '<i class="fa fa-info-circle"></i> See <a href="'
+                'https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/'
+                '2215051298/Organization+Data+Management#Search-for-Locations" '
+                'target="_blank"> Filter Definitions</a>.',
+                'When searching by location, put your location name in quotes to '
+                'show only exact matches. To more easily find a location, you may '
+                'specify multiple levels by separating with a "/". For example, '
+                '"Massachusetts/Suffolk/Boston". <a href="https://dimagi.atlassian'
+                '.net/wiki/spaces/commcarepublic/pages/2215051298/Organization+Data'
+                '+Management"target="_blank">Learn more</a>.'
+            ],
+        }
+        self.assertEqual(report_filter.filter_context, expected_context)

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -592,7 +592,7 @@ class TestReportFilterSubclasses(TestCase):
                     'selected': [
                         {'id': 'project_data', 'text': '[Project Data]'},
                     ],
-                    'placeholder': 'Add case owners to filter this report.',
+                    'placeholder': 'Please add case owners to filter the list of cases.',
                 },
                 'pagination': {
                     'enabled': False,
@@ -626,7 +626,7 @@ class TestReportFilterSubclasses(TestCase):
                     'selected': [
                         {'id': 'project_data', 'text': '[Project Data]'},
                     ],
-                    'placeholder': 'Add case owners to filter this report.',
+                    'placeholder': 'Please add case owners to filter the list of cases.',
                 },
                 'pagination': {
                     'enabled': False,

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -1,13 +1,21 @@
+from django.http import Http404
 from django.utils.decorators import method_decorator
-from django.utils.translation import gettext_lazy
+from django.utils.translation import gettext_lazy, gettext as _
 from django.views.generic import TemplateView
+from memoized import memoized
 
 from corehq import toggles
+from corehq.apps.data_cleaning.filters import (
+    CaseOwnersPinnedFilter,
+    CaseStatusPinnedFilter,
+)
+from corehq.apps.data_cleaning.models import PinnedFilterType
 from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
 from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.domain.views import DomainViewMixin
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.util.htmx_action import HqHtmxActionMixin
+from corehq.util.timezones.utils import get_timezone
 
 
 @method_decorator([
@@ -24,12 +32,36 @@ class PinnedFilterFormView(BulkEditSessionViewMixin, BaseFilterFormView):
     session_not_found_message = gettext_lazy("Cannot retrieve pinned filter, session was not found.")
 
     @property
+    @memoized
+    def timezone(self):
+        return get_timezone(self.request, self.domain)
+
+    @property
     def filter_type(self):
         return self.kwargs['filter_type']
+
+    @property
+    def form_filter_class(self):
+        filter_type_to_class = {
+            PinnedFilterType.CASE_OWNERS: CaseOwnersPinnedFilter,
+            PinnedFilterType.CASE_STATUS: CaseStatusPinnedFilter,
+        }
+        try:
+            return filter_type_to_class[self.filter_type]
+        except KeyError:
+            raise Http404(_("unsupported filter type: {}").format(self.filter_type))
+
+    @property
+    @memoized
+    def form_filter(self):
+        return self.form_filter_class(
+            self.request, self.domain, self.timezone, use_bootstrap5=True
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update({
             "filter_type": self.filter_type,
+            "rendered_filter": self.form_filter.render(),
         })
         return context

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/report_select2.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/report_select2.js
@@ -1,0 +1,167 @@
+import $ from 'jquery';
+import 'select2/dist/js/select2.full.min';
+import Alpine from 'alpinejs';
+
+import utils from 'hqwebapp/js/alpinejs/directives/select2';
+
+/***
+ * These directives are intended as alpine replacements for the knockout-based
+ * select2 utilities in `reports/js/filters/select2s`.
+ */
+
+Alpine.directive('report-select2', (el, { expression }, { cleanup }) => {
+    /**
+     * To use, add x-report-select2-multi to your select element.
+     *
+     *      <select x-report-select2="{% html_attr config %}"></select>
+     *
+     *      See CaseStatusPinnedFilter for an example of how to format the config
+     *      NOTE: this is **very** specific to Report Filter context.
+     *
+     */
+    const config = (expression) ? JSON.parse(expression) : {};
+    if (config.pagination.enabled) {
+        _createPaginatedSelect2(el, config);
+    } else {
+        _createSelect2(el, config);
+    }
+
+    cleanup(() => {
+        utils.select2Cleanup(el);
+    });
+});
+
+Alpine.directive('report-select2-multi', (el, { expression }, { cleanup }) => {
+    /**
+     * To use, add x-report-select2-multi to your select element.
+     *
+     *      <select x-report-select2-multi="{% html_attr config %}"></select>
+     *
+     *      See CaseOwnersPinnedFilter for an example of how to format the config.
+     *      NOTE: this is **very** specific to Report Filter context.
+     *
+     */
+    const config = (expression) ? JSON.parse(expression) : {};
+    if (config.endpoint !== undefined) {
+        _createAsyncSelect2Multi(el, config);
+    } else {
+        _createSelect2Multi(el, config);
+    }
+
+    cleanup(() => {
+        utils.select2Cleanup(el);
+    });
+});
+
+document.body.addEventListener('htmx:afterSettle', (event) => {
+    /**
+     * This fixes a bug for forms using x-select2 after submitting, validating, and swapping back into
+     * the DOM using HTMX.
+     *
+     * Without this fix, you will get the **visible** <select> stacked on top of the select2, and no
+     * validation classes are passed to the select2.
+     */
+    utils.fixSelect2htmx(event, '[x-report-select2]');
+    utils.fixSelect2htmx(event, '[x-report-select2-multi]');
+});
+
+const _createSelect2 = (el, config) => {
+    el.appendChild(new Option(config.select.default_text, ''));
+    config.select.options.forEach(option => {
+        el.appendChild(new Option(option.text, option.val));
+    });
+    $(el).select2({
+        clearable: true,
+    });
+};
+
+const _createPaginatedSelect2 = (el, config) => {
+    $(el).select2({
+        ajax: {
+            url: config.pagination.url,
+            type: 'POST',
+            dataType: 'json',
+            delay: 250,
+            data: function (params) {
+                return {
+                    q: params.term,
+                    page: params.page,
+                    handler: config.pagination.handler,
+                    action: config.pagination.action,
+                };
+            },
+            processResults: function (data, params) {
+                params.page = params.page || 1;
+                if (data.success) {
+                    var limit = data.limit;
+                    var hasMore = (params.page * limit) < data.total;
+                    return {
+                        results: data.items,
+                        pagination: {
+                            more: hasMore,
+                        },
+                    };
+                }
+            },
+        },
+        allowClear: true,
+        placeholder: config.select.default_text || ' ',
+    });
+};
+
+const _createAsyncSelect2Multi = (el, config) => {
+    const pageLimit = 10;
+    config.select.options.forEach(option => {
+        el.appendChild(new Option(option.text, option.val));
+    });
+    $(el).select2({
+        placeholder: config.select.placeholder,
+        ajax: {
+            url: config.endpoint,
+            dataType: 'json',
+            delay: 500,
+            data: function (params) {
+                return {
+                    q: params.term,
+                    page_limit: pageLimit,
+                    page: params.page,
+                };
+            },
+            processResults: function (data, params) {
+                params.page = params.page || 1;
+                const more = data.more || data.pagination && data.pagination.more || (params.page * pageLimit) < data.total;
+                return {
+                    results: data.results,
+                    pagination: {
+                        more: more,
+                    },
+                };
+            },
+        },
+        multiple: true,
+    });
+    if (config.select.selected && config.select.selected.length) {
+        config.select.selected.forEach(item => {
+            // NOTE: `id` used instead of `value` (above) due to inconsistencies in the original report filter
+            // eventually, we should make sure everything is consistent
+            el.appendChild(new Option(item.text, item.id));
+        });
+        $(el).trigger({
+            type: 'select2:select',
+            params: {
+                data: config.select.selected,
+            },
+        });
+        $(el).val(config.select.selected.map(item => item.id));
+        $(el).trigger('change.select2');
+    }
+};
+
+const _createSelect2Multi = (el, config) => {
+    config.select.options.forEach(option => {
+        el.appendChild(new Option(option.text, option.value));
+    });
+    $(el).select2({
+        multiple: true,
+    });
+};

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/report_select2.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/report_select2.js
@@ -15,8 +15,8 @@ Alpine.directive('report-select2', (el, { expression }, { cleanup }) => {
      *
      *      <select x-report-select2="{% html_attr config %}"></select>
      *
-     *      See CaseStatusPinnedFilter for an example of how to format the config
-     *      NOTE: this is **very** specific to Report Filter context.
+     *      See `CaseStatusPinnedFilter` for an example of how to format the config
+     *      The report-select2 config is very specific to the `filter_context` of that class.
      *
      */
     const config = (expression) ? JSON.parse(expression) : {};
@@ -37,8 +37,8 @@ Alpine.directive('report-select2-multi', (el, { expression }, { cleanup }) => {
      *
      *      <select x-report-select2-multi="{% html_attr config %}"></select>
      *
-     *      See CaseOwnersPinnedFilter for an example of how to format the config.
-     *      NOTE: this is **very** specific to Report Filter context.
+     *      See `CaseOwnersPinnedFilter` for an example of how to format the config.
+     *      The report-select2 config is very specific to the `filter_context` of that class.
      *
      */
     const config = (expression) ? JSON.parse(expression) : {};

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js
@@ -2,6 +2,24 @@ import $ from 'jquery';
 import 'select2/dist/js/select2.full.min';
 import Alpine from 'alpinejs';
 
+const fixSelect2htmx = (event, selector) => {
+    const elems = event.target.querySelectorAll(selector);
+    if (elems.length) {
+        elems.forEach((el) => {
+            const activeSelect2 = $(el).data('select2');
+            if (activeSelect2) {
+                $(el).addClass('select2-hidden-accessible');
+                const validationClasses = ['is-valid', 'is-invalid'];
+                validationClasses.forEach((validationClass) => {
+                    if ($(el).hasClass(validationClass)) {
+                        activeSelect2.$container.addClass(validationClass);
+                    }
+                });
+            }
+        });
+    }
+};
+
 const select2Cleanup = (el) => {
     if ($(el).data('select2')) {
         $(el).select2('destroy');
@@ -47,20 +65,10 @@ document.body.addEventListener('htmx:afterSettle', (event) => {
      * Without this fix, you will get the **visible** <select> stacked on top of the select2, and no
      * validation classes are passed to the select2.
      */
-    event.target.querySelectorAll('[x-select2]').forEach((el) => {
-        const activeSelect2 = $(el).data('select2');
-        if (activeSelect2) {
-            $(el).addClass('select2-hidden-accessible');
-            const validationClasses = ['is-valid', 'is-invalid'];
-            validationClasses.forEach((validationClass) => {
-                if ($(el).hasClass(validationClass)) {
-                    activeSelect2.$container.addClass(validationClass);
-                }
-            });
-        }
-    });
+    fixSelect2htmx(event, '[x-select2]');
 });
 
 export default {
     select2Cleanup,
+    fixSelect2htmx,
 };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js
@@ -2,6 +2,12 @@ import $ from 'jquery';
 import 'select2/dist/js/select2.full.min';
 import Alpine from 'alpinejs';
 
+const select2Cleanup = (el) => {
+    if ($(el).data('select2')) {
+        $(el).select2('destroy');
+        $(el).off('select2:select');
+    }
+};
 
 Alpine.directive('select2', (el, { expression }, { cleanup }) => {
     /**
@@ -29,10 +35,7 @@ Alpine.directive('select2', (el, { expression }, { cleanup }) => {
     $(el).select2(options);
 
     cleanup(() => {
-        if ($(el).data('select2')) {
-            $(el).select2('destroy');
-            $(el).off('select2:select');
-        }
+        select2Cleanup(el);
     });
 });
 
@@ -57,3 +60,7 @@ document.body.addEventListener('htmx:afterSettle', (event) => {
         }
     });
 });
+
+export default {
+    select2Cleanup,
+};

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js
@@ -33,7 +33,7 @@ Alpine.directive('select2', (el, { expression }, { cleanup }) => {
      *
      *      <select x-select2></select>
      *          or
-     *      <select x=select2="{{ options|JSON }}"></select>
+     *      <select x-select2="{% html_attr config %}"></select>
      *
      * This is especially useful in crispy forms for a choice field:
      *
@@ -49,8 +49,8 @@ Alpine.directive('select2', (el, { expression }, { cleanup }) => {
      *     ...
      * )
      */
-    const options = (expression) ? JSON.parse(expression) : {};
-    $(el).select2(options);
+    const config = (expression) ? JSON.parse(expression) : {};
+    $(el).select2(config);
 
     cleanup(() => {
         select2Cleanup(el);


### PR DESCRIPTION
## Technical Summary
This PR renders the UIs for the `BulkEditPinnedFilter`s associated with case data cleaning sessions (Case Owners and Case Status).

The idea here is to borrow as much functionality as possible from the existing report filters under the same name (present in the `CaseListReport`). Since the data cleaning session uses alpine instead of knockout, I needed to override the filter template as well as the `filter_context` in the newly created report filter subclasses.
- `CaseOwnersPinnedFilter` subclasses `CaseListFilter`
- `CaseStatusPinnedFilter` subclasses `SelectOpenCloseFilter`

I ended up creating a new Alpine.js [directives](https://alpinejs.dev/advanced/extending) module called `report_select2`. This module replicates the `select2` + `knockout` utilities from `reports/js/filters/select2s` for use in an alpine environment.
- `x-report-select2` supports the `initSingle` and `initSinglePaginated` utilities needed by `BaseSingleOptionFilter`s
- `x-report-select2-multi` supports the `initMulti` utility needed by `BaseMultipleOptionFilter`s

There are tests ensuring that the initial `form_context`s always come out as expected, in case the report filters `CaseOwnersPinnedFilter` and `CaseStatusPinnedFilter` are subclassing modify their context in an unexpected way.

Ideally, the report filters could really use a refactor...but that is not something I currently have time for. I've put the tests in place to mitigate any risks with my approach.

Here's what the UI is starting to look like, for those who are following along visually. Again, the green save button is temporary.
![Screenshot 2025-02-27 at 9 12 47 PM](https://github.com/user-attachments/assets/aaffa515-956d-46c8-83f6-e48960e3275c)
![Screenshot 2025-02-27 at 9 13 02 PM](https://github.com/user-attachments/assets/05975562-7713-492e-80d5-68443a984897)
![Screenshot 2025-02-27 at 9 12 54 PM](https://github.com/user-attachments/assets/21a8e00e-140e-4f7c-a815-fb5a6906b4ad)

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe. does not touch production workflows. tests added.

### Automated test coverage
yes.

### QA Plan
Not needed at this time.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
