### PR TITLE
Revert to Bootstrap 3, take 2

### DIFF
--- a/corehq/apps/campaign/static/campaign/js/dashboard.js
+++ b/corehq/apps/campaign/static/campaign/js/dashboard.js
@@ -1,6 +1,6 @@
 import "commcarehq";
 import "hqwebapp/js/htmx_and_alpine";
-import 'reports/js/bootstrap5/base';
+import 'reports/js/bootstrap3/base';
 import $ from 'jquery';
 import initialPageData from "hqwebapp/js/initial_page_data";
 import { Map, MapItem } from "geospatial/js/bootstrap3/models";
@@ -24,7 +24,7 @@ $(function () {
             mapWidget.initializeMap();
         }
     }
-    $('a[data-bs-toggle="tab"]').on('shown.bs.tab', tabSwitch);
+    $('a[data-toggle="tab"]').on('shown.bs.tab', tabSwitch);
     $('#print-to-pdf').on('click', printActiveTabToPdf);
 
     $modalTitleElement = $(widgetModalSelector).find(modalTitleSelector);
@@ -51,11 +51,11 @@ function tabSwitch(e) {
 }
 
 function printActiveTabToPdf() {
-    const activeTabId = $('.nav-tabs .nav-link.active').attr('href');
+    const activeTabId = $('.nav-tabs .active a').attr('href');
     const elementToPrint = document.querySelector(activeTabId);
     const pdfExportErrorElement =  document.querySelector('#pdf-export-error');
 
-    pdfExportErrorElement.classList.add('d-none');
+    pdfExportErrorElement.classList.add('hide');
 
     // Hide the map controls as they're not needed in the PDF
     const mapControlElements = elementToPrint.querySelectorAll('.mapboxgl-control-container');
@@ -81,7 +81,7 @@ function printActiveTabToPdf() {
     };
 
     html2pdf().from(elementToPrint).set(opt).save().catch(() => {
-        pdfExportErrorElement.classList.remove('d-none');
+        pdfExportErrorElement.classList.remove('hide');
     }).finally(() => {
         mapControlElements.forEach((element) => {
             element.style.visibility = 'visible';
@@ -132,7 +132,7 @@ var MapWidget = function (mapWidgetConfig) {
                 loadCases(data.items);
             },
             error: function () {
-                $(`#error-alert-${self.id}`).removeClass('d-none');
+                $(`#error-alert-${self.id}`).removeClass('hide');
             },
         });
     }
@@ -163,7 +163,7 @@ var MapWidget = function (mapWidgetConfig) {
 };
 
 var htmxAfterSwapWidgetForm = function (event) {
-    $('#widget-modal-spinner').addClass('d-none');
+    $('#widget-modal-spinner').addClass('hide');
 
     const requestMethod = event.detail.requestConfig.verb;
     const responseStatus = event.detail.xhr.status;
@@ -175,7 +175,7 @@ var htmxAfterSwapWidgetForm = function (event) {
 };
 
 var onHideWidgetModal = function () {
-    $('#widget-modal-spinner').removeClass('d-none');
+    $('#widget-modal-spinner').removeClass('hide');
     $('#widget-form').text('');
 };
 

--- a/corehq/apps/campaign/templates/campaign/dashboard.html
+++ b/corehq/apps/campaign/templates/campaign/dashboard.html
@@ -2,7 +2,7 @@
 {% load compress %}
 {% load hq_shared_tags %}
 {% load i18n %}
-{% js_entry "campaign/js/dashboard" %}
+{% js_entry_b3 "campaign/js/dashboard" %}
 
 {% block title %}
   {% trans "Campaign Dashboard" %}

--- a/corehq/apps/campaign/templates/campaign/dashboard.html
+++ b/corehq/apps/campaign/templates/campaign/dashboard.html
@@ -1,4 +1,4 @@
-{% extends 'hqwebapp/bootstrap5/base_section.html' %}
+{% extends 'hqwebapp/bootstrap3/base_section.html' %}
 {% load compress %}
 {% load hq_shared_tags %}
 {% load i18n %}
@@ -14,14 +14,14 @@
   {% initial_page_data 'map_report_widgets' map_report_widgets %}
   {% include "campaign/partials/add_widget_button.html" %}
 
-  <div class="d-flex justify-content-between align-items-center mb-3">
-    <h1>{% trans "Campaign Dashboard" %}</h1>
-    <button id="print-to-pdf" class="btn btn-info">
-      <i class="fa fa-file-pdf me-1"></i>
+  <div class="clearfix margin-bottom-10">
+    <h1 class="pull-left">{% trans "Campaign Dashboard" %}</h1>
+    <button id="print-to-pdf" class="btn btn-info pull-right">
+      <i class="fa fa-file-pdf-o margin-right-5"></i>
       {% trans "Export to PDF" %}
     </button>
   </div>
-  <div id="pdf-export-error" class="alert alert-danger d-none">
+  <div id="pdf-export-error" class="alert alert-danger hide">
     {% blocktrans %}
       There was an error while exporting to PDF! Please try again, and contact
       support if the issue persists.
@@ -29,22 +29,20 @@
   </div>
 
   <ul class="nav nav-tabs" role="tablist">
-    <li role="presentation" class="nav-item">
+    <li role="presentation" class="active">
       <a
-        class="nav-link active"
-        role="tab"
-        data-bs-toggle="tab"
         href="#cases-tab-content"
+        role="tab"
+        data-toggle="tab"
       >
         {% trans "Cases" %}
       </a>
     </li>
     <li>
       <a
-        class="nav-link"
-        role="tab"
-        data-bs-toggle="tab"
         href="#mobile-workers-tab-content"
+        role="tab"
+        data-toggle="tab"
       >
         {% trans "Mobile Workers" %}
       </a>

--- a/corehq/apps/campaign/templates/campaign/partials/add_widget_button.html
+++ b/corehq/apps/campaign/templates/campaign/partials/add_widget_button.html
@@ -1,28 +1,27 @@
 {% load i18n %}
 
-<div class="btn-group d-flex flex-row-reverse">
+<div class="btn-group pull-right">
   <div>
     <button
       type="button"
       class="btn btn-primary dropdown-toggle"
-      data-bs-toggle="dropdown"
+      data-toggle="dropdown"
       aria-expanded="false"
     >
-      {% trans "Add Widget" %}
+      {% trans "Add Widget" %} <span class="caret"></span>
     </button>
 
     <ul class="dropdown-menu">
       {% for value, label in widget_types %}
         <li>
           <a
-            class="dropdown-item"
             href="#"
             hx-get="{% url 'dashboard_widget' domain %}?widget_type={{ value }}"
             hq-hx-action="new_widget"
             hx-target="#widget-form"
             hx-swap="innerHTML"
-            data-bs-toggle="modal"
-            data-bs-target="#widget-modal"
+            data-toggle="modal"
+            data-target="#widget-modal"
           >
             {{ label }}
           </a>

--- a/corehq/apps/campaign/templates/campaign/partials/dashboard_map.html
+++ b/corehq/apps/campaign/templates/campaign/partials/dashboard_map.html
@@ -1,25 +1,25 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<div id="map-widget-{{ widget.id }}" class="paginated-map-widget mb-4">
-  <div class="card">
-    <div class="card-header d-flex justify-content-between align-items-center">
-      <h5 class="mb-0">{{ widget.title }}</h5>
+<div id="map-widget-{{ widget.id }}" class="paginated-map-widget margin-bottom-20">
+  <div class="panel panel-default">
+    <div class="panel-heading clearfix">
+      <h5 class="pull-left">{{ widget.title }}</h5>
       {% include "campaign/partials/edit_widget_button.html" with widget_type='map' %}
     </div>
 
     <!-- TODO: This needs pagination support -->
-    <div class="card-body p-0">
-      <div id="error-alert-{{ widget.id }}" class="alert alert-danger d-none">
+    <div class="panel-body no-padding">
+      <div id="error-alert-{{ widget.id }}" class="alert alert-danger hide">
         {% blocktrans %}
           Something went wrong while loading this widget! Please try again.
         {% endblocktrans %}
       </div>
-      <div class="row g-0">
+      <div class="row">
         <!-- Left Column: Filter Space -->
-        <div class="col-md-4 border-end">
-          <div id="map-widget-filters-{{ widget.id }}" class="p-3">
-            {% include "reports/standard/partials/bootstrap5/filter_panel.html" %}
+        <div class="col-md-4 border-right">
+          <div id="map-widget-filters-{{ widget.id }}" class="padding-10">
+            {% include "reports/standard/partials/bootstrap3/filter_panel.html" %}
           </div>
         </div>
 
@@ -43,9 +43,8 @@
 <!-- Popup for map markers -->
 <script type="text/html" id="select-case">
   <small data-bind="html: getItemType()"></small>
-  <div class="form-check">
+  <div class="checkbox">
     <label
-      class="form-check-label"
       data-bind="html: $data.link, attr: {for: selectCssId}"
     ></label>
   </div>

--- a/corehq/apps/campaign/templates/campaign/partials/edit_widget_button.html
+++ b/corehq/apps/campaign/templates/campaign/partials/edit_widget_button.html
@@ -2,10 +2,10 @@
 
 <button
   id="edit-widget-btn"
-  class="btn btn-default"
+  class="btn btn-default pull-right"
   type="button"
-  data-bs-toggle="modal"
-  data-bs-target="#widget-modal"
+  data-toggle="modal"
+  data-target="#widget-modal"
   hx-target="#widget-form"
   hx-get="{% url 'dashboard_widget' domain %}?widget_type={{ widget_type }}&widget_id={{ widget.id }}"
   hq-hx-action="edit_widget"

--- a/corehq/apps/campaign/templates/campaign/partials/widget_form.html
+++ b/corehq/apps/campaign/templates/campaign/partials/widget_form.html
@@ -2,16 +2,16 @@
 {% load i18n %}
 
 {% if show_success %}
-  <div class="alert alert-success alert-dismissable fade show" role="alert">
+  <div class="alert alert-success alert-dismissable" role="alert">
     {% blocktrans %}
       Saved! Reloading, please wait..
     {% endblocktrans %}
     <button
       type="button"
-      class="btn-close float-end"
-      data-bs-dismiss="alert"
+      class="close"
+      data-dismiss="alert"
       aria-label="{% trans Close %}"
-    ></button>
+    ><span aria-hidden="true">&times;</span></button>
   </div>
 {% endif %}
 

--- a/corehq/apps/campaign/templates/campaign/partials/widget_modal.html
+++ b/corehq/apps/campaign/templates/campaign/partials/widget_modal.html
@@ -4,17 +4,17 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"></h5>
         <button
           type="button"
-          class="btn-close"
-          data-bs-dismiss="modal"
+          class="close"
+          data-dismiss="modal"
           aria-label="Close"
-        ></button>
+        ><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title"></h4>
       </div>
       <div class="modal-body" id="widget-modal-body">
         <div id="widget-modal-spinner">
-          <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading..." %}
+          <i class="fa fa-spinner fa-spin"></i> {% trans "Loading..." %}
         </div>
         <div id="widget-form"></div>
       </div>

--- a/corehq/apps/campaign/views.py
+++ b/corehq/apps/campaign/views.py
@@ -22,7 +22,6 @@ from corehq.apps.es.case_search import CaseSearchES, case_property_missing
 from corehq.apps.geospatial.const import GPS_POINT_CASE_PROPERTY
 from corehq.apps.geospatial.utils import get_lat_lon_from_dict
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
-from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.reports.generic import get_filter_classes
 from corehq.apps.reports.standard.cases.basic import CaseListMixin
 from corehq.apps.reports.views import BaseProjectReportSectionView
@@ -63,7 +62,6 @@ class DashboardMapFilterMixin(object):
 
 @method_decorator(login_and_domain_required, name='dispatch')
 @method_decorator(toggles.CAMPAIGN_DASHBOARD.required_decorator(), name='dispatch')
-@method_decorator(use_bootstrap5, name='dispatch')
 class DashboardView(BaseProjectReportSectionView, DashboardMapFilterMixin):
     urlname = 'campaign_dashboard'
     page_title = gettext_lazy("Campaign Dashboard")
@@ -167,7 +165,6 @@ class PaginatedCasesWithGPSView(BaseDomainView, CaseListMixin):
 
 @method_decorator(login_and_domain_required, name='dispatch')
 @method_decorator(toggles.CAMPAIGN_DASHBOARD.required_decorator(), name='dispatch')
-@method_decorator(use_bootstrap5, name='dispatch')
 class DashboardWidgetView(HqHtmxActionMixin, BaseDomainView):
     urlname = "dashboard_widget"
     form_template_partial_name = 'campaign/partials/widget_form.html'
@@ -258,7 +255,6 @@ class DashboardWidgetView(HqHtmxActionMixin, BaseDomainView):
 
 @require_GET
 @login_and_domain_required
-@use_bootstrap5
 def get_geo_case_properties_view(request, domain):
     case_type = request.GET.get('case_type')
     if not case_type:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/72cae919-7d75-4ce7-ae54-60677b456a5f)

## Technical Summary

This pull request is similar to https://github.com/dimagi/commcare-hq/pull/36097 but instead of rebasing and then updating manually, I gave Claude 3.7 Sonnet the same prompt with the code in `master`. This is the result. Details given in the commit message.

## Feature Flag

campaign_dashboard

## Safety Assurance

### Safety story

Tested locally:
* Map filters
* Applying map filters
* Filter panel accordion
* Export to PDF
* Add widget

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
