### PR TITLE
Removed SKIP_CREATING_DEFAULT_BUILD_FILES_ON_BUILD

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4458,8 +4458,7 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
         if errors:
             raise AppValidationError(errors)
 
-        if copy.create_build_files_on_build:
-            copy.create_build_files()
+        copy.create_build_files()
 
         # since this hard to put in a test
         # I'm putting this assert here if copy._id is ever None
@@ -4511,11 +4510,6 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
         for name in other.lazy_list_attachments() or {}:
             if regexp is None or re.match(regexp, name):
                 self.lazy_put_attachment(other.lazy_fetch_attachment(name), name)
-
-    @property
-    @memoized
-    def create_build_files_on_build(self):
-        return not toggles.SKIP_CREATING_DEFAULT_BUILD_FILES_ON_BUILD.enabled(self.domain)
 
     def delete_app(self):
         domain_has_apps.clear(self.domain)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1990,14 +1990,6 @@ LOCATION_COLUMNS_APP_STATUS_REPORT = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-SKIP_CREATING_DEFAULT_BUILD_FILES_ON_BUILD = StaticToggle(
-    'skip_creating_default_build_files_on_build',
-    'Skips creating the build files for default profile each time a build is made'
-    'which helps speed up the build and revert process',
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN]
-)
-
 DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK = StaticToggle(
     'disable_case_update_rule_task',
     'Disable the `run_case_update_rules` periodic task '


### PR DESCRIPTION
## Technical Summary
This was a performance improvement for ICDS. Verified on prod and india that the only domains using it are test domains.

## Feature Flag
yep

## Safety Assurance

### Safety story
Removal of largely-dead code.

### Automated test coverage

There are tests of app builds.

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
