### PR TITLE
Get underscore out of HTML in icon display properties

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/key_value_mapping.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/key_value_mapping.html
@@ -35,7 +35,7 @@
           </div>
           <!-- /ko -->
           <!-- ko if: !$parent.values_are_icons() -->
-          <div class="col-sm-1 btn" data-bind="visible: !_([$parent.lang, null]).contains($parent.backup(value()).lang)">
+          <div class="col-sm-1 btn" data-bind="visible: ![$parent.lang, null].includes($parent.backup(value()).lang)">
             <a href="#" class="btn btn-info btn-xs lang-text"
                data-bind="
                             text: $parent.backup(value()).lang
@@ -164,7 +164,7 @@
 </div>
 
 <div id="icon_uploader_path" class="hide">
-  <div class="col-sm-1 btn" data-bind="visible: !_([$parents[1].lang, null]).contains($parents[1].backup($parent.value()).lang)">
+  <div class="col-sm-1 btn" data-bind="visible: ![$parents[1].lang, null].includes($parents[1].backup($parent.value()).lang)">
     <a href="#" class="btn btn-info btn-xs lang-text"
        data-bind="
             text: $parents[1].backup($parent.value()).lang

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/key_value_mapping.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/key_value_mapping.html
@@ -3,47 +3,73 @@
 <div id="key_value_mapping_editable_template" class="hide">
   <form class="form-horizontal hq-enum-editor" action="">
     <fieldset data-bind="sortable: items">
-      <div class="form-group hq-input-map container-fluid well well-sm"
-           data-bind="css: {'has-error': $parent.keyHasError(ko.utils.unwrapObservable(key))},
-                            attr: {'data-order': _sortableOrder}">
+      <div
+        class="form-group hq-input-map container-fluid well well-sm"
+        data-bind="css: {'has-error': $parent.keyHasError(ko.utils.unwrapObservable(key))},
+                            attr: {'data-order': _sortableOrder}"
+      >
         <div class="row">
           <div class="col-sm-1">
             <i class="sortable-handle fa-solid fa-up-down"></i>
           </div>
 
           <div class="col-sm-3">
-            <input type="text"
-                   class="enum-key form-control"
-                   data-bind="value: key, attr: {placeholder: $parent.labels().placeholder}"/>
-            <div class="help-block" data-bind='visible: $parent.isItemDuplicated(ko.utils.unwrapObservable(key)),
-                                                               text: $parent.labels().duplicated'></div>
-            <div class="help-block" data-bind='visible: $parent.hasBadXML(ko.utils.unwrapObservable(key)),
-                                                               text: $parent.labels().badXML'></div>
+            <input
+              type="text"
+              class="enum-key form-control"
+              data-bind="value: key, attr: {placeholder: $parent.labels().placeholder}"
+            />
+            <div
+              class="help-block"
+              data-bind="visible: $parent.isItemDuplicated(ko.utils.unwrapObservable(key)),
+                                                               text: $parent.labels().duplicated"
+            ></div>
+            <div
+              class="help-block"
+              data-bind="visible: $parent.hasBadXML(ko.utils.unwrapObservable(key)),
+                                                               text: $parent.labels().badXML"
+            ></div>
           </div>
 
-          <div class="col-sm-1 text-center" style="width: 3px">
-            &rarr;
-          </div>
-          <div class="col-sm-3" data-bind="visible: !$parent.values_are_icons()">
-            <input type="text" class="form-control enum-value" data-bind="
+          <div class="col-sm-1 text-center" style="width: 3px">&rarr;</div>
+          <div
+            class="col-sm-3"
+            data-bind="visible: !$parent.values_are_icons()"
+          >
+            <input
+              type="text"
+              class="form-control enum-value"
+              data-bind="
                             attr: {placeholder: $parent.backup(value()).value},
                             value: value()[$parent.lang]
-                        "/>
+                        "
+            />
           </div>
           <!-- ko if: $parent.values_are_icons() -->
-          <div data-bind="template: {name: 'value_icon_uploader', data: iconManager}">
-          </div>
+          <div
+            data-bind="template: {name: 'value_icon_uploader', data: iconManager}"
+          ></div>
           <!-- /ko -->
           <!-- ko if: !$parent.values_are_icons() -->
-          <div class="col-sm-1 btn" data-bind="visible: ![$parent.lang, null].includes($parent.backup(value()).lang)">
-            <a href="#" class="btn btn-info btn-xs lang-text"
-               data-bind="
+          <div
+            class="col-sm-1 btn"
+            data-bind="visible: ![$parent.lang, null].includes($parent.backup(value()).lang)"
+          >
+            <a
+              href="#"
+              class="btn btn-info btn-xs lang-text"
+              data-bind="
                             text: $parent.backup(value()).lang
-                        "></a>
+                        "
+            ></a>
           </div>
           <!-- /ko -->
           <div class="col-sm-1 pull-right">
-            <a href="#" data-bind="click: $parent.removeItem" class="btn btn-danger">
+            <a
+              href="#"
+              data-bind="click: $parent.removeItem"
+              class="btn btn-danger"
+            >
               <i class="icon-white fa fa-remove"></i>
             </a>
           </div>
@@ -51,25 +77,30 @@
         {% if app.supports_alt_text %}
           <div class="row">
             <!-- ko if: $parent.values_are_icons() -->
-            <div data-bind="template: {name: 'icon_alt_text', data: iconManager}"
-                style="margin-top: 3px">
-            </div>
+            <div
+              data-bind="template: {name: 'icon_alt_text', data: iconManager}"
+              style="margin-top: 3px"
+            ></div>
             <!-- /ko -->
           </div>
         {% endif %}
         <div class="row">
           <!-- ko if: $parent.values_are_icons() -->
-          <div data-bind="template: {name: 'icon_uploader_path', data: iconManager}"
-               style="margin-top: 3px">
-          </div>
+          <div
+            data-bind="template: {name: 'icon_uploader_path', data: iconManager}"
+            style="margin-top: 3px"
+          ></div>
           <!-- /ko -->
         </div>
       </div>
     </fieldset>
 
     <div class="col-sm-offset-1">
-      <a href="#" class="btn btn-primary"
-         data-bind="click: addItem, text: $data.labels().addButton">
+      <a
+        href="#"
+        class="btn btn-primary"
+        data-bind="click: addItem, text: $data.labels().addButton"
+      >
         <i class="icon-white fa fa-plus"></i>
         Add Key &rarr; Value Mapping
       </a>
@@ -87,14 +118,20 @@
           </button>
           <h4 class="modal-title" data-bind="text: $data.modalTitle"></h4>
         </div>
-        <div class="modal-body" style="max-height:372px; overflow-y: scroll;"
-             data-bind="template: {name: 'key_value_mapping_editable_template', data: mapList}"></div>
+        <div
+          class="modal-body"
+          style="max-height:372px; overflow-y: scroll;"
+          data-bind="template: {name: 'key_value_mapping_editable_template', data: mapList}"
+        ></div>
         <div class="modal-footer">
           <button class="btn btn-default" data-dismiss="modal">Cancel</button>
-          <button class="btn btn-primary" data-dismiss="modal"
-                  data-bind="disable: $data.mapList.hasError(),
+          <button
+            class="btn btn-primary"
+            data-dismiss="modal"
+            data-bind="disable: $data.mapList.hasError(),
                             text: $data.mapList.hasError() ? 'Fix errors' : 'OK',
-                            click: save"></button>
+                            click: save"
+          ></button>
         </div>
       </div>
     </div>
@@ -107,18 +144,27 @@
     <div>
       <strong data-bind="text: key"></strong>
       &rarr;
-      <span data-bind="visible: value()[$parent.lang], text: value()[$parent.lang]"></span>
-      <span data-bind="visible: !ko.utils.unwrapObservable(value()[$parent.lang])">
-                <i class="fa fa-times-circle"></i>
-            </span>
+      <span
+        data-bind="visible: value()[$parent.lang], text: value()[$parent.lang]"
+      ></span>
+      <span
+        data-bind="visible: !ko.utils.unwrapObservable(value()[$parent.lang])"
+      >
+        <i class="fa fa-times-circle"></i>
+      </span>
     </div>
   </div>
 </div>
 
 <!-- Read-only version of keys and values, displayed alongside button to pop up modal -->
 <div id="key_value_mapping_template" class="hide">
-  <div data-bind="template: {name: 'key_value_mapping_display_template', if: !$data.values_are_icons() }"></div>
-  <button class="btn btn-default" data-bind="click: openModal, visible: $data.edit">
+  <div
+    data-bind="template: {name: 'key_value_mapping_display_template', if: !$data.values_are_icons() }"
+  ></div>
+  <button
+    class="btn btn-default"
+    data-bind="click: openModal, visible: $data.edit"
+  >
     <i class="fa fa-pencil"></i>
     <span data-bind="text: $data.buttonText"></span>
   </button>
@@ -126,27 +172,40 @@
 
 <div id="value_icon_uploader" class="hide">
   <div class="col-sm-1" style="margin-right: 7px">
-    <a data-bind="if: isMediaMatched, attr: {href: url}" target="_blank" data-bind="visible: url" >
-      <img data-bind="attr: {src: thumbnailUrl}">
+    <a
+      data-bind="if: isMediaMatched, attr: {href: url}"
+      target="_blank"
+      data-bind="visible: url"
+    >
+      <img data-bind="attr: {src: thumbnailUrl}" />
     </a>
   </div>
   <div class="col-sm-2" id="$parent.cssId()">
-    <button type="button" class="btn btn-default" data-toggle="modal" data-target="#hqimage" data-bind="
+    <button
+      type="button"
+      class="btn btn-default"
+      data-toggle="modal"
+      data-target="#hqimage"
+      data-bind="
                            attr: { 'data-hqmediapath': currentPath },
                            event: {
                                 mediaUploadComplete: uploadComplete,
                                 click: function(){setCustomPath(); passToUploadController()}
-                           }">
+                           }"
+    >
       <i class="fa-solid fa-cloud-arrow-up"></i>
       <span data-bind="visible: isMediaMatched">{% trans 'Replace' %}</span>
       <span data-bind="visible: isMediaUnmatched">{% trans 'Upload' %}</span>
     </button>
   </div>
   <div class="col-sm-3">
-    <button type="button" class="btn btn-default pull-right"
-            data-bind="
+    <button
+      type="button"
+      class="btn btn-default pull-right"
+      data-bind="
                     visible: !$parent.editing(),
-                    click: function(){if (!useCustomPath()) setCustomPath(); $parent.toggleEditMode()}">
+                    click: function(){if (!useCustomPath()) setCustomPath(); $parent.toggleEditMode()}"
+    >
       <i class="fa fa-cog"></i>
       {% trans 'Set Path' %}
     </button>
@@ -156,34 +215,52 @@
 <div id="icon_alt_text" class="hide">
   <label class="control-label col-sm-1">{% trans 'Alt Text' %}</label>
   <div class="col-sm-4">
-    <input type="text" class="form-control"
-           placeholder="{% trans 'Alternative text description' %}"
-           data-bind="value: altText,
-                      valueUpdate: 'textchange'" />
+    <input
+      type="text"
+      class="form-control"
+      placeholder="{% trans 'Alternative text description' %}"
+      data-bind="value: altText,
+                      valueUpdate: 'textchange'"
+    />
   </div>
 </div>
 
 <div id="icon_uploader_path" class="hide">
-  <div class="col-sm-1 btn" data-bind="visible: ![$parents[1].lang, null].includes($parents[1].backup($parent.value()).lang)">
-    <a href="#" class="btn btn-info btn-xs lang-text"
-       data-bind="
+  <div
+    class="col-sm-1 btn"
+    data-bind="visible: ![$parents[1].lang, null].includes($parents[1].backup($parent.value()).lang)"
+  >
+    <a
+      href="#"
+      class="btn btn-info btn-xs lang-text"
+      data-bind="
             text: $parents[1].backup($parent.value()).lang
-        "></a>
+        "
+    ></a>
   </div>
 
   <div data-bind="visible: $parent.editing">
     <label class="control-label col-sm-1">Path</label>
     <div class="col-sm-4">
-      <input type="text" class="form-control"
-             data-bind="value: customPath,
-                              valueUpdate: 'textchange'" />
-      <input type="hidden" class="jr-resource-field"
-             data-bind="value: savedPath" />
+      <input
+        type="text"
+        class="form-control"
+        data-bind="value: customPath,
+                              valueUpdate: 'textchange'"
+      />
+      <input
+        type="hidden"
+        class="jr-resource-field"
+        data-bind="value: savedPath"
+      />
     </div>
     <div class="col-sm-3">
       <div class="col-sm-1">
-        <button type="button" class="btn btn-default"
-                data-bind="click: function(){setDefaultPath(); $parent.toggleEditMode()}">
+        <button
+          type="button"
+          class="btn btn-default"
+          data-bind="click: function(){setDefaultPath(); $parent.toggleEditMode()}"
+        >
           <i class="fa fa-remove"></i>
           {% trans 'Use Default Path' %}
         </button>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/key_value_mapping.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/key_value_mapping.html
@@ -35,7 +35,7 @@
           </div>
           <!-- /ko -->
           <!-- ko if: !$parent.values_are_icons() -->
-          <div class="col-md-1 btn" data-bind="visible: !_([$parent.lang, null]).contains($parent.backup(value()).lang)">
+          <div class="col-sm-1 btn" data-bind="visible: ![$parent.lang, null].includes($parent.backup(value()).lang)">
             <a href="#" class="btn btn-info btn-sm lang-text"
                data-bind="
                             text: $parent.backup(value()).lang
@@ -164,7 +164,7 @@
 </div>
 
 <div id="icon_uploader_path" class="hide">
-  <div class="col-md-1 btn" data-bind="visible: !_([$parents[1].lang, null]).contains($parents[1].backup($parent.value()).lang)">
+  <div class="col-sm-1 btn" data-bind="visible: ![$parents[1].lang, null].includes($parents[1].backup($parent.value()).lang)">
     <a href="#" class="btn btn-info btn-sm lang-text"
        data-bind="
             text: $parents[1].backup($parent.value()).lang

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/key_value_mapping.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/key_value_mapping.html
@@ -3,47 +3,73 @@
 <div id="key_value_mapping_editable_template" class="hide">
   <form class="form-horizontal hq-enum-editor" action="">
     <fieldset data-bind="sortable: items">
-      <div class="form-group hq-input-map container-fluid card well-sm"
-           data-bind="css: {'has-error': $parent.keyHasError(ko.utils.unwrapObservable(key))},
-                            attr: {'data-order': _sortableOrder}">
+      <div
+        class="form-group hq-input-map container-fluid card well-sm"
+        data-bind="css: {'has-error': $parent.keyHasError(ko.utils.unwrapObservable(key))},
+                            attr: {'data-order': _sortableOrder}"
+      >
         <div class="row">
           <div class="col-md-1">
             <i class="sortable-handle fa-solid fa-up-down"></i>
           </div>
 
           <div class="col-md-3">
-            <input type="text"
-                   class="enum-key form-control"
-                   data-bind="value: key, attr: {placeholder: $parent.labels().placeholder}"/>
-            <div class="help-block" data-bind='visible: $parent.isItemDuplicated(ko.utils.unwrapObservable(key)),
-                                                               text: $parent.labels().duplicated'></div>
-            <div class="help-block" data-bind='visible: $parent.hasBadXML(ko.utils.unwrapObservable(key)),
-                                                               text: $parent.labels().badXML'></div>
+            <input
+              type="text"
+              class="enum-key form-control"
+              data-bind="value: key, attr: {placeholder: $parent.labels().placeholder}"
+            />
+            <div
+              class="help-block"
+              data-bind="visible: $parent.isItemDuplicated(ko.utils.unwrapObservable(key)),
+                                                               text: $parent.labels().duplicated"
+            ></div>
+            <div
+              class="help-block"
+              data-bind="visible: $parent.hasBadXML(ko.utils.unwrapObservable(key)),
+                                                               text: $parent.labels().badXML"
+            ></div>
           </div>
 
-          <div class="col-md-1 text-center" style="width: 3px">
-            &rarr;
-          </div>
-          <div class="col-md-3" data-bind="visible: !$parent.values_are_icons()">
-            <input type="text" class="form-control enum-value" data-bind="
+          <div class="col-md-1 text-center" style="width: 3px">&rarr;</div>
+          <div
+            class="col-md-3"
+            data-bind="visible: !$parent.values_are_icons()"
+          >
+            <input
+              type="text"
+              class="form-control enum-value"
+              data-bind="
                             attr: {placeholder: $parent.backup(value()).value},
                             value: value()[$parent.lang]
-                        "/>
+                        "
+            />
           </div>
           <!-- ko if: $parent.values_are_icons() -->
-          <div data-bind="template: {name: 'value_icon_uploader', data: iconManager}">
-          </div>
+          <div
+            data-bind="template: {name: 'value_icon_uploader', data: iconManager}"
+          ></div>
           <!-- /ko -->
           <!-- ko if: !$parent.values_are_icons() -->
-          <div class="col-sm-1 btn" data-bind="visible: ![$parent.lang, null].includes($parent.backup(value()).lang)">
-            <a href="#" class="btn btn-info btn-sm lang-text"
-               data-bind="
+          <div
+            class="col-sm-1 btn"
+            data-bind="visible: ![$parent.lang, null].includes($parent.backup(value()).lang)"
+          >
+            <a
+              href="#"
+              class="btn btn-info btn-sm lang-text"
+              data-bind="
                             text: $parent.backup(value()).lang
-                        "></a>
+                        "
+            ></a>
           </div>
           <!-- /ko -->
           <div class="col-md-1 float-end">
-            <a href="#" data-bind="click: $parent.removeItem" class="btn btn-outline-danger">
+            <a
+              href="#"
+              data-bind="click: $parent.removeItem"
+              class="btn btn-outline-danger"
+            >
               <i class="icon-white fa fa-remove"></i>
             </a>
           </div>
@@ -51,25 +77,30 @@
         {% if app.supports_alt_text %}
           <div class="row">
             <!-- ko if: $parent.values_are_icons() -->
-            <div data-bind="template: {name: 'icon_alt_text', data: iconManager}"
-                style="margin-top: 3px">
-            </div>
+            <div
+              data-bind="template: {name: 'icon_alt_text', data: iconManager}"
+              style="margin-top: 3px"
+            ></div>
             <!-- /ko -->
           </div>
         {% endif %}
         <div class="row">
           <!-- ko if: $parent.values_are_icons() -->
-          <div data-bind="template: {name: 'icon_uploader_path', data: iconManager}"
-               style="margin-top: 3px">
-          </div>
+          <div
+            data-bind="template: {name: 'icon_uploader_path', data: iconManager}"
+            style="margin-top: 3px"
+          ></div>
           <!-- /ko -->
         </div>
       </div>
     </fieldset>
 
     <div class="col-sm-offset-1">
-      <a href="#" class="btn btn-primary"
-         data-bind="click: addItem, text: $data.labels().addButton">
+      <a
+        href="#"
+        class="btn btn-primary"
+        data-bind="click: addItem, text: $data.labels().addButton"
+      >
         <i class="icon-white fa fa-plus"></i>
         Add Key &rarr; Value Mapping
       </a>
@@ -87,14 +118,22 @@
           </button>
           <h4 class="modal-title" data-bind="text: $data.modalTitle"></h4>
         </div>
-        <div class="modal-body" style="max-height:372px; overflow-y: scroll;"
-             data-bind="template: {name: 'key_value_mapping_editable_template', data: mapList}"></div>
+        <div
+          class="modal-body"
+          style="max-height:372px; overflow-y: scroll;"
+          data-bind="template: {name: 'key_value_mapping_editable_template', data: mapList}"
+        ></div>
         <div class="modal-footer">
-          <button class="btn btn-outline-primary" data-bs-dismiss="modal">Cancel</button>
-          <button class="btn btn-primary" data-bs-dismiss="modal"
-                  data-bind="disable: $data.mapList.hasError(),
+          <button class="btn btn-outline-primary" data-bs-dismiss="modal">
+            Cancel
+          </button>
+          <button
+            class="btn btn-primary"
+            data-bs-dismiss="modal"
+            data-bind="disable: $data.mapList.hasError(),
                             text: $data.mapList.hasError() ? 'Fix errors' : 'OK',
-                            click: save"></button>
+                            click: save"
+          ></button>
         </div>
       </div>
     </div>
@@ -107,18 +146,27 @@
     <div>
       <strong data-bind="text: key"></strong>
       &rarr;
-      <span data-bind="visible: value()[$parent.lang], text: value()[$parent.lang]"></span>
-      <span data-bind="visible: !ko.utils.unwrapObservable(value()[$parent.lang])">
-                <i class="fa fa-times-circle"></i>
-            </span>
+      <span
+        data-bind="visible: value()[$parent.lang], text: value()[$parent.lang]"
+      ></span>
+      <span
+        data-bind="visible: !ko.utils.unwrapObservable(value()[$parent.lang])"
+      >
+        <i class="fa fa-times-circle"></i>
+      </span>
     </div>
   </div>
 </div>
 
 <!-- Read-only version of keys and values, displayed alongside button to pop up modal -->
 <div id="key_value_mapping_template" class="hide">
-  <div data-bind="template: {name: 'key_value_mapping_display_template', if: !$data.values_are_icons() }"></div>
-  <button class="btn btn-outline-primary" data-bind="click: openModal, visible: $data.edit">
+  <div
+    data-bind="template: {name: 'key_value_mapping_display_template', if: !$data.values_are_icons() }"
+  ></div>
+  <button
+    class="btn btn-outline-primary"
+    data-bind="click: openModal, visible: $data.edit"
+  >
     <i class="fa fa-pencil"></i>
     <span data-bind="text: $data.buttonText"></span>
   </button>
@@ -126,27 +174,40 @@
 
 <div id="value_icon_uploader" class="hide">
   <div class="col-md-1" style="margin-right: 7px">
-    <a data-bind="if: isMediaMatched, attr: {href: url}" target="_blank" data-bind="visible: url" >
-      <img data-bind="attr: {src: thumbnailUrl}">
+    <a
+      data-bind="if: isMediaMatched, attr: {href: url}"
+      target="_blank"
+      data-bind="visible: url"
+    >
+      <img data-bind="attr: {src: thumbnailUrl}" />
     </a>
   </div>
   <div class="col-md-2" id="$parent.cssId()">
-    <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#hqimage" data-bind="
+    <button
+      type="button"
+      class="btn btn-outline-primary"
+      data-bs-toggle="modal"
+      data-bs-target="#hqimage"
+      data-bind="
                            attr: { 'data-hqmediapath': currentPath },
                            event: {
                                 mediaUploadComplete: uploadComplete,
                                 click: function(){setCustomPath(); passToUploadController()}
-                           }">
+                           }"
+    >
       <i class="fa-solid fa-cloud-arrow-up"></i>
       <span data-bind="visible: isMediaMatched">{% trans 'Replace' %}</span>
       <span data-bind="visible: isMediaUnmatched">{% trans 'Upload' %}</span>
     </button>
   </div>
   <div class="col-md-3">
-    <button type="button" class="btn btn-outline-primary float-end"
-            data-bind="
+    <button
+      type="button"
+      class="btn btn-outline-primary float-end"
+      data-bind="
                     visible: !$parent.editing(),
-                    click: function(){if (!useCustomPath()) setCustomPath(); $parent.toggleEditMode()}">
+                    click: function(){if (!useCustomPath()) setCustomPath(); $parent.toggleEditMode()}"
+    >
       <i class="fa fa-cog"></i>
       {% trans 'Set Path' %}
     </button>
@@ -156,34 +217,52 @@
 <div id="icon_alt_text" class="hide">
   <label class="control-label col-sm-1">{% trans 'Alt Text' %}</label>
   <div class="col-md-4">
-    <input type="text" class="form-control"
-           placeholder="{% trans 'Alternative text description' %}"
-           data-bind="value: altText,
-                      valueUpdate: 'textchange'" />
+    <input
+      type="text"
+      class="form-control"
+      placeholder="{% trans 'Alternative text description' %}"
+      data-bind="value: altText,
+                      valueUpdate: 'textchange'"
+    />
   </div>
 </div>
 
 <div id="icon_uploader_path" class="hide">
-  <div class="col-sm-1 btn" data-bind="visible: ![$parents[1].lang, null].includes($parents[1].backup($parent.value()).lang)">
-    <a href="#" class="btn btn-info btn-sm lang-text"
-       data-bind="
+  <div
+    class="col-sm-1 btn"
+    data-bind="visible: ![$parents[1].lang, null].includes($parents[1].backup($parent.value()).lang)"
+  >
+    <a
+      href="#"
+      class="btn btn-info btn-sm lang-text"
+      data-bind="
             text: $parents[1].backup($parent.value()).lang
-        "></a>
+        "
+    ></a>
   </div>
 
   <div data-bind="visible: $parent.editing">
     <label class="control-label col-md-1">Path</label>
     <div class="col-md-4">
-      <input type="text" class="form-control"
-             data-bind="value: customPath,
-                              valueUpdate: 'textchange'" />
-      <input type="hidden" class="jr-resource-field"
-             data-bind="value: savedPath" />
+      <input
+        type="text"
+        class="form-control"
+        data-bind="value: customPath,
+                              valueUpdate: 'textchange'"
+      />
+      <input
+        type="hidden"
+        class="jr-resource-field"
+        data-bind="value: savedPath"
+      />
     </div>
     <div class="col-md-3">
       <div class="col-md-1">
-        <button type="button" class="btn btn-outline-primary"
-                data-bind="click: function(){setDefaultPath(); $parent.toggleEditMode()}">
+        <button
+          type="button"
+          class="btn btn-outline-primary"
+          data-bind="click: function(){setDefaultPath(); $parent.toggleEditMode()}"
+        >
           <i class="fa fa-remove"></i>
           {% trans 'Use Default Path' %}
         </button>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/key_value_mapping.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/key_value_mapping.html.diff.txt
@@ -1,13 +1,14 @@
 --- 
 +++ 
-@@ -3,15 +3,15 @@
- <div id="key_value_mapping_editable_template" class="hide">
+@@ -4,16 +4,16 @@
    <form class="form-horizontal hq-enum-editor" action="">
      <fieldset data-bind="sortable: items">
--      <div class="form-group hq-input-map container-fluid well well-sm"
-+      <div class="form-group hq-input-map container-fluid card well-sm"
-            data-bind="css: {'has-error': $parent.keyHasError(ko.utils.unwrapObservable(key))},
-                             attr: {'data-order': _sortableOrder}">
+       <div
+-        class="form-group hq-input-map container-fluid well well-sm"
++        class="form-group hq-input-map container-fluid card well-sm"
+         data-bind="css: {'has-error': $parent.keyHasError(ko.utils.unwrapObservable(key))},
+                             attr: {'data-order': _sortableOrder}"
+       >
          <div class="row">
 -          <div class="col-sm-1">
 +          <div class="col-md-1">
@@ -16,43 +17,45 @@
  
 -          <div class="col-sm-3">
 +          <div class="col-md-3">
-             <input type="text"
-                    class="enum-key form-control"
-                    data-bind="value: key, attr: {placeholder: $parent.labels().placeholder}"/>
-@@ -21,10 +21,10 @@
-                                                                text: $parent.labels().badXML'></div>
+             <input
+               type="text"
+               class="enum-key form-control"
+@@ -31,9 +31,9 @@
+             ></div>
            </div>
  
--          <div class="col-sm-1 text-center" style="width: 3px">
-+          <div class="col-md-1 text-center" style="width: 3px">
-             &rarr;
-           </div>
--          <div class="col-sm-3" data-bind="visible: !$parent.values_are_icons()">
-+          <div class="col-md-3" data-bind="visible: !$parent.values_are_icons()">
-             <input type="text" class="form-control enum-value" data-bind="
-                             attr: {placeholder: $parent.backup(value()).value},
-                             value: value()[$parent.lang]
-@@ -35,15 +35,15 @@
-           </div>
-           <!-- /ko -->
-           <!-- ko if: !$parent.values_are_icons() -->
--          <div class="col-sm-1 btn" data-bind="visible: !_([$parent.lang, null]).contains($parent.backup(value()).lang)">
--            <a href="#" class="btn btn-info btn-xs lang-text"
-+          <div class="col-md-1 btn" data-bind="visible: !_([$parent.lang, null]).contains($parent.backup(value()).lang)">
-+            <a href="#" class="btn btn-info btn-sm lang-text"
-                data-bind="
+-          <div class="col-sm-1 text-center" style="width: 3px">&rarr;</div>
+-          <div
+-            class="col-sm-3"
++          <div class="col-md-1 text-center" style="width: 3px">&rarr;</div>
++          <div
++            class="col-md-3"
+             data-bind="visible: !$parent.values_are_icons()"
+           >
+             <input
+@@ -57,18 +57,18 @@
+           >
+             <a
+               href="#"
+-              class="btn btn-info btn-xs lang-text"
++              class="btn btn-info btn-sm lang-text"
+               data-bind="
                              text: $parent.backup(value()).lang
-                         "></a>
+                         "
+             ></a>
            </div>
            <!-- /ko -->
 -          <div class="col-sm-1 pull-right">
--            <a href="#" data-bind="click: $parent.removeItem" class="btn btn-danger">
 +          <div class="col-md-1 float-end">
-+            <a href="#" data-bind="click: $parent.removeItem" class="btn btn-outline-danger">
+             <a
+               href="#"
+               data-bind="click: $parent.removeItem"
+-              class="btn btn-danger"
++              class="btn btn-outline-danger"
+             >
                <i class="icon-white fa fa-remove"></i>
              </a>
-           </div>
-@@ -82,7 +82,7 @@
+@@ -113,7 +113,7 @@
      <div class="modal-dialog">
        <div class="modal-content">
          <div class="modal-header">
@@ -61,73 +64,88 @@
              <span aria-hidden="true">&times;</span>
            </button>
            <h4 class="modal-title" data-bind="text: $data.modalTitle"></h4>
-@@ -90,8 +90,8 @@
-         <div class="modal-body" style="max-height:372px; overflow-y: scroll;"
-              data-bind="template: {name: 'key_value_mapping_editable_template', data: mapList}"></div>
+@@ -124,10 +124,12 @@
+           data-bind="template: {name: 'key_value_mapping_editable_template', data: mapList}"
+         ></div>
          <div class="modal-footer">
 -          <button class="btn btn-default" data-dismiss="modal">Cancel</button>
--          <button class="btn btn-primary" data-dismiss="modal"
-+          <button class="btn btn-outline-primary" data-bs-dismiss="modal">Cancel</button>
-+          <button class="btn btn-primary" data-bs-dismiss="modal"
-                   data-bind="disable: $data.mapList.hasError(),
++          <button class="btn btn-outline-primary" data-bs-dismiss="modal">
++            Cancel
++          </button>
+           <button
+             class="btn btn-primary"
+-            data-dismiss="modal"
++            data-bs-dismiss="modal"
+             data-bind="disable: $data.mapList.hasError(),
                              text: $data.mapList.hasError() ? 'Fix errors' : 'OK',
-                             click: save"></button>
-@@ -118,20 +118,20 @@
- <!-- Read-only version of keys and values, displayed alongside button to pop up modal -->
- <div id="key_value_mapping_template" class="hide">
-   <div data-bind="template: {name: 'key_value_mapping_display_template', if: !$data.values_are_icons() }"></div>
--  <button class="btn btn-default" data-bind="click: openModal, visible: $data.edit">
-+  <button class="btn btn-outline-primary" data-bind="click: openModal, visible: $data.edit">
+                             click: save"
+@@ -162,7 +164,7 @@
+     data-bind="template: {name: 'key_value_mapping_display_template', if: !$data.values_are_icons() }"
+   ></div>
+   <button
+-    class="btn btn-default"
++    class="btn btn-outline-primary"
+     data-bind="click: openModal, visible: $data.edit"
+   >
      <i class="fa fa-pencil"></i>
-     <span data-bind="text: $data.buttonText"></span>
-   </button>
+@@ -171,7 +173,7 @@
  </div>
  
  <div id="value_icon_uploader" class="hide">
 -  <div class="col-sm-1" style="margin-right: 7px">
 +  <div class="col-md-1" style="margin-right: 7px">
-     <a data-bind="if: isMediaMatched, attr: {href: url}" target="_blank" data-bind="visible: url" >
-       <img data-bind="attr: {src: thumbnailUrl}">
+     <a
+       data-bind="if: isMediaMatched, attr: {href: url}"
+       target="_blank"
+@@ -180,12 +182,12 @@
+       <img data-bind="attr: {src: thumbnailUrl}" />
      </a>
    </div>
 -  <div class="col-sm-2" id="$parent.cssId()">
--    <button type="button" class="btn btn-default" data-toggle="modal" data-target="#hqimage" data-bind="
 +  <div class="col-md-2" id="$parent.cssId()">
-+    <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#hqimage" data-bind="
+     <button
+       type="button"
+-      class="btn btn-default"
+-      data-toggle="modal"
+-      data-target="#hqimage"
++      class="btn btn-outline-primary"
++      data-bs-toggle="modal"
++      data-bs-target="#hqimage"
+       data-bind="
                             attr: { 'data-hqmediapath': currentPath },
                             event: {
-                                 mediaUploadComplete: uploadComplete,
-@@ -142,8 +142,8 @@
+@@ -198,10 +200,10 @@
        <span data-bind="visible: isMediaUnmatched">{% trans 'Upload' %}</span>
      </button>
    </div>
 -  <div class="col-sm-3">
--    <button type="button" class="btn btn-default pull-right"
 +  <div class="col-md-3">
-+    <button type="button" class="btn btn-outline-primary float-end"
-             data-bind="
+     <button
+       type="button"
+-      class="btn btn-default pull-right"
++      class="btn btn-outline-primary float-end"
+       data-bind="
                      visible: !$parent.editing(),
-                     click: function(){if (!useCustomPath()) setCustomPath(); $parent.toggleEditMode()}">
-@@ -155,7 +155,7 @@
+                     click: function(){if (!useCustomPath()) setCustomPath(); $parent.toggleEditMode()}"
+@@ -214,7 +216,7 @@
  
  <div id="icon_alt_text" class="hide">
    <label class="control-label col-sm-1">{% trans 'Alt Text' %}</label>
 -  <div class="col-sm-4">
 +  <div class="col-md-4">
-     <input type="text" class="form-control"
-            placeholder="{% trans 'Alternative text description' %}"
-            data-bind="value: altText,
-@@ -164,25 +164,25 @@
- </div>
- 
- <div id="icon_uploader_path" class="hide">
--  <div class="col-sm-1 btn" data-bind="visible: !_([$parents[1].lang, null]).contains($parents[1].backup($parent.value()).lang)">
--    <a href="#" class="btn btn-info btn-xs lang-text"
-+  <div class="col-md-1 btn" data-bind="visible: !_([$parents[1].lang, null]).contains($parents[1].backup($parent.value()).lang)">
-+    <a href="#" class="btn btn-info btn-sm lang-text"
-        data-bind="
+     <input
+       type="text"
+       class="form-control"
+@@ -232,7 +234,7 @@
+   >
+     <a
+       href="#"
+-      class="btn btn-info btn-xs lang-text"
++      class="btn btn-info btn-sm lang-text"
+       data-bind="
              text: $parents[1].backup($parent.value()).lang
-         "></a>
+         "
+@@ -240,8 +242,8 @@
    </div>
  
    <div data-bind="visible: $parent.editing">
@@ -135,18 +153,21 @@
 -    <div class="col-sm-4">
 +    <label class="control-label col-md-1">Path</label>
 +    <div class="col-md-4">
-       <input type="text" class="form-control"
-              data-bind="value: customPath,
-                               valueUpdate: 'textchange'" />
-       <input type="hidden" class="jr-resource-field"
-              data-bind="value: savedPath" />
+       <input
+         type="text"
+         class="form-control"
+@@ -254,11 +256,11 @@
+         data-bind="value: savedPath"
+       />
      </div>
 -    <div class="col-sm-3">
 -      <div class="col-sm-1">
--        <button type="button" class="btn btn-default"
 +    <div class="col-md-3">
 +      <div class="col-md-1">
-+        <button type="button" class="btn btn-outline-primary"
-                 data-bind="click: function(){setDefaultPath(); $parent.toggleEditMode()}">
+         <button
+           type="button"
+-          class="btn btn-default"
++          class="btn btn-outline-primary"
+           data-bind="click: function(){setDefaultPath(); $parent.toggleEditMode()}"
+         >
            <i class="fa fa-remove"></i>
-           {% trans 'Use Default Path' %}


### PR DESCRIPTION
## Technical Summary
This is really a two-line change, don't look at the diff counts. Review by commit.

Cherry picked from the app manager webpack migration. In webpack, underscore isn't automatically globally accessible for knockout bindings. In this case, there's no need for underscore here anymore anyway.

## Safety Assurance

### Safety story
The change itself is innocent, replacing an underscore call with an method that is now built in to js arrays.

There's a risk of a js error here breaking the whole menu settings page, although I think such an error would only affect apps using an icon in their case list/detail. I smoke tested this functionality locally.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
