### PR TITLE
create channel property and add caching

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy, gettext_noop, gettext as _
 import jsonfield
 
 from dimagi.utils.couch import CriticalSection
+from django.utils.functional import cached_property
 
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.locations.models import SQLLocation
@@ -605,12 +606,16 @@ class ConnectMessagingNumber:
 
     @property
     def phone_number(self):
-        return self.user_link.channel_id
+        return self.messaging_channel
 
-    @property
+    @cached_property
     def user_link(self):
         django_user = self.owner.get_django_user()
         return ConnectIDUserLink.objects.get(commcare_user=django_user)
+
+    @cached_property
+    def messaging_channel(self):
+        return self.user_link.messaging_channel
 
     @property
     def backend(self):

--- a/corehq/messaging/smsbackends/connectid/backend.py
+++ b/corehq/messaging/smsbackends/connectid/backend.py
@@ -16,11 +16,6 @@ class ConnectBackend:
         user = CouchUser.get_by_user_id(message.couch_recipient).get_django_user()
         user_link = ConnectIDUserLink.objects.get(commcare_user=user)
 
-        # create channel if it does not yet exist
-        if not user_link.channel_id:
-            self.create_channel(user_link)
-            user_link.refresh_from_db()
-
         raw_key = user_link.messaging_key.key
         key = base64.b64decode(raw_key)
         cipher = AES.new(key, AES.MODE_GCM)
@@ -33,7 +28,7 @@ class ConnectBackend:
         response = requests.post(
             settings.CONNECTID_MESSAGE_URL,
             json={
-                "channel": user_link.channel_id,
+                "channel": user_link.messaging_channel,
                 "content": content,
                 "message_id": str(message.message_id),
             },


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This is a followup to https://github.com/dimagi/commcare-hq/pull/35947 that moves the change down a level, so that channels are always created on access, rather than requiring code to know if it has been created and create it at the point of usage. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`COMMCARE_CONNECT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change is isolated to connect messaging, and doesn't impact already created channels.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
