### PR TITLE
Fixed case_load_counter usage in case import

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -592,7 +592,7 @@ class _CaseImportRow(object):
             self.domain,
             self.config.case_type
         )
-        _log_case_lookup(self.domain)()
+        _log_case_lookup(self.domain)
         if error == LookupErrors.MultipleResults:
             raise TooManyMatches()
         return case
@@ -619,7 +619,7 @@ class _CaseImportRow(object):
             if search_id:
                 parent_case, error = lookup_case(
                     search_field, search_id, self.domain, self.parent_type)
-                _log_case_lookup(self.domain)()
+                _log_case_lookup(self.domain)
                 if parent_case:
                     self.validate_parent_column()
                     if self.parent_relationship_type == 'child':
@@ -676,7 +676,7 @@ class _CaseImportRow(object):
 
 
 def _log_case_lookup(domain):
-    case_load_counter("case_importer", domain)
+    case_load_counter("case_importer", domain)()
 
 
 class _ImportResults(object):

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -592,7 +592,7 @@ class _CaseImportRow(object):
             self.domain,
             self.config.case_type
         )
-        _log_case_lookup(self.domain)
+        _log_case_lookup(self.domain)()
         if error == LookupErrors.MultipleResults:
             raise TooManyMatches()
         return case
@@ -619,7 +619,7 @@ class _CaseImportRow(object):
             if search_id:
                 parent_case, error = lookup_case(
                     search_field, search_id, self.domain, self.parent_type)
-                _log_case_lookup(self.domain)
+                _log_case_lookup(self.domain)()
                 if parent_case:
                     self.validate_parent_column()
                     if self.parent_relationship_type == 'child':


### PR DESCRIPTION
## Technical Summary
`case_load_counter` returns a function (see [here](https://github.com/dimagi/commcare-hq/blob/7c5867a8b84d1c510daf82bbaed9c1c8107bf85d/corehq/util/metrics/load_counters.py#L21-L24))

Compare with usage like [this](https://github.com/dimagi/commcare-hq/blob/73a11e1cc3f82fda244f6dc375ab1b4058faa924/corehq/messaging/tasks.py#L68).

## Safety Assurance

### Safety story
Pretty minor change, though in a heavily-used feature. I ran through a case import locally that created a few cases and updated a few existing cases.

### Automated test coverage

Case import has test coverage, yes.

### QA Plan

No.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
