### PR TITLE
Delete UI models when committing session

### DIFF
--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -2,6 +2,9 @@ from corehq.apps.celery import task
 
 from casexml.apps.case.mock import CaseBlock
 from corehq.apps.data_cleaning.models import (
+    BulkEditColumn,
+    BulkEditColumnFilter,
+    BulkEditPinnedFilter,
     BulkEditSession,
 )
 from corehq.apps.hqcase.utils import CASEBLOCK_CHUNKSIZE, submit_case_blocks
@@ -13,6 +16,11 @@ from corehq.form_processor.models import CommCareCase
 @task(queue='case_import_queue')
 def commit_data_cleaning(bulk_edit_session_id):
     session = BulkEditSession.objects.get(session_id=bulk_edit_session_id)
+
+    # Delete UI-only models
+    BulkEditColumnFilter.objects.filter(session=session).delete()
+    BulkEditPinnedFilter.objects.filter(session=session).delete()
+    BulkEditColumn.objects.filter(session=session).delete()
 
     form_ids = []
     case_index = 0

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -3,10 +3,15 @@ from django.test import TestCase
 from casexml.apps.case.mock import CaseFactory
 from corehq.apps.data_cleaning.models import (
     BulkEditChange,
+    BulkEditColumn,
+    BulkEditColumnFilter,
+    BulkEditPinnedFilter,
     BulkEditRecord,
     BulkEditSessionType,
     BulkEditSession,
+    DataType,
     EditActionType,
+    FilterMatchType,
 )
 from corehq.apps.data_cleaning.tasks import commit_data_cleaning
 from corehq.apps.domain.shortcuts import create_domain
@@ -40,6 +45,7 @@ class CommitCasesTest(TestCase):
             owner_id='crj123',
             case_name='Shadow',
             update={
+                'play_count': 10,
                 'speed': 'slow',
                 'year': '2023',
             },
@@ -143,3 +149,32 @@ class CommitCasesTest(TestCase):
 
         case = CommCareCase.objects.get_case(self.case.case_id, self.domain.name)
         self.assertEqual(case.get_case_property('speed'), 'slow!')
+
+    def test_delete_ui_models(self):
+        record = BulkEditRecord(
+            session=self.session,
+            doc_id=self.case.case_id,
+        )
+        record.save()
+
+        change = BulkEditChange(
+            session=self.session,
+            prop_id='speed',
+            action_type=EditActionType.UPPER_CASE,
+        )
+        change.save()
+
+        BulkEditPinnedFilter.create_default_filters(self.session)
+        BulkEditColumn.create_default_columns(self.session)
+        self.session.add_column_filter('play_count', DataType.INTEGER, FilterMatchType.GREATER_THAN, 1)
+        self.session.save()
+
+        self.assertTrue(BulkEditColumnFilter.objects.filter(session=self.session).count() > 0)
+        self.assertTrue(BulkEditPinnedFilter.objects.filter(session=self.session).count() > 0)
+        self.assertTrue(BulkEditColumn.objects.filter(session=self.session).count() > 0)
+
+        commit_data_cleaning(self.session.session_id)
+
+        self.assertEqual(BulkEditColumnFilter.objects.filter(session=self.session).count(), 0)
+        self.assertEqual(BulkEditPinnedFilter.objects.filter(session=self.session).count(), 0)
+        self.assertEqual(BulkEditColumn.objects.filter(session=self.session).count(), 0)


### PR DESCRIPTION
## Technical Summary
Add cleanup for UI models. There are a couple of different places this logic could go - in the view when the task is created, at the start of the task, at the end of the task. Putting it in the task at least means the user isn't waiting for the deletion to finish, and putting it at the beginning gets it done as soon as possible (and before potential errors later on).

## Feature Flag
Bulk data cleaning

## Safety Assurance

### Safety story
This is logic for deleting data, but it's a non-user-facing change in a feature that isn't live for anyone yet.

### Automated test coverage

In PR.

### QA Plan

No.


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
