### PR TITLE
If value is none, return match none query

### DIFF
--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -234,14 +234,10 @@ def _user_data(key, filter_):
 
 
 def query_user_data(key, value):
-    if not value:
-        return queries.match_all()
     return _user_data(key, queries.match(field='user_data_es.value', search_string=value))
 
 
 def login_as_user(value):
-    if not value:
-        return queries.match_all()
     return _user_data('login_as_user', filters.term('user_data_es.value', value))
 
 

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -234,6 +234,8 @@ def _user_data(key, filter_):
 
 
 def query_user_data(key, value):
+    if value is None:
+        return filters.match_none()
     return _user_data(key, queries.match(field='user_data_es.value', search_string=value))
 
 

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -234,10 +234,14 @@ def _user_data(key, filter_):
 
 
 def query_user_data(key, value):
+    if not value:
+        return queries.match_all()
     return _user_data(key, queries.match(field='user_data_es.value', search_string=value))
 
 
 def login_as_user(value):
+    if not value:
+        return queries.match_all()
     return _user_data('login_as_user', filters.term('user_data_es.value', value))
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-16815

This came up while working on https://dimagi.atlassian.net/browse/SAAS-16811. The ES Error is 
```
RequestError: TransportError(400, 'parsing_exception', '[match] unknown token [VALUE_NULL] after [query]')
```
which is due to a null value for the "query" key, like this:
```
{'query': None, 'operator': 'or', 'fuzziness': '0'}
```

If the caller passes `None` in for the search string, we should just default to `match_all`, similar to how it is done for the [search_string_query](https://github.com/dimagi/commcare-hq/blob/d3b856e9b883c6b1ec5870056487168deb3c8976/corehq/apps/es/queries.py#L68-L69) function.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
There was some conversation about the risk of matching all potentially returning _more_ data than the user should be able to access. I don't think that is a concern here though as it is up to the caller to avoid passing `None` to this function if they want to narrow results down, otherwise they should expect this filter to effectively do nothing, and that other filters in the query will be important to ensure data is adequately scoped to a domain, user, etc.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
