### PR TITLE
Create an empty dashboard if one doesn't exist yet

### DIFF
--- a/corehq/apps/campaign/tests/test_views.py
+++ b/corehq/apps/campaign/tests/test_views.py
@@ -121,6 +121,17 @@ class TestDashboardView(BaseTestCampaignView):
         }
 
 
+class TestDashboardViewNoDashboard(BaseTestCampaignView):
+    urlname = DashboardView.urlname
+
+    @flag_enabled('CAMPAIGN_DASHBOARD')
+    def test_no_dashboard(self):
+        assert not Dashboard.objects.filter(domain=self.domain).exists()
+        response = self._make_request(is_logged_in=True)
+        assert response.status_code == 200
+        assert Dashboard.objects.filter(domain=self.domain).exists()
+
+
 @es_test(requires=[case_search_adapter], setup_class=True)
 class TestPaginatedCasesWithGPSView(BaseTestCampaignView):
     case_type = 'person'

--- a/corehq/apps/campaign/tests/test_views.py
+++ b/corehq/apps/campaign/tests/test_views.py
@@ -52,7 +52,8 @@ class BaseTestCampaignView(TestCase):
     def login_endpoint(self):
         return reverse('domain_login', kwargs={'domain': self.domain})
 
-    def _make_request(self, query_data={}, is_logged_in=True):
+    def _make_request(self, query_data=None, is_logged_in=True):
+        query_data = query_data or {}
         if is_logged_in:
             self.client.login(username=self.username, password=self.password)
         return self.client.get(self.endpoint, query_data)

--- a/corehq/apps/campaign/views.py
+++ b/corehq/apps/campaign/views.py
@@ -63,12 +63,20 @@ class DashboardView(BaseProjectReportSectionView, DashboardMapFilterMixin):
     def page_url(self):
         return reverse(self.urlname, args=[self.domain])
 
+    @property
+    def dashboard(self):
+        """
+        Returns the campaign dashboard for the domain. Creates an empty
+        one if it doesn't exist yet.
+        """
+        dashboard, __ = Dashboard.objects.get_or_create(domain=self.domain)
+        return dashboard
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        dashboard = Dashboard.objects.get(domain=self.domain)
         context.update({
             'mapbox_access_token': settings.MAPBOX_ACCESS_TOKEN,
-            'map_report_widgets': dashboard.get_map_report_widgets_by_tab()
+            'map_report_widgets': self.dashboard.get_map_report_widgets_by_tab()
         })
         context.update(self.dashboard_map_case_filters_context())
         return context


### PR DESCRIPTION
## Technical Summary

[Sentry](https://dimagi.sentry.io/issues/6463257225/?project=136860)

Addresses `Dashboard.DoesNotExist` error for domains that navigate to the Campaign Dashboard before a dashboard instance has been created for them.

## Feature Flag

campaign_dashboard

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Test included

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
