### PR TITLE
Revert "Revert "Migration to invoke command for syncing couch and es webusers""

### DIFF
--- a/corehq/ex-submodules/pillowtop/migrations/0008_sync_es_with_couch_webusers.py
+++ b/corehq/ex-submodules/pillowtop/migrations/0008_sync_es_with_couch_webusers.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+from django.core.management import call_command
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def sync_couch_webusers_with_es(*args, **kwargs):
+    call_command('sync_es_webusers')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pillowtop', '0007_copy_xforms_checkpoint'),
+    ]
+
+    operations = [
+        migrations.RunPython(sync_couch_webusers_with_es)
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -828,6 +828,7 @@ pillowtop
  0005_kafkacheckpoint_doc_modification_time
  0006_add_geopoint_to_case_search_index
  0007_copy_xforms_checkpoint
+ 0008_sync_es_with_couch_webusers
 preindex
  0001_initial
  0002_initial


### PR DESCRIPTION
Reverts dimagi/commcare-hq#36037

Reintroduces the migration from this original [PR](https://github.com/dimagi/commcare-hq/pull/32864)