### PR TITLE
Append .0 if version miss patch version

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_util.py
+++ b/corehq/apps/receiverwrapper/tests/test_util.py
@@ -1,0 +1,23 @@
+import unittest
+from corehq.apps.receiverwrapper.util import get_commcare_version_from_appversion_text
+
+
+class TestGetCommcareVersionFromAppversionText(unittest.TestCase):
+
+    def test_full_version(self):
+        appversion_text = ('CommCare ODK, version "2.11.0"(29272). App v65. CommCare Version 2.11.'
+                          'Build 29272, built on: February-14-2014')
+        self.assertEqual(get_commcare_version_from_appversion_text(appversion_text), '2.11.0')
+
+    def test_missing_patch_version(self):
+        appversion_text = ('CommCare Android, version "2.56"(1). App v16. CommCare Version 2.56.0.'
+                          'Build 1, built on: 2025-03-05')
+        self.assertEqual(get_commcare_version_from_appversion_text(appversion_text), '2.56.0')
+
+    def test_different_language(self):
+        appversion_text = u'संस्करण "2.27.8" (414593)'
+        self.assertEqual(get_commcare_version_from_appversion_text(appversion_text), '2.27.8')
+
+    def test_empty_string(self):
+        appversion_text = ''
+        self.assertIsNone(get_commcare_version_from_appversion_text(appversion_text))

--- a/corehq/apps/receiverwrapper/tests/test_util.py
+++ b/corehq/apps/receiverwrapper/tests/test_util.py
@@ -21,3 +21,7 @@ class TestGetCommcareVersionFromAppversionText(unittest.TestCase):
     def test_empty_string(self):
         appversion_text = ''
         self.assertIsNone(get_commcare_version_from_appversion_text(appversion_text))
+
+    def test_only_major_version(self):
+        appversion_text = 'CommCare Android, version "3"(12345).'
+        self.assertEqual(get_commcare_version_from_appversion_text(appversion_text), '3.0.0')

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -154,7 +154,13 @@ def get_commcare_version_from_appversion_text(appversion_text):
         r'"([\d.]+)"\s+\(\d+\)',
         r'"\s*([\d.]+)\s*"',
     ]
-    return _first_group_match(appversion_text, patterns)
+    version = _first_group_match(appversion_text, patterns)
+
+    # Check if the version is in the format of major.minor and append .0 if needed
+    if version and len(version.split('.')) == 2:
+        version += '.0'
+
+    return version
 
 
 def _first_group_match(text, patterns):

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -156,8 +156,8 @@ def get_commcare_version_from_appversion_text(appversion_text):
     ]
     version = _first_group_match(appversion_text, patterns)
 
-    # Check if the version is in the format of major.minor and append .0 if needed
-    if version and len(version.split('.')) == 2:
+    # Check if the version is in the format of major.minor or major and append .0 if needed
+    while version and version.count('.') < 2:
         version += '.0'
 
     return version

--- a/corehq/ex-submodules/phonelog/tests/test_sumologic.py
+++ b/corehq/ex-submodules/phonelog/tests/test_sumologic.py
@@ -30,7 +30,7 @@ class TestSumologic(SimpleTestCase, TestXmlMixin):
         expected_log = (
             "[log_date=2018-02-13T20:19:30.622000Z] [log_submission_date={received}] [log_type=maintenance] "
             "[domain={domain}] [username=t1] [device_id=014915000230428] [app_version=260] "
-            "[cc_version=2.43] [msg=Succesfully submitted 1 device reports to server.]"
+            "[cc_version=2.43.0] [msg=Succesfully submitted 1 device reports to server.]"
         ).format(domain=self.domain, received=self.received_on)
 
         self.assertEqual(expected_log, compiled_log)
@@ -41,7 +41,7 @@ class TestSumologic(SimpleTestCase, TestXmlMixin):
         expected_log = (
             "[log_date=2018-02-22T22:21:21.201000Z] [log_submission_date={received}] [log_type=error-config] "
             "[domain={domain}] [username=t1] [device_id=014915000230428] [app_version=260] "
-            "[cc_version=2.43] [msg=This is a test user error] [app_id=73d5f08b9d55fe48602906a89672c214] "
+            "[cc_version=2.43.0] [msg=This is a test user error] [app_id=73d5f08b9d55fe48602906a89672c214] "
             "[user_id=37cc2dcdb1abf5c16bab0763f435e6b7] [session=session] [expr=an expression]"
         ).format(domain=self.domain, received=self.received_on)
 
@@ -53,7 +53,7 @@ class TestSumologic(SimpleTestCase, TestXmlMixin):
         expected_log = (
             "[log_date=2018-02-22T22:21:21.232000Z] [log_submission_date={received}] [log_type=forceclose] "
             "[domain={domain}] [username=t1] [device_id=014915000230428] [app_version=260] "
-            "[cc_version=2.43] "
+            "[cc_version=2.43.0] "
             "[msg=java.lang.RuntimeException: Unable to start activity "
             "ComponentInfo{{org.commcare.dalvik.debug/org.commcare.activities.MenuActivity}}: "
             """java.lang.RuntimeException


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Android code will truncate the patch version if the version is 'x.y.0', so it becomes 'x.y'
This results in the commcare_version we collected in hq is not consistent. Sometimes it is 'x.y.z', sometimes it is 'x.y'.
This code will append '.0' to the version number if patch version is missed.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-16819
We call `get_commcare_version_from_appversion_text` to get commcare version. So fix the logic from this function will fix every occurrence of `commcare_version`. Will have a follow up PR to do the migration.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe because just appending `.0` when patch version is missing. Usually the version should be the format of "x.y.z"

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added new test in corehq/apps/receiverwrapper/tests/test_util.py

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not planning on QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
