### PR TITLE
Upgrade to python-mimeparse>=2.0.0

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -524,7 +524,7 @@ python-imap==1.0.0
     # via -r base-requirements.in
 python-magic==0.4.27
     # via -r base-requirements.in
-python-mimeparse==1.6.0
+python-mimeparse==2.0.0
     # via django-tastypie
 python3-saml==1.12.0
     # via -r sso-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -424,7 +424,7 @@ python-imap==1.0.0
     # via -r base-requirements.in
 python-magic==0.4.27
     # via -r base-requirements.in
-python-mimeparse==1.6.0
+python-mimeparse==2.0.0
     # via django-tastypie
 pytz==2024.1
     # via

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -432,7 +432,7 @@ python-imap==1.0.0
     # via -r base-requirements.in
 python-magic==0.4.27
     # via -r base-requirements.in
-python-mimeparse==1.6.0
+python-mimeparse==2.0.0
     # via django-tastypie
 python3-saml==1.12.0
     # via -r sso-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -396,7 +396,7 @@ python-imap==1.0.0
     # via -r base-requirements.in
 python-magic==0.4.27
     # via -r base-requirements.in
-python-mimeparse==1.6.0
+python-mimeparse==2.0.0
     # via django-tastypie
 python3-saml==1.12.0
     # via -r sso-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -441,7 +441,7 @@ python-imap==1.0.0
     # via -r base-requirements.in
 python-magic==0.4.27
     # via -r base-requirements.in
-python-mimeparse==1.6.0
+python-mimeparse==2.0.0
     # via django-tastypie
 python3-saml==1.12.0
     # via -r sso-requirements.in


### PR DESCRIPTION
Minor version bump for Python 3.13 compatibility. Reviewed [recent issues](https://github.com/falconry/python-mimeparse/issues) and [commits](https://github.com/falconry/python-mimeparse/commits/2.0.0) (no concerns).

## Safety Assurance

### Safety story

`python-mimeparse` is an indirect dependency, and not used directly by HQ code.

### Automated test coverage

Not directly.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.