### PR TITLE
make select2 textarea placeholder font consistent with the rest of HQ

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
@@ -66,6 +66,11 @@
     }
 }
 
+.select2-search__field::placeholder {
+  font-size: $font-size-base;
+  font-family: $font-family-base;
+}
+
 .select2-container.select2-container-active > .select2-choice {
   box-shadow: 0 0 10px $cc-brand-mid;
 }

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
@@ -67,14 +67,18 @@
      .select2-search-field {
          width: 100% !important;
      }
-@@ -72,16 +64,127 @@
+@@ -72,16 +64,132 @@
      .select2-input {
          width: 100% !important;
      }
--
++}
+ 
 -    textarea.select2-search__field {    // Placeholder for multi-select
 -        line-height: 21px;
 -    }
++.select2-search__field::placeholder {
++  font-size: $font-size-base;
++  font-family: $font-family-base;
  }
  
  .select2-container.select2-container-active > .select2-choice {


### PR DESCRIPTION
## Technical Summary
From this:
![Screenshot 2025-02-27 at 10 37 15 PM](https://github.com/user-attachments/assets/fd774a35-5f48-4570-93d7-aa7ed6427daa)
to this
![Screenshot 2025-02-27 at 10 53 31 PM](https://github.com/user-attachments/assets/5c8cc4b7-c1c3-4c10-a473-e9a825237994)

my eyes shall now rest easy

## Safety Assurance

### Safety story
small stylistic change that improves consistency with UI. tested locally

### Automated test coverage
no

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
