### PR TITLE
Use QuerySet method

### DIFF
--- a/corehq/apps/integration/kyc/views.py
+++ b/corehq/apps/integration/kyc/views.py
@@ -173,11 +173,7 @@ class KycVerificationReportView(BaseDomainView):
 
     @property
     def domain_has_config(self):
-        try:
-            KycConfig.objects.get(domain=self.domain)
-        except KycConfig.DoesNotExist:
-            return False
-        return True
+        return KycConfig.objects.filter(domain=self.domain).exists()
 
     @property
     def page_url(self):


### PR DESCRIPTION
## Technical Summary

A tiny change to use the `QuerySet.exists()` method instead of fetching a record to determine whether it exists.

## Feature Flag

`KYC_VERIFICATION`

## Safety Assurance

### Safety story

Tiny change

### Automated test coverage

Tests included.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
