### PR TITLE
Visual change for case management

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
@@ -19,8 +19,6 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
 
         var CaseConfig = function (params) {
             var self = {};
-            self.title = gettext("Save Questions to Case Properties");
-
             self.trackGoogleEvent = function () {
                 hqImport('analytix/js/google').track.event(...arguments);
             };

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -483,6 +483,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
 
         var caseTransaction = function (data, caseConfig, hasPrivilege) {
             data.title = gettext("Save Questions to Case Properties");
+            data.type = 'case-property';
             var self = baseTransaction(caseTransactionMapping, caseConfig.saveButton, 'Form Level', data, caseConfig, hasPrivilege);
 
             self.case_type(self.case_type() || caseConfig.caseType);
@@ -508,6 +509,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
 
         var usercaseTransaction = function (data, caseConfig) {
             data.title = gettext("Save Questions to User Properties");
+            data.type = 'user-property';
             var self = baseTransaction(usercaseTransactionMapping, caseConfig.saveUsercaseButton, 'User Case Management', data, caseConfig, true);
 
             self.case_type = function () {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -482,7 +482,6 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
         };
 
         var caseTransaction = function (data, caseConfig, hasPrivilege) {
-            data.title = gettext("Save Questions to Case Properties");
             data.type = 'case-property';
             var self = baseTransaction(caseTransactionMapping, caseConfig.saveButton, 'Form Level', data, caseConfig, hasPrivilege);
 
@@ -508,7 +507,6 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
 
 
         var usercaseTransaction = function (data, caseConfig) {
-            data.title = gettext("Save Questions to User Properties");
             data.type = 'user-property';
             var self = baseTransaction(usercaseTransactionMapping, caseConfig.saveUsercaseButton, 'User Case Management', data, caseConfig, true);
 

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -77,7 +77,7 @@
 {% block pre_form_content %}
   <div class="appmanager-page-actions">
     {% include 'app_manager/partials/app_summary_button.html' %}
-    <a class="btn btn-primary" href="{% url "form_source" domain app.id form.unique_id %}">
+    <a class="btn btn-default" href="{% url "form_source" domain app.id form.unique_id %}">
       <i class="fa fa-pencil"></i> {% trans "Edit Form" %}
     </a>
   </div>

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -6,7 +6,8 @@
 
 {% block title %}{# controlled by app_manager/js/form_view.js #}{% endblock %}
 
-{% block stylesheets %}{{ block.super }}
+{% block stylesheets %}
+  {{ block.super }}
   <style>
     .nodeset {
       min-width: 400px;
@@ -14,13 +15,15 @@
   </style>
 {% endblock %}
 
-{% block js %}{{ block.super }}
+{% block js %}
+  {{ block.super }}
   {% compress js %}
     <script src="{% static 'app_manager/js/forms/form_view.js' %}"></script>
   {% endcompress %}
 {% endblock %}
 
-{% block js-inline %}{{ block.super }}
+{% block js-inline %}
+  {{ block.super }}
   {% compress js %}
     <script src="{% static 'app_manager/js/forms/case_knockout_bindings.js' %}"></script>
     <script src="{% static 'app_manager/js/case_config_utils.js' %}"></script>
@@ -53,7 +56,6 @@
   {% compress js %}
     <script src="{% static 'cloudcare/js/formplayer/utils/utils.js' %}"></script>
   {% endcompress %}
-
   {% include "app_manager/partials/xpathValidator.html" %}
   {% compress js %}
     <script src="{% static 'hqmedia/js/uploaders.js' %}"></script>
@@ -62,7 +64,7 @@
     <script src="{% static 'app_manager/js/nav_menu_media.js' %}"></script>
     <script src="{% static 'app_manager/js/forms/form_workflow.js' %}"></script>
   {% endcompress %}
-  {% if request|toggle_enabled:"CUSTOM_INSTANCES"%}
+  {% if request|toggle_enabled:"CUSTOM_INSTANCES" %}
     {% compress js %}
       <script src="{% static 'app_manager/js/forms/custom_instances.js' %}"></script>
     {% endcompress %}
@@ -77,7 +79,10 @@
 {% block pre_form_content %}
   <div class="appmanager-page-actions">
     {% include 'app_manager/partials/app_summary_button.html' %}
-    <a class="btn btn-default" href="{% url "form_source" domain app.id form.unique_id %}">
+    <a
+      class="btn btn-default"
+      href="{% url "form_source" domain app.id form.unique_id %}"
+    >
       <i class="fa fa-pencil"></i> {% trans "Edit Form" %}
     </a>
   </div>
@@ -97,7 +102,8 @@
   </div>
 
   <div class="appmanager-edit-description">
-    <inline-edit params="
+    <inline-edit
+      params="
           name: 'comment',
           id:'comment-id',
           value: '{{ form.comment|escapejs }}',
@@ -106,7 +112,8 @@
           saveValueName: 'comment',
           cols: 50,
           disallow_edit: {{ request.couch_user.can_edit_apps|yesno:"false,true" }},
-      "></inline-edit>
+      "
+    ></inline-edit>
   </div>
 
   <div id="build_errors"></div>
@@ -157,10 +164,13 @@
 
   <div class="tabbable appmanager-tabs-container">
     <ul class="nav nav-tabs sticky-tabs">
-
       {% if form.uses_cases %}
         <li>
-          <a id="case-configuration-tab" href="#case-configuration" data-toggle="tab">
+          <a
+            id="case-configuration-tab"
+            href="#case-configuration"
+            data-toggle="tab"
+          >
             {% trans "Case Management" %}
           </a>
         </li>
@@ -172,7 +182,11 @@
 
       {% if form.form_type == 'module_form' %}{% if allow_usercase or form.uses_usercase %}
         <li>
-          <a id="usercase-configuration-tab" href="#usercase-configuration" data-toggle="tab">
+          <a
+            id="usercase-configuration-tab"
+            href="#usercase-configuration"
+            data-toggle="tab"
+          >
             {% trans "User Properties" %}
           </a>
         </li>
@@ -198,7 +212,6 @@
     {% include 'app_manager/partials/forms/case_config_ko_templates.html' %}
 
     <div class="tab-content appmanager-tab-content">
-
       {% if form.uses_cases %}
         <div class="tab-pane" id="case-configuration">
           {% if xform_validation_missing %}
@@ -210,12 +223,24 @@
             <div class="alert alert-warning">
               {% trans "You are viewing a shadow form, therefore:" %}
               <ul>
-                <li>{% trans 'You will be unable to add "Open case" action' %}</li>
-                <li>{% trans 'Load/Update actions will be "merged" with the source form actions'%}</li>
-                <li>{% trans 'Every case tag in the source form load/update action configuration must appear in this configuration'%}</li>
-                <li>{% trans 'You are not allowed to specify load or save case properties'%}</li>
-                <li>{% trans 'The load and save case property behaviors specified in the shadow source form actions will be used for the actions with matching case tags specified here.'%}</li>
-                <li>{% trans 'You are not allowed to specify case closures here'%}</li>
+                <li>
+                  {% trans 'You will be unable to add "Open case" action' %}
+                </li>
+                <li>
+                  {% trans 'Load/Update actions will be "merged" with the source form actions' %}
+                </li>
+                <li>
+                  {% trans 'Every case tag in the source form load/update action configuration must appear in this configuration' %}
+                </li>
+                <li>
+                  {% trans 'You are not allowed to specify load or save case properties' %}
+                </li>
+                <li>
+                  {% trans 'The load and save case property behaviors specified in the shadow source form actions will be used for the actions with matching case tags specified here.' %}
+                </li>
+                <li>
+                  {% trans 'You are not allowed to specify case closures here' %}
+                </li>
               </ul>
             </div>
           {% endif %}
@@ -240,11 +265,9 @@
         </div>
       {% endif %}
 
-
       {% if nav_form %}
         {% include "app_manager/partials/forms/form_tab_settings.html" %}
       {% endif %}
-
 
       {% if form.form_type == 'module_form' %}{% if allow_usercase or form.uses_usercase %}
         <div class="tab-pane" id="usercase-configuration">
@@ -255,27 +278,39 @@
           {% elif form.source %}
             <div class="casexml" id="usercasexml_home">
               {% block usercase_management_content %}
-                {%  if form.uses_usercase and not allow_usercase %}
+                {% if form.uses_usercase and not allow_usercase %}
                   <div>
-                    <p>{% blocktrans %}
-                      The User Properties feature is no longer available because of the change in your
-                      CommCare subscription. Although currently-deployed applications will still
-                      function properly, it will not be possible to update or redeploy them unless
-                      the User Properties functionality is removed, or you upgrade your CommCare
-                      subscription.
-                    {% endblocktrans %}</p>
+                    <p>
+                      {% blocktrans %}
+                        The User Properties feature is no longer available
+                        because of the change in your CommCare subscription.
+                        Although currently-deployed applications will still
+                        function properly, it will not be possible to update or
+                        redeploy them unless the User Properties functionality
+                        is removed, or you upgrade your CommCare subscription.
+                      {% endblocktrans %}
+                    </p>
 
-                    <p class="alert alert-danger">{% blocktrans %}
-                      WARNING: By clicking "Remove User Properties" you will lose User Properties
-                      functionality if you redeploy your application. However, you will still be
-                      able to see all previously collected data.
-                    {% endblocktrans %}</p>
+                    <p class="alert alert-danger">
+                      {% blocktrans %}
+                        WARNING: By clicking "Remove User Properties" you will
+                        lose User Properties functionality if you redeploy your
+                        application. However, you will still be able to see all
+                        previously collected data.
+                      {% endblocktrans %}
+                    </p>
 
                     <p>
-                      <a href="{% url 'domain_select_plan' domain %}" class="btn btn-primary">
+                      <a
+                        href="{% url 'domain_select_plan' domain %}"
+                        class="btn btn-primary"
+                      >
                         {% trans "Change your subscription" %}
                       </a>
-                      <a href="{% url 'drop_usercase' domain app.id %}" class="btn btn-danger">
+                      <a
+                        href="{% url 'drop_usercase' domain app.id %}"
+                        class="btn btn-danger"
+                      >
                         {% trans "Remove User Properties" %}
                       </a>
                     </p>
@@ -293,7 +328,7 @@
       {% endif %}{% endif %}
 
       {% if form.form_type == 'advanced_form' or form.form_type == "shadow_form" %}
-        {% if module.has_schedule  %}
+        {% if module.has_schedule %}
           {% include "app_manager/partials/forms/form_tab_visit_scheduler.html" %}
         {% endif %}
       {% endif %}
@@ -305,7 +340,8 @@
   <div id="questions"></div>
 {% endblock %}
 
-{% block modals %}{{ block.super }}
+{% block modals %}
+  {{ block.super }}
   {% include "app_manager/partials/forms/form_view_modals.html" %}
   {% include "hqmedia/partials/multimedia_uploader.html" with id=multimedia.upload_managers.icon.slug type="image" %}
   {% include "hqmedia/partials/multimedia_uploader.html" with id=multimedia.upload_managers.audio.slug type="audio" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -200,8 +200,12 @@
         </div>
       </div>
       <i class="fa fa-arrow-right"></i><i class="fa fa-save"></i>
-      {# Location of title is different for regular and advanced forms #}
-      <!-- ko text: $data.title || $root.title --><!-- /ko -->
+      <!-- ko if: !$data.type || $data.type() == "case-property" -->
+      {% trans "Save Questions to Case Properties" %}
+      <!-- /ko -->
+      <!-- ko if: $data.type && $data.type() == "user-property" -->
+        {% trans "Save Questions to User Properties" %}
+      <!-- /ko -->
     </h4>
   </div>
   <div class="panel-body">

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -227,10 +227,10 @@
         </th>
         <th class="col-sm-1"></th>
         <th data-bind="class: saveOnlyEditedFormFieldsEnabled ? 'col-sm-3' : 'col-sm-4'">
-          <!-- ko if: $data.type() == "user-property" -->
+          <!-- ko if: $data.type && $data.type() == "user-property" -->
             {% trans "User Property" %}
           <!-- /ko -->
-          <!-- ko if: $data.type() == "case-property" -->
+          <!-- ko if: !$data.type || $data.type() == "case-property" -->
             {% trans "Case Property" %}
           <!-- /ko -->
         </th>
@@ -338,10 +338,10 @@
     <div class="add-property">
       <button class="btn btn-primary" data-bind="click: addProperty, visible: $parent.hasPrivilege">
         <i class="fa fa-plus"></i>
-        <!-- ko if: $data.type() == "case-property" -->
+        <!-- ko if: !$data.type || $data.type() == "case-property" -->
           {% trans "Add Case Property" %}
         <!-- /ko -->
-        <!-- ko if: $data.type() == "user-property" -->
+        <!-- ko if: $data.type && $data.type() == "user-property" -->
           {% trans "Add User Property" %}
         <!-- /ko -->
       </button>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -336,7 +336,7 @@
       {% trans "No properties will be saved" %}
     </div>
     <div class="add-property">
-      <button class="btn btn-default" data-bind="click: addProperty, visible: $parent.hasPrivilege">
+      <button class="btn btn-primary" data-bind="click: addProperty, visible: $parent.hasPrivilege">
         <i class="fa fa-plus"></i>
         <!-- ko if: $data.type() == "case-property" -->
           {% trans "Add Case Property" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -227,7 +227,12 @@
         </th>
         <th class="col-sm-1"></th>
         <th data-bind="class: saveOnlyEditedFormFieldsEnabled ? 'col-sm-3' : 'col-sm-4'">
-          {% trans "Case Property" %}
+          <!-- ko if: $data.type() == "user-property" -->
+            {% trans "User Property" %}
+          <!-- /ko -->
+          <!-- ko if: $data.type() == "case-property" -->
+            {% trans "Case Property" %}
+          <!-- /ko -->
         </th>
         {% comment %} The odd style additions in this block were necessary to put the question mark
         in line with the text when the text is both wrapped and unwrapped. {% endcomment %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -338,7 +338,12 @@
     <div class="add-property">
       <button class="btn btn-default" data-bind="click: addProperty, visible: $parent.hasPrivilege">
         <i class="fa fa-plus"></i>
-        {% trans "Add Property" %}
+        <!-- ko if: $data.type() == "case-property" -->
+          {% trans "Add Case Property" %}
+        <!-- /ko -->
+        <!-- ko if: $data.type() == "user-property" -->
+          {% trans "Add User Property" %}
+        <!-- /ko -->
       </button>
     </div>
     <!-- ko if: !case_properties().length && !$parent.hasPrivilege -->


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
- Make "Edit Form" a secondary button
<img width="636" alt="image" src="https://github.com/user-attachments/assets/0f5b255c-b873-4f96-8250-8b184d5072a3" />

- Make "Add Property" a primary button
- Change "Add Property" button to "Add Case Property" in Case Management tab, and to "Add User Property" in User Management Tab
<img width="953" alt="image" src="https://github.com/user-attachments/assets/7f5e7c99-0075-47b6-b95f-54cc22cd1b02" />

<img width="628" alt="image" src="https://github.com/user-attachments/assets/7a34f237-7068-490d-9fba-c3dc634fc274" />

- Change "Case Property" in User Management Tab to "User Property"
<img width="928" alt="image" src="https://github.com/user-attachments/assets/8638f6bd-c656-4be8-bda9-bddbd1d25b5f" />

In advanced form, say Case Property
<img width="553" alt="image" src="https://github.com/user-attachments/assets/c2f1baa0-9a5b-4dd4-92f0-9423f6f63f50" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-16782 and https://dimagi.atlassian.net/browse/SAAS-16848

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just some button style changes and text change. Tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
