### PR TITLE
Standardize Domain Name across Enterprise APIs

### DIFF
--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -160,7 +160,7 @@ class ODataEnterpriseReportResource(ODataResource):
     RETRY_IN_PROGRESS_DELAY = 60
     RETRY_CONFLICT_DELAY = 120
 
-    COLUMN_INDEX_MAP = {}  # Override with full mapping
+    COLUMN_MAP = {}  # Override with full mapping
 
     class Meta(ODataResource.Meta):
         authentication = EnterpriseODataAuthentication()
@@ -205,7 +205,7 @@ class ODataEnterpriseReportResource(ODataResource):
 
     def dehydrate(self, bundle):
         for (field_name, field) in self.fields.items():
-            obj = bundle.obj[self.COLUMN_INDEX_MAP[field_name]]
+            obj = bundle.obj[self.COLUMN_MAP[field_name]]
             if isinstance(field, fields.DateTimeField):
                 obj = self.convert_datetime(obj)
             bundle.data[field_name] = obj
@@ -240,7 +240,7 @@ class DomainResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.DOMAINS
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'domain': 8,
         'created_on': 0,
         'num_apps': 1,
@@ -267,7 +267,7 @@ class WebUserResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.WEB_USERS
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'email': 0,
         'name': 1,
         'role': 2,
@@ -278,10 +278,10 @@ class WebUserResource(ODataEnterpriseReportResource):
     }
 
     def dehydrate(self, bundle):
-        bundle.obj[self.COLUMN_INDEX_MAP['last_login']] = \
-            self.convert_not_available(bundle.obj[self.COLUMN_INDEX_MAP['last_login']])
-        bundle.obj[self.COLUMN_INDEX_MAP['last_access_date']] = \
-            self.convert_not_available(bundle.obj[self.COLUMN_INDEX_MAP['last_access_date']])
+        bundle.obj[self.COLUMN_MAP['last_login']] = \
+            self.convert_not_available(bundle.obj[self.COLUMN_MAP['last_login']])
+        bundle.obj[self.COLUMN_MAP['last_access_date']] = \
+            self.convert_not_available(bundle.obj[self.COLUMN_MAP['last_access_date']])
         bundle = super().dehydrate(bundle)
         bundle.data['name'] = self.convert_not_available(bundle.data['name'])
 
@@ -309,7 +309,7 @@ class MobileUserResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.MOBILE_USERS
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'username': 0,
         'name': 1,
         'email': 2,
@@ -334,7 +334,7 @@ class SMSResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.SMS
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'domain': 0,
         'num_sent': 1,
         'num_received': 2,
@@ -381,7 +381,7 @@ class ODataFeedResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.ODATA_FEEDS
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'domain': 0,
         'report_name': 1,
         'report_rows': 2,
@@ -406,6 +406,17 @@ class FormSubmissionResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.FORM_SUBMISSIONS
 
+    # Because FormSubmissionResource retrieves its data from an IterableEnterpriseFormQuery rather than
+    # an enterprise report, the columns are referenced by string rather than index
+    COLUMN_MAP = {
+        'form_id': 'form_id',
+        'form_name': 'form_name',
+        'submitted': 'submitted',
+        'app_name': 'app_name',
+        'username': 'username',
+        'domain': 'domain'
+    }
+
     def get_object_list(self, request):
         start_date = request.GET.get('startdate', None)
         if start_date:
@@ -426,16 +437,6 @@ class FormSubmissionResource(ODataEnterpriseReportResource):
 
         return IterableEnterpriseFormQuery(account, converter, start_date, end_date, **query_kwargs)
 
-    def dehydrate(self, bundle):
-        bundle.data['form_id'] = bundle.obj['form_id']
-        bundle.data['form_name'] = bundle.obj['form_name']
-        bundle.data['submitted'] = self.convert_datetime(bundle.obj['submitted'])
-        bundle.data['app_name'] = bundle.obj['app_name']
-        bundle.data['username'] = bundle.obj['username']
-        bundle.data['domain'] = bundle.obj['domain']
-
-        return bundle
-
     def get_primary_keys(self):
         return ('form_id', 'submitted',)
 
@@ -449,7 +450,7 @@ class CaseManagementResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.CASE_MANAGEMENT
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'domain': 0,
         'num_applications': 1,
         'num_surveys_only': 2,
@@ -470,7 +471,7 @@ class DataExportReportResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.DATA_EXPORTS
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'domain': 0,
         'name': 1,
         'export_type': 2,
@@ -487,7 +488,7 @@ class TwoFactorAuthResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.TWO_FACTOR_AUTH
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'domain_without_2fa': 0,
     }
 
@@ -503,7 +504,7 @@ class CommCareVersionComplianceResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.COMMCARE_VERSION_COMPLIANCE
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'mobile_worker': 0,
         'domain': 1,
         'latest_version_available_at_submission': 2,
@@ -524,7 +525,7 @@ class APIKeysResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.API_KEYS
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'web_user': 0,
         'api_key_name': 1,
         'scope': 2,
@@ -545,7 +546,7 @@ class DataForwardingResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.DATA_FORWARDING
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'domain': 0,
         'service_name': 1,
         'service_type': 2,
@@ -566,7 +567,7 @@ class ApplicationVersionComplianceResource(ODataEnterpriseReportResource):
 
     REPORT_SLUG = EnterpriseReport.APP_VERSION_COMPLIANCE
 
-    COLUMN_INDEX_MAP = {
+    COLUMN_MAP = {
         'mobile_worker': 0,
         'domain': 1,
         'application': 2,

--- a/corehq/apps/enterprise/tests/api/test_resources.py
+++ b/corehq/apps/enterprise/tests/api/test_resources.py
@@ -132,7 +132,7 @@ class TestDomainResourceMapping(SimpleTestCase):
     def test_headers(self):
         report = EnterpriseDomainReport(None, None)
 
-        header_mapping = {name: report.headers[index] for (name, index) in DomainResource.COLUMN_INDEX_MAP.items()}
+        header_mapping = {name: report.headers[index] for (name, index) in DomainResource.COLUMN_MAP.items()}
         expectedMapping = {
             'domain': 'Project Space Name',
             'created_on': 'Created On [UTC]',
@@ -153,7 +153,7 @@ class TestWebUserResourceMapping(SimpleTestCase):
         report = EnterpriseWebUserReport(None, None)
 
         header_mapping = {name: report.headers[index] for (name, index) in
-                          WebUserResource.COLUMN_INDEX_MAP.items()}
+                          WebUserResource.COLUMN_MAP.items()}
         expectedMapping = {
             'email': 'Email Address',
             'name': 'Name',
@@ -172,7 +172,7 @@ class TestMobileUserResourceMapping(SimpleTestCase):
         report = EnterpriseMobileWorkerReport(None, None)
 
         header_mapping = {name: report.headers[index] for (name, index) in
-                          MobileUserResource.COLUMN_INDEX_MAP.items()}
+                          MobileUserResource.COLUMN_MAP.items()}
         expectedMapping = {
             'username': 'Username',
             'name': 'Name',
@@ -193,7 +193,7 @@ class TestSMSResourceMapping(SimpleTestCase):
     def test_headers(self):
         report = EnterpriseSMSReport(None, None)
 
-        header_mapping = {name: report.headers[index] for (name, index) in SMSResource.COLUMN_INDEX_MAP.items()}
+        header_mapping = {name: report.headers[index] for (name, index) in SMSResource.COLUMN_MAP.items()}
         expectedMapping = {
             'domain': 'Project Space',
             'num_sent': '# Sent',
@@ -209,7 +209,7 @@ class TestODataFeedResourceMapping(SimpleTestCase):
         report = EnterpriseODataReport(None, None)
 
         header_mapping = {name: report.headers[index] for (name, index) in
-                          ODataFeedResource.COLUMN_INDEX_MAP.items()}
+                          ODataFeedResource.COLUMN_MAP.items()}
         expectedMapping = {
             'domain': 'Project Space',
             'report_name': 'Name',
@@ -224,7 +224,7 @@ class TestCaseManagementResourceMapping(SimpleTestCase):
         report = EnterpriseCaseManagementReport(None, None)
 
         header_mapping = {name: report.headers[index] for (name, index) in
-                          CaseManagementResource.COLUMN_INDEX_MAP.items()}
+                          CaseManagementResource.COLUMN_MAP.items()}
         expectedMapping = {
             'domain': 'Project Space',
             'num_applications': '# Applications',
@@ -241,7 +241,7 @@ class TestDataExportResourceMapping(SimpleTestCase):
         report = EnterpriseDataExportReport(None, None)
 
         header_mapping = {name: report.headers[index] for (name, index) in
-                          DataExportReportResource.COLUMN_INDEX_MAP.items()}
+                          DataExportReportResource.COLUMN_MAP.items()}
         expectedMapping = {
             'domain': 'Project Space',
             'name': 'Name',
@@ -258,7 +258,7 @@ class TestTwoFactorAuthResourceMapping(SimpleTestCase):
         report = Enterprise2FAReport(None, None)
 
         header_mapping = {name: report.headers[index] for (name, index) in
-                          TwoFactorAuthResource.COLUMN_INDEX_MAP.items()}
+                          TwoFactorAuthResource.COLUMN_MAP.items()}
         expectedMapping = {
             'domain_without_2fa': 'Project Space without 2FA',
         }
@@ -271,7 +271,7 @@ class TestCommCareVersionComplianceResourceMapping(SimpleTestCase):
         report = EnterpriseCommCareVersionReport(None, None)
 
         header_mapping = {name: report.headers[index] for (name, index) in
-                          CommCareVersionComplianceResource.COLUMN_INDEX_MAP.items()}
+                          CommCareVersionComplianceResource.COLUMN_MAP.items()}
         expectedMapping = {
             'mobile_worker': 'Mobile Worker',
             'domain': 'Project Space',
@@ -287,7 +287,7 @@ class TestAPIKeysResourceMapping(SimpleTestCase):
         report = EnterpriseAPIReport(None, None)
 
         header_mapping = {name: report.headers[index] for (name, index) in
-                          APIKeysResource.COLUMN_INDEX_MAP.items()}
+                          APIKeysResource.COLUMN_MAP.items()}
         expectedMapping = {
             'web_user': 'Web User',
             'api_key_name': 'API Key Name',
@@ -305,7 +305,7 @@ class TestDataForwardingResourceMapping(SimpleTestCase):
         report = EnterpriseDataForwardingReport(None, None)
 
         header_mapping = {name: report.headers[index] for (name, index) in
-                          DataForwardingResource.COLUMN_INDEX_MAP.items()}
+                          DataForwardingResource.COLUMN_MAP.items()}
         expectedMapping = {
             'domain': 'Project Space',
             'service_name': 'Service Name',
@@ -321,7 +321,7 @@ class TestApplicationVersionComplianceResourceMapping(SimpleTestCase):
         report = EnterpriseAppVersionComplianceReport(None, None)
 
         header_mapping = {name: report.headers[index] for (name, index) in
-                          ApplicationVersionComplianceResource.COLUMN_INDEX_MAP.items()}
+                          ApplicationVersionComplianceResource.COLUMN_MAP.items()}
         expectedMapping = {
             'mobile_worker': 'Mobile Worker',
             'domain': 'Project Space',

--- a/corehq/apps/enterprise/tests/api/test_resources.py
+++ b/corehq/apps/enterprise/tests/api/test_resources.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 
 from django.http import Http404
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, SimpleTestCase
 
 from tastypie.exceptions import ImmediateHttpResponse
 
@@ -12,9 +12,35 @@ from corehq.apps.accounting.models import (
 )
 from corehq.apps.accounting.tests.utils import generator
 from corehq.apps.domain.models import Domain
+from corehq.apps.enterprise.enterprise import (
+    EnterpriseDomainReport,
+    EnterpriseWebUserReport,
+    EnterpriseMobileWorkerReport,
+    EnterpriseSMSReport,
+    EnterpriseODataReport,
+    EnterpriseCaseManagementReport,
+    EnterpriseDataExportReport,
+    Enterprise2FAReport,
+    EnterpriseCommCareVersionReport,
+    EnterpriseAPIReport,
+    EnterpriseDataForwardingReport,
+    EnterpriseAppVersionComplianceReport,
+)
 from corehq.apps.enterprise.api.resources import (
     EnterpriseODataAuthentication,
+    DomainResource,
+    WebUserResource,
+    MobileUserResource,
     ODataAuthentication,
+    SMSResource,
+    ODataFeedResource,
+    CaseManagementResource,
+    DataExportReportResource,
+    TwoFactorAuthResource,
+    CommCareVersionComplianceResource,
+    APIKeysResource,
+    DataForwardingResource,
+    ApplicationVersionComplianceResource,
 )
 from corehq.apps.users.models import WebUser
 
@@ -100,3 +126,209 @@ class EnterpriseODataAuthenticationTests(TestCase):
         request.couch_user = user
         request.domain = domain
         return request
+
+
+class TestDomainResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = EnterpriseDomainReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in DomainResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'domain': 'Project Space Name',
+            'created_on': 'Created On [UTC]',
+            'num_apps': '# of Apps',
+            'num_mobile_users': '# of Mobile Users',
+            'num_web_users': '# of Web Users',
+            'num_sms_last_30_days': '# of SMS (last 30 days)',
+            'last_form_submission': 'Last Form Submission [UTC]',
+            'num_odata_feeds_used': 'OData Feeds Used',
+            'num_odata_feeds_available': 'OData Feeds Available',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)
+
+
+class TestWebUserResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = EnterpriseWebUserReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in
+                          WebUserResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'email': 'Email Address',
+            'name': 'Name',
+            'role': 'Role',
+            'last_login': 'Last Login [UTC]',
+            'last_access_date': 'Last Access Date [UTC]',
+            'status': 'Status',
+            'domain': 'Project Space Name',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)
+
+
+class TestMobileUserResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = EnterpriseMobileWorkerReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in
+                          MobileUserResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'username': 'Username',
+            'name': 'Name',
+            'email': 'Email Address',
+            'role': 'Role',
+            'created_at': 'Created Date [UTC]',
+            'last_sync': 'Last Sync [UTC]',
+            'last_submission': 'Last Submission [UTC]',
+            'commcare_version': 'CommCare Version',
+            'user_id': 'User ID',
+            'domain': 'Project Space Name',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)
+
+
+class TestSMSResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = EnterpriseSMSReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in SMSResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'domain': 'Project Space',
+            'num_sent': '# Sent',
+            'num_received': '# Received',
+            'num_error': '# Errors',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)
+
+
+class TestODataFeedResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = EnterpriseODataReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in
+                          ODataFeedResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'domain': 'Project Space',
+            'report_name': 'Name',
+            'report_rows': 'Number of Rows',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)
+
+
+class TestCaseManagementResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = EnterpriseCaseManagementReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in
+                          CaseManagementResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'domain': 'Project Space',
+            'num_applications': '# Applications',
+            'num_surveys_only': '# Surveys Only',
+            'num_cases_only': '# Cases Only',
+            'num_mixed': '# Mixed',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)
+
+
+class TestDataExportResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = EnterpriseDataExportReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in
+                          DataExportReportResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'domain': 'Project Space',
+            'name': 'Name',
+            'export_type': 'Type',
+            'export_subtype': 'SubType',
+            'owner': 'Created By',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)
+
+
+class TestTwoFactorAuthResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = Enterprise2FAReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in
+                          TwoFactorAuthResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'domain_without_2fa': 'Project Space without 2FA',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)
+
+
+class TestCommCareVersionComplianceResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = EnterpriseCommCareVersionReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in
+                          CommCareVersionComplianceResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'mobile_worker': 'Mobile Worker',
+            'domain': 'Project Space',
+            'latest_version_available_at_submission': 'Latest Version Available at Submission',
+            'version_in_use': 'Version in Use',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)
+
+
+class TestAPIKeysResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = EnterpriseAPIReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in
+                          APIKeysResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'web_user': 'Web User',
+            'api_key_name': 'API Key Name',
+            'scope': 'Scope',
+            'expiration_date': 'Expiration Date [UTC]',
+            'created_date': 'Created On [UTC]',
+            'last_used_date': 'Last Used On [UTC]',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)
+
+
+class TestDataForwardingResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = EnterpriseDataForwardingReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in
+                          DataForwardingResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'domain': 'Project Space',
+            'service_name': 'Service Name',
+            'service_type': 'Type',
+            'last_modified': 'Last Modified [UTC]',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)
+
+
+class TestApplicationVersionComplianceResourceMapping(SimpleTestCase):
+    def test_headers(self):
+        report = EnterpriseAppVersionComplianceReport(None, None)
+
+        header_mapping = {name: report.headers[index] for (name, index) in
+                          ApplicationVersionComplianceResource.COLUMN_INDEX_MAP.items()}
+        expectedMapping = {
+            'mobile_worker': 'Mobile Worker',
+            'domain': 'Project Space',
+            'application': 'Application',
+            'latest_version_available_when_last_used': 'Latest Version Available When Last Used',
+            'version_in_use': 'Version in Use',
+            'last_used': 'Last Used [UTC]',
+        }
+
+        self.assertEqual(header_mapping, expectedMapping)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-16685.

Our existing enterprise APIs were not standard in how they treated the `domain` field. Some returned the raw domain name (visible in URLs), while others returned the human readable name visible in a domain's properties. This PR standardizes these reports so that any 'domain' field in these APIs will return the raw domain value.

In addition, this PR does a lot of cleanup work that I had intended to do after 3751795e2c55fd602f1aa9ce765caf1d167f0d63. Because we were mapping values from the report to values in the API via a raw index, it was easy to mess up that index, especially if new fields were added or old fields were removed. I used this opportunity to create a mapping between the API's named column and the report's header, so that this becomes more error-proof in the future (with associated tests).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Verified that each API still ran locally

### Automated test coverage
New test suites were introduced in _enterprise/tests/test_resources_ to ensure the api name->header mapping stays in sync.

### QA Plan

No  QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
