### PR TITLE
Updated UCRs to support scheduled reports again

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -147,10 +147,12 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     template_name = 'userreports/configurable_report.html'
     slug = "configurable"
     prefix = slug
-    emailable = False
     is_exportable = True
     exportable_all = False
     show_filters = True
+
+    # The UCR UI does not currently support emailing. However, UCRs can be emailed via scheduled reports.
+    emailable = True
 
     _domain = None
 
@@ -374,7 +376,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             "type": self.type,
             "isExportable": self.is_exportable,
             "isExportAll": self.exportable_all,
-            "isEmailable": self.emailable,
+            "isEmailable": False,       # see emailable attr above
             "emailDefaultSubject": self.title,
         }
 


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SAAS-16709

Fixes bug where UCRs do not show up in the options to create a scheduled report.

## Technical Summary
Introduced by https://github.com/dimagi/commcare-hq/pull/35753/ - while doing that, I discovered that the UCR report has `emailable` set to True but the UI wasn't respecting that attribute, so I switched it to False to better reflect the true behavior. However, I didn't realize that `emailable` also controls which reports appear in the list of options for creating scheduled reports.

## Feature Flag
UCR

## Safety Assurance

### Safety story
This is in some sense a config change. This restores previous production behavior.

### Automated test coverage

doubt it

### QA Plan

no
### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
