### PR TITLE
Bulk data cleaning: gate based on permission + privilege + flag

### DIFF
--- a/corehq/apps/data_cleaning/decorators.py
+++ b/corehq/apps/data_cleaning/decorators.py
@@ -1,0 +1,31 @@
+from functools import wraps
+from no_exceptions.exceptions import Http403
+
+from django.http.response import Http404
+
+from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.privileges import BULK_DATA_CLEANING
+from corehq.toggles import DATA_CLEANING_CASES
+
+
+def require_bulk_data_cleaning_cases(view_func):
+    @wraps(view_func)
+    def _inner(request, *args, **kwargs):
+        if not bulk_data_cleaning_enabled_for_request(request):
+            raise Http403
+
+        if not DATA_CLEANING_CASES.enabled_for_request(request):
+            raise Http404
+
+        return view_func(request, *args, **kwargs)
+
+    return _inner
+
+
+def bulk_data_cleaning_enabled_for_request(request):
+    if domain_has_privilege(request.domain, BULK_DATA_CLEANING):
+        if hasattr(request, "couch_user"):
+            if request.couch_user.can_edit_data(request.domain):
+                return True
+
+    return False

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy
 from django.views.generic import TemplateView
 from memoized import memoized
 
-from corehq import toggles
+from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
 from corehq.apps.data_cleaning.forms.filters import AddColumnFilterForm
 from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
 from corehq.apps.domain.decorators import LoginAndDomainMixin
@@ -15,7 +15,7 @@ from corehq.util.timezones.utils import get_timezone
 
 @method_decorator([
     use_bootstrap5,
-    toggles.DATA_CLEANING_CASES.required_decorator(),
+    require_bulk_data_cleaning_cases,
 ], name='dispatch')
 class BaseFilterFormView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
     pass

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -10,7 +10,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.http import require_GET, require_POST
 from django.utils.translation import gettext_lazy, gettext as _
 
-from corehq import toggles
+from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
 from corehq.apps.data_cleaning.models import BulkEditSession
 from corehq.apps.data_cleaning.tasks import commit_data_cleaning
 from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
@@ -22,7 +22,7 @@ from corehq.util.view_utils import set_file_download
 
 @method_decorator([
     use_bootstrap5,
-    toggles.DATA_CLEANING_CASES.required_decorator(),
+    require_bulk_data_cleaning_cases,
 ], name='dispatch')
 class CleanCasesMainView(BaseProjectDataView):
     page_title = gettext_lazy("Clean Case Data")
@@ -41,7 +41,7 @@ class CleanCasesMainView(BaseProjectDataView):
 
 @method_decorator([
     use_bootstrap5,
-    toggles.DATA_CLEANING_CASES.required_decorator(),
+    require_bulk_data_cleaning_cases,
 ], name='dispatch')
 class CleanCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
     page_title = gettext_lazy("Clean Case Type")
@@ -91,7 +91,7 @@ class CleanCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
 
 @login_and_domain_required
 @require_POST
-@toggles.DATA_CLEANING_CASES.required_decorator()
+@require_bulk_data_cleaning_cases
 def save_case_session(request, domain, session_id):
     session = BulkEditSession.objects.get(session_id=session_id)
 
@@ -108,7 +108,7 @@ def save_case_session(request, domain, session_id):
 
 @login_and_domain_required
 @require_GET
-@toggles.DATA_CLEANING_CASES.required_decorator()
+@require_bulk_data_cleaning_cases
 def download_form_ids(request, domain, session_id):
     session = BulkEditSession.objects.get(session_id=session_id)
 

--- a/corehq/apps/data_cleaning/views/setup.py
+++ b/corehq/apps/data_cleaning/views/setup.py
@@ -4,7 +4,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
-from corehq import toggles
+from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
 from corehq.apps.data_cleaning.forms.setup import (
     SelectCaseTypeForm,
     ResumeOrRestartCaseSessionForm,
@@ -18,7 +18,7 @@ from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 @method_decorator([
     use_bootstrap5,
-    toggles.DATA_CLEANING_CASES.required_decorator(),
+    require_bulk_data_cleaning_cases,
 ], name='dispatch')
 class SetupCaseSessionFormView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
     urlname = "data_cleaning_select_case_type_form"

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from corehq import toggles
+from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
 from corehq.apps.data_cleaning.models import BulkEditSession
 from corehq.apps.data_cleaning.tables import (
     CleanCaseTable,
@@ -15,7 +15,7 @@ from corehq.apps.hqwebapp.tables.pagination import SelectablePaginatedTableView
 
 @method_decorator([
     use_bootstrap5,
-    toggles.DATA_CLEANING_CASES.required_decorator(),
+    require_bulk_data_cleaning_cases,
 ], name='dispatch')
 class BaseDataCleaningTableView(LoginAndDomainMixin, DomainViewMixin, SelectablePaginatedTableView):
     pass

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -32,6 +32,7 @@ from corehq.apps.app_manager.dbaccessors import (
 from corehq.apps.app_manager.util import is_remote_app, is_linked_app
 from corehq.apps.builds.views import EditMenuView
 from corehq.apps.data_dictionary.views import DataDictionaryView
+from corehq.apps.data_cleaning.decorators import bulk_data_cleaning_enabled_for_request
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.internal import ProjectLimitsView
 from corehq.apps.domain.views.releases import ManageReleasesByLocation
@@ -1004,7 +1005,10 @@ class ProjectDataTab(UITab):
 
     @property
     def _can_view_case_data_cleaning(self):
-        return toggles.DATA_CLEANING_CASES.enabled_for_request(self._request)
+        return (
+            bulk_data_cleaning_enabled_for_request(self._request)
+            and toggles.DATA_CLEANING_CASES.enabled_for_request(self._request)
+        )
 
     def _get_explore_data_views(self):
         explore_data_views = []

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -213,13 +213,14 @@ class privilege_enabled:
     supported, add it to ``self.imports``.
     """
     imports = (
+        'corehq.apps.app_manager.app_strings.domain_has_privilege',
+        'corehq.apps.data_cleaning.decorators.domain_has_privilege',
+        'corehq.apps.export.views.list.domain_has_privilege',
         'corehq.apps.users.landing_pages.domain_has_privilege',
         'corehq.apps.users.permissions.domain_has_privilege',
         'corehq.apps.users.views.mobile.users.domain_has_privilege',
-        'django_prbac.decorators.has_privilege',
-        'corehq.apps.export.views.list.domain_has_privilege',
         'corehq.pillows.case_search.domain_has_privilege',
-        'corehq.apps.app_manager.app_strings.domain_has_privilege',
+        'django_prbac.decorators.has_privilege',
     )
 
     def __init__(self, privilege_slug):


### PR DESCRIPTION
## Technical Summary
I was going to leave this until later, expecting to just do a quick PR replacing all flag checks with privilege checks, but after remembering it also involves the edit_data permission, decided it would be better to get this done now.

When the feature is ready for release, the only change needed will be removing the two feature flag checks - one in the decorator, one in tabclasses.

## Feature Flag
Bulk data cleaning

## Safety Assurance

### Safety story
Changes to a flagged feature not used by any production clients.

### Automated test coverage

In PR.

### QA Plan

No.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
