### PR TITLE
Refresh Payment Report Table on Verify Success

### DIFF
--- a/corehq/apps/integration/static/integration/js/payments/payments_verify.js
+++ b/corehq/apps/integration/static/integration/js/payments/payments_verify.js
@@ -34,6 +34,7 @@ $(document).on('htmx:afterRequest', function (event) {
         handler.selectedIds = [];
         updateVerifyButton([]);
     } else if (method === 'post') {
-        htmx.ajax('GET', event.detail.requestConfig.path, {target: '#payment-verify-table'});
+        const endpoint = requestPath + window.location.search;
+        htmx.ajax('GET', endpoint, {target: '#payment-verify-table'});
     }
 });

--- a/corehq/apps/integration/static/integration/js/payments/payments_verify.js
+++ b/corehq/apps/integration/static/integration/js/payments/payments_verify.js
@@ -39,6 +39,6 @@ $(document).on('htmx:afterRequest', function (event) {
         // doing a refresh
         setTimeout(() => {
             htmx.ajax('GET', endpoint, {target: '#payment-verify-table'});
-        }, 2000);
+        }, 3000);
     }
 });

--- a/corehq/apps/integration/static/integration/js/payments/payments_verify.js
+++ b/corehq/apps/integration/static/integration/js/payments/payments_verify.js
@@ -35,6 +35,10 @@ $(document).on('htmx:afterRequest', function (event) {
         updateVerifyButton([]);
     } else if (method === 'post') {
         const endpoint = requestPath + window.location.search;
-        htmx.ajax('GET', endpoint, {target: '#payment-verify-table'});
+        // The timeout is to allow the verification request enough time to update the affected cases in ES before
+        // doing a refresh
+        setTimeout(() => {
+            htmx.ajax('GET', endpoint, {target: '#payment-verify-table'});
+        }, 2000);
     }
 });

--- a/corehq/apps/integration/static/integration/js/payments/payments_verify.js
+++ b/corehq/apps/integration/static/integration/js/payments/payments_verify.js
@@ -3,6 +3,7 @@ import "hqwebapp/js/htmx_and_alpine";
 import 'reports/js/bootstrap5/base';
 import $ from "jquery";
 import { multiCheckboxSelectionHandler } from "integration/js/checkbox_selection_handler";
+import htmx from 'htmx.org';
 
 
 function updateVerifyButton(selectedIds) {
@@ -24,9 +25,15 @@ $(function () {
 $(document).on('htmx:afterRequest', function (event) {
     // Reset on pagination as the table is recreated after htmx request
     const requestPath = event.detail.requestConfig.path;
+    if (!requestPath.includes('/payments/verify/table/') || !event.detail.successful) {
+        return;
+    }
+
     const method = event.detail.requestConfig.verb;
-    if (requestPath.includes('/payments/verify/table/') && method === 'get' && event.detail.successful) {
+    if (method === 'get') {
         handler.selectedIds = [];
         updateVerifyButton([]);
+    } else if (method === 'post') {
+        htmx.ajax('GET', event.detail.requestConfig.path, {target: '#payment-verify-table'});
     }
 });

--- a/corehq/apps/integration/templates/payments/partials/payments_verify_alert.html
+++ b/corehq/apps/integration/templates/payments/partials/payments_verify_alert.html
@@ -4,6 +4,7 @@
   <div class="alert alert-success alert-dismissable fade show" role="alert">
     {% blocktrans %}
       Successfully submitted {{ success_count }} records for payments!
+      Verification status for these will be refreshed in a few seconds.
     {% endblocktrans %}
     <button
       type="button"

--- a/corehq/apps/integration/templates/payments/payments_verify_report.html
+++ b/corehq/apps/integration/templates/payments/payments_verify_report.html
@@ -36,6 +36,7 @@
     </button>
   </p>
   <div
+    id="payment-verify-table"
     hx-trigger="load"
     hx-get="{% url 'payments_verify_table' domain %}{% querystring %}"
   >


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
After making a verification request on the payments report for one or more rows, the table will now automatically refresh after 3 seconds:
![Peek 2025-04-03 11-48](https://github.com/user-attachments/assets/8148cb7e-0911-4472-9fdd-3e4a025e045c)

This should improve the user experience by allowing the affected rows to show the new verification status without the user needing to do a manual refresh.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-4395).

This is a relatively straightforward change where an HTMX Ajax request is done after the POST request for handling a verification is completed.

As noted in the in-code comment, a 3 second delay is added before actually doing a request to refresh the table. The reason for this is that after the cases have been updated it might take a few seconds for ES to be updated accordingly to reflect the new changes. The 3 second delay isn't a 100% guarantee and new changes could still not show on the table if ES takes longer to get updated.

An alternative solution to using a timeout would be to change how the `get_queryset()` function [here](https://github.com/dimagi/commcare-hq/blob/cd8ce3e8b79a323bc6597e0fb6ba89dfe7b43686/corehq/apps/integration/payments/views.py#L84) is fetching the case data. Instead of fetching the data directly from ES this can be changed to only fetch the relevant case IDs from ES. The list of IDs are then used to fetch the necessary case data from the DB (similar to how we do it [here](https://github.com/dimagi/commcare-hq/blob/cd8ce3e8b79a323bc6597e0fb6ba89dfe7b43686/corehq/apps/campaign/views.py#L183) in the `PaginatedCasesWithGPSView` class). The only downside to this approach is that it does mean additional DB queries.

Curious to hear from other folks whether the timeout delay sounds fine, or whether the alternative solution should be pursued.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`MTN_MOBILE_WORKER_VERIFICATION`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Small change to code behind an unused feature flag.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
