### PR TITLE
Resolve Invalid Jquery Selector Bootstrap 3

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/hq_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/hq_report.js.diff.txt
@@ -57,6 +57,15 @@
                      .addClass('btn-primary')
                      .removeClass('disabled')
                      .prop('disabled', false);
+@@ -188,7 +188,7 @@
+                 // This is necessary for pages that contain multiple filter panels, since we are using CSS IDs.
+                 const submitButton = $(e.target).closest('#reportFilters').find(self.filterSubmitSelector);
+                 $(submitButton)
+-                    .button('reset')
++                    .changeButtonState('reset')
+                     .addClass('btn-primary')
+                     .removeClass('disabled')
+                     .prop('disabled', false);
 @@ -257,16 +257,16 @@
  
              self.sendEmail = function () {

--- a/corehq/apps/reports/static/reports/js/bootstrap3/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/hq_report.js
@@ -188,7 +188,7 @@ hqDefine("reports/js/bootstrap3/hq_report", [
                 // This is necessary for pages that contain multiple filter panels, since we are using CSS IDs.
                 const submitButton = $(e.target).closest('#reportFilters').find(self.filterSubmitSelector);
                 $(submitButton)
-                    .changeButtonState('reset')
+                    .button('reset')
                     .addClass('btn-primary')
                     .removeClass('disabled')
                     .prop('disabled', false);


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-4292).

This ticket resolves a bug introduced with [this](https://github.com/dimagi/commcare-hq/pull/35953) PR. Specifically, a bug was introduced with the bootstrap 3 version of `hq_report.js` where a JQuery selector from the B5 file was used instead of the one that should be used with B3.

The above bug causes any report filters using the B3 JS file to stop applying filters correctly.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing has been done to ensure that the bug is resolved for reports using B3

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
