### PR TITLE
[Data Cleaning] Clear Filters bar UI and functionality

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -104,6 +104,14 @@ class BulkEditSession(models.Model):
         return round(self.result['percent'])
 
     @property
+    def has_any_filtering(self):
+        return self.has_pinned_values or self.has_filters
+
+    def reset_filtering(self):
+        self.reset_filters()
+        self.reset_pinned_filters()
+
+    @property
     def has_filters(self):
         return self.filters.count() > 0
 

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -103,6 +103,15 @@ class BulkEditSession(models.Model):
             return None
         return round(self.result['percent'])
 
+    @property
+    def has_pinned_values(self):
+        return any(self.pinned_filters.values_list('value', flat=True))
+
+    def reset_pinned_filters(self):
+        for pinned_filter in self.pinned_filters.all():
+            pinned_filter.value = None
+            pinned_filter.save()
+
     def add_filter(self, prop_id, data_type, match_type, value=None):
         BulkEditFilter.objects.create(
             session=self,

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -104,6 +104,13 @@ class BulkEditSession(models.Model):
         return round(self.result['percent'])
 
     @property
+    def has_filters(self):
+        return self.filters.count() > 0
+
+    def reset_filters(self):
+        self.filters.all().delete()
+
+    @property
     def has_pinned_values(self):
         return any(self.pinned_filters.values_list('value', flat=True))
 

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -11,7 +11,7 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
     record_class = EditableCaseSearchElasticRecord
 
     class Meta(BaseHtmxTable.Meta):
-        pass
+        template_name = "data_cleaning/tables/table_with_controls.html"
 
     @classmethod
     def get_columns_from_session(cls, session):

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -13,6 +13,10 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
     class Meta(BaseHtmxTable.Meta):
         template_name = "data_cleaning/tables/table_with_controls.html"
 
+    def __init__(self, session=None, **kwargs):
+        super().__init__(**kwargs)
+        self.session = session
+
     @classmethod
     def get_columns_from_session(cls, session):
         visible_columns = []

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/pinned_filter_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/pinned_filter_form.html
@@ -29,6 +29,17 @@
         >
           {% trans "Apply" %}
         </button>
+        {% if has_values %}
+          <button
+            class="btn btn-outline-primary"
+            type="button"
+            hx-post="{{ request.path_info }}"
+            hx-disabled-elt="this"
+            hq-hx-action="reset_filters"
+          >
+            {% trans "Reset" %}
+          </button>
+        {% endif %}
       </div>
     </form>
   </div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/offcanvas.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/offcanvas.html
@@ -17,15 +17,17 @@
   </div>
   <div class="offcanvas-body">
     <div
+      id="hq-hx-pinned-filters"
       hx-get="{% url "data_cleaning_pinned_filter_form" domain session_id %}"
-      hx-trigger="load"
+      hx-trigger="load, dcPinnedFilterRefresh"
     >
       {% include "data_cleaning/partials/loading_indicator.html" %}
     </div>
     <div
+      id="hq-hx-active-filters"
       class="mt-3"
       hx-get="{% url "data_cleaning_manage_filters" domain session_id %}"
-      hx-trigger="load"
+      hx-trigger="load, dcFilterRefresh"
     >
       {% include "data_cleaning/partials/loading_indicator.html" %}
     </div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -1,0 +1,21 @@
+{% extends "hqwebapp/tables/bootstrap5_htmx.html" %}
+{% load i18n %}
+{% load django_tables2 %}
+
+{% block before_table %}
+  <div class="d-flex align-items-center pb-2">
+
+    <div>
+      <div class="input-group">
+        <div class="input-group-text rounded-end"> {# todo: selection UI #}
+          <i class="fa-solid fa-circle-check me-2"></i>
+          {# todo: selection number #}
+          {% blocktrans %}
+            0 Records Selected
+          {% endblocktrans %}
+        </div>
+      </div>
+    </div>
+
+  </div>
+{% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -5,6 +5,32 @@
 {% block before_table %}
   <div class="d-flex align-items-center pb-2">
 
+    {% if table.session.has_any_filtering %}
+      <div class="pe-2">
+        <div class="input-group">
+          <div class="input-group-text">
+            <i class="fa-solid fa-filter me-2"></i>
+            {% blocktrans with table.page.paginator.count as num_records %}
+              Filters Applied: {{ num_records }} Matching Records
+            {% endblocktrans %}
+          </div>
+          <button
+            class="btn btn-outline-danger"
+            type="button"
+            hx-post="{{ request.path_info }}{% querystring %}"
+            hq-hx-action="clear_filters"
+            hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"
+            hx-swap="outerHTML"
+            hq-hx-loading="{{ table.loading_indicator_id }}"
+            hx-disable-elt="this"
+          >
+            <i class="fa-solid fa-close"></i>
+            <span class="visually-hidden">{% trans "Clear Filters" %}</span>
+          </button>
+        </div>
+      </div>
+    {% endif %}
+
     <div>
       <div class="input-group">
         <div class="input-group-text rounded-end"> {# todo: selection UI #}

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -242,3 +242,13 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             .OR(all_project_data_filter(self.domain_name, ['project_data']))  # default Case Owners pinned filter
         )
         self.assertEqual(query.es_query, expected_query.es_query)
+
+    def test_has_pinned_values_and_reset(self):
+        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        self.assertFalse(session.has_pinned_values)
+        pinned_filter = session.pinned_filters.all()[0]
+        pinned_filter.value = ['t__1']
+        pinned_filter.save()
+        self.assertTrue(session.has_pinned_values)
+        session.reset_pinned_filters()
+        self.assertFalse(session.has_pinned_values)

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -260,3 +260,17 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         self.assertTrue(session.has_pinned_values)
         session.reset_pinned_filters()
         self.assertFalse(session.has_pinned_values)
+
+    def test_has_any_filtering_and_reset(self):
+        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        self.assertFalse(session.has_any_filtering)
+        pinned_filter = session.pinned_filters.all()[0]
+        pinned_filter.value = ['t__1']
+        pinned_filter.save()
+        self.assertTrue(session.has_any_filtering)
+        session.reset_filtering()
+        self.assertFalse(session.has_any_filtering)
+        session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, '2')
+        self.assertTrue(session.has_any_filtering)
+        session.reset_filtering()
+        self.assertFalse(session.has_any_filtering)

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -243,6 +243,14 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         )
         self.assertEqual(query.es_query, expected_query.es_query)
 
+    def test_has_filters_and_reset(self):
+        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        self.assertFalse(session.has_filters)
+        session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, '2')
+        self.assertTrue(session.has_filters)
+        session.reset_filters()
+        self.assertFalse(session.has_filters)
+
     def test_has_pinned_values_and_reset(self):
         session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
         self.assertFalse(session.has_pinned_values)

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -44,6 +44,11 @@ class PinnedFilterFormView(BulkEditSessionViewMixin, BaseFilterFormView):
         [f.update_stored_value() for f in self.form_filters]
         return self.get(request, *args, **kwargs)
 
+    @hq_hx_action('post')
+    def reset_filters(self, request, *args, **kwargs):
+        self.session.reset_pinned_filters()
+        return self.get(request, *args, **kwargs)
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update({
@@ -51,6 +56,7 @@ class PinnedFilterFormView(BulkEditSessionViewMixin, BaseFilterFormView):
             'form_filters': [
                 f.render() for f in self.form_filters
             ],
+            'has_values': self.session.has_pinned_values,
         })
         return context
 

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -1,3 +1,5 @@
+import json
+
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
@@ -11,6 +13,7 @@ from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.domain.views import DomainViewMixin
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.tables.pagination import SelectablePaginatedTableView
+from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 
 @method_decorator([
@@ -21,7 +24,7 @@ class BaseDataCleaningTableView(LoginAndDomainMixin, DomainViewMixin, Selectable
     pass
 
 
-class CleanCasesTableView(BulkEditSessionViewMixin, BaseDataCleaningTableView):
+class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataCleaningTableView):
     urlname = "data_cleaning_cases_table"
     table_class = CleanCaseTable
 
@@ -36,6 +39,20 @@ class CleanCasesTableView(BulkEditSessionViewMixin, BaseDataCleaningTableView):
 
     def get_queryset(self):
         return self.session.get_queryset()
+
+    @hq_hx_action('post')
+    def clear_filters(self, request, *args, **kwargs):
+        self.session.reset_filtering()
+        response = self.get(request, *args, **kwargs)
+        response['HX-Trigger'] = json.dumps({
+            'dcPinnedFilterRefresh': {
+                'target': '#hq-hx-pinned-filters',
+            },
+            'dcFilterRefresh': {
+                'target': '#hq-hx-active-filters',
+            },
+        })
+        return response
 
 
 class CaseCleaningTasksTableView(BaseDataCleaningTableView):

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -31,6 +31,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin, BaseDataCleaningTableView):
             'record_kwargs': {
                 'session': self.session,
             },
+            'session': self.session,
         }
 
     def get_queryset(self):


### PR DESCRIPTION
## Technical Summary
Adds the clear all filters bar above the table. Also adds the placeholder for "num records selected"—selection functionality will come at a later PR.

this is what this PR implements:
<img width="299" alt="Screenshot 2025-03-19 at 10 15 27 AM" src="https://github.com/user-attachments/assets/c9b42415-0ce9-4071-b8bd-19c3ca71e827" />

additional UI context:
<img width="1112" alt="Screenshot 2025-03-19 at 10 15 34 AM" src="https://github.com/user-attachments/assets/d89c741a-94fb-4a42-a03e-c7db45ec4da9" />



## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
only affects code behind a feature flag. core functionality is tested. new tests added here!

### Automated test coverage
yes

### QA Plan
not needed yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
