### PR TITLE
KYC Dynamic Report Columns

### DIFF
--- a/corehq/apps/integration/kyc/models.py
+++ b/corehq/apps/integration/kyc/models.py
@@ -169,6 +169,12 @@ class KycUser:
         else:
             raise KeyError(item)
 
+    def get(self, item, default=None):
+        try:
+            return self[item]
+        except KeyError:
+            return default
+
     @property
     def user_data(self):
         if self._user_data is None:

--- a/corehq/apps/integration/kyc/services.py
+++ b/corehq/apps/integration/kyc/services.py
@@ -130,15 +130,11 @@ def get_user_data_for_api(kyc_user, config):
         Returns a dictionary of user data for the API.
         ``source`` is a CommCareUser or a CommCareCase.
     """
-    user_data_for_api = {}
-    for api_field, user_data_property in config.api_field_to_user_data_map.items():
-        try:
-            value = kyc_user[user_data_property]
-        except KeyError:
-            # Conservative approach to skip the API field if data is not available for the user
-            continue
-        user_data_for_api[api_field] = value
-    return user_data_for_api
+    return {
+        api_field: kyc_user.get(user_data_property)
+        for api_field, user_data_property in config.api_field_to_user_data_map.items()
+        if kyc_user.get(user_data_property) is not None
+    }
 
 
 def _validate_schema(endpoint, data):

--- a/corehq/apps/integration/kyc/tables.py
+++ b/corehq/apps/integration/kyc/tables.py
@@ -31,41 +31,26 @@ class KycVerifyTable(BaseHtmxTable):
             'th__input': {'name': 'select_all'},
         },
     )
-    first_name = columns.Column(
-        verbose_name=_('First Name'),
-    )
-    last_name = columns.Column(
-        verbose_name=_('Last Name'),
-    )
-    phone_number = columns.Column(
-        verbose_name=_('Phone Number'),
-    )
-    email = columns.Column(
-        verbose_name=_('Email Address'),
-    )
-    national_id_number = columns.Column(
-        verbose_name=_('National ID Number'),
-    )
-    street_address = columns.Column(
-        verbose_name=_('Street Address'),
-    )
-    city = columns.Column(
-        verbose_name=_('City'),
-    )
-    post_code = columns.Column(
-        verbose_name=_('Post Code'),
-    )
-    country = columns.Column(
-        verbose_name=_('Country'),
-    )
-    kyc_verification_status = columns.TemplateColumn(
-        template_name='kyc/partials/kyc_verify_status.html',
-        verbose_name=_('KYC Status'),
-    )
-    kyc_last_verified_at = columns.DateTimeColumn(
-        verbose_name=_('Last Verified'),
-    )
-    verify_btn = columns.TemplateColumn(
-        template_name='kyc/partials/kyc_verify_button.html',
-        verbose_name=_('Verify'),
-    )
+
+    @staticmethod
+    def get_extra_columns(kyc_config):
+        cols = []
+        for field in kyc_config.api_field_to_user_data_map.values():
+            name = field.replace('_', ' ').title()
+            cols.append(
+                (field, columns.Column(verbose_name=name))
+            )
+        cols.extend([
+            ('kyc_verification_status', columns.TemplateColumn(
+                template_name='kyc/partials/kyc_verify_status.html',
+                verbose_name=_('KYC Status')
+            )),
+            ('kyc_last_verified_at', columns.DateTimeColumn(
+                verbose_name=_('Last Verified')
+            )),
+            ('verify_btn', columns.TemplateColumn(
+                template_name='kyc/partials/kyc_verify_button.html',
+                verbose_name=_('Verify')
+            )),
+        ])
+        return cols

--- a/corehq/apps/integration/kyc/tests/test_tables.py
+++ b/corehq/apps/integration/kyc/tests/test_tables.py
@@ -1,0 +1,33 @@
+from django.test import SimpleTestCase
+
+from corehq.apps.integration.kyc.models import KycConfig, UserDataStore
+from corehq.apps.integration.kyc.tables import KycVerifyTable
+
+
+class TestKycVerifyTable(SimpleTestCase):
+    domain = 'test'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.kyc_config = KycConfig(
+            domain=cls.domain,
+            user_data_store=UserDataStore.CUSTOM_USER_DATA,
+            api_field_to_user_data_map={
+                'pants_type': 'apple_bottom_jeans',
+                'shoe_type': 'boots_with_fur',
+            }
+        )
+
+    def test_get_extra_columns(self):
+        extra_cols = KycVerifyTable.get_extra_columns(self.kyc_config)
+        expected_data = [
+            ('apple_bottom_jeans', 'Apple Bottom Jeans'),
+            ('boots_with_fur', 'Boots With Fur'),
+            ('kyc_verification_status', 'KYC Status'),
+            ('kyc_last_verified_at', 'Last Verified'),
+            ('verify_btn', 'Verify')
+        ]
+        for i, (name, verbose_name) in enumerate(expected_data):
+            assert extra_cols[i][0] == name
+            assert extra_cols[i][1].verbose_name == verbose_name

--- a/corehq/apps/integration/kyc/tests/test_views.py
+++ b/corehq/apps/integration/kyc/tests/test_views.py
@@ -140,7 +140,7 @@ class TestKycVerificationTableView(BaseTestKycView):
         super().setUpClass()
         cls.kyc_mapping = {
             # API field: User data
-            'first_name': 'first_name',
+            'first_name': 'name',
             'last_name': 'last_name',
             'email': 'email',
             'phone_number': 'phone_number',
@@ -166,6 +166,7 @@ class TestKycVerificationTableView(BaseTestKycView):
             last_name='Doe',
             email='jdoe@example.org',
             user_data={
+                'name': 'Johnny',
                 'phone_number': '1234567890',
                 'national_id_number': '1234567890',
                 'street_address': '123 Main St',
@@ -192,7 +193,7 @@ class TestKycVerificationTableView(BaseTestKycView):
                 data={
                     'first_name': 'Bob',
                     'last_name': 'Smith',
-                    'email': 'bsmith@example.org',
+                    'home_email': 'bsmith@example.org',
                     'phone_number': '0987654321',
                     'national_id_number': '0987654321',
                     'street_address': '456 Main St',
@@ -239,16 +240,18 @@ class TestKycVerificationTableView(BaseTestKycView):
                 assert row == {
                     'id': self.user2.user_id,
                     'has_invalid_data': True,
-                    'first_name': 'Jane',
-                    'last_name': 'Doe',
                     'kyc_verification_status': None,
                     'kyc_last_verified_at': None,
+                    'name': 'Jane Doe',
+                    'last_name': 'Doe',
                 }
             else:
                 assert row == {
                     'id': self.user1.user_id,
                     'has_invalid_data': False,
-                    'first_name': 'John',
+                    'kyc_verification_status': None,
+                    'kyc_last_verified_at': None,
+                    'name': 'Johnny',
                     'last_name': 'Doe',
                     'email': 'jdoe@example.org',
                     'phone_number': '1234567890',
@@ -257,8 +260,6 @@ class TestKycVerificationTableView(BaseTestKycView):
                     'city': 'Anytown',
                     'post_code': '12345',
                     'country': 'Anyplace',
-                    'kyc_verification_status': None,
-                    'kyc_last_verified_at': None,
                 }
 
     @flag_enabled('KYC_VERIFICATION')
@@ -268,7 +269,7 @@ class TestKycVerificationTableView(BaseTestKycView):
         self.kyc_config.api_field_to_user_data_map.update({
             'first_name': 'first_name',
             'last_name': 'last_name',
-            'email': 'email',
+            'email': 'home_email',
         })
         self.kyc_config.save()
 
@@ -280,26 +281,26 @@ class TestKycVerificationTableView(BaseTestKycView):
                 assert row == {
                     'id': self.case_list[1].case_id,
                     'has_invalid_data': True,
-                    'first_name': 'Foo',
-                    'last_name': 'Bar',
                     'kyc_verification_status': None,
                     'kyc_last_verified_at': None,
+                    'first_name': 'Foo',
+                    'last_name': 'Bar',
                 }
             else:
                 assert row == {
                     'id': self.case_list[0].case_id,
                     'has_invalid_data': False,
+                    'kyc_verification_status': None,
+                    'kyc_last_verified_at': None,
                     'first_name': 'Bob',
                     'last_name': 'Smith',
-                    'email': 'bsmith@example.org',
+                    'home_email': 'bsmith@example.org',
                     'phone_number': '0987654321',
                     'national_id_number': '0987654321',
                     'street_address': '456 Main St',
                     'city': 'Sometown',
                     'post_code': '54321',
                     'country': 'Someplace',
-                    'kyc_verification_status': None,
-                    'kyc_last_verified_at': None,
                 }
 
 

--- a/corehq/apps/integration/kyc/views.py
+++ b/corehq/apps/integration/kyc/views.py
@@ -4,6 +4,8 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 
+from django_tables2 import RequestConfig
+
 from corehq import toggles
 from corehq.apps.domain.decorators import login_required
 from corehq.apps.domain.views.base import BaseDomainView
@@ -11,12 +13,10 @@ from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.tables.pagination import SelectablePaginatedTableView
 from corehq.apps.integration.kyc.forms import KycConfigureForm
 from corehq.apps.integration.kyc.models import KycConfig, KycVerificationStatus
-from corehq.apps.integration.kyc.services import (
-    verify_users,
-)
+from corehq.apps.integration.kyc.services import verify_users
 from corehq.apps.integration.kyc.tables import KycVerifyTable
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
-from corehq.util.metrics import metrics_gauge, metrics_counter
+from corehq.util.metrics import metrics_counter, metrics_gauge
 
 
 @method_decorator(use_bootstrap5, name='dispatch')
@@ -83,41 +83,35 @@ class KycVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableView):
     def kyc_config(self):
         return KycConfig.objects.get(domain=self.request.domain)
 
-    def get_queryset(self):
-        row_objs = self.kyc_config.get_kyc_users()
-        return [self._parse_row(row_obj) for row_obj in row_objs]
+    def get_table(self, **kwargs):
+        table_class = self.get_table_class()
+        table = table_class(
+            data=self.get_table_data(),
+            extra_columns=KycVerifyTable.get_extra_columns(self.kyc_config),
+            **kwargs,
+        )
+        return RequestConfig(
+            self.request,
+            paginate=self.get_table_pagination(table),
+        ).configure(table)
 
-    def _parse_row(self, row_obj):
+    def get_queryset(self):
+        kyc_users = self.kyc_config.get_kyc_users()
+        return [self._parse_row(kyc_user) for kyc_user in kyc_users]
+
+    def _parse_row(self, kyc_user):
         row_data = {
-            'id': row_obj.user_id,
+            'id': kyc_user.user_id,
             'has_invalid_data': False,
+            'kyc_verification_status': kyc_user.get('kyc_verification_status'),
+            'kyc_last_verified_at': kyc_user.get('kyc_verification_status'),
         }
-        user_fields = (
-            'first_name',
-            'last_name',
-            'phone_number',
-            'email',
-            'national_id_number',
-            'street_address',
-            'city',
-            'post_code',
-            'country',
-        )
-        system_fields = (
-            'kyc_verification_status',
-            'kyc_last_verified_at',
-        )
-        for field in (user_fields + system_fields):
-            value = None
-            try:
-                value = row_obj[field]
-            except KeyError:
-                pass
-            finally:
-                if value in ['', None] and field in user_fields:
-                    row_data['has_invalid_data'] = True
-                else:
-                    row_data[field] = value
+        for field in self.kyc_config.api_field_to_user_data_map.values():
+            value = kyc_user.get(field)
+            if not value:
+                row_data['has_invalid_data'] = True
+            else:
+                row_data[field] = value
         return row_data
 
     @hq_hx_action('post')

--- a/corehq/apps/integration/kyc/views.py
+++ b/corehq/apps/integration/kyc/views.py
@@ -4,8 +4,6 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 
-from django_tables2 import RequestConfig
-
 from corehq import toggles
 from corehq.apps.domain.decorators import login_required
 from corehq.apps.domain.views.base import BaseDomainView
@@ -83,17 +81,10 @@ class KycVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableView):
     def kyc_config(self):
         return KycConfig.objects.get(domain=self.request.domain)
 
-    def get_table(self, **kwargs):
-        table_class = self.get_table_class()
-        table = table_class(
-            data=self.get_table_data(),
-            extra_columns=KycVerifyTable.get_extra_columns(self.kyc_config),
-            **kwargs,
-        )
-        return RequestConfig(
-            self.request,
-            paginate=self.get_table_pagination(table),
-        ).configure(table)
+    def get_table_kwargs(self):
+        return {
+            'extra_columns': KycVerifyTable.get_extra_columns(self.kyc_config),
+        }
 
     def get_queryset(self):
         kyc_users = self.kyc_config.get_kyc_users()


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The KYC verification report will now show column headers and data according to what has been specified in the KYC config:
![Screenshot from 2025-03-17 15-57-37](https://github.com/user-attachments/assets/f56261f5-99f4-408c-9543-8dca6806fd16)

For rows that do not have any matching data all the pre-existing rules still apply where a user will be unable to verify this row and the column with missing data will show as "---".


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-4365).

This PR is based on the work that @kaapstorm did in [this](https://github.com/dimagi/commcare-hq/pull/35963) PR. This PR simply expands on that slightly with some unit tests added in.

Instead of requiring that a KYC config mapping adhere to specific field names, the user is now able to specify any properties to be used for the config and verificaiton report. Of course, the user will still need to make sure that all the required fields are there for the KYC API, however they are no longer restricted to only using certain property names.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`KYC_VERIFICATION`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Unit tests exist

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests have been added to ensure that `extra_columns` for the KYC verification table return data in the expected format. Additionally, the unit tests for the verification report view have been tweaked slightly to test that any property names defined in the KYC config can be used for the report.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
