### PR TITLE
ES6 app manager lint

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_exchange.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_exchange.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine("app_manager/js/app_exchange", [
     "jquery",
     "knockout",
@@ -8,7 +8,7 @@ hqDefine("app_manager/js/app_exchange", [
 ], function (
     $,
     ko,
-    kissmetrics
+    kissmetrics,
 ) {
     var AppExchangeModel = function () {
         var self = {};

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -1,4 +1,4 @@
-'use strict';
+
 hqDefine('app_manager/js/app_manager', [
     'jquery',
     'knockout',
@@ -22,7 +22,7 @@ hqDefine('app_manager/js/app_manager', [
     alertUser,
     hqMain,
     appManagerMenu,
-    sectionChanger
+    sectionChanger,
 ) {
     var module = hqMain.eventize({});
     var _private = {};
@@ -145,9 +145,9 @@ hqDefine('app_manager/js/app_manager', [
                 } else {
                     area.find('*').hide();
                     upgradeMessage.append(
-                        $('<i></i>').addClass('fa fa-arrow-left')
+                        $('<i></i>').addClass('fa fa-arrow-left'),
                     ).append(
-                        $('<span></span>').text(' Requires CommCare ' + version)
+                        $('<span></span>').text(' Requires CommCare ' + version),
                     ).appendTo(area);
                 }
             });

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
@@ -1,4 +1,4 @@
-'use strict';
+
 hqDefine('app_manager/js/app_manager_media', function () {
     var appMenuMediaManager = function (o) {
         /* This interfaces the media reference for a form or module menu
@@ -8,12 +8,12 @@ hqDefine('app_manager/js/app_manager_media', function () {
                 isDefaultLanguage: initialPageData.get('current_language') === initialPageData.get('default_language'),
             };
 
-        self.trackGoogleEvent = function() {
+        self.trackGoogleEvent = function () {
             hqImport('analytix/js/google').track.event(...arguments);
         };
 
         self.enabled = ko.observable(
-            o.ref.use_default_media ? self.isDefaultLanguage : true
+            o.ref.use_default_media ? self.isDefaultLanguage : true,
         );
         self.ref = ko.observable(new MenuMediaReference(o.ref));
         self.refHasPath = ko.computed(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_utils.js
@@ -1,10 +1,10 @@
-'use strict';
+
 hqDefine('app_manager/js/app_manager_utils', [
     'jquery',
     'underscore',
 ], function (
     $,
-    _
+    _,
 ) {
     var getBitlyToPhoneticDict = function () {
         var natoPhonetic = {

--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -87,8 +87,7 @@ hqDefine("app_manager/js/app_view", function () {
                         error: function (data) {
                             if (data.hasOwnProperty('responseJSON')) {
                                 alert(data.responseJSON.message);
-                            }
-                            else {
+                            } else {
                                 alert(gettext('Oops, there was a problem loading this section. Please try again.'));
                             }
                             self.load_state('error');

--- a/corehq/apps/app_manager/static/app_manager/js/app_view_application.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view_application.js
@@ -1,4 +1,4 @@
-"use strict";
+
 /* Behavior for app_view.html, specific to Application documents (i.e., not remote apps) */
 hqDefine("app_manager/js/app_view_application", function () {
     $(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/apps_base.js
+++ b/corehq/apps/app_manager/static/app_manager/js/apps_base.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine("app_manager/js/apps_base", function () {
     $(function () {
         $('#deleted-app-modal').modal({

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_detail_print.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_detail_print.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine("app_manager/js/details/case_detail_print", function () {
     var printRef, printTemplateUploader;
     var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
@@ -7,7 +7,7 @@ hqDefine("app_manager/js/details/case_detail_print", function () {
     if (printUploader) {
         printTemplateUploader = uploaders.uploader(
             printUploader.slug,
-            printUploader.options
+            printUploader.options,
         );
         printRef = hqImport('hqmedia/js/media_reference_models').BaseMediaReference(initialPageData.get('print_ref'));
         printRef.upload_controller = printTemplateUploader;

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -1,4 +1,4 @@
-'use strict';
+
 /**
  * Model for a column in the Display Properties section of case list/detail.
  *

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -402,7 +402,7 @@ hqDefine("app_manager/js/details/screen", function () {
                     nodeset: tabs[i].nodeset,
                     nodesetCaseType: tabs[i].nodeset_case_type,
                     nodesetFilter: tabs[i].nodeset_filter,
-                }, _.pick(tabs[i], ["header", "isTab", "relevant"]))
+                }, _.pick(tabs[i], ["header", "isTab", "relevant"])),
             );
         }
         if (self.columnKey === 'long') {
@@ -574,7 +574,7 @@ hqDefine("app_manager/js/details/screen", function () {
                 }),
                 function (c) {
                     return c.serialize();
-                }
+                },
             ));
 
             // Add tabs
@@ -594,7 +594,7 @@ hqDefine("app_manager/js/details/screen", function () {
                 }),
                 function (c) {
                     return c.serialize();
-                }
+                },
             ));
 
             data.caseTileTemplate = self.caseTileTemplate();
@@ -666,7 +666,7 @@ hqDefine("app_manager/js/details/screen", function () {
         };
         self.addItem = function (columnConfiguration, index) {
             var column = self.initColumnAsColumn(
-                ColumnModel(columnConfiguration, self)
+                ColumnModel(columnConfiguration, self),
             );
             if (index === undefined) {
                 self.columns.push(column);

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -68,7 +68,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
                     allowsEmptyColumns: columnType === 'long',
                     caseTileTemplateOptions: spec.caseTileTemplateOptions,
                     caseTileTemplateConfigs: spec.caseTileTemplateConfigs,
-                }
+                },
             );
             self.screens.push(screen);
             return screen;
@@ -152,7 +152,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
                         spec.sortRows[j].blanks,
                         spec.sortRows[j].display[self.lang],
                         false,
-                        spec.sortRows[j].sort_calculation
+                        spec.sortRows[j].sort_calculation,
                     );
                 }
             }
@@ -168,7 +168,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
                 $caseListLookup,
                 spec.state.short,
                 spec.lang,
-                self.shortScreen.saveButton
+                self.shortScreen.saveButton,
             );
             // Set up case search
             var caseClaimModels = hqImport("app_manager/js/details/case_claim");
@@ -179,7 +179,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
                 _.pick(spec, caseClaimModels.searchConfigKeys),
                 spec.lang,
                 self.shortScreen.saveButton,
-                self.filter.filterText
+                self.filter.filterText,
             );
         }
         if (spec.state.long !== undefined) {
@@ -201,7 +201,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
                                 printRef.is_matched(false);
                                 printTemplateUploader.updateUploadFormUI();
                             }
-                        }
+                        },
                     );
                 },
             });

--- a/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
+++ b/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
@@ -3,10 +3,9 @@ hqDefine('app_manager/js/download_async_modal', [
     'underscore',
 ], function (
     $,
-    _
+    _,
 ) {
     var asyncDownloader = function ($el) {
-        "use strict";
         var self = {};
         self.POLL_FREQUENCY = 1500; //ms
         self.ERROR_MESSAGE = gettext("Sorry, something went wrong with the download. " +

--- a/corehq/apps/app_manager/static/app_manager/js/download_index_main.js
+++ b/corehq/apps/app_manager/static/app_manager/js/download_index_main.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine('app_manager/js/download_index_main',[
     'jquery',
     'underscore',

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine('app_manager/js/forms/advanced/actions', function () {
     var caseConfigUtils = hqImport('app_manager/js/case_config_utils'),
         caseProperty = hqImport('app_manager/js/forms/advanced/case_properties').caseProperty,
@@ -525,7 +525,7 @@ hqDefine('app_manager/js/forms/advanced/actions', function () {
             self.suggestedProperties = ko.computed(function () {
                 return caseConfigUtils.filteredSuggestedProperties(
                     actionBase.suggestedProperties(self, false),
-                    self.case_properties()
+                    self.case_properties(),
                 );
             });
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/app_notifications.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/app_notifications.js
@@ -1,4 +1,4 @@
-"use strict";
+
 /* globals moment */
 hqDefine('app_manager/js/forms/app_notifications', function () {
     var getMessage = function (redisMessage, userId) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -38,7 +38,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             self.moduleCaseTypes = params.moduleCaseTypes;
             self.allowUsercase = params.allowUsercase;
 
-            self.trackGoogleEvent = function() {
+            self.trackGoogleEvent = function () {
                 hqImport('analytix/js/google').track.event(...arguments);
             };
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
@@ -7,7 +7,7 @@ hqDefine("app_manager/js/forms/case_knockout_bindings", [
     $,
     ko,
     _,
-    DOMPurify
+    DOMPurify,
 ) {
     var utils = {
         _getIcon: function (question) {
@@ -81,7 +81,7 @@ hqDefine("app_manager/js/forms/case_knockout_bindings", [
                 var $warning = $('<div class="help-block"></div>').text(gettext(
                     'We cannot find this question in the allowed questions for this field. ' +
                     'It is likely that you deleted or renamed the question. ' +
-                    'Please choose a valid question from the dropdown.'
+                    'Please choose a valid question from the dropdown.',
                 ));
                 $(element).after($warning);
                 $(element).parent().addClass('has-error');

--- a/corehq/apps/app_manager/static/app_manager/js/forms/custom_instances.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/custom_instances.js
@@ -33,7 +33,7 @@ hqDefine("app_manager/js/forms/custom_instances", [
         self.addInstance = function (instance) {
             instance = instance || {instanceId: null, instancePath: null};
             self.customInstances.push(
-                customInstance(instance.instanceId, instance.instancePath)
+                customInstance(instance.instanceId, instance.instancePath),
             );
         };
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -55,7 +55,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                 // This code takes control of the top-left box with the form name.
                 $('#formdesigner .fd-content-left .fd-head-text').before(
                     // We add an edit button that opens a modal:
-                    $('#fd-hq-edit-formname-button').html()
+                    $('#fd-hq-edit-formname-button').html(),
                 // and we replace the form name Vellum put there
                 // with one that's translated to the app builder's currently selected language:
                 ).text(initialPageData.get('form_name'));
@@ -86,7 +86,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                 if (initialPageData.get('days_since_created') === 0) {
                     kissmetrixTrack = function () {
                         hqImport('analytix/js/kissmetrix').track.event(
-                            'Added question in Form Builder within first 24 hours'
+                            'Added question in Form Builder within first 24 hours',
                         );
                     };
                 }
@@ -192,7 +192,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                         $('#js-fd-form-actions').html(),
                         0,
                         function () {
-                        }
+                        },
                     );
                 }
 
@@ -200,11 +200,11 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                 hqImport('app_manager/js/app_manager').updatePageTitle(initialPageData.get("form_name"));
                 editDetails.initName(
                     initialPageData.get("form_name"),
-                    initialPageData.reverse("edit_form_attr", "name")
+                    initialPageData.reverse("edit_form_attr", "name"),
                 );
                 editDetails.initComment(
                     initialPageData.get("form_comment").replace(/\\n/g, "\n"),
-                    initialPageData.reverse("edit_form_attr", "comment")
+                    initialPageData.reverse("edit_form_attr", "comment"),
                 );
                 editDetails.setUpdateCallbackFn(function (name) {
                     $('#formdesigner .fd-content-left .fd-head-text').text(name);

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -48,7 +48,7 @@ hqDefine("app_manager/js/forms/form_view", function () {
         self.isUsercaseInUse = ko.observable(initialPageData.get('is_usercase_in_use'));
         self.usercaseReferenceNotAllowed = ko.computed(function () {
             return !self.isUsercaseInUse() && formFilterMatches(
-                self.formFilter(), patterns.usercase_substring
+                self.formFilter(), patterns.usercase_substring,
             );
         });
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
@@ -59,7 +59,7 @@ hqDefine("app_manager/js/forms/form_workflow", [
                 link.xpath,
                 link.uniqueId,
                 self,
-                link.datums
+                link.datums,
             );
         }));
     };
@@ -210,7 +210,7 @@ hqDefine("app_manager/js/forms/form_workflow", [
                 String(Math.random()).slice(2),  // random id
                 gettext("Manual Linking Datums"),
                 gettext("Set datums required to navigate to the selected form or menu"),
-                {key: gettext("Datum ID"), value: gettext("XPath Expression")}  // placeholders
+                {key: gettext("Datum ID"), value: gettext("XPath Expression")},  // placeholders
             );
             const datumsDict = {};
             _.each(datums, function (datum) {
@@ -241,7 +241,7 @@ hqDefine("app_manager/js/forms/form_workflow", [
                 function (data) {
                     self.datums(self.wrap_datums(data));
                 },
-                "json"
+                "json",
             ).fail(function () {
                 self.datumsFetched(false);
                 self.datumsError(true);

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
@@ -11,9 +11,8 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
     ko,
     _,
     initialPageData,
-    assertProperties
+    assertProperties,
 ) {
-    'use strict';
     $(function () {
         var AppRelease = function (details) {
             var self = {};

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_location.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_location.js
@@ -13,9 +13,8 @@ hqDefine('app_manager/js/manage_releases_by_location', [
     ko,
     _,
     initialPageData,
-    assertProperties
+    assertProperties,
 ) {
-    'use strict';
     $(function () {
         var enabledAppRelease = function (details) {
             var self = {};

--- a/corehq/apps/app_manager/static/app_manager/js/menu.js
+++ b/corehq/apps/app_manager/static/app_manager/js/menu.js
@@ -7,7 +7,7 @@ hqDefine("app_manager/js/menu", [
     $,
     initialPageData,
     layout,
-    utils
+    utils,
 ) {
     var setPublishStatus = function (isOn) {
         if (isOn) {

--- a/corehq/apps/app_manager/static/app_manager/js/modules/case_list_setting.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/case_list_setting.js
@@ -3,7 +3,7 @@ hqDefine("app_manager/js/modules/case_list_setting", [
     'underscore',
 ], function (
     $,
-    _
+    _,
 ) {
     function getLabel(slug) { return $('.case-list-setting-label[data-slug="' + slug + '"]'); }
     function getShow(slug) { return $('.case-list-setting-show[data-slug="' + slug + '"]'); }

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -120,7 +120,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
             if (!valueNoSpaces) {
                 $el.closest('.form-group').addClass('has-error');
                 showCaseTypeError(
-                    gettext("Case type is required.")
+                    gettext("Case type is required."),
                 );
                 return;
             }
@@ -132,12 +132,12 @@ hqDefine("app_manager/js/modules/module_view", function () {
             if (!valueNoSpaces.match(/^[\w-]*$/g)) {
                 $el.closest('.form-group').addClass('has-error');
                 showCaseTypeError(
-                    gettext("Case types can only include the characters a-z, 0-9, '-' and '_'")
+                    gettext("Case types can only include the characters a-z, 0-9, '-' and '_'"),
                 );
             } else if (valueNoSpaces === 'commcare-user' && moduleType !== 'advanced') {
                 $el.closest('.form-group').addClass('has-error');
                 showCaseTypeError(
-                    gettext("'commcare-user' is a reserved case type. Please change the case type")
+                    gettext("'commcare-user' is a reserved case type. Please change the case type"),
                 );
 
             } else {
@@ -251,7 +251,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
             var caseListForm = caseListFormModel(
                 caseListFormOptions ? caseListFormOptions.form.form_id : null,
                 caseListFormOptions ? caseListFormOptions.options : [],
-                caseListFormOptions ? caseListFormOptions.form.post_form_workflow : 'default'
+                caseListFormOptions ? caseListFormOptions.form.post_form_workflow : 'default',
             );
             $('#case-list-form').koApplyBindings(caseListForm);
 
@@ -271,7 +271,7 @@ hqDefine("app_manager/js/modules/module_view", function () {
                 shadowOptions.source_module_id,
                 shadowOptions.excluded_form_ids,
                 shadowOptions.form_session_endpoints,
-                shadowOptions.shadow_module_version
+                shadowOptions.shadow_module_version,
             ));
         } else if (moduleType === 'advanced') {
             if (moduleBrief.has_schedule || hqImport('hqwebapp/js/toggles').toggleEnabled('VISIT_SCHEDULER')) {

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view_report.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view_report.js
@@ -14,7 +14,7 @@ hqDefine("app_manager/js/modules/module_view_report", function () {
             navMenuMediaItem.menu_refs.image,
             navMenuMediaItem.menu_refs.audio,
             initialPageData.get("multimedia_object_map"),
-            navMenuMediaItem.default_file_name
+            navMenuMediaItem.default_file_name,
         );
 
         var saveURL = initialPageData.reverse("edit_report_module");

--- a/corehq/apps/app_manager/static/app_manager/js/modules/report_module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/report_module.js
@@ -390,7 +390,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
                 self.reportFilters,
                 self.lang,
                 self.languages,
-                self.changeSaveButton
+                self.changeSaveButton,
             );
             report.reportId.subscribe(function (reportId) {
                 report.display(self.defaultReportTitle(reportId));

--- a/corehq/apps/app_manager/static/app_manager/js/nav_menu_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/nav_menu_media.js
@@ -8,7 +8,7 @@ hqDefine("app_manager/js/nav_menu_media", function () {
                 item.menu_refs.image || "",
                 item.menu_refs.audio || "",
                 initialPageData.get("multimedia_object_map"),
-                item.default_file_name
+                item.default_file_name,
             );
         });
     });

--- a/corehq/apps/app_manager/static/app_manager/js/nav_menu_media_common.js
+++ b/corehq/apps/app_manager/static/app_manager/js/nav_menu_media_common.js
@@ -6,7 +6,7 @@ hqDefine("app_manager/js/nav_menu_media_common", function () {
     _.each(initialPageData.get("multimedia_upload_managers"), function (uploader, type) {
         uploaders[type] = uploadersModule.uploader(
             uploader.slug,
-            uploader.options
+            uploader.options,
         );
     });
 

--- a/corehq/apps/app_manager/static/app_manager/js/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine('app_manager/js/preview_app', [
     'jquery',
     'analytix/js/google',
@@ -10,7 +10,7 @@ hqDefine('app_manager/js/preview_app', [
     googleAnalytics,
     kissAnalytics,
     appManagerUtils,
-    layoutController
+    layoutController,
 ) {
     var module = {};
     var _private = {};
@@ -233,7 +233,7 @@ hqDefine('app_manager/js/preview_app', [
             kissAnalytics.track.event("[app-preview] Clicked Refresh App Preview");
             googleAnalytics.track.event("App Preview", "Clicked Refresh App Preview");
         });
-            appManagerUtils.handleAjaxAppChange(function () {
+        appManagerUtils.handleAjaxAppChange(function () {
             $(module.SELECTORS.BTN_REFRESH).addClass('app-out-of-date');
         });
         var onload = function () {

--- a/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
@@ -31,7 +31,7 @@ hqDefine("app_manager/js/releases/app_view_release_manager", function () {
                     self.releaseLogs(
                         _.map(data.app_release_logs, function (log) {
                             return ko.mapping.fromJS(log);
-                        })
+                        }),
                     );
                     self.totalItems(data.pagination.total);
                     self.fetchState('');

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -214,7 +214,7 @@ hqDefine("app_manager/js/releases/releases", [
 
         self.download_application_zip = function (multimediaOnly, buildProfile) {
             releasesMain.download_application_zip(
-                self.id(), multimediaOnly, buildProfile, self.download_targeted_version()
+                self.id(), multimediaOnly, buildProfile, self.download_targeted_version(),
             );
         };
 
@@ -396,7 +396,7 @@ hqDefine("app_manager/js/releases/releases", [
                     self.savedApps(
                         _.map(data.apps, function (app) {
                             return savedAppModel(app, self);
-                        })
+                        }),
                     );
                     self.totalItems(data.pagination.total);
                     self.fetchState('');

--- a/corehq/apps/app_manager/static/app_manager/js/settings/app_logos.js
+++ b/corehq/apps/app_manager/static/app_manager/js/settings/app_logos.js
@@ -44,7 +44,7 @@ hqDefine("app_manager/js/settings/app_logos", function () {
                 if (status === 'success') {
                     imageRefs[slug].url("");
                 }
-            }
+            },
         );
     };
 

--- a/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
@@ -127,7 +127,7 @@ hqDefine('app_manager/js/summary/case_summary',[
         $("#case-summary-header").koApplyBindings(caseSummaryController);
         models.initVersionsBox(
             $("#version-selector"),
-            {id: initialPageData.get("app_id"), text: initialPageData.get("app_version")}
+            {id: initialPageData.get("app_id"), text: initialPageData.get("app_version")},
         );
         models.initMenu([caseSummaryContent], caseSummaryMenu);
         models.initSummary(caseSummaryContent, caseSummaryController, "#case-summary");

--- a/corehq/apps/app_manager/static/app_manager/js/summary/form_diff.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/form_diff.js
@@ -105,11 +105,11 @@ hqDefine('app_manager/js/summary/form_diff',[
         $("#form-summary-header").koApplyBindings(formSummaryController);
         models.initVersionsBox(
             $("#first-version-selector"),
-            {id: initialPageData.get("first.app_id"), text: initialPageData.get("first.app_version")}
+            {id: initialPageData.get("first.app_id"), text: initialPageData.get("first.app_version")},
         );
         models.initVersionsBox(
             $("#second-version-selector"),
-            {id: initialPageData.get("second.app_id"), text: initialPageData.get("second.app_version")}
+            {id: initialPageData.get("second.app_id"), text: initialPageData.get("second.app_version")},
         );
 
         models.initMenu([firstFormSummaryContent, secondFormSummaryContent], formSummaryMenu);

--- a/corehq/apps/app_manager/static/app_manager/js/summary/form_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/form_summary.js
@@ -48,7 +48,7 @@ hqDefine('app_manager/js/summary/form_summary',[
         var formSummaryController = formModels.formSummaryControlModel([formSummaryContent]);
         models.initVersionsBox(
             $("#version-selector"),
-            {id: initialPageData.get("app_id"), text: initialPageData.get("app_version")}
+            {id: initialPageData.get("app_id"), text: initialPageData.get("app_version")},
         );
         $("#form-summary-header").koApplyBindings(formSummaryController);
         models.initMenu([formSummaryContent], formSummaryMenu);

--- a/corehq/apps/app_manager/static/app_manager/js/summary/models.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/models.js
@@ -157,7 +157,7 @@ hqDefine('app_manager/js/summary/models',[
                 }[attribute],
                 content = "<dl>" + _getPopoverText(
                     gettext("Case Property") + " " + loadOrSave + " " + gettext(change['type']),
-                    gettext("Case Property") + " <strong>" + caseProperty + "</strong> " + gettext("of Case Type") + " <strong>" + caseType + "</strong> " + gettext(change['type'])
+                    gettext("Case Property") + " <strong>" + caseProperty + "</strong> " + gettext("of Case Type") + " <strong>" + caseType + "</strong> " + gettext(change['type']),
                 ) + "</dl>";
 
             return _.defaults({

--- a/corehq/apps/app_manager/static/app_manager/js/visit_scheduler.js
+++ b/corehq/apps/app_manager/static/app_manager/js/visit_scheduler.js
@@ -67,7 +67,7 @@ hqDefine('app_manager/js/visit_scheduler', function () {
         self.phases = ko.observableArray(
             _.map(params.schedulePhases, function (phase) {
                 return phaseModel(phase.id, phase.anchor, phase.forms);
-            })
+            }),
         );
         self.phases.subscribe(function () {
             self.change();

--- a/corehq/apps/app_manager/static/app_manager/js/widgets.js
+++ b/corehq/apps/app_manager/static/app_manager/js/widgets.js
@@ -9,7 +9,7 @@ hqDefine("app_manager/js/widgets", [
     $,
     _,
     assertProperties,
-    initialPageData
+    initialPageData,
 ) {
     var initVersionDropdown = function ($select, options) {
         options = options || {};

--- a/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 import $ from "jquery";
 import _ from "underscore";
 import sinon from "sinon";
@@ -110,12 +111,12 @@ describe('App Releases', function () {
             this.server.respondWith(
                 "GET",
                 new RegExp(savedAppModel.URL_TYPES.SHORT_ODK_MEDIA_URL),
-                [200, { "Content-type": "text/html" }, 'http://bit.ly/media/']
+                [200, { "Content-type": "text/html" }, 'http://bit.ly/media/'],
             );
             this.server.respondWith(
                 "GET",
                 new RegExp(savedAppModel.URL_TYPES.SHORT_ODK_URL),
-                [200, { "Content-type": "text/html" }, 'http://bit.ly/nomedia/']
+                [200, { "Content-type": "text/html" }, 'http://bit.ly/nomedia/'],
             );
         });
 


### PR DESCRIPTION
## Technical Summary
This just re-runs `eslint --fix` on app manager files now that ESLint is configured to use ES6, which mostly means adding commas. The PR still fails the lint check because there are some non-automatically-fixable errors in some of these files.

## Safety Assurance

### Safety story
Lint changes, almost entirely automatically 

### Automated test coverage

no

### QA Plan

no

### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
