### PR TITLE
UCRs to use the report URL instead of `window.location`

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/standard_hq_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/standard_hq_report.js.diff.txt
@@ -20,7 +20,7 @@
      initialPageData,
      util,
      hqReportModule,
-@@ -56,7 +58,7 @@
+@@ -63,7 +65,7 @@
          var reportOptions = initialPageData.get('js_options') || {};
          if (reportOptions.slug && reportOptions.async) {
              let promise = $.Deferred();
@@ -29,7 +29,7 @@
                  var asyncHQReport = asyncHQReportModule({
                      standardReport: getStandard(),
                  });
-@@ -75,13 +77,19 @@
+@@ -82,13 +84,19 @@
      asyncReport = getAsync();
  
      $(function () {

--- a/corehq/apps/reports/static/reports/js/bootstrap3/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/hq_report.js
@@ -67,8 +67,8 @@ hqDefine("reports/js/bootstrap3/hq_report", [
                             e.preventDefault();
                             if (self.isExportAll) {
                                 $.ajax({
-                                    url: getReportBaseUrl("export"),
-                                    data: getReportParams(undefined),
+                                    url: self.getReportBaseUrl("export"),
+                                    data: self.getReportParams(undefined),
                                     type: "POST",
                                     success: function () {
                                         alertUser.alert_user(gettext("Your requested Excel report will be sent " +
@@ -200,7 +200,7 @@ hqDefine("reports/js/bootstrap3/hq_report", [
             if (params.includes('query_id=')) {
                 // getting the proper params for reports with obfuscated urls (Case List Explorer)
                 $.ajax({
-                    url: getReportBaseUrl('get_or_create_hash'),
+                    url: self.getReportBaseUrl('get_or_create_hash'),
                     type: 'POST',
                     dataType: 'json',
                     async: false,
@@ -227,8 +227,8 @@ hqDefine("reports/js/bootstrap3/hq_report", [
         }
 
         function getReportRenderUrl(renderType, additionalParams) {
-            var baseUrl = getReportBaseUrl(renderType);
-            var paramString = getReportParams(additionalParams);
+            var baseUrl = self.getReportBaseUrl(renderType);
+            var paramString = self.getReportParams(additionalParams);
             return baseUrl + "?" + paramString;
         }
 

--- a/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
@@ -28,9 +28,16 @@ hqDefine("reports/js/bootstrap3/standard_hq_report", [
         });
 
         if (initialPageData.get('override_report_render_url')) {
+            reportOptions.getReportBaseUrl = function (renderType) {
+                return reportOptions.url + "?format=" + renderType;
+            };
+            reportOptions.getReportParams = function () {
+                return util.urlSerialize($('#paramSelectorForm' + initialPageData.get('html_id_suffix')), ['format']);
+            };
             reportOptions.getReportRenderUrl = function (renderType) {
-                var params = util.urlSerialize($('#paramSelectorForm' + initialPageData.get('html_id_suffix')), ['format']);
-                return window.location.pathname + "?format=" + renderType + "&" + params;
+                var baseUrl = self.getReportBaseUrl(renderType);
+                var paramString = self.getReportParams();
+                return baseUrl + "&" + paramString;
             };
         }
 

--- a/corehq/apps/reports/static/reports/js/bootstrap5/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/hq_report.js
@@ -67,8 +67,8 @@ hqDefine("reports/js/bootstrap5/hq_report", [
                             e.preventDefault();
                             if (self.isExportAll) {
                                 $.ajax({
-                                    url: getReportBaseUrl("export"),
-                                    data: getReportParams(undefined),
+                                    url: self.getReportBaseUrl("export"),
+                                    data: self.getReportParams(undefined),
                                     type: "POST",
                                     success: function () {
                                         alertUser.alert_user(gettext("Your requested Excel report will be sent " +
@@ -200,7 +200,7 @@ hqDefine("reports/js/bootstrap5/hq_report", [
             if (params.includes('query_id=')) {
                 // getting the proper params for reports with obfuscated urls (Case List Explorer)
                 $.ajax({
-                    url: getReportBaseUrl('get_or_create_hash'),
+                    url: self.getReportBaseUrl('get_or_create_hash'),
                     type: 'POST',
                     dataType: 'json',
                     async: false,
@@ -227,8 +227,8 @@ hqDefine("reports/js/bootstrap5/hq_report", [
         }
 
         function getReportRenderUrl(renderType, additionalParams) {
-            var baseUrl = getReportBaseUrl(renderType);
-            var paramString = getReportParams(additionalParams);
+            var baseUrl = self.getReportBaseUrl(renderType);
+            var paramString = self.getReportParams(additionalParams);
             return baseUrl + "?" + paramString;
         }
 

--- a/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
@@ -30,9 +30,16 @@ hqDefine("reports/js/bootstrap5/standard_hq_report", [
         });
 
         if (initialPageData.get('override_report_render_url')) {
+            reportOptions.getReportBaseUrl = function (renderType) {
+                return reportOptions.url + "?format=" + renderType;
+            };
+            reportOptions.getReportParams = function () {
+                return util.urlSerialize($('#paramSelectorForm' + initialPageData.get('html_id_suffix')), ['format']);
+            };
             reportOptions.getReportRenderUrl = function (renderType) {
-                var params = util.urlSerialize($('#paramSelectorForm' + initialPageData.get('html_id_suffix')), ['format']);
-                return window.location.pathname + "?format=" + renderType + "&" + params;
+                var baseUrl = self.getReportBaseUrl(renderType);
+                var paramString = self.getReportParams();
+                return baseUrl + "&" + paramString;
             };
         }
 

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -378,6 +378,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             "isExportAll": self.exportable_all,
             "isEmailable": False,       # see emailable attr above
             "emailDefaultSubject": self.title,
+            "url": self.url,  # Used with {% initial_page_data 'override_report_render_url' True %}
         }
 
     def pop_report_builder_context_data(self):


### PR DESCRIPTION
## Technical Summary

The Campaign Dashboard will feature multiple UCRs in the same page. Currently reports use `window.location` to fetch their filters and data.

This change makes UCRs use their report view URL instead of `window.location`.

Jira: [SC-4385](https://dimagi.atlassian.net/browse/SC-4385)

(At the time this PR is opened, the base branch is `nh/dash/report_ids`.)

## Feature Flag

N/A

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

No

### QA Plan

QA for Campaign Dashboard pending.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-4385]: https://dimagi.atlassian.net/browse/SC-4385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ