### PR TITLE
Use get_menu_item_label for CommCare Version display in Manage Update Settings

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -141,7 +141,7 @@ class PromptUpdateSettingsForm(forms.Form):
         super(PromptUpdateSettingsForm, self).__init__(*args, **kwargs)
 
         self.fields['apk_version'].choices = [(LATEST_APK_VALUE, 'Latest Released Build')] + [
-            (build.to_string(), 'CommCare {}'.format(build.get_label()))
+            (build.to_string(), 'CommCare {}'.format(build.get_menu_item_label()))
             for build in get_commcare_builds(request_user)
         ]
 

--- a/corehq/apps/builds/management/commands/add_commcare_build.py
+++ b/corehq/apps/builds/management/commands/add_commcare_build.py
@@ -82,7 +82,7 @@ def _add_build_menu_item(build_config, version):
     build_menu_items = build_config.menu
 
     build = BuildSpec(version=version, latest=True)
-    build_menu_item = BuildMenuItem(build=build, label="CommCare {}".format(version))
+    build_menu_item = BuildMenuItem(build=build, label=version)
     build_menu_items.append(build_menu_item)
 
 


### PR DESCRIPTION
## Product Description
Swaps out one build label (pulled directly from the version number) for another (using the intended-to-be-human-readable name), to show notes like "dev" that are added into these labels.

Screenshots are of a local environment, production build numbers and notes are different.
Before:
![old_builds](https://github.com/user-attachments/assets/455932ef-61fb-4e9d-8d13-f5db41cd2f11)

After:
![new_builds](https://github.com/user-attachments/assets/3e3283e8-096a-4d10-b748-5bc6bff2a197)

## Technical Summary
[SAAS-16489](https://dimagi.atlassian.net/browse/SAAS-16489)
Changes which version of the build label we use for the "Manage Update Settings" page.

In looking into this issue, also found that builds were labeled inconsistently across environments -- production environments would use (e.g.) "2.56.0 (dev)" where staging or local environments would use "CommCare 2.56.0 (dev)". Text formatting in places these labels are used assumes that "CommCare" is _not_ prepended to the label, so this also updates the management command for importing builds to _not_ prepend "CommCare".

## Safety Assurance

### Safety story
Just changes display labels for builds, none of underlying version numbering.

### Automated test coverage
None here.

### QA Plan
Not planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16489]: https://dimagi.atlassian.net/browse/SAAS-16489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ