### PR TITLE
Webpack migration for pages that use Stripe

### DIFF
--- a/corehq/apps/accounting/.eslintrc.js
+++ b/corehq/apps/accounting/.eslintrc.js
@@ -1,7 +1,0 @@
-/* global module */
-// Temporary until weback migration is complete, requirejs is gone, and all of HQ can use the latest ecmaVersion
-module.exports = {
-    "parserOptions": {
-        "ecmaVersion": 6,
-    },
-};

--- a/corehq/apps/accounting/static/accounting/js/billing_account_form.js
+++ b/corehq/apps/accounting/static/accounting/js/billing_account_form.js
@@ -5,6 +5,7 @@ hqDefine('accounting/js/billing_account_form', [
     'hqwebapp/js/initial_page_data',
     'accounting/js/credits_tab',
     'accounting/js/widgets',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/accounting/static/accounting/js/billing_account_form.js
+++ b/corehq/apps/accounting/static/accounting/js/billing_account_form.js
@@ -1,4 +1,3 @@
-"use strict";
 hqDefine('accounting/js/billing_account_form', [
     'jquery',
     'knockout',
@@ -9,7 +8,7 @@ hqDefine('accounting/js/billing_account_form', [
 ], function (
     $,
     ko,
-    initialPageData
+    initialPageData,
 ) {
     var billingAccountFormModel = function (isActive, isCustomerBillingAccount, enterpriseAdminEmails, isSmsBillableReportVisible) {
         var self = {};

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -208,7 +208,9 @@ hqDefine('accounting/js/payment_method_handler', [
             self.serverErrorMsg('');
             self.newCard(stripeCardModel());
             if (self.cardElementMounted) {
-                self.cardElement.clear();
+                self.cardElementPromise.then(function (cardElement) {
+                    self.cardElement.clear();
+                });
             }
         };
 

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -206,7 +206,7 @@ hqDefine('accounting/js/payment_method_handler', [
         self.reset = function () {
             self.paymentIsComplete(false);
             self.serverErrorMsg('');
-            self.newCard(stripeCardModel());
+            self.newCard().reset();
             if (self.cardElementMounted) {
                 self.cardElementPromise.then(function (cardElement) {
                     cardElement.clear();
@@ -518,6 +518,17 @@ hqDefine('accounting/js/payment_method_handler', [
         self.isTestMode = ko.observable(false);
         self.isProcessing = ko.observable(false);
         self.newSavedCard = ko.observable(false);
+
+        self.reset = function () {
+            self.number(null);
+            self.expMonth(null);
+            self.expYear(null);
+            self.errorMsg(null);
+            self.token(null);
+            self.isTestMode(false);
+            self.isProcessing(false);
+            self.newSavedCard(false);
+        };
 
         self.autopayCard = ko.computed(function () {
             if (!self.newSavedCard()) {

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -512,7 +512,6 @@ hqDefine('accounting/js/payment_method_handler', [
         var self = {};
 
         self.number = ko.observable();
-        self.cvc = ko.observable();
         self.expMonth = ko.observable();
         self.expYear = ko.observable();
         self.errorMsg = ko.observable();
@@ -540,17 +539,9 @@ hqDefine('accounting/js/payment_method_handler', [
         self.showErrors = ko.computed(function () {
             return !! self.errorMsg();
         });
-        self.cleanedNumber = ko.computed(function () {
-            if (self.number()) {
-                return self.number().split('-').join('');
-            }
-            return null;
-        });
-
         self.cardName = ko.computed(function () {
             return self.cardType() + ' ' + self.number() + ' exp ' + self.expMonth() + '/' + self.expYear();
         });
-
 
         self.loadSavedData = function (data) {
             self.number('************' + data.last4);
@@ -558,7 +549,6 @@ hqDefine('accounting/js/payment_method_handler', [
             self.expMonth(data.exp_month);
             self.expYear(data.exp_year);
             self.token(data.id);
-            self.cvc('****');
             self.isSaved(true);
         };
 

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -1,4 +1,6 @@
-"use strict";
+/**
+ *  This module requires initial page data to provide "stripe_public_key".
+ */
 hqDefine('accounting/js/payment_method_handler', [
     'jquery',
     'knockout',

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -209,7 +209,7 @@ hqDefine('accounting/js/payment_method_handler', [
             self.newCard(stripeCardModel());
             if (self.cardElementMounted) {
                 self.cardElementPromise.then(function (cardElement) {
-                    self.cardElement.clear();
+                    cardElement.clear();
                 });
             }
         };

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -1,5 +1,7 @@
 /**
  *  This module requires initial page data to provide "stripe_public_key".
+ *  It also requires a container with the id stripe-card-container, which is where the credit card UI will be
+ *  mounted.
  */
 hqDefine('accounting/js/payment_method_handler', [
     'jquery',

--- a/corehq/apps/accounting/static/accounting/js/software_plan_version_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/software_plan_version_handler.js
@@ -1,4 +1,3 @@
-"use strict";
 hqDefine("accounting/js/software_plan_version_handler", [
     'jquery',
     'knockout',
@@ -14,13 +13,13 @@ hqDefine("accounting/js/software_plan_version_handler", [
     _,
     initialPageData,
     select2Handler,
-    multiselectUtils
+    multiselectUtils,
 ) {
     $(function () {
         var planVersionFormHandler = softwarePlanVersionFormHandler(
             initialPageData.get('role'),
             initialPageData.get('feature_rates'),
-            initialPageData.get('product_rates')
+            initialPageData.get('product_rates'),
         );
         $('#roles').koApplyBindings(planVersionFormHandler);
         planVersionFormHandler.init();

--- a/corehq/apps/accounting/static/accounting/js/software_plan_version_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/software_plan_version_handler.js
@@ -7,6 +7,7 @@ hqDefine("accounting/js/software_plan_version_handler", [
     'hqwebapp/js/select2_handler',
     'hqwebapp/js/multiselect_utils',
     'select2/dist/js/select2.full.min',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/accounting/static/accounting/js/stripe.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe.js
@@ -25,6 +25,6 @@ function createStripeToken(handleResponse) {
     self.stripePromise.then(function (stripe) {
         stripe.createToken(self.cardElement).then(handleResponse);
     });
-};
+}
 
 export { createStripeToken, getCardElementPromise };

--- a/corehq/apps/accounting/static/accounting/js/stripe.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe.js
@@ -1,0 +1,30 @@
+import { loadStripe } from '@stripe/stripe-js';
+
+self.stripePromise = undefined;
+self.cardElement = undefined;
+
+function getCardElementPromise(key) {
+    if (!key) {
+        throw new Error("Cannot load Stripe, key not provided");
+    }
+
+    let promise = new Promise((resolve) => {
+        self.stripePromise = loadStripe(key);
+        self.stripePromise.then(function (stripe) {
+            self.cardElement = stripe.elements().create('card', {
+                hidePostalCode: true,
+            });
+            resolve(self.cardElement);
+        });
+    });
+
+    return promise;
+}
+
+function createStripeToken(handleResponse) {
+    self.stripePromise.then(function (stripe) {
+        stripe.createToken(self.cardElement).then(handleResponse);
+    });
+};
+
+export { createStripeToken, getCardElementPromise };

--- a/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
@@ -1,5 +1,7 @@
 /**
  *  This module requires initial page data to provide "stripe_public_key".
+ *  It also requires a container with the id stripe-card-container, which is where the credit card UI will be
+ *  mounted.
  */
 hqDefine("accounting/js/stripe_card_manager", [
     'jquery',
@@ -20,7 +22,7 @@ hqDefine("accounting/js/stripe_card_manager", [
         self.cardElementMounted = false;
         self.cardElementPromise = hqStripe.getCardElementPromise(initialPageData.get("stripe_public_key"));
         self.cardElementPromise.then(function (cardElement) {
-            cardElement.mount(data.elementSelector);
+            cardElement.mount('#stripe-card-container');
             self.cardElementMounted = true;
         });
 
@@ -176,7 +178,6 @@ hqDefine("accounting/js/stripe_card_manager", [
         self.autoPayButtonEnabled = ko.observable(true);
         self.newCard = newStripeCardModel({
             url: data.url,
-            elementSelector: data.elementSelector,
         }, self);
 
         return self;

--- a/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
@@ -1,4 +1,6 @@
-"use strict";
+/**
+ *  This module requires initial page data to provide "stripe_public_key".
+ */
 hqDefine("accounting/js/stripe_card_manager", [
     'jquery',
     'knockout',

--- a/corehq/apps/accounting/static/accounting/js/subscriptions_main.js
+++ b/corehq/apps/accounting/static/accounting/js/subscriptions_main.js
@@ -4,6 +4,7 @@ hqDefine('accounting/js/subscriptions_main', [
     'hqwebapp/js/initial_page_data',
     'accounting/js/widgets',
     'accounting/js/base_subscriptions_main',
+    'commcarehq',
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/accounting/static/accounting/js/subscriptions_main.js
+++ b/corehq/apps/accounting/static/accounting/js/subscriptions_main.js
@@ -1,4 +1,3 @@
-"use strict";
 hqDefine('accounting/js/subscriptions_main', [
     'jquery',
     'hqwebapp/js/initial_page_data',
@@ -8,7 +7,7 @@ hqDefine('accounting/js/subscriptions_main', [
 ], function (
     $,
     initialPageData,
-    widgets
+    widgets,
 ) {
     $(function () {
         var asyncSelect2Handler = widgets.asyncSelect2Handler;

--- a/corehq/apps/accounting/templates/accounting/accounts.html
+++ b/corehq/apps/accounting/templates/accounting/accounts.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'accounting/js/billing_account_form' %}
+{% js_entry_b3 'accounting/js/billing_account_form' %}
 
 {% block page_content %}
   {% initial_page_data 'account_form_is_active' basic_form.is_active.value %}

--- a/corehq/apps/accounting/templates/accounting/accounts_base.html
+++ b/corehq/apps/accounting/templates/accounting/accounts_base.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'accounting/js/widgets' %}
+{% js_entry_b3 'accounting/js/widgets' %}
 
 {% block page_content %}
   {% crispy basic_form %}

--- a/corehq/apps/accounting/templates/accounting/invoice.html
+++ b/corehq/apps/accounting/templates/accounting/invoice.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main "accounting/js/widgets" %} {# Uses .ko-adjust-balance-form #}
+{% js_entry_b3 "accounting/js/widgets" %} {# Uses .ko-adjust-balance-form #}
 
 {% block page_content %}
   {% if adjust_balance_form %}

--- a/corehq/apps/accounting/templates/accounting/partials/new_stripe_card_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/new_stripe_card_template.html
@@ -22,57 +22,10 @@
                                     text: errorMsg">
           </div>
 
-          <div class="form-group">
-            <label class="control-label col-sm-3">
-              {% trans 'Card Number' %}
-            </label>
-            <div class="col-sm-9">
-              <input type="text"
-                     data-bind="value: number, disable: isProcessing"
-                     size="20"
-                     class="form-control"
-                     placeholder="xxxx-xxxx-xxxx-xxxx", />
-            </div>
-          </div>
+          <div id="stripe-card-container"></div>{# populated by a card element from Stripe #}
 
           <div class="form-group">
-            <label class="control-label col-sm-3">
-              {% trans 'CVC' context "Check digits of credit card"%}
-            </label>
-            <div class="col-sm-3">
-              <input type="text"
-                     data-bind="value: cvc, disable: isProcessing"
-                     size="4"
-                     class="form-control"
-                     placeholder="xxxx"/>
-            </div>
-          </div>
-
-          <div class="form-group">
-            <label class="control-label col-sm-3">
-              {% trans 'Expiration' %}
-            </label>
             <div class="col-sm-9">
-              <div class="row">
-                <div class="col-sm-2">
-                  <input type="text"
-                         data-bind="value: expMonth, disable: isProcessing"
-                         size="2"
-                         class="form-control"
-                         placeholder="MM" />
-                </div>
-                <div class="col-sm-4">
-                  <input type="text"
-                         data-bind="value: expYear, disable: isProcessing"
-                         size="4"
-                         class="form-control"
-                         placeholder="YYYY" />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="col-sm-offset-3 col-sm-9">
               <div class="checkbox">
                 <label>
                   <input type="checkbox" name="autopay" data-bind="checked: isAutopay, disable: isProcessing"/>
@@ -94,8 +47,7 @@
             {% trans 'Cancel' %}
           </button>
           <button type="button" class="btn btn-primary"
-                  data-bind="click: saveCard,
-                                       enable: !isProcessing()">
+                  data-bind="click: saveCard, enable: !isProcessing()">
             {% trans 'Save' %}
           </button>
         </div>

--- a/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
@@ -108,53 +108,8 @@
 
   <div data-bind="visible: showCardData">
     <div class="form-group">
-      <label class="control-label col-sm-3">
-        {% trans 'Card Number' %}
-      </label>
-      <div class="col-sm-9">
-        <input type="text"
-               data-bind="value: number"
-               size="20"
-               class="form-control"
-               placeholder="xxxx-xxxx-xxxx-xxxx" />
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label class="control-label col-sm-3">
-        {% trans 'CVC' %}
-      </label>
-
-      <div class="col-sm-2">
-        <input type="text"
-               data-bind="value: cvc"
-               size="4"
-               class="form-control"
-               placeholder="xxxx"/>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label class="control-label col-sm-3">
-        {% trans 'Expiration' %}
-      </label>
-      <div class="col-sm-9">
-        <div class="row">
-          <div class="col-sm-2">
-            <input type="text"
-                   data-bind="value: expMonth"
-                   size="2"
-                   class="form-control"
-                   placeholder="MM" />
-          </div>
-          <div class="col-sm-4">
-            <input type="text"
-                   data-bind="value: expYear"
-                   size="4"
-                   class="form-control"
-                   placeholder="YYYY" />
-          </div>
-        </div>
+      <div class="col-sm-9 col-sm-offset-3">
+        <div id="stripe-card-container"></div>{# populated by a card element from Stripe #}
       </div>
     </div>
     <div class="form-group">

--- a/corehq/apps/accounting/templates/accounting/plans.html
+++ b/corehq/apps/accounting/templates/accounting/plans.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main "accounting/js/software_plan_version_handler" %}
+{% js_entry_b3 "accounting/js/software_plan_version_handler" %}
 
 {% block page_content %}
   {% initial_page_data 'role' plan_version_form.role_dict %}

--- a/corehq/apps/accounting/templates/accounting/subscriptions.html
+++ b/corehq/apps/accounting/templates/accounting/subscriptions.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% load compress %}
 
-{% requirejs_main 'accounting/js/subscriptions_main' %}
+{% js_entry_b3 'accounting/js/subscriptions_main' %}
 
 {% block page_content %}
   {% initial_page_data 'current_version' subscription.plan_version.id %}

--- a/corehq/apps/domain/.eslintrc.js
+++ b/corehq/apps/domain/.eslintrc.js
@@ -1,7 +1,0 @@
-/* global module */
-// Temporary until weback migration is complete, requirejs is gone, and all of HQ can use the latest ecmaVersion
-module.exports = {
-    "parserOptions": {
-        "ecmaVersion": 6,
-    },
-};

--- a/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
@@ -6,7 +6,6 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
     'hqwebapp/js/initial_page_data',
     'accounting/js/payment_method_handler',
     'hqwebapp/js/bootstrap3/crud_paginated_list',
-    'stripe',
 ], function (
     $,
     _,
@@ -14,9 +13,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
     initialPageData,
     paymentMethodHandlers,
     CRUDPaginatedList,
-    Stripe
 ) {
-    Stripe.setPublishableKey(initialPageData.get("stripe_options").stripe_public_key);
     var wireInvoiceHandler = paymentMethodHandlers.wireInvoiceHandler;
     var paymentMethodHandler = paymentMethodHandlers.paymentMethodHandler;
     var invoice = paymentMethodHandlers.invoice;

--- a/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
@@ -69,7 +69,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
     for (var i = 0; i < handlers.length; i++) {
         handlers[i].handlers = handlers;
     }
-    var stripeCards = initialPageData.get("stripe_options").stripe_cards;
+    var stripeCards = initialPageData.get("stripe_cards");
     if (stripeCards) {
         bulkPaymentHandler.loadCards(stripeCards);
         paymentHandler.loadCards(stripeCards);

--- a/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
@@ -1,4 +1,3 @@
-'use strict';
 hqDefine("domain/js/bootstrap3/billing_statements", [
     'jquery',
     'underscore',
@@ -28,7 +27,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
             statusCodeText: pagination.status_codes,
             allowItemCreation: initialPageData.get('item_creation_allowed'),
             createItemForm: pagination.create_item_form,
-        }
+        },
     );
 
     $(function () {
@@ -41,7 +40,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
             submitBtnText: gettext("Submit Payment"),
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_bulk_payment_url,
-        }
+        },
     );
 
     var bulkWirePaymentHandler = wireInvoiceHandler(
@@ -51,7 +50,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
             isWire: true,
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_wire_invoice_url,
-        }
+        },
     );
 
     var paymentHandler = paymentMethodHandler(
@@ -60,7 +59,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
             submitBtnText: gettext("Submit Payment"),
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_invoice_payment_url,
-        }
+        },
     );
 
     // A sign that the data model isn't exactly right - credit cards are shared data.

--- a/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
@@ -6,6 +6,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
     'hqwebapp/js/initial_page_data',
     'accounting/js/payment_method_handler',
     'hqwebapp/js/bootstrap3/crud_paginated_list',
+    'commcarehq',
 ], function (
     $,
     _,

--- a/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
@@ -5,6 +5,7 @@ hqDefine('domain/js/bootstrap3/update_billing_contact_info', [
     'accounting/js/stripe_card_manager',
     'accounting/js/widgets',
     'hqwebapp/js/bootstrap3/knockout_bindings.ko', // openModal
+    'commcarehq',
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
@@ -3,17 +3,14 @@ hqDefine('domain/js/bootstrap3/update_billing_contact_info', [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'accounting/js/stripe_card_manager',
-    'stripe',
     'accounting/js/widgets',
     'hqwebapp/js/bootstrap3/knockout_bindings.ko', // openModal
 ], function (
     $,
     initialPageData,
     stripeCardManager,
-    Stripe
 ) {
     $(function () {
-        Stripe.setPublishableKey(initialPageData.get("stripe_public_key"));
         var cardManager = stripeCardManager.stripeCardManager({
             cards: initialPageData.get("cards"),
             url: initialPageData.reverse("cards_view"),

--- a/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
@@ -1,4 +1,3 @@
-'use strict';
 hqDefine('domain/js/bootstrap3/update_billing_contact_info', [
     'jquery',
     'hqwebapp/js/initial_page_data',

--- a/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
@@ -14,7 +14,6 @@ hqDefine('domain/js/bootstrap3/update_billing_contact_info', [
         var cardManager = stripeCardManager.stripeCardManager({
             cards: initialPageData.get("cards"),
             url: initialPageData.reverse("cards_view"),
-            elementSelector: '#stripe-card-container',
         });
         $("#card-manager").koApplyBindings(cardManager);
 

--- a/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
@@ -15,6 +15,7 @@ hqDefine('domain/js/bootstrap3/update_billing_contact_info', [
         var cardManager = stripeCardManager.stripeCardManager({
             cards: initialPageData.get("cards"),
             url: initialPageData.reverse("cards_view"),
+            elementSelector: '#stripe-card-container',
         });
         $("#card-manager").koApplyBindings(cardManager);
 

--- a/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
@@ -6,7 +6,6 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
     'hqwebapp/js/initial_page_data',
     'accounting/js/payment_method_handler',
     'hqwebapp/js/bootstrap5/crud_paginated_list',
-    'stripe',
 ], function (
     $,
     _,
@@ -14,9 +13,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
     initialPageData,
     paymentMethodHandlers,
     CRUDPaginatedList,
-    Stripe
 ) {
-    Stripe.setPublishableKey(initialPageData.get("stripe_options").stripe_public_key);
     var wireInvoiceHandler = paymentMethodHandlers.wireInvoiceHandler;
     var paymentMethodHandler = paymentMethodHandlers.paymentMethodHandler;
     var invoice = paymentMethodHandlers.invoice;

--- a/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
@@ -1,4 +1,3 @@
-'use strict';
 hqDefine("domain/js/bootstrap5/billing_statements", [
     'jquery',
     'underscore',
@@ -28,7 +27,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
             statusCodeText: pagination.status_codes,
             allowItemCreation: initialPageData.get('item_creation_allowed'),
             createItemForm: pagination.create_item_form,
-        }
+        },
     );
 
     $(function () {
@@ -41,7 +40,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
             submitBtnText: gettext("Submit Payment"),
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_bulk_payment_url,
-        }
+        },
     );
 
     var bulkWirePaymentHandler = wireInvoiceHandler(
@@ -51,7 +50,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
             isWire: true,
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_wire_invoice_url,
-        }
+        },
     );
 
     var paymentHandler = paymentMethodHandler(
@@ -60,7 +59,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
             submitBtnText: gettext("Submit Payment"),
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_invoice_payment_url,
-        }
+        },
     );
 
     // A sign that the data model isn't exactly right - credit cards are shared data.

--- a/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
@@ -6,6 +6,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
     'hqwebapp/js/initial_page_data',
     'accounting/js/payment_method_handler',
     'hqwebapp/js/bootstrap5/crud_paginated_list',
+    'commcarehq',
 ], function (
     $,
     _,

--- a/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
@@ -69,7 +69,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
     for (var i = 0; i < handlers.length; i++) {
         handlers[i].handlers = handlers;
     }
-    var stripeCards = initialPageData.get("stripe_options").stripe_cards;
+    var stripeCards = initialPageData.get("stripe_cards");
     if (stripeCards) {
         bulkPaymentHandler.loadCards(stripeCards);
         paymentHandler.loadCards(stripeCards);

--- a/corehq/apps/domain/static/domain/js/bootstrap5/update_billing_contact_info.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap5/update_billing_contact_info.js
@@ -3,17 +3,14 @@ hqDefine('domain/js/bootstrap5/update_billing_contact_info', [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'accounting/js/stripe_card_manager',
-    'stripe',
     'accounting/js/widgets',
     'hqwebapp/js/bootstrap5/knockout_bindings.ko', // openModal
 ], function (
     $,
     initialPageData,
     stripeCardManager,
-    Stripe
 ) {
     $(function () {
-        Stripe.setPublishableKey(initialPageData.get("stripe_public_key"));
         var cardManager = stripeCardManager.stripeCardManager({
             cards: initialPageData.get("cards"),
             url: initialPageData.reverse("cards_view"),

--- a/corehq/apps/domain/static/domain/js/bootstrap5/update_billing_contact_info.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap5/update_billing_contact_info.js
@@ -5,6 +5,7 @@ hqDefine('domain/js/bootstrap5/update_billing_contact_info', [
     'accounting/js/stripe_card_manager',
     'accounting/js/widgets',
     'hqwebapp/js/bootstrap5/knockout_bindings.ko', // openModal
+    'commcarehq',
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/domain/static/domain/js/bootstrap5/update_billing_contact_info.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap5/update_billing_contact_info.js
@@ -1,4 +1,3 @@
-'use strict';
 hqDefine('domain/js/bootstrap5/update_billing_contact_info', [
     'jquery',
     'hqwebapp/js/initial_page_data',

--- a/corehq/apps/domain/static/domain/js/confirm_billing_info.js
+++ b/corehq/apps/domain/static/domain/js/confirm_billing_info.js
@@ -28,6 +28,7 @@ hqDefine("domain/js/confirm_billing_info", [
     var cardManager = stripeCardManager.stripeCardManager({
         cards: initialPageData.get("cards"),
         url: initialPageData.reverse("cards_view"),
+        elementSelector: '#stripe-card-container',
     });
     $(function () {
         $("#card-manager").koApplyBindings(cardManager);

--- a/corehq/apps/domain/static/domain/js/confirm_billing_info.js
+++ b/corehq/apps/domain/static/domain/js/confirm_billing_info.js
@@ -5,6 +5,7 @@ hqDefine("domain/js/confirm_billing_info", [
     'hqwebapp/js/initial_page_data',
     'accounting/js/stripe_card_manager',
     'accounting/js/widgets',
+    'commcarehq',
 ], function (
     $,
     ko,

--- a/corehq/apps/domain/static/domain/js/confirm_billing_info.js
+++ b/corehq/apps/domain/static/domain/js/confirm_billing_info.js
@@ -27,7 +27,6 @@ hqDefine("domain/js/confirm_billing_info", [
     var cardManager = stripeCardManager.stripeCardManager({
         cards: initialPageData.get("cards"),
         url: initialPageData.reverse("cards_view"),
-        elementSelector: '#stripe-card-container',
     });
     $(function () {
         $("#card-manager").koApplyBindings(cardManager);

--- a/corehq/apps/domain/static/domain/js/confirm_billing_info.js
+++ b/corehq/apps/domain/static/domain/js/confirm_billing_info.js
@@ -3,14 +3,12 @@ hqDefine("domain/js/confirm_billing_info", [
     'jquery',
     'knockout',
     'hqwebapp/js/initial_page_data',
-    'stripe',
     'accounting/js/stripe_card_manager',
     'accounting/js/widgets',
 ], function (
     $,
     ko,
     initialPageData,
-    Stripe,
     stripeCardManager
 ) {
     $('a.breadcrumb-2').click(function (e) {
@@ -26,7 +24,6 @@ hqDefine("domain/js/confirm_billing_info", [
         document.getElementById('downgrade-email-note').value = initialPageData.get("downgrade_email_note");
     };
 
-    Stripe.setPublishableKey(initialPageData.get("stripe_public_key"));
     var cardManager = stripeCardManager.stripeCardManager({
         cards: initialPageData.get("cards"),
         url: initialPageData.reverse("cards_view"),

--- a/corehq/apps/domain/static/domain/js/confirm_billing_info.js
+++ b/corehq/apps/domain/static/domain/js/confirm_billing_info.js
@@ -1,4 +1,3 @@
-'use strict';
 hqDefine("domain/js/confirm_billing_info", [
     'jquery',
     'knockout',
@@ -10,7 +9,7 @@ hqDefine("domain/js/confirm_billing_info", [
     $,
     ko,
     initialPageData,
-    stripeCardManager
+    stripeCardManager,
 ) {
     $('a.breadcrumb-2').click(function (e) {
         e.preventDefault();

--- a/corehq/apps/domain/static/domain/js/current_subscription.js
+++ b/corehq/apps/domain/static/domain/js/current_subscription.js
@@ -1,4 +1,3 @@
-'use strict';
 hqDefine("domain/js/current_subscription", [
     'jquery',
     'hqwebapp/js/initial_page_data',
@@ -20,7 +19,7 @@ hqDefine("domain/js/current_subscription", [
                 credit_card_url: initialPageData.reverse("domain_credits_payment"),
                 wire_url: initialPageData.reverse("domain_wire_payment"),
                 wire_email: initialPageData.get("user_email"),
-            }
+            },
         );
         var plan = initialPageData.get("plan");
         if (plan.cards) {
@@ -32,7 +31,7 @@ hqDefine("domain/js/current_subscription", [
             plan.products,
             plan.features,
             paymentHandler,
-            initialPageData.get("can_purchase_credits")
+            initialPageData.get("can_purchase_credits"),
         );
         $('#subscriptionSummary').koApplyBindings(creditsHandler);
         creditsHandler.init();

--- a/corehq/apps/domain/static/domain/js/current_subscription.js
+++ b/corehq/apps/domain/static/domain/js/current_subscription.js
@@ -4,16 +4,13 @@ hqDefine("domain/js/current_subscription", [
     'hqwebapp/js/initial_page_data',
     'accounting/js/credits',
     'accounting/js/payment_method_handler',
-    'stripe',
 ], function (
     $,
     initialPageData,
     credits,
     paymentMethodHandler,
-    Stripe
 ) {
     $(function () {
-        Stripe.setPublishableKey(initialPageData.get('stripe_public_key'));
         var paymentHandler = paymentMethodHandler.paymentMethodHandler(
             "add-credit-form",
             {

--- a/corehq/apps/domain/static/domain/js/current_subscription.js
+++ b/corehq/apps/domain/static/domain/js/current_subscription.js
@@ -4,6 +4,7 @@ hqDefine("domain/js/current_subscription", [
     'hqwebapp/js/initial_page_data',
     'accounting/js/credits',
     'accounting/js/payment_method_handler',
+    'commcarehq',
 ], function (
     $,
     initialPageData,

--- a/corehq/apps/domain/templates/domain/bootstrap3/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/billing_statements.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'domain/js/bootstrap3/billing_statements' %}
+{% js_entry_b3 'domain/js/bootstrap3/billing_statements' %}
 
 {% block paginated_list_top %}
   {% initial_page_data 'pagination' pagination %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/billing_statements.html
@@ -6,7 +6,8 @@
 
 {% block paginated_list_top %}
   {% initial_page_data 'pagination' pagination %}
-  {% initial_page_data 'stripe_options' stripe_options %}
+  {% initial_page_data 'stripe_cards' stripe_cards %}
+  {% initial_page_data 'stripe_public_key' stripe_public_key %}
   {% initial_page_data 'payment_urls' payment_urls %}
   {% initial_page_data 'payment_error_messages' payment_error_messages %}
   {% initial_page_data 'item_creation_allowed' pagination.create.is_allowed %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/confirm_billing_info.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/confirm_billing_info.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'domain/js/confirm_billing_info' %}
+{% js_entry_b3 'domain/js/confirm_billing_info' %}
 
 {% block form_content %}
   {% initial_page_data "plan" plan %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'domain/js/current_subscription' %}
+{% js_entry_b3 'domain/js/current_subscription' %}
 
 {% block page_content %}
   {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/update_billing_contact_info.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/update_billing_contact_info.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'domain/js/bootstrap3/update_billing_contact_info' %}
+{% js_entry_b3 'domain/js/bootstrap3/update_billing_contact_info' %}
 
 {% block additional_initial_page_data %}{{ block.super }}
   {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/billing_statements.html
@@ -6,7 +6,8 @@
 
 {% block paginated_list_top %}
   {% initial_page_data 'pagination' pagination %}  {# todo B5: css-pagination #}
-  {% initial_page_data 'stripe_options' stripe_options %}
+  {% initial_page_data 'stripe_cards' stripe_cards %}
+  {% initial_page_data 'stripe_public_key' stripe_public_key %}
   {% initial_page_data 'payment_urls' payment_urls %}
   {% initial_page_data 'payment_error_messages' payment_error_messages %}
   {% initial_page_data 'item_creation_allowed' pagination.create.is_allowed %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/billing_statements.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main_b5 'domain/js/bootstrap5/billing_statements' %}
+{% js_entry 'domain/js/bootstrap5/billing_statements' %}
 
 {% block paginated_list_top %}
   {% initial_page_data 'pagination' pagination %}  {# todo B5: css-pagination #}

--- a/corehq/apps/domain/templates/domain/bootstrap5/confirm_billing_info.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/confirm_billing_info.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'domain/js/confirm_billing_info' %}
+{% js_entry 'domain/js/confirm_billing_info' %}
 
 {% block form_content %}
   {% initial_page_data "plan" plan %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'domain/js/current_subscription' %}
+{% js_entry 'domain/js/current_subscription' %}
 
 {% block page_content %}
   {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/update_billing_contact_info.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/update_billing_contact_info.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'domain/js/bootstrap5/update_billing_contact_info' %}
+{% js_entry 'domain/js/bootstrap5/update_billing_contact_info' %}
 
 {% block additional_initial_page_data %}{{ block.super }}
   {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -516,10 +516,8 @@ class DomainBillingStatementsView(DomainAccountingSettings, CRUDPaginatedViewMix
     def page_context(self):
         pagination_context = self.pagination_context
         pagination_context.update({
-            'stripe_options': {
-                'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
-                'stripe_cards': self.stripe_cards,
-            },
+            'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
+            'stripe_cards': self.stripe_cards,
             'payment_error_messages': PAYMENT_ERROR_MESSAGES,
             'payment_urls': {
                 'process_invoice_payment_url': reverse(

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -365,10 +365,8 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
     def page_context(self):
         pagination_context = self.pagination_context
         pagination_context.update({
-            'stripe_options': {
-                'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
-                'stripe_cards': self.stripe_cards,
-            },
+            'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
+            'stripe_cards': self.stripe_cards,
             'payment_error_messages': PAYMENT_ERROR_MESSAGES,
             'payment_urls': {
                 'process_invoice_payment_url': reverse(

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/billing_statements.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/billing_statements.html.diff.txt
@@ -6,8 +6,8 @@
  {% load i18n %}
  {% load hq_shared_tags %}
  
--{% requirejs_main 'domain/js/bootstrap3/billing_statements' %}
-+{% requirejs_main_b5 'domain/js/bootstrap5/billing_statements' %}
+-{% js_entry_b3 'domain/js/bootstrap3/billing_statements' %}
++{% js_entry 'domain/js/bootstrap5/billing_statements' %}
  
  {% block paginated_list_top %}
 -  {% initial_page_data 'pagination' pagination %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/billing_statements.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/billing_statements.html.diff.txt
@@ -12,10 +12,10 @@
  {% block paginated_list_top %}
 -  {% initial_page_data 'pagination' pagination %}
 +  {% initial_page_data 'pagination' pagination %}  {# todo B5: css-pagination #}
-   {% initial_page_data 'stripe_options' stripe_options %}
+   {% initial_page_data 'stripe_cards' stripe_cards %}
+   {% initial_page_data 'stripe_public_key' stripe_public_key %}
    {% initial_page_data 'payment_urls' payment_urls %}
-   {% initial_page_data 'payment_error_messages' payment_error_messages %}
-@@ -21,8 +21,8 @@
+@@ -22,8 +22,8 @@
        <p data-bind="visible: hasInitialLoadFinished() && totalDue()">
          <button type="button"
                  class="btn btn-primary"
@@ -26,7 +26,7 @@
                  id="bulkPaymentBtn">
            {% trans 'Pay by Credit Card' %}
          </button>
-@@ -30,14 +30,14 @@
+@@ -31,14 +31,14 @@
        <p data-bind="visible: hasInitialLoadFinished() && totalDue()">
          <button type="button"
                  class="btn btn-primary"
@@ -44,7 +44,7 @@
              <i class="fa fa-info-circle"></i>
              {% trans "Not Billing Admin, Can't Make Payment" %}
          </span>
-@@ -62,33 +62,33 @@
+@@ -63,33 +63,33 @@
  
  {% block pagination_templates %}
    <script type="text/html" id="statement-row-template">
@@ -87,7 +87,7 @@
        <a class="btn btn-primary"
           data-bind="attr: { href: pdfUrl }"
           target="_blank">{% trans 'Download' %}</a>
-@@ -98,14 +98,14 @@
+@@ -99,14 +99,14 @@
    {% include 'accounting/partials/stripe_card_ko_template.html' %}
  
    <script type="text/html" id="cost-item-template">
@@ -105,7 +105,7 @@
          <div class="radio">
            <label>
              <input type="radio"
-@@ -129,7 +129,7 @@
+@@ -130,7 +130,7 @@
                Pay a portion of the balance:
              {% endblocktrans %}
              <div class="input-group">
@@ -114,7 +114,7 @@
                <input type="text"
                       class="form-control"
                       name="customPaymentAmount"
-@@ -187,12 +187,12 @@
+@@ -188,12 +188,12 @@
  
  {% block modals %}{{ block.super }}
    {% with process_invoice_payment_url as process_payment_url %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_billing_info.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_billing_info.html.diff.txt
@@ -7,8 +7,8 @@
  {% load hq_shared_tags %}
  {% load i18n %}
  
--{% requirejs_main 'domain/js/confirm_billing_info' %}
-+{% requirejs_main_b5 'domain/js/confirm_billing_info' %}
+-{% js_entry_b3 'domain/js/confirm_billing_info' %}
++{% js_entry 'domain/js/confirm_billing_info' %}
  
  {% block form_content %}
    {% initial_page_data "plan" plan %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
@@ -6,8 +6,8 @@
  {% load hq_shared_tags %}
  {% load i18n %}
  
--{% requirejs_main 'domain/js/current_subscription' %}
-+{% requirejs_main_b5 'domain/js/current_subscription' %}
+-{% js_entry_b3 'domain/js/current_subscription' %}
++{% js_entry 'domain/js/current_subscription' %}
  
  {% block page_content %}
    {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/update_billing_contact_info.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/update_billing_contact_info.html.diff.txt
@@ -7,8 +7,8 @@
  {% load hq_shared_tags %}
  {% load i18n %}
  
--{% requirejs_main 'domain/js/bootstrap3/update_billing_contact_info' %}
-+{% requirejs_main_b5 'domain/js/bootstrap5/update_billing_contact_info' %}
+-{% js_entry_b3 'domain/js/bootstrap3/update_billing_contact_info' %}
++{% js_entry 'domain/js/bootstrap5/update_billing_contact_info' %}
  
  {% block additional_initial_page_data %}{{ block.super }}
    {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/billing_statements.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/billing_statements.js.diff.txt
@@ -11,6 +11,6 @@
      'accounting/js/payment_method_handler',
 -    'hqwebapp/js/bootstrap3/crud_paginated_list',
 +    'hqwebapp/js/bootstrap5/crud_paginated_list',
-     'stripe',
+     'commcarehq',
  ], function (
      $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/billing_statements.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/billing_statements.js.diff.txt
@@ -1,7 +1,6 @@
 --- 
 +++ 
-@@ -1,11 +1,11 @@
- 'use strict';
+@@ -1,10 +1,10 @@
 -hqDefine("domain/js/bootstrap3/billing_statements", [
 +hqDefine("domain/js/bootstrap5/billing_statements", [
      'jquery',

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/update_billing_contact_info.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/update_billing_contact_info.js.diff.txt
@@ -1,16 +1,23 @@
 --- 
 +++ 
-@@ -1,11 +1,11 @@
+@@ -1,10 +1,10 @@
  'use strict';
 -hqDefine('domain/js/bootstrap3/update_billing_contact_info', [
 +hqDefine('domain/js/bootstrap5/update_billing_contact_info', [
      'jquery',
      'hqwebapp/js/initial_page_data',
      'accounting/js/stripe_card_manager',
-     'stripe',
      'accounting/js/widgets',
 -    'hqwebapp/js/bootstrap3/knockout_bindings.ko', // openModal
 +    'hqwebapp/js/bootstrap5/knockout_bindings.ko', // openModal
+     'commcarehq',
  ], function (
      $,
-     initialPageData,
+@@ -15,7 +15,6 @@
+         var cardManager = stripeCardManager.stripeCardManager({
+             cards: initialPageData.get("cards"),
+             url: initialPageData.reverse("cards_view"),
+-            elementSelector: '#stripe-card-container',
+         });
+         $("#card-manager").koApplyBindings(cardManager);
+ 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/update_billing_contact_info.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/update_billing_contact_info.js.diff.txt
@@ -1,7 +1,6 @@
 --- 
 +++ 
-@@ -1,10 +1,10 @@
- 'use strict';
+@@ -1,9 +1,9 @@
 -hqDefine('domain/js/bootstrap3/update_billing_contact_info', [
 +hqDefine('domain/js/bootstrap5/update_billing_contact_info', [
      'jquery',
@@ -13,7 +12,7 @@
      'commcarehq',
  ], function (
      $,
-@@ -15,7 +15,6 @@
+@@ -14,7 +14,6 @@
          var cardManager = stripeCardManager.stripeCardManager({
              cards: initialPageData.get("cards"),
              url: initialPageData.reverse("cards_view"),

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/update_billing_contact_info.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/update_billing_contact_info.js.diff.txt
@@ -12,11 +12,3 @@
      'commcarehq',
  ], function (
      $,
-@@ -14,7 +14,6 @@
-         var cardManager = stripeCardManager.stripeCardManager({
-             cards: initialPageData.get("cards"),
-             url: initialPageData.reverse("cards_view"),
--            elementSelector: '#stripe-card-container',
-         });
-         $("#card-manager").koApplyBindings(cardManager);
- 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "@mapbox/mapbox-gl-draw": "1.4.3",
         "@mapbox/mapbox-gl-geocoder": "5.0.2",
         "@popperjs/core": "npm:@popperjs/core#2.11.6",
+        "@stripe/stripe-js": "^6.1.0",
         "@turf/turf": "6.5.0",
         "At.js": "millerdev/At.js#master",
         "Caret.js": "INTELOGIE/Caret.js#0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -744,6 +744,11 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz#282046f03e886e352b2d5f5da5eb755e01457f3f"
   integrity sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==
 
+"@stripe/stripe-js@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-6.1.0.tgz#de6468e8d290da474d296f09baa1b02fda5f4f08"
+  integrity sha512-/5zxRol+MU4I7fjZXPxP2M6E1nuHOxAzoc0tOEC/TLnC31Gzc+5EE93mIjoAnu28O1Sqpl7/BkceDHwnGmn75A==
+
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SAAS-15999

This migrates to webpack and upgrades our usage of Stripe to use their [module wrapper](https://www.npmjs.com/package/@stripe/stripe-js) and [newer API](https://docs.stripe.com/js). The newer API requires using Stripe UI elements rather than our own, so there's a bunch of HTML changes in here. The js is pretty async, as the Stripe script needs to be leaded from Stripe's servers, rather than having HQ host it.

## Safety Assurance

### Safety story
This area feels rather high risk, and it's my first time working with Stripe. I'm fairly reliant on code review and QA here.

### Automated test coverage

Accounting has tests, but I don't think it has javascript coverage.

### QA Plan
https://dimagi.atlassian.net/browse/QA-7597

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
