### PR TITLE
Improve criteria for whether to send invoice reminder email

### DIFF
--- a/corehq/apps/accounting/tests/test_unpaid_invoice.py
+++ b/corehq/apps/accounting/tests/test_unpaid_invoice.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import patch
 
 from corehq.apps.accounting import tasks, utils
 from corehq.apps.accounting.const import (
@@ -238,13 +239,22 @@ class TestInvoiceReminder(BaseAccountingTest):
         super().tearDownClass()
 
     def _send_invoice_reminders(self, days_before_due, is_customer_billing_account=False):
+        domain, latest_invoice = self._setup_invoices(
+            days_before_due, is_customer_billing_account=is_customer_billing_account)
+        self._run_action()
+        return domain, latest_invoice
+
+    def _setup_invoices(self, days_before_due, is_customer_billing_account=False):
         domain, latest_invoice = _generate_invoice_and_subscription(
             -(days_before_due),
             is_customer_billing_account=is_customer_billing_account
         )
         self.domains.append(domain)
-        InvoiceReminder.run_action()
         return domain, latest_invoice
+
+    @staticmethod
+    def _run_action():
+        InvoiceReminder.run_action()
 
     def test_invoice_reminder(self):
         domain, latest_invoice = self._send_invoice_reminders(
@@ -278,6 +288,31 @@ class TestInvoiceReminder(BaseAccountingTest):
         domain, latest_invoice = self._send_invoice_reminders(
             DAYS_BEFORE_DUE_TO_TRIGGER_REMINDER + 1,
         )
+
+        self.assertFalse(InvoiceCommunicationHistory.objects.filter(
+            invoice=latest_invoice,
+            communication_type=CommunicationType.INVOICE_REMINDER,
+        ).exists())
+
+    def test_no_reminder_if_not_should_send_email(self):
+        with patch('corehq.apps.accounting.models.BillingRecord.should_send_email', False):
+            domain, latest_invoice = self._send_invoice_reminders(
+                DAYS_BEFORE_DUE_TO_TRIGGER_REMINDER,
+            )
+
+        self.assertFalse(InvoiceCommunicationHistory.objects.filter(
+            invoice=latest_invoice,
+            communication_type=CommunicationType.INVOICE_REMINDER,
+        ).exists())
+
+    def test_no_reminder_if_skipped_email(self):
+        domain, latest_invoice = self._setup_invoices(
+            DAYS_BEFORE_DUE_TO_TRIGGER_REMINDER,
+        )
+        billing_record = latest_invoice.billingrecord_set.first()
+        billing_record.skipped_email = True
+        billing_record.save()
+        self._run_action()
 
         self.assertFalse(InvoiceCommunicationHistory.objects.filter(
             invoice=latest_invoice,


### PR DESCRIPTION
## Technical Summary
This adds the criteria from the invoice's associated `BillingRecord` to the check for whether we should send an invoice reminder. Essentially, if we didn't send out the invoice in the first place, we shouldn't send this follow-up email. We'll send fewer invoice reminders this way, which is the goal. There may be a small performance hit for having to fetch the billing record instance in order to check its properties -- I don't think this is a major concern, but if it is, we could recreate the `should_send_email` logic on the `InvoiceReminder` class instead.

## Safety Assurance

### Safety story
This uses properties that already exist on the `BillingRecord` or `CustomerBillingRecord` as additional checks for whether to send emails. Also adds a couple of test cases for this.

### Automated test coverage
`TestInvoiceReminder`

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
