### PR TITLE
Notify user when MoMo config is not configured

### DIFF
--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -29,6 +29,15 @@ class PaymentsVerificationReportView(BaseDomainView):
     def section_url(self):
         return reverse(self.urlname, args=(self.domain,))
 
+    @property
+    def page_context(self):
+        return {
+            'has_config': MoMoConfig.objects.filter(domain=self.domain).exists(),
+            'config_url': reverse(
+                'momo_configuration', args=(self.domain,),
+            )
+        }
+
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(toggles.MTN_MOBILE_WORKER_VERIFICATION.required_decorator(), name='dispatch')

--- a/corehq/apps/integration/templates/payments/payments_verify_report.html
+++ b/corehq/apps/integration/templates/payments/payments_verify_report.html
@@ -5,6 +5,15 @@
 {% js_entry "integration/js/payments/payments_verify" %}
 
 {% block page_content %}
+  {% if not has_config %}
+  <p class="alert alert-warning">
+    {% blocktrans %}
+    To request payments successfully, link this feature to a Connection Setting in your configuration by going to the
+    <a href="{{ config_url }}">Payments Configuration</a>
+    page.
+    {% endblocktrans %}
+  </p>
+  {% endif %}
   <div>
     <h1 class="py-3 m-0">{% trans "Payments Verification Report" %}</h1>
   </div>

--- a/corehq/apps/integration/templates/payments/payments_verify_report.html
+++ b/corehq/apps/integration/templates/payments/payments_verify_report.html
@@ -6,13 +6,13 @@
 
 {% block page_content %}
   {% if not has_config %}
-  <p class="alert alert-warning">
-    {% blocktrans %}
-    To request payments successfully, link this feature to a Connection Setting in your configuration by going to the
-    <a href="{{ config_url }}">Payments Configuration</a>
-    page.
-    {% endblocktrans %}
-  </p>
+    <p class="alert alert-warning">
+      {% blocktrans %}
+        To request payments successfully, add necessary settings on the
+        <a href="{{ config_url }}">Payments Configuration</a>
+        page.
+      {% endblocktrans %}
+    </p>
   {% endif %}
   <div>
     <h1 class="py-3 m-0">{% trans "Payments Verification Report" %}</h1>


### PR DESCRIPTION
## Product Description
Shows a notification to the user when a config is not configured for this domain.

![image](https://github.com/user-attachments/assets/1eceb10d-0e81-4910-a6e0-bedbcfea00f6)
 
## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SC-4373)

Shows a message to the user when no config is present for the domain.

## Feature Flag
MTN_MOBILE_WORKER_VERIFICATION

## Safety Assurance

### Safety story
Tested locally

### Automated test coverage
No automated tests

### QA Plan
No QA planned as this is a simple change that was tested locally.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
