### PR TITLE
Fix error preventing viewing application at specific version

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -148,6 +148,11 @@ def get_build_doc_by_version(domain, app_id, version):
     return get_build_by_version(domain, app_id, version, return_doc=True)
 
 
+def get_build_doc_by_build_id(build_id):
+    from .models import Application
+    return Application.get_db().get(build_id)
+
+
 def wrap_app(app_doc, wrap_cls=None):
     """Will raise DocTypeError if it can't figure out the correct class"""
     from corehq.apps.app_manager.util import get_correct_app_class

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -450,7 +450,10 @@ def get_all_apps(domain):
             include_docs=False,
             wrapper=lambda row: row['id'],
         )
-        correct_wrap = lambda app_doc: get_correct_app_class(app_doc).wrap(app_doc)
+
+        def correct_wrap(app_doc):
+            return get_correct_app_class(app_doc).wrap(app_doc)
+
         return map(correct_wrap, iter_docs(Application.get_db(), saved_app_ids))
 
     return chain(get_apps_in_domain(domain), _saved_apps())

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -341,11 +341,16 @@ hqDefine("app_manager/js/releases/releases", [
             return initialPageData.reverse.apply(null, arguments);
         };
         self.webAppsUrl = function (idObservable, copyOf) {
-            var url = initialPageData.reverse("formplayer_main"),
-                data = {
-                    appId: ko.utils.unwrapObservable(idObservable),
-                    copyOf: copyOf,
-                };
+            const buildId = ko.utils.unwrapObservable(idObservable);
+            var url = initialPageData.reverse(
+                "formplayer_main_view_build",
+                copyOf,
+                buildId,
+            );
+            var data = {
+                appId: buildId,
+                copyOf: copyOf,
+            };
 
             return url + '#' + encodeURI(JSON.stringify(data));
         };

--- a/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
@@ -57,6 +57,7 @@
   {% registerurl "download_multimedia_zip" app.domain '---' %}
   {% registerurl "project_report_dispatcher" app.domain 'application_error' %}
   {% registerurl "formplayer_main" app.domain %}
+  {% registerurl "formplayer_main_view_build" app.domain '---' '---' %}
   {% registerurl "app_form_summary" app.domain '---' %}
   <div class="tab-pane" id="releases">
     {% if show_release_mode %}

--- a/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
@@ -56,7 +56,6 @@
   {% registerurl "download_ccz" app.domain '---' %}
   {% registerurl "download_multimedia_zip" app.domain '---' %}
   {% registerurl "project_report_dispatcher" app.domain 'application_error' %}
-  {% registerurl "formplayer_main" app.domain %}
   {% registerurl "formplayer_main_view_build" app.domain '---' '---' %}
   {% registerurl "app_form_summary" app.domain '---' %}
   <div class="tab-pane" id="releases">

--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -16,6 +16,8 @@ from corehq.apps.hqwebapp.decorators import use_bootstrap5, waf_allow
 
 app_urls = [
     url(r'^v2/$', FormplayerMain.as_view(), name=FormplayerMain.urlname),
+    url(r'^v2/view_app/(?P<app_id>[\w-]+)/build/(?P<build_id>[\w-]+)/$', FormplayerMain.as_view(),
+        name='formplayer_main_view_build'),
     url(r'^v2/preview/$', FormplayerMainPreview.as_view(), name=FormplayerMainPreview.urlname),
     url(r'^preview_app/(?P<app_id>[\w-]+)/$', PreviewAppView.as_view(), name=PreviewAppView.urlname),
     url(r'^report_formplayer_error', report_formplayer_error, name='report_formplayer_error'),

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -1,9 +1,4 @@
-import json
-
 from django.conf import settings
-from django.urls import reverse
-
-from six.moves.urllib.parse import quote
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import (
@@ -73,30 +68,6 @@ def get_web_apps_available_to_user(domain, user, is_preview=False, fetch_app_fn=
 
 def should_show_preview_app(request, app, username):
     return not app.is_remote_app()
-
-
-def _webapps_url(domain, app_id, selections):
-    url = reverse('formplayer_main', args=[domain])
-    query_dict = {
-        'appId': app_id,
-        'selections': selections,
-        'page': None,
-        'search': None,
-    }
-    query_string = quote(json.dumps(query_dict))
-    return "{base_url}#{query}".format(base_url=url, query=query_string)
-
-
-def webapps_module_form_case(domain, app_id, module_id, form_id, case_id):
-    return _webapps_url(domain, app_id, selections=[module_id, form_id, case_id])
-
-
-def webapps_module_case_form(domain, app_id, module_id, case_id, form_id):
-    return _webapps_url(domain, app_id, selections=[module_id, case_id, form_id])
-
-
-def webapps_module(domain, app_id, module_id):
-    return _webapps_url(domain, app_id, selections=[module_id])
 
 
 @quickcache(['domain'], timeout=24 * 60 * 60)

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -7,8 +7,6 @@ from django.conf import settings
 from django.http import QueryDict
 from django.template import NodeList, TemplateSyntaxError, loader_tags
 from django.template.base import (
-    Token,
-    TokenType,
     Variable,
     VariableDoesNotExist,
 )
@@ -564,15 +562,15 @@ def is_new_user(user):
 
 
 @register.tag
-def registerurl(parser, token):
-    split_contents = token.split_contents()
+def registerurl(parser, original_token):
+    split_contents = original_token.split_contents()
     tag = split_contents[0]
     url_name = parse_literal(split_contents[1], parser, tag)
     expressions = [parser.compile_filter(arg) for arg in split_contents[2:]]
 
     class FakeNode(template.Node):
-        # must mock token or error handling code will fail and not reveal real error
-        token = Token(TokenType.TEXT, '', (0, 0), 0)
+        token = original_token
+        origin = parser.origin
 
         def render(self, context):
             args = [expression.resolve(context) for expression in expressions]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-15958.

From the app-builder version menu, if the user were to use the "Open in Web Apps" option, the opened web app would be the most recently released version, rather than the version requested. This PR fixes this behavior so that the desired build is opened instead.

## Feature Flag
No feature flag

## Safety Assurance

### Safety story
Locally tested:
- opening a non-released version using the above option works successfully
- opening apps directly through Web Apps still works as previous
- App Preview is unaffected
- switching users respects the requested build

### Automated test coverage
No tests

### QA Plan
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
