### PR TITLE
Fix demo_user filter

### DIFF
--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -180,8 +180,8 @@ def admin_users():
 
 
 def demo_users():
-    """Matches users whose username is demo_user"""
-    return username("demo_user")
+    """Matches users who has is_demo_user set to True"""
+    return filters.term("is_demo_user", True)
 
 
 def created(gt=None, gte=None, lt=None, lte=None):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Demo user filter is not working because the es filter determine by whether username is demo_user. The correct behavior should determine by whether user's `is_demo_user` is True


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-12457


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. Filter change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Add test in corehq/apps/es/tests/test_user_adapter.py
[Test ](https://github.com/dimagi/commcare-hq/actions/runs/13691217061/job/38284688881?pr=35898)failed before the fix is pushed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
