### PR TITLE
Fix an issue where empty keys were added in app bulk translations

### DIFF
--- a/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
@@ -112,7 +112,7 @@ class BulkUiTranslation(SimpleTestCase):
         ])
         self.assertEqual(len(warnings), 3)
         self.assertEqual([e.strip() for e in warnings], [
-            "Property 'unknown_string' is not a known CommCare UI string, but we added it anyway.",
+            "Property unknown_string is not a known CommCare UI string, but we added it anyway.",
             "Property 'updates.found' should contain ${0}, ${1} but en value contains no parameters.",
             "Property 'updates.found' should contain ${0}, ${1} but fra value contains ${0}, ${1}, ${2}.",
         ])

--- a/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
@@ -39,6 +39,32 @@ class BulkUiTranslation(SimpleTestCase):
         self.assertEqual(dict(translations), {})
         self.assertEqual(len(error_properties), 0)
 
+    def test_empty_key_warning(self):
+        headers = (('translations', ('property', 'en', 'fra')),)
+        data = (('', 'wobble', 'bobble'),
+                ('key.manage.title', 'wabble', 'babble'))
+
+        f = self._build_translation_download_file(headers, data)
+        translations, error_properties, warnings = process_ui_translation_upload(self.app, f)
+        self.assertEqual(
+            dict(translations),
+            {
+                'en': {
+                    'key.manage.title': 'wabble',
+                },
+                'fra': {
+                    'key.manage.title': 'babble',
+                }
+            }
+
+        )
+
+        self.assertEqual(len(error_properties), 0)
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual([e.strip() for e in warnings], [
+            "Property '' is empty, We did not add it to the translations"
+        ])
+
     def test_translation(self):
         headers = (('translations', ('property', 'en', 'fra')),)
         # on an update to 2.31.0, the keys date.tomorrow, entity.sort.title,

--- a/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
@@ -62,7 +62,7 @@ class BulkUiTranslation(SimpleTestCase):
         self.assertEqual(len(error_properties), 0)
         self.assertEqual(len(warnings), 1)
         self.assertEqual([e.strip() for e in warnings], [
-            "Property '' is empty, We did not add it to the translations"
+            "Property '' is empty. We did not add it to the translations"
         ])
 
     def test_translation(self):
@@ -112,7 +112,7 @@ class BulkUiTranslation(SimpleTestCase):
         ])
         self.assertEqual(len(warnings), 3)
         self.assertEqual([e.strip() for e in warnings], [
-            "Property unknown_string is not a known CommCare UI string, but we added it anyway.",
+            "Property 'unknown_string' is not a known CommCare UI string, but we added it anyway.",
             "Property 'updates.found' should contain ${0}, ${1} but en value contains no parameters.",
             "Property 'updates.found' should contain ${0}, ${1} but fra value contains ${0}, ${1}, ${2}.",
         ])

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -70,8 +70,8 @@ def process_ui_translation_upload(app, trans_file):
 
     for row in translations:
         if row["property"] == "":
-            warnings.append(_("Property {prop} is empty, "
-                            "We did not add it to the translations").format(prop=row["property"]))
+            warnings.append(_("Property '' is empty, "
+                            "We did not add it to the translations"))
             continue
         if row["property"] not in commcare_ui_strings:
             # Add a warning for  unknown properties, but still add them to the translation dict

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -4,14 +4,15 @@ from collections import defaultdict
 
 from django.utils.translation import gettext as _
 
+from commcare_translations import load_translations
+
 from couchexport.export import export_raw_to_writer
 
-from commcare_translations import load_translations
 from corehq.apps.app_manager import app_strings
 from corehq.apps.app_manager.ui_translations.commcare_versioning import (
     get_commcare_version_from_workbook,
-    set_commcare_version_in_workbook,
     get_strict_commcare_version_string,
+    set_commcare_version_in_workbook,
 )
 from corehq.apps.translations.models import TransifexBlacklist
 from corehq.util.workbook_json.excel import (
@@ -94,8 +95,8 @@ def process_ui_translation_upload(app, trans_file):
                                 expected=default_params_text,
                                 lang=lang,
                                 actual=params_text))
-                if not (lang_with_defaults == lang and
-                        row[lang] == default_trans.get(row["property"], "")):
+                if not (lang_with_defaults == lang
+                        and row[lang] == default_trans.get(row["property"], "")):
                     trans_dict[lang].update({row["property"]: row[lang]})
 
     return trans_dict, error_properties, warnings

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -68,6 +68,10 @@ def process_ui_translation_upload(app, trans_file):
         return ", ".join(["${{{}}}".format(num) for num in numbers])
 
     for row in translations:
+        if row["property"] == "":
+            warnings.append("Property '" + row["property"] + "' is empty, "
+                            "We did not add it to the translations")
+            continue
         if row["property"] not in commcare_ui_strings:
             # Add a warning for  unknown properties, but still add them to the translation dict
             warnings.append("Property '" + row["property"] + "' is not a known CommCare UI string, "

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -70,13 +70,13 @@ def process_ui_translation_upload(app, trans_file):
 
     for row in translations:
         if row["property"] == "":
-            warnings.append("Property '" + row["property"] + "' is empty, "
-                            "We did not add it to the translations")
+            warnings.append(_("Property {prop} is empty, "
+                            "We did not add it to the translations").format(prop=row["property"]))
             continue
         if row["property"] not in commcare_ui_strings:
             # Add a warning for  unknown properties, but still add them to the translation dict
-            warnings.append("Property '" + row["property"] + "' is not a known CommCare UI string, "
-                            "but we added it anyway.")
+            warnings.append(_("Property {prop} is not a known CommCare UI string, "
+                            "but we added it anyway.").format(prop=row["property"]))
         default = default_trans.get(row["property"])
         default_params_text = _get_params_text(_get_params(default)) if default else None
         for lang in app.langs:

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -70,12 +70,12 @@ def process_ui_translation_upload(app, trans_file):
 
     for row in translations:
         if row["property"] == "":
-            warnings.append(_("Property '' is empty, "
+            warnings.append(_("Property '' is empty. "
                             "We did not add it to the translations"))
             continue
         if row["property"] not in commcare_ui_strings:
             # Add a warning for  unknown properties, but still add them to the translation dict
-            warnings.append(_("Property {prop} is not a known CommCare UI string, "
+            warnings.append(_("Property '{prop}' is not a known CommCare UI string, "
                             "but we added it anyway.").format(prop=row["property"]))
         default = default_trans.get(row["property"])
         default_params_text = _get_params_text(_get_params(default)) if default else None


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
<!-- Where applicable, describe user-facing effects and include screenshots. -->
We had an issue with our bulk translations logic where we were allowing empty keys if they were present in uploaded Excel file. This empty key was causing issues with ES. (See https://github.com/dimagi/commcare-hq/pull/35889).

The issue is demonstrated by the test failure [here](https://github.com/dimagi/commcare-hq/actions/runs/13840998556/job/38728172429#step:5:673) 

## Safety Assurance
Does not change any functionality, fixes an issue, also have tests for the fix.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests are added
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

n/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
