### PR TITLE
More improvements to data cleaning tasks table

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -95,10 +95,10 @@ class BulkEditSession(models.Model):
     def status_tuple(self):
         if self.committed_on:
             if self.completed_on:
-                return ("complete", "success")
+                return ("Success", "success")
             else:
-                return ("in progress", "primary")
-        return ("pending", "secondary")
+                return ("In Progress", "primary")
+        return ("Pending", "secondary")
 
     def add_column_filter(self, prop_id, data_type, match_type, value=None):
         BulkEditColumnFilter.objects.create(

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -103,15 +103,6 @@ class BulkEditSession(models.Model):
             return None
         return round(self.result['percent'])
 
-    @property
-    def status_tuple(self):
-        if self.committed_on:
-            if self.completed_on:
-                return (_("Success"), "success")
-            else:
-                return (_("In Progress"), "primary")
-        return (_("Pending"), "secondary")
-
     def add_column_filter(self, prop_id, data_type, match_type, value=None):
         BulkEditColumnFilter.objects.create(
             session=self,

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -107,10 +107,10 @@ class BulkEditSession(models.Model):
     def status_tuple(self):
         if self.committed_on:
             if self.completed_on:
-                return ("Success", "success")
+                return (_("Success"), "success")
             else:
-                return ("In Progress", "primary")
-        return ("Pending", "secondary")
+                return (_("In Progress"), "primary")
+        return (_("Pending"), "secondary")
 
     def add_column_filter(self, prop_id, data_type, match_type, value=None):
         BulkEditColumnFilter.objects.create(

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -92,6 +92,12 @@ class BulkEditSession(models.Model):
         return cls.objects.filter(user=user, domain=domain_name, committed_on__isnull=False)
 
     @property
+    def form_ids(self):
+        if self.result is None or 'form_ids' not in self.result:
+            return []
+        return self.result['form_ids']
+
+    @property
     def percent_complete(self):
         if self.result is None or 'percent' not in self.result:
             return None

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -92,6 +92,12 @@ class BulkEditSession(models.Model):
         return cls.objects.filter(user=user, domain=domain_name, committed_on__isnull=False)
 
     @property
+    def percent_complete(self):
+        if self.result is None or 'percent' not in self.result:
+            return None
+        return round(self.result['percent'])
+
+    @property
     def status_tuple(self):
         if self.committed_on:
             if self.completed_on:

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -40,6 +40,9 @@ class CaseCleaningTasksTable(BaseHtmxTable, tables.Table):
     case_type = columns.Column(
         verbose_name=gettext_lazy("Case Type"),
     )
+    case_count = columns.Column(
+        verbose_name=gettext_lazy("# Cases Cleaned"),
+    )
     details = columns.Column(
         verbose_name=gettext_lazy("Details"),
     )

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -27,7 +27,8 @@ class CaseCleaningTasksTable(BaseHtmxTable, tables.Table):
     class Meta(BaseHtmxTable.Meta):
         pass
 
-    status = columns.Column(
+    status = columns.TemplateColumn(
+        template_name="data_cleaning/columns/task_status.html",
         verbose_name=gettext_lazy("Status"),
     )
     committed_on = columns.Column(

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -43,6 +43,7 @@ class CaseCleaningTasksTable(BaseHtmxTable, tables.Table):
     case_count = columns.Column(
         verbose_name=gettext_lazy("# Cases Cleaned"),
     )
-    details = columns.Column(
-        verbose_name=gettext_lazy("Details"),
+    form_ids = columns.TemplateColumn(
+        template_name="data_cleaning/columns/task_form_ids.html",
+        verbose_name=gettext_lazy("Form IDs"),
     )

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_form_ids.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_form_ids.html
@@ -1,0 +1,5 @@
+{% if record.has_form_ids %}
+  <a href="{{ record.form_ids_url }}" target="_blank">
+    <i class="fa fa-cloud-download"></i>
+  </a>
+{% endif %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
@@ -1,6 +1,9 @@
 {% load hq_shared_tags %}
+{% load i18n %}
 
-{% if record.percent and record.percent < 100 %}
+{% if record.completed_on %}
+  <span class="badge text-bg-success"> {% trans "Success" %} </span>
+{% elif record.percent and record.percent < 100 %}
   <div
     class="progress"
     role="progressbar"
@@ -16,8 +19,6 @@
       {{ record.percent }}%
     </div>
   </div>
-{% else %}
-  <span class="badge text-bg-{{ record.status_class }}">
-    {{ record.status_text }}
-  </span>
+{% elif record.committed_on %}
+  <span class="badge text-bg-secondary"> {% trans "Pending" %} </span>
 {% endif %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
@@ -1,0 +1,1 @@
+<span class='badge text-bg-{{ record.status_class }}'>{{ record.status_text }}</span>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
@@ -1,1 +1,23 @@
-<span class='badge text-bg-{{ record.status_class }}'>{{ record.status_text }}</span>
+{% load hq_shared_tags %}
+
+{% if record.percent and record.percent < 100 %}
+  <div
+    class="progress"
+    role="progressbar"
+    aria-label="{% trans_html_attr 'Cleaning progress' %}"
+    aria-valuenow="{{ record.percent }}"
+    aria-valuemin="0"
+    aria-valuemax="100"
+  >
+    <div
+      class="progress-bar progress-bar-striped progress-bar-animated"
+      style="width: {{ record.percent }}%"
+    >
+      {{ record.percent }}%
+    </div>
+  </div>
+{% else %}
+  <span class="badge text-bg-{{ record.status_class }}">
+    {{ record.status_text }}
+  </span>
+{% endif %}

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -123,7 +123,6 @@ class CommitCasesTest(TestCase):
         self.assertEqual(self.session.percent_complete, 100)
         self.assertListEqual(list(self.session.form_ids), form_ids)
         self.assertIsNotNone(self.session.completed_on)
-        self.assertListEqual(list(self.session.status_tuple), ['Success', 'success'])
 
     def test_chunking(self):
         cases = [self.case]

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -121,6 +121,7 @@ class CommitCasesTest(TestCase):
             'percent': 100,
         })
         self.assertEqual(self.session.percent_complete, 100)
+        self.assertListEqual(list(self.session.form_ids), form_ids)
         self.assertIsNotNone(self.session.completed_on)
         self.assertListEqual(list(self.session.status_tuple), ['Success', 'success'])
 

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -120,6 +120,7 @@ class CommitCasesTest(TestCase):
             'record_count': 1,
             'percent': 100,
         })
+        self.assertEqual(self.session.percent_complete, 100)
         self.assertIsNotNone(self.session.completed_on)
         self.assertListEqual(list(self.session.status_tuple), ['Success', 'success'])
 

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -121,7 +121,7 @@ class CommitCasesTest(TestCase):
             'percent': 100,
         })
         self.assertIsNotNone(self.session.completed_on)
-        self.assertListEqual(list(self.session.status_tuple), ['complete', 'success'])
+        self.assertListEqual(list(self.session.status_tuple), ['Success', 'success'])
 
     def test_chunking(self):
         cases = [self.case]

--- a/corehq/apps/data_cleaning/urls.py
+++ b/corehq/apps/data_cleaning/urls.py
@@ -6,6 +6,7 @@ from corehq.apps.data_cleaning.views.filters import (
 from corehq.apps.data_cleaning.views.main import (
     CleanCasesMainView,
     CleanCasesSessionView,
+    download_form_ids,
     save_case_session,
 )
 from corehq.apps.data_cleaning.views.tables import (
@@ -27,4 +28,5 @@ urlpatterns = [
     url(r'^cases/(?P<session_id>[\w\-]+)/filters/pinned/$', PinnedFilterFormView.as_view(),
         name=PinnedFilterFormView.urlname),
     url(r'^cases/save/(?P<session_id>[\w\-]+)/$', save_case_session, name='save_case_session'),
+    url(r'^form_ids/(?P<session_id>[\w\-]+)/$', download_form_ids, name='download_form_ids'),
 ]

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -1,3 +1,4 @@
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from corehq import toggles
 from corehq.apps.data_cleaning.models import BulkEditSession
@@ -55,6 +56,7 @@ class CaseCleaningTasksTableView(BaseDataCleaningTableView):
             "completed_on": session.completed_on,
             "case_type": session.identifier,
             "case_count": session.records.count(),
-            "details": session.result,
             "percent": session.percent_complete,
+            "form_ids_url": reverse('download_form_ids', args=(session.domain, session.session_id)),
+            "has_form_ids": bool(len(session.form_ids)),
         }

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -54,5 +54,6 @@ class CaseCleaningTasksTableView(BaseDataCleaningTableView):
             "committed_on": session.committed_on,
             "completed_on": session.completed_on,
             "case_type": session.identifier,
+            "case_count": session.records.count(),
             "details": session.result,
         }

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -56,4 +56,5 @@ class CaseCleaningTasksTableView(BaseDataCleaningTableView):
             "case_type": session.identifier,
             "case_count": session.records.count(),
             "details": session.result,
+            "percent": session.percent_complete,
         }

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -48,10 +48,7 @@ class CaseCleaningTasksTableView(BaseDataCleaningTableView):
         ]
 
     def _get_record(self, session):
-        (status_text, status_class) = session.status_tuple
         return {
-            "status_class": status_class,
-            "status_text": status_text,
             "committed_on": session.committed_on,
             "completed_on": session.completed_on,
             "case_type": session.identifier,


### PR DESCRIPTION
## Product Description
This replaces the "In Progress" badge with a progress bar, and it replaces the "Details" column with a download of system form IDs.

These are the last UI improvements I'm planning to make to this table, except for properly displaying tasks that fail.

![Screenshot 2025-03-11 at 9 53 04 AM](https://github.com/user-attachments/assets/8c19c5e8-ce5d-4ef3-a331-7e074ad933ad)


## Feature Flag
Bulk data cleaning

## Safety Assurance

### Safety story
UI changes for a feature that's flagged and not used by any real clients.

### Automated test coverage

In PR.

### QA Plan

No.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
