### PR TITLE
Add extra space under version info

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -123,7 +123,9 @@
             </div>
           </div>
           <small id="version-info" class="pb-5"></small>
-          <br>
+          {% if request.couch_user.can_edit_data %}
+            <br>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -124,7 +124,7 @@
           </div>
           <small id="version-info" class="pb-5"></small>
           {% if request.couch_user.can_edit_data %}
-            <div id="sticky-submit"></div>
+            <div class="pb-4"></div>
           {% endif %}
         </div>
       </div>

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -124,7 +124,7 @@
           </div>
           <small id="version-info" class="pb-5"></small>
           {% if request.couch_user.can_edit_data %}
-            <br>
+            <div id="sticky-submit"></div>
           {% endif %}
         </div>
       </div>

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -123,6 +123,7 @@
             </div>
           </div>
           <small id="version-info" class="pb-5"></small>
+          <br>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

This adds a small spacer under the app version info to give it a small bump in visibility since it was always hidden behind the data preview bar, across all browsers. The spacer is only there if the data preview bar is there.

Before:
<img width="1085" alt="Screenshot 2025-03-05 at 2 39 49 PM" src="https://github.com/user-attachments/assets/710739d4-3548-4489-9c30-ce0219c80823" />

After:
<img width="1088" alt="Screenshot 2025-03-07 at 4 38 45 PM" src="https://github.com/user-attachments/assets/2a8b8505-0e87-4b68-aa22-1a1b5b39c058" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/USH-5770)

Part of the work to make Safari a supported browser for CommCare. I realized this was an issue on Firefox and Chrome too so that's a bonus. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

UI change only

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
