### PR TITLE
Fix validation state multi-select select2 scss

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
@@ -119,7 +119,7 @@
 
 .select2-container--default.is-invalid,
 .select2-container--default.is-valid {
-  .select2-selection__rendered {
+  .select2-selection--single .select2-selection__rendered {
     padding-right: 66px !important;
   }
   .select2-selection--single::before {

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
@@ -189,8 +189,7 @@
   }
 }
 
-.select2-container--default.select2-container--disabled
-  .select2-selection--single {
+.select2-container--default.select2-container--disabled .select2-selection--single {
   border-color: $input-disabled-bg !important;
   background-color: $input-disabled-bg !important;
 }

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
@@ -8,39 +8,54 @@
      margin-left: 10px;
      margin-bottom: 3px;
    }
-@@ -14,74 +15,186 @@
+@@ -14,74 +15,185 @@
  }
  
  // Static width for select2 widgets, which otherwise grow too large on form view's case management tab
 -.case-config-select2s(@width) {
 -    .select2-container {
 -        width: @width;
+-    }
 +@mixin case-config-select2s($width) {
 +  .select2-container {
 +    width: $width;
 +  }
-+
+ 
+-    // This needs a static width so that text-overflow: ellipsis will work in Firefox.
+-    // Unusually specific selector to override select2's width: auto rule.
+-    > .select2-choice > .select2-chosen {
+-        width: @width - 35px;
+-    }
 +  // This needs a static width so that text-overflow: ellipsis will work in Firefox.
 +  // Unusually specific selector to override select2's width: auto rule.
 +  > .select2-choice > .select2-chosen {
 +    width: $width - 35px;
 +  }
-+}
-+
+ }
+ 
+-.property-descriptions(@width) {
+-    width: @width;
+-    white-space: nowrap;
+-    overflow: hidden;
+-    text-overflow: ellipsis;
+-    display: inline-block;
 +@mixin property-descriptions($width) {
 +  width: $width;
 +  white-space: nowrap;
 +  overflow: hidden;
 +  text-overflow: ellipsis;
 +  display: inline-block;
-+}
-+
+ }
+ 
+-#case-config-ko, #usercase-config-ko {
+-    @select2Width: 210px;
 +#case-config-ko,
 +#usercase-config-ko {
 +  $select2Width: 210px;
-+
+ 
+-    .case-config-select2s(@select2Width);
 +  @include case-config-select2s($select2Width);
-+
+ 
 +  .property-description {
 +    @include property-descriptions($select2Width);
 +  }
@@ -48,33 +63,10 @@
 +  .wide-select2s {
 +    $wideWidth: $select2Width * 1.5;
 +    @include case-config-select2s($wideWidth);
-+    .property-description {
+     .property-description {
+-      .property-descriptions(@select2Width);
 +      @include property-descriptions($wideWidth);
      }
--
--    // This needs a static width so that text-overflow: ellipsis will work in Firefox.
--    // Unusually specific selector to override select2's width: auto rule.
--    > .select2-choice > .select2-chosen {
--        width: @width - 35px;
--    }
--}
--
--.property-descriptions(@width) {
--    width: @width;
--    white-space: nowrap;
--    overflow: hidden;
--    text-overflow: ellipsis;
--    display: inline-block;
--}
--
--#case-config-ko, #usercase-config-ko {
--    @select2Width: 210px;
--
--    .case-config-select2s(@select2Width);
--
--    .property-description {
--      .property-descriptions(@select2Width);
--    }
 -
 -    .wide-select2s {
 -      @wideWidth: @select2Width * 1.5;
@@ -93,28 +85,45 @@
 +
 +  .select2-search-field {
      width: 100% !important;
--
++  }
+ 
 -    .select2-selection.select2-selection--single {
 -        height: @input-height-base;
-+  }
-+
+-    }
 +  .select2-input {
 +    width: 100% !important;
 +  }
 +}
-+
+ 
+-    .select2-selection.select2-selection--multiple {
+-        min-height: @input-height-base;
+-    }
+-
+-    .select2-search-field {
+-        width: 100% !important;
+-    }
+-
+-    .select2-input {
+-        width: 100% !important;
+-    }
+-
+-    textarea.select2-search__field {    // Placeholder for multi-select
+-        line-height: 21px;
+-    }
 +.select2-search__field::placeholder {
 +  font-size: $font-size-base;
 +  font-family: $font-family-base;
-+}
-+
-+.select2-container.select2-container-active > .select2-choice {
+ }
+ 
+ .select2-container.select2-container-active > .select2-choice {
+-  .box-shadow(0 0 10px @cc-brand-mid);
 +  box-shadow: 0 0 10px $cc-brand-mid;
-+}
-+
-+.select2-selection__placeholder {
+ }
+ 
+ .select2-selection__placeholder {
+-  color: @gray-base !important;
 +  color: $gray-base !important;
-+}
+ }
 +
 +.select2-container--default .select2-selection--single,
 +.select2-container--default .select2-selection--multiple {
@@ -154,7 +163,7 @@
 +
 +.select2-container--default.is-invalid,
 +.select2-container--default.is-valid {
-+  .select2-selection__rendered {
++  .select2-selection--single .select2-selection__rendered {
 +    padding-right: 66px !important;
 +  }
 +  .select2-selection--single::before {
@@ -177,32 +186,7 @@
 +    .select2-selection--single,
 +    .select2-selection--multiple {
 +      outline: 0;
-     }
--
--    .select2-selection.select2-selection--multiple {
--        min-height: @input-height-base;
--    }
--
--    .select2-search-field {
--        width: 100% !important;
--    }
--
--    .select2-input {
--        width: 100% !important;
--    }
--
--    textarea.select2-search__field {    // Placeholder for multi-select
--        line-height: 21px;
--    }
--}
--
--.select2-container.select2-container-active > .select2-choice {
--  .box-shadow(0 0 10px @cc-brand-mid);
--}
--
--.select2-selection__placeholder {
--  color: @gray-base !important;
--}
++    }
 +  }
 +}
 +
@@ -249,8 +233,7 @@
 +  }
 +}
 +
-+.select2-container--default.select2-container--disabled
-+  .select2-selection--single {
++.select2-container--default.select2-container--disabled .select2-selection--single {
 +  border-color: $input-disabled-bg !important;
 +  background-color: $input-disabled-bg !important;
 +}


### PR DESCRIPTION
## Technical Summary
This fixes multi-select select2s which are in a validation state.

Prior to the fix, validated multi-select select2 widgets would have a large amount of padding after the last element due to a custom css overrides we added for the validated single-select select2.
Here is a inspector highlight of this annoying padding. The cursor was blinking so it wasn't captured, but it appeared waay after the last selected item. Doesn't affect functionality, just looks really strange.
![Screenshot 2025-03-13 at 6 52 54 PM](https://github.com/user-attachments/assets/a9c2b207-c648-48ae-b32a-fa8ce82d7dd9)

It now looks normal:
![Screenshot 2025-03-13 at 6 52 09 PM](https://github.com/user-attachments/assets/1347a204-8b6d-4c9c-94ef-12ca0344dc4d)


## Safety Assurance

### Safety story
css change only. validated on styleguide and locally

### Automated test coverage
N/A

### QA Plan
Not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
