### PR TITLE
Updates the label of a field on KYC Configuration Page.  

### DIFF
--- a/corehq/apps/integration/kyc/forms.py
+++ b/corehq/apps/integration/kyc/forms.py
@@ -29,7 +29,7 @@ class KycConfigureForm(forms.ModelForm):
         ]
 
     user_data_store = forms.ChoiceField(
-        label=_('User Data Store'),
+        label=_('Recipient Data Store'),
         required=True,
         choices=UserDataStore.CHOICES,
     )
@@ -43,7 +43,7 @@ class KycConfigureForm(forms.ModelForm):
         choices=KycProviders.choices,
     )
     api_field_to_user_data_map = JsonField(
-        label=_('API Field to User Data Map'),
+        label=_('API Field to Recipient Data Map'),
         required=True,
         expected_type=dict,
     )

--- a/corehq/apps/integration/kyc/models.py
+++ b/corehq/apps/integration/kyc/models.py
@@ -64,7 +64,7 @@ class KycConfig(models.Model):
         ):
             raise ValidationError({
                 'other_case_type': _(
-                    'This field is required when "User Data Store" is set to '
+                    'This field is required when "Recipient Data Store" is set to '
                     '"Other Case Type".'
                 )
             })


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
TINY change to update the label of two fields on  the KYC Configuration Page. 
`User Data Store` is changed to `Recipient Data Store*` 

Also updated the associated field `API Field to User Data Map` to `API Field to Recipient Data Map`

Before:
![image](https://github.com/user-attachments/assets/83435322-372e-41a0-a4a7-262d45e8d127)

After:
![image](https://github.com/user-attachments/assets/4a6c8584-460e-42d1-852c-11f85df7235d)


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-4328)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
KYC_VERIFICATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local. Just a label change. Super Safe

### Automated test coverage
<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
