### PR TITLE
Move Dhis2EntityRepeater off of main queue

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1343,7 +1343,7 @@ class RepeatRecord(models.Model):
             # data from overwriting the work of another.
             return
 
-        if self.repeater_type in ['DataSourceRepeater']:
+        if self.repeater_type in ['DataSourceRepeater', 'Dhis2EntityRepeater']:
             # separated for improved datadog reporting
             task = retry_process_datasource_repeat_record if is_retry else process_datasource_repeat_record
         else:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-16858

This is a short term solution to resolving data forwarding issues. This datasource queue was intended for a specific solutions owned repeater that forwarded records to a solutions owned endpoint. However we haven't seen many active datasource repeaters recently, and therefore have a running process that isn't doing anything. This is a good way to put it to work!

The naming is a bit misleading, since `process_datasource_repeat_record` just passes through to `_process_repeat_record` and doesn't do any assertions around the repeater being a datasource repeater.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
