### PR TITLE
Support shadow forms in refresh_data_dictionary_from_app

### DIFF
--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -98,13 +98,13 @@ def refresh_data_dictionary_from_app(domain, app_id):
     for module in app.get_modules():
         if not module.is_surveys:
             for form in module.get_forms():
-                if form.form_type == 'advanced_form':
-                    for action in form.actions.load_update_cases:
-                        case_type_to_prop[action.case_type].update(action.case_properties)
-                else:
+                if form.form_type == 'module_form':
                     case_type_to_prop[module.case_type].update(form.actions.update_case.update)
                     if actions_use_usercase(form.actions):
                         case_type_to_prop[USERCASE_TYPE].update(form.actions.usercase_update.update)
+                else:
+                    for action in form.actions.load_update_cases:
+                        case_type_to_prop[action.case_type].update(action.case_properties)
     if case_type_to_prop:
         create_properties_for_case_types(domain, case_type_to_prop)
 

--- a/corehq/apps/app_manager/tests/test_tasks.py
+++ b/corehq/apps/app_manager/tests/test_tasks.py
@@ -122,6 +122,7 @@ class AppManagerTasksTest(TestCase):
         })
         m1, f1 = factory.new_advanced_module('advanced', 'case')
         factory.form_requires_case(f1, 'person')
+        factory.new_shadow_form(m1)
         factory.app.save()
         self.addCleanup(factory.app.delete)
 


### PR DESCRIPTION
## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/35876

It wasn't handling shadow forms, which are also advanced forms but use a different `form_type`.

Sentry: https://dimagi.sentry.io/issues/6388850956/?project=136860

## Feature Flag
Advanced modules

## Safety Assurance

### Safety story
This updates a celery task, so it's non-user-facing, and if it fails it's not a big deal.

### Automated test coverage

In PR.

### QA Plan

No.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
