### PR TITLE
Added missing dependencies to case_knockout_bindings.js

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
@@ -3,6 +3,8 @@ hqDefine("app_manager/js/forms/case_knockout_bindings", [
     'knockout',
     'underscore',
     'DOMPurify/dist/purify.min',
+    'hqwebapp/js/atwho',    // autocompleteAtwho
+    'select2/dist/js/select2.full.min',
 ], function (
     $,
     ko,


### PR DESCRIPTION
## Technical Summary
Cherry pick from app manager webpack migration.

## Safety Assurance

### Safety story
Pretty trivial. Tested locally that form settings still loads fine and case property dropdowns work.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
