### PR TITLE
Remove unsupported banner from Safari browser

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
@@ -427,15 +427,6 @@ hqDefine('hqwebapp/js/bootstrap3/main', [
         }
 
         function unsupportedBrowser() {
-            // check explicitly for Safari. Relying on browser capabilities would be preferred,
-            // but our issue with Safari is described here: https://dimagi-dev.atlassian.net/browse/SUPPORT-4778
-            // (history.replaceState raises security exceptions that aren't present in other browsers).
-            // This can be verified here: (https://jsfiddle.net/j1sxxLwy/),
-            // but it's not something that can be efficiently feature-checked
-            if (window.safari !== undefined) {
-                return true;    // found a Safari browser
-            }
-
             // Try to filter out legacy browsers like Internet Explorer.
             // We don't explicitly rely on SVG SMIL animation,
             // but it's a decent test for avoiding legacy IE.

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
@@ -431,15 +431,6 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
         }
 
         function unsupportedBrowser() {
-            // check explicitly for Safari. Relying on browser capabilities would be preferred,
-            // but our issue with Safari is described here: https://dimagi-dev.atlassian.net/browse/SUPPORT-4778
-            // (history.replaceState raises security exceptions that aren't present in other browsers).
-            // This can be verified here: (https://jsfiddle.net/j1sxxLwy/),
-            // but it's not something that can be efficiently feature-checked
-            if (window.safari !== undefined) {
-                return true;    // found a Safari browser
-            }
-
             // Try to filter out legacy browsers like Internet Explorer.
             // We don't explicitly rely on SVG SMIL animation,
             // but it's a decent test for avoiding legacy IE.

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/unsupported_browser.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/unsupported_browser.html
@@ -12,7 +12,8 @@
     {% blocktrans %}
         We recommend
         <a href="https://www.google.com/chrome">Chrome</a>
-        or <a href="http://www.mozilla.org/">Firefox</a>.
+        , <a href="http://www.mozilla.org/">Firefox</a>.
+        or <a href="https://www.apple.com/safari/">Safari</a>.
     {% endblocktrans %}
     </p>
 </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/unsupported_browser.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/unsupported_browser.html
@@ -10,6 +10,7 @@
   {% blocktrans %}
     We recommend
     <a href="https://www.google.com/chrome" class="alert-link">Chrome</a>
-    or <a href="http://www.mozilla.org/" class="alert-link">Firefox</a>.
+    , <a href="http://www.mozilla.org/" class="alert-link">Firefox</a>
+    or <a href="https://www.apple.com/safari/" class="alert-link">Safari</a>.
   {% endblocktrans %}
 </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/unsupported_browser.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/unsupported_browser.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,18 +1,15 @@
+@@ -1,19 +1,16 @@
  {% load i18n %}
  
  <div id="unsupported-browser"
@@ -15,10 +15,11 @@
 -    {% blocktrans %}
 -        We recommend
 -        <a href="https://www.google.com/chrome">Chrome</a>
--        or <a href="http://www.mozilla.org/">Firefox</a>.
+-        , <a href="http://www.mozilla.org/">Firefox</a>.
+-        or <a href="https://www.apple.com/safari/">Safari</a>.
 -    {% endblocktrans %}
 -    </p>
--</div>+     role="alert"
++     role="alert"
 +     class="alert alert-danger rounded-0 d-none">
 +  <i class="fa-solid fa-triangle-exclamation"></i>
 +  <strong>
@@ -27,6 +28,7 @@
 +  {% blocktrans %}
 +    We recommend
 +    <a href="https://www.google.com/chrome" class="alert-link">Chrome</a>
-+    or <a href="http://www.mozilla.org/" class="alert-link">Firefox</a>.
++    , <a href="http://www.mozilla.org/" class="alert-link">Firefox</a>
++    or <a href="https://www.apple.com/safari/" class="alert-link">Safari</a>.
 +  {% endblocktrans %}
-+</div>
+ </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
@@ -118,7 +118,7 @@
  
          $(document).on('click', '.track-usage-link', function (e) {
              var $link = $(e.currentTarget),
-@@ -452,8 +456,13 @@
+@@ -443,8 +447,13 @@
          // EULA modal
          var eulaCookie = "gdpr_rollout";
          if (!$.cookie(eulaCookie)) {
@@ -134,7 +134,7 @@
                  $("body").addClass("has-eula");
                  $("#eula-agree").click(function () {
                      $(this).disableButton();
-@@ -461,7 +470,7 @@
+@@ -452,7 +461,7 @@
                          url: initialPageData.reverse("agree_to_eula"),
                          method: "POST",
                          success: function () {
@@ -143,7 +143,7 @@
                              $("body").removeClass("has-eula");
                          },
                          error: function (xhr) {
-@@ -477,21 +486,22 @@
+@@ -468,21 +477,22 @@
                          },
                      });
                  });


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

As part of the requirements for Indiana MCH, we are required to [support the Safari browser](https://dimagi.atlassian.net/browse/USH-5448). This PR removes the "this browser isn't supported" banner from Safari browsers and adds Safari to the list of the supported browsers we recommend. 

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Jira ticket](https://dimagi.atlassian.net/browse/USH-5739)

Removing this banner also resolves a bunch of other UI issues that QA spotted the first time around mostly having to do with elements being pushed off screen at the bottom. 

Just noting here that the original reason we didn't recommend using Safari was because of [this error](https://dimagi-dev.atlassian.net/browse/SUPPORT-4778) caused by a limitation on how many times you can call `window.replaceState` in a given timespan. However, QA couldn't reproduce this error after I pointed it out to them (discussion in the jira ticket link above), maybe because it was resolved by [this PR](https://github.com/dimagi/Vellum/pull/985). The PR doesn't mention testing on Safari (it was targeting Firefox) but since it cuts down on the unnecessary amount of `window.replaceState` calls, I'm do believe it resolved the issue for both browsers. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Checked for consistency locally and on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
