### PR TITLE
Disable Interval Sync

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -154,7 +154,6 @@ hqDefine("cloudcare/js/formplayer/menus/api", [
                             if (parsedMenus.metaData) {
                                 attemptRestore = parsedMenus.metaData.attemptRestore;
                             }
-                            formplayerUtils.setSyncInterval(params.appId, attemptRestore);
                             sessionStorage.setItem("lastUserActivityTime",  Date.now());
                             FormplayerFrontend.trigger('clearProgress');
                             defer.resolve(parsedMenus);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -154,6 +154,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", [
                             if (parsedMenus.metaData) {
                                 attemptRestore = parsedMenus.metaData.attemptRestore;
                             }
+                            formplayerUtils.setSyncInterval(params.appId, attemptRestore);
                             sessionStorage.setItem("lastUserActivityTime",  Date.now());
                             FormplayerFrontend.trigger('clearProgress');
                             defer.resolve(parsedMenus);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_spec.js
@@ -20,6 +20,7 @@ describe('Render a case list', function () {
                 DYNAMICALLY_UPDATE_SEARCH_RESULTS: false,
                 USE_PROMINENT_PROGRESS_BAR: false,
                 ACTIVATE_DATADOG_APM_TRACES: false,
+                USH_DISABLE_INTERVAL_SYNC: false,
             },
         );
         sinon.stub(Utils, 'getCurrentQueryInputs').callsFake(function () { return {}; });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -458,6 +458,10 @@ hqDefine("cloudcare/js/formplayer/utils/utils", [
             customProperties = currentApp.attributes.profile.custom_properties || {};
         }
 
+        if (toggles.toggleEnabled('USH_DISABLE_INTERVAL_SYNC')) {
+            console.log("interval sync is disabled");
+            return;
+        }
         const useAggressiveSyncTiming = (customProperties[constants.POST_FORM_SYNC] === "yes");
         if (!useAggressiveSyncTiming) {
             return;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -459,7 +459,6 @@ hqDefine("cloudcare/js/formplayer/utils/utils", [
         }
 
         if (toggles.toggleEnabled('USH_DISABLE_INTERVAL_SYNC')) {
-            console.log("interval sync is disabled");
             return;
         }
         const useAggressiveSyncTiming = (customProperties[constants.POST_FORM_SYNC] === "yes");

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -3035,3 +3035,10 @@ ACTIVATE_DATADOG_APM_TRACES = StaticToggle(
     tag=TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN]
 )
+
+USH_DISABLE_INTERVAL_SYNC = StaticToggle(
+    slug='ush_disable_interval_sync',
+    label='Disable interval sync',
+    tag=TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This will only affect domains which enable the newly introduced FF `ush_disable_interval_sync`. Interval sync was originally introduced so that syncing could occur between users actions. The user-facing effects here is that syncing will only occur now upon user action.
 
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Interval Syncing was introduced as part of this [PR](https://github.com/dimagi/commcare-hq/pull/34161)
[USH-5814](https://dimagi.atlassian.net/browse/USH-5814)
A FF is introduced to allow disabling this feature as it is causing a bug for an urgent demo.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Interval Sync was only enabled for apps with app property `cc-sync-after-form` set to `yes`. This PR introduces the FF `ush_disable_interval_sync` so that domains can opt into disabled interval sync.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change is behind the FF `ush_disable_interval_sync` and will only affect domains that enable the FF. Users will start experiencing more wait time associated with actions if syncing occurs.  

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-5814]: https://dimagi.atlassian.net/browse/USH-5814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ