### PR TITLE
Upgrade wrapt to 1.17.2

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -751,7 +751,7 @@ wheel==0.38.1
     # via
     #   -r dev-requirements.in
     #   pip-tools
-wrapt==1.12.1
+wrapt==1.17.2
     # via
     #   ddtrace
     #   deprecated

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -611,7 +611,7 @@ webencodings==0.5.1
     #   tinycss2
 werkzeug==3.0.6
     # via -r base-requirements.in
-wrapt==1.12.1
+wrapt==1.17.2
     # via
     #   ddtrace
     #   deprecated

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -604,7 +604,7 @@ webencodings==0.5.1
     #   tinycss2
 werkzeug==3.0.6
     # via -r base-requirements.in
-wrapt==1.12.1
+wrapt==1.17.2
     # via
     #   ddtrace
     #   deprecated

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -555,7 +555,7 @@ webencodings==0.5.1
     #   tinycss2
 werkzeug==3.0.6
     # via -r base-requirements.in
-wrapt==1.12.1
+wrapt==1.17.2
     # via
     #   ddtrace
     #   deprecated

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -623,7 +623,7 @@ werkzeug==3.0.6
     # via -r base-requirements.in
 wheel==0.38.1
     # via pip-tools
-wrapt==1.12.1
+wrapt==1.17.2
     # via
     #   ddtrace
     #   deprecated


### PR DESCRIPTION
Minor version bump for Python 3.13 compatibility. Reviewed [release notes](https://wrapt.readthedocs.io/en/latest/changes.html), which do not note any breaking changes that would apply to HQ. Also reviewed [recent issues](https://github.com/GrahamDumpleton/wrapt/issues) (no concerns).

## Safety Assurance

### Safety story

`wrapt` is an indirect dependency via other libraries, and not used directly by HQ code.

### Automated test coverage

Not directly.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations