### PR TITLE
Upgrade kafka-python==2.1.4

### DIFF
--- a/corehq/apps/change_feed/connection.py
+++ b/corehq/apps/change_feed/connection.py
@@ -6,16 +6,6 @@ from kafka import KafkaClient, KafkaConsumer
 GENERIC_KAFKA_CLIENT_ID = 'cchq-kafka-client'
 
 
-def get_simple_kafka_client(client_id=GENERIC_KAFKA_CLIENT_ID):
-    from kafka.client import SimpleClient
-    # this uses the old SimpleClient because we are using the old SimpleProducer interface
-    return ClosingContextProxy(SimpleClient(
-        hosts=settings.KAFKA_BROKERS,
-        client_id=client_id,
-        timeout=30,  # seconds
-    ))
-
-
 def get_kafka_client(client_id=GENERIC_KAFKA_CLIENT_ID):
     return ClosingContextProxy(KafkaClient(
         bootstrap_servers=settings.KAFKA_BROKERS,

--- a/corehq/apps/change_feed/connection.py
+++ b/corehq/apps/change_feed/connection.py
@@ -1,13 +1,13 @@
 from django.conf import settings
 
 from corehq.util.io import ClosingContextProxy
-from kafka import KafkaConsumer
-from kafka.client import KafkaClient, SimpleClient
+from kafka import KafkaClient, KafkaConsumer
 
 GENERIC_KAFKA_CLIENT_ID = 'cchq-kafka-client'
 
 
 def get_simple_kafka_client(client_id=GENERIC_KAFKA_CLIENT_ID):
+    from kafka.client import SimpleClient
     # this uses the old SimpleClient because we are using the old SimpleProducer interface
     return ClosingContextProxy(SimpleClient(
         hosts=settings.KAFKA_BROKERS,

--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -4,8 +4,7 @@ from typing import Dict, Iterator, Optional
 
 from django.conf import settings
 
-from kafka import KafkaConsumer
-from kafka.common import TopicPartition
+from kafka import KafkaConsumer, TopicPartition
 
 from corehq.form_processor.document_stores import UnexpectedBackend
 from dimagi.utils.logging import notify_error

--- a/corehq/apps/change_feed/management/commands/create_kafka_topics.py
+++ b/corehq/apps/change_feed/management/commands/create_kafka_topics.py
@@ -1,7 +1,7 @@
 from django.core.management import BaseCommand
 
 from corehq.apps.change_feed import topics
-from corehq.apps.change_feed.connection import get_simple_kafka_client
+from corehq.apps.change_feed.connection import get_kafka_client
 
 
 class Command(BaseCommand):
@@ -11,11 +11,17 @@ class Command(BaseCommand):
 
 
 def create_kafka_topics():
-    with get_simple_kafka_client() as client:
+    # Use async client rather than admin client because the latter
+    # has no public API for automatic topic creation.
+    with get_kafka_client() as client:
+        client.poll(future=client.cluster.request_update())
+        new_topics = set(topics.ALL) - client.cluster.topics()
+        if new_topics:
+            future = client.set_topics(new_topics)
+            client.poll(future=future)
+            if not future.succeeded():
+                assert future.is_done
+                raise future.exception
         for topic in topics.ALL:
-            if client.has_metadata_for_topic(topic):
-                status = "already exists"
-            else:
-                client.ensure_topic_exists(topic, timeout=10)
-                status = "created"
-            print("topic {}: {}".format(status, topic))
+            status = "created" if topic in new_topics else "already exists"
+            print(f"topic {status}: {topic}")

--- a/corehq/apps/change_feed/tests/test_connection.py
+++ b/corehq/apps/change_feed/tests/test_connection.py
@@ -1,0 +1,11 @@
+from django.test import SimpleTestCase, override_settings
+
+from corehq.apps.change_feed.connection import get_kafka_client
+
+
+class TestKafkaConnection(SimpleTestCase):
+
+    @override_settings(KAFKA_API_VERSION=(3, 2, 3))
+    def test_get_kafka_client_with_api_version(self):
+        with get_kafka_client() as client:
+            client.poll()  # should not raise

--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -35,7 +35,7 @@ class ChangeFeedPillowTest(SimpleTestCase):
         self.consumer = KafkaConsumer(
             topics.CASE_SQL,
             bootstrap_servers=settings.KAFKA_BROKERS,
-            consumer_timeout_ms=100,
+            consumer_timeout_ms=500,
             enable_auto_commit=False,
         )
         try:

--- a/corehq/apps/change_feed/tests/utils.py
+++ b/corehq/apps/change_feed/tests/utils.py
@@ -16,7 +16,7 @@ def get_test_kafka_consumer(*topics):
     with trap_extra_setup(KafkaUnavailableError):
         configs = {
             'bootstrap_servers': settings.KAFKA_BROKERS,
-            'consumer_timeout_ms': 100,
+            'consumer_timeout_ms': 500,
             'enable_auto_commit': False,
         }
         consumer = KafkaConsumer(*topics, **configs)

--- a/corehq/apps/change_feed/tests/utils.py
+++ b/corehq/apps/change_feed/tests/utils.py
@@ -3,7 +3,7 @@ import uuid
 from django.conf import settings
 
 from kafka import KafkaConsumer
-from kafka.common import KafkaUnavailableError
+from kafka.errors import KafkaUnavailableError
 from nose.tools import nottest
 
 from corehq.util.test_utils import trap_extra_setup

--- a/corehq/apps/change_feed/tests/utils.py
+++ b/corehq/apps/change_feed/tests/utils.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.conf import settings
 
 from kafka import KafkaConsumer

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -1,5 +1,3 @@
-from kafka.common import OffsetRequestPayload
-
 from corehq.apps.app_manager.util import app_doc_types
 from corehq.apps.change_feed.connection import get_simple_kafka_client
 from corehq.apps.change_feed.exceptions import UnavailableKafkaOffset
@@ -93,6 +91,7 @@ def _get_topic_offsets(topics, latest):
     :param latest: True to fetch latest offsets, False to fetch earliest available
     :return: dict: { (topic, partition): offset, ... }
     """
+    from kafka.structs import OffsetRequestPayload  # not available in kafka-python>=2
 
     # https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetRequest
     # https://cfchou.github.io/blog/2015/04/23/a-closer-look-at-kafka-offsetrequest/

--- a/corehq/ex-submodules/pillow_retry/tests/test_retry.py
+++ b/corehq/ex-submodules/pillow_retry/tests/test_retry.py
@@ -48,7 +48,7 @@ class CouchPillowRetryProcessingTest(TestCase, TestMixin):
             topics.CASE_SQL,
             client_id='test-consumer',
             bootstrap_servers=settings.KAFKA_BROKERS,
-            consumer_timeout_ms=100,
+            consumer_timeout_ms=500,
             enable_auto_commit=False,
         )
         try:

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -48,8 +48,8 @@ class PillowCheckpoint(object):
 
     def get_or_create_wrapped(self, verify_unchanged=False):
         checkpoint = get_or_create_checkpoint(self.checkpoint_id, self.sequence_format)
-        if (verify_unchanged and self._last_checkpoint and
-                str(checkpoint.sequence) != str(self._last_checkpoint.sequence)):
+        if (verify_unchanged and self._last_checkpoint
+                and str(checkpoint.sequence) != str(self._last_checkpoint.sequence)):
             raise PillowtopCheckpointReset('Checkpoint {} expected seq {} but found {} in database.'.format(
                 self.checkpoint_id, self._last_checkpoint.sequence, checkpoint.sequence,
             ))

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.db import transaction
-from kafka.common import TopicPartition
+from kafka import TopicPartition
 
 from pillowtop.exceptions import PillowtopCheckpointReset
 from pillowtop.logger import pillow_logging

--- a/corehq/ex-submodules/pillowtop/models.py
+++ b/corehq/ex-submodules/pillowtop/models.py
@@ -1,6 +1,6 @@
 import json
 from django.db import models
-from kafka.common import TopicPartition
+from kafka import TopicPartition
 
 SEQUENCE_FORMATS = (
     ('text', 'text'),

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -12,7 +12,7 @@ from corehq.util.metrics import metrics_counter, metrics_gauge
 from corehq.util.metrics.const import MPM_MAX
 from corehq.util.timer import TimingContext
 from dimagi.utils.logging import notify_exception
-from kafka.common import TopicPartition
+from kafka import TopicPartition
 from pillowtop.const import CHECKPOINT_MIN_WAIT
 from pillowtop.dao.exceptions import DocumentMissingError
 from pillowtop.utils import force_seq_int

--- a/corehq/util/io.py
+++ b/corehq/util/io.py
@@ -1,6 +1,6 @@
 
 
-class ClosingContextProxy(object):
+class ClosingContextProxy:
     """Context manager wrapper for object with close() method
 
     Calls `wrapped_object.close()` on exit context.
@@ -16,7 +16,7 @@ class ClosingContextProxy(object):
         return iter(self._obj)
 
     def __enter__(self):
-        return self
+        return self._obj
 
     def __exit__(self, *args):
         self._obj.close()

--- a/corehq/util/tests/test_io.py
+++ b/corehq/util/tests/test_io.py
@@ -12,3 +12,13 @@ class TestClosingContextProxy(TestCase):
             tmp.seek(0)
             proxy = corehq.util.io.ClosingContextProxy(tmp)
             self.assertEqual(list(proxy), ["line 1\n", "line 2\n"])
+
+    def test_context_identity(self):
+        class Closeable:
+            def close(self):
+                self.closed = True
+
+        obj = Closeable()
+        with corehq.util.io.ClosingContextProxy(obj) as context:
+            assert obj is context
+        assert obj.closed

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -345,7 +345,7 @@ jsonschema==4.17.3
     # via -r base-requirements.in
 jwcrypto==1.5.6
     # via django-oauth-toolkit
-kafka-python==1.4.7
+kafka-python==2.1.4
     # via -r base-requirements.in
 kombu==5.2.4
     # via celery

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -291,7 +291,7 @@ jsonschema==4.17.3
     # via -r base-requirements.in
 jwcrypto==1.5.6
     # via django-oauth-toolkit
-kafka-python==1.4.7
+kafka-python==2.1.4
     # via -r base-requirements.in
 kombu==5.2.4
     # via celery

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -293,7 +293,7 @@ jsonschema==4.17.3
     # via -r base-requirements.in
 jwcrypto==1.5.6
     # via django-oauth-toolkit
-kafka-python==1.4.7
+kafka-python==2.1.4
     # via -r base-requirements.in
 kombu==5.2.4
     # via celery

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -275,7 +275,7 @@ jsonschema==4.17.3
     # via -r base-requirements.in
 jwcrypto==1.5.6
     # via django-oauth-toolkit
-kafka-python==1.4.7
+kafka-python==2.1.4
     # via -r base-requirements.in
 kombu==5.2.4
     # via celery

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -295,7 +295,7 @@ jsonschema==4.17.3
     # via -r base-requirements.in
 jwcrypto==1.5.6
     # via django-oauth-toolkit
-kafka-python==1.4.7
+kafka-python==2.1.4
     # via -r base-requirements.in
 kombu==5.2.4
     # via celery

--- a/testapps/test_pillowtop/tests/test_chunk_pillow.py
+++ b/testapps/test_pillowtop/tests/test_chunk_pillow.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.test import TestCase
-from kafka.common import KafkaUnavailableError
+from kafka.errors import KafkaUnavailableError
 from unittest.mock import MagicMock
 
 from corehq.apps.change_feed import topics


### PR DESCRIPTION
Version bump for Python 3.13 compatibility. Reviewed [change log](https://kafka-python.readthedocs.io/en/2.1.1/changelog.html) and [recent issues](https://github.com/dpkp/kafka-python/issues) (no concerns).

Some refactoring was needed to support v2. In general the refactored code should be more efficient.

## Safety Assurance

### Safety story

Major version update with some non-trivial refactoring required. Planning to test on staging.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.