### PR TITLE
allow setting channel name for connect messaging

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -125,6 +125,7 @@ from corehq.apps.registration.utils import project_logo_emails_context
 from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.users.models import CouchUser, WebUser
 from corehq.toggles import (
+    COMMCARE_CONNECT,
     EXPORTS_APPS_USE_ELASTICSEARCH,
     HIPAA_COMPLIANCE_CHECKBOX,
     MOBILE_UCR,
@@ -493,6 +494,12 @@ class DomainGlobalSettingsForm(forms.Form):
         )
     )
 
+    connect_messaging_channel_name = CharField(
+        label=gettext_lazy("Connect Messaging Channel Nmae"),
+        required=False,
+        help_text=gettext_lazy("Name of the channel created in connect messaging.")
+    )
+
     def __init__(self, *args, **kwargs):
         self.project = kwargs.pop('domain', None)
         self.domain = self.project.name
@@ -522,6 +529,9 @@ class DomainGlobalSettingsForm(forms.Form):
 
         if not MOBILE_UCR.enabled(self.domain):
             del self.fields['mobile_ucr_sync_interval']
+
+        if not COMMCARE_CONNECT.enabled(self.domain):
+            del self.fields['connect_messaging_channel_name']
 
         self._handle_call_limit_visibility()
         self._handle_account_confirmation_by_sms_settings()
@@ -575,6 +585,8 @@ class DomainGlobalSettingsForm(forms.Form):
             extra_fields.append('mobile_ucr_sync_interval')
         if EXPORTS_APPS_USE_ELASTICSEARCH.enabled(self.domain):
             extra_fields.append('exports_use_elasticsearch')
+        if COMMCARE_CONNECT.enabled(self.domain):
+            extra_fields.append('connect_messaging_channel_name')
         return extra_fields
 
     def _handle_account_confirmation_by_sms_settings(self):
@@ -778,6 +790,7 @@ class DomainGlobalSettingsForm(forms.Form):
         domain.project_description = self.cleaned_data['project_description']
         domain.default_mobile_ucr_sync_interval = self.cleaned_data.get('mobile_ucr_sync_interval', None)
         domain.default_geocoder_location = self.cleaned_data.get('default_geocoder_location')
+        domain.connect_messaging_channel_name = self.cleaned_data.get('connect_messaging_channel_name')
         if self.cleaned_data.get("operator_call_limit"):
             setting_obj = OperatorCallLimitSettings.objects.get(domain=self.domain)
             setting_obj.call_limit = self.cleaned_data.get("operator_call_limit")

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -453,6 +453,9 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     # For domains that have been migrated to a different environment
     redirect_url = StringProperty()
 
+    # name that users see for connect messaging channels tied to this domain
+    connect_messaging_channel_name = StringProperty()
+
     @classmethod
     def wrap(cls, data):
         # for domains that still use original_doc

--- a/corehq/messaging/smsbackends/connectid/backend.py
+++ b/corehq/messaging/smsbackends/connectid/backend.py
@@ -4,6 +4,7 @@ from Crypto.Cipher import AES
 
 from django.conf import settings
 
+from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import ConnectIDUserLink, CouchUser
 
 
@@ -42,11 +43,14 @@ class ConnectBackend:
         return response.status_code == requests.codes.OK
 
     def create_channel(self, user_link):
+        domain_obj = Domain.get_by_name(user_link.domain)
+        channel_name = domain_obj.connect_messaging_channel_name
         response = requests.post(
             settings.CONNECTID_CHANNEL_URL,
             data={
                 "connectid": user_link.connectid_username,
                 "channel_source": user_link.domain,
+                "channel_name": channel_name
             },
             auth=(settings.CONNECTID_CLIENT_ID, settings.CONNECTID_SECRET_KEY)
         )


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This allows users of connect messaging to specify the name the channel has on the mobile device. It is currently set to the name of the domain, but since those are often not super recognizable to mobile users, they can now be overwritten.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
COMMCARE_CONNECT

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This only affects connect messaging code, plus a simple form addition.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
