### PR TITLE
[Data Cleaning] Add row + page selection state frontend

### DIFF
--- a/corehq/apps/data_cleaning/columns.py
+++ b/corehq/apps/data_cleaning/columns.py
@@ -26,12 +26,15 @@ class DataCleaningHtmxColumn(TemplateColumn):
 
 class DataCleaningHtmxSelectionColumn(CheckBoxColumn):
     template_column = "data_cleaning/columns/selection.html"
+    template_header = "data_cleaning/columns/selection_header.html"
+    select_page_checkbox_id = "id-select-page-checkbox"
 
-    def __init__(self, session, request, select_row_action, *args, **kwargs):
+    def __init__(self, session, request, select_row_action, select_page_action, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.session = session
         self.request = request
         self.select_row_action = select_row_action
+        self.select_page_action = select_page_action
         self.attrs['th'] = {
             'class': 'select-header',
         }
@@ -39,6 +42,23 @@ class DataCleaningHtmxSelectionColumn(CheckBoxColumn):
     @classmethod
     def get_selected_record_checkbox_id(self, value):
         return f'id-selected-record-{value}'
+
+    @property
+    def header(self):
+        general = self.attrs.get("input")
+        specific = self.attrs.get("th__input")
+        attrs = AttributeDict(specific or general or {})
+        return mark_safe(  # nosec: render_to_string below will handle escaping
+            render_to_string(
+                self.template_header,
+                {
+                    'hq_hx_action': self.select_page_action,
+                    'css_id': self.select_page_checkbox_id,
+                    'attrs': attrs,
+                },
+                request=self.request,
+            )
+        )
 
     def render(self, value, bound_column, record):
         general = self.attrs.get("input")

--- a/corehq/apps/data_cleaning/columns.py
+++ b/corehq/apps/data_cleaning/columns.py
@@ -1,4 +1,8 @@
 from django_tables2.columns import TemplateColumn, CheckBoxColumn
+from django_tables2.utils import AttributeDict
+
+from corehq.toggles import mark_safe
+from couchexport.writers import render_to_string
 
 
 class DataCleaningHtmxColumn(TemplateColumn):
@@ -21,13 +25,40 @@ class DataCleaningHtmxColumn(TemplateColumn):
 
 
 class DataCleaningHtmxSelectionColumn(CheckBoxColumn):
+    template_column = "data_cleaning/columns/selection.html"
 
-    def __init__(self, session, *args, **kwargs):
+    def __init__(self, session, request, select_row_action, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.session = session
+        self.request = request
+        self.select_row_action = select_row_action
         self.attrs['th'] = {
             'class': 'select-header',
         }
+
+    @classmethod
+    def get_selected_record_checkbox_id(self, value):
+        return f'id-selected-record-{value}'
+
+    def render(self, value, bound_column, record):
+        general = self.attrs.get("input")
+        specific = self.attrs.get("td__input")
+        attrs = AttributeDict(specific or general or {})
+        return mark_safe(  # nosec: render_to_string below will handle escaping
+            render_to_string(
+                self.template_column,
+                {
+                    'hq_hx_action': self.select_row_action,
+                    'is_checked': self.is_checked(value, record),
+                    'value': value,
+                    'css_id': self.get_selected_record_checkbox_id(value),
+                    'record': record,
+                    'column': bound_column,
+                    'attrs': attrs,
+                },
+                request=self.request,
+            )
+        )
 
     def is_checked(self, value, record):
         # todo

--- a/corehq/apps/data_cleaning/columns.py
+++ b/corehq/apps/data_cleaning/columns.py
@@ -30,6 +30,15 @@ class DataCleaningHtmxSelectionColumn(CheckBoxColumn):
     select_page_checkbox_id = "id-select-page-checkbox"
 
     def __init__(self, session, request, select_row_action, select_page_action, *args, **kwargs):
+        """
+        Defines a django_tables2 compatible column that handles selecting
+        records in a data cleaning session.
+
+        :param session: BulkEditSession instance
+        :param request: a django request object from the session view
+        :param select_row_action: the hq_hx_action from the session view for selecting a row
+        :param select_page_action: the hq_hx_action from the session view for selecting all records in a page
+        """
         super().__init__(*args, **kwargs)
         self.session = session
         self.request = request

--- a/corehq/apps/data_cleaning/columns.py
+++ b/corehq/apps/data_cleaning/columns.py
@@ -1,4 +1,4 @@
-from django_tables2.columns import TemplateColumn
+from django_tables2.columns import TemplateColumn, CheckBoxColumn
 
 
 class DataCleaningHtmxColumn(TemplateColumn):
@@ -18,3 +18,17 @@ class DataCleaningHtmxColumn(TemplateColumn):
             *args, **kwargs
         )
         self.column_spec = column_spec
+
+
+class DataCleaningHtmxSelectionColumn(CheckBoxColumn):
+
+    def __init__(self, session, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.session = session
+        self.attrs['th'] = {
+            'class': 'select-header',
+        }
+
+    def is_checked(self, value, record):
+        # todo
+        return False

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -15,6 +15,10 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
 
     class Meta(BaseHtmxTable.Meta):
         template_name = "data_cleaning/tables/table_with_controls.html"
+        row_attrs = {
+            "x-data": "{ isRowSelected: $el.querySelector('input[type=checkbox]').checked }",
+            ":class": "{ 'table-primary': isRowSelected }",
+        }
 
     def __init__(self, session=None, **kwargs):
         super().__init__(**kwargs)
@@ -24,6 +28,11 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
     def get_select_column(cls, session, request, select_row_action, select_page_action):
         return DataCleaningHtmxSelectionColumn(
             session, request, select_row_action, select_page_action, accessor='case_id',
+            attrs={
+                'td__input': {
+                    "@click": "isRowSelected = $event.target.checked;",
+                },
+            },
         )
 
     @classmethod

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -21,9 +21,9 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         self.session = session
 
     @classmethod
-    def get_select_column(cls, session):
+    def get_select_column(cls, session, request, select_row_action):
         return DataCleaningHtmxSelectionColumn(
-            session, accessor='case_id',
+            session, request, select_row_action, accessor='case_id',
         )
 
     @classmethod

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -30,7 +30,20 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
             session, request, select_row_action, select_page_action, accessor='case_id',
             attrs={
                 'td__input': {
-                    "@click": "isRowSelected = $event.target.checked;",
+                    "@click": (
+                        "if ($event.target.checked !== isRowSelected) {"
+                        # `numRecordsSelected` defined in template
+                        "  $event.target.checked ? numRecordsSelected++ : numRecordsSelected--;"
+                        # `pageNumRecordsSelected` defined in template
+                        "  $event.target.checked ? pageNumRecordsSelected++ : pageNumRecordsSelected--; "
+                        "} "
+                        # `isRowSelected` defined in `row_attrs` in `class Meta`
+                        "isRowSelected = $event.target.checked;"
+                    ),
+                },
+                'th__input': {
+                    # `pageNumRecordsSelected`, `pageTotalRecords`: defined in template
+                    ":checked": "pageNumRecordsSelected == pageTotalRecords",
                 },
             },
         )
@@ -42,6 +55,14 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
             slug = column_spec.prop_id.replace('@', '')
             visible_columns.append((slug, DataCleaningHtmxColumn(column_spec)))
         return visible_columns
+
+    @property
+    def num_selected_records(self):
+        """
+        Return the number of selected records in the session.
+        """
+        # todo
+        return 0
 
 
 class CaseCleaningTasksTable(BaseHtmxTable, tables.Table):

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -21,9 +21,9 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         self.session = session
 
     @classmethod
-    def get_select_column(cls, session, request, select_row_action):
+    def get_select_column(cls, session, request, select_row_action, select_page_action):
         return DataCleaningHtmxSelectionColumn(
-            session, request, select_row_action, accessor='case_id',
+            session, request, select_row_action, select_page_action, accessor='case_id',
         )
 
     @classmethod

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -1,7 +1,10 @@
 from django.utils.translation import gettext_lazy
 from django_tables2 import columns, tables
 
-from corehq.apps.data_cleaning.columns import DataCleaningHtmxColumn
+from corehq.apps.data_cleaning.columns import (
+    DataCleaningHtmxColumn,
+    DataCleaningHtmxSelectionColumn,
+)
 from corehq.apps.data_cleaning.records import EditableCaseSearchElasticRecord
 from corehq.apps.hqwebapp.tables.elasticsearch.tables import ElasticTable
 from corehq.apps.hqwebapp.tables.htmx import BaseHtmxTable
@@ -16,6 +19,12 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
     def __init__(self, session=None, **kwargs):
         super().__init__(**kwargs)
         self.session = session
+
+    @classmethod
+    def get_select_column(cls, session):
+        return DataCleaningHtmxSelectionColumn(
+            session, accessor='case_id',
+        )
 
     @classmethod
     def get_columns_from_session(cls, session):

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
@@ -1,0 +1,17 @@
+{% load django_tables2 %}
+
+<input
+  id="{{ css_id }}"
+  class="form-check-input"
+  type="checkbox"
+  {% if is_checked %}
+    checked="checked"
+  {% endif %}
+  name="selected_record"
+  value="{{ value }}"
+  hx-post="{{ request.path_info }}{% querystring %}"
+  hq-hx-action="{{ hq_hx_action }}"
+  hx-swap="none"
+  hx-disabled-elt="this"
+  {{ attrs.as_html }}
+/>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
@@ -2,7 +2,7 @@
 
 <input
   id="{{ css_id }}"
-  class="form-check-input"
+  class="form-check-input htmx-disable-on-select-page"
   type="checkbox"
   {% if is_checked %}
     checked="checked"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection_header.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection_header.html
@@ -1,0 +1,13 @@
+{% load django_tables2 %}
+
+<input
+  id="{{ css_id }}"
+  class="form-check-input"
+  type="checkbox"
+  name="select_page"
+  hx-post="{{ request.path_info }}{% querystring %}"
+  hq-hx-action="{{ hq_hx_action }}"
+  hx-swap="none"
+  hx-disabled-elt="this"
+  {{ attrs.as_html }}
+/>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection_header.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection_header.html
@@ -2,12 +2,12 @@
 
 <input
   id="{{ css_id }}"
-  class="form-check-input"
+  class="form-check-input htmx-disable-on-select-page"
   type="checkbox"
   name="select_page"
   hx-post="{{ request.path_info }}{% querystring %}"
   hq-hx-action="{{ hq_hx_action }}"
   hx-swap="none"
-  hx-disabled-elt="this"
+  hx-disabled-elt=".htmx-disable-on-select-page"
   {{ attrs.as_html }}
 />

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -45,9 +45,12 @@
       <div class="input-group">
         <div class="input-group-text rounded-end"> {# todo: selection UI #}
           <i class="fa-solid fa-circle-check me-2"></i>
-          {# todo: selection number #}
+          <span
+            class="me-1"
+            x-text="numRecordsSelected"
+          ></span>
           {% blocktrans %}
-            0 Records Selected
+            Records Selected
           {% endblocktrans %}
         </div>
       </div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -2,6 +2,16 @@
 {% load i18n %}
 {% load django_tables2 %}
 
+{% block table-container-attrs %}
+  {{ block.super }}
+  x-data="{
+    numRecordsSelected: {{ table.num_selected_records }},
+    totalRecords: {{ table.page.paginator.count }},
+    pageTotalRecords: {{ table.paginated_rows|length }},
+    pageNumRecordsSelected: 0,
+  }"
+{% endblock %}
+
 {% block before_table %}
   <div class="d-flex align-items-center pb-2">
 

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -29,8 +29,15 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
     table_class = CleanCaseTable
 
     def get_table_kwargs(self):
+        extra_columns = [(
+            "selection",
+            self.table_class.get_select_column(
+                self.session,
+            )
+        )]
+        extra_columns.extend(self.table_class.get_columns_from_session(self.session))
         return {
-            'extra_columns': self.table_class.get_columns_from_session(self.session),
+            'extra_columns': extra_columns,
             'record_kwargs': {
                 'session': self.session,
             },

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -33,6 +33,8 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
             "selection",
             self.table_class.get_select_column(
                 self.session,
+                self.request,
+                select_row_action="select_row",
             )
         )]
         extra_columns.extend(self.table_class.get_columns_from_session(self.session))
@@ -60,6 +62,14 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
             },
         })
         return response
+
+    @hq_hx_action('post')
+    def select_row(self, request, *args, **kwargs):
+        """
+        Selects a single record.
+        """
+        # todo
+        return self.get(request, *args, **kwargs)
 
 
 class CaseCleaningTasksTableView(BaseDataCleaningTableView):

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -35,6 +35,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
                 self.session,
                 self.request,
                 select_row_action="select_row",
+                select_page_action="select_page",
             )
         )]
         extra_columns.extend(self.table_class.get_columns_from_session(self.session))
@@ -67,6 +68,14 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
     def select_row(self, request, *args, **kwargs):
         """
         Selects a single record.
+        """
+        # todo
+        return self.get(request, *args, **kwargs)
+
+    @hq_hx_action('post')
+    def select_page(self, request, *args, **kwargs):
+        """
+        Selects all records on the current page.
         """
         # todo
         return self.get(request, *args, **kwargs)

--- a/corehq/apps/hqwebapp/tables/elasticsearch/records.py
+++ b/corehq/apps/hqwebapp/tables/elasticsearch/records.py
@@ -73,6 +73,14 @@ class CaseSearchElasticRecord(BaseElasticRecord):
     def __getitem__(self, item):
         return self.record.get(item)
 
+    @property
+    def name(self):
+        """
+        Used to populate the name attribute of an input (checkbox) in the table.
+        Used by the built-in CheckBoxColumn from django_tables2.
+        """
+        return "selected_case"
+
     @staticmethod
     def get_sorted_query(query, accessors):
         for accessor in accessors:


### PR DESCRIPTION
## Technical Summary
review commit-by-commit please

This PR introduces the `DataCleaningHtmxSelectionColumn`, a subclass of `CheckBoxColumn`, which handles display of the selection checkbox in the data cleaning table view. 

NOTE: There are several `#todo` placeholders in this PR where I will eventually add the backend logic to retrieve and update the actual `BulkEditSession` selected record(s) state by updating the related `BulkEditRecord` objects.

Additionally, I introduce the client-side selection state logic, maintained through an alpine model.

Single record selection, updating the row styling:
![Screenshot 2025-03-31 at 8 34 31 PM](https://github.com/user-attachments/assets/ede14b03-91a5-4070-8d87-1f9ac39d5f0f)

All record selection, updating the selection state of the header checkbox:
![Screenshot 2025-03-31 at 8 34 00 PM](https://github.com/user-attachments/assets/bccfa824-8758-4edb-b07d-0d97b1297abb)
note: this PR does not include the functionality for clicking on the header checkbox to select all records on the page.

## Related JIRA ticket
https://dimagi.atlassian.net/browse/SAAS-16863

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
only affects logic behind a feature flag. no production workflows are affected

### Automated test coverage
most important logic is already tested

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
