### PR TITLE
AddColumnFilterForm - form validation and UI bugfixes for POSTed/validated states

### DIFF
--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -14,6 +14,12 @@ from corehq.apps.data_cleaning.models import (
 )
 from corehq.apps.data_cleaning.utils.cases import get_case_property_details
 
+EXCLUDED_FILTERED_PROPERTIES = [
+    '@case_type',  # Data cleaning only works with one case type at a time
+    '@status',  # the Case Status pinned filter takes care of this
+    '@owner_id',  # the Case Owner(s) pinned filter takes care of this
+]
+
 
 class AddColumnFilterForm(forms.Form):
     prop_id = forms.ChoiceField(
@@ -78,7 +84,7 @@ class AddColumnFilterForm(forms.Form):
 
         property_details = get_case_property_details(self.session.domain, self.session.identifier)
         self.fields['prop_id'].choices = [(None, None)] + [
-            (p, p) for p in sorted(property_details.keys())
+            (p, p) for p in sorted(property_details.keys()) if p not in EXCLUDED_FILTERED_PROPERTIES
         ]
 
         initial_prop_id = self.fields['prop_id'].initial

--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -87,7 +87,7 @@ class AddColumnFilterForm(forms.Form):
             (p, p) for p in sorted(property_details.keys()) if p not in EXCLUDED_FILTERED_PROPERTIES
         ]
 
-        initial_prop_id = self.fields['prop_id'].initial
+        initial_prop_id = self._get_initial_value('prop_id')
         is_initial_editable = (
             property_details[initial_prop_id]['is_editable'] if initial_prop_id else True
         )
@@ -95,7 +95,9 @@ class AddColumnFilterForm(forms.Form):
         offcanvas_selector = "#offcanvas-filter"
 
         alpine_data_model = {
-            "dataType": self.fields['data_type'].initial,
+            "dataType": self._get_initial_value(
+                'data_type', DataType.CASE_CHOICES[0][0]
+            ),
             "propId": initial_prop_id,
             "casePropertyDetails": property_details,
             "isEditable": is_initial_editable,
@@ -113,10 +115,18 @@ class AddColumnFilterForm(forms.Form):
             "multiSelectDataTypes": DataType.FILTER_CATEGORY_DATA_TYPES[
                 DataType.FILTER_CATEGORY_MULTI_SELECT
             ],
-            "textMatchType": self.fields['text_match_type'].initial,
-            "numberMatchType": self.fields['number_match_type'].initial,
-            "dateMatchType": self.fields['date_match_type'].initial,
-            "multiSelectMatchType": self.fields['multi_select_match_type'].initial,
+            "textMatchType": self._get_initial_value(
+                'text_match_type', FilterMatchType.TEXT_CHOICES[0][0]
+            ),
+            "numberMatchType": self._get_initial_value(
+                'number_match_type', FilterMatchType.NUMBER_CHOICES[0][0]
+            ),
+            "dateMatchType": self._get_initial_value(
+                'date_match_type', FilterMatchType.DATE_CHOICES[0][0]
+            ),
+            "multiSelectMatchType": self._get_initial_value(
+                'multi_select_match_type', FilterMatchType.MULTI_SELECT_CHOICES[0][0]
+            ),
             "matchTypesWithNoValue": [
                 f[0] for f in FilterMatchType.ALL_DATA_TYPES_CHOICES
             ],
@@ -140,7 +150,6 @@ class AddColumnFilterForm(forms.Form):
                 ),
                 crispy.Field(
                     'data_type',
-                    x_init="dataType = $el.value",
                     x_model="dataType",
                     **({
                         ":disabled": "!isEditable",
@@ -259,4 +268,9 @@ class AddColumnFilterForm(forms.Form):
                 ),
                 x_data=json.dumps(alpine_data_model),
             ),
+        )
+
+    def _get_initial_value(self, field_name, default_value=None):
+        return self.data.get(
+            field_name, self.fields[field_name].initial or default_value
         )

--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -86,7 +86,7 @@ class AddColumnFilterForm(forms.Form):
             property_details[initial_prop_id]['is_editable'] if initial_prop_id else True
         )
 
-        select2_parent_selector = "#offcanvas-filter"
+        offcanvas_selector = "#offcanvas-filter"
 
         alpine_data_model = {
             "dataType": self.fields['data_type'].initial,
@@ -124,7 +124,7 @@ class AddColumnFilterForm(forms.Form):
                     'prop_id',
                     x_select2=json.dumps({
                         "placeholder": _("Select a Case Property"),
-                        "dropdownParent": select2_parent_selector,
+                        "dropdownParent": offcanvas_selector,
                     }),
                     **({
                         "@select2change": "propId = $event.detail; "
@@ -144,7 +144,7 @@ class AddColumnFilterForm(forms.Form):
                     crispy.Field(
                         'text_match_type',
                         x_select2=json.dumps({
-                            "dropdownParent": select2_parent_selector,
+                            "dropdownParent": offcanvas_selector,
                         }),
                         **({
                             "@select2change": "textMatchType = $event.detail",
@@ -163,7 +163,7 @@ class AddColumnFilterForm(forms.Form):
                     crispy.Field(
                         'number_match_type',
                         x_select2=json.dumps({
-                            "dropdownParent": select2_parent_selector,
+                            "dropdownParent": offcanvas_selector,
                         }),
                         **({
                             "@select2change": "numberMatchType = $event.detail",
@@ -182,7 +182,7 @@ class AddColumnFilterForm(forms.Form):
                     crispy.Field(
                         'date_match_type',
                         x_select2=json.dumps({
-                            "dropdownParent": select2_parent_selector,
+                            "dropdownParent": offcanvas_selector,
                         }),
                         **({
                             "@select2change": "dateMatchType = $event.detail",
@@ -195,6 +195,7 @@ class AddColumnFilterForm(forms.Form):
                                 '<i class="fa-solid fa-calendar-days"></i>'
                             ),
                             x_datepicker=json.dumps({
+                                "container": offcanvas_selector,
                                 "useInputGroup": True,
                             }),
                         ),
@@ -209,6 +210,7 @@ class AddColumnFilterForm(forms.Form):
                             ),
                             x_datepicker=json.dumps({
                                 "datetime": True,
+                                "container": offcanvas_selector,
                                 "useInputGroup": True,
                             }),
                         ),
@@ -221,7 +223,7 @@ class AddColumnFilterForm(forms.Form):
                     crispy.Field(
                         'multi_select_match_type',
                         x_select2=json.dumps({
-                            "dropdownParent": select2_parent_selector,
+                            "dropdownParent": offcanvas_selector,
                         }),
                         **({
                             "@select2change": "multiSelectMatchType = $event.detail",

--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -24,6 +24,14 @@ EXCLUDED_FILTERED_PROPERTIES = [
 ]
 
 
+class DynamicMultipleChoiceField(forms.MultipleChoiceField):
+    def valid_value(self, value):
+        """
+        Override the parent valid_value method to allow any user-created value
+        """
+        return True
+
+
 class AddColumnFilterForm(forms.Form):
     prop_id = forms.ChoiceField(
         label=gettext_lazy("Case Property"),
@@ -76,7 +84,7 @@ class AddColumnFilterForm(forms.Form):
         choices=FilterMatchType.MULTI_SELECT_CHOICES + FilterMatchType.ALL_DATA_TYPES_CHOICES,
         required=False
     )
-    multi_select_value = forms.MultipleChoiceField(
+    multi_select_value = DynamicMultipleChoiceField(
         label=gettext_lazy("Value"),
         required=False
     )

--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -254,6 +254,7 @@ class AddColumnFilterForm(forms.Form):
                             x_dynamic_options_select2=json.dumps({
                                 "details": property_details,
                                 "eventName": 'updateAddFilterPropId',
+                                "initialPropId": initial_prop_id,
                             }),
                         ),
                         x_show="!matchTypesWithNoValue.includes(multiSelectMatchType)",

--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -16,6 +16,7 @@ from corehq.apps.data_cleaning.models import (
     BulkEditColumnFilter,
 )
 from corehq.apps.data_cleaning.utils.cases import get_case_property_details
+from corehq.apps.hqwebapp.widgets import AlpineSelect
 
 EXCLUDED_FILTERED_PROPERTIES = [
     '@case_type',  # Data cleaning only works with one case type at a time
@@ -39,6 +40,7 @@ class AddColumnFilterForm(forms.Form):
     )
     data_type = forms.ChoiceField(
         label=gettext_lazy("Data Type"),
+        widget=AlpineSelect,
         choices=DataType.CASE_CHOICES,
         required=False
     )

--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -159,12 +159,12 @@ class AddColumnFilterForm(forms.Form):
                                           "isEditable = casePropertyDetails[$event.detail].is_editable;",
                     })
                 ),
-                crispy.Field(
-                    'data_type',
-                    x_model="dataType",
-                    **({
-                        ":disabled": "!isEditable",
-                    })
+                crispy.Div(
+                    crispy.Field(
+                        'data_type',
+                        x_model="dataType",
+                    ),
+                    x_show="isEditable",
                 ),
                 crispy.Div(
                     crispy.Field(

--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -1,6 +1,7 @@
 import json
 
 from django import forms
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _, gettext_lazy
 
 from crispy_forms import bootstrap as twbscrispy
@@ -188,18 +189,29 @@ class AddColumnFilterForm(forms.Form):
                         })
                     ),
                     crispy.Div(
-                        crispy.Field(
+                        twbscrispy.AppendedText(
                             'date_value',
-                            x_datepicker="",
+                            mark_safe(  # nosec: no user input
+                                '<i class="fa-solid fa-calendar-days"></i>'
+                            ),
+                            x_datepicker=json.dumps({
+                                "useInputGroup": True,
+                            }),
                         ),
                         x_show="!matchTypesWithNoValue.includes(dateMatchType) "
                                "&& dateTypes.includes(dataType)"
                     ),
                     crispy.Div(
-                        'datetime_value',
-                        x_datepicker=json.dumps({
-                            "datetime": True,
-                        }),
+                        twbscrispy.AppendedText(
+                            'datetime_value',
+                            mark_safe(  # nosec: no user input
+                                '<i class="fcc fcc-fd-datetime"></i>'
+                            ),
+                            x_datepicker=json.dumps({
+                                "datetime": True,
+                                "useInputGroup": True,
+                            }),
+                        ),
                         x_show="!matchTypesWithNoValue.includes(dateMatchType) "
                                "&& datetimeTypes.includes(dataType)"
                     ),

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/directives/dynamic_options_select2.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/directives/dynamic_options_select2.js
@@ -51,5 +51,5 @@ Alpine.directive('dynamic-options-select2', (el, { expression }, { cleanup }) =>
 });
 
 document.body.addEventListener('htmx:afterSettle', (event) => {
-    utils.fixSelect2htmx(event, '[x-multi-option-select2]');
+    utils.fixSelect2htmx(event, '[x-dynamic-options-select2]');
 });

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -64,7 +64,7 @@ class ColumnFilterFormView(BulkEditSessionViewMixin, BaseFilterFormView):
         context = super().get_context_data(**kwargs)
         context.update({
             'container_id': 'column-filters',
-            'add_filter_form': kwargs.pop('filter_form', AddColumnFilterForm(self.session)),
+            'add_filter_form': kwargs.pop('filter_form', None) or AddColumnFilterForm(self.session),
         })
         return context
 

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -70,7 +70,7 @@ class ColumnFilterFormView(BulkEditSessionViewMixin, BaseFilterFormView):
 
     @hq_hx_action('post')
     def add_column_filter(self, request, *args, **kwargs):
-        filter_form = AddColumnFilterForm(request.POST)
+        filter_form = AddColumnFilterForm(self.session, request.POST)
         if filter_form.is_valid():
             filter_form = None
         return self.get(request, filter_form=filter_form, *args, **kwargs)

--- a/corehq/apps/data_cleaning/views/setup.py
+++ b/corehq/apps/data_cleaning/views/setup.py
@@ -28,7 +28,7 @@ class SetupCaseSessionFormView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActio
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update({
-            "form": kwargs.pop('form', SelectCaseTypeForm(self.domain)),
+            "form": kwargs.pop('form', None) or SelectCaseTypeForm(self.domain),
             "container_id": self.container_id,
             "next_action": kwargs.pop('next_action', 'validate_session'),
         })

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
@@ -1,6 +1,37 @@
 import { TempusDominus } from '@eonasdan/tempus-dominus';
 import '@eonasdan/tempus-dominus/dist/css/tempus-dominus.css';
 import Alpine from 'alpinejs';
+import _ from 'underscore';
+
+const defaultTranslations = {
+    clear: gettext('Clear selection'),
+    close: gettext('Close the picker'),
+    dayViewHeaderFormat: { month: gettext('long'), year: gettext('2-digit') },
+    decrementHour: gettext('Decrement Hour'),
+    decrementMinute: gettext('Decrement Minute'),
+    decrementSecond: gettext('Decrement Second'),
+    incrementHour: gettext('Increment Hour'),
+    incrementMinute: gettext('Increment Minute'),
+    incrementSecond: gettext('Increment Second'),
+    nextCentury: gettext('Next Century'),
+    nextDecade: gettext('Next Decade'),
+    nextMonth: gettext('Next Month'),
+    nextYear: gettext('Next Year'),
+    pickHour: gettext('Pick Hour'),
+    pickMinute: gettext('Pick Minute'),
+    pickSecond: gettext('Pick Second'),
+    previousCentury: gettext('Previous Century'),
+    previousDecade: gettext('Previous Decade'),
+    previousMonth: gettext('Previous Month'),
+    previousYear: gettext('Previous Year'),
+    selectDate: gettext('Select Date'),
+    selectDecade: gettext('Select Decade'),
+    selectMonth: gettext('Select Month'),
+    selectTime: gettext('Select Time'),
+    selectYear: gettext('Select Year'),
+    today: gettext('Go to today'),
+    toggleMeridiem: gettext('Toggle Meridiem'),
+};
 
 Alpine.directive('datepicker', (el, { expression }, { cleanup }) => {
     /**
@@ -44,7 +75,7 @@ Alpine.directive('datepicker', (el, { expression }, { cleanup }) => {
             theme: 'light',
             components: components,
         },
-        localization: localization,
+        localization: _.extend(defaultTranslations, localization),
     });
 
     cleanup(() => {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
@@ -76,9 +76,20 @@ Alpine.directive('datepicker', (el, { expression }, { cleanup }) => {
             theme: 'light',
             components: components,
             icons: faFiveIcons,
+            buttons: {
+                // show close button when date + time widget is used, as it is a multi-click action
+                close: !!config.datetime,
+            },
         },
         localization: _.extend(defaultTranslations, localization),
     });
+
+    if (!config.datetime) {
+        // Since picking a date is a single-click action, hide the picker on date selection
+        picker.subscribe('change.td',  () => {
+            picker.hide();
+        });
+    }
 
     cleanup(() => {
         picker.dispose();

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
@@ -1,4 +1,5 @@
 import { TempusDominus } from '@eonasdan/tempus-dominus';
+import {faFiveIcons} from '@eonasdan/tempus-dominus/dist/plugins/fa-five';
 import '@eonasdan/tempus-dominus/dist/css/tempus-dominus.css';
 import Alpine from 'alpinejs';
 import _ from 'underscore';
@@ -74,6 +75,7 @@ Alpine.directive('datepicker', (el, { expression }, { cleanup }) => {
         display: {
             theme: 'light',
             components: components,
+            icons: faFiveIcons,
         },
         localization: _.extend(defaultTranslations, localization),
     });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
@@ -91,6 +91,11 @@ Alpine.directive('datepicker', (el, { expression }, { cleanup }) => {
         });
     }
 
+    el.addEventListener('error.td', (event) => {
+        picker.dates.setValue(null);
+        event.stopPropagation();
+    });
+
     cleanup(() => {
         picker.dispose();
     });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
@@ -82,6 +82,7 @@ Alpine.directive('datepicker', (el, { expression }, { cleanup }) => {
             },
         },
         localization: _.extend(defaultTranslations, localization),
+        promptTimeOnDateChange: !!config.datetime,
     });
 
     if (!config.datetime) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
@@ -71,7 +71,16 @@ Alpine.directive('datepicker', (el, { expression }, { cleanup }) => {
         };
     }
 
-    const picker = new TempusDominus(el, {
+    let pickerEl = el;
+    if (config.useInputGroup) {
+        if (!el.parentElement.classList.contains('input-group')) {
+            throw new Error("useInputGroup - Please surround input with input-group or use AppendedText or PrependText in crispy forms.");
+        }
+        pickerEl = el.parentElement;
+        pickerEl.id = el.id + '-datepicker';
+    }
+
+    const picker = new TempusDominus(pickerEl, {
         display: {
             theme: 'light',
             components: components,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
@@ -92,6 +92,7 @@ Alpine.directive('datepicker', (el, { expression }, { cleanup }) => {
         },
         localization: _.extend(defaultTranslations, localization),
         promptTimeOnDateChange: !!config.datetime,
+        container: (config.container) ? document.querySelector(config.container) : undefined,
     });
 
     if (!config.datetime) {

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -209,3 +209,57 @@ class GeoCoderInput(Input):
             value = json.dumps(value)
         output = super(GeoCoderInput, self).render(name, value, attrs, renderer)
         return format_html('<div class="geocoder-proximity">{}</div>', output)
+
+
+class AlpineSelect(forms.Select):
+    """
+    * For crispy forms using an alpine model in `crispy.Layout`
+
+    When applying the `x_model="alpineVar"` attribute to a ChoiceField in crispy.Layout,
+    the rendered HTML appropriately adds `x-model="alpineVar"` to that
+    `<select>` element's rendered attributes. At this point, alpine JS will take over
+    setting the `selected="selected"` attribute on the child `<option>` elements.
+
+    While the client-side interactivity will behave as expected, updating the value of
+    `alpineVar` and showing the correct selection, POSTing the form will always return
+    `None` for the associated ChoiceField unless you use  this widget.
+
+    This widget ensures that the `selected` attribute on each child option is
+    properly updated when the value of the x-model variable changes.
+
+    usage example:
+
+        some_choice = forms.ChoiceField(
+            ...
+            widget=AlpineSelect,
+            ...
+        )
+
+    then in the layout...
+
+        self.helper.layout = crispy.Layout(
+            ...,
+            crispy.Field(
+                'some_choice',
+                x_model="alpineVar",
+                ...
+            ),
+            ...,
+        )
+
+    """
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        x_model = context["widget"]["attrs"].get('x-model')
+        if not x_model:
+            return context
+
+        for index, optgroup in enumerate(context["widget"]['optgroups']):
+            option_context = context["widget"]['optgroups'][index][1][0]
+            option_value = option_context['value']
+            option_context['attrs'].update({
+                ':selected': f"{x_model} == '{option_value}'"
+            })
+            context["widget"]['optgroups'][index][1][0] = option_context
+        return context


### PR DESCRIPTION
## Technical Summary
This PR implements form validation for the `AddColumnFilterForm`
In order to get to that point, I discovered several issues that needed to be addressed on directives and crispy forms widgets after the form is `POST`ed and is in an errored state.

Please review commit-by-commit. The commit messages contain enough information to explain what's going on.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
Safe changes made only to areas that are behind a feature flag.

### Automated test coverage
Tests already cover the most important things: view access and filtering logic. I want to add tests for form validation, but am deferring that work until the QA-ready functionality is complete for this feature. I don't want to get side tracked writing tons of tests again, when the core tests are already very solid.

### QA Plan
Not needed right now.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
