### PR TITLE
Dashboard widgets need to know their tab

### DIFF
--- a/corehq/apps/campaign/migrations/0003_add_dashboard_widget_fields.py
+++ b/corehq/apps/campaign/migrations/0003_add_dashboard_widget_fields.py
@@ -1,0 +1,65 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("campaign", "0002_dashboardmap_dashboardreport"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="dashboardmap",
+            options={"ordering": ["dashboard_tab", "display_order"]},
+        ),
+        migrations.AlterModelOptions(
+            name="dashboardreport",
+            options={"ordering": ["dashboard_tab", "display_order"]},
+        ),
+        migrations.AddField(
+            model_name="dashboardmap",
+            name="dashboard_tab",
+            field=models.CharField(
+                choices=[
+                    ("cases", "Cases"),
+                    ("mobile_workers", "Mobile Workers"),
+                ],
+                default="cases",
+                max_length=14,
+            ),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="dashboardmap",
+            name="description",
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="dashboardmap",
+            name="title",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.AddField(
+            model_name="dashboardreport",
+            name="dashboard_tab",
+            field=models.CharField(
+                choices=[
+                    ("cases", "Cases"),
+                    ("mobile_workers", "Mobile Workers"),
+                ],
+                default="cases",
+                max_length=14,
+            ),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="dashboardreport",
+            name="description",
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="dashboardreport",
+            name="title",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+    ]

--- a/corehq/apps/campaign/models.py
+++ b/corehq/apps/campaign/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from corehq.apps.userreports.models import ReportConfiguration
 
@@ -13,39 +14,61 @@ class Dashboard(models.Model):
         app_label = 'campaign'
 
 
-class DashboardMap(models.Model):
+class DashboardTab(models.TextChoices):
+    """
+    The tab on which a dashboard widget is displayed
+    """
+    CASES = 'cases', _('Cases')
+    MOBILE_WORKERS = 'mobile_workers', _('Mobile Workers')
+
+
+class DashboardWidgetBase(models.Model):
+    """
+    Base class for dashboard widgets
+    """
+    title = models.CharField(max_length=255, blank=True, null=True)
+    description = models.TextField(blank=True, null=True)
+    dashboard_tab = models.CharField(max_length=14, choices=DashboardTab.choices)
+    display_order = models.IntegerField(default=0)
+    dashboard = models.ForeignKey(
+        Dashboard,
+        on_delete=models.CASCADE,
+    )
+
+    class Meta:
+        abstract = True
+        ordering = ['dashboard_tab', 'display_order']
+
+
+class DashboardMap(DashboardWidgetBase):
     """
     Configuration for a map in a campaign dashboard
     """
     dashboard = models.ForeignKey(
         Dashboard,
         on_delete=models.CASCADE,
-        related_name='maps'
+        related_name='maps',
     )
-    display_order = models.IntegerField(default=0)
     case_type = models.CharField(max_length=255)
     geo_case_property = models.CharField(max_length=255)
 
-    class Meta:
+    class Meta(DashboardWidgetBase.Meta):
         app_label = 'campaign'
-        ordering = ['display_order']
 
 
-class DashboardReport(models.Model):
+class DashboardReport(DashboardWidgetBase):
     """
     Configuration for a report in a campaign dashboard
     """
     dashboard = models.ForeignKey(
         Dashboard,
         on_delete=models.CASCADE,
-        related_name='reports'
+        related_name='reports',
     )
-    display_order = models.IntegerField(default=0)
     report_configuration_id = models.CharField(max_length=36)
 
-    class Meta:
+    class Meta(DashboardWidgetBase.Meta):
         app_label = 'campaign'
-        ordering = ['display_order']
 
     @property
     def report_configuration(self):

--- a/corehq/apps/campaign/tests/test_models.py
+++ b/corehq/apps/campaign/tests/test_models.py
@@ -1,0 +1,120 @@
+import pytest
+
+from ..models import Dashboard, DashboardMap, DashboardReport, DashboardTab
+
+
+@pytest.fixture
+def dashboard():
+    return Dashboard.objects.create(domain='test-domain')
+
+
+@pytest.fixture
+def dashboard_maps(dashboard):
+    return [
+        DashboardMap.objects.create(
+            dashboard=dashboard,
+            title='Map 1',
+            case_type='type1',
+            geo_case_property='property1',
+            dashboard_tab=DashboardTab.CASES,
+            display_order=1,
+        ),
+        DashboardMap.objects.create(
+            dashboard=dashboard,
+            title='Map 2',
+            case_type='type2',
+            geo_case_property='property2',
+            dashboard_tab=DashboardTab.CASES,
+            display_order=2,
+        ),
+        DashboardMap.objects.create(
+            dashboard=dashboard,
+            title='Map 3',
+            case_type='type3',
+            geo_case_property='property3',
+            dashboard_tab=DashboardTab.MOBILE_WORKERS,
+            display_order=1,
+        ),
+        DashboardMap.objects.create(
+            dashboard=dashboard,
+            title='Map 4',
+            case_type='type4',
+            geo_case_property='property4',
+            dashboard_tab=DashboardTab.MOBILE_WORKERS,
+            display_order=2,
+        ),
+    ]
+
+
+@pytest.fixture
+def dashboard_reports(dashboard):
+    return [
+        DashboardReport.objects.create(
+            dashboard=dashboard,
+            title='Report 1',
+            report_configuration_id='report1',
+            dashboard_tab=DashboardTab.CASES,
+            display_order=1,
+        ),
+        DashboardReport.objects.create(
+            dashboard=dashboard,
+            title='Report 2',
+            report_configuration_id='report2',
+            dashboard_tab=DashboardTab.CASES,
+            display_order=2,
+        ),
+        DashboardReport.objects.create(
+            dashboard=dashboard,
+            title='Report 3',
+            report_configuration_id='report3',
+            dashboard_tab=DashboardTab.MOBILE_WORKERS,
+            display_order=1,
+        ),
+        DashboardReport.objects.create(
+            dashboard=dashboard,
+            title='Report 4',
+            report_configuration_id='report4',
+            dashboard_tab=DashboardTab.MOBILE_WORKERS,
+            display_order=2,
+        ),
+    ]
+
+
+@pytest.mark.django_db
+def test_dashboard_map_ordering(
+    dashboard,
+    dashboard_maps,
+):
+    map_titles = [map.title for map in dashboard.maps.all()]
+    assert map_titles == ['Map 1', 'Map 2', 'Map 3', 'Map 4']
+
+    map_ordering = [
+        (map.dashboard_tab, map.display_order)
+        for map in dashboard.maps.all()
+    ]
+    assert map_ordering == [
+        ('cases', 1),
+        ('cases', 2),
+        ('mobile_workers', 1),
+        ('mobile_workers', 2),
+    ]
+
+
+@pytest.mark.django_db
+def test_dashboard_report_ordering(
+    dashboard,
+    dashboard_reports,
+):
+    report_titles = [report.title for report in dashboard.reports.all()]
+    assert report_titles == ['Report 1', 'Report 2', 'Report 3', 'Report 4']
+
+    report_ordering = [
+        (report.dashboard_tab, report.display_order)
+        for report in dashboard.reports.all()
+    ]
+    assert report_ordering == [
+        ('cases', 1),
+        ('cases', 2),
+        ('mobile_workers', 1),
+        ('mobile_workers', 2),
+    ]

--- a/corehq/apps/campaign/tests/test_models.py
+++ b/corehq/apps/campaign/tests/test_models.py
@@ -16,78 +16,76 @@ def dashboard_fixture():
 @fixture
 def dashboard_maps():
     dashboard = dashboard_fixture()
-    yield [
-        DashboardMap.objects.create(
-            dashboard=dashboard,
-            title='Map 1',
-            case_type='type1',
-            geo_case_property='property1',
-            dashboard_tab=DashboardTab.CASES,
-            display_order=1,
-        ),
-        DashboardMap.objects.create(
-            dashboard=dashboard,
-            title='Map 2',
-            case_type='type2',
-            geo_case_property='property2',
-            dashboard_tab=DashboardTab.CASES,
-            display_order=2,
-        ),
-        DashboardMap.objects.create(
-            dashboard=dashboard,
-            title='Map 3',
-            case_type='type3',
-            geo_case_property='property3',
-            dashboard_tab=DashboardTab.MOBILE_WORKERS,
-            display_order=1,
-        ),
-        DashboardMap.objects.create(
-            dashboard=dashboard,
-            title='Map 4',
-            case_type='type4',
-            geo_case_property='property4',
-            dashboard_tab=DashboardTab.MOBILE_WORKERS,
-            display_order=2,
-        ),
-    ]
+    DashboardMap.objects.create(
+        dashboard=dashboard,
+        title='Map 1',
+        case_type='type1',
+        geo_case_property='property1',
+        dashboard_tab=DashboardTab.CASES,
+        display_order=1,
+    )
+    DashboardMap.objects.create(
+        dashboard=dashboard,
+        title='Map 2',
+        case_type='type2',
+        geo_case_property='property2',
+        dashboard_tab=DashboardTab.CASES,
+        display_order=2,
+    )
+    DashboardMap.objects.create(
+        dashboard=dashboard,
+        title='Map 3',
+        case_type='type3',
+        geo_case_property='property3',
+        dashboard_tab=DashboardTab.MOBILE_WORKERS,
+        display_order=1,
+    )
+    DashboardMap.objects.create(
+        dashboard=dashboard,
+        title='Map 4',
+        case_type='type4',
+        geo_case_property='property4',
+        dashboard_tab=DashboardTab.MOBILE_WORKERS,
+        display_order=2,
+    )
+    yield
 
 
 @fixture
 def dashboard_reports():
     dashboard = dashboard_fixture()
-    yield [
-        DashboardReport.objects.create(
-            dashboard=dashboard,
-            title='Report 1',
-            report_configuration_id='report1',
-            dashboard_tab=DashboardTab.CASES,
-            display_order=1,
-        ),
-        DashboardReport.objects.create(
-            dashboard=dashboard,
-            title='Report 2',
-            report_configuration_id='report2',
-            dashboard_tab=DashboardTab.CASES,
-            display_order=2,
-        ),
-        DashboardReport.objects.create(
-            dashboard=dashboard,
-            title='Report 3',
-            report_configuration_id='report3',
-            dashboard_tab=DashboardTab.MOBILE_WORKERS,
-            display_order=1,
-        ),
-        DashboardReport.objects.create(
-            dashboard=dashboard,
-            title='Report 4',
-            report_configuration_id='report4',
-            dashboard_tab=DashboardTab.MOBILE_WORKERS,
-            display_order=2,
-        ),
-    ]
+    DashboardReport.objects.create(
+        dashboard=dashboard,
+        title='Report 1',
+        report_configuration_id='report1',
+        dashboard_tab=DashboardTab.CASES,
+        display_order=1,
+    )
+    DashboardReport.objects.create(
+        dashboard=dashboard,
+        title='Report 2',
+        report_configuration_id='report2',
+        dashboard_tab=DashboardTab.CASES,
+        display_order=2,
+    )
+    DashboardReport.objects.create(
+        dashboard=dashboard,
+        title='Report 3',
+        report_configuration_id='report3',
+        dashboard_tab=DashboardTab.MOBILE_WORKERS,
+        display_order=1,
+    )
+    DashboardReport.objects.create(
+        dashboard=dashboard,
+        title='Report 4',
+        report_configuration_id='report4',
+        dashboard_tab=DashboardTab.MOBILE_WORKERS,
+        display_order=2,
+    )
+    yield
 
 
-@use(dashboard_maps)
+@use('db', dashboard_maps)
 def test_dashboard_map_ordering():
     dashboard = dashboard_fixture()
     map_ordering = [
@@ -102,7 +100,7 @@ def test_dashboard_map_ordering():
     ]
 
 
-@use(dashboard_reports)
+@use('db', dashboard_reports)
 def test_dashboard_report_ordering():
     dashboard = dashboard_fixture()
     report_ordering = [

--- a/corehq/apps/campaign/tests/test_models.py
+++ b/corehq/apps/campaign/tests/test_models.py
@@ -1,16 +1,22 @@
-import pytest
+from unmagic import fixture, use  # https://github.com/dimagi/pytest-unmagic
 
 from ..models import Dashboard, DashboardMap, DashboardReport, DashboardTab
 
 
-@pytest.fixture
-def dashboard():
-    return Dashboard.objects.create(domain='test-domain')
+@use('db')
+@fixture
+def dashboard_fixture():
+    dashboard = Dashboard.objects.create(domain='test-domain')
+    try:
+        yield dashboard
+    finally:
+        dashboard.delete()
 
 
-@pytest.fixture
-def dashboard_maps(dashboard):
-    return [
+@fixture
+def dashboard_maps():
+    dashboard = dashboard_fixture()
+    yield [
         DashboardMap.objects.create(
             dashboard=dashboard,
             title='Map 1',
@@ -46,9 +52,10 @@ def dashboard_maps(dashboard):
     ]
 
 
-@pytest.fixture
-def dashboard_reports(dashboard):
-    return [
+@fixture
+def dashboard_reports():
+    dashboard = dashboard_fixture()
+    yield [
         DashboardReport.objects.create(
             dashboard=dashboard,
             title='Report 1',
@@ -80,41 +87,31 @@ def dashboard_reports(dashboard):
     ]
 
 
-@pytest.mark.django_db
-def test_dashboard_map_ordering(
-    dashboard,
-    dashboard_maps,
-):
-    map_titles = [map.title for map in dashboard.maps.all()]
-    assert map_titles == ['Map 1', 'Map 2', 'Map 3', 'Map 4']
-
+@use(dashboard_maps)
+def test_dashboard_map_ordering():
+    dashboard = dashboard_fixture()
     map_ordering = [
-        (map.dashboard_tab, map.display_order)
+        (map.title, map.dashboard_tab, map.display_order)
         for map in dashboard.maps.all()
     ]
     assert map_ordering == [
-        ('cases', 1),
-        ('cases', 2),
-        ('mobile_workers', 1),
-        ('mobile_workers', 2),
+        ('Map 1', 'cases', 1),
+        ('Map 2', 'cases', 2),
+        ('Map 3', 'mobile_workers', 1),
+        ('Map 4', 'mobile_workers', 2),
     ]
 
 
-@pytest.mark.django_db
-def test_dashboard_report_ordering(
-    dashboard,
-    dashboard_reports,
-):
-    report_titles = [report.title for report in dashboard.reports.all()]
-    assert report_titles == ['Report 1', 'Report 2', 'Report 3', 'Report 4']
-
+@use(dashboard_reports)
+def test_dashboard_report_ordering():
+    dashboard = dashboard_fixture()
     report_ordering = [
-        (report.dashboard_tab, report.display_order)
+        (report.title, report.dashboard_tab, report.display_order)
         for report in dashboard.reports.all()
     ]
     assert report_ordering == [
-        ('cases', 1),
-        ('cases', 2),
-        ('mobile_workers', 1),
-        ('mobile_workers', 2),
+        ('Report 1', 'cases', 1),
+        ('Report 2', 'cases', 2),
+        ('Report 3', 'mobile_workers', 1),
+        ('Report 4', 'mobile_workers', 2),
     ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -212,6 +212,7 @@ blobs
 campaign
  0001_initial
  0002_dashboardmap_dashboardreport
+ 0003_add_dashboard_widget_fields
 case_importer
  0001_initial
  0002_auto_20161206_1937


### PR DESCRIPTION
## Technical Summary

No point only storing `display_order` if we don't know which tab to display the dashboard widget!

Thanks for spotting, @mkangia 

## Feature Flag

campaign_dashboard

## Safety Assurance

### Safety story

Not yet in use.

### Automated test coverage

This change is not covered by tests

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
