### PR TITLE
Add more gauge metrics

### DIFF
--- a/corehq/apps/campaign/const.py
+++ b/corehq/apps/campaign/const.py
@@ -2,4 +2,9 @@ from django.utils.translation import gettext_noop
 
 GAUGE_METRICS = (
     ('total_number_of_cases', gettext_noop('Total number of cases')),
+    ('total_number_of_mobile_workers', gettext_noop('Total number of mobile workers')),
+    ('total_number_of_active_mobile_workers', gettext_noop('Total number of active mobile workers')),
+    ('total_number_of_inactive_web_users', gettext_noop('Total number of inactive web users')),
+    ('total_number_of_forms_submitted_by_mobile_workers', gettext_noop(
+        'Total number of forms submitted by mobile workers'))
 )

--- a/corehq/apps/campaign/const.py
+++ b/corehq/apps/campaign/const.py
@@ -1,10 +1,9 @@
 from django.utils.translation import gettext_noop
 
 GAUGE_METRICS = (
-    ('total_number_of_cases', gettext_noop('Total number of cases')),
-    ('total_number_of_mobile_workers', gettext_noop('Total number of mobile workers')),
-    ('total_number_of_active_mobile_workers', gettext_noop('Total number of active mobile workers')),
-    ('total_number_of_inactive_web_users', gettext_noop('Total number of inactive web users')),
-    ('total_number_of_forms_submitted_by_mobile_workers', gettext_noop(
-        'Total number of forms submitted by mobile workers'))
+    ('number_of_cases', gettext_noop('Number of cases')),
+    ('number_of_mobile_workers', gettext_noop('Number of mobile workers')),
+    ('number_of_active_mobile_workers', gettext_noop('Number of active mobile workers')),
+    ('number_of_inactive_web_users', gettext_noop('Number of inactive web users')),
+    ('number_of_forms_submitted_by_mobile_workers', gettext_noop('Number of forms submitted by mobile workers'))
 )

--- a/corehq/apps/campaign/forms.py
+++ b/corehq/apps/campaign/forms.py
@@ -183,10 +183,10 @@ class DashboardGaugeForm(DashboardWidgetBaseForm):
 
     def __init__(self, domain, *args, **kwargs):
         super().__init__(domain, *args, **kwargs)
-        case_type_choices = [('', '')]
-        case_type_choices.extend(self._get_case_type_choices())
-        self.fields['case_type'].choices = case_type_choices
+        self.fields['case_type'].choices = self._get_case_type_choices()
 
     def _get_case_type_choices(self):
+        case_type_choices = [('', '---')]
         case_types = sorted(get_case_types_for_domain(self.domain))
-        return [(case_type, case_type) for case_type in case_types]
+        case_type_choices.extend([(case_type, case_type) for case_type in case_types])
+        return case_type_choices

--- a/corehq/apps/campaign/forms.py
+++ b/corehq/apps/campaign/forms.py
@@ -173,6 +173,7 @@ class DashboardGaugeForm(DashboardWidgetBaseForm):
 
     case_type = forms.ChoiceField(
         label=_('Case Type'),
+        required=False,
     )
 
     metric = forms.ChoiceField(
@@ -182,8 +183,10 @@ class DashboardGaugeForm(DashboardWidgetBaseForm):
 
     def __init__(self, domain, *args, **kwargs):
         super().__init__(domain, *args, **kwargs)
-        self.fields['case_type'].choices = self._get_case_types()
+        case_type_choices = [('', '')]
+        case_type_choices.extend(self._get_case_type_choices())
+        self.fields['case_type'].choices = case_type_choices
 
-    def _get_case_types(self):
+    def _get_case_type_choices(self):
         case_types = sorted(get_case_types_for_domain(self.domain))
         return [(case_type, case_type) for case_type in case_types]

--- a/corehq/apps/campaign/services.py
+++ b/corehq/apps/campaign/services.py
@@ -1,4 +1,4 @@
-from corehq.apps.es import CaseSearchES
+from corehq.apps.es import CaseSearchES, FormES, UserES
 
 
 def get_gauge_metric_value(gauge):
@@ -14,6 +14,26 @@ def _get_number_of_cases(gauge):
     return case_es_query.count()
 
 
+def _get_number_of_mobile_workers(gauge):
+    return UserES().domain(gauge.dashboard.domain).mobile_users().count()
+
+
+def _get_number_of_active_mobile_workers(gauge):
+    return UserES().domain(gauge.dashboard.domain).mobile_users().is_active().count()
+
+
+def _get_number_of_inactive_mobile_workers(gauge):
+    return UserES().domain(gauge.dashboard.domain).mobile_users().is_active(active=False).count()
+
+
+def _get_number_of_forms_submitted_by_mobile_workers(gauge):
+    return FormES().domain(gauge.dashboard.domain).user_type('mobile').count()
+
+
 metric_function_mapping = {
     'total_number_of_cases': _get_number_of_cases,
+    'total_number_of_mobile_workers': _get_number_of_mobile_workers,
+    'total_number_of_active_mobile_workers': _get_number_of_active_mobile_workers,
+    'total_number_of_inactive_mobile_workers': _get_number_of_inactive_mobile_workers,
+    'total_number_of_forms_submitted_by_mobile_workers': _get_number_of_forms_submitted_by_mobile_workers,
 }

--- a/corehq/apps/campaign/services.py
+++ b/corehq/apps/campaign/services.py
@@ -31,9 +31,9 @@ def _get_number_of_forms_submitted_by_mobile_workers(gauge):
 
 
 metric_function_mapping = {
-    'total_number_of_cases': _get_number_of_cases,
-    'total_number_of_mobile_workers': _get_number_of_mobile_workers,
-    'total_number_of_active_mobile_workers': _get_number_of_active_mobile_workers,
-    'total_number_of_inactive_mobile_workers': _get_number_of_inactive_mobile_workers,
-    'total_number_of_forms_submitted_by_mobile_workers': _get_number_of_forms_submitted_by_mobile_workers,
+    'number_of_cases': _get_number_of_cases,
+    'number_of_mobile_workers': _get_number_of_mobile_workers,
+    'number_of_active_mobile_workers': _get_number_of_active_mobile_workers,
+    'number_of_inactive_mobile_workers': _get_number_of_inactive_mobile_workers,
+    'number_of_forms_submitted_by_mobile_workers': _get_number_of_forms_submitted_by_mobile_workers,
 }

--- a/corehq/apps/campaign/services.py
+++ b/corehq/apps/campaign/services.py
@@ -8,7 +8,10 @@ def get_gauge_metric_value(gauge):
 def _get_number_of_cases(gauge):
     case_type = gauge.case_type
     domain = gauge.dashboard.domain
-    return CaseSearchES().domain(domain).case_type(case_type).count()
+    case_es_query = CaseSearchES().domain(domain)
+    if case_type:
+        case_es_query = case_es_query.case_type(case_type)
+    return case_es_query.count()
 
 
 metric_function_mapping = {

--- a/corehq/apps/campaign/services.py
+++ b/corehq/apps/campaign/services.py
@@ -2,7 +2,8 @@ from corehq.apps.es import CaseSearchES, FormES, UserES
 
 
 def get_gauge_metric_value(gauge):
-    return metric_function_mapping[gauge.metric](gauge)
+    if gauge.metric in metric_function_mapping:
+        return metric_function_mapping[gauge.metric](gauge)
 
 
 def _get_number_of_cases(gauge):

--- a/corehq/apps/campaign/static/campaign/js/dashboard.js
+++ b/corehq/apps/campaign/static/campaign/js/dashboard.js
@@ -26,13 +26,15 @@ $(function () {
     }
     const gaugeWidgetConfigs = initialPageData.get('gauge_widgets');
     for (const gaugeWidgetConfig of gaugeWidgetConfigs.cases) {
-        new RadialGauge({
-            renderTo: `gauge-widget-${ gaugeWidgetConfig.id }`,
-            value: gaugeWidgetConfig.value,
-            maxValue: gaugeWidgetConfig.max_value,
-            majorTicks: gaugeWidgetConfig.major_ticks,
-            valueDec: 0
-        }).draw();
+        if (gaugeWidgetConfig.value) {
+            new RadialGauge({
+                renderTo: `gauge-widget-${ gaugeWidgetConfig.id }`,
+                value: gaugeWidgetConfig.value,
+                maxValue: gaugeWidgetConfig.max_value,
+                majorTicks: gaugeWidgetConfig.major_ticks,
+                valueDec: 0
+            }).draw();
+        }
     }
     $('a[data-bs-toggle="tab"]').on('shown.bs.tab', tabSwitch);
 

--- a/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
+++ b/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
@@ -11,10 +11,21 @@
       {% include "campaign/partials/edit_widget_button.html" with widget_type='gauge' %}
     </div>
     <div class="card-body p-0 d-flex">
-      <canvas id="gauge-widget-{{ widget.id }}"></canvas>
+      {% if widget.value %}
+        <canvas id="gauge-widget-{{ widget.id }}"></canvas>
+      {% else %}
+        <canvas data-type="radial-gauge"></canvas>
+      {% endif %}
     </div>
     <div>
-      <b class="ms-2"> {% trans 'Metric' %} : {{ widget.metric_name }} </b>
+      <b class="ms-2">
+        {% trans 'Metric' %} :
+        {% if widget.metric_name %}
+          {{ widget.metric_name }}
+        {% else %}
+          {% trans 'Unknown metric' %}
+        {% endif %}
+      </b>
       {% if widget.case_type %}
         <b class="me-2 float-end">
           {% trans 'Case Type' %} : {{ widget.case_type }}

--- a/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
+++ b/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
@@ -15,9 +15,11 @@
     </div>
     <div>
       <b class="ms-2"> {% trans 'Metric' %} : {{ widget.metric_name }} </b>
-      <b class="me-2 float-end">
-        {% trans 'Case Type' %} : {{ widget.case_type }}
-      </b>
+      {% if widget.case_type %}
+        <b class="me-2 float-end">
+          {% trans 'Case Type' %} : {{ widget.case_type }}
+        </b>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/corehq/apps/campaign/tests/test_models.py
+++ b/corehq/apps/campaign/tests/test_models.py
@@ -306,7 +306,7 @@ def test_dashboard_gauge_widget():
         },
         'description': 'Gauge 1 described for type1 cases.',
         'id': 1,
-        'metric': 'total_number_of_cases',
+        'metric': 'number_of_cases',
         'title': 'Cases Gauge 1',
         'widget_type': 'DashboardGauge',
     }

--- a/corehq/apps/campaign/tests/test_services.py
+++ b/corehq/apps/campaign/tests/test_services.py
@@ -1,0 +1,120 @@
+from collections import namedtuple
+from unittest.mock import patch
+
+from corehq.apps.campaign.services import get_gauge_metric_value
+
+Dashboard = namedtuple('Dashboard', ['domain'])
+Gauge = namedtuple('Gauge', ['dashboard', 'case_type', 'metric'])
+
+
+@patch('corehq.apps.campaign.services.CaseSearchES')
+def test_get_number_of_cases_without_case_type(case_search_es_patch):
+    case_search_es = case_search_es_patch.return_value
+    dashboard = Dashboard(domain='test')
+
+    gauge = Gauge(
+        dashboard=dashboard,
+        metric='number_of_cases',
+        case_type='',
+    )
+
+    get_gauge_metric_value(gauge)
+
+    case_search_es.domain.assert_called_once()
+    case_search_es.domain.return_value.count.assert_called_once()
+
+
+@patch('corehq.apps.campaign.services.CaseSearchES')
+def test_get_number_of_cases_with_case_type(case_search_es_patch):
+    case_search_es = case_search_es_patch.return_value
+    dashboard = Dashboard(domain='test')
+
+    gauge = Gauge(
+        dashboard=dashboard,
+        metric='number_of_cases',
+        case_type='test_case_type',
+    )
+
+    get_gauge_metric_value(gauge)
+
+    case_search_es.domain.assert_called_once()
+    case_search_es.domain.return_value.case_type.assert_called_with('test_case_type')
+    case_search_es.domain.return_value.case_type.return_value.count.assert_called_once()
+
+
+@patch('corehq.apps.campaign.services.UserES')
+def test_get_number_of_mobile_workers(user_es_patch):
+    user_es = user_es_patch.return_value
+
+    dashboard = Dashboard(domain='test')
+
+    gauge = Gauge(
+        dashboard=dashboard,
+        metric='number_of_mobile_workers',
+        case_type='',
+    )
+
+    get_gauge_metric_value(gauge)
+
+    user_es.domain.assert_called_once()
+    user_es.domain.return_value.mobile_users.assert_called_once()
+    user_es.domain.return_value.mobile_users.return_value.count.assert_called_once()
+
+
+@patch('corehq.apps.campaign.services.UserES')
+def test_get_number_of_active_mobile_workers(user_es_patch):
+    user_es = user_es_patch.return_value
+
+    dashboard = Dashboard(domain='test')
+
+    gauge = Gauge(
+        dashboard=dashboard,
+        metric='number_of_active_mobile_workers',
+        case_type='',
+    )
+
+    get_gauge_metric_value(gauge)
+
+    user_es.domain.assert_called_once()
+    user_es.domain.return_value.mobile_users.assert_called_once()
+    user_es.domain.return_value.mobile_users.return_value.is_active.assert_called_once()
+    user_es.domain.return_value.mobile_users.return_value.is_active.return_value.count.assert_called_once()
+
+
+@patch('corehq.apps.campaign.services.UserES')
+def test_get_number_of_inactive_mobile_workers(user_es_patch):
+    user_es = user_es_patch.return_value
+
+    dashboard = Dashboard(domain='test')
+
+    gauge = Gauge(
+        dashboard=dashboard,
+        metric='number_of_inactive_mobile_workers',
+        case_type='',
+    )
+
+    get_gauge_metric_value(gauge)
+
+    user_es.domain.assert_called_once()
+    user_es.domain.return_value.mobile_users.assert_called_once()
+    user_es.domain.return_value.mobile_users.return_value.is_active.assert_called_once_with(active=False)
+    user_es.domain.return_value.mobile_users.return_value.is_active.return_value.count.assert_called_once()
+
+
+@patch('corehq.apps.campaign.services.FormES')
+def test_get_number_of_forms_submitted_by_mobile_workers(form_es_patch):
+    form_es = form_es_patch.return_value
+
+    dashboard = Dashboard(domain='test')
+
+    gauge = Gauge(
+        dashboard=dashboard,
+        metric='number_of_forms_submitted_by_mobile_workers',
+        case_type='',
+    )
+
+    get_gauge_metric_value(gauge)
+
+    form_es.domain.assert_called_once()
+    form_es.domain.return_value.user_type.assert_called_once_with('mobile')
+    form_es.domain.return_value.user_type.return_value.count.assert_called_once()

--- a/corehq/apps/campaign/tests/test_views.py
+++ b/corehq/apps/campaign/tests/test_views.py
@@ -165,8 +165,8 @@ class TestDashboardView(BaseTestCampaignView):
                 'case_type': 'foo',
                 'major_ticks': [0, 20, 40, 60, 80, 100],
                 'max_value': 100,
-                'metric': 'total_number_of_cases',
-                'metric_name': 'Total number of cases',
+                'metric': 'number_of_cases',
+                'metric_name': 'Number of cases',
                 'configuration': {},
                 'dashboard': {
                     'domain': 'test-domain',
@@ -196,8 +196,8 @@ class TestDashboardView(BaseTestCampaignView):
                 'case_type': 'bar',
                 'major_ticks': [0, 20, 40, 60, 80, 100],
                 'max_value': 100,
-                'metric': 'total_number_of_cases',
-                'metric_name': 'Total number of cases',
+                'metric': 'number_of_cases',
+                'metric_name': 'Number of cases',
                 'configuration': {},
                 'dashboard': {
                     'domain': 'test-domain',

--- a/corehq/apps/campaign/tests/test_views.py
+++ b/corehq/apps/campaign/tests/test_views.py
@@ -98,6 +98,15 @@ class TestDashboardView(BaseTestCampaignView):
             metric=GAUGE_METRICS[0][0],
             dashboard_tab=DashboardTab.CASES,
         )
+        cls.dashboard_gauge_widget_for_cases_with_removed_metric = DashboardGauge.objects.create(
+            dashboard=cls.dashboard,
+            title='Cases Gauge 2',
+            description='Gauge 2 described for foo cases.',
+            display_order=1,
+            case_type='foo',
+            metric='removed',
+            dashboard_tab=DashboardTab.CASES,
+        )
         cls.dashboard_gauge_widget_for_mobile_workers = DashboardGauge.objects.create(
             dashboard=cls.dashboard,
             title='Mobile Workers Gauge 1',
@@ -158,6 +167,21 @@ class TestDashboardView(BaseTestCampaignView):
                 'max_value': 100,
                 'metric': 'total_number_of_cases',
                 'metric_name': 'Total number of cases',
+                'configuration': {},
+                'dashboard': {
+                    'domain': 'test-domain',
+                },
+                'value': 10,
+                'widget_type': 'DashboardGauge',
+            }, {
+                'id': self.dashboard_gauge_widget_for_cases_with_removed_metric.id,
+                'title': 'Cases Gauge 2',
+                'description': 'Gauge 2 described for foo cases.',
+                'case_type': 'foo',
+                'major_ticks': [0, 20, 40, 60, 80, 100],
+                'max_value': 100,
+                'metric': 'removed',
+                'metric_name': '',
                 'configuration': {},
                 'dashboard': {
                     'domain': 'test-domain',

--- a/corehq/apps/campaign/views.py
+++ b/corehq/apps/campaign/views.py
@@ -110,12 +110,14 @@ class DashboardView(BaseProjectReportSectionView, DashboardMapFilterMixin):
     @staticmethod
     def _get_gauge_config(dashboard_gauge):
         config = dashboard_gauge.to_widget()
-        config['value'] = get_gauge_metric_value(dashboard_gauge)
-        # set max value of dial to nearest equivalent of 100
-        config['max_value'] = 10 ** len(str(config['value']))
-        number_of_ticks = 5
-        config['major_ticks'] = [int(config['max_value'] * i / 5)
-                                 for i in range(0, number_of_ticks + 1)]
+        gauge_metric_value = get_gauge_metric_value(dashboard_gauge)
+        if gauge_metric_value:
+            config['value'] = get_gauge_metric_value(dashboard_gauge)
+            # set max value of dial to nearest equivalent of 100
+            config['max_value'] = 10 ** len(str(config['value']))
+            number_of_ticks = 5
+            config['major_ticks'] = [int(config['max_value'] * i / 5)
+                                     for i in range(0, number_of_ticks + 1)]
         config['metric_name'] = dict(GAUGE_METRICS).get(dashboard_gauge.metric, '')
         return config
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Simply adds more gauge metric options, specifically for mobile workers and for number of form submissions by them.

And in case of an unknown metric we show a placeholder gauge with metric shown as "Unknown"

![Screenshot from 2025-03-31 01-47-16](https://github.com/user-attachments/assets/b6269d44-e58e-4213-a12e-4acea2bcd725)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
CAMPAIGN_DASHBOARD

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.
The base branch has just been deployed to staging, so I will update any gauges added manually, there are just a couple that would now fail due to name changes.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
