### PR TITLE
Bring back cross-cutting skip_fixtures logic

### DIFF
--- a/corehq/apps/case_search/fixtures.py
+++ b/corehq/apps/case_search/fixtures.py
@@ -68,7 +68,6 @@ def _get_index(domain):
 
 class CaseSearchFixtureProvider(FixtureProvider):
     id = 'case-search-fixture'
-    ignore_skip_fixtures_flag = True
 
     def __call__(self, restore_state):
         if not CSQL_FIXTURE.enabled(restore_state.domain):

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -104,7 +104,6 @@ def get_global_items_by_domain(domain, case_id):
 
 class ItemListsProvider(FixtureProvider):
     id = 'item-list'
-    ignore_skip_fixtures_flag = True
 
     def __call__(self, restore_state):
         restore_user = restore_state.restore_user

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -288,7 +288,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     :param device_id: ID of device performing restore
     :param user_id: ID of user performing restore (used in case of deleted user with same username)
     :param openrosa_version:
-    :param skip_fixtures: Do not include fixtures in sync payload
+    :param skip_fixtures: Do not include fixtures in sync payload.  Supports mobile background sync.
     :param auth_type: The type of auth that was used to authenticate the request.
         Used to determine if the request is coming from an actual user or as part of some automation.
     :param fail_hard: In case of exceptions, fail hardly by raising exception instead of logging

--- a/corehq/ex-submodules/casexml/apps/phone/fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/fixtures.py
@@ -49,7 +49,7 @@ def _fixture_generators():
     return [f for f in functions if f]
 
 
-def get_fixture_elements(restore_state, timing_context, skip_fixtures):
+def get_fixture_elements(restore_state, timing_context):
     if restore_state.version == V1:
         return  # V1 phones will never use or want fixtures
 
@@ -57,7 +57,6 @@ def get_fixture_elements(restore_state, timing_context, skip_fixtures):
         return
 
     for provider in _fixture_generators():
-        if not skip_fixtures or getattr(provider, 'ignore_skip_fixtures_flag', False):
-            with timing_context('fixture:{}'.format(provider.id)):
-                for element in provider(restore_state):
-                    yield element
+        with timing_context('fixture:{}'.format(provider.id)):
+            for element in provider(restore_state):
+                yield element

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -523,7 +523,7 @@ class RestoreConfig(object):
     :param restore_user:    The restore user requesting the restore
     :param params:          The RestoreParams associated with this (see above).
     :param cache_settings:  The RestoreCacheSettings associated with this (see above).
-    :param is_async:           Whether to get the restore response using a celery task
+    :param is_async:        Whether to get the restore response using a celery task
     :param skip_fixtures:   Whether to include fixtures in the restore payload
     """
 
@@ -733,9 +733,10 @@ class RestoreConfig(object):
             with self.timing_context('RegistrationElementProvider'):
                 content.append(get_registration_element(self.restore_state.restore_user))
 
-            with self.timing_context('FixtureElementProvider'):
-                for element in get_fixture_elements(self.restore_state, self.timing_context, self.skip_fixtures):
-                    content.append(element)
+            if not self.skip_fixtures:
+                with self.timing_context('FixtureElementProvider'):
+                    for element in get_fixture_elements(self.restore_state, self.timing_context):
+                        content.append(element)
 
             with self.timing_context('CasePayloadProvider'):
                 do_livequery(self.timing_context, self.restore_state, content, async_task)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -52,12 +52,7 @@ class OtaFixtureTest(TestCase):
         self.assertIn('<fixture ', restore)
 
         restore = device.sync(skip_fixtures=True).payload.decode('utf-8')
-        self.assertIn('<fixture ', restore)
-
-        item_lists.ignore_skip_fixtures_flag = False
-        restore = device.sync(skip_fixtures=True).payload.decode('utf-8')
         self.assertNotIn('<fixture ', restore)
-        item_lists.ignore_skip_fixtures_flag = True  # reset
 
     def test_fixture_ownership(self):
         device = MockDevice(self.domain, self.restore_user)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 from corehq.blobs import get_blob_db
 from casexml.apps.phone.utils import MockDevice
 from corehq.apps.domain.models import Domain
-from corehq.apps.fixtures.fixturegenerators import item_lists
 from corehq.apps.fixtures.models import (
     FIXTURE_BUCKET,
     Field,


### PR DESCRIPTION
## Product Description
Reverts the exceptions introduced in https://github.com/dimagi/commcare-hq/pull/35387 and https://github.com/dimagi/commcare-hq/pull/35612
The `skip_fixtures` flag was originally introduced as a performance optimization for faster restores on USH web apps projects that very frequently synced.  However, this meant that fixtures would only be included in the sync on certain types of restores - certain workflows might skip fixture syncing entirely, resulting in a stale sandbox (hence the `ignore_skip_fixtures` hack).  Now instead we're moving towards more targeted logic, where each fixture can decide whether it needs to be updated, based on whether the underlying data has changed since the last sync (eg locations fixture), or based on configured staleness allotments (eg mobile UCR).  Note that as of this writing, lookup tables don't have any smart sync logic - an obvious optimization target.

Separately, https://github.com/dimagi/commcare-android/pull/2680 piggy-backed off this existing flag for a different purpose.  CommCare Android has a "background sync" restore workflow which completely disregards the fixture nodes in the restore, if included.  In this latter case, it is desirable that we do skip fixture logic entirely, as smart syncing logic would be confused by a sync that ignores the restore response.

## Technical Summary
https://dimagi.atlassian.net/browse/USH-5710

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
