### PR TITLE
Added initial breadcrumb for enterprise settings & permissions pages

### DIFF
--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -247,17 +247,22 @@ def enterprise_settings(request, domain):
         form = EnterpriseSettingsForm(domain=domain, account=request.account, username=request.user.username,
                                       export_settings=export_settings)
 
-    context = {
+    context = get_page_context(
+        page_url=reverse('enterprise_settings', args=(domain,)),
+        page_title=_('Enterprise Settings'),
+        page_name=_('Enterprise Settings'),
+        domain=domain,
+        section=Section(
+            _('Enterprise Console'),
+            reverse('platform_overview', args=(domain,)),
+        ),
+    )
+    context.update({
         'account': request.account,
         'accounts_email': settings.ACCOUNTS_EMAIL,
-        'domain': domain,
         'restrict_signup': request.POST.get('restrict_signup', request.account.restrict_signup),
-        'current_page': {
-            'title': _('Enterprise Settings'),
-            'page_name': _('Enterprise Settings'),
-        },
         'settings_form': form,
-    }
+    })
     return render(request, "enterprise/enterprise_settings.html", context)
 
 
@@ -464,18 +469,23 @@ def enterprise_permissions(request, domain):
     all_domains = set(config.account.get_domains())
     ignored_domains = all_domains - set(config.domains) - {config.source_domain}
 
-    context = {
-        'domain': domain,
+    context = get_page_context(
+        page_url=reverse('enterprise_permissions', args=(domain,)),
+        page_title=_('Enterprise Permissions'),
+        page_name=_('Enterprise Permissions'),
+        domain=domain,
+        section=Section(
+            _('Enterprise Console'),
+            reverse('platform_overview', args=(domain,)),
+        ),
+    )
+    context.update({
         'all_domains': sorted(all_domains),
         'is_enabled': config.is_enabled,
         'source_domain': config.source_domain,
         'ignored_domains': sorted(list(ignored_domains)),
         'controlled_domains': sorted(config.domains),
-        'current_page': {
-            'page_name': _('Enterprise Permissions'),
-            'title': _('Enterprise Permissions'),
-        }
-    }
+    })
     return render(request, "enterprise/enterprise_permissions.html", context)
 
 


### PR DESCRIPTION
## Product Description
Bonus bug fix.

https://dimagi.atlassian.net/browse/SAAS-16467

## Feature Flag
Not a flag, but only visible to enterprise admins.

## Safety Assurance

### Safety story
This is a pretty safe change. Tested locally.

### Automated test coverage

Probably not of these code paths.

### QA Plan

Not requesting QA.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
