### PR TITLE
Do not leave domain tombstone if there is an error in subscription set up.

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1257,7 +1257,7 @@ class Subscription(models.Model):
         from corehq.apps.accounting.mixins import get_overdue_invoice
 
         super(Subscription, self).save(*args, **kwargs)
-        Subscription._get_active_subscription_by_domain.clear(Subscription, self.subscriber.domain)
+        Subscription.clear_caches(self.subscriber.domain)
         get_overdue_invoice.clear(self.subscriber.domain)
 
         domain = Domain.get_by_name(self.subscriber.domain)
@@ -1268,7 +1268,11 @@ class Subscription(models.Model):
 
     def delete(self, *args, **kwargs):
         super(Subscription, self).delete(*args, **kwargs)
-        Subscription._get_active_subscription_by_domain.clear(Subscription, self.subscriber.domain)
+        Subscription.clear_caches(self.subscriber.domain)
+
+    @classmethod
+    def clear_caches(cls, domain_name):
+        cls._get_active_subscription_by_domain.clear(cls, domain_name)
 
     @property
     def is_community(self):

--- a/corehq/apps/accounting/tests/utils.py
+++ b/corehq/apps/accounting/tests/utils.py
@@ -60,7 +60,7 @@ class DomainSubscriptionMixin(object):
             cls.__subscriptions[domain].delete()
             cls.__accounts[domain].delete()
         finally:
-            Subscription._get_active_subscription_by_domain.clear(Subscription, domain)
+            Subscription.clear_caches(domain)
 
 
 @contextmanager

--- a/corehq/apps/api/tests/test_ucr_resources.py
+++ b/corehq/apps/api/tests/test_ucr_resources.py
@@ -418,7 +418,7 @@ class TestUCRPaginated(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.domain = Domain.get_or_create_with_name('qwerty', is_active=True)
-        cls.addClassCleanup(Subscription._get_active_subscription_by_domain.clear, Subscription, cls.domain.name)
+        cls.addClassCleanup(Subscription.clear_caches, cls.domain.name)
         cls.addClassCleanup(cls.domain.delete)
         cls.username = 'rudolph@qwerty.commcarehq.org'
         cls.password = '***'

--- a/corehq/apps/api/tests/utils.py
+++ b/corehq/apps/api/tests/utils.py
@@ -76,7 +76,7 @@ class APIResourceTest(TestCase, metaclass=PatchMeta):
 
         Role.get_cache().clear()
         cls.domain = Domain.get_or_create_with_name('qwerty', is_active=True)
-        cls.addClassCleanup(Subscription._get_active_subscription_by_domain.clear, Subscription, cls.domain.name)
+        cls.addClassCleanup(Subscription.clear_caches, cls.domain.name)
         cls.addClassCleanup(cls.domain.delete)
         cls.list_endpoint = cls._get_list_endpoint()
         cls.username = 'rudolph@qwerty.commcarehq.org'

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -781,10 +781,9 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
             'domain/copied_from_snapshot', keys=[s._id for s in self.copied_from.snapshots()], include_docs=True
         )
 
-    def delete(self, leave_tombstone=False):
-        if not leave_tombstone and not settings.UNIT_TESTING:
-            raise ValueError(
-                'Cannot delete domain without leaving a tombstone except during testing')
+    def delete(self, *, leave_tombstone):
+        # The default vaule of leave_tombstone is set to False for tests.
+        # This can be temporarily undone with @suspend(domain_tombstones_patch)
         self._pre_delete()
         if leave_tombstone:
             domain = self.get(self._id)

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -68,6 +68,11 @@ from corehq.apps.data_interfaces.models import (
     CaseRuleSubmission,
     DomainCaseRuleRun,
 )
+from corehq.apps.domain.dbaccessors import (
+    deleted_domain_exists,
+    domain_exists,
+    domain_or_deleted_domain_exists,
+)
 from corehq.apps.domain.deletion import DOMAIN_DELETE_OPERATIONS
 from corehq.apps.domain.models import Domain, TransferDomainRequest
 from corehq.apps.es import case_adapter, case_search_adapter, form_adapter
@@ -147,7 +152,7 @@ from corehq.util.test_utils import flag_enabled
 from settings import HQ_ACCOUNT_ROOT
 
 from .. import deletion as mod
-from .test_utils import delete_es_docs_patch, suspend
+from .test_utils import delete_es_docs_patch, domain_tombstone_patch, suspend
 
 
 class TestDeleteDomain(TestCase):
@@ -1074,6 +1079,28 @@ class TestDeleteDomain(TestCase):
         self.assertEqual(count_lookup_table_row_owners(self.domain2.name), 1)
 
 
+@suspend(domain_tombstone_patch)
+class TestDomainTombstones(TestCase):
+
+    def setUp(self):
+        self.domain = Domain(name="test", is_active=True)
+        self.domain.save()
+        self.addCleanup(ensure_deleted, self.domain)
+
+    def test_delete_domain_leave_tombstone_argument_is_required(self):
+        with self.assertRaises(TypeError):
+            self.domain.delete()
+        self.assertTrue(domain_exists("test"))
+
+    def test_delete_domain_leave_tombstone(self):
+        self.domain.delete(leave_tombstone=True)
+        self.assertTrue(deleted_domain_exists("test"))
+
+    def test_delete_domain_dont_leave_tombstone(self):
+        self.domain.delete(leave_tombstone=False)
+        self.assertFalse(domain_or_deleted_domain_exists("test"))
+
+
 class HardDeleteFormsAndCasesInDomainTests(TestCase):
 
     def test_normal_forms_are_deleted(self):
@@ -1233,7 +1260,7 @@ def ensure_deleted(domain):
         with ExitStack() as stack:
             for op in DOMAIN_DELETE_OPERATIONS:
                 stack.enter_context(patch.object(op, "execute", make_exe(op)))
-            domain.delete()
+            domain.delete(leave_tombstone=False)
 
 
 def get_product_plan_version(edition=SoftwarePlanEdition.ADVANCED):

--- a/corehq/apps/domain/tests/test_utils.py
+++ b/corehq/apps/domain/tests/test_utils.py
@@ -1,4 +1,5 @@
 import json
+from functools import wraps
 from contextlib import contextmanager
 from random import randint
 from unittest.mock import patch
@@ -19,6 +20,7 @@ from corehq.apps.domain.utils import (
 from corehq.apps.users.models import CommCareUser
 from corehq.motech.utils import b64_aes_decrypt
 from corehq.tests.tools import nottest
+from corehq.tests.util.context import testcontextmanager
 from corehq.util.test_utils import generate_cases, unit_testing_only
 
 
@@ -219,21 +221,31 @@ class IsDomainInUseTests(SimpleTestCase):
         self.addCleanup(self.get_by_name_patcher.stop)
 
 
+@wraps(Domain.delete)
+@unit_testing_only
+def _delete_test_domain(self, leave_tombstone=False):
+    return _delete_test_domain.__wrapped__(self, leave_tombstone=leave_tombstone)
+
+
 delete_es_docs_patch = patch('corehq.apps.domain.deletion._delete_es_docs')
+domain_tombstone_patch = patch.object(Domain, 'delete', _delete_test_domain)
 
 
 def patch_domain_deletion():
-    """Do not delete docs in Elasticsearch when deleting a domain
+    """Setup domain deletion for tests
+
+    - Do not create a tombstone (unless requested) when deleting a domain.
+    - Do not delete docs in Elasticsearch when deleting a domain
 
     Without this, every test that deletes a domain would need to be
-    decorated with `@es_test`.
+    decorated with `@es_test` and call .delete(leave_tombstone=False)
     """
     # Use __enter__ and __exit__ to start/stop so patch.stopall() does not stop it.
     assert settings.UNIT_TESTING
     delete_es_docs_patch.__enter__()
+    domain_tombstone_patch.__enter__()
 
 
-@contextmanager
 def suspend(patch_obj):
     """Contextmanager/decorator to suspend an active patch
 
@@ -248,9 +260,13 @@ def suspend(patch_obj):
         with suspend(delete_es_docs_patch):
             ...  # do thing with ES docs deletion
     """
-    assert settings.UNIT_TESTING
-    patch_obj.__exit__(None, None, None)
-    try:
-        yield
-    finally:
-        patch_obj.__enter__()
+    @testcontextmanager
+    def suspend_patch():
+        assert settings.UNIT_TESTING
+        patch_obj.__exit__(None, None, None)
+        try:
+            yield
+        finally:
+            patch_obj.__enter__()
+
+    return suspend_patch

--- a/corehq/apps/registration/tests/test_utils.py
+++ b/corehq/apps/registration/tests/test_utils.py
@@ -31,7 +31,7 @@ _get_or_create = type(BillingContactInfo.objects).get_or_create
 
 
 def _issue_initializing_domain(self, *args, **kwargs):
-    # Create object, then raise excpetion. This will cause
+    # Create object, then raise exception. This will cause
     # _setup_subscription to fail, but SQL objects related to the domain
     # will have been saved to the database. They should be cleaned up on
     # transaction rollback caused by the exception.

--- a/corehq/apps/registration/tests/test_utils.py
+++ b/corehq/apps/registration/tests/test_utils.py
@@ -32,98 +32,91 @@ def _noop(*args, **kwargs):
     pass
 
 
+@mock.patch('corehq.apps.registration.utils.notify_exception', _noop)
 class TestRequestNewDomain(TestCase):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.new_user = WebUser.create(
-            None, 'new@dimagi.org', 'testpwd', None, None
-        )
+        cls.username = 'new@dimagi.org'
         cls.request = RequestFactory().get('/registration')
-        django_user = User.objects.get(username=cls.new_user.username)
-        cls.request.user = django_user
         cls.domain_sso_test = 'test-sso-1'
         cls.domain_test = 'test-1'
+
+    def setUp(self):
+        def delete_user_if_exists():
+            user = WebUser.get_by_username(self.username)
+            if user is not None:
+                # normally it will be deleted when the domain is deleted
+                user.delete(None, None)
+        self.new_user = WebUser.create(None, self.username, 'testpwd', None, None)
+        self.request.user = User.objects.get(username=self.username)
+        self.addClassCleanup(delete_user_if_exists)
 
     def tearDown(self):
         subscribed_domains = [self.domain_sso_test, self.domain_test]
         for domain in subscribed_domains:
-            Subscription._get_active_subscription_by_domain.clear(
-                Subscription,
-                domain
-            )
-        SelfSignupWorkflow.objects.filter(domain__in=subscribed_domains).delete()
-
-        failed_subscribed_domains = ['subscription-failed', 'init-default-roles-failed']
-        for test_domain in failed_subscribed_domains:
-            domain = Domain.get_by_name(test_domain)
-            if domain is not None:
-                domain.delete()
-
+            Subscription._get_active_subscription_by_domain.clear(Subscription, domain)
+            SelfSignupWorkflow.get_in_progress_for_domain.clear(SelfSignupWorkflow, domain)
         super().tearDown()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.new_user.delete(cls.domain_test, deleted_by=None)
-        super().tearDownClass()
 
     # if we don't patch the following, NoBrokersAvailable is thrown due to publish_domain_saved
     @mock.patch('corehq.apps.registration.utils._setup_subscription', _noop)
-    @mock.patch('corehq.apps.registration.utils.notify_exception', _noop)
     def test_domain_is_active_for_new_sso_user(self):
         """
         Ensure that the first domain created by a new SSO user is active.
         """
+        self.addCleanup(_cleanup_domain, 'test-sso-1')
         domain_name = request_new_domain(
             self.request,
             'test-sso-1',
             is_new_user=True,
             is_new_sso_user=True,
         )
+        self.addCleanup(_cleanup_domain, domain_name)  # possibly not 'test-sso-1'
         domain = Domain.get_by_name(domain_name)
         self.assertTrue(domain.is_active)
 
     # if we don't patch the following, NoBrokersAvailable is thrown due to publish_domain_saved
     @mock.patch('corehq.apps.registration.utils._setup_subscription', _noop)
-    @mock.patch('corehq.apps.registration.utils.notify_exception', _noop)
     def test_domain_is_not_active_for_new_user(self):
         """
         Ensure that the first domain created by a new user is not active.
         """
+        self.addCleanup(_cleanup_domain, 'test-sso-2')
         domain_name = request_new_domain(
             self.request,
             'test-sso-2',
             is_new_user=True,
         )
+        self.addCleanup(_cleanup_domain, domain_name)  # possibly not 'test-sso-2'
         domain = Domain.get_by_name(domain_name)
         self.assertFalse(domain.is_active)
 
     @suspend(domain_tombstone_patch)
     @mock.patch('corehq.apps.registration.utils._setup_subscription', _issue_initializing_domain)
-    @mock.patch('corehq.apps.registration.utils.notify_exception', _noop)
     def test_subscription_exception_raises_error_and_domain_is_deleted(self):
         # We want to ensure that errors during the Subscription initialization process
         # do not result in incomplete domains (a domain without a Subscription)
+        domain_name = 'subscription-failed'
+        self.addCleanup(_cleanup_domain, domain_name)
         with self.assertRaisesMessage(ErrorInitializingDomain,
                                       "Subscription setup failed for 'subscription-failed'"):
-            request_new_domain(
-                self.request,
-                'subscription-failed',
-                is_new_user=True,
-            )
-        self.assertFalse(domain_or_deleted_domain_exists('subscription-failed'))
+            request_new_domain(self.request, domain_name, is_new_user=True)
+
+        self.assertFalse(domain_or_deleted_domain_exists(domain_name))
 
     @mock.patch('corehq.apps.registration.utils._setup_subscription', _noop)
-    @mock.patch('corehq.apps.registration.utils.notify_exception', _noop)
     @mock.patch('django.conf.settings.IS_SAAS_ENVIRONMENT', True)
     def test_saas_environment_creates_self_signup_workflow(self):
-        request_new_domain(
+        self.addCleanup(_cleanup_domain, self.domain_test)
+        domain_name = request_new_domain(
             self.request,
             self.domain_test,
             is_new_user=True,
         )
-        workflow = SelfSignupWorkflow.get_in_progress_for_domain(self.domain_test)
+        self.addCleanup(_cleanup_domain, domain_name)  # possibly not self.domain_test
+        workflow = SelfSignupWorkflow.get_in_progress_for_domain(domain_name)
         self.assertIsInstance(workflow, SelfSignupWorkflow)
         self.assertEqual(workflow.initiating_user, self.new_user.username)
 
@@ -162,3 +155,9 @@ class TestUsingProjectLogoInEmails(TestCase):
             project_logo_emails_context(self.domain),
             {}
         )
+
+
+def _cleanup_domain(name):
+    domain = Domain.get_by_name(name)
+    if domain is not None:
+        domain.delete(leave_tombstone=False)

--- a/corehq/apps/registration/tests/test_utils.py
+++ b/corehq/apps/registration/tests/test_utils.py
@@ -56,7 +56,7 @@ class TestRequestNewDomain(TestCase):
     def tearDown(self):
         subscribed_domains = [self.domain_sso_test, self.domain_test]
         for domain in subscribed_domains:
-            Subscription._get_active_subscription_by_domain.clear(Subscription, domain)
+            Subscription.clear_caches(domain)
             SelfSignupWorkflow.get_in_progress_for_domain.clear(SelfSignupWorkflow, domain)
         super().tearDown()
 

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -16,6 +16,7 @@ from dimagi.utils.web import get_ip, get_static_url_prefix, get_url_base
 from corehq.apps.accounting.models import (
     BillingAccount,
     BillingContactInfo,
+    Subscription,
     SubscriptionAdjustmentMethod,
 )
 from corehq.apps.accounting.utils.subscription import (
@@ -168,6 +169,7 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
                 'first_domain_for_user': is_new_user,
                 'error': str(error),
             })
+            Subscription.clear_caches(new_domain.name)
             # It is safe to delete the domain without leaving a tombstone
             # because the domain was just created.
             new_domain.delete(leave_tombstone=False)
@@ -214,16 +216,19 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
 
 def _setup_subscription(domain_name, user, company_name):
     with transaction.atomic():
+        # All subscription objects related to the domain must be created
+        # within this transaction block so they are discarded if an
+        # error occurs.
         ensure_community_or_paused_subscription(
             domain_name, date.today(), SubscriptionAdjustmentMethod.USER,
             web_user=user.username,
         )
 
-    # add user's email as contact email for billing account for the domain
-    account = BillingAccount.get_account_by_domain(domain_name)
-    billing_contact, _ = BillingContactInfo.objects.get_or_create(account=account, company_name=company_name)
-    billing_contact.email_list = [user.email]
-    billing_contact.save()
+        # add user's email as contact email for billing account for the domain
+        account = BillingAccount.get_account_by_domain(domain_name)
+        billing_contact, _ = BillingContactInfo.objects.get_or_create(account=account, company_name=company_name)
+        billing_contact.email_list = [user.email]
+        billing_contact.save()
 
 
 def send_new_request_update_email(user, requesting_ip, entity_name, entity_type="domain",

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -168,7 +168,9 @@ def request_new_domain(request, project_name, is_new_user=True, is_new_sso_user=
                 'first_domain_for_user': is_new_user,
                 'error': str(error),
             })
-            new_domain.delete(leave_tombstone=True)
+            # It is safe to delete the domain without leaving a tombstone
+            # because the domain was just created.
+            new_domain.delete(leave_tombstone=False)
             raise ErrorInitializingDomain(f"Subscription setup failed for '{name}'")
 
         if settings.IS_SAAS_ENVIRONMENT:

--- a/corehq/apps/sms/tests/test_backfill_subevent.py
+++ b/corehq/apps/sms/tests/test_backfill_subevent.py
@@ -25,7 +25,7 @@ class TestBackfillSubevent(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.domain = Domain.get_or_create_with_name("backfill-test", is_active=True)
-        cls.addClassCleanup(Subscription._get_active_subscription_by_domain.clear, Subscription, cls.domain.name)
+        cls.addClassCleanup(Subscription.clear_caches, cls.domain.name)
         cls.addClassCleanup(cls.domain.delete)
 
     def test_update_from_email(self):

--- a/corehq/tests/util/context.py
+++ b/corehq/tests/util/context.py
@@ -1,4 +1,8 @@
+from contextlib import contextmanager
+from functools import partial, wraps
 from unittest import TestCase
+
+from corehq.tests.tools import nottest
 
 
 def add_context(context_manager, testcase):
@@ -16,3 +20,79 @@ def add_context(context_manager, testcase):
     else:
         testcase.addCleanup(context_manager.__exit__, None, None, None)
     return result
+
+
+@nottest
+def testcontextmanager(func=None, /, before_class=False):
+    """Decorator for creating test context managers
+
+    This is a thin wrapper around `contextlib.contextmanager` that also
+    works as a decorator for test classes.
+
+    :param before_class: See `decorate_test_class`.
+
+    Usage:
+    ```py
+        @testcontextmanager
+        def context():
+            print("start")
+            yield
+            print("stop")
+
+        # context manager
+        with context():
+            print("inside")
+
+        # test function decorator
+        @context
+        def test_func():
+            print("inside")
+
+        # class decorator
+        @context
+        class Test(TestCase):
+            def test_method(self):
+                print("inside")
+
+        # test method decorator
+        class Test(TestCase):
+            @context
+            def test_method(self):
+                print("inside")
+    ```
+    """
+    if func is None:
+        return partial(testcontextmanager, before_class=before_class)
+
+    @wraps(func)
+    def wrapper(test_class_or_func=None, /, **kw):
+        context = contextmanager(func)(**kw)
+        if test_class_or_func is None:
+            return context
+        if isinstance(test_class_or_func, type):
+            return decorate_test_class(context, test_class_or_func, before_class)
+        return context(test_class_or_func)
+    return wrapper
+
+
+def decorate_test_class(context, class_, before_class=False):
+    """Apply context manager to test class
+
+    :param before_class: If True, the context manager will start before
+        `setUpClass` is called when decorating a test class. Otherwise
+        it will start after `setUpClass` is called (the default). In
+        either case the context manager will be stopped with
+        `addClassCleanup`.
+    """
+    @classmethod
+    def setUpClass(cls):
+        if before_class:
+            add_context(context, cls)
+            original_setup()
+        else:
+            original_setup()
+            add_context(context, cls)
+
+    assert issubclass(class_, TestCase), class_
+    original_setup, class_.setUpClass = class_.setUpClass, setUpClass
+    return class_

--- a/corehq/tests/util/tests/test_context.py
+++ b/corehq/tests/util/tests/test_context.py
@@ -1,0 +1,48 @@
+from itertools import count
+
+from ..context import testcontextmanager
+
+
+def test_multi_use_testcontextmanager():
+    context, calls = make_context()
+
+    @context
+    def test(num):
+        calls.append(num)
+
+    with context():
+        calls.append(0)
+    with context():
+        calls.append(1)
+    test(2)
+
+    assert calls == [10, 0, 10, 11, 1, 11, 12, 2, 12]
+
+
+def test_nested_testcontextmanager():
+    context, calls = make_context()
+
+    @context
+    def test(num):
+        calls.append(num)
+
+    with context():
+        calls.append(0)
+        with context():
+            calls.append(1)
+            test(2)
+
+    assert calls == [10, 0, 11, 1, 12, 2, 12, 11, 10]
+
+
+def make_context():
+    @testcontextmanager
+    def context():
+        num = next(seq)
+        calls.append(num)
+        yield
+        calls.append(num)
+
+    seq = iter(count(10))
+    calls = []
+    return context, calls

--- a/corehq/tests/util/warnings.py
+++ b/corehq/tests/util/warnings.py
@@ -1,63 +1,12 @@
 """warnings test utilities"""
 import warnings
-from functools import wraps
-from unittest import TestCase
 
-from corehq.tests.tools import nottest
 from corehq.util.test_utils import unit_testing_only
 
-
-@nottest
-class TestContextDecorator:
-    """Context manager/decorator for wrapping tests
-
-    Initialize with a single context manager argument or override
-    `__init__`, `__repr__`, `__enter__` and `__exit__`.
-    """
-
-    def __init__(self, context):
-        self.context = context
-
-    def __repr__(self):
-        return f"{type(self).__name__}({self.context})"
-
-    def __enter__(self):
-        return self.context.__enter__()
-
-    def __exit__(self, *exc_info):
-        self.context.__exit__(*exc_info)
-
-    def start(self):
-        self.__enter__()
-
-    def stop(self):
-        self.__exit__(None, None, None)
-
-    def __call__(self, func):
-        if isinstance(func, type):
-            assert issubclass(func, TestCase), func
-            return self.decorate_class(func)
-        return self.decorate_callable(func)
-
-    def decorate_class(self, class_):
-        @classmethod
-        def setUpClass(cls):
-            self.start()
-            cls.addClassCleanup(self.stop)
-            original_setup()
-
-        original_setup, class_.setUpClass = class_.setUpClass, setUpClass
-        return class_
-
-    def decorate_callable(self, func):
-        @wraps(func)
-        def filtered(*args, **kw):
-            with self:
-                return func(*args, **kw)
-        return filtered
+from .context import testcontextmanager
 
 
-class filter_warnings(TestContextDecorator):
+class filter_warnings:
     """Context manager/test decorator for temporarily filtering warnings
 
     A thin wrapper around `warnings.catch_warnings()` and
@@ -93,16 +42,22 @@ class filter_warnings(TestContextDecorator):
     def __repr__(self):
         return f"{type(self).__name__}{self.filter}"
 
+    def __call__(self, func=None):
+        @testcontextmanager(before_class=True)
+        def filter_context():
+            with warnings.catch_warnings(record=True) as log:
+                warnings.filterwarnings(*self.filter)
+                yield log
+        return filter_context(func)
+
     def __enter__(self):
         """Start filtering warnings
 
         Returns a list that will be populated with captured warnings.
         """
-        if not hasattr(self, "context"):
-            self.context = warnings.catch_warnings(record=True)
-        log = self.context.__enter__()
-        warnings.filterwarnings(*self.filter)
-        return log
+        assert not hasattr(self, "context")
+        self.context = self()
+        return self.context.__enter__()
 
     def __exit__(self, *exc_info):
         """Stop filtering warnings."""


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-16362

Unless `leave_tombstone=...` is passed explicitly, `domain.delete()` will continue to fail except in tests. It is now possible to call `domain.delete(leave_tombstone=False)` outside of a test environment, but we only do that in one place.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Most of the changes here are additional tests and improvements to testing utilities. The domain deletion code got simpler and easier to read, and is well tested.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations