### PR TITLE
[Data Cleaning] Fix TypeError that QA noticed when loading non-data dictionary domain

### DIFF
--- a/corehq/apps/data_cleaning/urls.py
+++ b/corehq/apps/data_cleaning/urls.py
@@ -10,6 +10,7 @@ from corehq.apps.data_cleaning.views.filters import (
 from corehq.apps.data_cleaning.views.main import (
     CleanCasesMainView,
     CleanCasesSessionView,
+    clear_session_caches,
     download_form_ids,
     save_case_session,
 )
@@ -35,6 +36,8 @@ urlpatterns = [
         name=PinnedFilterFormView.urlname),
     url(r'^session/(?P<session_id>[\w\-]+)/columns/$', ManageColumnsFormView.as_view(),
         name=ManageColumnsFormView.urlname),
+    url(r'^session/(?P<session_id>[\w\-]+)/clear/$', clear_session_caches,
+        name="data_cleaning_clear_session_caches"),
     url(r'^cases/save/(?P<session_id>[\w\-]+)/$', save_case_session, name='save_case_session'),
     url(r'^form_ids/(?P<session_id>[\w\-]+)/$', download_form_ids, name='download_form_ids'),
 ]

--- a/corehq/apps/data_cleaning/utils/cases.py
+++ b/corehq/apps/data_cleaning/utils/cases.py
@@ -26,6 +26,11 @@ def clear_caches_case_data_cleaning(domain, case_type=None):
     for case_type in case_types:
         all_case_properties_by_domain.clear(
             domain=domain,
+            include_parent_properties=False,
+            exclude_deprecated_properties=False,
+        )
+        get_case_property_details.clear(
+            domain=domain,
             case_type=case_type,
         )
 

--- a/corehq/apps/data_cleaning/utils/cases.py
+++ b/corehq/apps/data_cleaning/utils/cases.py
@@ -91,7 +91,7 @@ def _get_data_type_from_data_dictionary(case_property):
 
 
 def _get_default_label(prop_id):
-    return prop_id.replace('_', ' ').title
+    return prop_id.replace('_', ' ').title()
 
 
 def _get_property_details_from_data_dictionary(domain, case_type):

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -13,6 +13,7 @@ from django.utils.translation import gettext_lazy, gettext as _
 from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
 from corehq.apps.data_cleaning.models import BulkEditSession
 from corehq.apps.data_cleaning.tasks import commit_data_cleaning
+from corehq.apps.data_cleaning.utils.cases import clear_caches_case_data_cleaning
 from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
@@ -87,6 +88,15 @@ class CleanCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
         return {
             "session_id": self.session_id,
         }
+
+
+@login_and_domain_required
+@require_bulk_data_cleaning_cases
+def clear_session_caches(request, domain, session_id):
+    session = BulkEditSession.objects.get(session_id=session_id)
+    clear_caches_case_data_cleaning(session.domain, session.identifier)
+    messages.success(request, _("Caches successfully cleared."))
+    return redirect(reverse(CleanCasesMainView.urlname, args=(domain,)))
 
 
 @login_and_domain_required


### PR DESCRIPTION
## Technical Summary
A `TypeError` was being thrown for domains that didn't have a label value set for a particular case property in the data dictionary. I didn't notice this in local testing because I had completely filled out the data dictionary for my cases in the testing domain.

https://dimagi.atlassian.net/browse/SAAS-16828

When we retrieve a property that doesn't have a label set in the data dictionary, we create a default label, which returns `label.title` on the final label string, when it should be calling `label.title()`. Because `title` returns a method and not a string, the `json.dumps` call wrapping the final alpine data model errors out as it includes these default labels returning `label.title`. The result is a `TypeError` every time the views for `AddFilterForm` and `AddColumnForm` were retrieved by an HTMX request.

Whoops. This is a problem easily avoided by proper tests, which I intentionally delayed creating due to time constraint pressures. I have created a spin off issue to ensure I don't forget to create these tests once the core of this feature is complete. https://dimagi.atlassian.net/browse/SAAS-16853

Additionally, this PR fixes an issue clearing caches related to a case session, and it creates a URL for support (or myself) to go to and manually clear those related caches for a given session.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change that fixes an error behind a feature flag

### Automated test coverage
most important functionality for the feature is already tested, and there is a followup test that will be created once pressure season has simmered down.

### QA Plan
Not needed yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
