### PR TITLE
[Data Cleaning] Add Logic + UI hook to remove columns

### DIFF
--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -158,6 +158,18 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             self.assertEqual(filters[index].prop_id, prop_id)
             self.assertEqual(filters[index].index, index)
 
+    def test_remove_column(self):
+        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        column_to_remove = session.columns.all()[1]  # owner_name
+        self.assertEqual(column_to_remove.prop_id, 'owner_name')
+        session.remove_column(column_to_remove.column_id)
+        columns = session.columns.all()
+        self.assertEqual(len(columns), 5)
+        for index, prop_id in enumerate(['name', 'date_opened', 'opened_by_username',
+                                         'last_modified', '@status']):
+            self.assertEqual(columns[index].prop_id, prop_id)
+            self.assertEqual(columns[index].index, index)
+
     def test_reorder_wrong_number_of_filter_ids_raises_error(self):
         session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)

--- a/corehq/apps/data_cleaning/views/columns.py
+++ b/corehq/apps/data_cleaning/views/columns.py
@@ -46,5 +46,5 @@ class ManageColumnsFormView(BulkEditSessionViewMixin,
 
     @hq_hx_action('post')
     def remove_column(self, request, *args, **kwargs):
-        # todo
+        self.session.remove_column(request.POST['delete_id'])
         return self.get(request, *args, **kwargs)


### PR DESCRIPTION
## Technical Summary
This PR adds logic (with simple, essential tests) to remove columns. It also adds the hook when POSTing an HTMX request to `ManageColumnsFormView` with `hq_hx_action` `remove_column`.
![Screenshot 2025-03-27 at 1 09 34 PM](https://github.com/user-attachments/assets/c125aaf2-67c4-4f91-a56c-20156fd281e4)


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change, does not modify any existing production workflows. all behind a feature flag

### Automated test coverage
most important functionality is tested.

### QA Plan
not yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
