### PR TITLE
Handle Missing Documents for DeID dates

### DIFF
--- a/corehq/ex-submodules/couchexport/deid.py
+++ b/corehq/ex-submodules/couchexport/deid.py
@@ -24,7 +24,7 @@ class JSONPath(object):
 
 
 def deid_date(val, doc, key_path='form/case/@case_id|form/case/case_id|_id', key=None):
-    if key is None:
+    if key is None and doc:
         key = JSONPath(key_path).search(doc)
     if not key or not val:
         return None

--- a/corehq/ex-submodules/couchexport/tests/test_deid.py
+++ b/corehq/ex-submodules/couchexport/tests/test_deid.py
@@ -1,0 +1,27 @@
+from django.test import SimpleTestCase
+from datetime import date, timedelta
+from couchexport.deid import deid_date
+
+
+class DeidTests(SimpleTestCase):
+    def test_deidentifies_date(self):
+        doc = {
+            '_id': '123'
+        }
+        original_value = date(year=2000, month=10, day=10)
+        deident_val = deid_date(original_value.isoformat(), doc)
+        difference = original_value - deident_val
+        self.assertLessEqual(difference, timedelta(days=32))
+        self.assertGreaterEqual(difference, timedelta(days=-31))
+
+    def test_deid_date_returns_none_when_key_is_not_found(self):
+        doc = {
+        }
+        self.assertIsNone(deid_date('2000-10-10', doc=doc, key=None))
+
+    def test_deid_date_returns_none_when_key_value_cannot_be_determined_from_document(self):
+        self.assertIsNone(deid_date('2000-10-10', doc='', key=None))
+
+    def test_doc_is_unnecessary_when_key_is_provided(self):
+        result = deid_date('2000-10-10', doc='', key='mydate')
+        self.assertIsInstance(result, date)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-16728.

Somehow, forms with repeat groups have been able to send empty items within those groups. What we'll see is something like the following XML:
```
<group>
  <item>...</item>
  <item>...</item>
  <item />
</group>
```

where the last item is essentially a fake object. When it gets fetched from Elasticsearch, that `<item />` object turns into an empty string `''`, which creates errors when it is fed down to functions expecting an object with certain properties. This PR allows deidentified dates to gracefully handle this error by just ignoring these objects.

## Feature Flag
No FF

## Safety Assurance

### Safety story
Replicated this issue on staging and verified that the PR allows the export to still be generated (and verified the output looks as expected)

### Automated test coverage

A new unit test suite was created to cover the deidentified date functionality

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
