### PR TITLE
Added select2 dependencies to app manager

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/utils.js
@@ -10,6 +10,7 @@ hqDefine("app_manager/js/details/utils", [
     "DOMPurify/dist/purify.min",
     "hqwebapp/js/toggles",
     "hqwebapp/js/initial_page_data",
+    "select2/dist/js/select2.full.min",
 ], function (
     $,
     _,

--- a/corehq/apps/app_manager/static/app_manager/js/releases/language_profiles.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/language_profiles.js
@@ -3,6 +3,7 @@ hqDefine("app_manager/js/releases/language_profiles", [
     "knockout",
     "underscore",
     "hqwebapp/js/bootstrap3/main",
+    "select2/dist/js/select2.full.min",
 ], function (
     $,
     ko,


### PR DESCRIPTION
## Technical Summary
Cherry pick from the app manager webpack migration. Pre-webpack, these dependencies don't have to be explicit, but in webpack they do. There's no harm in adding them now, and it makes the dependency lists more accurate.

## Safety Assurance

### Safety story
Safe. Adds a common dependency. I smoke tested that the languages area in app settings and the case properties ares in case list/details still load.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
