### PR TITLE
Remove growth email from invoice reminder bcc

### DIFF
--- a/corehq/apps/accounting/utils/unpaid_invoice.py
+++ b/corehq/apps/accounting/utils/unpaid_invoice.py
@@ -132,10 +132,8 @@ class InvoiceReminder(UnpaidInvoiceAction):
     def _send_reminder_email(invoice, communication_model, context):
         if invoice.is_customer_invoice:
             account_name = invoice.account.name
-            bcc = None
         else:
             account_name = invoice.get_domain()
-            bcc = [settings.GROWTH_EMAIL]
 
         subject = _(
             "Your CommCare Billing Statement for {account_name} is due in {num_days} days"
@@ -147,7 +145,6 @@ class InvoiceReminder(UnpaidInvoiceAction):
             render_to_string('accounting/email/invoice_reminder.html', context),
             render_to_string('accounting/email/invoice_reminder.txt', context),
             cc=[settings.ACCOUNTS_EMAIL],
-            bcc=bcc,
             email_from=get_dimagi_from_email())
         communication_model.objects.create(
             invoice=invoice,


### PR DESCRIPTION
## Product Description
Reduce the number of emails sent to internal users via the `GROWTH_EMAIL` group.

## Technical Summary
When adding the invoice reminder, I copied over the same conditionals from the "overdue" or "downgrade" invoice emails to send these too. However, because significantly more customers allow their invoices to get _close to_ the due date than become overdue, this has been very noisy for those who are part of this email group. Given an invoice "due soon" is not a state that requires immediate attention from internal staff, it is better to remove that group from these emails.

## Safety Assurance

### Safety story
Simple change to remove BCC email addresses from the InvoiceReminder email, should be minimal/no risk.

### Automated test coverage
`TestInvoiceReminder`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
