### PR TITLE
fetch main app id on local submissions

### DIFF
--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -28,7 +28,7 @@ def get_submit_url(domain, app_id=None):
         return "/a/{domain}/receiver/".format(domain=domain)
 
 
-def submit_form_locally(instance, domain, max_wait=..., app_id=None, **kwargs):
+def submit_form_locally(instance, domain, max_wait=..., app_id=None, build_id=None, **kwargs):
     """
     :param instance: XML instance (as a string) to submit
     :param domain: The domain to submit the form to
@@ -45,10 +45,8 @@ def submit_form_locally(instance, domain, max_wait=..., app_id=None, **kwargs):
         rate_limit_submission(domain, delay_rather_than_reject=True, max_wait=max_wait)
     # intentionally leave these unauth'd for now
     kwargs['auth_context'] = kwargs.get('auth_context') or DefaultAuthContext()
-    if app_id is not None:
+    if app_id is not None and build_id is None:
         app_id, build_id = get_app_and_build_ids(domain, app_id)
-    else:
-        build_id = None
     result = SubmissionPost(
         domain=domain,
         instance=instance,

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -28,7 +28,7 @@ def get_submit_url(domain, app_id=None):
         return "/a/{domain}/receiver/".format(domain=domain)
 
 
-def submit_form_locally(instance, domain, max_wait=..., **kwargs):
+def submit_form_locally(instance, domain, max_wait=..., app_id=None, **kwargs):
     """
     :param instance: XML instance (as a string) to submit
     :param domain: The domain to submit the form to
@@ -45,9 +45,15 @@ def submit_form_locally(instance, domain, max_wait=..., **kwargs):
         rate_limit_submission(domain, delay_rather_than_reject=True, max_wait=max_wait)
     # intentionally leave these unauth'd for now
     kwargs['auth_context'] = kwargs.get('auth_context') or DefaultAuthContext()
+    if app_id is not None:
+        app_id, build_id = get_app_and_build_ids(domain, app_id)
+    else:
+        build_id = None
     result = SubmissionPost(
         domain=domain,
         instance=instance,
+        app_id=app_id,
+        build_id=build_id,
         **kwargs
     ).run()
     if not 200 <= result.response.status_code < 300:


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
When forms are submitted via normal methods, we use the app id of the submission (which corresponds to the unique ID of the build) to look up the unique id of the main application doc. We then save both of those IDs on the `XFormInstance`. This happens in the view [form processing](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/receiverwrapper/views.py#L155-L161). When forms are submitted with `submit_form_locally`, we pass in the build id directly as the app id. One place this occurs is SMS surveys, although any local submission that uses apps will have the same issue.

This change adds the app lookup from the build id to our local submission method. I think that is better for two reasons: 

1) As a matter of correctness, we want these instances to save both the overall app id and the build, since that is what is how normal forms are stored, and allows easier lookup by the app id, since these would have otherwise been missed.
2) App ID is passed as parameter in repeat records, and it is being forwarded in incorrect and difficult to use ways (plus it is inconsistent for forms submitted by different versions of the same app).

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

The `get_app_and_build_ids` method is already used in normal form processing and handles cases where the app id is incorrect or does not exist. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
