### PR TITLE
Added case type tooltip to case modules

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/module_link.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/module_link.html
@@ -36,7 +36,15 @@
             data-toggle="tooltip"
             data-placement="right"
             data-container="body"></i>
-        <span {% if module.unique_id == selected_module.unique_id %}class="variable-module_name"{% endif %}>
+        <span
+          {% if module.unique_id == selected_module.unique_id %}class="variable-module_name"{% endif %}
+          {% if module.case_type %}
+            title="{% blocktrans  with module.case_type as case_type %}case type: {{case_type}}{% endblocktrans %}"
+            data-toggle="tooltip"
+            data-placement="right"
+            data-container="body"
+          {% endif %}
+        >
             {{ module.name|html_trans_prefix:langs }}
         </span>
     </a>


### PR DESCRIPTION
## Product Description
![case_name](https://github.com/user-attachments/assets/2d6926ba-5aa8-4f4c-86fd-8cf754b4f0e3)

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-16674.

While the ticket requested the case name on mouseover, we realized that we used bootstrap tooltips when hovering over the document icons for similar information. So, we're re-using that style here to display the case type. In some situations, it can look awkward, but the major advantage over a tooltip rather than inline text is that we don't have to deal with sizing issues when either the module name or case type is long.

## Feature Flag
No feature flag

## Safety Assurance

### Safety story
This is just a display item. Tested locally that this displays for case modules but not summary modules. I did not test for other types, but as it only displays if it finds a `case_type` property on the module, this should be fine.

### Automated test coverage

No tests

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
