### PR TITLE
auto-refresh CleanCaseTable after pinned filters are updated

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/pinned_filter_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/pinned_filter_form.html
@@ -4,6 +4,7 @@
   id="{{ container_id }}"
   class="card"
   hx-swap="outerHTML"
+  hq-hx-refresh-swap="#CleanCaseTable"
 >
   <div class="card-body">
     <form


### PR DESCRIPTION
## Technical Summary
Very small change to auto-referesh the clean case table after pinned filters are updated. 

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
very safe changes

### Automated test coverage
most important things (like access and query logic) are tested

### QA Plan
Not needed yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
