### PR TITLE
Sort on keyword not text field

### DIFF
--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -398,7 +398,7 @@ class GroupChoiceProvider(ChainableChoiceProvider):
     @staticmethod
     def get_choices_from_es_query(group_es):
         return [Choice(group_id, name)
-                for group_id, name in group_es.values_list('_id', 'name', scroll=True)]
+                for group_id, name in group_es.values_list('_id', 'name')]
 
     def default_value(self, user):
         return None

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -380,7 +380,7 @@ class GroupChoiceProvider(ChainableChoiceProvider):
         group_es = (
             GroupES().domain(self.domain).is_case_sharing()
             .search_string_query(query_context.query, default_fields=['name'])
-            .size(query_context.limit).start(query_context.offset).sort('name')
+            .size(query_context.limit).start(query_context.offset).sort('name.exact')
         )
         return self.get_choices_from_es_query(group_es)
 

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -10,6 +10,7 @@ from corehq.apps.es.client import manager
 from corehq.apps.es.fake.groups_fake import GroupESFake
 from corehq.apps.es.fake.users_fake import UserESFake
 from corehq.apps.es.tests.utils import es_test
+from corehq.apps.es.groups import group_adapter
 from corehq.apps.es.users import user_adapter
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.tests.util import LocationHierarchyTestCase
@@ -328,21 +329,24 @@ class UserChoiceProviderTest(SimpleTestCase, ChoiceProviderTestMixin):
         )
 
 
-@mock.patch('corehq.apps.userreports.reports.filters.choice_providers.GroupES', GroupESFake)
-class GroupChoiceProviderTest(SimpleTestCase, ChoiceProviderTestMixin):
+@es_test(requires=[group_adapter], setup_class=True)
+class GroupChoiceProviderTest(TestCase, ChoiceProviderTestMixin):
     domain = 'group-choice-provider'
 
     @classmethod
     def make_group(cls, name, domain=None):
         domain = domain or cls.domain
         group = Group(name=name, domain=domain, case_sharing=True)
-        GroupESFake.save_doc(group._doc)
+        # need it for the _id
+        group.save()
+        cls.addClassCleanup(group.delete)
+
+        group_adapter.index(group._doc)
         return group
 
     @classmethod
-    @mock.patch('corehq.apps.groups.dbaccessors.get_group_id_name_map_by_user', mock.Mock(return_value=[]))
     def setUpClass(cls):
-        super(GroupChoiceProviderTest, cls).setUpClass()
+        super().setUpClass()
         report = ReportConfiguration(domain=cls.domain)
 
         cls.groups = [
@@ -352,6 +356,7 @@ class GroupChoiceProviderTest(SimpleTestCase, ChoiceProviderTestMixin):
             cls.make_group('Team E yes'),
             cls.make_group('Team A yes'),
         ]
+        manager.index_refresh(group_adapter.index_name)
         choices = [
             SearchableChoice(group.get_id, group.name, searchable_text=[group.name])
             for group in cls.groups if group.domain == cls.domain]
@@ -359,11 +364,6 @@ class GroupChoiceProviderTest(SimpleTestCase, ChoiceProviderTestMixin):
         cls.choice_provider = GroupChoiceProvider(report, None)
         cls.static_choice_provider = StaticChoiceProvider(choices)
         cls.web_user = UserChoiceProviderTest.make_web_user('web-user@example.com', domain=cls.domain)
-
-    @classmethod
-    def tearDownClass(cls):
-        GroupESFake.reset_docs()
-        super(GroupChoiceProviderTest, cls).tearDownClass()
 
     def test_query_search(self):
         self._test_query(ChoiceQueryContext('yes', limit=10, page=0))


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-16811

We recently switched to new mappings for elasticsearch in preparation for the upgrade to ES6. This mapping change included a change where Elasticsearch removed the "string" field type in favor of two new types, "text" and "keyword". The notable difference between these two fields is that by default, you can only aggregate (including sort) by "keyword" fields, not by "text" fields.

So the bug here is that we are attempting to sort by a "text" field, which requires additional configuration and more resources to effectively use, whereas the "keyword" type is designed for aggregations. The fix is to access the "keyword" type which does exist in our mapping, but is a subfield of "name". So "name.exact" uses the keyword type instead of the text type.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is a small change used specifically for providing options for groups in report filters. I've tested this exact code in a django shell and saw the results I expected.

The other risk is removing scroll from the group choice provider, but given the query context defaults to [a limit of 20](https://github.com/dimagi/commcare-hq/blob/769ead9fbd17903be300e6910718594fd5781794/corehq/apps/userreports/reports/filters/choice_providers.py#L39-L39), I can't think of a reason that we _need_ to scroll here. I removed it because it appeared to be the case that using `scroll` was causing ES to ignore the size parameter (all groups were being returned in tests).
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Updated automated tests that hit this code, and made the tests more robust by no longer using a mock.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
