### PR TITLE
Do not forward forms for excluded users

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -655,6 +655,7 @@ class FormRepeater(Repeater):
                 not self.white_listed_form_xmlns
                 or payload.xmlns in self.white_listed_form_xmlns
             )
+            and payload.user_id not in self.user_blocklist
         )
 
     def get_url(self, repeat_record):

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -692,6 +692,11 @@ class TestFormRepeaterAllowedToForward(RepeaterTestCase):
         payload = Mock(xmlns='http://openrosa.org/formdesigner/def456')
         self.assertFalse(self.repeater.allowed_to_forward(payload))
 
+    def test_payload_user_blocked(self):
+        self.repeater.user_blocklist = ['deadbeef']
+        payload = Mock(user_id='deadbeef')
+        self.assertFalse(self.repeater.allowed_to_forward(payload))
+
 
 class TestRepeatRecordManager(RepeaterTestCase):
     before_now = datetime.utcnow() - timedelta(days=1)


### PR DESCRIPTION
Looks like this was missed in the repeaters Couch to SQL migration. It was previously implemented for Couch `FormRepeater`. Easy to miss when the feature is untested.

https://github.com/dimagi/commcare-hq/blob/be4bbabc1f7b0fcd9be4c30f29a4fa5eb58778a3/corehq/motech/repeaters/models.py#L1221

https://dimagi.atlassian.net/browse/SAAS-13499

## Safety Assurance

### Safety story

Small change: restores a check in form forwarding.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations