### PR TITLE
Updates to Select Plan page

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -195,11 +195,21 @@ hqDefine('accounting/js/pricing_table', [
         return self;
     };
 
+    var planDisplayName = function (name) {
+        const plans = {
+            'Community': 'Free Edition',
+            'Standard': 'Standard',
+            'Pro': 'Pro',
+            'Advanced': 'Advanced',
+        };
+        return plans[name] || '';
+    };
+
     var PlanOption = function (data, parent) {
         'use strict';
         var self = this;
 
-        self.oName = ko.observable(data.name);
+        self.oName = ko.observable(planDisplayName(data.name));
         self.oSlug = ko.observable(data.name.toLowerCase());
 
         self.oMonthlyPrice = ko.observable(data.monthly_price);

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -216,6 +216,10 @@ hqDefine('accounting/js/pricing_table', [
         self.oAnnualPrice = ko.observable(data.annual_price);
         self.oDescription = ko.observable(data.description);
 
+        self.oIsCommunityPlan = ko.computed(function () {
+            return self.oSlug() === 'community';
+        });
+
         self.oIsCurrentPlan = ko.computed(function () {
             return self.oSlug() === parent.oCurrentPlan();
         });

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -45,12 +45,6 @@ hqDefine('accounting/js/pricing_table', [
 
         self.oShowAnnualPricing = ko.observable(false);
 
-        self.oRefundCss = ko.computed(function () {
-            if (self.oShowAnnualPricing()) {
-                return "show-refund";
-            }
-        });
-
         self.oIsSubmitDisabled = ko.computed(function () {
             var isCurrentPlan = self.oSelectedPlan() === self.oCurrentPlan() && !self.oNextSubscription(),
                 isNextPlan = self.oNextSubscription() && self.oSelectedPlan() === self.oNextSubscription().toLowerCase();

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -191,7 +191,7 @@ hqDefine('accounting/js/pricing_table', [
 
     var planDisplayName = function (name) {
         const plans = {
-            'Community': 'Free Edition',
+            'Community': gettext('Free edition'),
             'Standard': 'Standard',
             'Pro': 'Pro',
             'Advanced': 'Advanced',

--- a/corehq/apps/accounting/user_text.py
+++ b/corehq/apps/accounting/user_text.py
@@ -4,9 +4,8 @@ from corehq.apps.accounting.models import FeatureType, SoftwarePlanEdition
 
 DESC_BY_EDITION = {
     SoftwarePlanEdition.COMMUNITY: {
-        'name': _("Community"),
-        'description': _("For projects in a pilot phase with a small group (up to {}) of "
-                         "mobile users that only need very basic CommCare features."),
+        'name': _("Free"),
+        'description': _("For practice purposes. Not intended for live projects. {} users maximum."),
     },
     SoftwarePlanEdition.STANDARD: {
         'name': _("Standard"),

--- a/corehq/apps/accounting/user_text.py
+++ b/corehq/apps/accounting/user_text.py
@@ -10,25 +10,20 @@ DESC_BY_EDITION = {
     },
     SoftwarePlanEdition.STANDARD: {
         'name': _("Standard"),
-        'description': _("For programs with one-time data collection needs, "
-                         "simple case management workflows, and basic M&E "
-                         "requirements. "
-                         "({} mobile workers included)"),
+        'description': _("Get started. Build secure apps for offline mobile data collection and case management. "
+                         "{} users included."),
     },
     SoftwarePlanEdition.PRO: {
         'name': _("Pro"),
-        'description': _("For programs with complex case management needs, "
-                         "field staff collaborating on tasks, and M&E teams "
-                         "that need to clean and report on data. "
-                         "({} mobile workers included)"),
+        'description': _("Beyond the basics. Unlock reporting, case sharing, and hands-on support. "
+                         "{} users included."),
     },
     SoftwarePlanEdition.ADVANCED: {
         'name': _("Advanced"),
-        'description': _("For programs with distributed field staff, "
-                         "facility-based workflows, and advanced security "
-                         "needs. Also for M&E teams integrating data with "
-                         "3rd party analytics. "
-                         "({} mobile workers included)")
+        'description': _("Unlock everything. Our most secure plan, built for managing connected systems across "
+                         "locations and user profiles, featuring web apps, advanced security, and robust admin "
+                         "and data management tools. "
+                         "{} users included.")
     },
     SoftwarePlanEdition.ENTERPRISE: {
         'name': _("Enterprise"),

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -177,15 +177,6 @@
       {% endblocktrans %}
     </div>
 
-    <div class="community-plan-notice alert alert-info text-center"
-         data-bind="visible: oIsCurrentPlanCommunity">
-      <p class="lead">
-        {% blocktrans %}
-          You are currently on the FREE CommCare Community plan.
-        {% endblocktrans %}
-      </p>
-    </div>
-
     <form
       {% if is_renewal %}
         action="{% url 'domain_subscription_renewal_confirmation' domain %}"

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -2,7 +2,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 {% load menu_tags %}
-
 {% js_entry_b3 'accounting/js/pricing_table' %}
 
 {% block form_content %}
@@ -26,11 +25,14 @@
   </p>
 
   <section id="plans" class="ko-template">
-
     <p class="switch-label text-center">
       {% trans "Pay Monthly" %}
       <label class="switch">
-        <input type="checkbox" id="pricing-toggle" data-bind="{checked: oShowAnnualPricing}">
+        <input
+          type="checkbox"
+          id="pricing-toggle"
+          data-bind="{checked: oShowAnnualPricing}"
+        />
         <span class="slider round slider-blue slider-blue-on"></span>
       </label>
       {% trans "Pay Annually" %}
@@ -44,8 +46,7 @@
 
     <p class="refund-text text-center" data-bind="visible: oShowAnnualPricing">
       <i class="fa fa-check"></i>
-      <a href="https://dimagi.com/terms/latest/tos/"
-         class="check-icon blue">
+      <a href="https://dimagi.com/terms/latest/tos/" class="check-icon blue">
         {% trans '30 day refund policy' %}
       </a>
     </p>
@@ -53,9 +54,7 @@
     <div class="select-plan-row">
       <!-- ko foreach: oPlanOptions -->
       <div class="select-plan-col">
-        <a href="#"
-           class="tile"
-           data-bind="css: oCssClass, click: selectPlan">
+        <a href="#" class="tile" data-bind="css: oCssClass, click: selectPlan">
           <h3 data-bind="text: oName"></h3>
           <p
             class="pricing-type"
@@ -70,13 +69,18 @@
           <p
             class="plan-monthly-label"
             data-bind="attr: { 'aria-hidden': oIsCommunityPlan() }"
-          >{% trans "monthly" %}
-            <span data-bind="visible: oDisplayDiscountNotice">({% trans 'discounted' %})</span>
+          >
+            {% trans "monthly" %}
+            <span data-bind="visible: oDisplayDiscountNotice"
+              >({% trans 'discounted' %})</span
+            >
           </p>
           <p class="plan-desc" data-bind="text: oDescription"></p>
 
-          <p class="plan-downgrade-notice text-warning"
-             data-bind="visible: oShowDowngradeNotice">
+          <p
+            class="plan-downgrade-notice text-warning"
+            data-bind="visible: oShowDowngradeNotice"
+          >
             <i class="fa fa-warning"></i>
             {% blocktrans %}
               This plan will be downgrading to
@@ -85,8 +89,10 @@
             {% endblocktrans %}
           </p>
 
-          <p class="plan-downgrade-notice text-warning"
-             data-bind="visible: oShowPausedNotice">
+          <p
+            class="plan-downgrade-notice text-warning"
+            data-bind="visible: oShowPausedNotice"
+          >
             <i class="fa fa-warning"></i>
             {% blocktrans %}
               This plan will be pausing on<br />
@@ -94,13 +100,11 @@
             {% endblocktrans %}
           </p>
 
-          <div class="btn btn-current"
-               data-bind="visible: oIsCurrentPlan">
+          <div class="btn btn-current" data-bind="visible: oIsCurrentPlan">
             {% trans "Current Plan" %}
           </div>
 
-          <div class="btn btn-select"
-               data-bind="visible: !oIsCurrentPlan()">
+          <div class="btn btn-select" data-bind="visible: !oIsCurrentPlan()">
             {% trans "Select Plan" %}
           </div>
         </a>
@@ -108,10 +112,14 @@
       <!-- /ko -->
     </div>
 
-    <div data-bind="visible: !oIsCurrentPlanCommunity() && !oIsNextPlanPaused() && !oIsCurrentPlanPaused()">
-      <a href="#"
-         class="tile tile-paused"
-         data-bind="click: selectPausedPlan, css: oPausedCss">
+    <div
+      data-bind="visible: !oIsCurrentPlanCommunity() && !oIsNextPlanPaused() && !oIsCurrentPlanPaused()"
+    >
+      <a
+        href="#"
+        class="tile tile-paused"
+        data-bind="click: selectPausedPlan, css: oPausedCss"
+      >
         <h4 class="text-center">
           {% blocktrans %}
             Pause Subscription
@@ -125,8 +133,8 @@
         <ul>
           <li>
             {% blocktrans %}
-              You will lose access to your project space, but you will be
-              able to re-subscribe anytime in the future.
+              You will lose access to your project space, but you will be able
+              to re-subscribe anytime in the future.
             {% endblocktrans %}
           </li>
           <li>
@@ -138,8 +146,10 @@
       </a>
     </div>
 
-    <div class="alert {% if can_domain_unpause %}alert-info{% else %}alert-danger{% endif %} text-center"
-         data-bind="visible: oIsCurrentPlanPaused">
+    <div
+      class="alert {% if can_domain_unpause %}alert-info{% else %}alert-danger{% endif %} text-center"
+      data-bind="visible: oIsCurrentPlanPaused"
+    >
       <p class="lead">
         {% if can_domain_unpause %}
           <i class="fa-regular fa-circle-pause"></i>
@@ -153,34 +163,38 @@
             Your subscription is currently paused because you have
             <a href="{{ url_statements }}">past-due invoices</a>.
           {% endblocktrans %}
-            <br />
+          <br />
           {% blocktrans %}
-            You will not be allowed to un-pause your project until
-            these invoices are paid.
+            You will not be allowed to un-pause your project until these
+            invoices are paid.
           {% endblocktrans %}
         {% endif %}
       </p>
     </div>
 
-    <div class="alert alert-warning text-center"
-         data-bind="visible: oIsNextPlanPaused">
+    <div
+      class="alert alert-warning text-center"
+      data-bind="visible: oIsNextPlanPaused"
+    >
       <i class="fa fa-warning"></i>
       {% blocktrans %}
         Your subscription will be pausing on
-        <span data-bind="text: oStartDateAfterMinimumSubscription"></span> unless
-        you select a different plan above.
+        <span data-bind="text: oStartDateAfterMinimumSubscription"></span>
+        unless you select a different plan above.
       {% endblocktrans %}
     </div>
 
-    <div class="alert alert-warning text-center"
-         style="margin-top: 20px;"
-         data-bind="visible: oIsNextPlanDowngrade">
+    <div
+      class="alert alert-warning text-center"
+      style="margin-top: 20px;"
+      data-bind="visible: oIsNextPlanDowngrade"
+    >
       <i class="fa fa-warning"></i>
       {% blocktrans %}
         Your subscription will be downgrading to
         <span data-bind="text: oNextSubscription"></span> on
-        <span data-bind="text: oStartDateAfterMinimumSubscription"></span> unless
-        you select a different plan above.
+        <span data-bind="text: oStartDateAfterMinimumSubscription"></span>
+        unless you select a different plan above.
       {% endblocktrans %}
     </div>
 
@@ -190,52 +204,67 @@
       {% else %}
         action="{% url 'confirm_selected_plan' domain %}"
       {% endif %}
-        class="form"
-        id="select-plan-form"
-        method="post"
-        data-bind="visible: oShowNext"
-        style="display: none;"
-        action="{% url 'confirm_selected_plan' domain %}">
+      class="form"
+      id="select-plan-form"
+      method="post"
+      data-bind="visible: oShowNext"
+      style="display: none;"
+      action="{% url 'confirm_selected_plan' domain %}"
+    >
       {% csrf_token %}
       {% if is_renewal %}
-        <input type="hidden" name="from_plan_page" value="true">
+        <input type="hidden" name="from_plan_page" value="true" />
       {% endif %}
 
       {% if can_domain_unpause %}
-        <input type="hidden" name="plan_edition" data-bind="value: oSelectedPlan">
+        <input
+          type="hidden"
+          name="plan_edition"
+          data-bind="value: oSelectedPlan"
+        />
         <div class="text-center plan-next">
-          <button type="submit"
-                  class="btn btn-primary btn-lg"
-                  data-bind="click: openMinimumSubscriptionModal, disable: oIsSubmitDisabled">
+          <button
+            type="submit"
+            class="btn btn-primary btn-lg"
+            data-bind="click: openMinimumSubscriptionModal, disable: oIsSubmitDisabled"
+          >
             {% trans 'Next' %}
           </button>
         </div>
       {% else %}
         <div class="text-center plan-next">
-          <button type="button"
-                  class="btn btn-primary btn-lg"
-                  disabled="disabled">
+          <button
+            type="button"
+            class="btn btn-primary btn-lg"
+            disabled="disabled"
+          >
             {% trans 'Next' %}
           </button>
         </div>
       {% endif %}
     </form>
 
-    <form action="{% url 'annual_plan_request_quote' domain %}"
-          data-bind="visible: !oShowNext()">
+    <form
+      action="{% url 'annual_plan_request_quote' domain %}"
+      data-bind="visible: !oShowNext()"
+    >
       {% csrf_token %}
-      <input type="hidden" name="plan_edition" data-bind="value: oSelectedPlan">
+      <input
+        type="hidden"
+        name="plan_edition"
+        data-bind="value: oSelectedPlan"
+      />
       <div class="text-center plan-next">
         <button class="btn btn-primary btn-lg" data-bind="click: contactSales">
           {% trans 'Talk to Sales' %}
         </button>
       </div>
     </form>
-
   </section>
 {% endblock %}
 
-{% block modals %}{{ block.super }}
+{% block modals %}
+  {{ block.super }}
   <div class="modal fade" id="modal-minimum-subscription">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -246,12 +275,18 @@
           </button>
           <h4 class="modal-title">Downgrading?</h4>
         </div>
-        <div class="modal-body">
-          <br><br>
-        </div>
+        <div class="modal-body"><br /><br /></div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary" data-dismiss="modal">{% trans "Dismiss" %}</button>
-          <button type="button" class="btn btn-danger" data-bind="click: submitDowngradeForm">{% trans "Continue" %}</button>
+          <button type="button" class="btn btn-primary" data-dismiss="modal">
+            {% trans "Dismiss" %}
+          </button>
+          <button
+            type="button"
+            class="btn btn-danger"
+            data-bind="click: submitDowngradeForm"
+          >
+            {% trans "Continue" %}
+          </button>
         </div>
       </div>
     </div>

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -58,12 +58,20 @@
            class="tile"
            data-bind="css: oCssClass, click: selectPlan">
           <h3 data-bind="text: oName"></h3>
-          <p class="pricing-type"
-             data-bind="text: oPricingTypeText, css: oPricingTypeCssClass"></p>
+          <p
+            class="pricing-type"
+            data-bind="
+                css: oPricingTypeCssClass,
+                text: oPricingTypeText,
+                attr: { 'aria-hidden': oIsCommunityPlan() }
+            "
+          ></p>
 
           <p class="plan-price" data-bind="text: oDisplayPrice"></p>
-          <p class="plan-monthly-label">
-            {% trans "monthly" %}
+          <p
+            class="plan-monthly-label"
+            data-bind="attr: { 'aria-hidden': oIsCommunityPlan() }"
+          >{% trans "monthly" %}
             <span data-bind="visible: oDisplayDiscountNotice">({% trans 'discounted' %})</span>
           </p>
           <p class="plan-desc" data-bind="text: oDescription"></p>

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -36,18 +36,17 @@
       {% trans "Pay Annually" %}
     </p>
 
-    <p class="text-center">
+    <p class="text-center" data-bind="visible: !oShowAnnualPricing()">
       {% blocktrans %}
         Save close to 20% when you pay annually.
       {% endblocktrans %}
     </p>
 
-    <p class="refund-text text-center"
-       data-bind="css: oRefundCss">
+    <p class="refund-text text-center" data-bind="visible: oShowAnnualPricing">
       <i class="fa fa-check"></i>
       <a href="https://dimagi.com/terms/latest/tos/"
          class="check-icon blue">
-        {% trans '90 day refund policy' %}
+        {% trans '30 day refund policy' %}
       </a>
     </p>
 

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -21,8 +21,8 @@
   <p class="lead text-center">
     {{ lead_text }}
     <a href="{% prelogin_url 'public_pricing' %}" target="_blank">
-      {% trans "Learn More" %}
-    </a>
+      {% trans "Learn More" %}</a
+    >.
   </p>
 
   <section id="plans" class="ko-template">

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -66,6 +66,11 @@
           data-bind="css: oCssClass, click: selectPlan"
         >
           <h3 data-bind="text: oName"></h3>
+
+          {% comment %}
+          We could hide this text block for Community, but instead just make
+          its contents invisible to avoid layout shifting
+          {% endcomment %}
           <p
             class="pricing-type"
             data-bind="
@@ -79,6 +84,11 @@
             class="plan-price"
             data-bind="text: oDisplayPrice"
           ></p>
+
+          {% comment %}
+          We could hide this text block for Community, but instead just make
+          its contents invisible to avoid layout shifting
+          {% endcomment %}
           <p
             class="plan-monthly-label"
             data-bind="attr: { 'aria-hidden': oIsCommunityPlan() }"

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -38,13 +38,19 @@
       {% trans "Pay Annually" %}
     </p>
 
-    <p class="text-center" data-bind="visible: !oShowAnnualPricing()">
+    <p
+      class="text-center"
+      data-bind="visible: !oShowAnnualPricing()"
+    >
       {% blocktrans %}
         Save close to 20% when you pay annually.
       {% endblocktrans %}
     </p>
 
-    <p class="refund-text text-center" data-bind="visible: oShowAnnualPricing">
+    <p
+      class="refund-text text-center"
+      data-bind="visible: oShowAnnualPricing"
+    >
       <i class="fa fa-check"></i>
       <a href="https://dimagi.com/terms/latest/tos/" class="check-icon blue">
         {% trans '30 day refund policy' %}
@@ -54,7 +60,11 @@
     <div class="select-plan-row">
       <!-- ko foreach: oPlanOptions -->
       <div class="select-plan-col">
-        <a href="#" class="tile" data-bind="css: oCssClass, click: selectPlan">
+        <a
+          href="#"
+          class="tile"
+          data-bind="css: oCssClass, click: selectPlan"
+        >
           <h3 data-bind="text: oName"></h3>
           <p
             class="pricing-type"
@@ -65,7 +75,10 @@
             "
           ></p>
 
-          <p class="plan-price" data-bind="text: oDisplayPrice"></p>
+          <p
+            class="plan-price"
+            data-bind="text: oDisplayPrice"
+          ></p>
           <p
             class="plan-monthly-label"
             data-bind="attr: { 'aria-hidden': oIsCommunityPlan() }"
@@ -75,7 +88,10 @@
               >({% trans 'discounted' %})</span
             >
           </p>
-          <p class="plan-desc" data-bind="text: oDescription"></p>
+          <p
+            class="plan-desc"
+            data-bind="text: oDescription"
+          ></p>
 
           <p
             class="plan-downgrade-notice text-warning"
@@ -100,11 +116,17 @@
             {% endblocktrans %}
           </p>
 
-          <div class="btn btn-current" data-bind="visible: oIsCurrentPlan">
+          <div
+            class="btn btn-current"
+            data-bind="visible: oIsCurrentPlan"
+          >
             {% trans "Current Plan" %}
           </div>
 
-          <div class="btn btn-select" data-bind="visible: !oIsCurrentPlan()">
+          <div
+            class="btn btn-select"
+            data-bind="visible: !oIsCurrentPlan()"
+          >
             {% trans "Select Plan" %}
           </div>
         </a>
@@ -255,7 +277,10 @@
         data-bind="value: oSelectedPlan"
       />
       <div class="text-center plan-next">
-        <button class="btn btn-primary btn-lg" data-bind="click: contactSales">
+        <button
+          class="btn btn-primary btn-lg"
+          data-bind="click: contactSales"
+        >
           {% trans 'Talk to Sales' %}
         </button>
       </div>
@@ -269,7 +294,11 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal">
+          <button
+            type="button"
+            class="close"
+            data-dismiss="modal"
+          >
             <span aria-hidden="true">&times;</span>
             <span class="sr-only">{% trans "Close" %}</span>
           </button>
@@ -277,7 +306,11 @@
         </div>
         <div class="modal-body"><br /><br /></div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary" data-dismiss="modal">
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-dismiss="modal"
+          >
             {% trans "Dismiss" %}
           </button>
           <button

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -53,7 +53,9 @@
     >
       <i class="fa fa-check"></i>
       <a href="https://dimagi.com/terms/latest/tos/" class="check-icon blue">
-        {% trans '30 day refund policy' %}
+        {% blocktrans with days=30 %}
+          {{days}} day refund policy
+        {% endblocktrans %}
       </a>
     </p>
 

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -54,7 +54,7 @@
       <i class="fa fa-check"></i>
       <a href="https://dimagi.com/terms/latest/tos/" class="check-icon blue">
         {% blocktrans with days=30 %}
-          {{days}} day refund policy
+          {{ days }} day refund policy
         {% endblocktrans %}
       </a>
     </p>

--- a/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
@@ -2,7 +2,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 {% load menu_tags %}
-
 {% js_entry 'accounting/js/pricing_table' %}
 
 {% block form_content %}
@@ -26,11 +25,14 @@
   </p>
 
   <section id="plans" class="ko-template">
-
     <p class="switch-label text-center">
       {% trans "Pay Monthly" %}
       <label class="switch">
-        <input type="checkbox" id="pricing-toggle" data-bind="{checked: oShowAnnualPricing}">  {# todo B5: css-checkbox #}
+        <input
+          type="checkbox"
+          id="pricing-toggle"
+          data-bind="{checked: oShowAnnualPricing}"
+        />  {# todo B5: css-checkbox #}
         <span class="slider round slider-blue slider-blue-on"></span>
       </label>
       {% trans "Pay Annually" %}
@@ -44,8 +46,7 @@
 
     <p class="refund-text text-center" data-bind="visible: oShowAnnualPricing">
       <i class="fa fa-check"></i>
-      <a href="https://dimagi.com/terms/latest/tos/"
-         class="check-icon blue">
+      <a href="https://dimagi.com/terms/latest/tos/" class="check-icon blue">
         {% trans '30 day refund policy' %}
       </a>
     </p>
@@ -53,9 +54,7 @@
     <div class="select-plan-row">
       <!-- ko foreach: oPlanOptions -->
       <div class="select-plan-col">
-        <a href="#"
-           class="tile"
-           data-bind="css: oCssClass, click: selectPlan">
+        <a href="#" class="tile" data-bind="css: oCssClass, click: selectPlan">
           <h3 data-bind="text: oName"></h3>
           <p
             class="pricing-type"
@@ -70,13 +69,18 @@
           <p
             class="plan-monthly-label"
             data-bind="attr: { 'aria-hidden': oIsCommunityPlan() }"
-          >{% trans "monthly" %}
-            <span data-bind="visible: oDisplayDiscountNotice">({% trans 'discounted' %})</span>
+          >
+            {% trans "monthly" %}
+            <span data-bind="visible: oDisplayDiscountNotice"
+              >({% trans 'discounted' %})</span
+            >
           </p>
           <p class="plan-desc" data-bind="text: oDescription"></p>
 
-          <p class="plan-downgrade-notice text-warning"
-             data-bind="visible: oShowDowngradeNotice">
+          <p
+            class="plan-downgrade-notice text-warning"
+            data-bind="visible: oShowDowngradeNotice"
+          >
             <i class="fa fa-warning"></i>
             {% blocktrans %}
               This plan will be downgrading to
@@ -85,8 +89,10 @@
             {% endblocktrans %}
           </p>
 
-          <p class="plan-downgrade-notice text-warning"
-             data-bind="visible: oShowPausedNotice">
+          <p
+            class="plan-downgrade-notice text-warning"
+            data-bind="visible: oShowPausedNotice"
+          >
             <i class="fa fa-warning"></i>
             {% blocktrans %}
               This plan will be pausing on<br />
@@ -94,13 +100,11 @@
             {% endblocktrans %}
           </p>
 
-          <div class="btn btn-current"
-               data-bind="visible: oIsCurrentPlan">
+          <div class="btn btn-current" data-bind="visible: oIsCurrentPlan">
             {% trans "Current Plan" %}
           </div>
 
-          <div class="btn btn-select"
-               data-bind="visible: !oIsCurrentPlan()">
+          <div class="btn btn-select" data-bind="visible: !oIsCurrentPlan()">
             {% trans "Select Plan" %}
           </div>
         </a>
@@ -108,10 +112,14 @@
       <!-- /ko -->
     </div>
 
-    <div data-bind="visible: !oIsCurrentPlanCommunity() && !oIsNextPlanPaused() && !oIsCurrentPlanPaused()">
-      <a href="#"
-         class="tile tile-paused"
-         data-bind="click: selectPausedPlan, css: oPausedCss">
+    <div
+      data-bind="visible: !oIsCurrentPlanCommunity() && !oIsNextPlanPaused() && !oIsCurrentPlanPaused()"
+    >
+      <a
+        href="#"
+        class="tile tile-paused"
+        data-bind="click: selectPausedPlan, css: oPausedCss"
+      >
         <h4 class="text-center">
           {% blocktrans %}
             Pause Subscription
@@ -125,8 +133,8 @@
         <ul>
           <li>
             {% blocktrans %}
-              You will lose access to your project space, but you will be
-              able to re-subscribe anytime in the future.
+              You will lose access to your project space, but you will be able
+              to re-subscribe anytime in the future.
             {% endblocktrans %}
           </li>
           <li>
@@ -138,8 +146,10 @@
       </a>
     </div>
 
-    <div class="alert {% if can_domain_unpause %}alert-info{% else %}alert-danger{% endif %} text-center"
-         data-bind="visible: oIsCurrentPlanPaused">
+    <div
+      class="alert {% if can_domain_unpause %}alert-info{% else %}alert-danger{% endif %} text-center"
+      data-bind="visible: oIsCurrentPlanPaused"
+    >
       <p class="lead">
         {% if can_domain_unpause %}
           <i class="fa-regular fa-circle-pause"></i>
@@ -153,34 +163,38 @@
             Your subscription is currently paused because you have
             <a href="{{ url_statements }}">past-due invoices</a>.
           {% endblocktrans %}
-            <br />
+          <br />
           {% blocktrans %}
-            You will not be allowed to un-pause your project until
-            these invoices are paid.
+            You will not be allowed to un-pause your project until these
+            invoices are paid.
           {% endblocktrans %}
         {% endif %}
       </p>
     </div>
 
-    <div class="alert alert-warning text-center"
-         data-bind="visible: oIsNextPlanPaused">
+    <div
+      class="alert alert-warning text-center"
+      data-bind="visible: oIsNextPlanPaused"
+    >
       <i class="fa fa-warning"></i>
       {% blocktrans %}
         Your subscription will be pausing on
-        <span data-bind="text: oStartDateAfterMinimumSubscription"></span> unless
-        you select a different plan above.
+        <span data-bind="text: oStartDateAfterMinimumSubscription"></span>
+        unless you select a different plan above.
       {% endblocktrans %}
     </div>
 
-    <div class="alert alert-warning text-center"
-         style="margin-top: 20px;"  {# todo B5: inline-style #}
-         data-bind="visible: oIsNextPlanDowngrade">
+    <div
+      class="alert alert-warning text-center"
+      style="margin-top: 20px;"  {# todo B5: inline-style #}
+      data-bind="visible: oIsNextPlanDowngrade"
+    >
       <i class="fa fa-warning"></i>
       {% blocktrans %}
         Your subscription will be downgrading to
         <span data-bind="text: oNextSubscription"></span> on
-        <span data-bind="text: oStartDateAfterMinimumSubscription"></span> unless
-        you select a different plan above.
+        <span data-bind="text: oStartDateAfterMinimumSubscription"></span>
+        unless you select a different plan above.
       {% endblocktrans %}
     </div>
 
@@ -190,52 +204,67 @@
       {% else %}
         action="{% url 'confirm_selected_plan' domain %}"
       {% endif %}
-        class="form"
-        id="select-plan-form"
-        method="post"
-        data-bind="visible: oShowNext"
-        style="display: none;"  {# todo B5: inline-style #}
-        action="{% url 'confirm_selected_plan' domain %}">
+      class="form"
+      id="select-plan-form"
+      method="post"
+      data-bind="visible: oShowNext"
+      style="display: none;"  {# todo B5: inline-style #}
+      action="{% url 'confirm_selected_plan' domain %}"
+    >
       {% csrf_token %}
       {% if is_renewal %}
-        <input type="hidden" name="from_plan_page" value="true">
+        <input type="hidden" name="from_plan_page" value="true" />
       {% endif %}
 
       {% if can_domain_unpause %}
-        <input type="hidden" name="plan_edition" data-bind="value: oSelectedPlan">
+        <input
+          type="hidden"
+          name="plan_edition"
+          data-bind="value: oSelectedPlan"
+        />
         <div class="text-center plan-next">
-          <button type="submit"
-                  class="btn btn-primary btn-lg"
-                  data-bind="click: openMinimumSubscriptionModal, disable: oIsSubmitDisabled">
+          <button
+            type="submit"
+            class="btn btn-primary btn-lg"
+            data-bind="click: openMinimumSubscriptionModal, disable: oIsSubmitDisabled"
+          >
             {% trans 'Next' %}
           </button>
         </div>
       {% else %}
         <div class="text-center plan-next">
-          <button type="button"
-                  class="btn btn-primary btn-lg"
-                  disabled="disabled">
+          <button
+            type="button"
+            class="btn btn-primary btn-lg"
+            disabled="disabled"
+          >
             {% trans 'Next' %}
           </button>
         </div>
       {% endif %}
     </form>
 
-    <form action="{% url 'annual_plan_request_quote' domain %}"
-          data-bind="visible: !oShowNext()">
+    <form
+      action="{% url 'annual_plan_request_quote' domain %}"
+      data-bind="visible: !oShowNext()"
+    >
       {% csrf_token %}
-      <input type="hidden" name="plan_edition" data-bind="value: oSelectedPlan">
+      <input
+        type="hidden"
+        name="plan_edition"
+        data-bind="value: oSelectedPlan"
+      />
       <div class="text-center plan-next">
         <button class="btn btn-primary btn-lg" data-bind="click: contactSales">
           {% trans 'Talk to Sales' %}
         </button>
       </div>
     </form>
-
   </section>
 {% endblock %}
 
-{% block modals %}{{ block.super }}
+{% block modals %}
+  {{ block.super }}
   <div class="modal fade" id="modal-minimum-subscription">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -246,12 +275,18 @@
           </button>
           <h4 class="modal-title">Downgrading?</h4>
         </div>
-        <div class="modal-body">
-          <br><br>
-        </div>
+        <div class="modal-body"><br /><br /></div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">{% trans "Dismiss" %}</button>
-          <button type="button" class="btn btn-outline-danger" data-bind="click: submitDowngradeForm">{% trans "Continue" %}</button>
+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">
+            {% trans "Dismiss" %}
+          </button>
+          <button
+            type="button"
+            class="btn btn-outline-danger"
+            data-bind="click: submitDowngradeForm"
+          >
+            {% trans "Continue" %}
+          </button>
         </div>
       </div>
     </div>

--- a/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
@@ -21,8 +21,8 @@
   <p class="lead text-center">
     {{ lead_text }}
     <a href="{% prelogin_url 'public_pricing' %}" target="_blank">
-      {% trans "Learn More" %}
-    </a>
+      {% trans "Learn More" %}</a
+    >.
   </p>
 
   <section id="plans" class="ko-template">
@@ -36,18 +36,17 @@
       {% trans "Pay Annually" %}
     </p>
 
-    <p class="text-center">
+    <p class="text-center" data-bind="visible: !oShowAnnualPricing()">
       {% blocktrans %}
         Save close to 20% when you pay annually.  {# todo B5: css-close #}
       {% endblocktrans %}
     </p>
 
-    <p class="refund-text text-center"
-       data-bind="css: oRefundCss">
+    <p class="refund-text text-center" data-bind="visible: oShowAnnualPricing">
       <i class="fa fa-check"></i>
       <a href="https://dimagi.com/terms/latest/tos/"
          class="check-icon blue">
-        {% trans '90 day refund policy' %}
+        {% trans '30 day refund policy' %}
       </a>
     </p>
 
@@ -58,12 +57,20 @@
            class="tile"
            data-bind="css: oCssClass, click: selectPlan">
           <h3 data-bind="text: oName"></h3>
-          <p class="pricing-type"
-             data-bind="text: oPricingTypeText, css: oPricingTypeCssClass"></p>
+          <p
+            class="pricing-type"
+            data-bind="
+                css: oPricingTypeCssClass,
+                text: oPricingTypeText,
+                attr: { 'aria-hidden': oIsCommunityPlan() }
+            "
+          ></p>
 
           <p class="plan-price" data-bind="text: oDisplayPrice"></p>
-          <p class="plan-monthly-label">
-            {% trans "monthly" %}
+          <p
+            class="plan-monthly-label"
+            data-bind="attr: { 'aria-hidden': oIsCommunityPlan() }"
+          >{% trans "monthly" %}
             <span data-bind="visible: oDisplayDiscountNotice">({% trans 'discounted' %})</span>
           </p>
           <p class="plan-desc" data-bind="text: oDescription"></p>
@@ -175,15 +182,6 @@
         <span data-bind="text: oStartDateAfterMinimumSubscription"></span> unless
         you select a different plan above.
       {% endblocktrans %}
-    </div>
-
-    <div class="community-plan-notice alert alert-info text-center"
-         data-bind="visible: oIsCurrentPlanCommunity">
-      <p class="lead">
-        {% blocktrans %}
-          You are currently on the FREE CommCare Community plan.
-        {% endblocktrans %}
-      </p>
     </div>
 
     <form

--- a/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
@@ -38,13 +38,19 @@
       {% trans "Pay Annually" %}
     </p>
 
-    <p class="text-center" data-bind="visible: !oShowAnnualPricing()">
+    <p
+      class="text-center"
+      data-bind="visible: !oShowAnnualPricing()"
+    >
       {% blocktrans %}
         Save close to 20% when you pay annually.  {# todo B5: css-close #}
       {% endblocktrans %}
     </p>
 
-    <p class="refund-text text-center" data-bind="visible: oShowAnnualPricing">
+    <p
+      class="refund-text text-center"
+      data-bind="visible: oShowAnnualPricing"
+    >
       <i class="fa fa-check"></i>
       <a href="https://dimagi.com/terms/latest/tos/" class="check-icon blue">
         {% trans '30 day refund policy' %}
@@ -54,7 +60,11 @@
     <div class="select-plan-row">
       <!-- ko foreach: oPlanOptions -->
       <div class="select-plan-col">
-        <a href="#" class="tile" data-bind="css: oCssClass, click: selectPlan">
+        <a
+          href="#"
+          class="tile"
+          data-bind="css: oCssClass, click: selectPlan"
+        >
           <h3 data-bind="text: oName"></h3>
           <p
             class="pricing-type"
@@ -65,7 +75,10 @@
             "
           ></p>
 
-          <p class="plan-price" data-bind="text: oDisplayPrice"></p>
+          <p
+            class="plan-price"
+            data-bind="text: oDisplayPrice"
+          ></p>
           <p
             class="plan-monthly-label"
             data-bind="attr: { 'aria-hidden': oIsCommunityPlan() }"
@@ -75,7 +88,10 @@
               >({% trans 'discounted' %})</span
             >
           </p>
-          <p class="plan-desc" data-bind="text: oDescription"></p>
+          <p
+            class="plan-desc"
+            data-bind="text: oDescription"
+          ></p>
 
           <p
             class="plan-downgrade-notice text-warning"
@@ -100,11 +116,17 @@
             {% endblocktrans %}
           </p>
 
-          <div class="btn btn-current" data-bind="visible: oIsCurrentPlan">
+          <div
+            class="btn btn-current"
+            data-bind="visible: oIsCurrentPlan"
+          >
             {% trans "Current Plan" %}
           </div>
 
-          <div class="btn btn-select" data-bind="visible: !oIsCurrentPlan()">
+          <div
+            class="btn btn-select"
+            data-bind="visible: !oIsCurrentPlan()"
+          >
             {% trans "Select Plan" %}
           </div>
         </a>
@@ -255,7 +277,10 @@
         data-bind="value: oSelectedPlan"
       />
       <div class="text-center plan-next">
-        <button class="btn btn-primary btn-lg" data-bind="click: contactSales">
+        <button
+          class="btn btn-primary btn-lg"
+          data-bind="click: contactSales"
+        >
           {% trans 'Talk to Sales' %}
         </button>
       </div>
@@ -269,7 +294,11 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="btn-close" data-bs-dismiss="modal">  {# todo B5: css-close #}
+          <button
+            type="button"
+            class="btn-close"
+            data-bs-dismiss="modal"
+          >  {# todo B5: css-close #}
             <span aria-hidden="true">&times;</span>
             <span class="sr-only">{% trans "Close" %}</span>
           </button>
@@ -277,7 +306,11 @@
         </div>
         <div class="modal-body"><br /><br /></div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-bs-dismiss="modal"
+          >
             {% trans "Dismiss" %}
           </button>
           <button

--- a/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
@@ -66,6 +66,11 @@
           data-bind="css: oCssClass, click: selectPlan"
         >
           <h3 data-bind="text: oName"></h3>
+
+          {% comment %}
+          We could hide this text block for Community, but instead just make
+          its contents invisible to avoid layout shifting
+          {% endcomment %}
           <p
             class="pricing-type"
             data-bind="
@@ -79,6 +84,11 @@
             class="plan-price"
             data-bind="text: oDisplayPrice"
           ></p>
+
+          {% comment %}
+          We could hide this text block for Community, but instead just make
+          its contents invisible to avoid layout shifting
+          {% endcomment %}
           <p
             class="plan-monthly-label"
             data-bind="attr: { 'aria-hidden': oIsCommunityPlan() }"

--- a/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
@@ -53,7 +53,9 @@
     >
       <i class="fa fa-check"></i>
       <a href="https://dimagi.com/terms/latest/tos/" class="check-icon blue">
-        {% trans '30 day refund policy' %}
+        {% blocktrans with days=30 %}
+          {{days}} day refund policy
+        {% endblocktrans %}
       </a>
     </p>
 

--- a/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
@@ -54,7 +54,7 @@
       <i class="fa fa-check"></i>
       <a href="https://dimagi.com/terms/latest/tos/" class="check-icon blue">
         {% blocktrans with days=30 %}
-          {{days}} day refund policy
+          {{ days }} day refund policy
         {% endblocktrans %}
       </a>
     </p>

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -977,24 +977,22 @@ class PlanViewBase(DomainAccountingSettings):
                 SoftwarePlanEdition.STANDARD,
                 "$300",
                 "$250",
-                _("For programs with one-time data collection needs, simple "
-                  "case management workflows, and basic M&E requirements."),
+                _("Get started. Build secure apps for offline mobile data collection and case management. "
+                  "50 users included."),
             ),
             PlanOption(
                 SoftwarePlanEdition.PRO,
                 "$600",
                 "$500",
-                _("For programs with complex case management needs, field "
-                  "staff collaborating on tasks, and M&E teams that need to "
-                  "clean and report on data."),
+                _("Beyond the basics. Unlock reporting, case sharing, and hands-on support. 250 users included."),
             ),
             PlanOption(
                 SoftwarePlanEdition.ADVANCED,
                 "$1200",
                 "$1000",
-                _("For programs with distributed field staff, facility-based "
-                  "workflows, and advanced security needs. Also for M&E teams "
-                  "integrating data with 3rd party analytics."),
+                _("Unlock everything. Our most secure plan, built for managing connected systems across "
+                  "locations and user profiles, featuring web apps, advanced security, and robust admin and data "
+                  "management tools. 500 users included."),
             ),
         ]
 

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -972,7 +972,7 @@ class PlanViewBase(DomainAccountingSettings):
 
     @property
     def plan_options(self):
-        return [
+        options = [
             PlanOption(
                 SoftwarePlanEdition.STANDARD,
                 "$300",
@@ -995,6 +995,19 @@ class PlanViewBase(DomainAccountingSettings):
                   "management tools. 500 users included."),
             ),
         ]
+        if (
+            self.current_subscription is not None
+            and self.current_subscription.plan_version.plan.edition == SoftwarePlanEdition.COMMUNITY
+        ):
+            options.insert(
+                0, PlanOption(
+                    SoftwarePlanEdition.COMMUNITY,
+                    "Free",
+                    "Free",
+                    _("For practice purposes. Not intended for live projects. 5 users maximum."),
+                )
+            )
+        return options
 
     @property
     def start_date_after_minimum_subscription(self):

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -993,7 +993,7 @@ class PlanViewBase(DomainAccountingSettings):
                 "$1000",
                 _("Unlock everything. Our most secure plan, built for managing connected systems across "
                   "locations and user profiles, featuring web apps, advanced security, and robust admin and data "
-                  "management tools. {num_users} users included.").format(num_users=250),
+                  "management tools. {num_users} users included.").format(num_users=500),
             ),
         ]
         if (

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -978,13 +978,14 @@ class PlanViewBase(DomainAccountingSettings):
                 "$300",
                 "$250",
                 _("Get started. Build secure apps for offline mobile data collection and case management. "
-                  "125 users included."),
+                  "{num_users} users included.").format(num_users=125),
             ),
             PlanOption(
                 SoftwarePlanEdition.PRO,
                 "$600",
                 "$500",
-                _("Beyond the basics. Unlock reporting, case sharing, and hands-on support. 250 users included."),
+                _("Beyond the basics. Unlock reporting, case sharing, and hands-on support. "
+                  "{num_users} users included.").format(num_users=250),
             ),
             PlanOption(
                 SoftwarePlanEdition.ADVANCED,
@@ -992,7 +993,7 @@ class PlanViewBase(DomainAccountingSettings):
                 "$1000",
                 _("Unlock everything. Our most secure plan, built for managing connected systems across "
                   "locations and user profiles, featuring web apps, advanced security, and robust admin and data "
-                  "management tools. 500 users included."),
+                  "management tools. {num_users} users included.").format(num_users=250),
             ),
         ]
         if (
@@ -1004,7 +1005,8 @@ class PlanViewBase(DomainAccountingSettings):
                     SoftwarePlanEdition.COMMUNITY,
                     "Free",
                     "Free",
-                    _("For practice purposes. Not intended for live projects. 5 users maximum."),
+                    _("For practice purposes. Not intended for live projects. "
+                      "{num_users} users maximum.").format(num_users=5),
                 )
             )
         return options

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -978,7 +978,7 @@ class PlanViewBase(DomainAccountingSettings):
                 "$300",
                 "$250",
                 _("Get started. Build secure apps for offline mobile data collection and case management. "
-                  "50 users included."),
+                  "125 users included."),
             ),
             PlanOption(
                 SoftwarePlanEdition.PRO,

--- a/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
+++ b/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
@@ -1,5 +1,5 @@
-@import '../../hqwebapp/less/_hq/includes/variables.less';
-@import '../../hqwebapp/less/_hq/includes/mixins.less';
+@import "../../hqwebapp/less/_hq/includes/variables.less";
+@import "../../hqwebapp/less/_hq/includes/mixins.less";
 
 @toggle-switch-height: 34px;
 @toggle-switch-width: 60px;
@@ -25,7 +25,7 @@
   right: 0;
   bottom: 0;
   position: absolute;
-  transition: .4s;
+  transition: 0.4s;
 
   &::before {
     background-color: #ffffff;
@@ -34,7 +34,7 @@
     height: @slider-height;
     left: @slider-padding;
     position: absolute;
-    transition: .4s;
+    transition: 0.4s;
     width: @slider-height;
   }
 }
@@ -64,7 +64,7 @@ input:checked + .slider:before {
   font-weight: bold;
 
   .switch {
-    margin-bottom: -@slider-height * .45;
+    margin-bottom: -@slider-height * 0.45;
     margin-left: @slider-padding * 2;
     margin-right: @slider-padding * 2;
   }
@@ -90,7 +90,7 @@ input:checked + .slider:before {
     padding: 1px 4px;
     border: 1px solid transparent;
     display: inline-block;
-    transition: all .4 ease-in-out;
+    transition: all 0.4 ease-in-out;
   }
 
   .pricing-type-annual {
@@ -113,10 +113,10 @@ input:checked + .slider:before {
   }
 
   &:before {
-    border: 1px solid rgba(0, 0, 0, .12);
+    border: 1px solid rgba(0, 0, 0, 0.12);
     border-radius: inherit;
     bottom: 0;
-    content: ' ';
+    content: " ";
     display: block;
     left: 0;
     pointer-events: none;
@@ -124,14 +124,14 @@ input:checked + .slider:before {
     right: 0;
     top: 0;
     z-index: 99;
-    transition: border .4s ease-in-out;
+    transition: border 0.4s ease-in-out;
   }
 
   &:after { // scss-lint:disable PropertyCount
     border: 4px solid @cc-brand-mid;
     border-radius: inherit;
     bottom: 0;
-    content: ' ';
+    content: " ";
     display: block;
     left: 0;
     opacity: 0;
@@ -140,7 +140,7 @@ input:checked + .slider:before {
     right: 0;
     top: 0;
     z-index: 99;
-    transition: opacity .4s ease-in-out;
+    transition: opacity 0.4s ease-in-out;
   }
 
   &:hover,
@@ -156,13 +156,11 @@ input:checked + .slider:before {
   opacity: 1;
 }
 
-
 .tile.selected-plan {
   &:before {
     border-width: 8px;
   }
 }
-
 
 .tile h3 {
   text-transform: uppercase;
@@ -275,7 +273,6 @@ input:checked + .slider:before {
   @media (max-width: 1199px) {
     width: 24%;
   }
-
 
   .tile {
     margin: 0 auto;

--- a/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
+++ b/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
@@ -71,12 +71,7 @@ input:checked + .slider:before {
 }
 
 .refund-text {
-  transition: .4s opacity ease-in-out;
   color: @cc-brand-mid;
-  opacity: 0;
-}
-.show-refund {
-  opacity: 1.0;
 }
 
 .tile {

--- a/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
+++ b/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
@@ -91,6 +91,7 @@ input:checked + .slider:before {
     font-size: 11px;
     text-transform: uppercase;
     letter-spacing: 1px;
+    height: 1.75em;
     padding: 1px 4px;
     border: 1px solid transparent;
     display: inline-block;
@@ -234,6 +235,16 @@ input:checked + .slider:before {
 
   .btn-current {
     color: @_color-tile !important;
+  }
+}
+
+.tile-community {
+  ._make-color-tile(@cc-neutral-mid);
+  .pricing-type {
+    opacity: 0;
+  }
+  .plan-monthly-label {
+    opacity: 0;
   }
 }
 

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -422,7 +422,7 @@ def prelogin_url(urlname):
     """
     urlname_to_url = {
         'go_to_pricing': 'https://dimagi.com/commcare-pricing/',
-        'public_pricing': 'https://dimagi.com/commcare-pricing/',
+        'public_pricing': 'https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/CommCare+Pricing+Overview',  # noqa: E501
 
     }
     return urlname_to_url.get(urlname, 'https://dimagi.com/commcare/')

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/select_plan.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/select_plan.html.diff.txt
@@ -1,54 +1,53 @@
 --- 
 +++ 
-@@ -1,9 +1,9 @@
+@@ -1,8 +1,8 @@
 -{% extends "domain/bootstrap3/base_change_plan.html" %}
 +{% extends "domain/bootstrap5/base_change_plan.html" %}
  {% load hq_shared_tags %}
  {% load i18n %}
  {% load menu_tags %}
- 
 -{% js_entry_b3 'accounting/js/pricing_table' %}
 +{% js_entry 'accounting/js/pricing_table' %}
  
  {% block form_content %}
    {% initial_page_data 'editions' editions %}
-@@ -30,7 +30,7 @@
-     <p class="switch-label text-center">
-       {% trans "Pay Monthly" %}
-       <label class="switch">
--        <input type="checkbox" id="pricing-toggle" data-bind="{checked: oShowAnnualPricing}">
-+        <input type="checkbox" id="pricing-toggle" data-bind="{checked: oShowAnnualPricing}">  {# todo B5: css-checkbox #}
+@@ -32,7 +32,7 @@
+           type="checkbox"
+           id="pricing-toggle"
+           data-bind="{checked: oShowAnnualPricing}"
+-        />
++        />  {# todo B5: css-checkbox #}
          <span class="slider round slider-blue slider-blue-on"></span>
        </label>
        {% trans "Pay Annually" %}
-@@ -38,7 +38,7 @@
+@@ -40,7 +40,7 @@
  
-     <p class="text-center">
+     <p class="text-center" data-bind="visible: !oShowAnnualPricing()">
        {% blocktrans %}
 -        Save close to 20% when you pay annually.
 +        Save close to 20% when you pay annually.  {# todo B5: css-close #}
        {% endblocktrans %}
      </p>
  
-@@ -166,7 +166,7 @@
-     </div>
+@@ -186,7 +186,7 @@
  
-     <div class="alert alert-warning text-center"
--         style="margin-top: 20px;"
-+         style="margin-top: 20px;"  {# todo B5: inline-style #}
-          data-bind="visible: oIsNextPlanDowngrade">
+     <div
+       class="alert alert-warning text-center"
+-      style="margin-top: 20px;"
++      style="margin-top: 20px;"  {# todo B5: inline-style #}
+       data-bind="visible: oIsNextPlanDowngrade"
+     >
        <i class="fa fa-warning"></i>
-       {% blocktrans %}
-@@ -196,7 +196,7 @@
-         id="select-plan-form"
-         method="post"
-         data-bind="visible: oShowNext"
--        style="display: none;"
-+        style="display: none;"  {# todo B5: inline-style #}
-         action="{% url 'confirm_selected_plan' domain %}">
+@@ -208,7 +208,7 @@
+       id="select-plan-form"
+       method="post"
+       data-bind="visible: oShowNext"
+-      style="display: none;"
++      style="display: none;"  {# todo B5: inline-style #}
+       action="{% url 'confirm_selected_plan' domain %}"
+     >
        {% csrf_token %}
-       {% if is_renewal %}
-@@ -242,7 +242,7 @@
+@@ -269,7 +269,7 @@
      <div class="modal-dialog">
        <div class="modal-content">
          <div class="modal-header">
@@ -57,14 +56,18 @@
              <span aria-hidden="true">&times;</span>
              <span class="sr-only">{% trans "Close" %}</span>
            </button>
-@@ -252,8 +252,8 @@
-           <br><br>
+@@ -277,12 +277,12 @@
          </div>
+         <div class="modal-body"><br /><br /></div>
          <div class="modal-footer">
--          <button type="button" class="btn btn-primary" data-dismiss="modal">{% trans "Dismiss" %}</button>
--          <button type="button" class="btn btn-danger" data-bind="click: submitDowngradeForm">{% trans "Continue" %}</button>
-+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">{% trans "Dismiss" %}</button>
-+          <button type="button" class="btn btn-outline-danger" data-bind="click: submitDowngradeForm">{% trans "Continue" %}</button>
-         </div>
-       </div>
-     </div>
+-          <button type="button" class="btn btn-primary" data-dismiss="modal">
++          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">
+             {% trans "Dismiss" %}
+           </button>
+           <button
+             type="button"
+-            class="btn btn-danger"
++            class="btn btn-outline-danger"
+             data-bind="click: submitDowngradeForm"
+           >
+             {% trans "Continue" %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/select_plan.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/select_plan.html.diff.txt
@@ -20,16 +20,16 @@
          <span class="slider round slider-blue slider-blue-on"></span>
        </label>
        {% trans "Pay Annually" %}
-@@ -40,7 +40,7 @@
- 
-     <p class="text-center" data-bind="visible: !oShowAnnualPricing()">
+@@ -43,7 +43,7 @@
+       data-bind="visible: !oShowAnnualPricing()"
+     >
        {% blocktrans %}
 -        Save close to 20% when you pay annually.
 +        Save close to 20% when you pay annually.  {# todo B5: css-close #}
        {% endblocktrans %}
      </p>
  
-@@ -186,7 +186,7 @@
+@@ -220,7 +220,7 @@
  
      <div
        class="alert alert-warning text-center"
@@ -38,7 +38,7 @@
        data-bind="visible: oIsNextPlanDowngrade"
      >
        <i class="fa fa-warning"></i>
-@@ -208,7 +208,7 @@
+@@ -242,7 +242,7 @@
        id="select-plan-form"
        method="post"
        data-bind="visible: oShowNext"
@@ -47,21 +47,26 @@
        action="{% url 'confirm_selected_plan' domain %}"
      >
        {% csrf_token %}
-@@ -269,7 +269,7 @@
-     <div class="modal-dialog">
-       <div class="modal-content">
+@@ -308,9 +308,9 @@
          <div class="modal-header">
--          <button type="button" class="close" data-dismiss="modal">
-+          <button type="button" class="btn-close" data-bs-dismiss="modal">  {# todo B5: css-close #}
+           <button
+             type="button"
+-            class="close"
+-            data-dismiss="modal"
+-          >
++            class="btn-close"
++            data-bs-dismiss="modal"
++          >  {# todo B5: css-close #}
              <span aria-hidden="true">&times;</span>
              <span class="sr-only">{% trans "Close" %}</span>
            </button>
-@@ -277,12 +277,12 @@
-         </div>
-         <div class="modal-body"><br /><br /></div>
-         <div class="modal-footer">
--          <button type="button" class="btn btn-primary" data-dismiss="modal">
-+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">
+@@ -321,13 +321,13 @@
+           <button
+             type="button"
+             class="btn btn-primary"
+-            data-dismiss="modal"
++            data-bs-dismiss="modal"
+           >
              {% trans "Dismiss" %}
            </button>
            <button


### PR DESCRIPTION
## Product Description
Visual and text updates to the "Select Plan" and "Confirm Plan" pages, specifically:
- adds "free edition" plan card, only when currently on that plan
- removes "Community" blue banner that would appear when currently on that plan
- updates descriptive text for all plans
- swaps between "30 day refund policy" and "save close to 20% when you pay annually" with toggle switch

Before:
![image](https://github.com/user-attachments/assets/95f090af-05d0-47b8-a6a3-e99e733cff9c)

After:
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/e26a217d-ead6-4983-b380-ede5f3de71a4" />



## Technical Summary
[SAAS-16831](https://dimagi.atlassian.net/browse/SAAS-16831)
[SAAS-16837](https://dimagi.atlassian.net/browse/SAAS-16837)
The bulk of lines changed here are formatting to html templates. Each commit is fairly small outside of that. Recommend reviewing by commit.

## Safety Assurance

### Safety story
These changes are primarily visual, updating text and certain element visibility, with the addition of one new conditional to check whether the current plan is Community edition before we add its card. Tested visuals and functionality in multiple browsers locally and on staging.

### Automated test coverage
Not likely.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-16831]: https://dimagi.atlassian.net/browse/SAAS-16831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-16837]: https://dimagi.atlassian.net/browse/SAAS-16837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ