### PR TITLE
Fix bug in BS3 async.js

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/async.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/async.js.diff.txt
@@ -55,7 +55,7 @@
                          loadFilters(data);
                      }
                      self.issueAttempts = 0;
--                    if ($('loadingIssueModal').hasClass('show')) {
+-                    if (self.loadingIssueModal.hasClass('show')) {
 -                        self.loadingIssueModal.modal('hide');
 +                    if (self.loadingIssueModalElem.hasClass('show')) {
 +                        self.loadingIssueModal.hide();

--- a/corehq/apps/reports/static/reports/js/bootstrap3/async.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/async.js
@@ -163,7 +163,7 @@ hqDefine("reports/js/bootstrap3/async", [
                         loadFilters(data);
                     }
                     self.issueAttempts = 0;
-                    if ($('loadingIssueModal').hasClass('show')) {
+                    if (self.loadingIssueModal.hasClass('show')) {
                         self.loadingIssueModal.modal('hide');
                     }
                     self.hqLoading = $(self.loaderClass);


### PR DESCRIPTION
## Technical Summary

Tiny. Fixes a bug in (Bootstrap3) `reports/js/bootstrap3/async.js` where a jQuery selector is set to the name of a variable. The fix uses the variable, which is already defined using the correct jQuery selector.

(The bug has been resolved in (Bootstrap5) `reports/js/bootstrap5/async.js` already.)

## Feature Flag

N/A

## Safety Assurance

### Safety story

Not tested.

### Automated test coverage

No.

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
