### PR TITLE
Fix issue where date widget subtracts a day each time it's parsed

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -373,7 +373,7 @@ hqDefine('cloudcare/js/utils', [
             useCurrent: false,
         };
         if (selectedDate) {
-            options.viewDate = new hqTempusDominus.tempusDominus.DateTime(selectedDate);
+            options.viewDate = new Date(selectedDate);
         }
         let picker = hqTempusDominus.createDatePicker($el.get(0), options);
 


### PR DESCRIPTION
## Product Description 

## Technical Summary
https://dimagi.atlassian.net/browse/USH-5812
https://dimagi.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/issue/SUPPORT-23482
Don't convert date input to datetime.  That gets timezone adjusted and then truncated, effectively subtracting a date anywhere west of Greenwich, but apparently only in `YYYY-MM-DD` format?  It doesn't do that with `MM/DD/YYYY.`

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
