### PR TITLE
Upgrade kombu==5.4.2

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -347,7 +347,7 @@ jwcrypto==1.5.6
     # via django-oauth-toolkit
 kafka-python==1.4.7
     # via -r base-requirements.in
-kombu==5.2.4
+kombu==5.4.2
     # via celery
 looseversion==1.0.3
     # via -r base-requirements.in
@@ -706,7 +706,7 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==9.2.3
     # via -r base-requirements.in
-typing-extensions==4.8.0
+typing-extensions==4.12.2
     # via
     #   asgiref
     #   bytecode
@@ -714,9 +714,12 @@ typing-extensions==4.8.0
     #   django-countries
     #   faker
     #   jwcrypto
+    #   kombu
     #   oic
     #   qrcode
     #   stripe
+tzdata==2025.1
+    # via kombu
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0
@@ -734,7 +737,7 @@ user-agents==2.2.0
     # via django-user-agents
 uwsgi==2.0.22
     # via -r test-requirements.in
-vine==5.0.0
+vine==5.1.0
     # via
     #   amqp
     #   celery

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -293,7 +293,7 @@ jwcrypto==1.5.6
     # via django-oauth-toolkit
 kafka-python==1.4.7
     # via -r base-requirements.in
-kombu==5.2.4
+kombu==5.4.2
     # via celery
 looseversion==1.0.3
     # via -r base-requirements.in
@@ -572,17 +572,20 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==9.2.3
     # via -r base-requirements.in
-typing-extensions==4.8.0
+typing-extensions==4.12.2
     # via
     #   asgiref
     #   bytecode
     #   ddtrace
     #   django-countries
     #   jwcrypto
+    #   kombu
     #   pydantic
     #   pydantic-core
     #   qrcode
     #   stripe
+tzdata==2025.1
+    # via kombu
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0
@@ -598,7 +601,7 @@ urllib3==1.26.19
     #   sentry-sdk
 user-agents==2.2.0
     # via django-user-agents
-vine==5.0.0
+vine==5.1.0
     # via
     #   amqp
     #   celery

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -295,7 +295,7 @@ jwcrypto==1.5.6
     # via django-oauth-toolkit
 kafka-python==1.4.7
     # via -r base-requirements.in
-kombu==5.2.4
+kombu==5.4.2
     # via celery
 looseversion==1.0.3
     # via -r base-requirements.in
@@ -564,17 +564,20 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==9.2.3
     # via -r base-requirements.in
-typing-extensions==4.8.0
+typing-extensions==4.12.2
     # via
     #   asgiref
     #   bytecode
     #   ddtrace
     #   django-countries
     #   jwcrypto
+    #   kombu
     #   pydantic
     #   pydantic-core
     #   qrcode
     #   stripe
+tzdata==2025.1
+    # via kombu
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0
@@ -591,7 +594,7 @@ user-agents==2.2.0
     # via django-user-agents
 uwsgi==2.0.22
     # via -r prod-requirements.in
-vine==5.0.0
+vine==5.1.0
     # via
     #   amqp
     #   celery

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -277,7 +277,7 @@ jwcrypto==1.5.6
     # via django-oauth-toolkit
 kafka-python==1.4.7
     # via -r base-requirements.in
-kombu==5.2.4
+kombu==5.4.2
     # via celery
 looseversion==1.0.3
     # via -r base-requirements.in
@@ -517,17 +517,20 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==9.2.3
     # via -r base-requirements.in
-typing-extensions==4.8.0
+typing-extensions==4.12.2
     # via
     #   asgiref
     #   bytecode
     #   ddtrace
     #   django-countries
     #   jwcrypto
+    #   kombu
     #   pydantic
     #   pydantic-core
     #   qrcode
     #   stripe
+tzdata==2025.1
+    # via kombu
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0
@@ -542,7 +545,7 @@ urllib3==1.26.19
     #   sentry-sdk
 user-agents==2.2.0
     # via django-user-agents
-vine==5.0.0
+vine==5.1.0
     # via
     #   amqp
     #   celery

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -297,7 +297,7 @@ jwcrypto==1.5.6
     # via django-oauth-toolkit
 kafka-python==1.4.7
     # via -r base-requirements.in
-kombu==5.2.4
+kombu==5.4.2
     # via celery
 looseversion==1.0.3
     # via -r base-requirements.in
@@ -580,7 +580,7 @@ turn-python==0.0.1
     # via -r base-requirements.in
 twilio==9.2.3
     # via -r base-requirements.in
-typing-extensions==4.8.0
+typing-extensions==4.12.2
     # via
     #   asgiref
     #   bytecode
@@ -588,10 +588,13 @@ typing-extensions==4.8.0
     #   django-countries
     #   faker
     #   jwcrypto
+    #   kombu
     #   pydantic
     #   pydantic-core
     #   qrcode
     #   stripe
+tzdata==2025.1
+    # via kombu
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0
@@ -608,7 +611,7 @@ user-agents==2.2.0
     # via django-user-agents
 uwsgi==2.0.22
     # via -r test-requirements.in
-vine==5.0.0
+vine==5.1.0
     # via
     #   amqp
     #   celery


### PR DESCRIPTION
Version bump for Python 3.13 compatibility. Reviewed [release notes](https://docs.celeryq.dev/projects/kombu/en/v5.4.2/changelog.html) and [recent issues](https://github.com/celery/kombu/issues). [This bug](https://github.com/celery/kombu/issues/2258) is the reason that this PR is not going all the way to v5.5 just yet. Given the greenness of v5.5 (released days ago), it seems prudent to wait for that to stabilize (major change: drop pycurl in favor of urllib3), even though 5.4.2 does not officially support Python 3.13. Hopefully a better solution will be available before we upgrade our production environments to Python 3.13.

There is a question about whether Celery should also be updated to 5.3 or 5.4, both of which are also in the state of not officially supporting Python 3.13 (coming in Celery 5.5).

## Safety Assurance

### Safety story

`kombu` is a dependency of `celery`, and not used directly by HQ code. Planning to test on staging.

### Automated test coverage

Not directly.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations