### PR TITLE
Show retry date for records that will be retried

### DIFF
--- a/corehq/apps/cleanup/management/commands/fire_repeaters.py
+++ b/corehq/apps/cleanup/management/commands/fire_repeaters.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand
 
-from corehq.motech.repeaters.models import RepeatRecord, State
+from corehq.motech.repeaters.const import RECORD_QUEUED_STATES
+from corehq.motech.repeaters.models import RepeatRecord
 
 
 class Command(BaseCommand):
@@ -13,7 +14,7 @@ class Command(BaseCommand):
         records = RepeatRecord.objects.filter(
             domain=domain,
             next_check__isnull=False,
-            state__in=[State.Pending, State.Fail],
+            state__in=RECORD_QUEUED_STATES,
         )
         for record in records:
             record.fire(force_send=True)

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -134,7 +134,7 @@ from corehq.form_processor.backends.sql.dbaccessors import doc_type_to_state
 from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.form_processor.tests.utils import create_case, create_form_for_test
 from corehq.motech.models import ConnectionSettings, RequestLog
-from corehq.motech.repeaters.const import RECORD_SUCCESS_STATE
+from corehq.motech.repeaters.const import State
 from corehq.motech.repeaters.models import (
     CaseRepeater,
     Repeater,
@@ -1010,7 +1010,7 @@ class TestDeleteDomain(TestCase):
                 domain=domain_name,
                 registered_at=datetime.utcnow(),
             )
-            record.attempt_set.create(state=RECORD_SUCCESS_STATE)
+            record.attempt_set.create(state=State.Success)
             self._assert_repeaters_count(domain_name, 1)
             self.addCleanup(repeater.delete)
 

--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -35,14 +35,6 @@ class State(IntegerChoices):
     InvalidPayload = 32, _('Invalid Payload')  # Implies Cancelled.
 
 
-RECORD_PENDING_STATE = State.Pending
-RECORD_SUCCESS_STATE = State.Success
-RECORD_FAILURE_STATE = State.Fail
-RECORD_CANCELLED_STATE = State.Cancelled
-RECORD_EMPTY_STATE = State.Empty
-RECORD_INVALIDPAYLOAD_STATE = State.InvalidPayload
-
-
 class UCRRestrictionFFStatus(IntegerChoices):
     Enabled = 1, _('Is enabled')
     NotEnabled = 2, _('Is not enabled')

--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -35,6 +35,9 @@ class State(IntegerChoices):
     InvalidPayload = 32, _('Invalid Payload')  # Implies Cancelled.
 
 
+RECORD_QUEUED_STATES = (State.Pending, State.Fail)
+
+
 class UCRRestrictionFFStatus(IntegerChoices):
     Enabled = 1, _('Is enabled')
     NotEnabled = 2, _('Is not enabled')

--- a/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
@@ -6,10 +6,7 @@ from django.core.management.base import BaseCommand
 
 from memoized import memoized
 
-from corehq.motech.repeaters.const import (
-    RECORD_CANCELLED_STATE,
-    RECORD_SUCCESS_STATE,
-)
+from corehq.motech.repeaters.const import State
 from corehq.motech.repeaters.models import Repeater, RepeatRecord
 
 
@@ -34,7 +31,7 @@ class Command(BaseCommand):
     def most_recent_success(self):
         res = {}
         for record in RepeatRecord.objects.iterate(
-                self.domain, repeater_id=self.repeater_id, state=RECORD_SUCCESS_STATE):
+                self.domain, repeater_id=self.repeater_id, state=State.Success):
             if record.last_checked:
                 res[record.payload_id] = max(res.get(record.payload_id, datetime.datetime.min),
                                              record.last_checked)
@@ -48,7 +45,7 @@ class Command(BaseCommand):
 
         redundant_records = []
         records_by_payload_id = defaultdict(list)
-        records = RepeatRecord.objects.iterate(domain, repeater_id=repeater_id, state=RECORD_CANCELLED_STATE)
+        records = RepeatRecord.objects.iterate(domain, repeater_id=repeater_id, state=State.Cancelled)
         total_records = 0
         for record in records:
             total_records += 1

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -110,6 +110,7 @@ from .const import (
     MAX_RETRY_WAIT,
     PROCESS_REPEATERS_INTERVAL,
     RATE_LIMITER_DELAY_RANGE,
+    RECORD_QUEUED_STATES,
     State,
 )
 from .models import (
@@ -275,7 +276,7 @@ def _process_repeat_record(repeat_record):
                 # with the intent of avoiding clumping and spreading load
                 repeat_record.postpone_by(random.uniform(*RATE_LIMITER_DELAY_RANGE))
                 action = 'rate_limited'
-            elif repeat_record.is_queued():
+            elif repeat_record.state in RECORD_QUEUED_STATES:
                 report_repeater_attempt(repeat_record.repeater.repeater_id)
                 with timer('fire_timing') as fire_timer:
                     repeat_record.fire(timing_context=fire_timer)
@@ -430,7 +431,7 @@ def process_ready_repeat_record(repeat_record_id):
 def is_repeat_record_ready(repeat_record):
     # Fail loudly if repeat_record is not ready.
     # process_ready_repeat_record() will log an exception.
-    assert repeat_record.state in (State.Pending, State.Fail)
+    assert repeat_record.state in RECORD_QUEUED_STATES
 
     # The repeater could have been paused or rate-limited while it was
     # being processed

--- a/corehq/motech/repeaters/tests/test_display.py
+++ b/corehq/motech/repeaters/tests/test_display.py
@@ -54,6 +54,18 @@ class RepeaterTestCase(TestCase):
             )
             self.assertEqual(display.next_check, '2025-01-01 00:00:00')
 
+    def test_record_display_succeeded(self):
+        jan_1 = datetime.strptime('2025-01-01 00:00:00', self.date_format)
+        self.repeater.next_attempt_at = jan_1
+        with make_repeat_record(self.repeater, State.Success) as record:
+            display = RepeatRecordDisplay(
+                record,
+                pytz.UTC,
+                date_format=self.date_format,
+                process_repeaters_enabled=True,
+            )
+            self.assertEqual(display.next_check, '---')
+
     def test_record_display_repeater_paused(self):
         self.repeater.is_paused = True
         with make_repeat_record(self.repeater, State.Pending) as record:

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -22,6 +22,7 @@ from corehq.util.test_utils import _create_case, flag_enabled
 from ..const import (
     MAX_ATTEMPTS,
     MAX_BACKOFF_ATTEMPTS,
+    RECORD_QUEUED_STATES,
     State,
 )
 from ..models import (
@@ -858,7 +859,7 @@ class TestRepeatRecordManager(RepeaterTestCase):
 
     def make_records(self, n, domain=DOMAIN, state=State.Pending, payload_id="c0ffee"):
         now = timezone.now() - timedelta(seconds=10)
-        is_pending = state in [State.Pending, State.Fail]
+        is_pending = state in RECORD_QUEUED_STATES
         records = RepeatRecord.objects.bulk_create(RepeatRecord(
             domain=domain,
             repeater=self.repeater,

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -177,22 +177,28 @@ class RepeaterManagerTests(RepeaterTestCase):
             self.assertEqual(len(repeater_ids), 0)
 
     def test_all_ready_paused(self):
-        with make_repeat_record(self.repeater, State.Pending), \
-                pause(self.repeater):
+        with (
+            make_repeat_record(self.repeater, State.Pending),
+            pause(self.repeater)
+        ):
             repeater_ids = Repeater.objects.get_all_ready_ids_by_domain()
             self.assertEqual(len(repeater_ids), 0)
 
     def test_all_ready_next_future(self):
         in_five_mins = timezone.now() + timedelta(minutes=5)
-        with make_repeat_record(self.repeater, State.Pending), \
-                set_next_attempt_at(self.repeater, in_five_mins):
+        with (
+            make_repeat_record(self.repeater, State.Pending),
+            set_next_attempt_at(self.repeater, in_five_mins)
+        ):
             repeater_ids = Repeater.objects.get_all_ready_ids_by_domain()
             self.assertEqual(len(repeater_ids), 0)
 
     def test_all_ready_next_past(self):
         five_mins_ago = timezone.now() - timedelta(minutes=5)
-        with make_repeat_record(self.repeater, State.Pending), \
-                set_next_attempt_at(self.repeater, five_mins_ago):
+        with (
+            make_repeat_record(self.repeater, State.Pending),
+            set_next_attempt_at(self.repeater, five_mins_ago)
+        ):
             repeater_ids = Repeater.objects.get_all_ready_ids_by_domain()
             self.assertEqual(
                 dict(repeater_ids),
@@ -977,8 +983,10 @@ class TestRepeatRecordMethodsNoDB(SimpleTestCase):
             state=State.Fail
         )
 
-        with patch.object(RepeatRecord, "num_attempts", 0), \
-                patch.object(repeat_record, "max_possible_tries", 1):
+        with (
+            patch.object(RepeatRecord, "num_attempts", 0),
+            patch.object(repeat_record, "max_possible_tries", 1)
+        ):
             self.assertFalse(repeat_record.exceeded_max_retries)
 
     def test_exceeded_max_retries_returns_true_if_equal(self):
@@ -989,8 +997,10 @@ class TestRepeatRecordMethodsNoDB(SimpleTestCase):
             state=State.Fail
         )
 
-        with patch.object(RepeatRecord, "num_attempts", 1), \
-                patch.object(repeat_record, "max_possible_tries", 1):
+        with (
+            patch.object(RepeatRecord, "num_attempts", 1),
+            patch.object(repeat_record, "max_possible_tries", 1)
+        ):
             self.assertTrue(repeat_record.exceeded_max_retries)
 
     def test_exceeded_max_retries_returns_true_if_more_tries_than_possible(self):
@@ -1001,8 +1011,10 @@ class TestRepeatRecordMethodsNoDB(SimpleTestCase):
             state=State.Fail
         )
 
-        with patch.object(RepeatRecord, "num_attempts", 2), \
-                patch.object(repeat_record, "max_possible_tries", 1):
+        with (
+            patch.object(RepeatRecord, "num_attempts", 2),
+            patch.object(repeat_record, "max_possible_tries", 1)
+        ):
             self.assertTrue(repeat_record.exceeded_max_retries)
 
     def test_exceeded_max_retries_returns_false_if_not_failure_state(
@@ -1014,8 +1026,10 @@ class TestRepeatRecordMethodsNoDB(SimpleTestCase):
             state=State.Success,
         )
 
-        with patch.object(RepeatRecord, "num_attempts", 2), \
-                patch.object(repeat_record, "max_possible_tries", 1):
+        with (
+            patch.object(RepeatRecord, "num_attempts", 2),
+            patch.object(repeat_record, "max_possible_tries", 1)
+        ):
             self.assertFalse(repeat_record.exceeded_max_retries)
 
 

--- a/corehq/motech/repeaters/tests/test_models_slow.py
+++ b/corehq/motech/repeaters/tests/test_models_slow.py
@@ -15,10 +15,7 @@ from corehq.apps.accounting.utils import clear_plan_version_cache
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.motech.models import ConnectionSettings
-from corehq.motech.repeaters.const import (
-    RECORD_FAILURE_STATE,
-    RECORD_SUCCESS_STATE,
-)
+from corehq.motech.repeaters.const import State
 from corehq.motech.repeaters.models import FormRepeater
 from corehq.util.test_utils import timelimit
 
@@ -70,7 +67,7 @@ class ServerErrorTests(TestCase, DomainSubscriptionMixin):
             self.repeat_record.fire()
 
             self.assertEqual(self.repeat_record.attempts.last().state,
-                             RECORD_SUCCESS_STATE)
+                             State.Success)
             repeater = self.reget_repeater()
             repeat_record = repeater.repeat_records.last()
             self.assertIsNone(repeat_record.next_check)
@@ -83,7 +80,7 @@ class ServerErrorTests(TestCase, DomainSubscriptionMixin):
             self.repeat_record.fire()
 
             self.assertEqual(self.repeat_record.attempts.last().state,
-                             RECORD_FAILURE_STATE)
+                             State.Fail)
             repeater = self.reget_repeater()
             repeat_record = repeater.repeat_records.last()
             # Trying tomorrow is just as likely to work as in 5 minutes
@@ -97,7 +94,7 @@ class ServerErrorTests(TestCase, DomainSubscriptionMixin):
             self.repeat_record.fire()
 
             self.assertEqual(self.repeat_record.attempts.last().state,
-                             RECORD_FAILURE_STATE)
+                             State.Fail)
             repeater = self.reget_repeater()
             repeat_record = repeater.repeat_records.last()
             self.assertIsNotNone(repeat_record.next_check)
@@ -133,7 +130,7 @@ class ServerErrorTests(TestCase, DomainSubscriptionMixin):
             self.repeat_record.fire()
 
             self.assertEqual(self.repeat_record.attempts.last().state,
-                             RECORD_FAILURE_STATE)
+                             State.Fail)
             repeater = self.reget_repeater()
             repeat_record = repeater.repeat_records.last()
             self.assertIsNotNone(repeat_record.next_check)
@@ -145,7 +142,7 @@ class ServerErrorTests(TestCase, DomainSubscriptionMixin):
             self.repeat_record.fire()
 
             self.assertEqual(self.repeat_record.attempts.last().state,
-                             RECORD_FAILURE_STATE)
+                             State.Fail)
             repeater = self.reget_repeater()
             repeat_record = repeater.repeat_records.last()
             self.assertIsNotNone(repeat_record.next_check)

--- a/corehq/motech/repeaters/views/repeat_record_display.py
+++ b/corehq/motech/repeaters/views/repeat_record_display.py
@@ -37,6 +37,8 @@ class RepeatRecordDisplay:
 
     @property
     def next_check(self):
+        if self.record.state not in (RECORD_PENDING_STATE, RECORD_FAILURE_STATE):
+            return '---'
         if self.record.repeater.is_paused:
             return _('Paused')
         if self.process_repeaters_enabled:

--- a/corehq/motech/repeaters/views/repeat_record_display.py
+++ b/corehq/motech/repeaters/views/repeat_record_display.py
@@ -1,7 +1,7 @@
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 
-from corehq.motech.repeaters.const import State
+from corehq.motech.repeaters.const import RECORD_QUEUED_STATES, State
 from corehq.util.timezones.conversions import ServerTime
 
 MISSING_VALUE = '---'
@@ -30,7 +30,7 @@ class RepeatRecordDisplay:
 
     @property
     def next_check(self):
-        if self.record.state not in (State.Pending, State.Fail):
+        if self.record.state not in RECORD_QUEUED_STATES:
             return '---'
         if self.record.repeater.is_paused:
             return _('Paused')

--- a/corehq/motech/repeaters/views/repeat_record_display.py
+++ b/corehq/motech/repeaters/views/repeat_record_display.py
@@ -1,14 +1,7 @@
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 
-from corehq.motech.repeaters.const import (
-    RECORD_CANCELLED_STATE,
-    RECORD_EMPTY_STATE,
-    RECORD_FAILURE_STATE,
-    RECORD_INVALIDPAYLOAD_STATE,
-    RECORD_PENDING_STATE,
-    RECORD_SUCCESS_STATE,
-)
+from corehq.motech.repeaters.const import State
 from corehq.util.timezones.conversions import ServerTime
 
 MISSING_VALUE = '---'
@@ -37,7 +30,7 @@ class RepeatRecordDisplay:
 
     @property
     def next_check(self):
-        if self.record.state not in (RECORD_PENDING_STATE, RECORD_FAILURE_STATE):
+        if self.record.state not in (State.Pending, State.Fail):
             return '---'
         if self.record.repeater.is_paused:
             return _('Paused')
@@ -71,22 +64,22 @@ class RepeatRecordDisplay:
 
 
 def _get_state_tuple(record):
-    if record.state == RECORD_SUCCESS_STATE:
+    if record.state == State.Success:
         label_cls = 'success'
         label_text = _('Success')
-    elif record.state == RECORD_PENDING_STATE:
+    elif record.state == State.Pending:
         label_cls = 'warning'
         label_text = _('Pending')
-    elif record.state == RECORD_CANCELLED_STATE:
+    elif record.state == State.Cancelled:
         label_cls = 'danger'
         label_text = _('Cancelled')
-    elif record.state == RECORD_FAILURE_STATE:
+    elif record.state == State.Fail:
         label_cls = 'danger'
         label_text = _('Failed')
-    elif record.state == RECORD_EMPTY_STATE:
+    elif record.state == State.Empty:
         label_cls = 'success'
         label_text = _('Empty')
-    elif record.state == RECORD_INVALIDPAYLOAD_STATE:
+    elif record.state == State.InvalidPayload:
         label_cls = 'danger'
         label_text = _('Invalid Payload')
     else:

--- a/corehq/motech/repeaters/views/repeat_record_display.py
+++ b/corehq/motech/repeaters/views/repeat_record_display.py
@@ -55,7 +55,8 @@ class RepeatRecordDisplay:
 
     @property
     def state(self):
-        return format_html('<span class="label label-{}">{}</span>', *_get_state_tuple(self.record))
+        label_cls, label_text = _get_state_tuple(self.record)
+        return format_html(f'<span class="label label-{label_cls}">{label_text}</span>')
 
     def _format_date(self, date):
         if not date:
@@ -64,26 +65,12 @@ class RepeatRecordDisplay:
 
 
 def _get_state_tuple(record):
-    if record.state == State.Success:
-        label_cls = 'success'
-        label_text = _('Success')
-    elif record.state == State.Pending:
-        label_cls = 'warning'
-        label_text = _('Pending')
-    elif record.state == State.Cancelled:
-        label_cls = 'danger'
-        label_text = _('Cancelled')
-    elif record.state == State.Fail:
-        label_cls = 'danger'
-        label_text = _('Failed')
-    elif record.state == State.Empty:
-        label_cls = 'success'
-        label_text = _('Empty')
-    elif record.state == State.InvalidPayload:
-        label_cls = 'danger'
-        label_text = _('Invalid Payload')
-    else:
-        label_cls = ''
-        label_text = ''
-
-    return label_cls, label_text
+    state_map = {
+        State.Success: ('success', _('Success')),
+        State.Pending: ('warning', _('Pending')),
+        State.Cancelled: ('danger', _('Cancelled')),
+        State.Fail: ('danger', _('Failed')),
+        State.Empty: ('success', _('Empty')),
+        State.InvalidPayload: ('danger', _('Invalid payload')),
+    }
+    return state_map.get(record.state, ('', ''))

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -40,7 +40,7 @@ from corehq.motech.dhis2.repeaters import Dhis2EntityRepeater
 from corehq.motech.dhis2.parse_response import get_errors, get_diagnosis_message
 from corehq.motech.models import RequestLog
 
-from ..const import State, RECORD_CANCELLED_STATE
+from ..const import State
 from ..models import RepeatRecord
 from ..exceptions import BulkActionMissingParameters
 from .repeat_record_display import RepeatRecordDisplay
@@ -213,7 +213,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
             self._make_resend_payload_button(record.id),
         ]
 
-        if record.state == RECORD_CANCELLED_STATE:
+        if record.state == State.Cancelled:
             row.append(self._make_requeue_payload_button(record.id))
         elif record.is_queued():
             row.append(self._make_cancel_payload_button(record.id))

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -24,13 +24,9 @@ from corehq.apps.users.models import HqPermissions
 from corehq.motech.const import PASSWORD_PLACEHOLDER
 from corehq.motech.models import ConnectionSettings
 
-from ..const import State
+from ..const import RECORD_QUEUED_STATES, State
 from ..forms import CaseRepeaterForm, FormRepeaterForm, GenericRepeaterForm
-from ..models import (
-    Repeater,
-    RepeatRecord,
-    get_all_repeater_types,
-)
+from ..models import Repeater, RepeatRecord, get_all_repeater_types
 
 RepeaterTypeInfo = namedtuple('RepeaterTypeInfo',
                               'class_name friendly_name has_config instances')
@@ -79,7 +75,7 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
             'pending_record_count': sum(
                 count for repeater_id, states in state_counts.items()
                 for state, count in states.items()
-                if state == State.Pending or state == State.Fail
+                if state in RECORD_QUEUED_STATES
             ),
             'user_can_configure': (
                 self.request.couch_user.is_superuser


### PR DESCRIPTION
## Technical Summary

Context:
  * [SC-4352](https://dimagi.atlassian.net/browse/SC-4352)
  * [QA-7534](https://dimagi.atlassian.net/browse/QA-7534)

Small.

When the `PROCESS_REPEATERS` feature flag is enabled, the repeat records report shows values for "Retry Date" for repeat records that are not going to be retried (because they have succeeded, have been cancelled, etc.)

This change fixes that.

![image](https://github.com/user-attachments/assets/e184a97a-f1ea-4f6b-819e-b57158bad6ff)


## Feature Flag

PROCESS_REPEATERS

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Test included

### QA Plan

Discovered by [QA-7534](https://dimagi.atlassian.net/browse/QA-7534)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-4352]: https://dimagi.atlassian.net/browse/SC-4352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QA-7534]: https://dimagi.atlassian.net/browse/QA-7534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QA-7534]: https://dimagi.atlassian.net/browse/QA-7534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ