### PR TITLE
Removed requirejs conversions from bootstrap migration tool

### DIFF
--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -62,12 +62,12 @@ def test_make_select_form_control_renames_bootstrap5():
 
 
 def test_make_template_tag_renames_bootstrap5():
-    line = """        {% requirejs_main "data_dictionary/js/data_dictionary" %}\n"""
+    line = """        {% js_entry_b3 "data_dictionary/js/data_dictionary" %}\n"""
     final_line, renames = make_template_tag_renames(
         line, get_spec('bootstrap_3_to_5')
     )
-    eq(final_line, """        {% requirejs_main_b5 "data_dictionary/js/data_dictionary" %}\n""")
-    eq(renames, ['renamed requirejs_main to requirejs_main_b5'])
+    eq(final_line, """        {% js_entry "data_dictionary/js/data_dictionary" %}\n""")
+    eq(renames, ['renamed js_entry_b3 to js_entry'])
 
 
 def test_make_data_attribute_renames_bootstrap5():
@@ -152,34 +152,34 @@ def test_make_template_dependency_renames_extends():
     eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 
-def test_check_bootstrap3_references_in_template_requirejs():
-    line = """    {% requirejs_main 'hqwebapp/bootstrap3/foo' %}\n"""
+def test_check_bootstrap3_references_in_template_webpack():
+    line = """    {% js_entry_b3 'hqwebapp/bootstrap3/foo' %}\n"""
     issues = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
-    eq(issues, ["This template references a bootstrap 3 requirejs file. "
-                "It should also use requirejs_main_b5 instead of requirejs_main."])
+    eq(issues, ["This template references a bootstrap 3 webpack entry point. "
+                "It should also use js_entry instead of js_entry_b3."])
 
 
-def test_make_template_dependency_renames_requirejs():
-    line = """    {% requirejs_main 'hqwebapp/js/bootstrap3/foo' %}\n"""
+def test_make_template_dependency_renames_webpack():
+    line = """    {% js_entry_b3 'hqwebapp/js/bootstrap3/foo' %}\n"""
     final_line, renames = make_template_dependency_renames(
         line, get_spec('bootstrap_3_to_5')
     )
-    eq(final_line, """    {% requirejs_main 'hqwebapp/js/bootstrap5/foo' %}\n""")
+    eq(final_line, """    {% js_entry_b3 'hqwebapp/js/bootstrap5/foo' %}\n""")
     eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 
-def test_check_bootstrap3_references_in_template_requirejs_b5():
-    line = """    {% requirejs_main_b5 'hqwebapp/js-test/bootstrap3/foo' %}\n"""
+def test_check_bootstrap3_references_in_template_js_entry():
+    line = """    {% js_entry 'hqwebapp/js-test/bootstrap3/foo' %}\n"""
     issues = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
-    eq(issues, ['This template references a bootstrap 3 requirejs file.'])
+    eq(issues, ['This template references a bootstrap 3 webpack entry point.'])
 
 
-def test_make_template_dependency_renames_requirejs_b5():
-    line = """    {% requirejs_main_b5 'hqwebapp/js-test/bootstrap3/foo' %}\n"""
+def test_make_template_dependency_renames_js_entry():
+    line = """    {% js_entry 'hqwebapp/js-test/bootstrap3/foo' %}\n"""
     final_line, renames = make_template_dependency_renames(
         line, get_spec('bootstrap_3_to_5')
     )
-    eq(final_line, """    {% requirejs_main_b5 'hqwebapp/js-test/bootstrap5/foo' %}\n""")
+    eq(final_line, """    {% js_entry 'hqwebapp/js-test/bootstrap5/foo' %}\n""")
     eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 
@@ -213,10 +213,10 @@ def test_make_template_dependency_renames_include():
     eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 
-def test_flag_requirejs_main_references_in_template():
-    line = """    {% requirejs_main 'hqwebapp/js/foo' %}\n"""
+def test_flag_js_entry_b3_references_in_template():
+    line = """    {% js_entry_b3 'hqwebapp/js/foo' %}\n"""
     issues = check_bootstrap3_references_in_template(line, get_spec('bootstrap_3_to_5'))
-    eq(issues, ['This template should use requirejs_main_b5 instead of requirejs_main.'])
+    eq(issues, ['This template should use js_entry instead of js_entry_b3.'])
 
 
 def test_flag_any_bootstrap3_references_in_template():

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -223,19 +223,12 @@ def check_bootstrap3_references_in_template(line, spec):
                 issues.append("This template references a bootstrap 3 static file.")
             if tag == "include":
                 issues.append("This template includes a bootstrap 3 template.")
-            if tag == "requirejs_main":
-                issues.append("This template references a bootstrap 3 requirejs file. "
-                             "It should also use requirejs_main_b5 instead of requirejs_main.")
-            if tag == "requirejs_main_b5":
-                issues.append("This template references a bootstrap 3 requirejs file.")
             if tag == "js_entry_b3":
                 issues.append("This template references a bootstrap 3 webpack entry point. "
                              "It should also use js_entry instead of js_entry_b3.")
             if tag == "js_entry":
                 issues.append("This template references a bootstrap 3 webpack entry point.")
         elif re.search(tag_only_regex, line):
-            if tag == "requirejs_main":
-                issues.append("This template should use requirejs_main_b5 instead of requirejs_main.")
             if tag == "js_entry_b3":
                 issues.append("This template should use js_entry instead of js_entry_b3.")
     regex = r"(=[\"\'][\w\/]+)(\/bootstrap3\/)"

--- a/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/spec/bootstrap_3_to_5.json
@@ -68,7 +68,6 @@
         "col-xs-offset-<num>": "offset-sm-<num>"
     },
     "template_tag_renames": {
-        "requirejs_main": "requirejs_main_b5",
         "js_entry_b3": "js_entry"
     },
     "data_attribute_renames": {
@@ -116,8 +115,6 @@
         "extends",
         "js_entry",
         "js_entry_b3",
-        "requirejs_main",
-        "requirejs_main_b5",
         "static",
         "include"
     ]


### PR DESCRIPTION
## Technical Summary
There are no more requirejs pages, so the tool no longer needs to handle them.

## Safety Assurance

### Safety story
Removal of dead code in an internal engineering tool.

### Automated test coverage

yes, updated in PR

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
