### PR TITLE
Added references to root in releases_table.html

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -37,7 +37,7 @@
       <a class="btn btn-default" data-bind="
                 attr: {href: compareUnbuiltChangesUrl},
                 visible: savedApps().length,
-                click: function () { return trackClick('Compare App Versions: Clicked Version Preview'); }
+                click: function () { return $root.trackClick('Compare App Versions: Clicked Version Preview'); }
                 ">
         <i class="fa-solid fa-right-left"></i>
         {% trans "Preview" %}
@@ -51,7 +51,7 @@
     {% endif %}
     <button class="btn btn-primary" data-bind="
             click: function() {
-              trackClick('Clicked Make New Version');
+              $root.trackClick('Clicked Make New Version');
               return makeNewBuild();
             },
             attr: {disabled: !buildButtonEnabled() ? 'disabled' : undefined},
@@ -156,7 +156,7 @@
             <button type="button"
                     class="btn btn-xs"
                     data-bind="click: $root.toggleRelease,
-                                attr: {disabled: !showReleaseOperations()},
+                                attr: {disabled: !$root.showReleaseOperations()},
                                            css: {
                                               'active': is_released(),
                                               'btn-primary': is_released(),
@@ -167,7 +167,7 @@
             <button type="button"
                     class="btn btn-xs btn-default"
                     data-bind="click: $root.toggleRelease,
-                                attr: {disabled: !showReleaseOperations()},
+                                attr: {disabled: !$root.showReleaseOperations()},
                                            css: {
                                               'active': !is_released(),
                                               'btn-primary': !is_released(),
@@ -220,7 +220,7 @@
                             $data.id())
                           },
                     click: function () {
-                        return trackClick('Compare App Versions: Clicked View Changes');
+                        return $root.trackClick('Compare App Versions: Clicked View Changes');
                     }
                     visible: $parent.previousBuildId($index())">
             <i class="fa-solid fa-right-left"></i>


### PR DESCRIPTION
## Technical Summary
Cherry pick from app manager webpack migration. I don't know why, but with webpack turned on, these bindings fail unless `$root` is explicitly specified. Without webpack on, they work with or without `$root`.

## Safety Assurance

### Safety story
Quite minor. Tested locally.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
