### PR TITLE
Check that case search is enabled before displaying on case list

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -62,8 +62,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
                     containsFixtureConfiguration: (columnType === "short" && hqImport('hqwebapp/js/toggles').toggleEnabled('FIXTURE_CASE_SELECTION')),
                     containsFilterConfiguration: columnType === "short",
                     containsCaseListLookupConfiguration: (columnType === "short" && (hqImport('hqwebapp/js/toggles').toggleEnabled('CASE_LIST_LOOKUP') || hqImport('hqwebapp/js/toggles').toggleEnabled('BIOMETRIC_INTEGRATION'))),
-                    // TODO: Check case_search_enabled_for_domain(), not toggle. FB 225343
-                    containsSearchConfiguration: (columnType === "short" && hqImport('hqwebapp/js/toggles').toggleEnabled('SYNC_SEARCH_CASE_CLAIM')),
+                    containsSearchConfiguration: (columnType === "short" && hqImport('hqwebapp/js/initial_page_data').get('case_search_enabled')),
                     containsCustomXMLConfiguration: columnType === "short",
                     allowsTabs: columnType === 'long',
                     allowsEmptyColumns: columnType === 'long',

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -65,6 +65,7 @@
   {% initial_page_data 'js_options' js_options %}
   {% initial_page_data 'multimedia_object_map' multimedia.object_map %}
   {% initial_page_data 'case_list_form_options' case_list_form_options %}
+  {% initial_page_data 'case_search_enabled' js_options.is_search_enabled %}
   {% initial_page_data 'form_endpoint_options' form_endpoint_options %}
   {% initial_page_data 'case_list_form_not_allowed_reasons' case_list_form_not_allowed_reasons %}
   {% initial_page_data 'case_type' module.case_type %}


### PR DESCRIPTION
## Product Description
No user-facing change.

## Technical Summary
From https://github.com/dimagi/commcare-hq/pull/11438

This TODO comment keeps showing up in my webpack app manager migration diffs and it's bugging me.

`is_search_enabled` gets defined [here](https://github.com/dimagi/commcare-hq/blob/c8e76d7ba5da445cada2c687ebff62aedc582844/corehq/apps/app_manager/views/modules.py#L242).

## Feature Flag
Case search

## Safety Assurance

### Safety story
Tested locally, which is sufficient for the scope of this change.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
