### PR TITLE
Add Bulk Edit Pinned Filter UIs (part two-final!)

### DIFF
--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -47,6 +47,11 @@ class CaseOwnersPinnedFilter(SessionPinnedFilterMixin, CaseListFilter):
             'filter_help': filter_help,
         }
 
+    @property
+    @memoized
+    def selected(self):
+        return self._get_selected_from_selected_ids(self.pinned_filter.value)
+
 
 class CaseStatusPinnedFilter(SessionPinnedFilterMixin, SelectOpenCloseFilter):
     template = "data_cleaning/filters/pinned/single_option.html"

--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -62,3 +62,8 @@ class CaseStatusPinnedFilter(SessionPinnedFilterMixin, SelectOpenCloseFilter):
         return {
             'report_select2_config': super().filter_context,
         }
+
+    @property
+    @memoized
+    def selected(self):
+        return self.pinned_filter.value[0] if self.pinned_filter.value else ""

--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -29,6 +29,27 @@ class SessionPinnedFilterMixin(ABC):
     def pinned_filter(self):
         return self.session.pinned_filters.get(filter_type=self.filter_type)
 
+    @abstractmethod
+    def get_value_for_db(self):
+        """
+        This method is different from the original class method of
+        `get_value(request, domain)` from `BaseReportFilter` and its subclasses.
+
+        This method should return the value that will be stored as the
+        `BulkEditPinnedFilter` value of the same `filter_type`.
+
+        :return: None if the value is the default value,
+            otherwise a list of at least one value
+        """
+        raise NotImplementedError("please implement get_value_for_db")
+
+    def update_stored_value(self):
+        value = self.get_value_for_db()
+        if value != self.pinned_filter.value:
+            # update the pinned filter only if the value has changed
+            self.pinned_filter.value = value
+            self.pinned_filter.save()
+
 
 class CaseOwnersPinnedFilter(SessionPinnedFilterMixin, CaseListFilter):
     template = "data_cleaning/filters/pinned/multi_option.html"
@@ -52,6 +73,14 @@ class CaseOwnersPinnedFilter(SessionPinnedFilterMixin, CaseListFilter):
     def selected(self):
         return self._get_selected_from_selected_ids(self.pinned_filter.value)
 
+    @classmethod
+    def _get_default_db_value(cls):
+        return [s[0] for s in cls.default_selections]
+
+    def get_value_for_db(self):
+        value = self.get_value(self.request, self.domain)
+        return None if value == self._get_default_db_value() else value
+
 
 class CaseStatusPinnedFilter(SessionPinnedFilterMixin, SelectOpenCloseFilter):
     template = "data_cleaning/filters/pinned/single_option.html"
@@ -67,3 +96,7 @@ class CaseStatusPinnedFilter(SessionPinnedFilterMixin, SelectOpenCloseFilter):
     @memoized
     def selected(self):
         return self.pinned_filter.value[0] if self.pinned_filter.value else ""
+
+    def get_value_for_db(self):
+        value = self.get_value(self.request, self.domain)
+        return None if not value else [value]

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -435,6 +435,16 @@ class BulkEditPinnedFilter(models.Model):
                 filter_type=filter_type,
             )
 
+    def get_report_filter_class(self):
+        from corehq.apps.data_cleaning.filters import (
+            CaseOwnersPinnedFilter,
+            CaseStatusPinnedFilter,
+        )
+        return {
+            PinnedFilterType.CASE_OWNERS: CaseOwnersPinnedFilter,
+            PinnedFilterType.CASE_STATUS: CaseStatusPinnedFilter,
+        }[self.filter_type]
+
 
 class BulkEditColumn(models.Model):
     session = models.ForeignKey(BulkEditSession, related_name="columns", on_delete=models.CASCADE)

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/pinned/base.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/pinned/base.html
@@ -1,9 +1,7 @@
 {% load i18n %}
 
-<div class="row mb-2">
-  <label for="{{ css_id }}" class="form-label col-2">{{ label }}</label>
-  <div class="col-10">
-    {% block filter_content %}
-    {% endblock %}
-  </div>
+<div class="mb-3">
+  <label for="{{ css_id }}" class="form-label">{{ label }}</label>
+  {% block filter_content %}
+  {% endblock %}
 </div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/pinned/single_option.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/pinned/single_option.html
@@ -2,16 +2,9 @@
 {% load hq_shared_tags %}
 
 {% block filter_content %}
-  <div
-    x-data="{
-      selected: '{{ report_select2_config.select.selected|default:'' }}',
-    }"
-  >
-    <select
-      class="form-select"
-      name="{{ slug }}"
-      x-model="selected"
-      x-report-select2="{% html_attr report_select2_config %}"
-    ></select>
-  </div>
+  <select
+    class="form-select"
+    name="{{ slug }}"
+    x-report-select2="{% html_attr report_select2_config %}"
+  ></select>
 {% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/pinned_filter_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/pinned_filter_form.html
@@ -11,6 +11,10 @@
       hx-target="#{{ container_id }}"
       hx-disabled-elt="find button"
       hq-hx-action="update_filters"
+      x-data="{
+        isSubmitEnabled: false,
+      }"
+      @report-filter-updated.camel="isSubmitEnabled = true;"
     >
       {% for form_filter in form_filters %}
         {{ form_filter }}
@@ -19,6 +23,8 @@
         <button
           class="btn btn-disabled"
           type="submit"
+          :disabled="!isSubmitEnabled"
+          :class="(isSubmitEnabled) ? 'btn-primary' : 'btn-disabled';"
         >
           {% trans "Apply" %}
         </button>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/pinned_filter_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/pinned_filter_form.html
@@ -1,3 +1,28 @@
 {% load i18n %}
 
-{{ rendered_filter }}
+<div
+  id="{{ container_id }}"
+  class="card"
+  hx-swap="outerHTML"
+>
+  <div class="card-body">
+    <form
+      hx-post="{{ request.path_info }}"
+      hx-target="#{{ container_id }}"
+      hx-disabled-elt="find button"
+      hq-hx-action="update_filters"
+    >
+      {% for form_filter in form_filters %}
+        {{ form_filter }}
+      {% endfor %}
+      <div class="py-1">
+        <button
+          class="btn btn-disabled"
+          type="submit"
+        >
+          {% trans "Apply" %}
+        </button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/offcanvas.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/offcanvas.html
@@ -16,14 +16,12 @@
     ></button>
   </div>
   <div class="offcanvas-body">
-    {% for filter_type in pinned_filter_types %}
-      <div
-        hx-get="{% url "data_cleaning_pinned_filter_form" domain session_id filter_type %}"
-        hx-trigger="load"
-      >
-        {% include "data_cleaning/partials/loading_indicator.html" %}
-      </div>
-    {% endfor %}
+    <div
+      hx-get="{% url "data_cleaning_pinned_filter_form" domain session_id %}"
+      hx-trigger="load"
+    >
+      {% include "data_cleaning/partials/loading_indicator.html" %}
+    </div>
   </div>
 </div>
 

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -13,6 +13,7 @@ from corehq.apps.data_cleaning.models import (
     BulkEditColumnFilter,
     DataType,
     FilterMatchType,
+    BulkEditSession,
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
@@ -577,10 +578,13 @@ class TestReportFilterSubclasses(TestCase):
         self.request.can_access_all_locations = True
         self.request.couch_user = self.web_user
         self.request.project = self.domain
+        self.session = BulkEditSession.new_case_session(
+            self.web_user.get_django_user(), self.domain_name, 'plants',
+        )
 
     def test_case_owners_report_filter_context(self):
         report_filter = CaseOwnersPinnedFilter(
-            self.request, self.domain_name, use_bootstrap5=True
+            self.session, self.request, self.domain_name, use_bootstrap5=True
         )
         expected_context = {
             'report_select2_config': {
@@ -614,7 +618,7 @@ class TestReportFilterSubclasses(TestCase):
     @mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting
     def test_case_owners_report_filter_context_locations(self):
         report_filter = CaseOwnersPinnedFilter(
-            self.request, self.domain_name, use_bootstrap5=True
+            self.session, self.request, self.domain_name, use_bootstrap5=True
         )
         expected_context = {
             'report_select2_config': {
@@ -653,7 +657,7 @@ class TestReportFilterSubclasses(TestCase):
 
     def test_case_status_report_filter_context(self):
         report_filter = CaseStatusPinnedFilter(
-            self.request, self.domain_name, use_bootstrap5=True
+            self.session, self.request, self.domain_name, use_bootstrap5=True
         )
         expected_context = {
             'report_select2_config': {

--- a/corehq/apps/data_cleaning/urls.py
+++ b/corehq/apps/data_cleaning/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
         name=CleanCasesSessionView.urlname),
     url(r'^cases/(?P<session_id>[\w\-]+)/table/$', CleanCasesTableView.as_view(),
         name=CleanCasesTableView.urlname),
-    url(r'^cases/(?P<session_id>[\w\-]+)/filters/pinned/(?P<filter_type>[\w\-]+)/$',
-        PinnedFilterFormView.as_view(), name=PinnedFilterFormView.urlname),
+    url(r'^cases/(?P<session_id>[\w\-]+)/filters/pinned/$', PinnedFilterFormView.as_view(),
+        name=PinnedFilterFormView.urlname),
     url(r'^cases/save/(?P<session_id>[\w\-]+)/$', save_case_session, name='save_case_session'),
 ]

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -21,7 +21,7 @@ from corehq.util.timezones.utils import get_timezone
     use_bootstrap5,
     toggles.DATA_CLEANING_CASES.required_decorator(),
 ], name='dispatch')
-class BaseFilterFormView(HqHtmxActionMixin, LoginAndDomainMixin, DomainViewMixin, TemplateView):
+class BaseFilterFormView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
     pass
 
 

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -40,7 +40,7 @@ class PinnedFilterFormView(BulkEditSessionViewMixin, BaseFilterFormView):
 
     @hq_hx_action('post')
     def update_filters(self, request, *args, **kwargs):
-        # todo
+        [f.update_stored_value() for f in self.form_filters]
         return self.get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -1,6 +1,5 @@
-from django.http import Http404
 from django.utils.decorators import method_decorator
-from django.utils.translation import gettext_lazy, gettext as _
+from django.utils.translation import gettext_lazy
 from django.views.generic import TemplateView
 from memoized import memoized
 
@@ -14,7 +13,7 @@ from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
 from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.domain.views import DomainViewMixin
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
-from corehq.util.htmx_action import HqHtmxActionMixin
+from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 from corehq.util.timezones.utils import get_timezone
 
 
@@ -32,36 +31,36 @@ class PinnedFilterFormView(BulkEditSessionViewMixin, BaseFilterFormView):
     session_not_found_message = gettext_lazy("Cannot retrieve pinned filter, session was not found.")
 
     @property
-    @memoized
     def timezone(self):
         return get_timezone(self.request, self.domain)
 
-    @property
-    def filter_type(self):
-        return self.kwargs['filter_type']
-
-    @property
-    def form_filter_class(self):
-        filter_type_to_class = {
+    @staticmethod
+    def get_form_filter_class(filter_type):
+        return {
             PinnedFilterType.CASE_OWNERS: CaseOwnersPinnedFilter,
             PinnedFilterType.CASE_STATUS: CaseStatusPinnedFilter,
-        }
-        try:
-            return filter_type_to_class[self.filter_type]
-        except KeyError:
-            raise Http404(_("unsupported filter type: {}").format(self.filter_type))
+        }[filter_type]
 
     @property
     @memoized
-    def form_filter(self):
-        return self.form_filter_class(
-            self.request, self.domain, self.timezone, use_bootstrap5=True
-        )
+    def form_filters(self):
+        return [
+            (f.filter_type, self.get_form_filter_class(f.filter_type)(
+                self.request, self.domain, self.timezone, use_bootstrap5=True
+            )) for f in self.session.pinned_filters.all()
+        ]
+
+    @hq_hx_action('post')
+    def update_filters(self, request, *args, **kwargs):
+        # todo
+        return self.get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update({
-            "filter_type": self.filter_type,
-            "rendered_filter": self.form_filter.render(),
+            'container_id': 'pinned-filters',
+            'form_filters': [
+                f[1].render() for f in self.form_filters
+            ],
         })
         return context

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -83,7 +83,6 @@ class CleanCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
     def page_context(self):
         return {
             "session_id": self.session_id,
-            "pinned_filter_types": [f.filter_type for f in self.session.pinned_filters.all()],
         }
 
 

--- a/corehq/apps/data_cleaning/views/setup.py
+++ b/corehq/apps/data_cleaning/views/setup.py
@@ -20,7 +20,7 @@ from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
     use_bootstrap5,
     toggles.DATA_CLEANING_CASES.required_decorator(),
 ], name='dispatch')
-class SetupCaseSessionFormView(HqHtmxActionMixin, LoginAndDomainMixin, DomainViewMixin, TemplateView):
+class SetupCaseSessionFormView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
     urlname = "data_cleaning_select_case_type_form"
     template_name = "data_cleaning/forms/next_action_form.html"
     container_id = "setup-case-session"

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/report_select2.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/report_select2.js
@@ -9,6 +9,18 @@ import utils from 'hqwebapp/js/alpinejs/directives/select2';
  * select2 utilities in `reports/js/filters/select2s`.
  */
 
+const _updateFormOnChange = (el) => {
+    $(el).on('change', () => {
+        const parentForm = el.form;
+        if (parentForm) {
+            parentForm.dispatchEvent(new CustomEvent('reportFilterUpdated', {
+                el: el,
+                name: el.name,
+            }));
+        }
+    });
+};
+
 Alpine.directive('report-select2', (el, { expression }, { cleanup }) => {
     /**
      * To use, add x-report-select2-multi to your select element.
@@ -25,6 +37,8 @@ Alpine.directive('report-select2', (el, { expression }, { cleanup }) => {
     } else {
         _createSelect2(el, config);
     }
+
+    _updateFormOnChange(el);
 
     cleanup(() => {
         utils.select2Cleanup(el);
@@ -47,6 +61,8 @@ Alpine.directive('report-select2-multi', (el, { expression }, { cleanup }) => {
     } else {
         _createSelect2Multi(el, config);
     }
+
+    _updateFormOnChange(el);
 
     cleanup(() => {
         utils.select2Cleanup(el);

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/report_select2.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/report_select2.js
@@ -89,6 +89,10 @@ const _createSelect2 = (el, config) => {
     $(el).select2({
         clearable: true,
     });
+    if (config.select.selected) {
+        $(el).val(config.select.selected);
+        $(el).trigger('change.select2');
+    }
 };
 
 const _createPaginatedSelect2 = (el, config) => {

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -288,6 +288,9 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         selected_ids = DatatablesServerSideParams.get_value_from_request(
             self.request, self.slug, as_list=True
         )
+        return self._get_selected_from_selected_ids(selected_ids)
+
+    def _get_selected_from_selected_ids(self, selected_ids):
         if not selected_ids:
             return [{'id': selection_tuple[0], 'text': selection_tuple[1]}
                     for selection_tuple in self.get_default_selections()]


### PR DESCRIPTION
## Technical Summary
This PR completes the UI implementation of the `BulkEditPinnedFilter` UI.
Note: the filtering of the `CaseSearchES` query from the values of the `BulkEditPinnedFilter`s will come in a later PR, as I am currently working on a lot of tests for those changes.

This PR:
- updates the `PinnedFilterFormView` to render all the session's pinned filters in the same view/form, rather than having a separate endpoint for each `filter_type`. This allows the whole form to submit changes to all pinned filters together for a single request and update to the db.
- completes the UI for the pinned filters + Apply button. Like Report filters, the Apply button is disabled until changes are made to the pinned filter select2s.
- updates `report_select2s` to send an event to its parent form that the filter value has changed
- updates `report_select2s` for single select to populate the 'selected' value from the 'config' rather than relying on an external `x-data` model from alpine. (there is a race condition happening between `select2` and `alpine` that I'm not interested in solving right now)
- makes sure that submitting the `PinnedFilterFormView` actually updates the values of the pinned filters.
- tests for all of the above changes! woo!

![Screenshot 2025-03-03 at 9 35 09 PM](https://github.com/user-attachments/assets/ae540b2c-475b-4944-9131-b32d4f8aaf23)
![Screenshot 2025-03-03 at 9 35 21 PM](https://github.com/user-attachments/assets/e9bdb6a9-85b4-427d-bc81-0ed6ebc8a25e)


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
very safe changes, only affecting feature flagged workflows. well tested

### Automated test coverage
yes

### QA Plan
not yet needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
