### PR TITLE
[Data Cleaning] Logic and UI hook for adding columns to BulkEditSession

### DIFF
--- a/corehq/apps/data_cleaning/forms/columns.py
+++ b/corehq/apps/data_cleaning/forms/columns.py
@@ -148,3 +148,10 @@ class AddColumnForm(forms.Form):
                     )
                 )
         return cleaned_data
+
+    def add_column(self):
+        self.session.add_column(
+            self.cleaned_data['column_prop_id'],
+            self.cleaned_data['column_label'],
+            self.cleaned_data['column_data_type']
+        )

--- a/corehq/apps/data_cleaning/forms/columns.py
+++ b/corehq/apps/data_cleaning/forms/columns.py
@@ -42,8 +42,9 @@ class AddColumnForm(forms.Form):
         self.session = session
 
         property_details = get_case_property_details(self.session.domain, self.session.identifier)
+        self.existing_columns = self.session.columns.values_list('prop_id', flat=True)
         self.fields['column_prop_id'].choices = [(None, None)] + [
-            (p, p) for p in sorted(property_details.keys())
+            (p, p) for p in sorted(property_details.keys()) if p not in self.existing_columns
         ]
 
         initial_prop_id = self.data.get('column_prop_id')

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -608,8 +608,8 @@ class BulkEditColumn(models.Model):
     def create_default_columns(cls, session):
         default_properties = {
             BulkEditSessionType.CASE: (
-                'name', 'owner_name', 'opened_on', 'opened_by_username',
-                'modified_on', '@status',
+                'name', 'owner_name', 'date_opened', 'opened_by_username',
+                'last_modified', '@status',
             ),
         }.get(session.session_type)
 

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -618,6 +618,7 @@ class BulkEditColumn(models.Model):
 
         from corehq.apps.data_cleaning.utils.cases import (
             get_system_property_label,
+            get_system_property_data_type,
         )
         for index, prop_id in enumerate(default_properties):
             cls.objects.create(
@@ -625,6 +626,7 @@ class BulkEditColumn(models.Model):
                 index=index,
                 prop_id=prop_id,
                 label=get_system_property_label(prop_id),
+                data_type=get_system_property_data_type(prop_id),
                 is_system=cls.is_system_property(prop_id),
             )
 

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -599,18 +599,6 @@ class BulkEditColumn(models.Model):
         ordering = ["index"]
 
     @staticmethod
-    def get_default_label(prop_id):
-        known_labels = {
-            'name': _("Name"),
-            'owner_name': _('Owner'),
-            'opened_on': _("Opened On"),
-            'opened_by_username': _("Created By"),
-            'modified_on': _("Last Modified On"),
-            '@status': _("Status"),
-        }
-        return known_labels.get(prop_id, prop_id)
-
-    @staticmethod
     def is_system_property(prop_id):
         return prop_id in set(METADATA_IN_REPORTS).difference({
             'name', 'case_name', 'external_id',
@@ -628,12 +616,15 @@ class BulkEditColumn(models.Model):
         if not default_properties:
             raise NotImplementedError(f"{session.session_type} default columns not yet supported")
 
+        from corehq.apps.data_cleaning.utils.cases import (
+            get_system_property_label,
+        )
         for index, prop_id in enumerate(default_properties):
             cls.objects.create(
                 session=session,
                 index=index,
                 prop_id=prop_id,
-                label=cls.get_default_label(prop_id),
+                label=get_system_property_label(prop_id),
                 is_system=cls.is_system_property(prop_id),
             )
 

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_columns_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_columns_form.html
@@ -4,6 +4,7 @@
 <div
   id="{{ container_id }}"
   hx-swap="outerHTML"
+  hq-hx-refresh-swap="#CleanCaseTable"
 >
   {% if active_columns %}
     <div class="mb-3">

--- a/corehq/apps/data_cleaning/utils/cases.py
+++ b/corehq/apps/data_cleaning/utils/cases.py
@@ -44,7 +44,7 @@ def _get_system_property_data_type(prop_id):
     }.get(prop_id, DataType.TEXT)
 
 
-def _get_system_property_label(prop_id):
+def get_system_property_label(prop_id):
     return {
         '@case_id': _("Case ID"),
         '@case_type': _("Case Type"),
@@ -71,7 +71,7 @@ def _get_system_property_details():
         if prop_id in SKIPPED_SYSTEM_PROPERTIES:
             continue
         system_properties[prop_id] = PropertyDetail(
-            label=_get_system_property_label(prop_id),
+            label=get_system_property_label(prop_id),
             data_type=_get_system_property_data_type(prop_id),
             prop_id=prop_id,
             is_editable=prop_id in EDITABLE_SYSTEM_PROPERTIES,

--- a/corehq/apps/data_cleaning/utils/cases.py
+++ b/corehq/apps/data_cleaning/utils/cases.py
@@ -35,7 +35,7 @@ def clear_caches_case_data_cleaning(domain, case_type=None):
         )
 
 
-def _get_system_property_data_type(prop_id):
+def get_system_property_data_type(prop_id):
     return {
         'date_opened': DataType.DATETIME,
         'closed_on': DataType.DATETIME,
@@ -72,7 +72,7 @@ def _get_system_property_details():
             continue
         system_properties[prop_id] = PropertyDetail(
             label=get_system_property_label(prop_id),
-            data_type=_get_system_property_data_type(prop_id),
+            data_type=get_system_property_data_type(prop_id),
             prop_id=prop_id,
             is_editable=prop_id in EDITABLE_SYSTEM_PROPERTIES,
             options=None,

--- a/corehq/apps/data_cleaning/views/columns.py
+++ b/corehq/apps/data_cleaning/views/columns.py
@@ -34,7 +34,7 @@ class ManageColumnsFormView(BulkEditSessionViewMixin,
     def add_column(self, request, *args, **kwargs):
         column_form = AddColumnForm(self.session, request.POST)
         if column_form.is_valid():
-            # todo add column to session
+            column_form.add_column()
             column_form = None
         return self.get(request, column_form=column_form, *args, **kwargs)
 


### PR DESCRIPTION
## Technical Summary
review commit by commit

High level:
- updates logic that creates default columns to make sure the correct system property slug is used, consolidates logic to define default label, data type with utils in `data_cleaning.utils.cases`
- adds form validation to `AddColumnForm`
- adds method to `BulkEditSession` to add new columns to the session
- actually adds column to session when `AddColumnForm` is submitted and valid
- column list shows the new column
- table auto refreshes and adds the new column

![Screenshot 2025-03-25 at 2 39 44 PM](https://github.com/user-attachments/assets/f2d98f7d-5280-4c0e-aa7b-6386b06895a1)


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
very safe change. most important logic has tests
I have todo tickets for supplementary / more extensive tests later

### Automated test coverage
yes

### QA Plan
not needed yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
