### PR TITLE
Resolve Docker warning

### DIFF
--- a/docker/hq-compose-os-default.yml
+++ b/docker/hq-compose-os-default.yml
@@ -1,7 +1,5 @@
 # Default arch-specific configurations (x86_64 architecture).
 
-version: '2.3'
-
 services:
   postgres:
     image: docker.io/dimagi/docker-postgresql:${DOCKER_HQ_POSTGRES_VERSION}

--- a/docker/hq-compose-os-macos-m1-11.yml
+++ b/docker/hq-compose-os-macos-m1-11.yml
@@ -1,7 +1,5 @@
 # Service configurations specific to 'arm64' (Apple M1) architecture for MacOS Big Sur (v 11).
 
-version: '2.3'
-
 services:
   postgres:
     # TODO: enumerate differences with 'dimagi/docker-postgresql' image

--- a/docker/hq-compose-os-macos-m1-12.yml
+++ b/docker/hq-compose-os-macos-m1-12.yml
@@ -1,7 +1,5 @@
 # Service configurations specific to 'arm64' (Apple M1) architecture for MacOS Monterey (v 12).
 
-version: '2.3'
-
 services:
   postgres:
     image: docker.io/dimagi/docker-postgresql:${DOCKER_HQ_POSTGRES_VERSION}

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -1,5 +1,3 @@
-version: '2.3'
-
 volumes:
   shared_files: {}
 

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -1,5 +1,3 @@
-version: '2.3'
-
 services:
   formplayer:
     extends:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   web:
     build:


### PR DESCRIPTION
## Technical Summary

Resolves the Docker warning:

WARN[0000] docker/hq-compose-services.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

## Safety Assurance

### Safety story

Tested locally.

### Automated test coverage

N/A

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
