### PR TITLE
Check if profiler obj present on report class

### DIFF
--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -355,6 +355,10 @@ class ESQueryProfilerMixin(object):
     def profiler(self):
         return self._profiler
 
+    @property
+    def should_profile(self):
+        return self.profiler_enabled and self.profiler
+
     def _get_search_class(self):
         if not self.search_class:
             raise NotImplementedError("You must define a search_class attribute.")
@@ -369,7 +373,7 @@ def profile(name=None):
     def decorator(func):
         @wraps(func)
         def wrapper(obj, *args, **kwargs):
-            if obj.profiler_enabled and obj.profiler:
+            if obj.should_profile:
                 with obj.profiler.timing_context(name):
                     return func(obj, *args, **kwargs)
             return func(obj, *args, **kwargs)

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -369,7 +369,7 @@ def profile(name=None):
     def decorator(func):
         @wraps(func)
         def wrapper(obj, *args, **kwargs):
-            if obj.profiler_enabled:
+            if obj.profiler_enabled and obj.profiler:
                 with obj.profiler.timing_context(name):
                     return func(obj, *args, **kwargs)
             return func(obj, *args, **kwargs)

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -245,8 +245,7 @@ class CaseListReport(CaseListMixin, ProjectReport, ReportDataSource):
 
     @property
     def json_response(self):
-        should_profile = self.profiler_enabled and self.profiler
-        with self.profiler.timing_context if should_profile else contextlib.nullcontext():
+        with self.profiler.timing_context if self.should_profile else contextlib.nullcontext():
             response = super().json_response
 
         if self.profiler_enabled:

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -245,7 +245,8 @@ class CaseListReport(CaseListMixin, ProjectReport, ReportDataSource):
 
     @property
     def json_response(self):
-        with self.profiler.timing_context if self.profiler_enabled else contextlib.nullcontext():
+        should_profile = self.profiler_enabled and self.profiler
+        with self.profiler.timing_context if should_profile else contextlib.nullcontext():
             response = super().json_response
 
         if self.profiler_enabled:


### PR DESCRIPTION
## Technical Summary
Fixes [a bug](https://github.com/dimagi/commcare-hq/pull/35830#issuecomment-2703001649) where the profiler object was not set on the report class during an export operation. 

Currently I view this fix as a patch while I'm not sure why the profiler obj was not instantiated when the export is being done, but noting that we really don't care about profiling when the export is done, so maybe this fix could be a permanent solution as well.

I'll have to do some digging...

## Safety Assurance

### Safety story
Tested locally that exports can now happen (was able to reproduce the bug first, then tested the solution).

### Migrations
- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
