### PR TITLE
Update Kafka image to avoid NullPointerException

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -136,7 +136,7 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/opt/zookeeper-3.7/data
 
   kafka:
-    image: docker.io/confluentinc/cp-kafka:7.2.2 # kafka v3.2.2
+    image: docker.io/confluentinc/cp-kafka:7.2.14  # Kafka v3.2.3
     expose:
       - "9092"
     environment:


### PR DESCRIPTION
## Technical Summary

confluentinc/cp-kafka:7.2.2 throws a NullPointerException in docker-ce 5:28.0.1-1~ubuntu.22.04~jammy

Upgrading to the latest 7.2.x release (7.2.14, which uses Kafka 3.2.3) avoids that.

[Edit: Corrected Kafka version.]

## Feature Flag

N/A

## Safety Assurance

### Safety story

* Only affects developers
* Tested locally

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
