### PR TITLE
When AuthnContext not match request a fresh authentication

### DIFF
--- a/corehq/apps/sso/configuration.py
+++ b/corehq/apps/sso/configuration.py
@@ -71,7 +71,7 @@ def _get_advanced_saml2_settings(identity_provider):
             "wantNameId": True,
             "wantMessagesSigned": False,  # Entra ID does not support this, premium or standard
             "wantNameIdEncrypted": False,  # Entra ID will not accept if True
-            "requestedAuthnContext": False,
+            "failOnAuthnContextMismatch": True,  # very important
             "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
             "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
             "metadataValidUntil": metadata_valid_until.isoformat(),

--- a/corehq/apps/sso/configuration.py
+++ b/corehq/apps/sso/configuration.py
@@ -71,7 +71,7 @@ def _get_advanced_saml2_settings(identity_provider):
             "wantNameId": True,
             "wantMessagesSigned": False,  # Entra ID does not support this, premium or standard
             "wantNameIdEncrypted": False,  # Entra ID will not accept if True
-            "failOnAuthnContextMismatch": True,  # very important
+            "requestedAuthnContext": False,
             "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
             "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
             "metadataValidUntil": metadata_valid_until.isoformat(),

--- a/corehq/apps/sso/views/saml.py
+++ b/corehq/apps/sso/views/saml.py
@@ -121,7 +121,7 @@ def sso_saml_login(request, idp_slug):
     This view initiates a SAML 2.0 login request with the Identity Provider.
     """
     login_url = add_username_hint_to_login_url(
-        request.saml2_auth.login(return_to=request.GET.get('next')),
+        request.saml2_auth.login(return_to=request.GET.get('next'), force_authn=True),
         request
     )
     return HttpResponseRedirect(login_url)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Ticket: https://dimagi.atlassian.net/browse/SAAS-16515

This is added very specific to a client's situation. Their device is managed by Microsoft Intune and connected with Entra., they're using Microsoft Edge as their working browser. They're automatically logged in to their edge browser, it is by default configured with the user login to the laptops.

When they open commcare hq in their edge browser, they saw the following error.
<img width="534" alt="image" src="https://github.com/user-attachments/assets/89b39e0d-33ab-41cc-8ff6-47bd0b0ba040" />

The reason is, user is previously authenticated by a different way other than password, but we only accept password authentication, so the user cannot pass our authentication.

This is [microsoft's recommendation](https://learn.microsoft.com/en-us/troubleshoot/entra/entra-id/app-integration/error-code-aadsts75011-auth-method-mismatch) to solve the issue.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
`requestedAuthNContext` is default to True in [python3-saml](https://github.com/SAML-Toolkits/python3-saml/blob/0320fd4c4ae27d3ce5b8faeca6bb5807468626e8/README.md?plain=1#L470-L474), when it is true, AuthNContext is set to `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`...

Three possible solution:
1) Pass an array to `requestedAuthNContext`, `["urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport", "urn:oasis:names:tc:SAML:2.0:ac:classes:X509"]`, but I cannot find corresponding class for X509 Device and Multifactor in this [doc](https://docs.oasis-open.org/security/saml/v2.0/saml-authn-context-2.0-os.pdf).
2) Set `requestedAuthNContext` to False, so we don't always require user is log in to Entra by password, as long as user can be authenticated,  we accept the previous auth method.
3) Set `force_authn` to True, so when AuthnContext doesn't match, we request a fresh authentication.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA Ticket: https://dimagi.atlassian.net/browse/QA-7565
QA should do a regression test on it make sure everything with SSO still works.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
