### PR TITLE
Improve basic HTMX error template

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_base.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_base.js
@@ -44,6 +44,7 @@ document.body.addEventListener('htmx:responseError', (evt) => {
             showHtmxErrorModal(
                 errorCode,
                 gettext('Gateway Timeout Error. Max retries exceeded.'),
+                evt,
             );
         }
         return;
@@ -51,6 +52,7 @@ document.body.addEventListener('htmx:responseError', (evt) => {
     showHtmxErrorModal(
         errorCode,
         evt.detail.xhr.statusText,
+        evt,
     );
 });
 
@@ -66,6 +68,7 @@ document.body.addEventListener('htmx:timeout', (evt) => {
         showHtmxErrorModal(
             HTTP_REQUEST_TIMEOUT,
             gettext('Request timed out. Max retries exceeded.'),
+            evt,
         );
     }
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/errors.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/errors.js
@@ -11,9 +11,10 @@ const DEFAULT_MODAL_ID = 'htmxRequestErrorModal';
  *
  * @param {number} errorCode - The HTTP error code representing the type of error.
  * @param {string} errorText - A descriptive error message to display in the modal.
+ * @param {CustomEvent} errorEvent - The event related to the error.
  * @param {string} [errorModalId=DEFAULT_MODAL_ID] - The ID of the modal element in the DOM (default is `DEFAULT_MODAL_ID`).
  */
-const showHtmxErrorModal = (errorCode, errorText, errorModalId = DEFAULT_MODAL_ID) => {
+const showHtmxErrorModal = (errorCode, errorText, errorEvent, errorModalId = DEFAULT_MODAL_ID) => {
     const modalElem = document.getElementById(errorModalId);
     if (!modalElem) {return;} // Exit if modal element is not found
 
@@ -22,6 +23,8 @@ const showHtmxErrorModal = (errorCode, errorText, errorModalId = DEFAULT_MODAL_I
         detail: {
             errorCode: errorCode,
             errorText: errorText,
+            eventError: errorEvent.detail.error || gettext("Unknown Event"),
+            requestPath: (errorEvent.detail.pathInfo) ? errorEvent.detail.pathInfo.requestPath : gettext("Unknown Path"),
         },
     }));
     errorModal.show();

--- a/corehq/apps/hqwebapp/templates/hqwebapp/htmx/error_modal.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/htmx/error_modal.html
@@ -9,9 +9,13 @@
     x-data="{
       errorCode: '',
       errorText: '',
+      eventError: '',
+      requestPath: '',
       updateError(evt) {
         this.errorCode = evt.detail.errorCode;
         this.errorText = evt.detail.errorText;
+        this.eventError = evt.detail.eventError;
+        this.requestPath = evt.detail.requestPath;
       },
     }"
     @update-htmx-request-error-modal.camel.window="updateError"
@@ -30,7 +34,7 @@
         >
 
           {% block modal_title %}
-            {% trans "Server Error Encountered" %}
+            {% trans "HTMX Request: Server Error Encountered" %}
           {% endblock %}
 
         </h5>
@@ -46,6 +50,20 @@
         {% block modal_content %}
           <p x-text="errorCode"></p>
           <p x-text="errorText"></p>
+          <div
+            class="card"
+            x-show="eventError && requestPath"
+          >
+            <div class="card-body">
+              <h5>{% trans "Additional Details" %}</h5>
+              <dl>
+                <dt>{% trans "HTMX Event Error" %}</dt>
+                <dd x-text="eventError"></dd>
+                <dt>{% trans "Request Path" %}</dt>
+                <dd x-text="requestPath"></dd>
+              </dl>
+            </div>
+          </div>
         {% endblock %}
 
       </div>


### PR DESCRIPTION
## Technical Summary
This improves the default template for HTMX errors so that it's clearer to QA that the error is coming from an HTMX request and not an action that they are taking on a page. It also includes some additional details to assist with debugging.
<img width="536" alt="Screenshot 2025-03-24 at 1 36 54 PM" src="https://github.com/user-attachments/assets/2ca7f981-8e5c-42ac-b244-e7d085ef8b98" />

## Safety Assurance

### Safety story
improves an error template, just JS and html additions. Tested locally

### Automated test coverage
no

### QA Plan
not needed. small enough and clear enough change

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
