### PR TITLE
Combine maps & reports

### DIFF
--- a/corehq/apps/campaign/models.py
+++ b/corehq/apps/campaign/models.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from jsonfield.fields import JSONField
 
 from corehq.apps.userreports.models import ReportConfiguration
+from corehq.util.view_utils import absolute_reverse
 
 
 class Dashboard(models.Model):
@@ -74,6 +75,18 @@ class DashboardReport(DashboardWidgetBase):
     @property
     def report_configuration(self):
         return ReportConfiguration.get(self.report_configuration_id)
+
+    @property
+    def url(self):
+        """
+        Returns the URL of the view for the user-configurable report.
+
+        e.g. http://example.org/a/test-domain/reports/configurable/abc123/
+        """
+        return absolute_reverse(
+            'configurable',
+            args=[self.dashboard.domain, self.report_configuration_id],
+        )
 
 
 class DashboardGauge(DashboardWidgetBase):

--- a/corehq/apps/campaign/static/campaign/js/dashboard.js
+++ b/corehq/apps/campaign/static/campaign/js/dashboard.js
@@ -10,10 +10,12 @@ let mobileWorkerMapsInitialized = false;
 
 $(function () {
     // Only init case map widgets since this is the default tab
-    const mapWidgetConfigs = initialPageData.get('map_widgets');
-    for (const mapWidgetConfig of mapWidgetConfigs.cases) {
-        const mapWidget = new MapWidget(mapWidgetConfig);
-        mapWidget.initializeMap();
+    const widgetConfigs = initialPageData.get('map_report_widgets');
+    for (const widgetConfig of widgetConfigs.cases) {
+        if (widgetConfig.widget_type === 'DashboardMap') {
+            const mapWidget = new MapWidget(widgetConfig);
+            mapWidget.initializeMap();
+        }
     }
     $('a[data-bs-toggle="tab"]').on('shown.bs.tab', tabSwitch);
 });
@@ -24,10 +26,12 @@ function tabSwitch(e) {
     // Only load mobile worker map widgets when tab is clicked to prevent weird map sizing behaviour
     if (!mobileWorkerMapsInitialized && tabContentId === '#mobile-workers-tab-content') {
         mobileWorkerMapsInitialized = true;
-        const mapWidgetConfigs = initialPageData.get('map_widgets');
-        for (const mapWidgetConfig of mapWidgetConfigs.mobile_workers) {
-            const mapWidget = new MapWidget(mapWidgetConfig);
-            mapWidget.initializeMap();
+        const widgetConfigs = initialPageData.get('map_report_widgets');
+        for (const widgetConfig of widgetConfigs.mobile_workers) {
+            if (widgetConfig.widget_type === 'DashboardMap') {
+                const mapWidget = new MapWidget(widgetConfig);
+                mapWidget.initializeMap();
+            }
         }
     }
 }

--- a/corehq/apps/campaign/templates/campaign/dashboard.html
+++ b/corehq/apps/campaign/templates/campaign/dashboard.html
@@ -11,7 +11,7 @@
 {% block page_content %}
   {% initial_page_data 'mapbox_access_token' mapbox_access_token %}
   {% registerurl 'api_cases_with_gps' request.domain %}
-  {% initial_page_data 'map_widgets' map_widgets %}
+  {% initial_page_data 'map_report_widgets' map_report_widgets %}
 
   <ul class="nav nav-tabs" role="tablist">
     <li role="presentation" class="nav-item">
@@ -48,8 +48,10 @@
       <div class="row">
         <h2>{% trans "Reports" %}</h2>
         <div id="map-reports-container-cases">
-          {% for widget in map_widgets.cases %}
-            {% include 'campaign/partials/dashboard_map.html' %}
+          {% for widget in map_report_widgets.cases %}
+            {% if widget.widget_type == 'DashboardMap' %}
+              {% include 'campaign/partials/dashboard_map.html' %}
+            {% endif %}
           {% endfor %}
         </div>
       </div>
@@ -66,8 +68,10 @@
       <div class="row">
         <h2>{% trans "Reports" %}</h2>
         <div id="map-reports-container-mobile-workers">
-          {% for widget in map_widgets.mobile_workers %}
-            {% include 'campaign/partials/dashboard_map.html' %}
+          {% for widget in map_report_widgets.mobile_workers %}
+            {% if widget.widget_type == 'DashboardMap' %}
+              {% include 'campaign/partials/dashboard_map.html' %}
+            {% endif %}
           {% endfor %}
         </div>
       </div>

--- a/corehq/apps/campaign/tests/test_models.py
+++ b/corehq/apps/campaign/tests/test_models.py
@@ -115,3 +115,10 @@ def test_dashboard_report_ordering():
         ('Report 3', 'mobile_workers', 1),
         ('Report 4', 'mobile_workers', 2),
     ]
+
+
+@use(dashboard_reports)
+def test_dashboard_report_url():
+    dashboard = dashboard_fixture()
+    report = dashboard.reports.first()
+    assert report.url == 'http://localhost:8000/a/test-domain/reports/configurable/report1/'

--- a/corehq/apps/campaign/tests/test_models.py
+++ b/corehq/apps/campaign/tests/test_models.py
@@ -18,6 +18,7 @@ def dashboard_fixture():
 def dashboard_maps():
     dashboard = dashboard_fixture()
     DashboardMap.objects.create(
+        id=1,
         dashboard=dashboard,
         title='Map 1',
         case_type='type1',
@@ -26,28 +27,31 @@ def dashboard_maps():
         display_order=1,
     )
     DashboardMap.objects.create(
+        id=2,
         dashboard=dashboard,
         title='Map 2',
         case_type='type2',
         geo_case_property='property2',
         dashboard_tab=DashboardTab.CASES,
-        display_order=2,
+        display_order=3,
     )
     DashboardMap.objects.create(
+        id=3,
         dashboard=dashboard,
         title='Map 3',
         case_type='type3',
         geo_case_property='property3',
         dashboard_tab=DashboardTab.MOBILE_WORKERS,
-        display_order=1,
+        display_order=2,
     )
     DashboardMap.objects.create(
+        id=4,
         dashboard=dashboard,
         title='Map 4',
         case_type='type4',
         geo_case_property='property4',
         dashboard_tab=DashboardTab.MOBILE_WORKERS,
-        display_order=2,
+        display_order=4,
     )
     yield
 
@@ -57,20 +61,23 @@ def dashboard_maps():
 def dashboard_reports():
     dashboard = dashboard_fixture()
     DashboardReport.objects.create(
+        id=1,
         dashboard=dashboard,
         title='Report 1',
         report_configuration_id='report1',
         dashboard_tab=DashboardTab.CASES,
-        display_order=1,
+        display_order=2,
     )
     DashboardReport.objects.create(
+        id=2,
         dashboard=dashboard,
         title='Report 2',
         report_configuration_id='report2',
         dashboard_tab=DashboardTab.CASES,
-        display_order=2,
+        display_order=4,
     )
     DashboardReport.objects.create(
+        id=3,
         dashboard=dashboard,
         title='Report 3',
         report_configuration_id='report3',
@@ -78,11 +85,12 @@ def dashboard_reports():
         display_order=1,
     )
     DashboardReport.objects.create(
+        id=4,
         dashboard=dashboard,
         title='Report 4',
         report_configuration_id='report4',
         dashboard_tab=DashboardTab.MOBILE_WORKERS,
-        display_order=2,
+        display_order=3,
     )
     yield
 
@@ -96,10 +104,27 @@ def test_dashboard_map_ordering():
     ]
     assert map_ordering == [
         ('Map 1', 'cases', 1),
-        ('Map 2', 'cases', 2),
-        ('Map 3', 'mobile_workers', 1),
-        ('Map 4', 'mobile_workers', 2),
+        ('Map 2', 'cases', 3),
+        ('Map 3', 'mobile_workers', 2),
+        ('Map 4', 'mobile_workers', 4),
     ]
+
+
+@use(dashboard_maps)
+def test_dashboard_map_widget():
+    dashboard = dashboard_fixture()
+    widget = dashboard.maps.first().to_widget()
+    assert widget == {
+        'case_type': 'type1',
+        'dashboard': {
+            'domain': 'test-domain',
+        },
+        'description': None,
+        'geo_case_property': 'property1',
+        'id': 1,
+        'title': 'Map 1',
+        'widget_type': 'DashboardMap',
+    }
 
 
 @use(dashboard_reports)
@@ -110,10 +135,10 @@ def test_dashboard_report_ordering():
         for report in dashboard.reports.all()
     ]
     assert report_ordering == [
-        ('Report 1', 'cases', 1),
-        ('Report 2', 'cases', 2),
+        ('Report 1', 'cases', 2),
+        ('Report 2', 'cases', 4),
         ('Report 3', 'mobile_workers', 1),
-        ('Report 4', 'mobile_workers', 2),
+        ('Report 4', 'mobile_workers', 3),
     ]
 
 
@@ -122,3 +147,120 @@ def test_dashboard_report_url():
     dashboard = dashboard_fixture()
     report = dashboard.reports.first()
     assert report.url == 'http://localhost:8000/a/test-domain/reports/configurable/report1/'
+
+
+@use(dashboard_reports)
+def test_dashboard_report_widget():
+    dashboard = dashboard_fixture()
+    widget = dashboard.reports.first().to_widget()
+    assert widget == {
+        'dashboard': {
+            'domain': 'test-domain',
+        },
+        'description': None,
+        'id': 1,
+        'report_configuration_id': 'report1',
+        'title': 'Report 1',
+        'url': 'http://localhost:8000/a/test-domain/reports/configurable/report1/',
+        'widget_type': 'DashboardReport',
+    }
+
+
+@use(dashboard_maps, dashboard_reports)
+def test_dashboard_map_report_widgets():
+    dashboard = dashboard_fixture()
+    widgets = dashboard.get_map_report_widgets_by_tab()
+    assert widgets == {
+        'cases': [
+            {
+                'case_type': 'type1',
+                'dashboard': {
+                    'domain': 'test-domain',
+                },
+                'description': None,
+                'geo_case_property': 'property1',
+                'id': 1,
+                'title': 'Map 1',
+                'widget_type': 'DashboardMap',
+            },
+            {
+                'dashboard': {
+                    'domain': 'test-domain',
+                },
+                'description': None,
+                'id': 1,
+                'report_configuration_id': 'report1',
+                'title': 'Report 1',
+                'url': 'http://localhost:8000/a/test-domain/reports/configurable/report1/',
+                'widget_type': 'DashboardReport',
+            },
+            {
+                'case_type': 'type2',
+                'dashboard': {
+                    'domain': 'test-domain',
+                },
+                'description': None,
+                'geo_case_property': 'property2',
+                'id': 2,
+                'title': 'Map 2',
+                'widget_type': 'DashboardMap',
+            },
+            {
+                'dashboard': {
+                    'domain': 'test-domain',
+                },
+                'description': None,
+                'id': 2,
+                'report_configuration_id': 'report2',
+                'title': 'Report 2',
+                'url': 'http://localhost:8000/a/test-domain/reports/configurable/report2/',
+                'widget_type': 'DashboardReport',
+            },
+        ],
+        'mobile_workers': [
+            {
+                'dashboard': {
+                    'domain': 'test-domain',
+                },
+                'description': None,
+                'id': 3,
+                'report_configuration_id': 'report3',
+                'title': 'Report 3',
+                'url': 'http://localhost:8000/a/test-domain/reports/configurable/report3/',
+                'widget_type': 'DashboardReport',
+            },
+            {
+                'case_type': 'type3',
+                'dashboard': {
+                    'domain': 'test-domain',
+                },
+                'description': None,
+                'geo_case_property': 'property3',
+                'id': 3,
+                'title': 'Map 3',
+                'widget_type': 'DashboardMap',
+            },
+            {
+                'dashboard': {
+                    'domain': 'test-domain',
+                },
+                'description': None,
+                'id': 4,
+                'report_configuration_id': 'report4',
+                'title': 'Report 4',
+                'url': 'http://localhost:8000/a/test-domain/reports/configurable/report4/',
+                'widget_type': 'DashboardReport',
+            },
+            {
+                'case_type': 'type4',
+                'dashboard': {
+                    'domain': 'test-domain',
+                },
+                'description': None,
+                'geo_case_property': 'property4',
+                'id': 4,
+                'title': 'Map 4',
+                'widget_type': 'DashboardMap',
+            },
+        ],
+    }

--- a/corehq/apps/campaign/tests/test_views.py
+++ b/corehq/apps/campaign/tests/test_views.py
@@ -95,13 +95,17 @@ class TestDashboardView(BaseTestCampaignView):
         assert response.status_code == 200
 
         context = response.context
-        assert context['map_widgets'] == {
+        assert context['map_report_widgets'] == {
             'cases': [{
                 'id': self.dashboard_map_cases.id,
                 'title': 'Cases Map',
                 'description': None,
                 'case_type': 'foo',
                 'geo_case_property': 'somewhere',
+                'dashboard': {
+                    'domain': 'test-domain',
+                },
+                'widget_type': 'DashboardMap',
             }],
             'mobile_workers': [{
                 'id': self.dashboard_map_mobile_workers.id,
@@ -109,6 +113,10 @@ class TestDashboardView(BaseTestCampaignView):
                 'description': 'My cool map',
                 'case_type': 'bar',
                 'geo_case_property': 'nowhere',
+                'dashboard': {
+                    'domain': 'test-domain',
+                },
+                'widget_type': 'DashboardMap',
             }],
         }
 

--- a/corehq/apps/campaign/views.py
+++ b/corehq/apps/campaign/views.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.core.paginator import Paginator
-from django.forms.models import model_to_dict
 from django.http import JsonResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -66,24 +65,13 @@ class DashboardView(BaseProjectReportSectionView, DashboardMapFilterMixin):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        dashboard = Dashboard.objects.get(domain=self.domain)
         context.update({
             'mapbox_access_token': settings.MAPBOX_ACCESS_TOKEN,
-            'map_widgets': self._dashboard_map_configs,
+            'map_report_widgets': dashboard.get_map_report_widgets_by_tab()
         })
         context.update(self.dashboard_map_case_filters_context())
         return context
-
-    @property
-    def _dashboard_map_configs(self):
-        dashboard_maps = Dashboard.objects.get(domain=self.domain).maps.all()
-        dashboard_map_configs = {
-            'cases': [],
-            'mobile_workers': [],
-        }
-        for dashboard_map in dashboard_maps:
-            config = model_to_dict(dashboard_map, exclude=['dashboard', 'dashboard_tab', 'display_order'])
-            dashboard_map_configs[dashboard_map.dashboard_tab].append(config)
-        return dashboard_map_configs
 
 
 @method_decorator([login_and_domain_required, require_GET], name='dispatch')


### PR DESCRIPTION
## Technical Summary

This is a small change to avoid merge conflicts from getting uglier and uglier.

It combines map and report widgets, so that they can be displayed together in their section of the campaign dashboard.

It moves some code from `views.py` to `models.py` and adds tests for it.

## Feature Flag

campaign_dashboard

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Includes tests

### QA Plan

QA TBD

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
