### PR TITLE
Upgrade hiredis==3.1.0

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -289,7 +289,7 @@ gunicorn==22.0.0
     # via -r base-requirements.in
 haversine==2.8.0
     # via -r base-requirements.in
-hiredis==2.0.0
+hiredis==3.1.0
     # via -r base-requirements.in
 hl7apy==1.3.4
     # via -r base-requirements.in

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -247,7 +247,7 @@ gunicorn==22.0.0
     # via -r base-requirements.in
 haversine==2.8.0
     # via -r base-requirements.in
-hiredis==2.0.0
+hiredis==3.1.0
     # via -r base-requirements.in
 hl7apy==1.3.4
     # via -r base-requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -246,7 +246,7 @@ gunicorn==22.0.0
     # via -r base-requirements.in
 haversine==2.8.0
     # via -r base-requirements.in
-hiredis==2.0.0
+hiredis==3.1.0
     # via -r base-requirements.in
 hl7apy==1.3.4
     # via -r base-requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -235,7 +235,7 @@ gunicorn==22.0.0
     # via -r base-requirements.in
 haversine==2.8.0
     # via -r base-requirements.in
-hiredis==2.0.0
+hiredis==3.1.0
     # via -r base-requirements.in
 hl7apy==1.3.4
     # via -r base-requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -252,7 +252,7 @@ gunicorn==22.0.0
     # via -r base-requirements.in
 haversine==2.8.0
     # via -r base-requirements.in
-hiredis==2.0.0
+hiredis==3.1.0
     # via -r base-requirements.in
 hl7apy==1.3.4
     # via -r base-requirements.in


### PR DESCRIPTION
Version bump for Python 3.13 compatibility. Reviewed [releases](https://github.com/redis/hiredis-py/releases), [change log](https://github.com/redis/hiredis-py/blob/master/CHANGELOG.md), hiredis (the C library) [change log](https://github.com/redis/hiredis/blob/master/CHANGELOG.md), and [recent issues](https://github.com/redis/hiredis-py/issues) (no concerns).

Also verified that we are not using any of the set operations mentioned in [this issue](https://github.com/redis/hiredis-py/issues/197).

## Safety Assurance

### Safety story

`HiredisParser` is referenced in [dev settings](https://github.com/dimagi/commcare-hq/blob/63acdf9665e5333549c6debccbd54c82022a48a8/dev_settings.py#L90) and the [localsettings template in commcare-cloud](https://github.com/dimagi/commcare-cloud/blob/d8318d29b10fef8571f7f016b54227fa37008e92/src/commcare_cloud/ansible/roles/commcarehq/templates/localsettings.py.j2#L442). Presumably it is the parser used for all redis interactions, so should be well covered by tests.

### Automated test coverage

Not directly.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations