### PR TITLE
Allow updates to multiple checkpoint

### DIFF
--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -302,6 +302,7 @@ class ESSyncUtil:
             for cname in cnames:
                 current_index_name, older_index_name = self._get_current_and_older_index_name(cname)
                 if older_index_name in old_checkpoint_id:
+                    assert new_checkpoint_id.count(older_index_name) == 1, (new_checkpoint_id, older_index_name)
                     new_checkpoint_id = new_checkpoint_id.replace(older_index_name, current_index_name)
                     checkpoint_updated = True
             if checkpoint_updated:

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -267,33 +267,44 @@ class ESSyncUtil:
         older_index = getattr(es_consts, f"HQ_{cname.upper()}_INDEX_NAME")
         return (current_index, older_index)
 
-    def set_checkpoints_for_new_index(self, cname):
+    def set_checkpoints_for_new_index(self, cnames):
         """
-        Takes in an index cname and create new checkpoint for all the pillows that use the older index name
+        Takes in an index cnames and create new checkpoint for all the pillows that use the older index name
         for that cname.
+        If 'all' is passed, it will copy checkpoints for all the indices.
         Can only be performed when indexes are still multiplexed and not swapped.
         When we swap the indexes, the primary index changes which updates the checkpoint names.
         We should stop the pillows and copy the checkpoint to the new checkpoint ids, swap the indexes
         and then start the pillows.
         """
-        adapter = doc_adapter_from_cname(cname)
-        if not isinstance(adapter, ElasticMultiplexAdapter):
-            raise IndexNotMultiplexedException(f"""Checkpoints can be copied on multiplexed indexes.
-                Make sure you have set ES_{cname.upper()}_INDEX_MULTIPLEXED to True """)
-
-        current_index_name, older_index_name = self._get_current_and_older_index_name(cname)
-
-        if getattr(es_consts, f'ES_{cname.upper()}_INDEX_SWAPPED'):
-            raise IndexAlreadySwappedException(
-                f"""Checkpoints can only be copied before swapping indexes.
-                Make sure you have set ES_{cname.upper()}_INDEX_SWAPPED to False."""
-            )
-
         all_pillows = get_all_pillow_instances()
+        if 'all' in cnames:
+            cnames = iter_index_cnames()
+        for cname in cnames:
+            adapter = doc_adapter_from_cname(cname)
+            if not isinstance(adapter, ElasticMultiplexAdapter):
+                raise IndexNotMultiplexedException(f"""Checkpoints can be copied on multiplexed indexes.
+                    Make sure you have set ES_{cname.upper()}_INDEX_MULTIPLEXED to True """)
+
+            current_index_name, older_index_name = self._get_current_and_older_index_name(cname)
+
+            if getattr(es_consts, f'ES_{cname.upper()}_INDEX_SWAPPED'):
+                raise IndexAlreadySwappedException(
+                    f"""Checkpoints can only be copied before swapping indexes.
+                    Make sure you have set ES_{cname.upper()}_INDEX_SWAPPED to False."""
+                )
+
         for pillow in all_pillows:
             old_checkpoint_id = pillow.checkpoint.checkpoint_id
-            if older_index_name in old_checkpoint_id:
-                new_checkpoint_id = old_checkpoint_id.replace(older_index_name, current_index_name)
+            new_checkpoint_id = old_checkpoint_id
+            checkpoint_updated = False
+            for cname in cnames:
+                current_index_name, older_index_name = self._get_current_and_older_index_name(cname)
+                if older_index_name in old_checkpoint_id:
+                    new_checkpoint_id = new_checkpoint_id.replace(older_index_name, current_index_name)
+                    checkpoint_updated = True
+            if checkpoint_updated:
+                print(old_checkpoint_id, new_checkpoint_id)
                 print(f"Copying checkpoints of Checkpoint ID -  [{old_checkpoint_id}] to [{new_checkpoint_id}]")
                 self._copy_checkpoints(pillow, new_checkpoint_id)
 
@@ -561,8 +572,9 @@ class Command(BaseCommand):
         copy_checkpoint_cmd.set_defaults(func=self.es_helper.set_checkpoints_for_new_index)
         copy_checkpoint_cmd.add_argument(
             'index_cname',
-            choices=INDEXES,
-            help="""Cannonical Name of the index whose checkpoints are to be copied""",
+            nargs='+',
+            choices=INDEXES + ['all'],
+            help="""Cannonical Names of the indices whose checkpoints are to be copied""",
         )
 
         # Set replicas for secondary index

--- a/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
+++ b/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
@@ -320,7 +320,7 @@ class TestCopyCheckpointsBeforeIndexSwap(TestCase):
             return_value=patched_case_adapter
         ):
             with self.assertRaises(IndexNotMultiplexedException):
-                ESSyncUtil().set_checkpoints_for_new_index('cases')
+                ESSyncUtil().set_checkpoints_for_new_index(['cases'])
 
     @patch.object(es_consts, 'ES_CASES_INDEX_SWAPPED', True)
     def test_set_checkpoints_for_new_index_raises_swapped_multiplexed_index(self):
@@ -330,7 +330,7 @@ class TestCopyCheckpointsBeforeIndexSwap(TestCase):
             return_value=patched_case_adapter
         ):
             with self.assertRaises(IndexAlreadySwappedException):
-                ESSyncUtil().set_checkpoints_for_new_index('cases')
+                ESSyncUtil().set_checkpoints_for_new_index(['cases'])
 
     def test_set_checkpoints_for_new_index(self):
 
@@ -370,7 +370,7 @@ class TestCopyCheckpointsBeforeIndexSwap(TestCase):
                 'corehq.apps.es.management.commands.elastic_sync_multiplexed.doc_adapter_from_cname',
                 return_value=patched_case_adapter
             ):
-                ESSyncUtil().set_checkpoints_for_new_index('cases')
+                ESSyncUtil().set_checkpoints_for_new_index(['cases'])
 
         # Swap indexes and patch adapter to return multiplexed adapter
         # with secondary index as main index


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

<!-- Where applicable, describe user-facing effects and include screenshots. -->

Improve Checkpoint Update Logic for Multiple Index Swaps

### Problem

The current checkpoint update process is designed to handle swapping one index at a time. When we need to swap multiple indices simultaneously (which is more efficient for smaller indices), the current approach fails.

### Current Behavior Example:

If a Case Pillow has checkpoint ID: `case-pillow-cases-old-index-case-search-old-index-messaging-sync`

And we want to swap both `cases` and `case-search` indices together:

1. Running `copy_checkpoints cases` creates: `case-pillow-cases-new-index-case-search-old-index-messaging-sync`
2. Running `copy_checkpoints case-search` creates: `case-pillow-cases-old-index-case-search-new-index-messaging-sync`

But after swapping both indices, the pillow will look for: `case-pillow-cases-new-index-case-search-new-index-messaging-sync`

Since this checkpoint doesn't exist, the pillow will rewind to the earliest available checkpoint, causing unnecessary reprocessing.

## Solution

This PR modifies the checkpoint update logic to handle multiple index swaps in a single operation. The command now accepts multiple index names and properly updates all relevant checkpoints with all specified index name changes at once.

Now you can run:

```
./manage.py elastic_sync_multiplexed copy_checkpoints cases case-search
```

This will create the correct checkpoint ID: `case-pillow-cases-new-index-case-search-new-index-messaging-sync`

This change makes the index swapping process more flexible and efficient, especially when dealing with multiple smaller indices.


## Safety Assurance
Just affects a management command. 

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The script have been tested on staging, india and prod on a django manage shell.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
