### PR TITLE
Data cleaning tasks table improvements

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -92,13 +92,13 @@ class BulkEditSession(models.Model):
         return cls.objects.filter(user=user, domain=domain_name, committed_on__isnull=False)
 
     @property
-    def status(self):
+    def status_tuple(self):
         if self.committed_on:
             if self.completed_on:
-                return "complete"
+                return ("complete", "success")
             else:
-                return "in progress"
-        return "pending"
+                return ("in progress", "primary")
+        return ("pending", "secondary")
 
     def add_column_filter(self, prop_id, data_type, match_type, value=None):
         BulkEditColumnFilter.objects.create(

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -144,6 +144,27 @@ class BulkEditSession(models.Model):
             query = pinned_filter.filter_query(query)
         return query
 
+    def update_result(self, record_count, form_id=None):
+        result = self.result or {}
+
+        if 'form_ids' not in result:
+            result['form_ids'] = []
+        if 'record_count' not in result:
+            result['record_count'] = 0
+        if 'percent' not in result:
+            result['percent'] = 0
+
+        if form_id:
+            result['form_ids'].append(form_id)
+        result['record_count'] += record_count
+        if self.records.count() == 0:
+            result['percent'] = 100
+        else:
+            result['percent'] = result['record_count'] * 100 / self.records.count()
+
+        self.result = result
+        self.save()
+
 
 class DataType:
     TEXT = 'text'

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -17,12 +17,14 @@ def commit_data_cleaning(bulk_edit_session_id):
 
     form_ids = []
     case_index = 0
+    session.update_result(0)
     while case_index < session.records.count():
         records = session.records.all()[case_index:case_index + CASEBLOCK_CHUNKSIZE]
         case_index += CASEBLOCK_CHUNKSIZE
         blocks = _create_case_blocks(session, records)
         xform = _submit_case_blocks(session, blocks)
         form_ids.append(xform.form_id)
+        session.update_result(len(records), xform.form_id)
         session.save()
 
     session.completed_on = datetime.now()

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from django.test import TestCase
 
 from casexml.apps.case.mock import CaseFactory
@@ -50,6 +51,7 @@ class CommitCasesTest(TestCase):
             user=self.web_user.get_django_user(),
             session_type=BulkEditSessionType.CASE,
             identifier=self.case_type,
+            committed_on=datetime.utcnow(),
         )
         self.session.save()
 
@@ -118,6 +120,8 @@ class CommitCasesTest(TestCase):
             'record_count': 1,
             'percent': 100,
         })
+        self.assertIsNotNone(self.session.completed_on)
+        self.assertListEqual(list(self.session.status_tuple), ['complete', 'success'])
 
     def test_chunking(self):
         cases = [self.case]

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -1,3 +1,4 @@
+from celery import uuid
 from datetime import datetime
 from memoized import memoized
 
@@ -91,8 +92,13 @@ class CleanCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
 @toggles.DATA_CLEANING_CASES.required_decorator()
 def save_case_session(request, domain, session_id):
     session = BulkEditSession.objects.get(session_id=session_id)
+
+    task_id = uuid()
+    session.task_id = task_id
     session.committed_on = datetime.utcnow()
     session.save()
-    commit_data_cleaning.delay(session_id)
+
+    commit_data_cleaning.apply_async((session_id,), task_id=task_id)
+
     messages.success(request, _("Session saved."))
     return redirect(reverse(CleanCasesMainView.urlname, args=(domain,)))


### PR DESCRIPTION
## Product Description
This makes a couple of updates to the tasks table. It's (obviously) incomplete, I'm making a habit of PRing early and often.

### Before

![Screenshot 2025-03-10 at 4 54 03 PM](https://github.com/user-attachments/assets/b174ec6c-9f1c-4a97-a2d1-7da97ea1a52a)

### After

![Screenshot 2025-03-10 at 4 52 57 PM](https://github.com/user-attachments/assets/d3e4053c-0fe3-4f94-bd74-7879ef3cbaf2)


## Feature Flag
Bulk data cleaning cases

## Safety Assurance

### Safety story
UI changes to a flagged feature not being used by any real users.

### Automated test coverage

There's some in the PR.

### QA Plan

No.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
