### PR TITLE
Use dropdown for the Other case type field in KYC Config Page

### DIFF
--- a/corehq/apps/integration/kyc/forms.py
+++ b/corehq/apps/integration/kyc/forms.py
@@ -7,11 +7,14 @@ from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
 
+from corehq.apps.app_manager.const import USERCASE_TYPE
+from corehq.apps.commtrack.const import USER_LOCATION_OWNER_MAP_TYPE
 from corehq.apps.integration.kyc.models import (
     KycConfig,
     KycProviders,
     UserDataStore,
 )
+from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain
 from corehq.apps.userreports.ui.fields import JsonField
 from corehq.motech.models import ConnectionSettings
 
@@ -59,7 +62,7 @@ class KycConfigureForm(forms.ModelForm):
         self.fields['connection_settings'].queryset = ConnectionSettings.objects.filter(
             domain=self.instance.domain
         )
-
+        self.fields['other_case_type'].choices = self._get_case_types()
         self.helper = FormHelper()
         self.helper.form_tag = False
 
@@ -101,3 +104,10 @@ class KycConfigureForm(forms.ModelForm):
                 }),
             )
         )
+
+    def _get_case_types(self):
+        case_types = sorted(get_case_types_for_domain(self.instance.domain))
+        return [
+            (case, case) for case in case_types
+            if case not in (USERCASE_TYPE, USER_LOCATION_OWNER_MAP_TYPE)
+        ]

--- a/corehq/apps/integration/kyc/forms.py
+++ b/corehq/apps/integration/kyc/forms.py
@@ -33,7 +33,7 @@ class KycConfigureForm(forms.ModelForm):
         required=True,
         choices=UserDataStore.CHOICES,
     )
-    other_case_type = forms.CharField(
+    other_case_type = forms.ChoiceField(
         label=_('Other Case Type'),
         required=False,
     )

--- a/corehq/apps/integration/kyc/tests/test_views.py
+++ b/corehq/apps/integration/kyc/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
@@ -75,7 +77,8 @@ class TestKycConfigurationView(BaseTestKycView):
         assert response.status_code == 404
 
     @flag_enabled('KYC_VERIFICATION')
-    def test_success(self):
+    @patch('corehq.apps.integration.kyc.forms.get_case_types_for_domain', return_value=['case-1'])
+    def test_success(self, *args):
         response = self._make_request()
         assert response.status_code == 200
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The change replaces the text field with a dropdown for the `Other Case Type` field in the KYC Config Page. The case types are populated in the same way as we do for the Case Type filter in the Case List Explore and other reports.
Note: `commcare_user` is omitted from the choice as we have a dedicated option `User Case` for that in the `Recipient Data Store` setting.

**Before:**
![image](https://github.com/user-attachments/assets/7c4c45e1-0db9-4117-bb50-cd2bbbf4dad8)


**After**
![image](https://github.com/user-attachments/assets/c9f27768-3972-4892-a36c-ec3aecfb6e36)


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-4329)

Note the case types are fetched in the same way as we do the Case Type filter in the reports. This includes a union of case types from CaseES index and ones from the data dictionary. [Here](https://github.com/dimagi/commcare-hq/blob/9d6ae056c24d0fec8db51bccf5bbdcf71a7b621a/corehq/apps/reports/analytics/esaccessors.py#L656) is the source method. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
KYC_VERIFICATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local Testing done. Minor UI form field change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None as simple UI change

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
