### PR TITLE
Tag sumologic log header correctly for staging env

### DIFF
--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -290,6 +290,7 @@ class SumoLogicLog(object):
 
         return data
 
+
 def clear_device_log_request(domain, xform):
     from corehq.apps.ota.models import DeviceLogRequest
     user_subreport = _get_logs(xform.form_data, 'user_subreport', 'user')

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -206,6 +206,8 @@ class SumoLogicLog(object):
             environment = 'india'
         if settings.SERVER_ENVIRONMENT == 'production':
             environment = 'prod'
+        if settings.SERVER_ENVIRONMENT == 'staging':
+            environment = 'staging'
 
         header = "{env}/{domain}/{fmt}".format(env=environment, domain=self.domain, fmt=fmt)
         return {"X-Sumo-Category": header}


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
@avazirna was trying to enable sumologic logs for staging and while looking at the code I realised that it is not correctly tagged. So the PR correctly tags the logs coming in from staging env.


## Safety Assurance
Very safe change. Only affects logs going to sumologic from staging
<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
