### PR TITLE
Update prepayment invoice email template

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2715,9 +2715,15 @@ class WirePrepaymentBillingRecord(WireBillingRecord):
         else:
             account_or_domain = self.invoice.get_domain()
 
-        subject = f"CommCare Subscription Prepayment Invoice for {account_or_domain}"
         if self.invoice.date_due is not None:
-            subject = subject + " due {date}".format(date=self.invoice.due_date)
+            subject = _(
+                "CommCare Subscription Prepayment Invoice for {account_or_domain} due {due_date}"
+            ).format(account_or_domain=account_or_domain, due_date=self.invoice.date_due)
+        else:
+            subject = _(
+                "CommCare Subscription Prepayment Invoice for {account_or_domain}"
+            ).format(account_or_domain=account_or_domain)
+
         return subject
 
     def can_view_statement(self, web_user):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2709,7 +2709,16 @@ class WirePrepaymentBillingRecord(WireBillingRecord):
         proxy = True
 
     def email_subject(self):
-        return _("Your prepayment invoice")
+        account = self.invoice.account
+        if account is not None and account.is_customer_billing_account:
+            account_or_domain = account
+        else:
+            account_or_domain = self.invoice.get_domain()
+
+        subject = f"CommCare Subscription Prepayment Invoice for {account_or_domain}"
+        if self.invoice.date_due is not None:
+            subject = subject + " due {date}".format(date=self.invoice.due_date)
+        return subject
 
     def can_view_statement(self, web_user):
         return web_user.is_domain_admin(self.invoice.get_domain())

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2682,6 +2682,11 @@ class WireBillingRecord(BillingRecordBase):
     def is_email_throttled():
         return False
 
+    def email_context(self):
+        context = super().email_context()
+        context.update({'date_due': self.invoice.date_due})
+        return context
+
     def email_subject(self):
         month_name = self.invoice.date_start.strftime("%B")
         return "Your %(month)s Bulk Billing Statement for Project Space %(domain)s" % {

--- a/corehq/apps/accounting/templates/accounting/email/wire_invoice.html
+++ b/corehq/apps/accounting/templates/accounting/email/wire_invoice.html
@@ -4,7 +4,7 @@
 
 <p>
   {% blocktrans %}
-    The Wire Payment Invoice you requested for project {{ domain }} is now available.
+    Please find attached the prepayment invoice for your CommCare subscription.
   {% endblocktrans %}
 </p>
 
@@ -35,17 +35,36 @@
       {{ amount_due }}
     </td>
   </tr>
+  {% if date_due %}
+    <tr>
+      <th align="right">
+        {% trans 'Due Date' %}:
+      </th>
+      <td>
+        {{ date_due }}
+      </td>
+    </tr>
+  {% endif %}
 </table>
 
 <p>
   {% blocktrans %}
-    <b>Instructions for Wire Payment</b>
+    <b>Note:</b> Any on-demand charges for excess users or SMS will be billed separately
+    based on actual usage in the following month. If you prefer, you may also prepay for
+    expected on-demand usage. Please contact us if you would like to explore this option.
   {% endblocktrans %}
 </p>
 
 <p>
   {% blocktrans %}
-    Dimagi accepts wire payments via ACH and wire transfer. To complete the Wire Payment, please follow these instructions:
+    <b>Instructions for Payment</b>
+  {% endblocktrans %}
+</p>
+
+<p>
+  {% blocktrans %}
+    Dimagi accepts payments via ACH, wire transfer, and credit card. All payment options are listed in the attached invoice.
+    If paying by wire, please follow these instructions to ensure timely processing and identification of your payment:
   {% endblocktrans %}
 </p>
 

--- a/corehq/apps/accounting/templates/accounting/email/wire_invoice.txt
+++ b/corehq/apps/accounting/templates/accounting/email/wire_invoice.txt
@@ -3,15 +3,25 @@
 {% blocktrans %}
 {{ greeting }}
 
-The Wire Payment Invoice you requested for project {{ domain }} is now available.
+Please find attached the prepayment invoice for your CommCare subscription.
+{% endblocktrans %}
 
-Invoice No.: {{ statement_number }}
-Project Space: {{ domain }}
-Amount Due: {{ amount_due }}
+{% trans 'Invoice No.' %}: {{ statement_number }}
+{% trans 'Project Space' %}: {{ domain }}
+{% trans 'Amount Due' %}: {{ amount_due }}
+{% if date_due %}
+    {% trans 'Due Date' %}: {{ date_due }}
+{% endif %}
 
-Instructions for Wire Payment
+{% blocktrans %}
+Note: Any on-demand charges for excess users or SMS will be billed separately
+based on actual usage in the following month. If you prefer, you may also prepay for
+expected on-demand usage. Please contact us if you would like to explore this option.
 
-Dimagi accepts wire payments via ACH and wire transfer. To complete the Wire Payment, please follow these instructions:
+Instructions for Payment
+
+Dimagi accepts payments via ACH, wire transfer, and credit card. All payment options are listed in the attached invoice.
+If paying by wire, please follow these instructions to ensure timely processing and identification of your payment:
 
 1. Send the wire payment to Dimagi’s bank account and include the invoice ID in the wire payment details. Dimagi’s bank account details and the invoice ID can be found in the attached invoice.
 


### PR DESCRIPTION
## Product Description
Updates subject line and wording for prepayment invoice email template.

## Technical Summary
[SAAS-16746](https://dimagi.atlassian.net/browse/SAAS-16746)
Technically we have both a "wire invoice" and a "wire prepayment invoice" available, though in practice only "wire prepayment invoice" is used - every instance of a `WireInvoice` on production is actually a `WirePrepaymentInvoice`. 

This change isn't intended to address that, but it does apply the email context to the `WireBillingRecord`, because that class determines the email template to use, and the email subject to `WirePrepaymentBillingRecord`, because a `WireBillingRecord` has its own subject line.

## Safety Assurance

### Safety story
These changes are limited to email templates (plus subject line and context) only. Their use is for generating and sending prepayment invoices and has minimal interaction with any other code. 

Tested on staging to see email sends correctly and looks as expected.

### Automated test coverage
Just a little, in `TestWireInvoice`.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16746]: https://dimagi.atlassian.net/browse/SAAS-16746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ