### PR TITLE
Adjusted button position in prepayment modal

### DIFF
--- a/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
@@ -19,10 +19,10 @@
         </div>
         <div data-bind="visible: isSavedCard" class="row">
           <div class="col-sm-8">
-            <select class="form-control"
+            <select class="form-control m-0"
                     data-bind="options: savedCards,
-                                           optionsText: 'cardName',
-                                           value: selectedSavedCard"></select>
+                               optionsText: 'cardName',
+                               value: selectedSavedCard"></select>
           </div>
           <div class="col-sm-3">
             <button type="button"


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/QA-7608

## Technical Summary
In the prepayment modal, the X button's padding overlaps the dropdown, which means clicking on the very right side of the dropdown doesn't open it.
![Screenshot 2025-03-31 at 9 40 15 AM](https://github.com/user-attachments/assets/d0e76b7b-eeb4-4612-b71d-4085077aefae)

Fix by adding a little spacing. It didn't look great having the dropdown and button right next to each other anyway:
![Screenshot 2025-03-31 at 9 38 04 AM](https://github.com/user-attachments/assets/be457a50-6e37-4bf8-9720-5ed4b6fc7c5f)

## Safety Assurance

### Safety story
Tiny styling change. Tested locally.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
