### PR TITLE
Sync ES with Couch Users - Handle not found users

### DIFF
--- a/corehq/ex-submodules/pillowtop/management/commands/sync_es_webusers.py
+++ b/corehq/ex-submodules/pillowtop/management/commands/sync_es_webusers.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.signals import update_user_in_es
+from elasticsearch5.exceptions import NotFoundError
 
 
 class Command(BaseCommand):
@@ -11,4 +12,9 @@ class Command(BaseCommand):
         web_users_docs = get_all_docs_with_doc_types(db=CouchUser.get_db(), doc_types=["WebUser"])
 
         for user_doc in web_users_docs:
-            update_user_in_es(None, CouchUser.wrap_correctly(user_doc))
+            try:
+                update_user_in_es(None, CouchUser.wrap_correctly(user_doc))
+            except NotFoundError as e:
+                self.stdout.write(self.style.WARNING(
+                    f"User not found in Elasticsearch: {user_doc.get('_id')} - {str(e)}"
+                ))


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
no user-facing effects

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
When running this [migration](https://github.com/dimagi/commcare-hq/pull/32864) on a production private release, it was resulting in the error `elasticsearch5.exceptions.NotFoundError: TransportError(...`.

This error results from encountering a user that exists in CouchDB but not in the Elasticsearch index. This PR will catch those exceptions and skip those users. Those users can be skipped since they already do not exist on the ES index so updates do not apply.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change is limited to a management command.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
