### PR TITLE
Removed $ from HTML bindings

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_filter.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_filter.html
@@ -15,7 +15,7 @@
       <div data-bind="css: {'has-error': !allowed()}">
             <textarea name="form_filter" class="form-control" data-bind="
                     xpathValidator: {text: formFilter, allowCaseHashtags: true,
-                                     errorHtml: $('#formFilterXpathErrorHtml').html()}
+                                     errorHtml: document.getElementById('formFilterXpathErrorHtml').innerHTML}
             "></textarea>
         <div class="help-block" data-bind="visible: !allowed()">
           <span data-bind="visible: caseReferenceNotAllowed">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -295,7 +295,11 @@
                        spellcheck="false"
                        data-bind="
                          value: search_button_display_condition,
-                         xpathValidator: {text: search_button_display_condition, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}
+                         xpathValidator: {
+                           text: search_button_display_condition,
+                           allowCaseHashtags: true,
+                           errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
+                         }
                        "
               ></textarea>
             </div>
@@ -308,7 +312,13 @@
                     data-content="{% trans_html_attr "An XPath expression to filter the search results." %}">
             </label>
             <div class="{% css_field_class %}">
-              <textarea data-bind="value: search_filter, xpathValidator: {text: search_filter, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}"
+              <textarea data-bind="
+                          value: search_filter,
+                          xpathValidator: {
+                            text: search_filter,
+                            allowCaseHashtags: true,
+                            errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
+                          }"
                         class="form-control vertical-resize"
                         id="search-filter"
                         spellcheck="false"
@@ -331,7 +341,13 @@
               </span>
             </label>
             <div class="{% css_field_class %}">
-              <textarea data-bind="value: additional_relevant, xpathValidator: {text: additional_relevant, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}"
+              <textarea data-bind="
+                          value: additional_relevant,
+                          xpathValidator: {
+                            text: additional_relevant,
+                            allowCaseHashtags: true,
+                            errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
+                          }"
                         class="form-control vertical-resize"
                         id="claim-relevant-condition"
                         spellcheck="false"
@@ -348,7 +364,11 @@
             <div class="{% css_field_class %}">
               <textarea data-bind="
                 value: blacklisted_owner_ids_expression,
-                xpathValidator: {text: blacklisted_owner_ids_expression, allowCaseHashtags: true, errorHtml: $('#searchFilterXpathErrorHtml').html()}
+                xpathValidator: {
+                  text: blacklisted_owner_ids_expression,
+                  allowCaseHashtags: true,
+                  errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
+                }
               "
                         class="form-control vertical-resize"
                         id="blacklisted-user-ids"
@@ -413,8 +433,11 @@
                         <td>
                           <textarea data-bind="
                               value: caseIdXpath,
-                              xpathValidator: {text: caseIdXpath, allowCaseHashtags: false, errorHtml: $('#searchFilterXpathErrorHtml').html()}
-                              "
+                              xpathValidator: {
+                                text: caseIdXpath,
+                                allowCaseHashtags: false,
+                                errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
+                              }"
                                     class="form-control vertical-resize"
                                     spellcheck="false"
                           ></textarea>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_filter.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_filter.html
@@ -14,7 +14,7 @@
               data-bind="xpathValidator: {
                     text: {% if ko_value %}{{ ko_value }}{% else %}xpath{% endif %},
                     allowCaseHashtags: false,
-                    errorHtml: $('#module-filter-xpath-error-html').html()
+                    errorHtml: document.getElementById('module-filter-xpath-error-html').innerHTML,
                 }"></textarea>
       <script type="text/html" id="module-filter-xpath-error-html" class="hide">
         There is something wrong with the logic in the filter.


### PR DESCRIPTION
## Product Description
No user-facing change.

## Technical Summary
Cherry pick from app manager webpack migration.

Using jQuery in bindings needs additional code in webpack. In these cases, it's very easy to just remove the jQuery.

## Safety Assurance

### Safety story
Pretty minor HTML changes. Tested locally:
* form filter
* module filter
* report module filter
* case search properties like the claim condition

![Screenshot 2025-03-13 at 6 59 30 PM](https://github.com/user-attachments/assets/63a6f51c-40a4-40c2-b794-4c2428cefba5)


### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
