### PR TITLE
Upgrade to zope-interface==7.2

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -771,7 +771,7 @@ zipp==3.21.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
-zope-interface==6.1
+zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -627,7 +627,7 @@ zipp==3.21.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
-zope-interface==6.1
+zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -622,7 +622,7 @@ zipp==3.21.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
-zope-interface==6.1
+zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -573,7 +573,7 @@ zipp==3.21.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
-zope-interface==6.1
+zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -641,7 +641,7 @@ zipp==3.21.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
-zope-interface==6.1
+zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Minor version bump for Python 3.13 compatibility. Reviewed [release notes](https://github.com/zopefoundation/zope.interface/blob/master/CHANGES.rst) and [recent issues](https://github.com/zopefoundation/zope.interface/issues) (no concerns).

## Safety Assurance

### Safety story

`zope-interface` is an indirect dependency of gevent, and not used directly by HQ code.

### Automated test coverage

Not directly.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations