### PR TITLE
Removed redundant metric in case import

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -31,7 +31,7 @@ from corehq.toggles import (
     DOMAIN_PERMISSIONS_MIRROR,
     MTN_MOBILE_WORKER_VERIFICATION,
 )
-from corehq.util.metrics import metrics_counter, metrics_histogram
+from corehq.util.metrics import metrics_histogram
 from corehq.util.metrics.load_counters import case_load_counter
 from corehq.util.soft_assert import soft_assert
 from corehq.util.timer import TimingContext
@@ -377,11 +377,6 @@ class _TimedAndThrottledImporter:
             'commcare.case_importer.duration_per_case', active_duration_per_case,
             buckets=[50, 70, 100, 150, 250, 350, 500], bucket_tag='duration', bucket_unit='ms',
         )
-
-        for rows, status in ((rows_created, 'created'),
-                             (rows_updated, 'updated'),
-                             (rows_failed, 'error')):
-            metrics_counter("commcare.case_importer.cases", rows, tags={"status": status, "domain": self.domain})
 
 
 class SubmitCaseBlockHandler:


### PR DESCRIPTION
## Technical Summary
After the fix in https://github.com/dimagi/commcare-hq/pull/35940, this is no longer providing unique information.

## Safety Assurance

### Safety story
Quite safe, just removes a few lines of code that nothing else depends on.

### Automated test coverage

I think so, case importer has test coverage.

### QA Plan

no


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
