### PR TITLE
Show Dashboard link even if project has no apps

### DIFF
--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -27,7 +27,6 @@ from corehq.apps.accounting.views import (
     TriggerRemovedSsoUserAutoDeactivationView,
 )
 from corehq.apps.app_manager.dbaccessors import (
-    domain_has_apps,
     get_brief_apps_in_domain,
 )
 from corehq.apps.app_manager.util import is_remote_app, is_linked_app
@@ -311,11 +310,8 @@ class DashboardTab(UITab):
     @property
     def _is_viewable(self):
         if self.domain and self.project and not self.project.is_snapshot and self.couch_user:
-            if self.couch_user.is_commcare_user():
-                # never show the dashboard for mobile workers
-                return False
-            else:
-                return domain_has_apps(self.domain)
+            # never show the dashboard for mobile workers
+            return not self.couch_user.is_commcare_user()
         return False
 
     @property


### PR DESCRIPTION
## Product Description
Makes the Dashboard navbar link visible on projects that don't have any applications. This is particularly relevant because new projects no longer have default template apps and therefore wouldn't see this link, which may be confusing for new users trying to navigate the platform.
![image](https://github.com/user-attachments/assets/1e1452b6-d699-44fd-9bf7-6a89d754e6a6)


## Technical Summary
[SAAS-16734](https://dimagi.atlassian.net/browse/SAAS-16734)

## Safety Assurance

### Safety story
This just increases the number of projects seeing a link that the vast majority of projects already see. Tested locally to see it has the intended effect.

### Automated test coverage
Not for this particular link visibility.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16734]: https://dimagi.atlassian.net/browse/SAAS-16734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ