### PR TITLE
Add validation to prevent global to domain scope change

### DIFF
--- a/corehq/project_limits/exceptions.py
+++ b/corehq/project_limits/exceptions.py
@@ -1,0 +1,2 @@
+class SystemLimitIllegalScopeChange(Exception):
+    pass

--- a/corehq/project_limits/models.py
+++ b/corehq/project_limits/models.py
@@ -120,7 +120,7 @@ class SystemLimit(models.Model):
             try:
                 previous_domain = SystemLimit.objects.get(id=self.id).domain
             except SystemLimit.DoesNotExist:
-                previous_domain = self.domain
+                return
             if not previous_domain:
                 raise SystemLimitIllegalScopeChange(
                     "This is scoped globally. You cannot modify it to a domain scope."

--- a/corehq/project_limits/models.py
+++ b/corehq/project_limits/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.conf import settings
 from field_audit import audit_fields
 
+from corehq.project_limits.exceptions import SystemLimitIllegalScopeChange
 from corehq.util.quickcache import quickcache
 
 AVG = 'AVG'
@@ -104,6 +105,7 @@ class SystemLimit(models.Model):
         return f"{domain}{self.key}: {self.limit}"
 
     def save(self, *args, **kwargs):
+        self._prevent_changing_from_global_to_domain_scope()
         super().save(*args, **kwargs)
         SystemLimit._get_global_limit.clear(self.key)
         SystemLimit._get_domain_specific_limit.clear(self.key, self.domain)
@@ -112,6 +114,17 @@ class SystemLimit(models.Model):
         super().delete(*args, **kwargs)
         SystemLimit._get_global_limit.clear(self.key)
         SystemLimit._get_domain_specific_limit.clear(self.key, self.domain)
+
+    def _prevent_changing_from_global_to_domain_scope(self):
+        if self.domain:
+            try:
+                previous_domain = SystemLimit.objects.get(id=self.id).domain
+            except SystemLimit.DoesNotExist:
+                previous_domain = self.domain
+            if not previous_domain:
+                raise SystemLimitIllegalScopeChange(
+                    "This is scoped globally. You cannot modify it to a domain scope."
+                )
 
     @classmethod
     def for_key(cls, key, domain=''):

--- a/corehq/project_limits/tests/test_system_limit.py
+++ b/corehq/project_limits/tests/test_system_limit.py
@@ -31,9 +31,10 @@ class TestSystemLimitMethods(TestCase):
             global_limit.domain = 'new-domain'  # this is changing scope from global to domain
             global_limit.save()
 
-        # nothing stops you from changing a domain scope to a global scope apart from the db constraint
+    def test_no_error_is_raised_if_changing_scope_from_domain_to_global(self):
         new_limit = SystemLimit.objects.create(key="domain_limit", limit=5, domain='test')
         new_limit.domain = ''
+        # should not fail
         new_limit.save()
 
     def test_raises_db_error_if_conflicting_global_scopes(self):

--- a/corehq/project_limits/tests/test_system_limit.py
+++ b/corehq/project_limits/tests/test_system_limit.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
+from django.db import IntegrityError
 
+from corehq.project_limits.exceptions import SystemLimitIllegalScopeChange
 from corehq.project_limits.models import SystemLimit
 
 
@@ -22,3 +24,21 @@ class TestSystemLimitMethods(TestCase):
         SystemLimit.objects.create(key="general_limit", limit=20, domain="specific")
         self.assertEqual(SystemLimit.for_key("general_limit"), 10)
         self.assertEqual(SystemLimit.for_key("general_limit", domain="specific"), 20)
+
+    def test_raises_error_if_changing_scope_from_global_to_domain(self):
+        global_limit = SystemLimit.objects.create(key="general_limit", limit=10)
+        with self.assertRaises(SystemLimitIllegalScopeChange):
+            global_limit.domain = 'new-domain'  # this is changing scope from global to domain
+            global_limit.save()
+
+        # nothing stops you from changing a domain scope to a global scope apart from the db constraint
+        new_limit = SystemLimit.objects.create(key="domain_limit", limit=5, domain='test')
+        new_limit.domain = ''
+        new_limit.save()
+
+    def test_raises_db_error_if_conflicting_global_scopes(self):
+        SystemLimit.objects.create(key="general_limit", limit=10)
+        domain_limit = SystemLimit.objects.create(key="general_limit", limit=5, domain='test')
+        with self.assertRaises(IntegrityError):
+            domain_limit.domain = ''
+            domain_limit.save()


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
No ticket, just wanted to get this done. Since it is relatively easy to update SystemLimit's in the django admin, I wanted to add some validation to prevent someone from easily changing a globally scoped limit to a domain scope, since this could have pretty large impacts on the system.

Another possible solution was to add a constraint on the table to ensure a globally scoped limit exists if attempting to add a domain scoped limit, but it isn't unreasonable for a default limit defined in code to be sufficient, and therefore a global limit to not exist in the database before wanting to add a domain specific limit. So I chose this path instead.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
SystemLimit's are not used widely yet (only used by the device rate limiter at the moment), so the blast radius here is inherently small. I added tests to ensure this behaves as I expect it to.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests in test_system_limit.py.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
