### PR TITLE
[Data Cleaning] Improve Filter List UI and Re-Order/Sort Filters

### DIFF
--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -309,7 +309,7 @@ class AddColumnFilterForm(forms.Form):
             self.add_error('data_type', _("Please specify a data type."))
             return cleaned_data
 
-        category = self.get_data_type_category(data_type)
+        category = DataType.get_filter_category(data_type)
         clean_fn = {
             DataType.FILTER_CATEGORY_TEXT: lambda x: self._clean_text_filter(x),
             DataType.FILTER_CATEGORY_NUMBER: lambda x: self._clean_number_filter(x),
@@ -322,12 +322,6 @@ class AddColumnFilterForm(forms.Form):
             return cleaned_data
 
         return clean_fn(cleaned_data)
-
-    @staticmethod
-    def get_data_type_category(data_type):
-        for category, valid_data_types in DataType.FILTER_CATEGORY_DATA_TYPES.items():
-            if data_type in valid_data_types:
-                return category
 
     def _clean_text_filter(self, cleaned_data):
         match_type = self._clean_required_match_type('text_match_type', cleaned_data)

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -389,6 +389,10 @@ class BulkEditFilter(models.Model):
         return property_details.get(self.prop_id, {}).get('is_editable', True)
 
     @property
+    def human_readable_data_type(self):
+        return dict(DataType.CASE_CHOICES).get(self.data_type, _("unknown"))
+
+    @property
     def human_readable_match_type(self):
         category = DataType.get_filter_category(self.data_type)
         match_to_text = {

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -116,11 +116,11 @@ class BulkEditSession(models.Model):
     def remove_filter(self, filter_id):
         self.filters.get(filter_id=filter_id).delete()
         remaining_ids = self.filters.values_list('filter_id', flat=True)
-        self.reorder_filters(remaining_ids)
+        self.update_filter_order(remaining_ids)
 
-    def reorder_filters(self, filter_ids):
+    def update_filter_order(self, filter_ids):
         """
-        This updates the order of column filters for this session
+        This updates the order of filters for this session
         :param filter_ids: list of uuids matching filter_id field of BulkEditFilters
         """
         if len(filter_ids) != self.filters.count():

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -242,6 +242,21 @@ class DataType:
         FILTER_CATEGORY_MULTI_SELECT: (MULTIPLE_OPTION,),
     }
 
+    ICON_CLASSES = {
+        TEXT: 'fcc fcc-fd-text',
+        INTEGER: 'fcc fcc-fd-numeric',
+        PHONE_NUMBER: 'fa fa-signal',
+        DECIMAL: 'fcc fcc-fd-decimal',
+        DATE: 'fa-solid fa-calendar-days',
+        TIME: 'fa-regular fa-clock',
+        DATETIME: 'fcc fcc-fd-datetime',
+        SINGLE_OPTION: 'fcc fcc-fd-single-select',
+        MULTIPLE_OPTION: 'fcc fcc-fd-multi-select',
+        GPS: 'fa-solid fa-location-dot',
+        BARCODE: 'fa fa-barcode',
+        PASSWORD: 'fa fa-key',
+    }
+
     @classmethod
     def get_filter_category(cls, data_type):
         for category, valid_data_types in cls.FILTER_CATEGORY_DATA_TYPES.items():

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -373,6 +373,25 @@ class BulkEditFilter(models.Model):
         property_details = get_case_property_details(self.session.domain, self.session.identifier)
         return property_details.get(self.prop_id, {}).get('is_editable', True)
 
+    @property
+    def human_readable_match_type(self):
+        category = DataType.get_filter_category(self.data_type)
+        match_to_text = {
+            DataType.FILTER_CATEGORY_TEXT: dict(
+                FilterMatchType.TEXT_CHOICES + FilterMatchType.ALL_DATA_TYPES_CHOICES
+            ),
+            DataType.FILTER_CATEGORY_NUMBER: dict(
+                FilterMatchType.NUMBER_CHOICES + FilterMatchType.ALL_DATA_TYPES_CHOICES
+            ),
+            DataType.FILTER_CATEGORY_DATE: dict(
+                FilterMatchType.DATE_CHOICES + FilterMatchType.ALL_DATA_TYPES_CHOICES
+            ),
+            DataType.FILTER_CATEGORY_MULTI_SELECT: dict(
+                FilterMatchType.MULTI_SELECT_CHOICES + FilterMatchType.ALL_DATA_TYPES_CHOICES
+            ),
+        }.get(category, {})
+        return match_to_text.get(self.match_type, _("unknown"))
+
     def filter_query(self, query):
         filter_query_functions = {
             FilterMatchType.IS_EMPTY: lambda q: q.empty(self.prop_id),

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -124,7 +124,7 @@ class BulkEditSession(models.Model):
         :param filter_ids: list of uuids matching filter_id field of BulkEditFilters
         """
         if len(filter_ids) != self.filters.count():
-            raise ValueError("the lengths of column_ids and available column filters do not match")
+            raise ValueError("the lengths of filter_ids and available filters do not match")
         for index, filter_id in enumerate(filter_ids):
             active_filter = self.filters.get(filter_id=filter_id)
             active_filter.index = index

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -242,6 +242,12 @@ class DataType:
         FILTER_CATEGORY_MULTI_SELECT: (MULTIPLE_OPTION,),
     }
 
+    @classmethod
+    def get_filter_category(cls, data_type):
+        for category, valid_data_types in cls.FILTER_CATEGORY_DATA_TYPES.items():
+            if data_type in valid_data_types:
+                return category
+
 
 class FilterMatchType:
     EXACT = "exact"
@@ -392,10 +398,9 @@ class BulkEditFilter(models.Model):
             DataType.FILTER_CATEGORY_DATE: dict(FilterMatchType.DATE_CHOICES),
             DataType.FILTER_CATEGORY_MULTI_SELECT: dict(FilterMatchType.MULTI_SELECT_CHOICES),
         }
-        for category, valid_data_types in DataType.FILTER_CATEGORY_DATA_TYPES.items():
-            if data_type in valid_data_types:
-                return match_type in matches_by_category[category]
-
+        category = DataType.get_filter_category(data_type)
+        if category:
+            return match_type in matches_by_category[category]
         return False
 
     @staticmethod

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -3,6 +3,7 @@ import 'hqwebapp/js/htmx_base';
 import 'hqwebapp/js/alpinejs/directives/select2';
 import 'hqwebapp/js/alpinejs/directives/report_select2';
 import 'hqwebapp/js/alpinejs/directives/datepicker';
+import 'hqwebapp/js/alpinejs/directives/tooltip';
 import 'data_cleaning/js/directives/dynamic_options_select2';
 
 import Alpine from 'alpinejs';

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -3,6 +3,7 @@ import 'hqwebapp/js/htmx_base';
 import 'hqwebapp/js/alpinejs/directives/select2';
 import 'hqwebapp/js/alpinejs/directives/report_select2';
 import 'hqwebapp/js/alpinejs/directives/datepicker';
+import 'hqwebapp/js/alpinejs/directives/htmx_sortable';
 import 'hqwebapp/js/alpinejs/directives/tooltip';
 import 'data_cleaning/js/directives/dynamic_options_select2';
 

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/formatted_value.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/formatted_value.html
@@ -1,6 +1,6 @@
 {% if values_list %}
   {% for value in values_list %}
-    <span class="badge rounded-pill text-bg-primary fs-6">
+    <span class="badge rounded-pill text-bg-primary fs-6 my-1">
       {{ value }}
     </span>
   {% endfor %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/formatted_value.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/formatted_value.html
@@ -1,0 +1,10 @@
+{% if values_list %}
+  {% for value in values_list %}
+    <span class="badge rounded-pill text-bg-primary">
+      {{ value }}
+    </span>
+  {% endfor %}
+{% endif %}
+{% if value %}
+  {{ value }}
+{% endif %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/formatted_value.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/formatted_value.html
@@ -1,6 +1,6 @@
 {% if values_list %}
   {% for value in values_list %}
-    <span class="badge rounded-pill text-bg-primary">
+    <span class="badge rounded-pill text-bg-primary fs-6">
       {{ value }}
     </span>
   {% endfor %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
@@ -1,36 +1,46 @@
 {% load i18n %}
 {% load data_cleaning_filters %}
 
-<li class="list-group-item d-flex">
-  <a class="link p-1 flex-grow-1">
-    <i class="fa-solid fa-up-down"></i>
-    <input
-      type="hidden"
-      name="filter_ids"
-      value="{{ filter.filter_id }}"
-    />
-    <span class="ps-2">
-      {{ filter.prop_id }}
-    </span>
-    <span class="ms-2 badge text-bg-secondary">
-      {{ filter.human_readable_match_type }}
-    </span>
-    {% if filter.value %}
-      <span class="ps-2">
-        {{ filter|dc_filter_value }}
-      </span>
-    {% endif %}
-  </a>
-  <button
-    class="btn btn-outline-danger btn-sm"
-    type="button"
-    name="delete_id"
-    value="{{ filter.filter_id }}"
-    hx-post="{{ request.path_info }}"
-    hq-hx-action="delete_filter"
-    hx-disabled-elt="this"
-    hx-target="#{{ container_id }}"
-  >
-    <i class="fa-solid fa-close"></i>
-  </button>
-</li>
+<a href="#" class="list-group-item list-group-item-action">
+  <div class="d-flex">
+    <div class="p-2 align-self-center fs-5">
+      <i class="fa-solid fa-up-down"></i>
+      <input
+        type="hidden"
+        name="filter_ids"
+        value="{{ filter.filter_id }}"
+      />
+    </div>
+    <div class="p-2 flex-fill">
+      <h5 class="mb-1">
+        {{ filter.prop_id }}
+      </h5>
+      <div class="mb-1 d-flex align-items-center">
+        <div>
+          <span class="badge text-bg-secondary fs-6">
+            {{ filter.human_readable_match_type }}
+          </span>
+        </div>
+        {% if filter.value %}
+          <div class="ps-2">
+            {{ filter|dc_filter_value }}
+          </div>
+        {% endif %}
+      </div>
+    </div>
+    <div class="p-2 align-self-center">
+      <button
+        class="btn btn-outline-danger btn-sm"
+        type="button"
+        name="delete_id"
+        value="{{ filter.filter_id }}"
+        hx-post="{{ request.path_info }}"
+        hq-hx-action="delete_filter"
+        hx-disabled-elt="this"
+        hx-target="#{{ container_id }}"
+      >
+        <i class="fa-solid fa-close"></i>
+      </button>
+    </div>
+  </div>
+</a>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load data_cleaning_filters %}
 
 <li class="list-group-item d-flex">
   <a class="link p-1 flex-grow-1">
@@ -16,7 +17,7 @@
     </span>
     {% if filter.value %}
       <span class="ps-2">
-        {{ filter.value }}
+        {{ filter|dc_filter_value }}
       </span>
     {% endif %}
   </a>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
@@ -12,7 +12,7 @@
       {{ filter.prop_id }}
     </span>
     <span class="ms-2 badge text-bg-secondary">
-      {{ filter.match_type }}
+      {{ filter.human_readable_match_type }}
     </span>
     {% if filter.value %}
       <span class="ps-2">

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
@@ -24,6 +24,7 @@
         {% if filter.value %}
           <div
             class="ps-2"
+            aria-label="{{ filter.human_readable_data_type }}"
             data-bs-title="{{ filter.human_readable_data_type }}"
             x-tooltip=""
           >

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
@@ -24,7 +24,7 @@
         {% if filter.value %}
           <div
             class="ps-2"
-            data-bs-title="{{ filter.data_type }}"
+            data-bs-title="{{ filter.human_readable_data_type }}"
             x-tooltip=""
           >
             {{ filter|dc_filter_icon }}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
@@ -22,7 +22,11 @@
           </span>
         </div>
         {% if filter.value %}
-          <div class="ps-2">
+          <div
+            class="ps-2"
+            data-bs-title="{{ filter.data_type }}"
+            x-tooltip=""
+          >
             {{ filter|dc_filter_icon }}
           </div>
           <div class="ps-2">

--- a/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/filters/list_item.html
@@ -23,6 +23,9 @@
         </div>
         {% if filter.value %}
           <div class="ps-2">
+            {{ filter|dc_filter_icon }}
+          </div>
+          <div class="ps-2">
             {{ filter|dc_filter_value }}
           </div>
         {% endif %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
@@ -14,11 +14,11 @@
         hq-hx-action="reorder_filters"
         hx-trigger="end"
       >
-        <ul class="list-group">
+        <div class="list-group">
           {% for filter in active_filters %}
             {% include "data_cleaning/filters/list_item.html" %}
           {% endfor %}
-        </ul>
+        </div>
       </form>
     </div>
   {% endif %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
@@ -15,7 +15,10 @@
         hq-hx-action="reorder_filters"
         hx-trigger="end"
       >
-        <div class="list-group">
+        <div
+          class="list-group"
+          x-htmx-sortable=""
+        >
           {% for filter in active_filters %}
             {% include "data_cleaning/filters/list_item.html" %}
           {% endfor %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
@@ -12,7 +12,7 @@
         hx-post="{{ request.path_info }}"
         hx-target="#{{ container_id }}"
         hx-disabled-elt="find button"
-        hq-hx-action="reorder_filters"
+        hq-hx-action="update_filter_order"
         hx-trigger="end"
       >
         <div

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
@@ -4,6 +4,7 @@
 <div
   id="{{ container_id }}"
   hx-swap="outerHTML"
+  hq-hx-refresh-swap="#CleanCaseTable"
 >
   {% if active_filters %}
     <div class="mb-3">

--- a/corehq/apps/data_cleaning/templatetags/data_cleaning_filters.py
+++ b/corehq/apps/data_cleaning/templatetags/data_cleaning_filters.py
@@ -21,7 +21,7 @@ def dc_filter_value(dc_filter):
         context['values_list'] = dc_filter.value.split(" ")
     else:
         context['value'] = dc_filter.value
-    return mark_safe(  # nosec: render_to_string should have already handled escaping
+    return mark_safe(  # nosec: render_to_string below will handle escaping
         render_to_string(
             "data_cleaning/filters/formatted_value.html",
             context

--- a/corehq/apps/data_cleaning/templatetags/data_cleaning_filters.py
+++ b/corehq/apps/data_cleaning/templatetags/data_cleaning_filters.py
@@ -1,5 +1,6 @@
 from django import template
 from django.template.loader import render_to_string
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
 from corehq.apps.data_cleaning.models import DataType
@@ -25,4 +26,14 @@ def dc_filter_value(dc_filter):
             "data_cleaning/filters/formatted_value.html",
             context
         )
+    )
+
+
+@register.filter
+def dc_filter_icon(dc_filter):
+    icon_class = DataType.ICON_CLASSES.get(
+        dc_filter.data_type, DataType.ICON_CLASSES[DataType.TEXT]
+    )
+    return format_html(
+        '<i class="{}"></i>', icon_class
     )

--- a/corehq/apps/data_cleaning/templatetags/data_cleaning_filters.py
+++ b/corehq/apps/data_cleaning/templatetags/data_cleaning_filters.py
@@ -1,0 +1,28 @@
+from django import template
+from django.template.loader import render_to_string
+from django.utils.safestring import mark_safe
+
+from corehq.apps.data_cleaning.models import DataType
+
+register = template.Library()
+
+
+@register.filter
+def dc_filter_value(dc_filter):
+    """
+    Renders an appropriately formatted value for a
+    `BulkEditFilter` based on the `data_type`.
+    """
+    if dc_filter.value is None:
+        return ""
+    context = {}
+    if dc_filter.data_type == DataType.MULTIPLE_OPTION:
+        context['values_list'] = dc_filter.value.split(" ")
+    else:
+        context['value'] = dc_filter.value
+    return mark_safe(  # nosec: render_to_string should have already handled escaping
+        render_to_string(
+            "data_cleaning/filters/formatted_value.html",
+            context
+        )
+    )

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -168,7 +168,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         filters = session.filters.all()
         new_order = [filters[1].filter_id, filters[2].filter_id]
         with self.assertRaises(ValueError):
-            session.reorder_filters(new_order)
+            session.update_filter_order(new_order)
 
     def test_reorder_filters(self):
         session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
@@ -185,7 +185,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             filters[4].filter_id,
             filters[3].filter_id,
         ]
-        session.reorder_filters(new_order)
+        session.update_filter_order(new_order)
         reordered_prop_ids = [c.prop_id for c in session.filters.all()]
         self.assertEqual(
             reordered_prop_ids,

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -79,7 +79,8 @@ class ManageFiltersFormView(BulkEditSessionViewMixin, BaseFilterFormView):
 
     @hq_hx_action('post')
     def reorder_filters(self, request, *args, **kwargs):
-        # todo
+        filter_ids = request.POST.getlist('filter_ids')
+        self.session.reorder_filters(filter_ids)
         return self.get(request, *args, **kwargs)
 
     @hq_hx_action('post')

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -78,9 +78,9 @@ class ManageFiltersFormView(BulkEditSessionViewMixin, BaseFilterFormView):
         return self.get(request, filter_form=filter_form, *args, **kwargs)
 
     @hq_hx_action('post')
-    def reorder_filters(self, request, *args, **kwargs):
+    def update_filter_order(self, request, *args, **kwargs):
         filter_ids = request.POST.getlist('filter_ids')
-        self.session.reorder_filters(filter_ids)
+        self.session.update_filter_order(filter_ids)
         return self.get(request, *args, **kwargs)
 
     @hq_hx_action('post')

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/htmx_sortable.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/htmx_sortable.js
@@ -1,0 +1,37 @@
+import Sortable from 'sortablejs';
+import Alpine from 'alpinejs';
+
+
+Alpine.directive('htmx-sortable', (el, { expression }, { cleanup }) => {
+    /**
+     * To use, add x-htmx-sortable to your `<ul>` or similarly-styled `list-group`
+     * parent.
+     *
+     * NOTE: This directive is intended to be paired with HTMX, which will do the sorting and
+     * population of the list on the backend and re-render the partial.
+     *
+     * For an alpine-only client-side approach, see the `@alpinejs/sort` plugin,
+     * or `x-sort`, which updates the alpine data model appropriately, sorting a list
+     * defined in the model.
+     *
+     *      <div x-htmx-sortable="{% html_attr config %}">...</div>
+     *
+     */
+    const config = expression ? JSON.parse(expression) : {};
+    const indicatorClass = config.htmxIndicatorClass || 'htmx-indicator';
+    const sortable = new Sortable(el, {
+        animation: 150,
+        // if present, make sure the HTMX indicator is not sortable
+        filter: `.${indicatorClass}`,
+        onMove: (evt) => {
+            // make sure the htmx-indicator is never moved
+            return evt.related.className.indexOf(indicatorClass) === -1;
+        },
+        onEnd: () => {
+            sortable.option('disabled', true);
+        },
+    });
+    cleanup(() => {
+        sortable.destroy();
+    });
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/tooltip.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/tooltip.js
@@ -1,0 +1,20 @@
+import { Tooltip } from 'bootstrap5';
+import Alpine from 'alpinejs';
+
+
+Alpine.directive('tooltip', (el, { expression }, { cleanup }) => {
+    /**
+     * To use, add x-tooltip to your element.
+     *
+     *      <div x-tooltip="{% html_attr config %}" >...</div>
+     *
+     *      Note: this tooltip will also understand `data-bs` attributes
+     *      as defined in the Bootstrap docs.
+     *
+     */
+    const config = expression ? JSON.parse(expression) : {};
+    const tooltip = new Tooltip(el, config);
+    cleanup(() => {
+        tooltip.dispose();
+    });
+});

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "requirejs-babel7": "^1.3.2",
         "select2": "4.1.0-rc.0",
         "signature_pad": "^5.0.4",
+        "sortablejs": "^1.15.6",
         "string-replace-loader": "3.1.0",
         "style-loader": "^4.0.0",
         "uglify-js": "3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7215,6 +7215,11 @@ socks@^2.7.1:
     ip-address "^9.0.5"
     smart-buffer "^4.2.0"
 
+sortablejs@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.15.6.tgz#ff93699493f5b8ab8d828f933227b4988df1d393"
+  integrity sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==
+
 source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"


### PR DESCRIPTION
## Technical Summary
This PR updates the data cleaning filter list UI to use human-friendly text, data type icons, clearer language and layout. Additionally, this PR adds `sortablejs` to allow the user to sort the list of filters. While sorting filters isn't essential with AND logic, it's helpful for organization and it will be needed to sort columns (next).

Additionally, two alpine directives were added
- `x-tooltip` to activate a bootstrap 5 tooltip on an element, as bootstrap 5 requires manual activation of tooltips now.
- `x-htmx-sortable` for sorting a list of items where the sorting logic is handled by the backend with an HTMX request

<img width="371" alt="Screenshot 2025-03-18 at 1 41 58 PM" src="https://github.com/user-attachments/assets/18715990-2c69-40aa-be11-ea49a5138435" />

with tooltip over data type (and `aria-label`)
<img width="415" alt="Screenshot 2025-03-18 at 1 56 01 PM" src="https://github.com/user-attachments/assets/07266f4f-a80c-499b-931d-e29fa8e6ac86" />


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe changes all made behind feature flag, no production workflows affected. tests for the most important logic

### Automated test coverage
yes

### QA Plan
not yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
