### PR TITLE
Make HTML IDs unique to support multiple reports

### DIFF
--- a/corehq/apps/fixtures/templates/fixtures/fixtures_base.html
+++ b/corehq/apps/fixtures/templates/fixtures/fixtures_base.html
@@ -26,8 +26,6 @@
 {% endblock %}
 
 {% block page_content %}
-  {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
-
   <div id="report-content">
     {% block reportcontent %}
     {% endblock %}

--- a/corehq/apps/fixtures/templates/fixtures/fixtures_base.html
+++ b/corehq/apps/fixtures/templates/fixtures/fixtures_base.html
@@ -26,6 +26,8 @@
 {% endblock %}
 
 {% block page_content %}
+  {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
+
   <div id="report-content">
     {% block reportcontent %}
     {% endblock %}

--- a/corehq/apps/geospatial/templates/geospatial/gps_capture_view.html
+++ b/corehq/apps/geospatial/templates/geospatial/gps_capture_view.html
@@ -19,6 +19,14 @@
 {% registerurl 'paginate_mobile_workers' domain %}
 {% initial_page_data 'case_types_with_gps' case_types_with_gps %}
 {% initial_page_data 'couch_user_username' couch_user_username %}
+{% comment %}
+  'html_id_suffix' is required by reports/js/bootstrapX/maps_utils.js
+  to use the reportFiltersAccordion. `<div id="reportFiltersAccordion">`
+  is defined in reports/standard/partials/bootstrapX/filter_panel.html.
+  This file is one of the two templates that includes that template,
+  and so we set 'html_id_suffix' here to ensure it is always set.
+{% endcomment %}
+{% initial_page_data 'html_id_suffix' '' %}
 
 {% include 'geospatial/partials/index_alert.html' %}
 <ul id="tabs-list" class="nav nav-tabs">

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -309,6 +309,9 @@ class GPSCaptureView(BaseGeospatialView):
                 'title': self.page_name,
                 'section_name': self.section_name,
                 'show_filters': True,
+                # Used in reports/standard/partials/bootstrapX/filter_panel.html
+                # to support pages that have multiple reports:
+                'html_id_suffix': '',
             },
             'report_filters': [
                 dict(field=f.render(), slug=f.slug) for f in self.filter_classes

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_section.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_section.html
@@ -3,6 +3,10 @@
 
 {% block title %}{% if current_page.title %}{{ current_page.title }} : {% endif %}{{ section.page_name }} :: {% endblock %}
 
+{% block page_content %}
+  {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
+{% endblock page_content %}
+
 {% block page_breadcrumbs %}
   {% captureas page_actions_block %}{% block page_actions %}{% endblock page_actions %}{% endcaptureas %}
   {% if page_actions_block %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_section.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_section.html
@@ -3,10 +3,6 @@
 
 {% block title %}{% if current_page.title %}{{ current_page.title }} : {% endif %}{{ section.page_name }} :: {% endblock %}
 
-{% block page_content %}
-  {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
-{% endblock page_content %}
-
 {% block page_breadcrumbs %}
   {% captureas page_actions_block %}{% block page_actions %}{% endblock page_actions %}{% endcaptureas %}
   {% if page_actions_block %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_section.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_section.html
@@ -3,6 +3,10 @@
 
 {% block title %}{% if current_page.title %}{{ current_page.title }} : {% endif %}{{ section.page_name }} :: {% endblock %}
 
+{% block page_content %}
+  {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
+{% endblock page_content %}
+
 {% block page_breadcrumbs %}
   {% captureas page_actions_block %}{% block page_actions %}{% endblock page_actions %}{% endcaptureas %}
   {% if page_actions_block %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_section.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_section.html
@@ -3,10 +3,6 @@
 
 {% block title %}{% if current_page.title %}{{ current_page.title }} : {% endif %}{{ section.page_name }} :: {% endblock %}
 
-{% block page_content %}
-  {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
-{% endblock page_content %}
-
 {% block page_breadcrumbs %}
   {% captureas page_actions_block %}{% block page_actions %}{% endblock page_actions %}{% endcaptureas %}
   {% if page_actions_block %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/base.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/base.js.diff.txt
@@ -29,10 +29,10 @@
 -        defaultConfig.datespan_slug = null;
 +import $ from 'jquery';
  
--        var $savedReports = $("#savedReports");
+-        var $savedReports = $("#savedReports" + initialPageData.get("html_id_suffix"));
 -        if ($savedReports.length) {
 -            var reportConfigsView = reportConfigModels.reportConfigsViewModel({
--                filterForm: $("#reportFilters"),
+-                filterForm: $("#reportFilters" + initialPageData.get("html_id_suffix")),
 -                items: initialPageData.get('report_configs'),
 -                defaultItem: defaultConfig,
 -                saveUrl: initialPageData.reverse("add_report_config"),
@@ -42,7 +42,7 @@
 -        }
 +import {Tooltip} from 'bootstrap5';
  
--        $('#email-enabled').tooltip({
+-        $('#email-enabled' + initialPageData.get('html_id_suffix')).tooltip({
 +import initialPageData from 'hqwebapp/js/initial_page_data';
 +import filtersMain from 'reports/js/filters/bootstrap5/main';
 +import reportConfigModels from 'reports/js/bootstrap5/report_config_models';
@@ -62,10 +62,10 @@
 +    defaultConfig.datespan_filters = [];
 +    defaultConfig.datespan_slug = null;
 +
-+    var $savedReports = $("#savedReports");
++    var $savedReports = $("#savedReports" + initialPageData.get("html_id_suffix"));
 +    if ($savedReports.length) {
 +        var reportConfigsView = reportConfigModels.reportConfigsViewModel({
-+            filterForm: $("#reportFilters"),
++            filterForm: $("#reportFilters" + initialPageData.get("html_id_suffix")),
 +            items: initialPageData.get('report_configs'),
 +            defaultItem: defaultConfig,
 +            saveUrl: initialPageData.reverse("add_report_config"),

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
@@ -1,16 +1,18 @@
 --- 
 +++ 
-@@ -1,340 +1,308 @@
+@@ -1,342 +1,309 @@
 -hqDefine("reports/js/bootstrap3/datatables_config", [
 -    'jquery',
 -    'underscore',
 -    'analytix/js/google',
+-    'hqwebapp/js/initial_page_data',
 -    'datatables.bootstrap',
 -    'datatables.fixedColumns',
 -], function (
 -    $,
 -    _,
 -    googleAnalytics,
+-    initialPageData,
 -) {
 -    var HQReportDataTables = function (options) {
 -        var self = {};
@@ -40,6 +42,7 @@
 +
 +import _ from 'underscore';
 +import googleAnalytics from 'analytix/js/google';
++import initialPageData from 'hqwebapp/js/initial_page_data';
 +import {Tooltip} from 'bootstrap5';
 +
 +
@@ -310,12 +313,12 @@
 -                });
 -
 -                var $dataTablesFilter = $(".dataTables_filter");
--                if ($dataTablesFilter && $("#extra-filter-info")) {
+-                if ($dataTablesFilter && $("#extra-filter-info" + initialPageData.get("html_id_suffix"))) {
 -                    if ($dataTablesFilter.length > 1) {
 -                        $($dataTablesFilter.first()).remove();
 -                        $dataTablesFilter = $($dataTablesFilter.last());
 -                    }
--                    $("#extra-filter-info").html($dataTablesFilter);
+-                    $("#extra-filter-info" + initialPageData.get("html_id_suffix")).html($dataTablesFilter);
 -                    $dataTablesFilter.addClass("form-search");
 -                    var $inputField = $dataTablesFilter.find("input"),
 -                        $inputLabel = $dataTablesFilter.find("label");
@@ -523,12 +526,12 @@
 +            });
 +
 +            var $dataTablesFilter = $(".dataTables_filter");
-+            if ($dataTablesFilter && $("#extra-filter-info")) {
++            if ($dataTablesFilter && $("#extra-filter-info" + initialPageData.get("html_id_suffix"))) {
 +                if ($dataTablesFilter.length > 1) {
 +                    $($dataTablesFilter.first()).remove();
 +                    $dataTablesFilter = $($dataTablesFilter.last());
 +                }
-+                $("#extra-filter-info").html($dataTablesFilter);
++                $("#extra-filter-info" + initialPageData.get("html_id_suffix")).html($dataTablesFilter);
 +                $dataTablesFilter.addClass("form-search");
 +                var $inputField = $dataTablesFilter.find("input"),
 +                    $inputLabel = $dataTablesFilter.find("label");

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/hq_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/hq_report.js.diff.txt
@@ -50,7 +50,7 @@
              $(self.filterAccordion).on('show.bs.collapse', showFilterButtonStatus);
 @@ -178,7 +178,7 @@
          self.resetFilterState = function () {
-             $('#paramSelectorForm fieldset button, #paramSelectorForm fieldset span[data-dropdown="dropdown"]').click(function () {
+             $('#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset button, #paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset span[data-dropdown="dropdown"]').click(function () {
                  $(self.filterSubmitSelector)
 -                    .button('reset')
 +                    .changeButtonState('reset')
@@ -59,7 +59,7 @@
                      .prop('disabled', false);
 @@ -188,7 +188,7 @@
                  // This is necessary for pages that contain multiple filter panels, since we are using CSS IDs.
-                 const submitButton = $(e.target).closest('#reportFilters').find(self.filterSubmitSelector);
+                 const submitButton = $(e.target).closest('#reportFilters' + initialPageData.get('html_id_suffix')).find(self.filterSubmitSelector);
                  $(submitButton)
 -                    .button('reset')
 +                    .changeButtonState('reset')

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/hq_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/hq_report.js.diff.txt
@@ -15,7 +15,7 @@
  ], function (
      $,
      ko,
-@@ -56,7 +56,7 @@
+@@ -57,7 +57,7 @@
  
                  if (self.needsFilters) {
                      self.filterSubmitButton
@@ -24,7 +24,7 @@
                          .addClass('btn-primary')
                          .removeClass('disabled')
                          .prop('disabled', false);
-@@ -148,19 +148,19 @@
+@@ -149,19 +149,19 @@
          };
  
          var checkFilterAccordionToggleState = function () {
@@ -48,25 +48,25 @@
              };
  
              $(self.filterAccordion).on('show.bs.collapse', showFilterButtonStatus);
-@@ -178,7 +178,7 @@
+@@ -179,7 +179,7 @@
          self.resetFilterState = function () {
-             $('#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset button, #paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset span[data-dropdown="dropdown"]').click(function () {
+             $('#paramSelectorForm' + self.htmlIDSuffix + ' fieldset button, #paramSelectorForm' + self.htmlIDSuffix + ' fieldset span[data-dropdown="dropdown"]').click(function () {
                  $(self.filterSubmitSelector)
 -                    .button('reset')
 +                    .changeButtonState('reset')
                      .addClass('btn-primary')
                      .removeClass('disabled')
                      .prop('disabled', false);
-@@ -188,7 +188,7 @@
+@@ -189,7 +189,7 @@
                  // This is necessary for pages that contain multiple filter panels, since we are using CSS IDs.
-                 const submitButton = $(e.target).closest('#reportFilters' + initialPageData.get('html_id_suffix')).find(self.filterSubmitSelector);
+                 const submitButton = $(e.target).closest('#reportFilters' + self.htmlIDSuffix).find(self.filterSubmitSelector);
                  $(submitButton)
 -                    .button('reset')
 +                    .changeButtonState('reset')
                      .addClass('btn-primary')
                      .removeClass('disabled')
                      .prop('disabled', false);
-@@ -257,16 +257,16 @@
+@@ -258,16 +258,16 @@
  
              self.sendEmail = function () {
                  var $sendButton = $(hqReport.emailReportModal).find('.send-button');
@@ -86,7 +86,7 @@
                          self.resetModal();
                          const errors = JSON.parse(response.responseText);
                          let messages = [hqReport.emailErrorMessage].concat(errors);
-@@ -276,7 +276,7 @@
+@@ -277,7 +277,7 @@
              };
  
              self.resetModal = function () {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/maps_utils.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/maps_utils.js.diff.txt
@@ -8,6 +8,6 @@
      'underscore',
 -    'reports/js/bootstrap3/datatables_config',
 +    'reports/js/bootstrap5/datatables_config',
+     'hqwebapp/js/initial_page_data',
      'leaflet',
  ], function (
-     $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/standard_hq_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/standard_hq_report.js.diff.txt
@@ -20,7 +20,7 @@
      initialPageData,
      util,
      hqReportModule,
-@@ -56,7 +58,7 @@
+@@ -63,7 +65,7 @@
          var reportOptions = initialPageData.get('js_options') || {};
          if (reportOptions.slug && reportOptions.async) {
              let promise = $.Deferred();
@@ -29,7 +29,7 @@
                  var asyncHQReport = asyncHQReportModule({
                      standardReport: getStandard(),
                  });
-@@ -75,13 +77,19 @@
+@@ -82,13 +84,19 @@
      asyncReport = getAsync();
  
      $(function () {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/userreports/js/base.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/userreports/js/base.js.diff.txt
@@ -16,8 +16,70 @@
  ], function (
      $,
      initialPageData,
+@@ -25,10 +25,10 @@
+             if (chartSpecs !== null && chartSpecs.length > 0) {
+                 var isReportBuilderReport = initialPageData.get('created_by_builder');
+                 if (data.iTotalRecords > 25 && isReportBuilderReport) {
+-                    $("#chart-warning" + initialPageData.get('html_id_suffix')).removeClass("hide");
++                    $("#chart-warning" + initialPageData.get('html_id_suffix')).removeClass("d-none");
+                     charts.clear($("#chart-container" + initialPageData.get('html_id_suffix')));
+                 } else {
+-                    $("#chart-warning" + initialPageData.get('html_id_suffix')).addClass("hide");
++                    $("#chart-warning" + initialPageData.get('html_id_suffix')).addClass("d-none");
+                     charts.render(chartSpecs, data.aaData, $("#chart-container" + initialPageData.get('html_id_suffix')));
+                 }
+             }
+@@ -49,9 +49,9 @@
+                         $('#info-message' + initialPageData.get('html_id_suffix')).html(
+                             gettext('Showing the current page of data. Switch pages to see more data.'),
+                         );
+-                        $('#report-info' + initialPageData.get('html_id_suffix')).removeClass('hide');
++                        $('#report-info' + initialPageData.get('html_id_suffix')).removeClass('d-none');
+                     } else {
+-                        $('#report-info' + initialPageData.get('html_id_suffix')).addClass('hide');
++                        $('#report-info' + initialPageData.get('html_id_suffix')).addClass('d-none');
+                     }
+                 }
+             }
+@@ -59,22 +59,22 @@
+ 
+         var errorCallback = function (jqXHR, textStatus, errorThrown) {
+             $('#error-message' + initialPageData.get('html_id_suffix')).html(errorThrown);
+-            $('#report-error' + initialPageData.get('html_id_suffix')).removeClass('hide');
++            $('#report-error' + initialPageData.get('html_id_suffix')).removeClass('d-none');
+         };
+ 
+         var successCallback = function (data) {
+             if (data.error || data.error_message) {
+                 const message = data.error || data.error_message;
+                 $('#error-message' + initialPageData.get('html_id_suffix')).html(message);
+-                $('#report-error' + initialPageData.get('html_id_suffix')).removeClass('hide');
++                $('#report-error' + initialPageData.get('html_id_suffix')).removeClass('d-none');
+             } else {
+-                $('#report-error' + initialPageData.get('html_id_suffix')).addClass('hide');
++                $('#report-error' + initialPageData.get('html_id_suffix')).addClass('d-none');
+             }
+             if (data.warning) {
+                 $('#warning-message' + initialPageData.get('html_id_suffix')).html(data.warning);
+-                $('#report-warning' + initialPageData.get('html_id_suffix')).removeClass('hide');
++                $('#report-warning' + initialPageData.get('html_id_suffix')).removeClass('d-none');
+             } else {
+-                $('#report-warning' + initialPageData.get('html_id_suffix')).addClass('hide');
++                $('#report-warning' + initialPageData.get('html_id_suffix')).addClass('d-none');
+             }
+         };
+ 
+@@ -100,7 +100,7 @@
+         });
+         $('#paramSelectorForm' + initialPageData.get('html_id_suffix')).submit(function (event) {
+             $('#reportHint' + initialPageData.get('html_id_suffix')).remove();
+-            $('#reportContent' + initialPageData.get('html_id_suffix')).removeClass('hide');
++            $('#reportContent' + initialPageData.get('html_id_suffix')).removeClass('d-none');
+             event.preventDefault();
+             reportTables.render();
+         });
 @@ -109,7 +109,7 @@
-         $("#apply-filters").prop('disabled', false);
+         $("#apply-filters" + initialPageData.get('html_id_suffix')).prop('disabled', false);
  
          $(function () {
 -            $('.header-popover').popover({

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/userreports/js/configurable_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/userreports/js/configurable_report.js.diff.txt
@@ -21,12 +21,21 @@
      'commcarehq',
  ], function (
      $,
+@@ -62,7 +62,7 @@
+         }
+ 
+         var reportConfigsView = reportConfigModels.reportConfigsViewModel({
+-            filterForm: $("#paramSelectorForm" + initialPageData.get("html_id_suffix")),
++            filterForm: $("#paramSelectorForm" + initialPageData.get('html_id_suffix')),
+             items: initialPageData.get("report_configs"),
+             defaultItem: defaultConfig,
+             saveUrl: initialPageData.reverse("add_report_config"),
 @@ -70,7 +70,7 @@
-         $("#savedReports").koApplyBindings(reportConfigsView);
+         $("#savedReports" + initialPageData.get('html_id_suffix')).koApplyBindings(reportConfigsView);
          reportConfigsView.setUserConfigurableConfigBeingViewed(reportConfigModels.reportConfig(defaultConfig));
  
--        $('#email-enabled').tooltip({
-+        $('#email-enabled').tooltip({  /* todo B5: js-tooltip */
+-        $('#email-enabled' + initialPageData.get('html_id_suffix')).tooltip({
++        $('#email-enabled' + initialPageData.get('html_id_suffix')).tooltip({  /* todo B5: js-tooltip */
              placement: 'right',
              html: true,
              title: gettext("You can email a saved version<br />of this report."),

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/async/default.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/async/default.html.diff.txt
@@ -7,9 +7,9 @@
 +
 +{% if show_time_notice %}{% include "hqwebapp/partials/bootstrap5/time_notice.html" with hide=1 %}{% endif %}
  
- {% block page_content %}
-   {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
-@@ -16,7 +17,7 @@
+ {% block reportcontent %}
+   {% if report.slug %}
+@@ -12,7 +13,7 @@
        </div>
      </div>
    {% else %}
@@ -18,7 +18,7 @@
    {% endif %}
  {% endblock %}
  
-@@ -29,23 +30,40 @@
+@@ -25,23 +26,40 @@
  {% block modals %}
    <div class="loading-backdrop collapse"></div>
  
@@ -67,7 +67,7 @@
              {% endblocktrans %}
            </p>
          </div>
-@@ -53,9 +71,16 @@
+@@ -49,9 +67,16 @@
            <button
               class="btn btn-primary try-again"
               data-loading-text="{% trans 'Trying Again...' %}"

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/async/default.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/async/default.html.diff.txt
@@ -7,9 +7,9 @@
 +
 +{% if show_time_notice %}{% include "hqwebapp/partials/bootstrap5/time_notice.html" with hide=1 %}{% endif %}
  
- {% block reportcontent %}
-   {% if report.slug %}
-@@ -12,7 +13,7 @@
+ {% block page_content %}
+   {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
+@@ -16,7 +17,7 @@
        </div>
      </div>
    {% else %}
@@ -18,13 +18,13 @@
    {% endif %}
  {% endblock %}
  
-@@ -25,23 +26,40 @@
+@@ -29,23 +30,40 @@
  {% block modals %}
    <div class="loading-backdrop collapse"></div>
  
--  <div class="modal fade" tabindex="-1" role="dialog" id="loadingReportIssueModal">
+-  <div class="modal fade" tabindex="-1" role="dialog" id="loadingReportIssueModal{{ report.html_id_suffix }}">
 +  <div
-+    id="loadingReportIssueModal"
++    id="loadingReportIssueModal{{ report.html_id_suffix }}"
 +    class="modal fade"
 +    tabindex="-1"
 +    role="dialog"
@@ -67,7 +67,7 @@
              {% endblocktrans %}
            </p>
          </div>
-@@ -49,9 +67,16 @@
+@@ -53,9 +71,16 @@
            <button
               class="btn btn-primary try-again"
               data-loading-text="{% trans 'Trying Again...' %}"

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
@@ -86,7 +86,7 @@
  {% endblock %}
  
  {% block page_content %}
-@@ -68,19 +81,18 @@
+@@ -69,19 +82,18 @@
    {% initial_page_data 'slug' report.slug %}
  
    {% block filter_panel %}
@@ -112,7 +112,7 @@
              <h4 class="modal-title">
                {% trans "Email report:" %}
                {{ datespan.startdate|date:"Y-m-d" }}
-@@ -89,15 +101,21 @@
+@@ -90,15 +102,21 @@
                {% endif %}
                {{ datespan.enddate|date:"Y-m-d" }}
              </h4>
@@ -136,7 +136,7 @@
        <h4>{% trans 'Notice' %}</h4>
        <p>{{ report.special_notice }}</p>
      </div>
-@@ -107,7 +125,7 @@
+@@ -108,7 +126,7 @@
        {% block reportcontent %}
        {% endblock %}
      {% else %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/partials/filter_panel.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/partials/filter_panel.html.diff.txt
@@ -3,23 +3,23 @@
 @@ -1,26 +1,34 @@
  {% load hq_shared_tags %}
  {% load i18n %}
--<div class="panel panel-default{% if report.is_async%} hide{% endif %}" id="reportFiltersAccordion">
+-<div class="panel panel-default{% if report.is_async%} hide{% endif %}" id="reportFiltersAccordion{{ report.html_id_suffix }}">
 +<div
 +  class="card card-default{% if report.is_async%} d-none{% endif %}"
-+  id="reportFiltersAccordion"
++  id="reportFiltersAccordion{{ report.html_id_suffix }}"
 +>
    {% if report.show_filters %}
--    <div id="reportFilters" class="panel-body collapse">
-+    <div id="reportFilters" class="card-body collapse">
+-    <div id="reportFilters{{ report.html_id_suffix }}" class="panel-body collapse">
++    <div id="reportFilters{{ report.html_id_suffix }}" class="card-body collapse">
        <div class="accordion-inner">
          {% block report_description %}{% endblock %}
--        <form method="get" id="paramSelectorForm" class="form form-horizontal">
+-        <form method="get" id="paramSelectorForm{{ report.html_id_suffix }}" class="form form-horizontal">
 +        <form
 +          method="get"
-+          id="paramSelectorForm"
++          id="paramSelectorForm{{ report.html_id_suffix }}"
 +          class="form"
 +        >
-           <div id="hq-report-filters">
+           <div id="hq-report-filters{{ report.html_id_suffix }}">
              {% block report_filters %}
                {% if not report.is_async %}
 -                {% include "reports/async/bootstrap3/filters.html" %}
@@ -35,9 +35,9 @@
 -                        disabled="disabled"
 -                        data-loading-text="{% trans "Generating Report..." %}"
 -                        data-standard-text="{% trans "Apply" %}"
--                        id="apply-btn">
+-                        id="apply-btn{{ report.html_id_suffix }}">
 +                <button
-+                  class="btn disabled" id="apply-btn"
++                  class="btn disabled" id="apply-btn{{ report.html_id_suffix }}"
 +                  disabled="disabled" type="submit"
 +                  data-loading-text="{% trans "Generating Report..." %}"
 +                  data-standard-text="{% trans "Apply" %}"
@@ -49,8 +49,8 @@
          </form>
        </div>
        {% if report.slug == 'mpr_report' %}
--        <span style="font-style: italic" id="mpr-banner-info">The report is currently available at Sector and Anganwadi Center level. The expansion to levels above is currently under development</span>
-+        <span style="font-style: italic" id="mpr-banner-info">The report is currently available at Sector and Anganwadi Center level. The expansion to levels above is currently under development</span>  {# todo B5: inline style #}
+-        <span style="font-style: italic" id="mpr-banner-info{{ report.html_id_suffix }}">The report is currently available at Sector and Anganwadi Center level. The expansion to levels above is currently under development</span>
++        <span style="font-style: italic" id="mpr-banner-info{{ report.html_id_suffix }}">The report is currently available at Sector and Anganwadi Center level. The expansion to levels above is currently under development</span>  {# todo B5: inline style #}
        {% endif %}
      </div>
    {% endif %}
@@ -64,13 +64,13 @@
          {% if report.show_filters %}
 -          <a href="#reportFilters"
 -             class="btn btn-default"
--             id="toggle-report-filters"
+-             id="toggle-report-filters{{ report.html_id_suffix }}"
 -             data-toggle="collapse"
 -             data-open-text="{% trans "Show Filter Options" %}"
 -             data-close-text="{% trans "Hide Filter Options" %}">
 +          <button
 +            class="btn btn-outline-primary"
-+            id="toggle-report-filters"
++            id="toggle-report-filters{{ report.html_id_suffix }}"
 +            type="button"
 +            data-bs-toggle="collapse"
 +            data-bs-target="#reportFilters"
@@ -84,10 +84,10 @@
 +
          {% block export %}
            {% if report.is_exportable and request.couch_user.can_download_reports %}
--            <a href="#" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" id="export-report-excel">
+-            <a href="#" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" id="export-report-excel{{ report.html_id_suffix }}">
 +            <button
 +              class="btn btn-outline-primary{% if report.needs_filters %} d-none{% endif %}"
-+              id="export-report-excel"
++              id="export-report-excel{{ report.html_id_suffix }}"
 +              type="button"
 +            >
                <i class="fa fa-share"></i>
@@ -98,12 +98,12 @@
          {% endblock %}
 +
          {% if report.is_emailable and request.couch_user.can_download_reports %}
--          <a href="#email-report-modal" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" data-toggle="modal" id="email-report">
+-          <a href="#email-report-modal" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" data-toggle="modal" id="email-report{{ report.html_id_suffix }}">
 -            <i class="fa fa-envelope"></i> {% trans "Email report" %}
 -          </a>
 +          <button
 +            class="btn btn-outline-primary{% if report.needs_filters %} d-none{% endif %}"
-+            id="email-report"
++            id="email-report{{ report.html_id_suffix }}"
 +            type="button"
 +            data-bs-target="#email-report-modal"
 +            data-bs-toggle="modal"
@@ -114,12 +114,12 @@
          {% endif %}
  
          {% if report.is_printable %}
--          <a href="#" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" id="print-report">
+-          <a href="#" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" id="print-report{{ report.html_id_suffix }}">
 -            <i class="fa fa-print"></i> {% trans "Print" %}
 -          </a>
 +          <button
 +            class="btn btn-outline-primary{% if report.needs_filters %} d-none{% endif %}"
-+            id="print-report"
++            id="print-report{{ report.html_id_suffix }}"
 +            type="button"
 +          >
 +            <i class="fa fa-print"></i>
@@ -128,8 +128,8 @@
          {% endif %}
 +
        </div>
--      <div id="extra-filter-info" class="col-xs-4"></div>
-+      <div id="extra-filter-info" class="col-sm-4"></div>
+-      <div id="extra-filter-info{{ report.html_id_suffix }}" class="col-xs-4"></div>
++      <div id="extra-filter-info{{ report.html_id_suffix }}" class="col-sm-4"></div>
      </div>
    </div>
  </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/partials/filter_panel.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/partials/filter_panel.html.diff.txt
@@ -62,7 +62,7 @@
 +      <div class="col-sm-8">
 +
          {% if report.show_filters %}
--          <a href="#reportFilters"
+-          <a href="#reportFilters{{ report.html_id_suffix }}"
 -             class="btn btn-default"
 -             id="toggle-report-filters{{ report.html_id_suffix }}"
 -             data-toggle="collapse"
@@ -73,7 +73,7 @@
 +            id="toggle-report-filters{{ report.html_id_suffix }}"
 +            type="button"
 +            data-bs-toggle="collapse"
-+            data-bs-target="#reportFilters"
++            data-bs-target="#reportFilters{{ report.html_id_suffix }}"
 +            data-open-text="{% trans "Show Filter Options" %}"
 +            data-close-text="{% trans "Hide Filter Options" %}"
 +          >

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/userreports/base.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/userreports/base.html.diff.txt
@@ -6,23 +6,23 @@
  {% load hq_shared_tags %}
  {% load i18n %}
  {% load compress %}
-@@ -41,13 +41,13 @@
-   {% initial_page_data 'url' url %}
+@@ -42,13 +42,13 @@
+   {% initial_page_data 'html_id_suffix' report.html_id_suffix %}
  
    {% block report_alerts %}
--    <div id="report-error" class="alert alert-danger hide">
-+    <div id="report-error" class="alert alert-danger d-none">
+-    <div id="report-error{{ report.html_id_suffix }}" class="alert alert-danger hide">
++    <div id="report-error{{ report.html_id_suffix }}" class="alert alert-danger d-none">
        {% blocktrans %}
          There was an error rendering your report.
        {% endblocktrans %}
-       <div id="error-message"></div>
+       <div id="error-message{{ report.html_id_suffix }}"></div>
      </div>
--    <div id="report-warning" class="alert alert-warning hide">
-+    <div id="report-warning" class="alert alert-warning d-none">
+-    <div id="report-warning{{ report.html_id_suffix }}" class="alert alert-warning hide">
++    <div id="report-warning{{ report.html_id_suffix }}" class="alert alert-warning d-none">
        {% blocktrans %}
          Warning:
        {% endblocktrans %}
-@@ -56,7 +56,7 @@
+@@ -57,7 +57,7 @@
    {% endblock report_alerts %}
    {% block main_column_content %}
      {% block filter_panel %}
@@ -31,36 +31,36 @@
      {% endblock %}
  
      <hr />
-@@ -64,22 +64,22 @@
+@@ -65,22 +65,22 @@
        <h4><i class="fa fa-info-circle"></i> {% blocktrans %}Why can't I see any data?{% endblocktrans %}</h4>
        <p>{% blocktrans %}Please choose your filters above and click <strong>Apply</strong> to see report data.{% endblocktrans %}</p>
      </div>
--    <div id="reportContent" class="hide">
-+    <div id="reportContent" class="d-none">
+-    <div id="reportContent{{ report.html_id_suffix }}" class="hide">
++    <div id="reportContent{{ report.html_id_suffix }}" class="d-none">
        {% block reportcharts %}
--        <section id="chart-container" style="display: none;">
-+        <section id="chart-container" style="display: none;">  {# todo B5: inline-style #}
+-        <section id="chart-container{{ report.html_id_suffix }}" style="display: none;">
++        <section id="chart-container{{ report.html_id_suffix }}" style="display: none;">  {# todo B5: inline-style #}
          </section>
--        <section id="chart-warning" class="alert alert-warning hide">
-+        <section id="chart-warning" class="alert alert-warning d-none">
+-        <section id="chart-warning{{ report.html_id_suffix }}" class="alert alert-warning hide">
++        <section id="chart-warning{{ report.html_id_suffix }}" class="alert alert-warning d-none">
            {% blocktrans %}
              Charts cannot be displayed with more than 25 categories. Please filter the data or change your report to limit the number of rows.
            {% endblocktrans %}
          </section>
--        <section id="map-container" style="display: none;" >
-+        <section id="map-container" style="display: none;" >  {# todo B5: inline-style #}
+-        <section id="map-container{{ report.html_id_suffix }}" class="map-container" style="display: none;" >
++        <section id="map-container{{ report.html_id_suffix }}" class="map-container" style="display: none;" >  {# todo B5: inline-style #}
          </section>
--        <div id="zoomtofit" class="leaflet-control-layers" style="display: none;">
-+        <div id="zoomtofit" class="leaflet-control-layers" style="display: none;">  {# todo B5: inline-style #}
-           <div id="zoomtofit-target" class="zoomtofit leaflet-control-layers-toggle" title="{% trans "Fit all data into view" %}"></div>
+-        <div id="zoomtofit{{ report.html_id_suffix }}" class="leaflet-control-layers" style="display: none;">
++        <div id="zoomtofit{{ report.html_id_suffix }}" class="leaflet-control-layers" style="display: none;">  {# todo B5: inline-style #}
+           <div id="zoomtofit-target{{ report.html_id_suffix }}" class="zoomtofit leaflet-control-layers-toggle" title="{% trans "Fit all data into view" %}"></div>
          </div>
  
--        <div id="report-info" class="alert alert-info hide">
-+        <div id="report-info" class="alert alert-info d-none">
+-        <div id="report-info{{ report.html_id_suffix }}" class="alert alert-info hide">
++        <div id="report-info{{ report.html_id_suffix }}" class="alert alert-info d-none">
            {% blocktrans %}
              Note:
            {% endblocktrans %}
-@@ -87,11 +87,11 @@
+@@ -88,11 +88,11 @@
          </div>
        {% endblock %}
        {% block reporttable %}
@@ -72,6 +72,6 @@
            </div>
 -          <div class="panel-body hq-datatable-container">
 +          <div class="card-body hq-datatable-container">
-             <table id="report_table_{{ report.slug }}" class="table table-striped">
+             <table id="report_table_{{ report.slug }}{{ report.html_id_suffix }}" class="table table-striped">
                <thead>
                {{ headers.render_html }}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/userreports/partials/filter_panel.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/userreports/partials/filter_panel.html.diff.txt
@@ -7,7 +7,7 @@
  {% load i18n %}
  
 @@ -10,14 +10,14 @@
-           <button id="apply-filters"
+           <button id="apply-filters{{ report.html_id_suffix }}"
                    type="submit"
                    class="filters btn btn-primary"
 -                  data-loading-text="{% trans 'Generating Report...' %}"
@@ -37,8 +37,8 @@
          </a>
  
          {% if report.is_emailable %}
--          <div style="display: inline-block; margin-left:0.5em;" class="label label-info" id="email-enabled">
-+          <div style="display: inline-block; margin-left:0.5em;" class="badge text-bg-info" id="email-enabled">  {# todo B5: inline-style #}
+-          <div style="display: inline-block; margin-left:0.5em;" class="label label-info" id="email-enabled{{ report.html_id_suffix }}">
++          <div style="display: inline-block; margin-left:0.5em;" class="badge text-bg-info" id="email-enabled{{ report.html_id_suffix }}">  {# todo B5: inline-style #}
              <i class="fa fa-info-circle"></i> {% trans "Email Supported" %}
            </div>
          {% endif %}

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -588,6 +588,7 @@ class GenericReportView(object):
             'needsFilters': self.needs_filters,
             'slug': self.slug,
             'subReportSlug': None,
+            'html_id_suffix': '',
             'emailDefaultSubject': self.rendered_report_title,
             'type': self.dispatcher.prefix,
             'urlRoot': self.url_root,

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -541,6 +541,7 @@ class GenericReportView(object):
                 section_name=self.section_name,
                 slug=self.slug,
                 sub_slug=None,
+                html_id_suffix='',
                 type=self.dispatcher.prefix,
                 url_root=self.url_root,
                 is_async=self.asynchronous,

--- a/corehq/apps/reports/static/reports/js/bootstrap3/base.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/base.js
@@ -24,10 +24,10 @@ hqDefine("reports/js/bootstrap3/base", [
         defaultConfig.datespan_filters = [];
         defaultConfig.datespan_slug = null;
 
-        var $savedReports = $("#savedReports");
+        var $savedReports = $("#savedReports" + initialPageData.get("html_id_suffix"));
         if ($savedReports.length) {
             var reportConfigsView = reportConfigModels.reportConfigsViewModel({
-                filterForm: $("#reportFilters"),
+                filterForm: $("#reportFilters" + initialPageData.get("html_id_suffix")),
                 items: initialPageData.get('report_configs'),
                 defaultItem: defaultConfig,
                 saveUrl: initialPageData.reverse("add_report_config"),
@@ -36,7 +36,7 @@ hqDefine("reports/js/bootstrap3/base", [
             reportConfigsView.setConfigBeingViewed(reportConfigModels.reportConfig(defaultConfig));
         }
 
-        $('#email-enabled').tooltip({
+        $('#email-enabled' + initialPageData.get('html_id_suffix')).tooltip({
             placement: 'right',
             html: true,
             title: gettext("You can email a saved version<br />of this report."),

--- a/corehq/apps/reports/static/reports/js/bootstrap3/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/datatables_config.js
@@ -2,12 +2,14 @@ hqDefine("reports/js/bootstrap3/datatables_config", [
     'jquery',
     'underscore',
     'analytix/js/google',
+    'hqwebapp/js/initial_page_data',
     'datatables.bootstrap',
     'datatables.fixedColumns',
 ], function (
     $,
     _,
     googleAnalytics,
+    initialPageData,
 ) {
     var HQReportDataTables = function (options) {
         var self = {};
@@ -235,12 +237,12 @@ hqDefine("reports/js/bootstrap3/datatables_config", [
                 });
 
                 var $dataTablesFilter = $(".dataTables_filter");
-                if ($dataTablesFilter && $("#extra-filter-info")) {
+                if ($dataTablesFilter && $("#extra-filter-info" + initialPageData.get("html_id_suffix"))) {
                     if ($dataTablesFilter.length > 1) {
                         $($dataTablesFilter.first()).remove();
                         $dataTablesFilter = $($dataTablesFilter.last());
                     }
-                    $("#extra-filter-info").html($dataTablesFilter);
+                    $("#extra-filter-info" + initialPageData.get("html_id_suffix")).html($dataTablesFilter);
                     $dataTablesFilter.addClass("form-search");
                     var $inputField = $dataTablesFilter.find("input"),
                         $inputLabel = $dataTablesFilter.find("label");

--- a/corehq/apps/reports/static/reports/js/bootstrap3/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/hq_report.js
@@ -68,8 +68,8 @@ hqDefine("reports/js/bootstrap3/hq_report", [
                             e.preventDefault();
                             if (self.isExportAll) {
                                 $.ajax({
-                                    url: getReportBaseUrl("export"),
-                                    data: getReportParams(undefined),
+                                    url: self.getReportBaseUrl("export"),
+                                    data: self.getReportParams(undefined),
                                     type: "POST",
                                     success: function () {
                                         alertUser.alert_user(gettext("Your requested Excel report will be sent " +
@@ -201,7 +201,7 @@ hqDefine("reports/js/bootstrap3/hq_report", [
             if (params.includes('query_id=')) {
                 // getting the proper params for reports with obfuscated urls (Case List Explorer)
                 $.ajax({
-                    url: getReportBaseUrl('get_or_create_hash'),
+                    url: self.getReportBaseUrl('get_or_create_hash'),
                     type: 'POST',
                     dataType: 'json',
                     async: false,
@@ -228,8 +228,8 @@ hqDefine("reports/js/bootstrap3/hq_report", [
         }
 
         function getReportRenderUrl(renderType, additionalParams) {
-            var baseUrl = getReportBaseUrl(renderType);
-            var paramString = getReportParams(additionalParams);
+            var baseUrl = self.getReportBaseUrl(renderType);
+            var paramString = self.getReportParams(additionalParams);
             return baseUrl + "?" + paramString;
         }
 

--- a/corehq/apps/reports/static/reports/js/bootstrap3/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/hq_report.js
@@ -21,14 +21,15 @@ hqDefine("reports/js/bootstrap3/hq_report", [
         self.datespan = options.datespan;
         self.filterSet = options.filterSet || false;
         self.needsFilters = options.needsFilters || false;
-        self.filterAccordion = options.filterAccordion || "#reportFilters" + initialPageData.get('html_id_suffix');
-        self.filterSubmitSelector = options.filterSubmitSelector || '#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' button[type="submit"]';
+        self.htmlIDSuffix = options.html_id_suffix;
+        self.filterAccordion = options.filterAccordion || "#reportFilters" + self.htmlIDSuffix;
+        self.filterSubmitSelector = options.filterSubmitSelector || '#paramSelectorForm' + self.htmlIDSuffix + ' button[type="submit"]';
         self.filterSubmitButton = $(self.filterSubmitSelector);
-        self.toggleFiltersButton = options.toggleFiltersButton || "#toggle-report-filters" + initialPageData.get('html_id_suffix');
-        self.exportReportButton = options.exportReportButton || "#export-report-excel" + initialPageData.get('html_id_suffix');
-        self.emailReportButton = options.emailReportButton || "#email-report" + initialPageData.get('html_id_suffix');
-        self.printReportButton = options.printReportButton || "#print-report" + initialPageData.get('html_id_suffix');
-        self.emailReportModal = options.emailReportModal || "#email-report-modal" + initialPageData.get('html_id_suffix');
+        self.toggleFiltersButton = options.toggleFiltersButton || "#toggle-report-filters" + self.htmlIDSuffix;
+        self.exportReportButton = options.exportReportButton || "#export-report-excel" + self.htmlIDSuffix;
+        self.emailReportButton = options.emailReportButton || "#email-report" + self.htmlIDSuffix;
+        self.printReportButton = options.printReportButton || "#print-report" + self.htmlIDSuffix;
+        self.emailReportModal = options.emailReportModal || "#email-report-modal" + self.htmlIDSuffix;
         self.isExportable = options.isExportable || false;
         self.isExportAll = options.isExportAll || false;
         self.isEmailable = options.isEmailable || false;
@@ -176,17 +177,17 @@ hqDefine("reports/js/bootstrap3/hq_report", [
         });
 
         self.resetFilterState = function () {
-            $('#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset button, #paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset span[data-dropdown="dropdown"]').click(function () {
+            $('#paramSelectorForm' + self.htmlIDSuffix + ' fieldset button, #paramSelectorForm' + self.htmlIDSuffix + ' fieldset span[data-dropdown="dropdown"]').click(function () {
                 $(self.filterSubmitSelector)
                     .button('reset')
                     .addClass('btn-primary')
                     .removeClass('disabled')
                     .prop('disabled', false);
             });
-            $('#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset').on('change apply', function (e) {
+            $('#paramSelectorForm' + self.htmlIDSuffix + ' fieldset').on('change apply', function (e) {
                 // Ensure correct submit button is found in context of which form the button belongs to.
                 // This is necessary for pages that contain multiple filter panels, since we are using CSS IDs.
-                const submitButton = $(e.target).closest('#reportFilters' + initialPageData.get('html_id_suffix')).find(self.filterSubmitSelector);
+                const submitButton = $(e.target).closest('#reportFilters' + self.htmlIDSuffix).find(self.filterSubmitSelector);
                 $(submitButton)
                     .button('reset')
                     .addClass('btn-primary')

--- a/corehq/apps/reports/static/reports/js/bootstrap3/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/hq_report.js
@@ -21,14 +21,14 @@ hqDefine("reports/js/bootstrap3/hq_report", [
         self.datespan = options.datespan;
         self.filterSet = options.filterSet || false;
         self.needsFilters = options.needsFilters || false;
-        self.filterAccordion = options.filterAccordion || "#reportFilters";
-        self.filterSubmitSelector = options.filterSubmitSelector || '#paramSelectorForm button[type="submit"]';
+        self.filterAccordion = options.filterAccordion || "#reportFilters" + initialPageData.get('html_id_suffix');
+        self.filterSubmitSelector = options.filterSubmitSelector || '#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' button[type="submit"]';
         self.filterSubmitButton = $(self.filterSubmitSelector);
-        self.toggleFiltersButton = options.toggleFiltersButton || "#toggle-report-filters";
-        self.exportReportButton = options.exportReportButton || "#export-report-excel";
-        self.emailReportButton = options.emailReportButton || "#email-report";
-        self.printReportButton = options.printReportButton || "#print-report";
-        self.emailReportModal = options.emailReportModal || "#email-report-modal";
+        self.toggleFiltersButton = options.toggleFiltersButton || "#toggle-report-filters" + initialPageData.get('html_id_suffix');
+        self.exportReportButton = options.exportReportButton || "#export-report-excel" + initialPageData.get('html_id_suffix');
+        self.emailReportButton = options.emailReportButton || "#email-report" + initialPageData.get('html_id_suffix');
+        self.printReportButton = options.printReportButton || "#print-report" + initialPageData.get('html_id_suffix');
+        self.emailReportModal = options.emailReportModal || "#email-report-modal" + initialPageData.get('html_id_suffix');
         self.isExportable = options.isExportable || false;
         self.isExportAll = options.isExportAll || false;
         self.isEmailable = options.isEmailable || false;
@@ -176,17 +176,17 @@ hqDefine("reports/js/bootstrap3/hq_report", [
         });
 
         self.resetFilterState = function () {
-            $('#paramSelectorForm fieldset button, #paramSelectorForm fieldset span[data-dropdown="dropdown"]').click(function () {
+            $('#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset button, #paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset span[data-dropdown="dropdown"]').click(function () {
                 $(self.filterSubmitSelector)
                     .button('reset')
                     .addClass('btn-primary')
                     .removeClass('disabled')
                     .prop('disabled', false);
             });
-            $('#paramSelectorForm fieldset').on('change apply', function (e) {
+            $('#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset').on('change apply', function (e) {
                 // Ensure correct submit button is found in context of which form the button belongs to.
                 // This is necessary for pages that contain multiple filter panels, since we are using CSS IDs.
-                const submitButton = $(e.target).closest('#reportFilters').find(self.filterSubmitSelector);
+                const submitButton = $(e.target).closest('#reportFilters' + initialPageData.get('html_id_suffix')).find(self.filterSubmitSelector);
                 $(submitButton)
                     .button('reset')
                     .addClass('btn-primary')

--- a/corehq/apps/reports/static/reports/js/bootstrap3/maps_utils.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/maps_utils.js
@@ -256,8 +256,8 @@ hqDefine("reports/js/bootstrap3/maps_utils", [
             setMapHeight(map);
         };
         $(window).resize(resize);
-        $('#reportFiltersAccordion').on('shown', resize);
-        $('#reportFiltersAccordion').on('hidden', resize);
+        $('#reportFiltersAccordion').on('shown', resize);  // This ignores 'html_id_suffix'
+        $('#reportFiltersAccordion').on('hidden', resize);  // and can't be used for UCRs.
         resize();
     }
 

--- a/corehq/apps/reports/static/reports/js/bootstrap3/maps_utils.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/maps_utils.js
@@ -3,12 +3,14 @@ hqDefine("reports/js/bootstrap3/maps_utils", [
     'knockout',
     'underscore',
     'reports/js/bootstrap3/datatables_config',
+    'hqwebapp/js/initial_page_data',
     'leaflet',
 ], function (
     $,
     ko,
     _,
     dataTablesConfig,
+    initialPageData,
     L,
 ) {
     var module = {};
@@ -256,8 +258,9 @@ hqDefine("reports/js/bootstrap3/maps_utils", [
             setMapHeight(map);
         };
         $(window).resize(resize);
-        $('#reportFiltersAccordion').on('shown', resize);  // This ignores 'html_id_suffix'
-        $('#reportFiltersAccordion').on('hidden', resize);  // and can't be used for UCRs.
+        var htmlIDSuffix = initialPageData.get('html_id_suffix');
+        $('#reportFiltersAccordion' + htmlIDSuffix).on('shown', resize);
+        $('#reportFiltersAccordion' + htmlIDSuffix).on('hidden', resize);
         resize();
     }
 

--- a/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
@@ -28,9 +28,16 @@ hqDefine("reports/js/bootstrap3/standard_hq_report", [
         });
 
         if (initialPageData.get('override_report_render_url')) {
+            reportOptions.getReportBaseUrl = function (renderType) {
+                return reportOptions.url + "?format=" + renderType;
+            };
+            reportOptions.getReportParams = function () {
+                return util.urlSerialize($('#paramSelectorForm' + initialPageData.get('html_id_suffix')), ['format']);
+            };
             reportOptions.getReportRenderUrl = function (renderType) {
-                var params = util.urlSerialize($('#paramSelectorForm' + initialPageData.get('html_id_suffix')), ['format']);
-                return window.location.pathname + "?format=" + renderType + "&" + params;
+                var baseUrl = self.getReportBaseUrl(renderType);
+                var paramString = self.getReportParams();
+                return baseUrl + "&" + paramString;
             };
         }
 

--- a/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
@@ -29,7 +29,7 @@ hqDefine("reports/js/bootstrap3/standard_hq_report", [
 
         if (initialPageData.get('override_report_render_url')) {
             reportOptions.getReportRenderUrl = function (renderType) {
-                var params = util.urlSerialize($('#paramSelectorForm'), ['format']);
+                var params = util.urlSerialize($('#paramSelectorForm' + initialPageData.get('html_id_suffix')), ['format']);
                 return window.location.pathname + "?format=" + renderType + "&" + params;
             };
         }

--- a/corehq/apps/reports/static/reports/js/bootstrap5/base.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/base.js
@@ -23,10 +23,10 @@ $(function () {
     defaultConfig.datespan_filters = [];
     defaultConfig.datespan_slug = null;
 
-    var $savedReports = $("#savedReports");
+    var $savedReports = $("#savedReports" + initialPageData.get("html_id_suffix"));
     if ($savedReports.length) {
         var reportConfigsView = reportConfigModels.reportConfigsViewModel({
-            filterForm: $("#reportFilters"),
+            filterForm: $("#reportFilters" + initialPageData.get("html_id_suffix")),
             items: initialPageData.get('report_configs'),
             defaultItem: defaultConfig,
             saveUrl: initialPageData.reverse("add_report_config"),

--- a/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
@@ -6,6 +6,7 @@ import 'datatables.net-fixedcolumns-bs5/js/fixedColumns.bootstrap5';
 
 import _ from 'underscore';
 import googleAnalytics from 'analytix/js/google';
+import initialPageData from 'hqwebapp/js/initial_page_data';
 import {Tooltip} from 'bootstrap5';
 
 
@@ -223,12 +224,12 @@ var HQReportDataTables = function (options) {
             });
 
             var $dataTablesFilter = $(".dataTables_filter");
-            if ($dataTablesFilter && $("#extra-filter-info")) {
+            if ($dataTablesFilter && $("#extra-filter-info" + initialPageData.get("html_id_suffix"))) {
                 if ($dataTablesFilter.length > 1) {
                     $($dataTablesFilter.first()).remove();
                     $dataTablesFilter = $($dataTablesFilter.last());
                 }
-                $("#extra-filter-info").html($dataTablesFilter);
+                $("#extra-filter-info" + initialPageData.get("html_id_suffix")).html($dataTablesFilter);
                 $dataTablesFilter.addClass("form-search");
                 var $inputField = $dataTablesFilter.find("input"),
                     $inputLabel = $dataTablesFilter.find("label");

--- a/corehq/apps/reports/static/reports/js/bootstrap5/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/hq_report.js
@@ -21,14 +21,15 @@ hqDefine("reports/js/bootstrap5/hq_report", [
         self.datespan = options.datespan;
         self.filterSet = options.filterSet || false;
         self.needsFilters = options.needsFilters || false;
-        self.filterAccordion = options.filterAccordion || "#reportFilters" + initialPageData.get('html_id_suffix');
-        self.filterSubmitSelector = options.filterSubmitSelector || '#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' button[type="submit"]';
+        self.htmlIDSuffix = options.html_id_suffix;
+        self.filterAccordion = options.filterAccordion || "#reportFilters" + self.htmlIDSuffix;
+        self.filterSubmitSelector = options.filterSubmitSelector || '#paramSelectorForm' + self.htmlIDSuffix + ' button[type="submit"]';
         self.filterSubmitButton = $(self.filterSubmitSelector);
-        self.toggleFiltersButton = options.toggleFiltersButton || "#toggle-report-filters" + initialPageData.get('html_id_suffix');
-        self.exportReportButton = options.exportReportButton || "#export-report-excel" + initialPageData.get('html_id_suffix');
-        self.emailReportButton = options.emailReportButton || "#email-report" + initialPageData.get('html_id_suffix');
-        self.printReportButton = options.printReportButton || "#print-report" + initialPageData.get('html_id_suffix');
-        self.emailReportModal = options.emailReportModal || "#email-report-modal" + initialPageData.get('html_id_suffix');
+        self.toggleFiltersButton = options.toggleFiltersButton || "#toggle-report-filters" + self.htmlIDSuffix;
+        self.exportReportButton = options.exportReportButton || "#export-report-excel" + self.htmlIDSuffix;
+        self.emailReportButton = options.emailReportButton || "#email-report" + self.htmlIDSuffix;
+        self.printReportButton = options.printReportButton || "#print-report" + self.htmlIDSuffix;
+        self.emailReportModal = options.emailReportModal || "#email-report-modal" + self.htmlIDSuffix;
         self.isExportable = options.isExportable || false;
         self.isExportAll = options.isExportAll || false;
         self.isEmailable = options.isEmailable || false;
@@ -176,17 +177,17 @@ hqDefine("reports/js/bootstrap5/hq_report", [
         });
 
         self.resetFilterState = function () {
-            $('#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset button, #paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset span[data-dropdown="dropdown"]').click(function () {
+            $('#paramSelectorForm' + self.htmlIDSuffix + ' fieldset button, #paramSelectorForm' + self.htmlIDSuffix + ' fieldset span[data-dropdown="dropdown"]').click(function () {
                 $(self.filterSubmitSelector)
                     .changeButtonState('reset')
                     .addClass('btn-primary')
                     .removeClass('disabled')
                     .prop('disabled', false);
             });
-            $('#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset').on('change apply', function (e) {
+            $('#paramSelectorForm' + self.htmlIDSuffix + ' fieldset').on('change apply', function (e) {
                 // Ensure correct submit button is found in context of which form the button belongs to.
                 // This is necessary for pages that contain multiple filter panels, since we are using CSS IDs.
-                const submitButton = $(e.target).closest('#reportFilters' + initialPageData.get('html_id_suffix')).find(self.filterSubmitSelector);
+                const submitButton = $(e.target).closest('#reportFilters' + self.htmlIDSuffix).find(self.filterSubmitSelector);
                 $(submitButton)
                     .changeButtonState('reset')
                     .addClass('btn-primary')

--- a/corehq/apps/reports/static/reports/js/bootstrap5/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/hq_report.js
@@ -21,14 +21,14 @@ hqDefine("reports/js/bootstrap5/hq_report", [
         self.datespan = options.datespan;
         self.filterSet = options.filterSet || false;
         self.needsFilters = options.needsFilters || false;
-        self.filterAccordion = options.filterAccordion || "#reportFilters";
-        self.filterSubmitSelector = options.filterSubmitSelector || '#paramSelectorForm button[type="submit"]';
+        self.filterAccordion = options.filterAccordion || "#reportFilters" + initialPageData.get('html_id_suffix');
+        self.filterSubmitSelector = options.filterSubmitSelector || '#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' button[type="submit"]';
         self.filterSubmitButton = $(self.filterSubmitSelector);
-        self.toggleFiltersButton = options.toggleFiltersButton || "#toggle-report-filters";
-        self.exportReportButton = options.exportReportButton || "#export-report-excel";
-        self.emailReportButton = options.emailReportButton || "#email-report";
-        self.printReportButton = options.printReportButton || "#print-report";
-        self.emailReportModal = options.emailReportModal || "#email-report-modal";
+        self.toggleFiltersButton = options.toggleFiltersButton || "#toggle-report-filters" + initialPageData.get('html_id_suffix');
+        self.exportReportButton = options.exportReportButton || "#export-report-excel" + initialPageData.get('html_id_suffix');
+        self.emailReportButton = options.emailReportButton || "#email-report" + initialPageData.get('html_id_suffix');
+        self.printReportButton = options.printReportButton || "#print-report" + initialPageData.get('html_id_suffix');
+        self.emailReportModal = options.emailReportModal || "#email-report-modal" + initialPageData.get('html_id_suffix');
         self.isExportable = options.isExportable || false;
         self.isExportAll = options.isExportAll || false;
         self.isEmailable = options.isEmailable || false;
@@ -176,17 +176,17 @@ hqDefine("reports/js/bootstrap5/hq_report", [
         });
 
         self.resetFilterState = function () {
-            $('#paramSelectorForm fieldset button, #paramSelectorForm fieldset span[data-dropdown="dropdown"]').click(function () {
+            $('#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset button, #paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset span[data-dropdown="dropdown"]').click(function () {
                 $(self.filterSubmitSelector)
                     .changeButtonState('reset')
                     .addClass('btn-primary')
                     .removeClass('disabled')
                     .prop('disabled', false);
             });
-            $('#paramSelectorForm fieldset').on('change apply', function (e) {
+            $('#paramSelectorForm' + initialPageData.get('html_id_suffix') + ' fieldset').on('change apply', function (e) {
                 // Ensure correct submit button is found in context of which form the button belongs to.
                 // This is necessary for pages that contain multiple filter panels, since we are using CSS IDs.
-                const submitButton = $(e.target).closest('#reportFilters').find(self.filterSubmitSelector);
+                const submitButton = $(e.target).closest('#reportFilters' + initialPageData.get('html_id_suffix')).find(self.filterSubmitSelector);
                 $(submitButton)
                     .changeButtonState('reset')
                     .addClass('btn-primary')

--- a/corehq/apps/reports/static/reports/js/bootstrap5/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/hq_report.js
@@ -68,8 +68,8 @@ hqDefine("reports/js/bootstrap5/hq_report", [
                             e.preventDefault();
                             if (self.isExportAll) {
                                 $.ajax({
-                                    url: getReportBaseUrl("export"),
-                                    data: getReportParams(undefined),
+                                    url: self.getReportBaseUrl("export"),
+                                    data: self.getReportParams(undefined),
                                     type: "POST",
                                     success: function () {
                                         alertUser.alert_user(gettext("Your requested Excel report will be sent " +
@@ -201,7 +201,7 @@ hqDefine("reports/js/bootstrap5/hq_report", [
             if (params.includes('query_id=')) {
                 // getting the proper params for reports with obfuscated urls (Case List Explorer)
                 $.ajax({
-                    url: getReportBaseUrl('get_or_create_hash'),
+                    url: self.getReportBaseUrl('get_or_create_hash'),
                     type: 'POST',
                     dataType: 'json',
                     async: false,
@@ -228,8 +228,8 @@ hqDefine("reports/js/bootstrap5/hq_report", [
         }
 
         function getReportRenderUrl(renderType, additionalParams) {
-            var baseUrl = getReportBaseUrl(renderType);
-            var paramString = getReportParams(additionalParams);
+            var baseUrl = self.getReportBaseUrl(renderType);
+            var paramString = self.getReportParams(additionalParams);
             return baseUrl + "?" + paramString;
         }
 

--- a/corehq/apps/reports/static/reports/js/bootstrap5/maps_utils.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/maps_utils.js
@@ -256,8 +256,8 @@ hqDefine("reports/js/bootstrap5/maps_utils", [
             setMapHeight(map);
         };
         $(window).resize(resize);
-        $('#reportFiltersAccordion').on('shown', resize);
-        $('#reportFiltersAccordion').on('hidden', resize);
+        $('#reportFiltersAccordion').on('shown', resize);  // This ignores 'html_id_suffix'
+        $('#reportFiltersAccordion').on('hidden', resize);  // and can't be used for UCRs.
         resize();
     }
 

--- a/corehq/apps/reports/static/reports/js/bootstrap5/maps_utils.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/maps_utils.js
@@ -3,12 +3,14 @@ hqDefine("reports/js/bootstrap5/maps_utils", [
     'knockout',
     'underscore',
     'reports/js/bootstrap5/datatables_config',
+    'hqwebapp/js/initial_page_data',
     'leaflet',
 ], function (
     $,
     ko,
     _,
     dataTablesConfig,
+    initialPageData,
     L,
 ) {
     var module = {};
@@ -256,8 +258,9 @@ hqDefine("reports/js/bootstrap5/maps_utils", [
             setMapHeight(map);
         };
         $(window).resize(resize);
-        $('#reportFiltersAccordion').on('shown', resize);  // This ignores 'html_id_suffix'
-        $('#reportFiltersAccordion').on('hidden', resize);  // and can't be used for UCRs.
+        var htmlIDSuffix = initialPageData.get('html_id_suffix');
+        $('#reportFiltersAccordion' + htmlIDSuffix).on('shown', resize);
+        $('#reportFiltersAccordion' + htmlIDSuffix).on('hidden', resize);
         resize();
     }
 

--- a/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
@@ -30,9 +30,16 @@ hqDefine("reports/js/bootstrap5/standard_hq_report", [
         });
 
         if (initialPageData.get('override_report_render_url')) {
+            reportOptions.getReportBaseUrl = function (renderType) {
+                return reportOptions.url + "?format=" + renderType;
+            };
+            reportOptions.getReportParams = function () {
+                return util.urlSerialize($('#paramSelectorForm' + initialPageData.get('html_id_suffix')), ['format']);
+            };
             reportOptions.getReportRenderUrl = function (renderType) {
-                var params = util.urlSerialize($('#paramSelectorForm' + initialPageData.get('html_id_suffix')), ['format']);
-                return window.location.pathname + "?format=" + renderType + "&" + params;
+                var baseUrl = self.getReportBaseUrl(renderType);
+                var paramString = self.getReportParams();
+                return baseUrl + "&" + paramString;
             };
         }
 

--- a/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
@@ -31,7 +31,7 @@ hqDefine("reports/js/bootstrap5/standard_hq_report", [
 
         if (initialPageData.get('override_report_render_url')) {
             reportOptions.getReportRenderUrl = function (renderType) {
-                var params = util.urlSerialize($('#paramSelectorForm'), ['format']);
+                var params = util.urlSerialize($('#paramSelectorForm' + initialPageData.get('html_id_suffix')), ['format']);
                 return window.location.pathname + "?format=" + renderType + "&" + params;
             };
         }

--- a/corehq/apps/reports/templates/reports/async/bootstrap3/default.html
+++ b/corehq/apps/reports/templates/reports/async/bootstrap3/default.html
@@ -29,7 +29,7 @@
 {% block modals %}
   <div class="loading-backdrop collapse"></div>
 
-  <div class="modal fade" tabindex="-1" role="dialog" id="loadingReportIssueModal">
+  <div class="modal fade" tabindex="-1" role="dialog" id="loadingReportIssueModal{{ report.html_id_suffix }}">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">

--- a/corehq/apps/reports/templates/reports/async/bootstrap3/default.html
+++ b/corehq/apps/reports/templates/reports/async/bootstrap3/default.html
@@ -2,6 +2,10 @@
 {% load i18n %}
 {% if show_time_notice %}{% include "hqwebapp/partials/bootstrap3/time_notice.html" with hide=1 %}{% endif %}
 
+{% block page_content %}
+  {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
+{% endblock page_content %}
+
 {% block reportcontent %}
   {% if report.slug %}
     <div class="report-loading-container">

--- a/corehq/apps/reports/templates/reports/async/bootstrap3/default.html
+++ b/corehq/apps/reports/templates/reports/async/bootstrap3/default.html
@@ -2,10 +2,6 @@
 {% load i18n %}
 {% if show_time_notice %}{% include "hqwebapp/partials/bootstrap3/time_notice.html" with hide=1 %}{% endif %}
 
-{% block page_content %}
-  {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
-{% endblock page_content %}
-
 {% block reportcontent %}
   {% if report.slug %}
     <div class="report-loading-container">

--- a/corehq/apps/reports/templates/reports/async/bootstrap5/default.html
+++ b/corehq/apps/reports/templates/reports/async/bootstrap5/default.html
@@ -3,6 +3,10 @@
 
 {% if show_time_notice %}{% include "hqwebapp/partials/bootstrap5/time_notice.html" with hide=1 %}{% endif %}
 
+{% block page_content %}
+  {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
+{% endblock page_content %}
+
 {% block reportcontent %}
   {% if report.slug %}
     <div class="report-loading-container">

--- a/corehq/apps/reports/templates/reports/async/bootstrap5/default.html
+++ b/corehq/apps/reports/templates/reports/async/bootstrap5/default.html
@@ -3,10 +3,6 @@
 
 {% if show_time_notice %}{% include "hqwebapp/partials/bootstrap5/time_notice.html" with hide=1 %}{% endif %}
 
-{% block page_content %}
-  {% initial_page_data 'html_id_suffix' report.html_id_suffix|default:'' %}
-{% endblock page_content %}
-
 {% block reportcontent %}
   {% if report.slug %}
     <div class="report-loading-container">

--- a/corehq/apps/reports/templates/reports/async/bootstrap5/default.html
+++ b/corehq/apps/reports/templates/reports/async/bootstrap5/default.html
@@ -31,7 +31,7 @@
   <div class="loading-backdrop collapse"></div>
 
   <div
-    id="loadingReportIssueModal"
+    id="loadingReportIssueModal{{ report.html_id_suffix }}"
     class="modal fade"
     tabindex="-1"
     role="dialog"

--- a/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
@@ -48,6 +48,7 @@
 
 {% block page_content %}
   {% initial_page_data 'js_options' report.js_options %}
+  {% initial_page_data 'html_id_suffix' report.html_id_suffix %}
   {% initial_page_data 'rendered_as' rendered_as %}
   {% initial_page_data 'report_table_js_options' report_table_js_options %}
 

--- a/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
@@ -61,6 +61,7 @@
 
 {% block page_content %}
   {% initial_page_data 'js_options' report.js_options %}
+  {% initial_page_data 'html_id_suffix' report.html_id_suffix %}
   {% initial_page_data 'rendered_as' rendered_as %}
   {% initial_page_data 'report_table_js_options' report_table_js_options %}
 

--- a/corehq/apps/reports/templates/reports/standard/partials/bootstrap3/filter_panel.html
+++ b/corehq/apps/reports/templates/reports/standard/partials/bootstrap3/filter_panel.html
@@ -1,12 +1,12 @@
 {% load hq_shared_tags %}
 {% load i18n %}
-<div class="panel panel-default{% if report.is_async%} hide{% endif %}" id="reportFiltersAccordion">
+<div class="panel panel-default{% if report.is_async%} hide{% endif %}" id="reportFiltersAccordion{{ report.html_id_suffix }}">
   {% if report.show_filters %}
-    <div id="reportFilters" class="panel-body collapse">
+    <div id="reportFilters{{ report.html_id_suffix }}" class="panel-body collapse">
       <div class="accordion-inner">
         {% block report_description %}{% endblock %}
-        <form method="get" id="paramSelectorForm" class="form form-horizontal">
-          <div id="hq-report-filters">
+        <form method="get" id="paramSelectorForm{{ report.html_id_suffix }}" class="form form-horizontal">
+          <div id="hq-report-filters{{ report.html_id_suffix }}">
             {% block report_filters %}
               {% if not report.is_async %}
                 {% include "reports/async/bootstrap3/filters.html" %}
@@ -20,7 +20,7 @@
                         disabled="disabled"
                         data-loading-text="{% trans "Generating Report..." %}"
                         data-standard-text="{% trans "Apply" %}"
-                        id="apply-btn">
+                        id="apply-btn{{ report.html_id_suffix }}">
                   {% trans "Apply" %}
                 </button>
               </div>
@@ -29,7 +29,7 @@
         </form>
       </div>
       {% if report.slug == 'mpr_report' %}
-        <span style="font-style: italic" id="mpr-banner-info">The report is currently available at Sector and Anganwadi Center level. The expansion to levels above is currently under development</span>
+        <span style="font-style: italic" id="mpr-banner-info{{ report.html_id_suffix }}">The report is currently available at Sector and Anganwadi Center level. The expansion to levels above is currently under development</span>
       {% endif %}
     </div>
   {% endif %}
@@ -39,7 +39,7 @@
         {% if report.show_filters %}
           <a href="#reportFilters"
              class="btn btn-default"
-             id="toggle-report-filters"
+             id="toggle-report-filters{{ report.html_id_suffix }}"
              data-toggle="collapse"
              data-open-text="{% trans "Show Filter Options" %}"
              data-close-text="{% trans "Hide Filter Options" %}">
@@ -48,25 +48,25 @@
         {% endif %}
         {% block export %}
           {% if report.is_exportable and request.couch_user.can_download_reports %}
-            <a href="#" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" id="export-report-excel">
+            <a href="#" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" id="export-report-excel{{ report.html_id_suffix }}">
               <i class="fa fa-share"></i>
               {% trans "Export to" %} {% if report.export_target %}{{ report.export_target }}{% else %}Excel{% endif %}
             </a>
           {% endif %}
         {% endblock %}
         {% if report.is_emailable and request.couch_user.can_download_reports %}
-          <a href="#email-report-modal" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" data-toggle="modal" id="email-report">
+          <a href="#email-report-modal" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" data-toggle="modal" id="email-report{{ report.html_id_suffix }}">
             <i class="fa fa-envelope"></i> {% trans "Email report" %}
           </a>
         {% endif %}
 
         {% if report.is_printable %}
-          <a href="#" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" id="print-report">
+          <a href="#" class="btn btn-default{% if report.needs_filters %} hide{% endif %}" id="print-report{{ report.html_id_suffix }}">
             <i class="fa fa-print"></i> {% trans "Print" %}
           </a>
         {% endif %}
       </div>
-      <div id="extra-filter-info" class="col-xs-4"></div>
+      <div id="extra-filter-info{{ report.html_id_suffix }}" class="col-xs-4"></div>
     </div>
   </div>
 </div>

--- a/corehq/apps/reports/templates/reports/standard/partials/bootstrap3/filter_panel.html
+++ b/corehq/apps/reports/templates/reports/standard/partials/bootstrap3/filter_panel.html
@@ -37,7 +37,7 @@
     <div class="row">
       <div class="col-xs-8">
         {% if report.show_filters %}
-          <a href="#reportFilters"
+          <a href="#reportFilters{{ report.html_id_suffix }}"
              class="btn btn-default"
              id="toggle-report-filters{{ report.html_id_suffix }}"
              data-toggle="collapse"

--- a/corehq/apps/reports/templates/reports/standard/partials/bootstrap5/filter_panel.html
+++ b/corehq/apps/reports/templates/reports/standard/partials/bootstrap5/filter_panel.html
@@ -2,18 +2,18 @@
 {% load i18n %}
 <div
   class="card card-default{% if report.is_async%} d-none{% endif %}"
-  id="reportFiltersAccordion"
+  id="reportFiltersAccordion{{ report.html_id_suffix }}"
 >
   {% if report.show_filters %}
-    <div id="reportFilters" class="card-body collapse">
+    <div id="reportFilters{{ report.html_id_suffix }}" class="card-body collapse">
       <div class="accordion-inner">
         {% block report_description %}{% endblock %}
         <form
           method="get"
-          id="paramSelectorForm"
+          id="paramSelectorForm{{ report.html_id_suffix }}"
           class="form"
         >
-          <div id="hq-report-filters">
+          <div id="hq-report-filters{{ report.html_id_suffix }}">
             {% block report_filters %}
               {% if not report.is_async %}
                 {% include "reports/async/bootstrap5/filters.html" %}
@@ -24,7 +24,7 @@
             {% block report_filter_actions %}
               <div class="{{ report_filter_form_action_css_class }}">
                 <button
-                  class="btn disabled" id="apply-btn"
+                  class="btn disabled" id="apply-btn{{ report.html_id_suffix }}"
                   disabled="disabled" type="submit"
                   data-loading-text="{% trans "Generating Report..." %}"
                   data-standard-text="{% trans "Apply" %}"
@@ -37,7 +37,7 @@
         </form>
       </div>
       {% if report.slug == 'mpr_report' %}
-        <span style="font-style: italic" id="mpr-banner-info">The report is currently available at Sector and Anganwadi Center level. The expansion to levels above is currently under development</span>  {# todo B5: inline style #}
+        <span style="font-style: italic" id="mpr-banner-info{{ report.html_id_suffix }}">The report is currently available at Sector and Anganwadi Center level. The expansion to levels above is currently under development</span>  {# todo B5: inline style #}
       {% endif %}
     </div>
   {% endif %}
@@ -49,7 +49,7 @@
         {% if report.show_filters %}
           <button
             class="btn btn-outline-primary"
-            id="toggle-report-filters"
+            id="toggle-report-filters{{ report.html_id_suffix }}"
             type="button"
             data-bs-toggle="collapse"
             data-bs-target="#reportFilters"
@@ -64,7 +64,7 @@
           {% if report.is_exportable and request.couch_user.can_download_reports %}
             <button
               class="btn btn-outline-primary{% if report.needs_filters %} d-none{% endif %}"
-              id="export-report-excel"
+              id="export-report-excel{{ report.html_id_suffix }}"
               type="button"
             >
               <i class="fa fa-share"></i>
@@ -76,7 +76,7 @@
         {% if report.is_emailable and request.couch_user.can_download_reports %}
           <button
             class="btn btn-outline-primary{% if report.needs_filters %} d-none{% endif %}"
-            id="email-report"
+            id="email-report{{ report.html_id_suffix }}"
             type="button"
             data-bs-target="#email-report-modal"
             data-bs-toggle="modal"
@@ -89,7 +89,7 @@
         {% if report.is_printable %}
           <button
             class="btn btn-outline-primary{% if report.needs_filters %} d-none{% endif %}"
-            id="print-report"
+            id="print-report{{ report.html_id_suffix }}"
             type="button"
           >
             <i class="fa fa-print"></i>
@@ -98,7 +98,7 @@
         {% endif %}
 
       </div>
-      <div id="extra-filter-info" class="col-sm-4"></div>
+      <div id="extra-filter-info{{ report.html_id_suffix }}" class="col-sm-4"></div>
     </div>
   </div>
 </div>

--- a/corehq/apps/reports/templates/reports/standard/partials/bootstrap5/filter_panel.html
+++ b/corehq/apps/reports/templates/reports/standard/partials/bootstrap5/filter_panel.html
@@ -52,7 +52,7 @@
             id="toggle-report-filters{{ report.html_id_suffix }}"
             type="button"
             data-bs-toggle="collapse"
-            data-bs-target="#reportFilters"
+            data-bs-target="#reportFilters{{ report.html_id_suffix }}"
             data-open-text="{% trans "Show Filter Options" %}"
             data-close-text="{% trans "Hide Filter Options" %}"
           >

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -379,6 +379,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             "isExportAll": self.exportable_all,
             "isEmailable": False,       # see emailable attr above
             "emailDefaultSubject": self.title,
+            "url": self.url,  # Used with {% initial_page_data 'override_report_render_url' True %}
         }
 
     def pop_report_builder_context_data(self):

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -373,6 +373,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             "domain": self.domain,
             "slug": self.slug,
             "subReportSlug": self.sub_slug,
+            "html_id_suffix": self.html_id_suffix,
             "type": self.type,
             "isExportable": self.is_exportable,
             "isExportAll": self.exportable_all,

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -522,6 +522,10 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
         """
         return self.report_config_id
 
+    @property
+    def html_id_suffix(self):
+        return f"-{self.report_config_id}"
+
     @classmethod
     def get_report(cls, domain, slug, report_config_id):
         report = cls()

--- a/corehq/apps/userreports/static/userreports/js/bootstrap3/base.js
+++ b/corehq/apps/userreports/static/userreports/js/bootstrap3/base.js
@@ -25,11 +25,11 @@ hqDefine('userreports/js/bootstrap3/base', [
             if (chartSpecs !== null && chartSpecs.length > 0) {
                 var isReportBuilderReport = initialPageData.get('created_by_builder');
                 if (data.iTotalRecords > 25 && isReportBuilderReport) {
-                    $("#chart-warning").removeClass("hide");
-                    charts.clear($("#chart-container"));
+                    $("#chart-warning" + initialPageData.get('html_id_suffix')).removeClass("hide");
+                    charts.clear($("#chart-container" + initialPageData.get('html_id_suffix')));
                 } else {
-                    $("#chart-warning").addClass("hide");
-                    charts.render(chartSpecs, data.aaData, $("#chart-container"));
+                    $("#chart-warning" + initialPageData.get('html_id_suffix')).addClass("hide");
+                    charts.render(chartSpecs, data.aaData, $("#chart-container" + initialPageData.get('html_id_suffix')));
                 }
             }
         };
@@ -38,7 +38,7 @@ hqDefine('userreports/js/bootstrap3/base', [
         var updateMap = function (data) {
             if (mapSpec) {
                 mapSpec.mapboxAccessToken = initialPageData.get('MAPBOX_ACCESS_TOKEN');
-                maps.render(mapSpec, data.aaData, $("#map-container"));
+                maps.render(mapSpec, data.aaData, $("#map-container" + initialPageData.get('html_id_suffix')));
             }
         };
 
@@ -46,40 +46,40 @@ hqDefine('userreports/js/bootstrap3/base', [
             if (mapSpec) {  // Only show warning for map reports
                 if (data.aaData !== undefined && data.iTotalRecords !== undefined) {
                     if (data.aaData.length < data.iTotalRecords) {
-                        $('#info-message').html(
+                        $('#info-message' + initialPageData.get('html_id_suffix')).html(
                             gettext('Showing the current page of data. Switch pages to see more data.'),
                         );
-                        $('#report-info').removeClass('hide');
+                        $('#report-info' + initialPageData.get('html_id_suffix')).removeClass('hide');
                     } else {
-                        $('#report-info').addClass('hide');
+                        $('#report-info' + initialPageData.get('html_id_suffix')).addClass('hide');
                     }
                 }
             }
         };
 
         var errorCallback = function (jqXHR, textStatus, errorThrown) {
-            $('#error-message').html(errorThrown);
-            $('#report-error').removeClass('hide');
+            $('#error-message' + initialPageData.get('html_id_suffix')).html(errorThrown);
+            $('#report-error' + initialPageData.get('html_id_suffix')).removeClass('hide');
         };
 
         var successCallback = function (data) {
             if (data.error || data.error_message) {
                 const message = data.error || data.error_message;
-                $('#error-message').html(message);
-                $('#report-error').removeClass('hide');
+                $('#error-message' + initialPageData.get('html_id_suffix')).html(message);
+                $('#report-error' + initialPageData.get('html_id_suffix')).removeClass('hide');
             } else {
-                $('#report-error').addClass('hide');
+                $('#report-error' + initialPageData.get('html_id_suffix')).addClass('hide');
             }
             if (data.warning) {
-                $('#warning-message').html(data.warning);
-                $('#report-warning').removeClass('hide');
+                $('#warning-message' + initialPageData.get('html_id_suffix')).html(data.warning);
+                $('#report-warning' + initialPageData.get('html_id_suffix')).removeClass('hide');
             } else {
-                $('#report-warning').addClass('hide');
+                $('#report-warning' + initialPageData.get('html_id_suffix')).addClass('hide');
             }
         };
 
         var reportTables = dataTablesConfig.HQReportDataTables({
-            dataTableElem: '#report_table_' + initialPageData.get('report_slug'),
+            dataTableElem: '#report_table_' + initialPageData.get('report_slug') + initialPageData.get('html_id_suffix'),
             defaultRows: initialPageData.get('table_default_rows'),
             startAtRowNum: initialPageData.get('table_start_at_row'),
             showAllRowsOption: initialPageData.get('table_show_all_rows'),
@@ -90,7 +90,7 @@ hqDefine('userreports/js/bootstrap3/base', [
             ajaxSource: getReportUrl(),
             ajaxMethod: initialPageData.get('ajax_method'),
             ajaxParams: function () {
-                return $('#paramSelectorForm').serializeArray();
+                return $('#paramSelectorForm' + initialPageData.get('html_id_suffix')).serializeArray();
             },
             fixColumns: initialPageData.get('left_col_is_fixed'),
             fixColsNumLeft: initialPageData.get('left_col_fixed_num'),
@@ -98,15 +98,15 @@ hqDefine('userreports/js/bootstrap3/base', [
             successCallbacks: [successCallback, updateCharts, updateMap, paginationNotice],
             errorCallbacks: [errorCallback],
         });
-        $('#paramSelectorForm').submit(function (event) {
-            $('#reportHint').remove();
-            $('#reportContent').removeClass('hide');
+        $('#paramSelectorForm' + initialPageData.get('html_id_suffix')).submit(function (event) {
+            $('#reportHint' + initialPageData.get('html_id_suffix')).remove();
+            $('#reportContent' + initialPageData.get('html_id_suffix')).removeClass('hide');
             event.preventDefault();
             reportTables.render();
         });
         // after we've registered the event that prevents the default form submission
         // we can enable the submit button
-        $("#apply-filters").prop('disabled', false);
+        $("#apply-filters" + initialPageData.get('html_id_suffix')).prop('disabled', false);
 
         $(function () {
             $('.header-popover').popover({

--- a/corehq/apps/userreports/static/userreports/js/bootstrap3/configurable_report.js
+++ b/corehq/apps/userreports/static/userreports/js/bootstrap3/configurable_report.js
@@ -26,7 +26,7 @@ hqDefine("userreports/js/bootstrap3/configurable_report", [
 
         // Set up analytics
         if (initialPageData.get("created_by_builder")) {
-            var $applyFiltersButton = $("#apply-filters"),
+            var $applyFiltersButton = $("#apply-filters" + initialPageData.get('html_id_suffix')),
                 builderType = initialPageData.get("builder_report_type"),
                 reportType = initialPageData.get("type");
             $applyFiltersButton.click(function () {
@@ -34,7 +34,7 @@ hqDefine("userreports/js/bootstrap3/configurable_report", [
                 analytics.track.event("View Report Builder Report", label);
             });
             analytics.track.event("Loaded Report Builder Report");
-            $("#edit-report-link").click(function () {
+            $("#edit-report-link" + initialPageData.get('html_id_suffix')).click(function () {
                 kissmetrics.track.event("RBv2 - Click Edit Report");
             });
         }
@@ -62,15 +62,15 @@ hqDefine("userreports/js/bootstrap3/configurable_report", [
         }
 
         var reportConfigsView = reportConfigModels.reportConfigsViewModel({
-            filterForm: $("#paramSelectorForm"),
+            filterForm: $("#paramSelectorForm" + initialPageData.get("html_id_suffix")),
             items: initialPageData.get("report_configs"),
             defaultItem: defaultConfig,
             saveUrl: initialPageData.reverse("add_report_config"),
         });
-        $("#savedReports").koApplyBindings(reportConfigsView);
+        $("#savedReports" + initialPageData.get('html_id_suffix')).koApplyBindings(reportConfigsView);
         reportConfigsView.setUserConfigurableConfigBeingViewed(reportConfigModels.reportConfig(defaultConfig));
 
-        $('#email-enabled').tooltip({
+        $('#email-enabled' + initialPageData.get('html_id_suffix')).tooltip({
             placement: 'right',
             html: true,
             title: gettext("You can email a saved version<br />of this report."),

--- a/corehq/apps/userreports/static/userreports/js/bootstrap5/base.js
+++ b/corehq/apps/userreports/static/userreports/js/bootstrap5/base.js
@@ -25,11 +25,11 @@ hqDefine('userreports/js/bootstrap5/base', [
             if (chartSpecs !== null && chartSpecs.length > 0) {
                 var isReportBuilderReport = initialPageData.get('created_by_builder');
                 if (data.iTotalRecords > 25 && isReportBuilderReport) {
-                    $("#chart-warning").removeClass("hide");
-                    charts.clear($("#chart-container"));
+                    $("#chart-warning" + initialPageData.get('html_id_suffix')).removeClass("d-none");
+                    charts.clear($("#chart-container" + initialPageData.get('html_id_suffix')));
                 } else {
-                    $("#chart-warning").addClass("hide");
-                    charts.render(chartSpecs, data.aaData, $("#chart-container"));
+                    $("#chart-warning" + initialPageData.get('html_id_suffix')).addClass("d-none");
+                    charts.render(chartSpecs, data.aaData, $("#chart-container" + initialPageData.get('html_id_suffix')));
                 }
             }
         };
@@ -38,7 +38,7 @@ hqDefine('userreports/js/bootstrap5/base', [
         var updateMap = function (data) {
             if (mapSpec) {
                 mapSpec.mapboxAccessToken = initialPageData.get('MAPBOX_ACCESS_TOKEN');
-                maps.render(mapSpec, data.aaData, $("#map-container"));
+                maps.render(mapSpec, data.aaData, $("#map-container" + initialPageData.get('html_id_suffix')));
             }
         };
 
@@ -46,40 +46,40 @@ hqDefine('userreports/js/bootstrap5/base', [
             if (mapSpec) {  // Only show warning for map reports
                 if (data.aaData !== undefined && data.iTotalRecords !== undefined) {
                     if (data.aaData.length < data.iTotalRecords) {
-                        $('#info-message').html(
+                        $('#info-message' + initialPageData.get('html_id_suffix')).html(
                             gettext('Showing the current page of data. Switch pages to see more data.'),
                         );
-                        $('#report-info').removeClass('hide');
+                        $('#report-info' + initialPageData.get('html_id_suffix')).removeClass('d-none');
                     } else {
-                        $('#report-info').addClass('hide');
+                        $('#report-info' + initialPageData.get('html_id_suffix')).addClass('d-none');
                     }
                 }
             }
         };
 
         var errorCallback = function (jqXHR, textStatus, errorThrown) {
-            $('#error-message').html(errorThrown);
-            $('#report-error').removeClass('hide');
+            $('#error-message' + initialPageData.get('html_id_suffix')).html(errorThrown);
+            $('#report-error' + initialPageData.get('html_id_suffix')).removeClass('d-none');
         };
 
         var successCallback = function (data) {
             if (data.error || data.error_message) {
                 const message = data.error || data.error_message;
-                $('#error-message').html(message);
-                $('#report-error').removeClass('hide');
+                $('#error-message' + initialPageData.get('html_id_suffix')).html(message);
+                $('#report-error' + initialPageData.get('html_id_suffix')).removeClass('d-none');
             } else {
-                $('#report-error').addClass('hide');
+                $('#report-error' + initialPageData.get('html_id_suffix')).addClass('d-none');
             }
             if (data.warning) {
-                $('#warning-message').html(data.warning);
-                $('#report-warning').removeClass('hide');
+                $('#warning-message' + initialPageData.get('html_id_suffix')).html(data.warning);
+                $('#report-warning' + initialPageData.get('html_id_suffix')).removeClass('d-none');
             } else {
-                $('#report-warning').addClass('hide');
+                $('#report-warning' + initialPageData.get('html_id_suffix')).addClass('d-none');
             }
         };
 
         var reportTables = dataTablesConfig.HQReportDataTables({
-            dataTableElem: '#report_table_' + initialPageData.get('report_slug'),
+            dataTableElem: '#report_table_' + initialPageData.get('report_slug') + initialPageData.get('html_id_suffix'),
             defaultRows: initialPageData.get('table_default_rows'),
             startAtRowNum: initialPageData.get('table_start_at_row'),
             showAllRowsOption: initialPageData.get('table_show_all_rows'),
@@ -90,7 +90,7 @@ hqDefine('userreports/js/bootstrap5/base', [
             ajaxSource: getReportUrl(),
             ajaxMethod: initialPageData.get('ajax_method'),
             ajaxParams: function () {
-                return $('#paramSelectorForm').serializeArray();
+                return $('#paramSelectorForm' + initialPageData.get('html_id_suffix')).serializeArray();
             },
             fixColumns: initialPageData.get('left_col_is_fixed'),
             fixColsNumLeft: initialPageData.get('left_col_fixed_num'),
@@ -98,15 +98,15 @@ hqDefine('userreports/js/bootstrap5/base', [
             successCallbacks: [successCallback, updateCharts, updateMap, paginationNotice],
             errorCallbacks: [errorCallback],
         });
-        $('#paramSelectorForm').submit(function (event) {
-            $('#reportHint').remove();
-            $('#reportContent').removeClass('hide');
+        $('#paramSelectorForm' + initialPageData.get('html_id_suffix')).submit(function (event) {
+            $('#reportHint' + initialPageData.get('html_id_suffix')).remove();
+            $('#reportContent' + initialPageData.get('html_id_suffix')).removeClass('d-none');
             event.preventDefault();
             reportTables.render();
         });
         // after we've registered the event that prevents the default form submission
         // we can enable the submit button
-        $("#apply-filters").prop('disabled', false);
+        $("#apply-filters" + initialPageData.get('html_id_suffix')).prop('disabled', false);
 
         $(function () {
             $('.header-popover').popover({  /* todo B5: js-popover */

--- a/corehq/apps/userreports/static/userreports/js/bootstrap5/configurable_report.js
+++ b/corehq/apps/userreports/static/userreports/js/bootstrap5/configurable_report.js
@@ -26,7 +26,7 @@ hqDefine("userreports/js/bootstrap5/configurable_report", [
 
         // Set up analytics
         if (initialPageData.get("created_by_builder")) {
-            var $applyFiltersButton = $("#apply-filters"),
+            var $applyFiltersButton = $("#apply-filters" + initialPageData.get('html_id_suffix')),
                 builderType = initialPageData.get("builder_report_type"),
                 reportType = initialPageData.get("type");
             $applyFiltersButton.click(function () {
@@ -34,7 +34,7 @@ hqDefine("userreports/js/bootstrap5/configurable_report", [
                 analytics.track.event("View Report Builder Report", label);
             });
             analytics.track.event("Loaded Report Builder Report");
-            $("#edit-report-link").click(function () {
+            $("#edit-report-link" + initialPageData.get('html_id_suffix')).click(function () {
                 kissmetrics.track.event("RBv2 - Click Edit Report");
             });
         }
@@ -62,15 +62,15 @@ hqDefine("userreports/js/bootstrap5/configurable_report", [
         }
 
         var reportConfigsView = reportConfigModels.reportConfigsViewModel({
-            filterForm: $("#paramSelectorForm"),
+            filterForm: $("#paramSelectorForm" + initialPageData.get('html_id_suffix')),
             items: initialPageData.get("report_configs"),
             defaultItem: defaultConfig,
             saveUrl: initialPageData.reverse("add_report_config"),
         });
-        $("#savedReports").koApplyBindings(reportConfigsView);
+        $("#savedReports" + initialPageData.get('html_id_suffix')).koApplyBindings(reportConfigsView);
         reportConfigsView.setUserConfigurableConfigBeingViewed(reportConfigModels.reportConfig(defaultConfig));
 
-        $('#email-enabled').tooltip({  /* todo B5: js-tooltip */
+        $('#email-enabled' + initialPageData.get('html_id_suffix')).tooltip({  /* todo B5: js-tooltip */
             placement: 'right',
             html: true,
             title: gettext("You can email a saved version<br />of this report."),

--- a/corehq/apps/userreports/templates/userreports/bootstrap3/base.html
+++ b/corehq/apps/userreports/templates/userreports/bootstrap3/base.html
@@ -12,7 +12,7 @@
 
 {% block head %}{{ block.super }}
   <style>
-    #map-container {
+    .map-container {
       height: 500px;
     }
   </style>
@@ -42,17 +42,17 @@
   {% initial_page_data 'html_id_suffix' report.html_id_suffix %}
 
   {% block report_alerts %}
-    <div id="report-error" class="alert alert-danger hide">
+    <div id="report-error{{ report.html_id_suffix }}" class="alert alert-danger hide">
       {% blocktrans %}
         There was an error rendering your report.
       {% endblocktrans %}
-      <div id="error-message"></div>
+      <div id="error-message{{ report.html_id_suffix }}"></div>
     </div>
-    <div id="report-warning" class="alert alert-warning hide">
+    <div id="report-warning{{ report.html_id_suffix }}" class="alert alert-warning hide">
       {% blocktrans %}
         Warning:
       {% endblocktrans %}
-      <div id="warning-message"></div>
+      <div id="warning-message{{ report.html_id_suffix }}"></div>
     </div>
   {% endblock report_alerts %}
   {% block main_column_content %}
@@ -61,30 +61,30 @@
     {% endblock %}
 
     <hr />
-    <div id="reportHint" class="alert alert-info">
+    <div id="reportHint{{ report.html_id_suffix }}" class="alert alert-info">
       <h4><i class="fa fa-info-circle"></i> {% blocktrans %}Why can't I see any data?{% endblocktrans %}</h4>
       <p>{% blocktrans %}Please choose your filters above and click <strong>Apply</strong> to see report data.{% endblocktrans %}</p>
     </div>
-    <div id="reportContent" class="hide">
+    <div id="reportContent{{ report.html_id_suffix }}" class="hide">
       {% block reportcharts %}
-        <section id="chart-container" style="display: none;">
+        <section id="chart-container{{ report.html_id_suffix }}" style="display: none;">
         </section>
-        <section id="chart-warning" class="alert alert-warning hide">
+        <section id="chart-warning{{ report.html_id_suffix }}" class="alert alert-warning hide">
           {% blocktrans %}
             Charts cannot be displayed with more than 25 categories. Please filter the data or change your report to limit the number of rows.
           {% endblocktrans %}
         </section>
-        <section id="map-container" style="display: none;" >
+        <section id="map-container{{ report.html_id_suffix }}" class="map-container" style="display: none;" >
         </section>
-        <div id="zoomtofit" class="leaflet-control-layers" style="display: none;">
-          <div id="zoomtofit-target" class="zoomtofit leaflet-control-layers-toggle" title="{% trans "Fit all data into view" %}"></div>
+        <div id="zoomtofit{{ report.html_id_suffix }}" class="leaflet-control-layers" style="display: none;">
+          <div id="zoomtofit-target{{ report.html_id_suffix }}" class="zoomtofit leaflet-control-layers-toggle" title="{% trans "Fit all data into view" %}"></div>
         </div>
 
-        <div id="report-info" class="alert alert-info hide">
+        <div id="report-info{{ report.html_id_suffix }}" class="alert alert-info hide">
           {% blocktrans %}
             Note:
           {% endblocktrans %}
-          <span id="info-message"></span>
+          <span id="info-message{{ report.html_id_suffix }}"></span>
         </div>
       {% endblock %}
       {% block reporttable %}
@@ -93,7 +93,7 @@
             <h4>{{ report.title }}</h4>
           </div>
           <div class="panel-body hq-datatable-container">
-            <table id="report_table_{{ report.slug }}" class="table table-striped">
+            <table id="report_table_{{ report.slug }}{{ report.html_id_suffix }}" class="table table-striped">
               <thead>
               {{ headers.render_html }}
               </thead>

--- a/corehq/apps/userreports/templates/userreports/bootstrap3/base.html
+++ b/corehq/apps/userreports/templates/userreports/bootstrap3/base.html
@@ -39,6 +39,7 @@
   {% initial_page_data 'created_by_builder' report.spec.report_meta.created_by_builder %}
   {% initial_page_data 'charts' report.spec.charts %}
   {% initial_page_data 'url' url %}
+  {% initial_page_data 'html_id_suffix' report.html_id_suffix %}
 
   {% block report_alerts %}
     <div id="report-error" class="alert alert-danger hide">

--- a/corehq/apps/userreports/templates/userreports/bootstrap3/base.html
+++ b/corehq/apps/userreports/templates/userreports/bootstrap3/base.html
@@ -39,7 +39,6 @@
   {% initial_page_data 'created_by_builder' report.spec.report_meta.created_by_builder %}
   {% initial_page_data 'charts' report.spec.charts %}
   {% initial_page_data 'url' url %}
-  {% initial_page_data 'html_id_suffix' report.html_id_suffix %}
 
   {% block report_alerts %}
     <div id="report-error{{ report.html_id_suffix }}" class="alert alert-danger hide">

--- a/corehq/apps/userreports/templates/userreports/bootstrap3/base.html
+++ b/corehq/apps/userreports/templates/userreports/bootstrap3/base.html
@@ -39,6 +39,7 @@
   {% initial_page_data 'created_by_builder' report.spec.report_meta.created_by_builder %}
   {% initial_page_data 'charts' report.spec.charts %}
   {% initial_page_data 'url' url %}
+  {% initial_page_data 'html_id_suffix' report.html_id_suffix %}
 
   {% block report_alerts %}
     <div id="report-error{{ report.html_id_suffix }}" class="alert alert-danger hide">

--- a/corehq/apps/userreports/templates/userreports/bootstrap3/report_error.html
+++ b/corehq/apps/userreports/templates/userreports/bootstrap3/report_error.html
@@ -9,13 +9,13 @@
 
 {% block page_content %}
   {% block report_alerts %}
-    <div id="report-error" class="alert alert-danger">
+    <div id="report-error{{ report.html_id_suffix }}" class="alert alert-danger">
       <p>{{ error_message }}</p>
       {% if details %}
         <p>{% trans "Technical Details:" %}</p>
         {{ details }}
       {% endif %}
-      <div id="error-message"></div>
+      <div id="error-message{{ report.html_id_suffix }}"></div>
     </div>
   {% endblock report_alerts %}
   {% if allow_delete %}

--- a/corehq/apps/userreports/templates/userreports/bootstrap5/base.html
+++ b/corehq/apps/userreports/templates/userreports/bootstrap5/base.html
@@ -12,7 +12,7 @@
 
 {% block head %}{{ block.super }}
   <style>
-    #map-container {
+    .map-container {
       height: 500px;
     }
   </style>
@@ -42,17 +42,17 @@
   {% initial_page_data 'html_id_suffix' report.html_id_suffix %}
 
   {% block report_alerts %}
-    <div id="report-error" class="alert alert-danger d-none">
+    <div id="report-error{{ report.html_id_suffix }}" class="alert alert-danger d-none">
       {% blocktrans %}
         There was an error rendering your report.
       {% endblocktrans %}
-      <div id="error-message"></div>
+      <div id="error-message{{ report.html_id_suffix }}"></div>
     </div>
-    <div id="report-warning" class="alert alert-warning d-none">
+    <div id="report-warning{{ report.html_id_suffix }}" class="alert alert-warning d-none">
       {% blocktrans %}
         Warning:
       {% endblocktrans %}
-      <div id="warning-message"></div>
+      <div id="warning-message{{ report.html_id_suffix }}"></div>
     </div>
   {% endblock report_alerts %}
   {% block main_column_content %}
@@ -61,30 +61,30 @@
     {% endblock %}
 
     <hr />
-    <div id="reportHint" class="alert alert-info">
+    <div id="reportHint{{ report.html_id_suffix }}" class="alert alert-info">
       <h4><i class="fa fa-info-circle"></i> {% blocktrans %}Why can't I see any data?{% endblocktrans %}</h4>
       <p>{% blocktrans %}Please choose your filters above and click <strong>Apply</strong> to see report data.{% endblocktrans %}</p>
     </div>
-    <div id="reportContent" class="d-none">
+    <div id="reportContent{{ report.html_id_suffix }}" class="d-none">
       {% block reportcharts %}
-        <section id="chart-container" style="display: none;">  {# todo B5: inline-style #}
+        <section id="chart-container{{ report.html_id_suffix }}" style="display: none;">  {# todo B5: inline-style #}
         </section>
-        <section id="chart-warning" class="alert alert-warning d-none">
+        <section id="chart-warning{{ report.html_id_suffix }}" class="alert alert-warning d-none">
           {% blocktrans %}
             Charts cannot be displayed with more than 25 categories. Please filter the data or change your report to limit the number of rows.
           {% endblocktrans %}
         </section>
-        <section id="map-container" style="display: none;" >  {# todo B5: inline-style #}
+        <section id="map-container{{ report.html_id_suffix }}" class="map-container" style="display: none;" >  {# todo B5: inline-style #}
         </section>
-        <div id="zoomtofit" class="leaflet-control-layers" style="display: none;">  {# todo B5: inline-style #}
-          <div id="zoomtofit-target" class="zoomtofit leaflet-control-layers-toggle" title="{% trans "Fit all data into view" %}"></div>
+        <div id="zoomtofit{{ report.html_id_suffix }}" class="leaflet-control-layers" style="display: none;">  {# todo B5: inline-style #}
+          <div id="zoomtofit-target{{ report.html_id_suffix }}" class="zoomtofit leaflet-control-layers-toggle" title="{% trans "Fit all data into view" %}"></div>
         </div>
 
-        <div id="report-info" class="alert alert-info d-none">
+        <div id="report-info{{ report.html_id_suffix }}" class="alert alert-info d-none">
           {% blocktrans %}
             Note:
           {% endblocktrans %}
-          <span id="info-message"></span>
+          <span id="info-message{{ report.html_id_suffix }}"></span>
         </div>
       {% endblock %}
       {% block reporttable %}
@@ -93,7 +93,7 @@
             <h4>{{ report.title }}</h4>
           </div>
           <div class="card-body hq-datatable-container">
-            <table id="report_table_{{ report.slug }}" class="table table-striped">
+            <table id="report_table_{{ report.slug }}{{ report.html_id_suffix }}" class="table table-striped">
               <thead>
               {{ headers.render_html }}
               </thead>

--- a/corehq/apps/userreports/templates/userreports/bootstrap5/base.html
+++ b/corehq/apps/userreports/templates/userreports/bootstrap5/base.html
@@ -39,7 +39,6 @@
   {% initial_page_data 'created_by_builder' report.spec.report_meta.created_by_builder %}
   {% initial_page_data 'charts' report.spec.charts %}
   {% initial_page_data 'url' url %}
-  {% initial_page_data 'html_id_suffix' report.html_id_suffix %}
 
   {% block report_alerts %}
     <div id="report-error{{ report.html_id_suffix }}" class="alert alert-danger d-none">

--- a/corehq/apps/userreports/templates/userreports/bootstrap5/base.html
+++ b/corehq/apps/userreports/templates/userreports/bootstrap5/base.html
@@ -39,6 +39,7 @@
   {% initial_page_data 'created_by_builder' report.spec.report_meta.created_by_builder %}
   {% initial_page_data 'charts' report.spec.charts %}
   {% initial_page_data 'url' url %}
+  {% initial_page_data 'html_id_suffix' report.html_id_suffix %}
 
   {% block report_alerts %}
     <div id="report-error{{ report.html_id_suffix }}" class="alert alert-danger d-none">

--- a/corehq/apps/userreports/templates/userreports/bootstrap5/base.html
+++ b/corehq/apps/userreports/templates/userreports/bootstrap5/base.html
@@ -39,6 +39,7 @@
   {% initial_page_data 'created_by_builder' report.spec.report_meta.created_by_builder %}
   {% initial_page_data 'charts' report.spec.charts %}
   {% initial_page_data 'url' url %}
+  {% initial_page_data 'html_id_suffix' report.html_id_suffix %}
 
   {% block report_alerts %}
     <div id="report-error" class="alert alert-danger d-none">

--- a/corehq/apps/userreports/templates/userreports/bootstrap5/report_error.html
+++ b/corehq/apps/userreports/templates/userreports/bootstrap5/report_error.html
@@ -9,13 +9,13 @@
 
 {% block page_content %}
   {% block report_alerts %}
-    <div id="report-error" class="alert alert-danger">
+    <div id="report-error{{ report.html_id_suffix }}" class="alert alert-danger">
       <p>{{ error_message }}</p>
       {% if details %}
         <p>{% trans "Technical Details:" %}</p>
         {{ details }}
       {% endif %}
-      <div id="error-message"></div>
+      <div id="error-message{{ report.html_id_suffix }}"></div>
     </div>
   {% endblock report_alerts %}
   {% if allow_delete %}

--- a/corehq/apps/userreports/templates/userreports/partials/bootstrap3/filter_panel.html
+++ b/corehq/apps/userreports/templates/userreports/partials/bootstrap3/filter_panel.html
@@ -4,10 +4,10 @@
 
 {% block report_filter_actions %}
   <div class="{{ report_filter_form_action_css_class }}">
-    <div id="savedReports">
+    <div id="savedReports{{ report.html_id_suffix }}">
       <div class="btn-toolbar">
         <div class="btn-group">
-          <button id="apply-filters"
+          <button id="apply-filters{{ report.html_id_suffix }}"
                   type="submit"
                   class="filters btn btn-primary"
                   data-loading-text="{% trans 'Generating Report...' %}"
@@ -42,14 +42,14 @@
         </a>
 
         {% if report.is_emailable %}
-          <div style="display: inline-block; margin-left:0.5em;" class="label label-info" id="email-enabled">
+          <div style="display: inline-block; margin-left:0.5em;" class="label label-info" id="email-enabled{{ report.html_id_suffix }}">
             <i class="fa fa-info-circle"></i> {% trans "Email Supported" %}
           </div>
         {% endif %}
         {# TODO: I think we need a block here for exportable or some shit? #}
       </div>
 
-      <div class="modal fade" id="report-config-modal" data-bind="modal: configBeingEdited">
+      <div class="modal fade" id="report-config-modal{{ report.html_id_suffix }}" data-bind="modal: configBeingEdited">
         <div class="modal-dialog">
           <div class="modal-content" data-bind="with: configBeingEdited">
             <div class="modal-header">

--- a/corehq/apps/userreports/templates/userreports/partials/bootstrap5/filter_panel.html
+++ b/corehq/apps/userreports/templates/userreports/partials/bootstrap5/filter_panel.html
@@ -4,10 +4,10 @@
 
 {% block report_filter_actions %}
   <div class="{{ report_filter_form_action_css_class }}">
-    <div id="savedReports">
+    <div id="savedReports{{ report.html_id_suffix }}">
       <div class="btn-toolbar">
         <div class="btn-group">
-          <button id="apply-filters"
+          <button id="apply-filters{{ report.html_id_suffix }}"
                   type="submit"
                   class="filters btn btn-primary"
                   data-loading-text="{% trans 'Generating Report...' %}"  {# todo B5: stateful button #}
@@ -42,14 +42,14 @@
         </a>
 
         {% if report.is_emailable %}
-          <div style="display: inline-block; margin-left:0.5em;" class="badge text-bg-info" id="email-enabled">  {# todo B5: inline-style #}
+          <div style="display: inline-block; margin-left:0.5em;" class="badge text-bg-info" id="email-enabled{{ report.html_id_suffix }}">  {# todo B5: inline-style #}
             <i class="fa fa-info-circle"></i> {% trans "Email Supported" %}
           </div>
         {% endif %}
         {# TODO: I think we need a block here for exportable or some shit? #}
       </div>
 
-      <div class="modal fade" id="report-config-modal" data-bind="modal: configBeingEdited">
+      <div class="modal fade" id="report-config-modal{{ report.html_id_suffix }}" data-bind="modal: configBeingEdited">
         <div class="modal-dialog">
           <div class="modal-content" data-bind="with: configBeingEdited">
             <div class="modal-header">

--- a/corehq/apps/userreports/templates/userreports/partials/edit_report_button.html
+++ b/corehq/apps/userreports/templates/userreports/partials/edit_report_button.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<a class="btn btn-primary track-usage-link" id="edit-report-link"
+<a class="btn btn-primary track-usage-link" id="edit-report-link{{ report.html_id_suffix }}"
   {% if report.spec.report_meta.created_by_builder %}
    href="{% url 'edit_report_in_builder' domain report.report_config_id %}"
    data-category="Report Builder"


### PR DESCRIPTION
## Technical Summary

The Campaign Dashboard will feature multiple UCRs in the same page. To allow for that, this change makes the HTML IDs used in a rendered report unique by adding a suffix.

Jira: [SC-4384](https://dimagi.atlassian.net/browse/SC-4384)

Only UCRs have a suffix. The suffix for other reports is an empty string.

I have not modified `reports/js/bootstrap{3,5}/async.js`. It does not appear to be used by UCRs. (Where is it used?)

I have tried to ensure that all relevant IDs have been suffixed, but I couldn't think of a way to guarantee that I caught every single one.

The IDs of input fields have not been changed, to preserve how submitted form data is handled.

I used AI to parse the repo and determine the base templates used by all reports. It identified a few base templates that I have intentionally skipped:
* Mocha Test Templates: `corehq/apps/reports/templates/reports/spec/bootstrap{3,5}/mocha.html`
* Email Templates:
   + `corehq/apps/reports/templates/reports/async/email_report.html`
   + `corehq/apps/reports/templates/reports/email/report_list.html`
* MOTECH reports under the `corehq/motech/` directory.

## Feature Flag

No.

## Safety Assurance

### Safety story

Tested UCRs, Case List, Case List Explorer, Case Data and Form Data reports locally.

### Automated test coverage

No

### QA Plan

QA for Campaign Dashboard pending. I will ensure that checking reports across HQ is included.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-4384]: https://dimagi.atlassian.net/browse/SC-4384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ