### PR TITLE
Add option to process only open cases

### DIFF
--- a/corehq/apps/userreports/management/commands/async_rebuild_table.py
+++ b/corehq/apps/userreports/management/commands/async_rebuild_table.py
@@ -36,6 +36,8 @@ class Command(BaseCommand):
         parser.add_argument('--start_date', type=date_type,
                             help='Rebuild on forms received or cases updated on or after this date (inclusive).'
                                  'Format YYYY-MM-DD.')
+        parser.add_argument('--open_only', action='store_true',
+                            help='Rebuild open cases only')
 
     def handle(self, domain, type_, case_type_or_xmlns, data_source_ids, **options):
         assert type_ in ('xform', 'case')
@@ -55,6 +57,7 @@ class Command(BaseCommand):
         self.case_type_or_xmlns = case_type_or_xmlns
         self.bulk = options['bulk']
         self.database = options['database']
+        self.open_only = options['open_only']
 
         self.config_ids = [config._id for config in configs]
         ids = []
@@ -106,6 +109,8 @@ class Command(BaseCommand):
             )
             if start_date:
                 cases = cases.filter(server_modified_on__gte=start_date)
+            if self.open_only:
+                cases = cases.filter(closed=False)
             return cases.values_list('case_id', flat=True)
         elif self.referenced_type == XFORM_DOC_TYPE:
             forms = (


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user facing change

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-4391
Allow option to rebuild datasource with only open cases when doing so from the backend.
This is useful at times in limiting the number of cases to be processed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally that a closed case is skipped if the option --only_open is passed to the command

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
