### PR TITLE
Added exception to edit broadcast schedule URL to prevent 404s

### DIFF
--- a/corehq/messaging/scheduling/urls.py
+++ b/corehq/messaging/scheduling/urls.py
@@ -21,7 +21,8 @@ urlpatterns = [
     url(r'^broadcasts/$', BroadcastListView.as_view(), name=BroadcastListView.urlname),
     url(r'^broadcasts/add/$', waf_allow('XSS_BODY')(CreateScheduleView.as_view()),
         name=CreateScheduleView.urlname),
-    url(r'^broadcasts/edit/(?P<broadcast_type>[\w-]+)/(?P<broadcast_id>[\w-]+)/$', EditScheduleView.as_view(),
+    url(r'^broadcasts/edit/(?P<broadcast_type>[\w-]+)/(?P<broadcast_id>[\w-]+)/$',
+        waf_allow('XSS_BODY')(EditScheduleView.as_view()),
         name=EditScheduleView.urlname),
     url(r'^conditional/$', ConditionalAlertListView.as_view(), name=ConditionalAlertListView.urlname),
     # System URL only, to enabling data refresh without logging as user activity


### PR DESCRIPTION
## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-16494

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
The decorator applied to this URL is only for the purposes of a separate management command -- it doesn't change functionality of the code itself. Verified locally that I can still edit the broadcast schedule.

### Automated test coverage

No tests

### QA Plan

No  QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
