### PR TITLE
Fixes an issue with widget form which reloads even when the form fails to save.

### DIFF
--- a/corehq/apps/campaign/static/campaign/js/dashboard.js
+++ b/corehq/apps/campaign/static/campaign/js/dashboard.js
@@ -31,7 +31,7 @@ $(function () {
     $(widgetModalSelector).on('hidden.bs.modal', onHideWidgetModal);
     $(widgetModalSelector).on('show.bs.modal', onShowWidgetModal);
 
-    $(widgetModalSelector).on('htmx:afterSwap', htmxAfterSwapWidgetForm);
+    $(widgetModalSelector).on('htmx:beforeSwap', htmxBeforeSwapWidgetForm);
 });
 
 function tabSwitch(e) {
@@ -162,15 +162,23 @@ var MapWidget = function (mapWidgetConfig) {
     }
 };
 
-var htmxAfterSwapWidgetForm = function (event) {
+var htmxBeforeSwapWidgetForm = function (event) {
     $('#widget-modal-spinner').addClass('d-none');
 
     const requestMethod = event.detail.requestConfig.verb;
     const responseStatus = event.detail.xhr.status;
     if (requestMethod === 'post' && responseStatus === 200) {
-        setTimeout(function () {
-            window.location.reload();
-        }, 1000);
+        // If form is saved successfully, show success message and reload the page
+        const contentType = event.detail.xhr.getResponseHeader("Content-Type");
+        if (contentType && contentType.includes('application/json')) {
+            const response = JSON.parse(event.detail.xhr.response);
+            if (response.success) {
+                $('#widget-success-message').removeClass('d-none');
+                event.detail.shouldSwap = false;
+                $('#widget-form').text('');
+                window.location.reload();
+            }
+        }
     }
 };
 

--- a/corehq/apps/campaign/templates/campaign/partials/widget_form.html
+++ b/corehq/apps/campaign/templates/campaign/partials/widget_form.html
@@ -7,8 +7,8 @@
   hx-target="#widget-form"
   hx-swap="innerHTML"
   hx-vals='{
-    "widget_type": "{{ widget_type }}",
-    "widget_id": "{{ widget.id }}"
+    "widget_type": "{{ widget_type }}"
+    {% if widget.id %},"widget_id": "{{ widget.id }}"{% endif %}
   }'
   hx-disabled-elt="find input[type='submit']"
 >

--- a/corehq/apps/campaign/templates/campaign/partials/widget_form.html
+++ b/corehq/apps/campaign/templates/campaign/partials/widget_form.html
@@ -1,20 +1,6 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% if show_success %}
-  <div class="alert alert-success alert-dismissable fade show" role="alert">
-    {% blocktrans %}
-      Saved! Reloading, please wait..
-    {% endblocktrans %}
-    <button
-      type="button"
-      class="btn-close float-end"
-      data-bs-dismiss="alert"
-      aria-label="{% trans Close %}"
-    ></button>
-  </div>
-{% endif %}
-
 <form
   hq-hx-action="save_widget"
   hx-post="{{ request.path_info }}"

--- a/corehq/apps/campaign/templates/campaign/partials/widget_modal.html
+++ b/corehq/apps/campaign/templates/campaign/partials/widget_modal.html
@@ -16,6 +16,9 @@
         <div id="widget-modal-spinner">
           <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading..." %}
         </div>
+        <div id="widget-success-message" class="alert alert-success d-none">
+          {% trans "Saved! Reloading, please wait.." %}
+        </div>
         <div id="widget-form"></div>
       </div>
     </div>

--- a/corehq/apps/campaign/tests/test_views.py
+++ b/corehq/apps/campaign/tests/test_views.py
@@ -212,10 +212,15 @@ class TestDashboardWidgetView(BaseTestCampaignView):
         assert response.status_code == 404
 
     @staticmethod
-    def _assert_for_success(response, widget_type):
+    def _assert_for_get_form_success(response, widget_type):
         assert response.status_code == 200
         assert response.context['widget_type'] == widget_type
         assert isinstance(response.context['widget_form'], WidgetType.get_form_class(widget_type))
+
+    @staticmethod
+    def _assert_for_save_form_success(response, widget_type):
+        assert response.status_code == 200
+        assert response.json()['success'] is True
 
 
 class TestNewWidget(TestDashboardWidgetView):
@@ -229,7 +234,7 @@ class TestNewWidget(TestDashboardWidgetView):
             is_logged_in=True,
         )
 
-        self._assert_for_success(response, WidgetType.MAP)
+        self._assert_for_get_form_success(response, WidgetType.MAP)
 
     @flag_enabled('CAMPAIGN_DASHBOARD')
     @patch('corehq.apps.campaign.forms.DashboardReportForm._get_report_configurations', return_value=[])
@@ -240,7 +245,7 @@ class TestNewWidget(TestDashboardWidgetView):
             is_logged_in=True,
         )
 
-        self._assert_for_success(response, WidgetType.REPORT)
+        self._assert_for_get_form_success(response, WidgetType.REPORT)
 
     @flag_enabled('CAMPAIGN_DASHBOARD')
     def test_new_widget_invalid_widget_type(self, *args):
@@ -270,7 +275,7 @@ class TestNewWidget(TestDashboardWidgetView):
             headers={'hq-hx-action': self.HQ_ACTION_SAVE_WIDGET},
         )
 
-        self._assert_for_success(response, WidgetType.MAP)
+        self._assert_for_save_form_success(response, WidgetType.MAP)
         assert DashboardMap.objects.count() == 1
 
     @flag_enabled('CAMPAIGN_DASHBOARD')
@@ -292,7 +297,7 @@ class TestNewWidget(TestDashboardWidgetView):
             headers={'hq-hx-action': self.HQ_ACTION_SAVE_WIDGET},
         )
 
-        self._assert_for_success(response, WidgetType.REPORT)
+        self._assert_for_save_form_success(response, WidgetType.REPORT)
         assert DashboardReport.objects.count() == 1
 
     @flag_enabled('CAMPAIGN_DASHBOARD')
@@ -309,7 +314,7 @@ class TestNewWidget(TestDashboardWidgetView):
             headers={'hq-hx-action': self.HQ_ACTION_SAVE_WIDGET},
         )
 
-        self._assert_for_success(response, WidgetType.REPORT)
+        self._assert_for_get_form_success(response, WidgetType.REPORT)
         assert DashboardReport.objects.count() == 0
         assert response.context["widget_form"].errors == {'report_configuration_id': ['This field is required.']}
 
@@ -330,7 +335,7 @@ class TestEditWidget(TestDashboardWidgetView):
             is_logged_in=True,
         )
 
-        self._assert_for_success(response, WidgetType.MAP)
+        self._assert_for_get_form_success(response, WidgetType.MAP)
         assert response.context['widget'] == map_widget
 
     def _sample_map_widget(self):
@@ -356,7 +361,7 @@ class TestEditWidget(TestDashboardWidgetView):
             is_logged_in=True,
         )
 
-        self._assert_for_success(response, WidgetType.REPORT)
+        self._assert_for_get_form_success(response, WidgetType.REPORT)
         assert response.context['widget'] == report_widget
 
     def _sample_report_widget(self, report_id):
@@ -388,7 +393,7 @@ class TestEditWidget(TestDashboardWidgetView):
             is_logged_in=True,
         )
 
-        self._assert_for_success(response, WidgetType.MAP)
+        self._assert_for_save_form_success(response, WidgetType.MAP)
         saved_map_widget = DashboardMap.objects.get(pk=map_widget.id)
         assert saved_map_widget.title == 'New Title'
 
@@ -412,7 +417,7 @@ class TestEditWidget(TestDashboardWidgetView):
             headers={'hq-hx-action': self.HQ_ACTION_SAVE_WIDGET},
         )
 
-        self._assert_for_success(response, WidgetType.REPORT)
+        self._assert_for_save_form_success(response, WidgetType.REPORT)
         saved_report_widget = DashboardReport.objects.get(pk=report_widget.id)
         assert saved_report_widget.title == 'New Title'
         assert saved_report_widget.dashboard_tab == DashboardTab.MOBILE_WORKERS

--- a/corehq/apps/campaign/views.py
+++ b/corehq/apps/campaign/views.py
@@ -216,18 +216,13 @@ class DashboardWidgetView(HqHtmxActionMixin, BaseDomainView):
             widget = self.model_class(dashboard=self.dashboard)
 
         form = self.form_class(self.domain, request.POST, instance=widget)
-        show_success = False
         if form.is_valid():
             form.save(commit=True)
-            show_success = True
-            # Returns empty form if new widget created successfully
-            if not self.widget_id:
-                form = self.form_class(self.domain)
+            return JsonResponse({'success': True})
 
         context = {
             'widget_form': form,
             'widget_type': self.widget_type,
-            'show_success': show_success,
             'widget': widget,
         }
         return self.render_htmx_partial_response(request, self.form_template_partial_name, context)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This PR fixes an issue with widget form which reloads even when the form fails to save.

Srceenshots with fixed behaviour:

Form with error. 
![image](https://github.com/user-attachments/assets/9603f9a0-9fa0-4877-bd54-2d648a896336)

Success Form:
![image](https://github.com/user-attachments/assets/25212b39-6340-4e88-81e6-939d8205ffc7)


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

Django by default uses a HTTP 200 code for both form success and form errors.  The current logic for reload used a check for 200 status code and hence the page reloads even with the form errors.
In this fix, we return an explicit success response when the form saves successfully. I have used JSON response instead of html because it better to do a comparison check.

Additonally, a small fix was made which essentially reverts this e803d2e7e43497c71c943fd9c28f33414ce3bd6f as it caused an issue with Add widget form and form errors. (widget_id was set to `None`)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
CAMPAIGN_DASHBOARD

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Makes a small fix. Sits behind unused FF.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Local Testing done.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
