### PR TITLE
Shrink and center dashboard icons

### DIFF
--- a/corehq/apps/dashboard/templates/dashboard/base.html
+++ b/corehq/apps/dashboard/templates/dashboard/base.html
@@ -50,7 +50,11 @@
             <div class="card-body">
 
               <!-- Icon in a watermark style, displayed under item list -->
-              <i data-bind="css: icon, visible: showBackgroundIcon" class="dashboard-icon dashboard-icon-medium dashboard-icon-bg"></i>
+              <!-- ko ifnot: showIconLink -->
+              <div class="d-flex justify-content-center align-items-center dashboard-icon-bg-container">
+                <i data-bind="css: icon, visible: showBackgroundIcon" class="dashboard-icon"></i>
+              </div>
+              <!-- /ko -->
 
               <!-- Spinner -->
               <i class="fa fa-spinner fa-spin fa-5x" data-bind="visible: showSpinner"></i>
@@ -83,18 +87,21 @@
 
               <!-- No items to show or there's an error, just show an icon that links -->
               <!-- ko if: showIconLink -->
-              <a class="dashboard-link"
-                 data-bind="
-                                   attr: {href: url},
-                                   popover: {
-                                       title: title,
-                                       content: helpText,
-                                       placement: 'top',
-                                       trigger: 'hover',
-                                   },
-                               ">
-                <i class="dashboard-icon dashboard-icon-medium" data-bind="css: icon"></i>
-              </a>
+              <div class="d-flex justify-content-center align-items-center">
+                <a
+                  class="dashboard-link"
+                  data-bind="
+                                attr: {href: url},
+                                popover: {
+                                    title: title,
+                                    content: helpText,
+                                    placement: 'top',
+                                    trigger: 'hover',
+                                },
+                            ">
+                  <i class="dashboard-icon" data-bind="css: icon"></i>
+                </a>
+              </div>
               <!-- /ko -->
 
             </div>

--- a/corehq/apps/hqwebapp/static/dashboard/scss/dashboard-main.scss
+++ b/corehq/apps/hqwebapp/static/dashboard/scss/dashboard-main.scss
@@ -1,52 +1,29 @@
 $card-dashboard-border: darken($navbar-default-bg, 5);
 $card-dashboard-header-bg: $navbar-default-bg;
+$dashboard-card-body-height: 197px;
+$dashboard-icon-size: 100px;
 
 .dashboard-icon {
-  display: block;
-  text-align: center;
+  font-size: $dashboard-icon-size;
 }
 
-.dashboard-icon-large {
-  margin: 0 auto;
-  $icon-size: 220px;
-  width: $icon-size;
-  height: $icon-size;
-  font-size: 200px;
-}
-
-.dashboard-icon-medium {
-  $icon-size: 230px;
-  width: 100%;
-  height: $icon-size;
-  margin: 0 auto;
-  font-size: 170px;
-  @include media-breakpoint-down(lg) {
-    font-size: 140px;
-    padding-top: 15px;
-  }
-  @include media-breakpoint-down(md) {
-    font-size: 170px;
-  }
-}
-
-.dashboard-icon-bg {
+.dashboard-icon-bg-container {
   position: absolute;
-  top: 4.75 * $font-size-base;
-  left: 0;
-  width: 100%;
-  text-align: center;
-  color: #e7e7e7;
+  width: calc(100% - 32px);
+  height: $dashboard-card-body-height;
+  .dashboard-icon {
+    color: #e7e7e7;
+  }
 }
 
-.dashboard-link,
-.dashboard-button {
+.dashboard-link {
+  $y-padding: calc(($dashboard-card-body-height - $dashboard-icon-size) / 2);
+  $x-padding: calc((100% - $dashboard-icon-size) / 2);
+  padding: $y-padding $x-padding;
   &:hover,
   &:focus {
     text-decoration: none;
     outline: none;
-    .dashboard-icon-medium {
-      background-position: 0px -189px;
-    }
   }
 }
 

--- a/corehq/apps/hqwebapp/static/dashboard/scss/dashboard-main.scss
+++ b/corehq/apps/hqwebapp/static/dashboard/scss/dashboard-main.scss
@@ -25,6 +25,9 @@ $dashboard-icon-size: 100px;
     text-decoration: none;
     outline: none;
   }
+  i.dashboard-icon::before{
+    padding: 7px 0;
+  }
 }
 
 .card-dashboard {


### PR DESCRIPTION
## Product Description
Shrinks and centers icons on the HQ dashboard and keeps them the same size regardless of window width.

Before:

https://github.com/user-attachments/assets/87b80ef4-4241-4871-9b29-f2cc5390fd37


After:

https://github.com/user-attachments/assets/92a01683-417f-4757-98f0-d97724cb6781

## Technical Summary
Simplifies the SCSS quite a bit by adding a simple conditional and a wrapper div with some B5 helpers. Also removes the previously unused `.dashboard-icon-large` and now-unused `.dashboard-icon-medium`. Also makes the mouse target area for dashboard links a bit more accurate with padding that adjusts based on card size.

## Safety Assurance

### Safety story
These are just visual changes, so the risk is pretty low. Changes to HTML structure carry some risk, but have tested to see that the icon links and tooltips, loading spinners, and table content on top of background icons still all look & work as expected. Checked on Chrome, Firefox, and Safari on Mac.

### Automated test coverage
Nope.

### QA Plan
Nope.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
