### PR TITLE
Change two-factor setup field to use TextInput widget

### DIFF
--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -188,7 +188,7 @@ class HQTOTPDeviceForm(TOTPDeviceForm):
         max_value=int('9' * totp_digits()),
         widget=forms.TextInput(
             attrs={
-                'pattern': r'^[0-9]{6}$',
+                'pattern': r'^[0-9]{%s}$' % totp_digits(),
                 'maxlength': totp_digits(),
                 'inputmode': 'numeric',
             }

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -190,6 +190,7 @@ class HQTOTPDeviceForm(TOTPDeviceForm):
             attrs={
                 'pattern': r'^[0-9]{6}$',
                 'maxlength': totp_digits(),
+                'inputmode': 'numeric',
             }
         ),
     )

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -181,7 +181,18 @@ class HQTwoFactorMethodForm(MethodForm):
 
 
 class HQTOTPDeviceForm(TOTPDeviceForm):
-    token = forms.IntegerField(required=False, label=_("Token"), min_value=1, max_value=int('9' * totp_digits()))
+    token = forms.IntegerField(
+        required=False,
+        label=_("Token"),
+        min_value=1,
+        max_value=int('9' * totp_digits()),
+        widget=forms.TextInput(
+            attrs={
+                'pattern': r'^[0-9]{6}$',
+                'maxlength': totp_digits(),
+            }
+        ),
+    )
 
     def __init__(self, key, user, **kwargs):
         super(HQTOTPDeviceForm, self).__init__(key, user, **kwargs)


### PR DESCRIPTION
## Product Description
Changes the two-factor setup field to use a text input.

## Technical Summary
[SAAS-16290](https://dimagi.atlassian.net/browse/SAAS-16290), related to #35874 but without causing [SAAS-16722](https://dimagi.atlassian.net/browse/SAAS-16722).
The issue with the previous change to a `RegexField` was that `TOTPDeviceForm` in the `two_factor` library expects `token` to be an integer, and it wasn't. This just changes the widget to a `TextInput`, but leaves the form field as an `IntegerField`, which django will cast to an integer while validating the form. Adds tests to ensure token validation works or fails as expected. 

## Safety Assurance

### Safety story
Added tests to ensure tokens entered in the form are still validated correctly and that the text input is cast to an integer. Tested on staging to see that enabling two-factor authentication is possible with the TextField input.

### Automated test coverage
Added `TestHQTOTPDeviceForm`.

### QA Plan
I don't think this is needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16290]: https://dimagi.atlassian.net/browse/SAAS-16290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-16722]: https://dimagi.atlassian.net/browse/SAAS-16722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ