### PR TITLE
Use RegexField for two-factor setup

### DIFF
--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -181,7 +181,13 @@ class HQTwoFactorMethodForm(MethodForm):
 
 
 class HQTOTPDeviceForm(TOTPDeviceForm):
-    token = forms.IntegerField(required=False, label=_("Token"), min_value=1, max_value=int('9' * totp_digits()))
+    # https://github.com/jazzband/django-two-factor-auth/issues/84
+    # override the underlying form input because a two-factor code is not an integer
+    token = forms.RegexField(required=False,
+                             label=_("Token"),
+                             regex=r'^[0-9]*$',
+                             min_length=totp_digits(),
+                             max_length=totp_digits())
 
     def __init__(self, key, user, **kwargs):
         super(HQTOTPDeviceForm, self).__init__(key, user, **kwargs)


### PR DESCRIPTION
## Product Description
Makes the "Token" field on the "Enable Two-Factor Authentication" form appear as a regular text input using django's regular expression validation, removing the up/down arrows as in the attached ticket. Also resolves an unreported issue where an entry would have any leading 0's stripped.

## Technical Summary
[SAAS-16290](https://dimagi.atlassian.net/browse/SAAS-16290)
It seems like this change may eventually happen in the library `django-two-factor-auth` that we pull this functionality from, based on discussion in the referenced issue: https://github.com/jazzband/django-two-factor-auth/issues/84. But for now we're just overriding the input type in HQ.

## Safety Assurance

### Safety story
This changes an `IntegerField` to a `RegexField` as used elsewhere in `django-two-factor-auth` forms.

### Automated test coverage
We don't have tests for this form.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16290]: https://dimagi.atlassian.net/browse/SAAS-16290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ