### PR TITLE
Update vellum-to-hq to not skip ci

### DIFF
--- a/scripts/vellum-to-hq
+++ b/scripts/vellum-to-hq
@@ -162,7 +162,7 @@ def update_hq(path, branch, base_branch, vellum_dir, vellum_rev, push, target):
     sh.tar("xf", vellum_tar, "-C", hq_vellum)
     git.add("--all", hq_vellum)
 
-    message = "{}:{}\n\n[ci skip]".format(target, vellum_rev)
+    message = "{}:{}\n\n".format(target, vellum_rev)
     if branch == 'vellum-staging':
         message += """
 

--- a/scripts/vellum-to-hq
+++ b/scripts/vellum-to-hq
@@ -162,7 +162,7 @@ def update_hq(path, branch, base_branch, vellum_dir, vellum_rev, push, target):
     sh.tar("xf", vellum_tar, "-C", hq_vellum)
     git.add("--all", hq_vellum)
 
-    message = "{}:{}\n\n".format(target, vellum_rev)
+    message = "{}:{}".format(target, vellum_rev)
     if branch == 'vellum-staging':
         message += """
 


### PR DESCRIPTION
## Technical Summary
`skip ci` is annoying now that tests passing is required on all PRs.

## Safety Assurance

### Safety story
Minor change to a developer tool.

### Automated test coverage

I don't think so.

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
