### PR TITLE
Replace require with import in reports javascript

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/standard_hq_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/standard_hq_report.js.diff.txt
@@ -24,9 +24,9 @@
          var reportOptions = initialPageData.get('js_options') || {};
          if (reportOptions.slug && reportOptions.async) {
              let promise = $.Deferred();
--            require(["reports/js/bootstrap3/async"], function (asyncHQReportModule) {
-+            require(["reports/js/bootstrap5/async"], function (asyncHQReportModule) {
-                 var asyncHQReport = asyncHQReportModule({
+-            import("reports/js/bootstrap3/async").then(function (asyncHQReportModule) {
++            import("reports/js/bootstrap5/async").then(function (asyncHQReportModule) {
+                 var asyncHQReport = asyncHQReportModule.default({
                      standardReport: getStandard(),
                  });
 @@ -75,13 +77,19 @@

--- a/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/standard_hq_report.js
@@ -56,8 +56,8 @@ hqDefine("reports/js/bootstrap3/standard_hq_report", [
         var reportOptions = initialPageData.get('js_options') || {};
         if (reportOptions.slug && reportOptions.async) {
             let promise = $.Deferred();
-            require(["reports/js/bootstrap3/async"], function (asyncHQReportModule) {
-                var asyncHQReport = asyncHQReportModule({
+            import("reports/js/bootstrap3/async").then(function (asyncHQReportModule) {
+                var asyncHQReport = asyncHQReportModule.default({
                     standardReport: getStandard(),
                 });
                 asyncHQReport.init();

--- a/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/standard_hq_report.js
@@ -58,8 +58,8 @@ hqDefine("reports/js/bootstrap5/standard_hq_report", [
         var reportOptions = initialPageData.get('js_options') || {};
         if (reportOptions.slug && reportOptions.async) {
             let promise = $.Deferred();
-            require(["reports/js/bootstrap5/async"], function (asyncHQReportModule) {
-                var asyncHQReport = asyncHQReportModule({
+            import("reports/js/bootstrap5/async").then(function (asyncHQReportModule) {
+                var asyncHQReport = asyncHQReportModule.default({
                     standardReport: getStandard(),
                 });
                 asyncHQReport.init();

--- a/corehq/apps/reports_core/static/reports_core/js/bootstrap3/maps.js
+++ b/corehq/apps/reports_core/static/reports_core/js/bootstrap3/maps.js
@@ -12,10 +12,16 @@ hqDefine('reports_core/js/bootstrap3/maps', [
     // Reset images needed for map markers, which don't play well with webpack.
     // See https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-483402699
     delete L.Icon.Default.prototype._getIconUrl;
-    L.Icon.Default.mergeOptions({
-        iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
-        iconUrl: require('leaflet/dist/images/marker-icon.png'),
-        shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
+    import('leaflet/dist/images/marker-icon-2x.png').then(function (iconRetina) {
+        import('leaflet/dist/images/marker-icon.png').then(function (icon) {
+            import('leaflet/dist/images/marker-shadow.png').then(function (shadow) {
+                L.Icon.Default.mergeOptions({
+                    iconRetinaUrl: iconRetina.default,
+                    iconUrl: icon.default,
+                    shadowUrl: shadow.default,
+                });
+            });
+        });
     });
 
     var module = {},

--- a/corehq/apps/reports_core/static/reports_core/js/bootstrap3/maps.js
+++ b/corehq/apps/reports_core/static/reports_core/js/bootstrap3/maps.js
@@ -39,8 +39,8 @@ hqDefine('reports_core/js/bootstrap3/maps', [
         });
     };
 
-    var init_map = function (config, mapContainer) {
-        if (!privates.hasOwnProperty('map')) {
+    var initMap = function (config, mapContainer) {
+        if (!_.has(privates, 'map')) {
             mapContainer.show();
             mapContainer.empty();
             var streets = getTileLayer('mapbox/streets-v11', config.mapboxAccessToken),
@@ -99,13 +99,13 @@ hqDefine('reports_core/js/bootstrap3/maps', [
     };
 
     module.render = function (config, data, mapContainer) {
-        init_map(config, mapContainer);
+        initMap(config, mapContainer);
         initPopupTemplate(config);
 
-        var bad_re = /[a-zA-Z()]+/;
+        var badRegex = /[a-zA-Z()]+/;
         var points = _.compact(_.map(data, function (row) {
             var val = row[config.location_column_id];
-            if (val !== null && !bad_re.test(val)) {
+            if (val !== null && !badRegex.test(val)) {
                 var latlon = val.split(" ").slice(0, 2);
                 return L.marker(latlon).bindPopup(privates.template({row: row, columns: privates.columns}));
             }

--- a/corehq/apps/reports_core/static/reports_core/js/bootstrap5/maps.js
+++ b/corehq/apps/reports_core/static/reports_core/js/bootstrap5/maps.js
@@ -39,8 +39,8 @@ hqDefine('reports_core/js/bootstrap5/maps', [
         });
     };
 
-    var init_map = function (config, mapContainer) {
-        if (!privates.hasOwnProperty('map')) {
+    var initMap = function (config, mapContainer) {
+        if (!_.has(privates, 'map')) {
             mapContainer.show();
             mapContainer.empty();
             var streets = getTileLayer('mapbox/streets-v11', config.mapboxAccessToken),
@@ -99,13 +99,13 @@ hqDefine('reports_core/js/bootstrap5/maps', [
     };
 
     module.render = function (config, data, mapContainer) {
-        init_map(config, mapContainer);
+        initMap(config, mapContainer);
         initPopupTemplate(config);
 
-        var bad_re = /[a-zA-Z()]+/;
+        var badRegex = /[a-zA-Z()]+/;
         var points = _.compact(_.map(data, function (row) {
             var val = row[config.location_column_id];
-            if (val !== null && !bad_re.test(val)) {
+            if (val !== null && !badRegex.test(val)) {
                 var latlon = val.split(" ").slice(0, 2);
                 return L.marker(latlon).bindPopup(privates.template({row: row, columns: privates.columns}));
             }

--- a/corehq/apps/reports_core/static/reports_core/js/bootstrap5/maps.js
+++ b/corehq/apps/reports_core/static/reports_core/js/bootstrap5/maps.js
@@ -12,10 +12,16 @@ hqDefine('reports_core/js/bootstrap5/maps', [
     // Reset images needed for map markers, which don't play well with webpack.
     // See https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-483402699
     delete L.Icon.Default.prototype._getIconUrl;
-    L.Icon.Default.mergeOptions({
-        iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
-        iconUrl: require('leaflet/dist/images/marker-icon.png'),
-        shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
+    import('leaflet/dist/images/marker-icon-2x.png').then(function (iconRetina) {
+        import('leaflet/dist/images/marker-icon.png').then(function (icon) {
+            import('leaflet/dist/images/marker-shadow.png').then(function (shadow) {
+                L.Icon.Default.mergeOptions({
+                    iconRetinaUrl: iconRetina.default,
+                    iconUrl: icon.default,
+                    shadowUrl: shadow.default,
+                });
+            });
+        });
     });
 
     var module = {},


### PR DESCRIPTION
## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/35753/#issuecomment-2651627767 (that should link to Jing's Feb 11 comments, but the link doesn't seem to be working).

I don't remember what I was thinking using `require`.

## Safety Assurance

### Safety story
Errors here, particularly in `standard_hq_report.js`, would affect all of reports. However, these are small changes, and I think local testing is appropriate. I've locally tested
* The case list (for the B5 standard_hq_report change)
* The case activity report (for the B3 standard_hq_report change)
* A UCR that uses a map (for the B3 maps change, there aren't any B5 pages using maps)

### Automated test coverage

no

### QA Plan

no

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
