### PR TITLE
update indentsize for scss to 2 in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,5 +21,8 @@ indent_size = 2
 [*.yml]
 indent_size = 2
 
+[*.scss]
+indent_size = 2
+
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
## Technical Summary
recently switched from pycharm to vs code and noticed we didn't have an entry for `scss` files in `.editorconfig`. Let's make sure we keep our stylesheets consistent!

## Safety Assurance

### Safety story
just an editor config change

### Automated test coverage
n/a

### QA Plan
n/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
