### PR TITLE
Upgrade freezegun==1.5.1

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -261,7 +261,7 @@ flake8==6.1.0
     # via -r dev-requirements.in
 flaky==3.8.1
     # via -r test-requirements.in
-freezegun==1.1.0
+freezegun==1.5.1
     # via -r test-requirements.in
 frozenlist==1.4.1
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -229,7 +229,7 @@ faker==32.1.0
     # via -r test-requirements.in
 flaky==3.8.1
     # via -r test-requirements.in
-freezegun==1.1.0
+freezegun==1.5.1
     # via -r test-requirements.in
 frozenlist==1.4.1
     # via


### PR DESCRIPTION
Minor version bump for Python 3.13 compatibility. Reviewed [release notes](https://github.com/spulec/freezegun/blob/master/CHANGELOG) and [recent issues](https://github.com/spulec/freezegun/issues) (no concerns if tests pass).

It looks like the maintainers of this library have not had much time to put into maintaining it in the past year or so. For example, while it may work on Python 3.13, other than [this ticket](https://github.com/spulec/freezegun/issues/560) that seems to be undocumented. There appears to be at least [one issue on 3.13](https://github.com/spulec/freezegun/issues/568) that has not yet been addressed (severity unclear). If maintenance continues to languish we may want to consider switching to another library such as time-machine as referenced in [this issue](https://github.com/spulec/freezegun/issues/557).

## Safety Assurance

### Safety story

`freezegun` is a testing library that is not used in production code.

### Automated test coverage

Not directly.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations