### PR TITLE
Enable slow logs on elasticsearch

### DIFF
--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -316,7 +316,8 @@ class ElasticManageAdapter(BaseAdapter):
 
         :param index: ``str`` index for which to change the settings
         """
-        return self._index_put_settings(index, INDEX_CONF_STANDARD)
+        standard_settings = INDEX_CONF_STANDARD | INDEX_SLOWLOG_CONF
+        return self._index_put_settings(index, standard_settings)
 
     def index_configure_slow_logs(self, index):
         """Update an index with settings to collect logs on slow requests

--- a/corehq/apps/es/client.py
+++ b/corehq/apps/es/client.py
@@ -33,6 +33,7 @@ from .const import (
     HQ_CASE_SEARCH_INDEX_CANONICAL_NAME,
     INDEX_CONF_REINDEX,
     INDEX_CONF_STANDARD,
+    INDEX_SLOWLOG_CONF,
     SCROLL_KEEPALIVE,
     SCROLL_SIZE,
 )
@@ -316,6 +317,13 @@ class ElasticManageAdapter(BaseAdapter):
         :param index: ``str`` index for which to change the settings
         """
         return self._index_put_settings(index, INDEX_CONF_STANDARD)
+
+    def index_configure_slow_logs(self, index):
+        """Update an index with settings to collect logs on slow requests
+
+        :param index: ``str`` index for which to change the settings
+        """
+        return self._index_put_settings(index, INDEX_SLOWLOG_CONF)
 
     def _index_put_settings(self, index, settings):
         self._validate_single_index(index)

--- a/corehq/apps/es/const.py
+++ b/corehq/apps/es/const.py
@@ -22,6 +22,12 @@ INDEX_CONF_STANDARD = {
     "index.max_result_window": SIZE_LIMIT,
 }
 
+INDEX_SLOWLOG_CONF = {
+    "index.search.slowlog.threshold.query.warn": "10s",
+    "index.search.slowlog.threshold.query.info": "5s",
+    "index.search.slowlog.threshold.query.debug": "2s",
+    "index.search.slowlog.threshold.query.trace": "500ms",
+}
 
 HQ_APPS_INDEX_CANONICAL_NAME = "apps"
 HQ_APPS_INDEX_NAME = "apps-20230524"


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15796

This was unintentionally removed during the last ES upgrade [here](https://github.com/dimagi/commcare-cloud/pull/6241/files#diff-46db8f1c5e7f99a39d01567a0fa8698c657c00c984d1d56222903c36925513a4L74-L77). It became an index level setting which meant we needed to change how we apply these settings, hence why it was removed.

We do have the ability to customize this per index if so desired, but for now it just seemed good to get the settings we once had in place back in, so this PR does not focus on how to make this customizable per index but continues to use the default values.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This only impacts new indices, and is a setting that does not conflict with any current settings. This is something we used to do with no issues so we are just reintroducing it.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
