### PR TITLE
[Data Cleaning] Logic + UI hook for updating column order

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -137,10 +137,6 @@ class BulkEditSession(models.Model):
             value=value,
         )
 
-    def remove_filter(self, filter_id):
-        self.filters.get(filter_id=filter_id).delete()
-        remaining_ids = self.filters.values_list('filter_id', flat=True)
-        self.update_filter_order(remaining_ids)
 
     def update_filter_order(self, filter_ids):
         """
@@ -153,6 +149,11 @@ class BulkEditSession(models.Model):
             active_filter = self.filters.get(filter_id=filter_id)
             active_filter.index = index
             active_filter.save()
+
+    def remove_filter(self, filter_id):
+        self.filters.get(filter_id=filter_id).delete()
+        remaining_ids = self.filters.values_list('filter_id', flat=True)
+        self.update_filter_order(remaining_ids)
 
     def get_queryset(self):
         query = CaseSearchES().domain(self.domain).case_type(self.identifier)

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -148,17 +148,35 @@ class BulkEditSession(models.Model):
         """
         return BulkEditColumn.create_for_session(self, prop_id, label, data_type)
 
+    @staticmethod
+    def _update_order(related_manager, id_field, provided_ids):
+        """
+        Updates the ordering of related objects by setting their `index` field.
+
+        :param related_manager: a Django RelatedManager (e.g., self.filters, self.columns)
+        :param id_field: string name of the object's unique identifier (e.g., 'filter_id')
+        :param provided_ids: list of UUIDs in desired order
+        """
+        if len(provided_ids) != related_manager.count():
+            raise ValueError("The lengths of provided_ids and existing objects do not match.")
+        for index, object_id in enumerate(provided_ids):
+            obj = related_manager.get(**{id_field: object_id})
+            obj.index = index
+            obj.save()
+
     def update_filter_order(self, filter_ids):
         """
         This updates the order of filters for this session
         :param filter_ids: list of uuids matching filter_id field of BulkEditFilters
         """
-        if len(filter_ids) != self.filters.count():
-            raise ValueError("the lengths of filter_ids and available filters do not match")
-        for index, filter_id in enumerate(filter_ids):
-            active_filter = self.filters.get(filter_id=filter_id)
-            active_filter.index = index
-            active_filter.save()
+        self._update_order(self.filters, 'filter_id', filter_ids)
+
+    def update_column_order(self, column_ids):
+        """
+        This updates the order of columns for this session
+        :param column_ids: list of uuids matching column_id field of BulkEditColumns
+        """
+        self._update_order(self.columns, 'column_id', column_ids)
 
     def remove_filter(self, filter_id):
         self.filters.get(filter_id=filter_id).delete()

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -137,6 +137,16 @@ class BulkEditSession(models.Model):
             value=value,
         )
 
+    def add_column(self, prop_id, label, data_type=None):
+        """
+        Add a column to this session.
+
+        :param prop_id: string - The property ID (e.g., case property)
+        :param label: string - The column label to display
+        :param data_type: DataType - Optional. Will be inferred for system props
+        :return: The created BulkEditColumn
+        """
+        return BulkEditColumn.create_for_session(self, prop_id, label, data_type)
 
     def update_filter_order(self, filter_ids):
         """
@@ -176,17 +186,6 @@ class BulkEditSession(models.Model):
         for pinned_filter in self.pinned_filters.all():
             query = pinned_filter.filter_query(query)
         return query
-
-    def add_column(self, prop_id, label, data_type=None):
-        """
-        Add a column to this session.
-
-        :param prop_id: string - The property ID (e.g., case property)
-        :param label: string - The column label to display
-        :param data_type: DataType - Optional. Will be inferred for system props
-        :return: The created BulkEditColumn
-        """
-        return BulkEditColumn.create_for_session(self, prop_id, label, data_type)
 
     def update_result(self, record_count, form_id=None):
         result = self.result or {}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/partials/column_list_item.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/partials/column_list_item.html
@@ -7,7 +7,7 @@
       <i class="fa-solid fa-up-down"></i>
       <input
         type="hidden"
-        name="filter_ids"
+        name="column_ids"
         value="{{ column.column_id }}"
       />
     </div>

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -192,6 +192,31 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             ['name', 'watered_on', 'num_leaves', 'height_cm', 'pot_type']
         )
 
+    def test_reorder_wrong_number_of_column_ids_raises_error(self):
+        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        columns = session.columns.all()
+        new_order = [columns[1].column_id, columns[2].column_id]
+        with self.assertRaises(ValueError):
+            session.update_column_order(new_order)
+
+    def test_update_column_order(self):
+        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        columns = session.columns.all()
+        new_order = [
+            columns[1].column_id,
+            columns[0].column_id,
+            columns[2].column_id,
+            columns[4].column_id,
+            columns[5].column_id,
+            columns[3].column_id,
+        ]
+        session.update_column_order(new_order)
+        reordered_prop_ids = [c.prop_id for c in session.columns.all()]
+        self.assertEqual(
+            reordered_prop_ids,
+            ['owner_name', 'name', 'date_opened', 'last_modified', '@status', 'opened_by_username']
+        )
+
     def test_get_queryset_multiple_filters(self):
         session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)

--- a/corehq/apps/data_cleaning/views/columns.py
+++ b/corehq/apps/data_cleaning/views/columns.py
@@ -40,7 +40,8 @@ class ManageColumnsFormView(BulkEditSessionViewMixin,
 
     @hq_hx_action('post')
     def update_column_order(self, request, *args, **kwargs):
-        # todo
+        column_ids = request.POST.getlist('column_ids')
+        self.session.update_column_order(column_ids)
         return self.get(request, *args, **kwargs)
 
     @hq_hx_action('post')


### PR DESCRIPTION
## Technical Summary
This PR
- sets up the logic for updating column order (with tests!)
- adds the hook in the UI to actually update the order of columns when the sortable list is sorted and the new order is POSTed to `ManageColumnsFormView`

<img width="1383" alt="Screenshot 2025-03-26 at 12 04 16 PM" src="https://github.com/user-attachments/assets/aafd17c1-1a98-49ac-a88e-2deb4ba7f4e0" />


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change behind feature flag. affects no active production workflows. most important logic has basic tests to ensure overall integrity for future updates.

### Automated test coverage
yes

### QA Plan
not yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
