### PR TITLE
GA persistent menu

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -183,7 +183,6 @@
 - id: persistent_menu
   name: Show Persistent Menu
   description: Show the persistent menu on the side of the web app.
-  toggle: PERSISTENT_MENU_SETTING
   widget: bool
   default: false
   since: '2.54'
@@ -191,7 +190,6 @@
 - id: show_breadcrumbs
   name: Show Breadcrumbs
   description: Show the breadcrumbs on top of the web app.
-  toggle: PERSISTENT_MENU_SETTING
   widget: bool
   default: false
   since: '2.54'

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1174,13 +1174,6 @@ PAUSE_DATA_FORWARDING = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-PERSISTENT_MENU_SETTING = StaticToggle(
-    "persistent_menu_setting",
-    "Show Persistent Menu option in Web Apps settings",
-    TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN],
-)
-
 
 def _ensure_search_index_is_enabled(domain, enabled):
     from corehq.apps.case_search.tasks import reindex_case_search_for_domain


### PR DESCRIPTION
## Product Description

Remove persistent menu feature flag, Make option available to everyone

## Technical Summary

https://dimagi.atlassian.net/browse/USH-5198

## Feature Flag

Not anymore

## Safety Assurance

### Safety story

Feature has been tested behind the feature flag. This is just removing the flag.

### Automated test coverage

No

### QA Plan

No additional QA needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
