### PR TITLE
Implement CaseSearchES Filtering for `BulkEditPinnedFilter`s

### DIFF
--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -29,6 +29,21 @@ class SessionPinnedFilterMixin(ABC):
     def pinned_filter(self):
         return self.session.pinned_filters.get(filter_type=self.filter_type)
 
+    @classmethod
+    def filter_query(cls, query, pinned_filter):
+        """
+        This method should return a filtered `ESQuery` object based on the value
+        stored in the database.
+
+        This will be called by the `filter_query(query)` function of
+        the `BulkEditPinnedFilter` instance.
+
+        :param query: an `ESQuery` instance (e.g. `CaseSearchQuery`)
+        :param pinned_filter: Instance of `BulkEditPinnedFilter`
+        :return: `ESQuery` of the same type as `query`
+        """
+        raise NotImplementedError("please implement `filter_query")
+
     @abstractmethod
     def get_value_for_db(self):
         """

--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -4,8 +4,16 @@ from memoized import memoized
 from django.utils.translation import gettext_lazy
 
 from corehq.apps.data_cleaning.models import PinnedFilterType
+from corehq.apps.es import cases as case_es
 from corehq.apps.reports.filters.case_list import CaseListFilter
 from corehq.apps.reports.filters.select import SelectOpenCloseFilter
+from corehq.apps.reports.standard.cases.utils import (
+    all_project_data_filter,
+    deactivated_case_owners,
+    get_case_owners,
+    query_location_restricted_cases,
+)
+from corehq.apps.users.models import CouchUser
 
 
 class SessionPinnedFilterMixin(ABC):
@@ -95,6 +103,55 @@ class CaseOwnersPinnedFilter(SessionPinnedFilterMixin, CaseListFilter):
     def get_value_for_db(self):
         value = self.get_value(self.request, self.domain)
         return None if value == self._get_default_db_value() else value
+
+    @classmethod
+    def filter_query(cls, query, pinned_filter):
+        """
+        todo: it would be nice to de-duplicate the logic here
+        with the logic in CaseListReport, but we can address that at a later date.
+        """
+        couch_user = CouchUser.get_by_username(pinned_filter.session.user.username)
+        domain = pinned_filter.session.domain
+        can_access_all_locations = couch_user.has_permission(
+            domain, 'access_all_locations'
+        )
+        emwf_slugs = pinned_filter.value or cls._get_default_db_value()
+
+        if can_access_all_locations and cls.show_all_data(emwf_slugs):
+            # don't apply any case owner filters
+            return query
+
+        case_owner_filters = []
+
+        if can_access_all_locations and cls.show_project_data(emwf_slugs):
+            case_owner_filters.append(
+                all_project_data_filter(domain, emwf_slugs)
+            )
+
+        if can_access_all_locations and cls.show_deactivated_data(emwf_slugs):
+            case_owner_filters.append(deactivated_case_owners(domain))
+
+        if (
+            cls.selected_user_ids(emwf_slugs)
+            or cls.selected_user_types(emwf_slugs)
+            or cls.selected_group_ids(emwf_slugs)
+            or cls.selected_location_ids(emwf_slugs)
+        ):
+            case_owners = get_case_owners(
+                can_access_all_locations, domain, emwf_slugs
+            )
+            if case_owners:
+                case_owner_filters.append(case_es.owner(case_owners))
+
+        if case_owner_filters:
+            query = query.OR(*case_owner_filters)
+
+        if not can_access_all_locations:
+            query = query_location_restricted_cases(
+                query, domain, couch_user,
+            )
+
+        return query
 
 
 class CaseStatusPinnedFilter(SessionPinnedFilterMixin, SelectOpenCloseFilter):

--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -172,3 +172,13 @@ class CaseStatusPinnedFilter(SessionPinnedFilterMixin, SelectOpenCloseFilter):
     def get_value_for_db(self):
         value = self.get_value(self.request, self.domain)
         return None if not value else [value]
+
+    @classmethod
+    def filter_query(cls, query, pinned_filter):
+        case_status = pinned_filter.value
+        if case_status:
+            # the `pinned_filter` values are always stored in an `ArrayField`,
+            # and the value is either a list or `None`,
+            # so we need to call `case_status[0]`
+            query = query.is_closed(case_status[0] == 'closed')
+        return query

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -571,33 +571,33 @@ class BulkEditColumnFilterXpathTest(TestCase):
 
 
 class TestReportFilterSubclasses(TestCase):
-    domain_name = 'report-filter-pinned-test'
+    domain = 'report-filter-pinned-test'
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.domain = create_domain(cls.domain_name)
-        cls.addClassCleanup(cls.domain.delete)
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
 
         cls.web_user = WebUser.create(
-            cls.domain.name, 'tester@datacleaning.org', 'testpwd', None, None
+            cls.domain, 'tester@datacleaning.org', 'testpwd', None, None
         )
-        cls.addClassCleanup(cls.web_user.delete, cls.domain.name, deleted_by=None)
+        cls.addClassCleanup(cls.web_user.delete, cls.domain, deleted_by=None)
 
     def setUp(self):
         super().setUp()
         self.request = RequestFactory().get('/cases/')
-        self.request.domain = self.domain_name
+        self.request.domain = self.domain
         self.request.can_access_all_locations = True
         self.request.couch_user = self.web_user
-        self.request.project = self.domain
+        self.request.project = self.domain_obj
         self.session = BulkEditSession.new_case_session(
-            self.web_user.get_django_user(), self.domain_name, 'plants',
+            self.web_user.get_django_user(), self.domain, 'plants',
         )
 
     def test_case_owners_report_filter_context(self):
         report_filter = CaseOwnersPinnedFilter(
-            self.session, self.request, self.domain_name, use_bootstrap5=True
+            self.session, self.request, self.domain, use_bootstrap5=True
         )
         expected_context = {
             'report_select2_config': {
@@ -631,7 +631,7 @@ class TestReportFilterSubclasses(TestCase):
     @mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting
     def test_case_owners_report_filter_context_locations(self):
         report_filter = CaseOwnersPinnedFilter(
-            self.session, self.request, self.domain_name, use_bootstrap5=True
+            self.session, self.request, self.domain, use_bootstrap5=True
         )
         expected_context = {
             'report_select2_config': {
@@ -676,7 +676,7 @@ class TestReportFilterSubclasses(TestCase):
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
         self.assertIsNone(pinned_filter.value)
         report_filter = CaseOwnersPinnedFilter(
-            self.session, self.request, self.domain_name, use_bootstrap5=True
+            self.session, self.request, self.domain, use_bootstrap5=True
         )
         report_filter.update_stored_value()
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
@@ -693,7 +693,7 @@ class TestReportFilterSubclasses(TestCase):
 
     def test_case_status_report_filter_context(self):
         report_filter = CaseStatusPinnedFilter(
-            self.session, self.request, self.domain_name, use_bootstrap5=True
+            self.session, self.request, self.domain, use_bootstrap5=True
         )
         expected_context = {
             'report_select2_config': {
@@ -724,7 +724,7 @@ class TestReportFilterSubclasses(TestCase):
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_STATUS)
         self.assertIsNone(pinned_filter.value)
         report_filter = CaseStatusPinnedFilter(
-            self.session, self.request, self.domain_name, use_bootstrap5=True
+            self.session, self.request, self.domain, use_bootstrap5=True
         )
         report_filter.update_stored_value()
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_STATUS)

--- a/corehq/apps/data_cleaning/tests/test_views.py
+++ b/corehq/apps/data_cleaning/tests/test_views.py
@@ -21,13 +21,15 @@ from corehq.apps.data_cleaning.views.setup import (
     SetupCaseSessionFormView,
 )
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.es import group_adapter
 from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.es.tests.utils import es_test
+from corehq.apps.es.users import user_adapter
 from corehq.apps.users.models import WebUser
 from corehq.util.test_utils import flag_enabled
 
 
-@es_test(requires=[case_search_adapter])
+@es_test(requires=[case_search_adapter, user_adapter, group_adapter], setup_class=True)
 class CleanCasesViewAccessTest(TestCase):
     domain_name = 'clean-data-view-test'
     other_domain_name = 'no-access-view-test'

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -128,7 +128,9 @@ class CaseListMixin(ESQueryProfilerMixin, ElasticProjectInspectionReport, Projec
     @memoized
     def case_owners(self):
         mobile_user_and_group_slugs = self.get_request_param(EMWF.slug, as_list=True)
-        return get_case_owners(self.request, self.domain, mobile_user_and_group_slugs)
+        return get_case_owners(
+            self.request.can_access_all_locations, self.domain, mobile_user_and_group_slugs
+        )
 
     def get_case(self, row):
         if '_source' in row:

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -64,7 +64,17 @@ def deactivated_case_owners(domain):
 
 def get_case_owners(can_access_all_locations, domain, mobile_user_and_group_slugs):
     """
-    For unrestricted user
+    Returns a list of user, group, and location ids that are owners for cases.
+
+    :param can_access_all_locations: boolean
+        - generally obtained from `request.can_access_all_locations`
+    :param domain: string
+        - the domain string that the case owners belong to
+    :param mobile_user_and_group_slugs: list
+        - a list of user ids and special formatted strings returned by
+          the `ExpandedMobileWorkerFilter` and its subclasses
+
+    For unrestricted user (can_access_all_locations = True)
     :return:
     user ids for selected user types
     for selected reporting group ids, returns user_ids belonging to these groups
@@ -76,7 +86,7 @@ def get_case_owners(can_access_all_locations, domain, mobile_user_and_group_slug
     ids and descendants ids of selected locations
         assigned users at selected locations and their descendants
 
-    For restricted user
+    For restricted user (can_access_all_locations = False)
     :return:
     selected user ids
         also finds the sharing groups which has any user from the above selected users

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -62,7 +62,7 @@ def deactivated_case_owners(domain):
     return case_es.owner(owner_ids)
 
 
-def get_case_owners(request, domain, mobile_user_and_group_slugs):
+def get_case_owners(can_access_all_locations, domain, mobile_user_and_group_slugs):
     """
     For unrestricted user
     :return:
@@ -87,7 +87,7 @@ def get_case_owners(request, domain, mobile_user_and_group_slugs):
     special_owner_ids, selected_sharing_group_ids, selected_reporting_group_users = [], [], []
     sharing_group_ids, location_owner_ids, assigned_user_ids_at_selected_locations = [], [], []
 
-    if request.can_access_all_locations:
+    if can_access_all_locations:
         user_types = EMWF.selected_user_types(mobile_user_and_group_slugs)
 
         special_owner_ids = _get_special_owner_ids(

--- a/corehq/apps/reports/tests/standard/cases/test_utils.py
+++ b/corehq/apps/reports/tests/standard/cases/test_utils.py
@@ -1,0 +1,328 @@
+from corehq.apps.es.client import manager
+from corehq.apps.es.groups import group_adapter
+from corehq.apps.es.tests.utils import (
+    es_test,
+)
+from corehq.apps.es.users import user_adapter
+from corehq.apps.groups.models import Group
+from corehq.apps.locations.tests.util import LocationHierarchyTestCase
+from corehq.apps.reports.models import HQUserType
+from corehq.apps.reports.standard.cases.utils import get_case_owners
+from corehq.apps.users.models import WebUser, CommCareUser
+
+
+class BaseCaseOwnersTest(LocationHierarchyTestCase):
+    location_type_names = ['state', 'county', 'city']
+    location_structure = [
+        ('Massachusetts', [
+            ('Middlesex', [
+                ('Cambridge', []),
+                ('Somerville', []),
+            ]),
+            ('Suffolk', [
+                ('Boston', []),
+                ('Revere', []),
+            ])
+        ]),
+        ('New York', [
+            ('New York City', [
+                ('Manhattan', []),
+                ('Brooklyn', []),
+                ('Queens', []),
+            ]),
+        ]),
+    ]
+
+    @classmethod
+    def _set_up_commcare_users(cls):
+        cls.users = []
+        for index in range(6):
+            user = CommCareUser.create(
+                cls.domain, f'user-test-{index}', 'Passw0rd!', None, None
+            )
+            if index < 2:
+                user.set_location(cls.locations['Massachusetts'])
+                user.add_to_assigned_locations(cls.locations['Suffolk'])
+                user.save()
+            elif 2 <= index < 4:
+                user.set_location(cls.locations['Middlesex'])
+                user.add_to_assigned_locations(cls.locations['Cambridge'])
+                user.save()
+            elif 4 <= index:
+                user.set_location(cls.locations['New York'])
+                user.add_to_assigned_locations(cls.locations['Brooklyn'])
+                user.add_to_assigned_locations(cls.locations['Queens'])
+                user.save()
+            user_adapter.index(user)
+            cls.users.append(user)
+
+    @classmethod
+    def _set_up_web_users(cls):
+        cls.web_users = []
+        for index in range(2):
+            web_user = WebUser.create(
+                cls.domain, f'tester-{index}@iloveplants.org', 'Passw0rd!', None, None
+            )
+            user_adapter.index(web_user)
+            cls.web_users.append(web_user)
+
+    @classmethod
+    def _set_up_groups(cls):
+        cls.group1 = Group(
+            name='test-group1',
+            domain=cls.domain,
+            users=[cls.users[1]._id, cls.users[3]._id, cls.users[5]._id],
+        )
+        cls.group1.save()
+        group_adapter.index(cls.group1)
+
+        cls.group2 = Group(
+            name='test-group2',
+            domain=cls.domain,
+            case_sharing=True,
+            users=[cls.users[0]._id, cls.users[2]._id, cls.users[4]._id],
+        )
+        cls.group2.save()
+        group_adapter.index(cls.group2)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.location_types['state'].view_descendants = True
+        cls.location_types['state'].save()
+        cls.location_types['city'].shares_cases = True
+        cls.location_types['city'].save()
+
+        cls._set_up_commcare_users()
+        cls._set_up_web_users()
+        cls._set_up_groups()
+
+        manager.index_refresh(user_adapter.index_name)
+        manager.index_refresh(group_adapter.index_name)
+
+    @classmethod
+    def tearDownClass(cls):
+        for group in [cls.group1, cls.group2]:
+            group.delete()
+
+        for user in cls.users + cls.web_users:
+            from couchdbkit import ResourceNotFound
+            try:
+                user.delete(cls.domain, None)
+            except ResourceNotFound:
+                pass
+
+        super().tearDownClass()
+
+
+@es_test(requires=[user_adapter, group_adapter], setup_class=True)
+class CaseOwnersTest(BaseCaseOwnersTest):
+    domain = 'get-case-owners-test'
+
+    def test_web_users(self):
+        owners = get_case_owners(True, self.domain, [f't__{HQUserType.WEB}'])
+        web_user_ids = [u._id for u in self.web_users]
+        self.assertListEqual(sorted(owners), sorted(web_user_ids))
+
+    def test_web_users_restricted(self):
+        owners = get_case_owners(False, self.domain, [f't__{HQUserType.WEB}'])
+        self.assertListEqual(owners, [])
+
+    def test_deactivated_users(self):
+        owners = get_case_owners(True, self.domain, [f't__{HQUserType.DEACTIVATED}'])
+        self.assertListEqual(owners, [])
+
+    def test_deactivated_users_restricted(self):
+        owners = get_case_owners(False, self.domain, [f't__{HQUserType.DEACTIVATED}'])
+        self.assertListEqual(owners, [])
+
+    def test_demo_users(self):
+        owners = get_case_owners(True, self.domain, [f't__{HQUserType.DEMO_USER}'])
+        expected_owners = [
+            'demo_user',
+            'demo_user_group_id',
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_demo_users_restricted(self):
+        owners = get_case_owners(False, self.domain, [f't__{HQUserType.DEMO_USER}'])
+        self.assertListEqual(owners, [])
+
+    def test_reporting_groups(self):
+        owners = get_case_owners(True, self.domain, [f'g__{self.group1._id}'])
+        expected_owners = [
+            self.users[1]._id,
+            self.users[3]._id,
+            self.users[5]._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_reporting_groups_restricted(self):
+        owners = get_case_owners(False, self.domain, [f'g__{self.group1._id}'])
+        self.assertListEqual(owners, [])
+
+    def test_case_sharing_groups(self):
+        owners = get_case_owners(True, self.domain, [f'g__{self.group2._id}'])
+        expected_owners = [
+            self.group2._id,
+            self.users[0]._id,
+            self.users[2]._id,
+            self.users[4]._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_case_sharing_groups_restricted(self):
+        owners = get_case_owners(False, self.domain, [f'g__{self.group2._id}'])
+        self.assertListEqual(owners, [])
+
+    def test_location_case_sharing(self):
+        location_id = self.locations['Brooklyn'].location_id
+        owners = get_case_owners(True, self.domain, [f'l__{location_id}'])
+        expected_owners = [
+            location_id,
+            self.users[4]._id,
+            self.users[5]._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_location_case_sharing_restricted(self):
+        location_id = self.locations['Brooklyn'].location_id
+        owners = get_case_owners(False, self.domain, [f'l__{location_id}'])
+        expected_owners = [
+            location_id,
+            self.users[4]._id,
+            self.users[5]._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_location_case_sharing_other_users(self):
+        location_id = self.locations['Brooklyn'].location_id
+        outside_user_id = self.users[2]._id
+        owners = get_case_owners(True, self.domain, [
+            f'l__{location_id}', f'u__{outside_user_id}'
+        ])
+        expected_owners = [
+            location_id,
+            self.locations['Middlesex'].location_id,
+            self.locations['Cambridge'].location_id,
+            self.locations['Somerville'].location_id,
+            self.users[2]._id,
+            self.users[4]._id,
+            self.users[5]._id,
+            self.group2._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_location_case_sharing_other_users_restricted(self):
+        location_id = self.locations['Brooklyn'].location_id
+        outside_user_id = self.users[2]._id
+        owners = get_case_owners(False, self.domain, [
+            f'l__{location_id}', f'u__{outside_user_id}'
+        ])
+        expected_owners = [
+            location_id,
+            self.locations['Middlesex'].location_id,
+            self.locations['Cambridge'].location_id,
+            self.locations['Somerville'].location_id,
+            self.users[2]._id,
+            self.users[4]._id,
+            self.users[5]._id,
+            self.group2._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_location_descendants(self):
+        location_id = self.locations['New York'].location_id
+        owners = get_case_owners(True, self.domain, [f'l__{location_id}'])
+        expected_owners = [
+            location_id,
+            self.locations['New York City'].location_id,
+            self.locations['Manhattan'].location_id,
+            self.locations['Brooklyn'].location_id,
+            self.locations['Queens'].location_id,
+            self.users[4]._id,
+            self.users[5]._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_location_descendants_restricted(self):
+        location_id = self.locations['New York'].location_id
+        owners = get_case_owners(False, self.domain, [f'l__{location_id}'])
+        expected_owners = [
+            location_id,
+            self.locations['New York City'].location_id,
+            self.locations['Manhattan'].location_id,
+            self.locations['Brooklyn'].location_id,
+            self.locations['Queens'].location_id,
+            self.users[4]._id,
+            self.users[5]._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_selected_user_ids(self):
+        selected_users = [
+            self.users[2],
+            self.users[0],
+        ]
+        owners = get_case_owners(
+            True, self.domain, [f'u__{u._id}' for u in selected_users]
+        )
+        expected_owners = [
+            self.locations['Massachusetts'].location_id,
+            self.locations['Middlesex'].location_id,
+            self.locations['Cambridge'].location_id,
+            self.locations['Somerville'].location_id,
+            self.locations['Suffolk'].location_id,
+            self.locations['Boston'].location_id,
+            self.locations['Revere'].location_id,
+            self.users[0]._id,
+            self.users[2]._id,
+            self.group2._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_selected_user_ids_restricted(self):
+        selected_users = [
+            self.users[2],
+            self.users[0],
+        ]
+        owners = get_case_owners(
+            False, self.domain, [f'u__{u._id}' for u in selected_users]
+        )
+        expected_owners = [
+            self.locations['Massachusetts'].location_id,
+            self.locations['Middlesex'].location_id,
+            self.locations['Cambridge'].location_id,
+            self.locations['Somerville'].location_id,
+            self.locations['Suffolk'].location_id,
+            self.locations['Boston'].location_id,
+            self.locations['Revere'].location_id,
+            self.users[0]._id,
+            self.users[2]._id,
+            self.group2._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_selected_web_user_ids(self):
+        selected_users = [
+            self.web_users[0],
+        ]
+        owners = get_case_owners(
+            True, self.domain, [f'u__{u._id}' for u in selected_users]
+        )
+        expected_owners = [
+            self.web_users[0]._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))
+
+    def test_selected_web_user_ids_restricted(self):
+        selected_users = [
+            self.web_users[0],
+        ]
+        owners = get_case_owners(
+            False, self.domain, [f'u__{u._id}' for u in selected_users]
+        )
+        expected_owners = [
+            self.web_users[0]._id,
+        ]
+        self.assertListEqual(sorted(owners), sorted(expected_owners))

--- a/corehq/apps/reports/v2/filters/case_report.py
+++ b/corehq/apps/reports/v2/filters/case_report.py
@@ -37,7 +37,7 @@ class CaseOwnerReportFilter(BaseReportFilter):
             return query.filter(deactivated_case_owners(self.domain))
 
         selected_user_types = [v['id'] for v in self.value]
-        case_owners = get_case_owners(self.request, self.domain, selected_user_types)
+        case_owners = get_case_owners(self.request.can_access_all_locations, self.domain, selected_user_types)
         return query.owner(case_owners)
 
 

--- a/custom/inddex/food.py
+++ b/custom/inddex/food.py
@@ -378,7 +378,7 @@ class FoodData:
                     .show_only_inactive()
                     .domain(domain)
                     .get_ids())
-        return get_case_owners(request, domain, slugs)
+        return get_case_owners(request.can_access_all_locations, domain, slugs)
 
     def _matches_in_memory_filters(self, row):
         # If a gap type is specified, show only rows with gaps of that type


### PR DESCRIPTION
## Technical Summary
This PR introduces the logic to filter an `ESQuery` (`CaseSearchES`, specifically) based on the values saved in the db. This is a followup to https://github.com/dimagi/commcare-hq/pull/35880).

In order to achieve this, I needed to modify the `get_case_owners` utility from reports to be `request`-agnostic. The change is straightforward and referenced in only a few places. I tested the `Case Owner(s)` filter locally on `Case List` and `Case List Explorer` and it works fine. I think the update is safe and small enough to merge without formal QA.

I also decided to take the opportunity (perhaps miscalculated in the amount of time it would take) to write tests for `get_case_owners`, since we have very few tests for our report filter components. 

While doing this I discovered a bug! The bug is: `get_case_owners` does not return `UnknownUser` and `AdminUser` types ([created here](https://github.com/dimagi/commcare-hq/blob/9a36a655aefeced6c1213d73d6d083349eaabbed/corehq/pillows/user.py#L19-L41)). However, I didn't solve this bug in this PR. I felt solving that bug introduced a slightly more substantial change, and I didn't want to block the Bulk Case Cleaning work from being merged. The bug fix is in [this commit](https://github.com/dimagi/commcare-hq/commit/1c8fef58433641b738d02e719cec94fbace1e2a5), which I will PR separately and put on staging after this PR is merged.


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
lots of thorough tests have been written for these changes. Most of the code only touches code behind a feature flag. However, `get_case_owners` was modified very slightly and its usages updated. The change for `get_case_owners` is very small and easily testable locally, so QA isn't needed.

### Automated test coverage
Yes. Lots of tests. I added nearly 100 tests!

### QA Plan
Not needed at this time.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
