### PR TITLE
Upgrade botocore==1.37.15

### DIFF
--- a/corehq/blobs/__init__.py
+++ b/corehq/blobs/__init__.py
@@ -1,3 +1,4 @@
+import warnings
 from .exceptions import Error, NotFound  # noqa: F401
 
 _db = []  # singleton/global, stack for tests to push temporary dbs
@@ -20,6 +21,10 @@ def get_blob_db():
 def _get_s3_db(settings, key="S3_BLOB_DB_SETTINGS"):
     from .s3db import S3BlobDB
     config = getattr(settings, key, None)
+    if config and config.get("config", {}).get("signature_version") == "s3":
+        warnings.warn("S3_BLOB_DB_SETTINGS config signature_version 's3' is "
+                      "not valid and should be removed.")
+        del config["config"]["signature_version"]
     return None if config is None else S3BlobDB(config)
 
 

--- a/corehq/blobs/tests/util.py
+++ b/corehq/blobs/tests/util.py
@@ -64,7 +64,7 @@ class TemporaryBlobDBMixin(object):
         try:
             # verify get_blob_db() returns our new db
             assert blobs.get_blob_db() is self, 'got wrong blob db'
-        except:
+        except:  # noqa: E722
             self.close()
             raise
 
@@ -106,6 +106,9 @@ class TemporaryS3BlobDB(TemporaryBlobDBMixin, S3BlobDB):
     def __init__(self, config):
         name_parts = ["test", config.get("s3_bucket", "blobdb"), uuid4().hex]
         config = dict(config)
+        if config.get("config", {}).get("signature_version") == "s3":
+            raise ValueError("S3_BLOB_DB_SETTINGS config signature_version 's3'"
+                             " is not valid and must be removed.")
         config["s3_bucket"] = "-".join(name_parts)
         super(TemporaryS3BlobDB, self).__init__(config)
         assert self.s3_bucket_name == config["s3_bucket"], \

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -167,7 +167,6 @@ if settingshelper.is_testing():
         "config": {
             "connect_timeout": 3,
             "read_timeout": 5,
-            "signature_version": "s3"
         },
     }
 

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -111,7 +111,6 @@ S3_BLOB_DB_SETTINGS = {
     "config": {
         "connect_timeout": 3,
         "read_timeout": 5,
-        "signature_version": "s3"
     },
 }
 

--- a/docker/min_settings.py
+++ b/docker/min_settings.py
@@ -70,7 +70,6 @@ S3_BLOB_DB_SETTINGS = {
     "config": {
         "connect_timeout": 3,
         "read_timeout": 5,
-        "signature_version": "s3"
     },
 }
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -49,9 +49,9 @@ billiard==3.6.4.0
     # via celery
 bleach==6.1.0
     # via -r base-requirements.in
-boto3==1.24.96
+boto3==1.37.15
     # via -r base-requirements.in
-botocore==1.27.96
+botocore==1.37.15
     # via
     #   boto3
     #   s3transfer
@@ -587,7 +587,7 @@ requests-toolbelt==1.0.0
     # via -r base-requirements.in
 rjsmin==1.2.1
     # via django-compressor
-s3transfer==0.6.0
+s3transfer==0.11.4
     # via boto3
 schema==0.7.5
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -45,9 +45,9 @@ billiard==3.6.4.0
     # via celery
 bleach==6.1.0
     # via -r base-requirements.in
-boto3==1.24.96
+boto3==1.37.15
     # via -r base-requirements.in
-botocore==1.27.96
+botocore==1.37.15
     # via
     #   boto3
     #   s3transfer
@@ -477,7 +477,7 @@ requests-toolbelt==1.0.0
     # via -r base-requirements.in
 rjsmin==1.2.1
     # via django-compressor
-s3transfer==0.6.0
+s3transfer==0.11.4
     # via boto3
 schema==0.7.5
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -45,9 +45,9 @@ billiard==3.6.4.0
     # via celery
 bleach==6.1.0
     # via -r base-requirements.in
-boto3==1.24.96
+boto3==1.37.15
     # via -r base-requirements.in
-botocore==1.27.96
+botocore==1.37.15
     # via
     #   boto3
     #   s3transfer
@@ -485,7 +485,7 @@ requests-toolbelt==1.0.0
     # via -r base-requirements.in
 rjsmin==1.2.1
     # via django-compressor
-s3transfer==0.6.0
+s3transfer==0.11.4
     # via boto3
 schema==0.7.5
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -41,9 +41,9 @@ billiard==3.6.4.0
     # via celery
 bleach==6.1.0
     # via -r base-requirements.in
-boto3==1.24.96
+boto3==1.37.15
     # via -r base-requirements.in
-botocore==1.27.96
+botocore==1.37.15
     # via
     #   boto3
     #   s3transfer
@@ -448,7 +448,7 @@ requests-toolbelt==1.0.0
     # via -r base-requirements.in
 rjsmin==1.2.1
     # via django-compressor
-s3transfer==0.6.0
+s3transfer==0.11.4
     # via boto3
 schema==0.7.5
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -41,9 +41,9 @@ billiard==3.6.4.0
     # via celery
 bleach==6.1.0
     # via -r base-requirements.in
-boto3==1.24.96
+boto3==1.37.15
     # via -r base-requirements.in
-botocore==1.27.96
+botocore==1.37.15
     # via
     #   boto3
     #   s3transfer
@@ -498,7 +498,7 @@ requests-toolbelt==1.0.0
     # via -r base-requirements.in
 rjsmin==1.2.1
     # via django-compressor
-s3transfer==0.6.0
+s3transfer==0.11.4
     # via boto3
 schema==0.7.5
     # via -r base-requirements.in


### PR DESCRIPTION
Also upgrades boto3==1.37.15 and s3transfer==0.11.4

Version bump for Python 3.13 compatibility. Reviewed release notes for [botocore](https://github.com/boto/botocore/blob/develop/CHANGELOG.rst), [boto3](https://github.com/boto/boto3/blob/develop/CHANGELOG.rst), and [s3transfer](https://github.com/boto/s3transfer/blob/develop/CHANGELOG.rst). The change logs are huge! Updates are published frequently with extremely detailed descriptions. I did not read every word, but rather searched for keywords such as "break", "compat", "backw", etc. (no concerns)

## Safety Assurance

### Safety story

`boto3`, `botocore`, and `s3transfer` are AWS S3 client libraries maintained by AWS. They are stable and widely used. I would expect any breaking changes to be highlighted in the release notes.

### Automated test coverage

Yes, blob db tests (and probably others as well) exercise these dependencies.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.
