### PR TITLE
Removed notifications from form builder

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -1,3 +1,4 @@
+/* global require */
 hqDefine("app_manager/js/forms/form_designer", function () {
     var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         appcues = hqImport('analytix/js/appcues'),

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -1,4 +1,3 @@
-/* globals require, WS4Redis */
 hqDefine("app_manager/js/forms/form_designer", function () {
     var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
         appcues = hqImport('analytix/js/appcues'),
@@ -154,17 +153,6 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                         $("#edit").hide();
                         $('#hq-footer').hide();
                         $('#formdesigner').vellum(VELLUM_OPTIONS);
-                        var notificationOptions = initialPageData.get("notification_options");
-                        if (notificationOptions) {
-                            var notifications = hqImport('app_manager/js/forms/app_notifications'),
-                                vellum = $("#formdesigner").vellum("get");
-                            // initialize redis
-                            WS4Redis({
-                                uri: notificationOptions.WEBSOCKET_URI + notificationOptions.notify_facility + '?subscribe-broadcast',
-                                receive_message: notifications.alertUser(notificationOptions.user_id, vellum.alertUser, vellum),
-                                heartbeat_msg: notificationOptions.WS4REDIS_HEARTBEAT,
-                            });
-                        }
                     });
                 });
                 hqImport('analytix/js/kissmetrix').track.event('Entered the Form Builder');


### PR DESCRIPTION
## Product Description
This turns off the "Bob is editing this form" notifications in form builder.

Planning to merge for next week's deploy. Marking "don't merge" so it doesn't get released before then.

## Technical Summary
Fully removing this code has several technical and communication steps. This PR just removes the feature from the UI so that superusers won't see js errors during any gaps between removing different pieces.

Removal of related HQ code is in https://github.com/dimagi/commcare-hq/pull/35881/

Removal of related cloud code is here in https://github.com/dimagi/commcare-cloud/pull/6481

https://dimagi.atlassian.net/browse/SAAS-16761

## Feature Flag
This is a superuser-only feature.

## Safety Assurance

### Safety story
Change itself should be safe, just removes some javascript. Tested locally.

### Automated test coverage

No.

### QA Plan

No.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
