### PR TITLE
Campaign dashboard models (rebased)

### DIFF
--- a/corehq/apps/campaign/migrations/0001_initial.py
+++ b/corehq/apps/campaign/migrations/0001_initial.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name="Dashboard",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "domain",
+                    models.CharField(
+                        db_index=True,
+                        max_length=126,
+                        unique=True,
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/corehq/apps/campaign/migrations/0002_dashboardmap_dashboardreport.py
+++ b/corehq/apps/campaign/migrations/0002_dashboardmap_dashboardreport.py
@@ -1,0 +1,66 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaign', '0001_initial'),
+    ]
+    operations = [
+        migrations.CreateModel(
+            name="DashboardMap",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("display_order", models.IntegerField(default=0)),
+                ("case_type", models.CharField(max_length=255)),
+                ("geo_case_property", models.CharField(max_length=255)),
+                (
+                    "dashboard",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="maps",
+                        to="campaign.dashboard",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["display_order"],
+            },
+        ),
+        migrations.CreateModel(
+            name="DashboardReport",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("display_order", models.IntegerField(default=0)),
+                ("report_configuration_id", models.CharField(max_length=36)),
+                (
+                    "dashboard",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="reports",
+                        to="campaign.dashboard",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["display_order"],
+            },
+        ),
+    ]

--- a/corehq/apps/campaign/models.py
+++ b/corehq/apps/campaign/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 
+from corehq.apps.userreports.models import ReportConfiguration
+
 
 class Dashboard(models.Model):
     """
@@ -9,3 +11,42 @@ class Dashboard(models.Model):
 
     class Meta:
         app_label = 'campaign'
+
+
+class DashboardMap(models.Model):
+    """
+    Configuration for a map in a campaign dashboard
+    """
+    dashboard = models.ForeignKey(
+        Dashboard,
+        on_delete=models.CASCADE,
+        related_name='maps'
+    )
+    display_order = models.IntegerField(default=0)
+    case_type = models.CharField(max_length=255)
+    geo_case_property = models.CharField(max_length=255)
+
+    class Meta:
+        app_label = 'campaign'
+        ordering = ['display_order']
+
+
+class DashboardReport(models.Model):
+    """
+    Configuration for a report in a campaign dashboard
+    """
+    dashboard = models.ForeignKey(
+        Dashboard,
+        on_delete=models.CASCADE,
+        related_name='reports'
+    )
+    display_order = models.IntegerField(default=0)
+    report_configuration_id = models.CharField(max_length=36)
+
+    class Meta:
+        app_label = 'campaign'
+        ordering = ['display_order']
+
+    @property
+    def report_configuration(self):
+        return ReportConfiguration.get(self.report_configuration_id)

--- a/corehq/apps/campaign/models.py
+++ b/corehq/apps/campaign/models.py
@@ -1,1 +1,11 @@
-# Create your models here.
+from django.db import models
+
+
+class Dashboard(models.Model):
+    """
+    Model to store campaign dashboard configuration
+    """
+    domain = models.CharField(max_length=126, db_index=True, unique=True)
+
+    class Meta:
+        app_label = 'campaign'

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -501,6 +501,7 @@ DOMAIN_DELETE_OPERATIONS = [
     ModelDeletion('geospatial', 'GeoConfig', 'domain'),
     ModelDeletion('email', 'EmailSettings', 'domain'),
     ModelDeletion('hqmedia', 'LogoForSystemEmailsReference', 'domain'),
+    ModelDeletion('campaign', 'Dashboard', 'domain'),
 ]
 
 

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -501,7 +501,10 @@ DOMAIN_DELETE_OPERATIONS = [
     ModelDeletion('geospatial', 'GeoConfig', 'domain'),
     ModelDeletion('email', 'EmailSettings', 'domain'),
     ModelDeletion('hqmedia', 'LogoForSystemEmailsReference', 'domain'),
-    ModelDeletion('campaign', 'Dashboard', 'domain'),
+    ModelDeletion('campaign', 'Dashboard', 'domain', extra_models=[
+        'DashboardMap',
+        'DashboardReport',
+    ]),
 ]
 
 

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -43,6 +43,8 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('case_search.FuzzyProperties', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('case_search.IgnorePatterns', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('campaign.Dashboard', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('campaign.DashboardMap', SimpleFilter('dashboard__domain')),
+    FilteredModelIteratorBuilder('campaign.DashboardReport', SimpleFilter('dashboard__domain')),
     UniqueFilteredModelIteratorBuilder('scheduling.SMSContent', SimpleFilter('alertevent__schedule__domain')),
     UniqueFilteredModelIteratorBuilder('scheduling.SMSContent', SimpleFilter('timedevent__schedule__domain')),
     UniqueFilteredModelIteratorBuilder('scheduling.SMSContent',

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -42,6 +42,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('case_search.CaseSearchConfig', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('case_search.FuzzyProperties', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('case_search.IgnorePatterns', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('campaign.Dashboard', SimpleFilter('domain')),
     UniqueFilteredModelIteratorBuilder('scheduling.SMSContent', SimpleFilter('alertevent__schedule__domain')),
     UniqueFilteredModelIteratorBuilder('scheduling.SMSContent', SimpleFilter('timedevent__schedule__domain')),
     UniqueFilteredModelIteratorBuilder('scheduling.SMSContent',

--- a/migrations.lock
+++ b/migrations.lock
@@ -210,7 +210,7 @@ blobs
  0013_drop_icds_cas_index
  0014_alter_deletedblobmeta_id
 campaign
- (no migrations)
+ 0001_initial
 case_importer
  0001_initial
  0002_auto_20161206_1937

--- a/migrations.lock
+++ b/migrations.lock
@@ -211,6 +211,7 @@ blobs
  0014_alter_deletedblobmeta_id
 campaign
  0001_initial
+ 0002_dashboardmap_dashboardreport
 case_importer
  0001_initial
  0002_auto_20161206_1937


### PR DESCRIPTION
## Technical Summary

Jira:
* [SC-4347]
* [SC-4348]

This adds campaign dashboard models for maps and reports. It is rebased off `master`, and merges backend work by myself and @zandre-eng 

This PR squashes commits from https://github.com/dimagi/commcare-hq/pull/35934 and incorporates feedback from that PR.

## Feature Flag

`campaign_dashboard`

## Safety Assurance

### Safety story

Not yet used.

### Automated test coverage

I haven't added model tests because the models don't really do anything yet.

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-4347]: https://dimagi.atlassian.net/browse/SC-4347
[SC-4348]: https://dimagi.atlassian.net/browse/SC-4348