### PR TITLE
Replaced hqRequire with import in reports/js/bootstrap5/datatables_config

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
@@ -466,7 +466,7 @@
 +                    applyBootstrapMagic();
 +                    if ('context' in data) {
 +                        let iconPath = data['icon_path'] || $(".base-maps-data").data("icon_path");
-+                        hqRequire(["reports/js/bootstrap5/maps_utils"], function (mapsUtils) {
++                        import("reports/js/bootstrap5/maps_utils").then(function (mapsUtils) {
 +                            mapsUtils.load(data['context'], iconPath);
 +                        });
 +                    }

--- a/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
@@ -166,7 +166,7 @@ var HQReportDataTables = function (options) {
                     applyBootstrapMagic();
                     if ('context' in data) {
                         let iconPath = data['icon_path'] || $(".base-maps-data").data("icon_path");
-                        hqRequire(["reports/js/bootstrap5/maps_utils"], function (mapsUtils) {
+                        import("reports/js/bootstrap5/maps_utils").then(function (mapsUtils) {
                             mapsUtils.load(data['context'], iconPath);
                         });
                     }


### PR DESCRIPTION
## Technical Summary
Tiny.

## Safety Assurance

### Safety story
This code isn't hit in prod, as there aren't reports that use maps that have been migrated to B5. If it were, it would be broken, as `hqRequire` isn't available on pages using webpack.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
