### PR TITLE
Revert "Revert "Webpack migration for pages that use Stripe""

### DIFF
--- a/corehq/apps/accounting/.eslintrc.js
+++ b/corehq/apps/accounting/.eslintrc.js
@@ -1,7 +1,0 @@
-/* global module */
-// Temporary until weback migration is complete, requirejs is gone, and all of HQ can use the latest ecmaVersion
-module.exports = {
-    "parserOptions": {
-        "ecmaVersion": 6,
-    },
-};

--- a/corehq/apps/accounting/static/accounting/js/base_subscriptions_main.js
+++ b/corehq/apps/accounting/static/accounting/js/base_subscriptions_main.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine('accounting/js/base_subscriptions_main', [
     'jquery',
     'knockout',
@@ -9,7 +9,7 @@ hqDefine('accounting/js/base_subscriptions_main', [
 ], function (
     $,
     ko,
-    widgets
+    widgets,
 ) {
     var subscriptionInfoHandlerModel = function () {
         var self = {};

--- a/corehq/apps/accounting/static/accounting/js/billing_account_form.js
+++ b/corehq/apps/accounting/static/accounting/js/billing_account_form.js
@@ -1,14 +1,14 @@
-"use strict";
 hqDefine('accounting/js/billing_account_form', [
     'jquery',
     'knockout',
     'hqwebapp/js/initial_page_data',
     'accounting/js/credits_tab',
     'accounting/js/widgets',
+    'commcarehq',
 ], function (
     $,
     ko,
-    initialPageData
+    initialPageData,
 ) {
     var billingAccountFormModel = function (isActive, isCustomerBillingAccount, enterpriseAdminEmails, isSmsBillableReportVisible) {
         var self = {};

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine('accounting/js/confirm_plan', [
     'jquery',
     'knockout',
@@ -9,7 +9,7 @@ hqDefine('accounting/js/confirm_plan', [
     $,
     ko,
     _,
-    initialPageData
+    initialPageData,
 ) {
     var PROJECT_ENDED = gettext("My project ended");
     var FUNDING_ENDED = gettext("The funding for my project ended");
@@ -114,7 +114,7 @@ hqDefine('accounting/js/confirm_plan', [
             initialPageData.get('is_upgrade'),
             initialPageData.get('is_same_edition'),
             initialPageData.get('is_paused'),
-            initialPageData.get('current_plan')
+            initialPageData.get('current_plan'),
         );
 
         $('#confirm-plan-content').koApplyBindings(confirmPlan);

--- a/corehq/apps/accounting/static/accounting/js/credits.js
+++ b/corehq/apps/accounting/static/accounting/js/credits.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine('accounting/js/credits', [
     'jquery',
     'knockout',
@@ -9,7 +9,7 @@ hqDefine('accounting/js/credits', [
     $,
     ko,
     _,
-    paymentMethodHandler
+    paymentMethodHandler,
 ) {
     var creditsManager = function (products, features, paymentHandler, canPurchaseCredits) {
         var self = {};

--- a/corehq/apps/accounting/static/accounting/js/credits_tab.js
+++ b/corehq/apps/accounting/static/accounting/js/credits_tab.js
@@ -1,10 +1,10 @@
-"use strict";
+
 hqDefine("accounting/js/credits_tab", [
     'jquery',
     'knockout',
 ], function (
     $,
-    ko
+    ko,
 ) {
     $(function () {
         var $form = $('#credit-form');

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -1,14 +1,20 @@
-"use strict";
+/**
+ *  This module requires initial page data to provide "stripe_public_key".
+ *  It also requires a container with the id stripe-card-container, which is where the credit card UI will be
+ *  mounted.
+ */
 hqDefine('accounting/js/payment_method_handler', [
     'jquery',
     'knockout',
     'underscore',
-    'stripe',
+    'accounting/js/stripe',
+    'hqwebapp/js/initial_page_data',
 ], function (
     $,
     ko,
     _,
-    Stripe
+    hqStripe,
+    initialPageData,
 ) {
     var billingHandler = function (formId, opts) {
         var self = {};
@@ -131,6 +137,24 @@ hqDefine('accounting/js/payment_method_handler', [
         self.isNewCard = ko.computed(function () {
             return self.selectedCardType() === 'new';
         });
+        // Stripe can't attach the card UI to the page until its container exists.
+        // Its container is removed and re-added from the DOM depending on the user's
+        // selections, so mount and unmount it as needed.
+        self.cardElementPromise = hqStripe.getCardElementPromise(initialPageData.get("stripe_public_key"));
+        self.cardElementMounted = false;
+        self.isNewCard.subscribe(function (newValue) {
+            self.cardElementPromise.then(function (cardElement) {
+                _.delay(function () {
+                    if (newValue) {
+                        cardElement.mount('#stripe-card-container');
+                        self.cardElementMounted = true;
+                    } else {
+                        cardElement.unmount();
+                        self.cardElementMounted = false;
+                    }
+                });
+            });
+        });
 
         self.newCard = ko.observable(stripeCardModel());
 
@@ -185,7 +209,12 @@ hqDefine('accounting/js/payment_method_handler', [
         self.reset = function () {
             self.paymentIsComplete(false);
             self.serverErrorMsg('');
-            self.newCard(stripeCardModel());
+            self.newCard().reset();
+            if (self.cardElementMounted) {
+                self.cardElementPromise.then(function (cardElement) {
+                    cardElement.clear();
+                });
+            }
         };
 
         self.processPayment = function () {
@@ -493,7 +522,6 @@ hqDefine('accounting/js/payment_method_handler', [
         var self = {};
 
         self.number = ko.observable();
-        self.cvc = ko.observable();
         self.expMonth = ko.observable();
         self.expYear = ko.observable();
         self.errorMsg = ko.observable();
@@ -501,6 +529,17 @@ hqDefine('accounting/js/payment_method_handler', [
         self.isTestMode = ko.observable(false);
         self.isProcessing = ko.observable(false);
         self.newSavedCard = ko.observable(false);
+
+        self.reset = function () {
+            self.number(null);
+            self.expMonth(null);
+            self.expYear(null);
+            self.errorMsg(null);
+            self.token(null);
+            self.isTestMode(false);
+            self.isProcessing(false);
+            self.newSavedCard(false);
+        };
 
         self.autopayCard = ko.computed(function () {
             if (!self.newSavedCard()) {
@@ -521,17 +560,9 @@ hqDefine('accounting/js/payment_method_handler', [
         self.showErrors = ko.computed(function () {
             return !! self.errorMsg();
         });
-        self.cleanedNumber = ko.computed(function () {
-            if (self.number()) {
-                return self.number().split('-').join('');
-            }
-            return null;
-        });
-
         self.cardName = ko.computed(function () {
             return self.cardType() + ' ' + self.number() + ' exp ' + self.expMonth() + '/' + self.expYear();
         });
-
 
         self.loadSavedData = function (data) {
             self.number('************' + data.last4);
@@ -539,7 +570,6 @@ hqDefine('accounting/js/payment_method_handler', [
             self.expMonth(data.exp_month);
             self.expYear(data.exp_year);
             self.token(data.id);
-            self.cvc('****');
             self.isSaved(true);
         };
 
@@ -549,24 +579,19 @@ hqDefine('accounting/js/payment_method_handler', [
                 callbackOnSuccess();
                 return;
             }
-            Stripe.card.createToken({
-                number: self.number(),
-                cvc: self.cvc(),
-                exp_month: self.expMonth(),
-                exp_year: self.expYear(),
-            }, function (status, response) {
+            hqStripe.createStripeToken(function (response) {
                 if (response.error) {
                     self.errorMsg(response.error.message);
                     self.isProcessing(false);
                 } else {
                     self.errorMsg('');
-                    self.token(response.id);
-                    self.isTestMode(!response.livemode);
+                    self.token(response.token.id);
+                    self.isTestMode(!response.token.livemode);
                     if (self.token()) {
                         callbackOnSuccess();
                     } else {
                         self.isProcessing(false);
-                        self.errorMsg('Response from Stripe did not complete properly.');
+                        self.errorMsg(gettext('Response from Stripe did not complete properly.'));
                     }
                 }
             });

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -157,7 +157,7 @@ hqDefine('accounting/js/payment_method_handler', [
             });
         };
         self.isNewCard.subscribe(function (newValue) {
-            _.delay(function () { self.showOrHideStripeUI(newValue) });
+            _.delay(function () { self.showOrHideStripeUI(newValue); });
         });
 
         self.newCard = ko.observable(stripeCardModel());
@@ -191,7 +191,7 @@ hqDefine('accounting/js/payment_method_handler', [
             return self.paymentIsNotComplete() && self.savedCards().length > 0;
         });
         self.mustCreateNewCard.subscribe(function (newValue) {
-            _.delay(function () { self.showOrHideStripeUI(newValue) });
+            _.delay(function () { self.showOrHideStripeUI(newValue); });
         });
 
         self.isSubmitDisabled = ko.computed(function () {

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine('accounting/js/pricing_table', [
     'jquery',
     'knockout',
@@ -13,7 +13,7 @@ hqDefine('accounting/js/pricing_table', [
     _,
     initialPageData,
     utils,
-    assertProperties
+    assertProperties,
 ) {
     var PricingTable = function (options) {
         assertProperties.assert(options, [
@@ -109,7 +109,7 @@ hqDefine('accounting/js/pricing_table', [
                         "<p>Continuing ahead will allow you to schedule your current <%- oldPlan %> " +
                         "Edition Plan subscription to be paused on <strong> <%- date %> </strong></p>" +
                         "<p>If you have questions or if you would like to speak to us about your subscription, " +
-                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>.</p>"
+                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>.</p>",
                     ))({
                         date: newStartDate,
                         newPlan: newPlan,
@@ -125,7 +125,7 @@ hqDefine('accounting/js/pricing_table', [
                         "Plan subscription to be downgraded to the <%- newPlan %> Edition Plan " +
                         "on <strong> <%- date %> </strong></p>" +
                         "<p>If you have questions or if you would like to speak to us about your subscription, " +
-                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>.</p>"
+                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>.</p>",
                     ))({
                         oldPlan: oldPlan,
                         date: newStartDate,
@@ -141,7 +141,7 @@ hqDefine('accounting/js/pricing_table', [
                         "Plan subscription to be downgraded to the <%- newPlan %> Edition Plan " +
                         "on <strong> <%- date %> </strong></p>" +
                         "<p>If you have questions or if you would like to speak to us about your subscription, " +
-                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>.</p>"
+                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>.</p>",
                     ))({
                         oldPlan: oldPlan,
                         nextSubscription: self.oNextSubscription(),
@@ -156,7 +156,7 @@ hqDefine('accounting/js/pricing_table', [
                         "Plan subscription to be downgraded to the <%- newPlan %> Edition Plan " +
                         "on <strong> <%- date %> </strong></p>" +
                         "If you have questions or if you would like to speak to us about your subscription, " +
-                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>."
+                        "please reach out to <a href='mailto: <%- invoicingContact %>'><%- invoicingContact %></a>.",
                     ))({
                         oldPlan: oldPlan,
                         date: newStartDate,
@@ -196,7 +196,6 @@ hqDefine('accounting/js/pricing_table', [
     };
 
     var PlanOption = function (data, parent) {
-        'use strict';
         var self = this;
 
         self.oName = ko.observable(data.name);

--- a/corehq/apps/accounting/static/accounting/js/renew_plan_selection.js
+++ b/corehq/apps/accounting/static/accounting/js/renew_plan_selection.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine('accounting/js/renew_plan_selection', [
     'jquery',
     'knockout',
@@ -8,7 +8,7 @@ hqDefine('accounting/js/renew_plan_selection', [
 ], function (
     $,
     ko,
-    initialPageData
+    initialPageData,
 ) {
     var PlanRenewalView = function (options) {
         var self = this;

--- a/corehq/apps/accounting/static/accounting/js/software_plan_version_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/software_plan_version_handler.js
@@ -1,4 +1,3 @@
-"use strict";
 hqDefine("accounting/js/software_plan_version_handler", [
     'jquery',
     'knockout',
@@ -7,19 +6,20 @@ hqDefine("accounting/js/software_plan_version_handler", [
     'hqwebapp/js/select2_handler',
     'hqwebapp/js/multiselect_utils',
     'select2/dist/js/select2.full.min',
+    'commcarehq',
 ], function (
     $,
     ko,
     _,
     initialPageData,
     select2Handler,
-    multiselectUtils
+    multiselectUtils,
 ) {
     $(function () {
         var planVersionFormHandler = softwarePlanVersionFormHandler(
             initialPageData.get('role'),
             initialPageData.get('feature_rates'),
-            initialPageData.get('product_rates')
+            initialPageData.get('product_rates'),
         );
         $('#roles').koApplyBindings(planVersionFormHandler);
         planVersionFormHandler.init();

--- a/corehq/apps/accounting/static/accounting/js/stripe.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe.js
@@ -1,0 +1,30 @@
+import { loadStripe } from '@stripe/stripe-js';
+
+self.stripePromise = undefined;
+self.cardElement = undefined;
+
+function getCardElementPromise(key) {
+    if (!key) {
+        throw new Error("Cannot load Stripe, key not provided");
+    }
+
+    let promise = new Promise((resolve) => {
+        self.stripePromise = loadStripe(key);
+        self.stripePromise.then(function (stripe) {
+            self.cardElement = stripe.elements().create('card', {
+                hidePostalCode: true,
+            });
+            resolve(self.cardElement);
+        });
+    });
+
+    return promise;
+}
+
+function createStripeToken(handleResponse) {
+    self.stripePromise.then(function (stripe) {
+        stripe.createToken(self.cardElement).then(handleResponse);
+    });
+}
+
+export { createStripeToken, getCardElementPromise };

--- a/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
@@ -1,24 +1,45 @@
-"use strict";
+/**
+ *  This module requires initial page data to provide "stripe_public_key".
+ *  It also requires a container with the id stripe-card-container, which is where the credit card UI will be
+ *  mounted.
+ */
 hqDefine("accounting/js/stripe_card_manager", [
     'jquery',
     'knockout',
-    'stripe',
+    'accounting/js/stripe',
+    'hqwebapp/js/initial_page_data',
 ], function (
     $,
     ko,
-    Stripe
+    hqStripe,
+    initialPageData,
 ) {
     var newStripeCardModel = function (data, cardManager) {
         var self = {};
+
+        // This assumes this model won't be created until the page is loaded,
+        // which is reasonable because knockout bindings don't get applied until then.
+        self.cardElementMounted = false;
+        self.cardElementPromise = hqStripe.getCardElementPromise(initialPageData.get("stripe_public_key"));
+        self.cardElementPromise.then(function (cardElement) {
+            cardElement.mount('#stripe-card-container');
+            self.cardElementMounted = true;
+        });
+
         var mapping = {
-            observe: ['number', 'cvc', 'expMonth','expYear', 'isAutopay', 'token'],
+            observe: ['isAutopay', 'token'],
         };
 
         self.wrap = function (data) {
             ko.mapping.fromJS(data, mapping, self);
         };
         self.reset = function () {
-            self.wrap({'number': '', 'cvc': '', 'expMonth': '', 'expYear': '', 'isAutopay': false, 'token': ''});
+            self.wrap({'isAutopay': false, 'token': ''});
+            if (self.cardElementMounted) {
+                self.cardElementPromise.then(function (cardElement) {
+                    cardElement.clear();
+                });
+            }
         };
         self.reset();
 
@@ -50,29 +71,20 @@ hqDefine("accounting/js/stripe_card_manager", [
             });
         };
 
-        var handleStripeResponse = function (status, response) {
+        var handleStripeResponse = function (response) {
             if (response.error) {
                 self.isProcessing(false);
                 self.errorMsg(response.error.message);
             } else {
                 self.errorMsg('');
-                self.token(response.id);
+                self.token(response.token.id);
                 submit();
             }
         };
 
-        var createStripeToken = function () {
-            Stripe.card.createToken({
-                number: self.number(),
-                cvc: self.cvc(),
-                exp_month: self.expMonth(),
-                exp_year: self.expYear(),
-            }, handleStripeResponse);
-        };
-
         self.saveCard = function () {
             self.isProcessing(true);
-            createStripeToken();
+            hqStripe.createStripeToken(handleStripeResponse);
         };
 
         return self;
@@ -164,7 +176,9 @@ hqDefine("accounting/js/stripe_card_manager", [
         self.wrap(data);
 
         self.autoPayButtonEnabled = ko.observable(true);
-        self.newCard = newStripeCardModel({url: data.url}, self);
+        self.newCard = newStripeCardModel({
+            url: data.url,
+        }, self);
 
         return self;
     };

--- a/corehq/apps/accounting/static/accounting/js/subscriptions_main.js
+++ b/corehq/apps/accounting/static/accounting/js/subscriptions_main.js
@@ -1,13 +1,13 @@
-"use strict";
 hqDefine('accounting/js/subscriptions_main', [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'accounting/js/widgets',
     'accounting/js/base_subscriptions_main',
+    'commcarehq',
 ], function (
     $,
     initialPageData,
-    widgets
+    widgets,
 ) {
     $(function () {
         var asyncSelect2Handler = widgets.asyncSelect2Handler;

--- a/corehq/apps/accounting/static/accounting/js/widgets.js
+++ b/corehq/apps/accounting/static/accounting/js/widgets.js
@@ -1,4 +1,4 @@
-"use strict";
+
 hqDefine('accounting/js/widgets', [
     'jquery',
     'knockout',
@@ -10,7 +10,7 @@ hqDefine('accounting/js/widgets', [
     $,
     ko,
     _,
-    emailUtils
+    emailUtils,
 ) {
     var asyncSelect2Handler = function (field, multiple, handlerSlug) {
         var self = {};

--- a/corehq/apps/accounting/templates/accounting/accounts.html
+++ b/corehq/apps/accounting/templates/accounting/accounts.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'accounting/js/billing_account_form' %}
+{% js_entry_b3 'accounting/js/billing_account_form' %}
 
 {% block page_content %}
   {% initial_page_data 'account_form_is_active' basic_form.is_active.value %}

--- a/corehq/apps/accounting/templates/accounting/accounts_base.html
+++ b/corehq/apps/accounting/templates/accounting/accounts_base.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'accounting/js/widgets' %}
+{% js_entry_b3 'accounting/js/widgets' %}
 
 {% block page_content %}
   {% crispy basic_form %}

--- a/corehq/apps/accounting/templates/accounting/invoice.html
+++ b/corehq/apps/accounting/templates/accounting/invoice.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main "accounting/js/widgets" %} {# Uses .ko-adjust-balance-form #}
+{% js_entry_b3 "accounting/js/widgets" %} {# Uses .ko-adjust-balance-form #}
 
 {% block page_content %}
   {% if adjust_balance_form %}

--- a/corehq/apps/accounting/templates/accounting/partials/new_stripe_card_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/new_stripe_card_template.html
@@ -22,57 +22,10 @@
                                     text: errorMsg">
           </div>
 
-          <div class="form-group">
-            <label class="control-label col-sm-3">
-              {% trans 'Card Number' %}
-            </label>
-            <div class="col-sm-9">
-              <input type="text"
-                     data-bind="value: number, disable: isProcessing"
-                     size="20"
-                     class="form-control"
-                     placeholder="xxxx-xxxx-xxxx-xxxx", />
-            </div>
-          </div>
+          <div id="stripe-card-container"></div>{# populated by a card element from Stripe #}
 
           <div class="form-group">
-            <label class="control-label col-sm-3">
-              {% trans 'CVC' context "Check digits of credit card"%}
-            </label>
-            <div class="col-sm-3">
-              <input type="text"
-                     data-bind="value: cvc, disable: isProcessing"
-                     size="4"
-                     class="form-control"
-                     placeholder="xxxx"/>
-            </div>
-          </div>
-
-          <div class="form-group">
-            <label class="control-label col-sm-3">
-              {% trans 'Expiration' %}
-            </label>
             <div class="col-sm-9">
-              <div class="row">
-                <div class="col-sm-2">
-                  <input type="text"
-                         data-bind="value: expMonth, disable: isProcessing"
-                         size="2"
-                         class="form-control"
-                         placeholder="MM" />
-                </div>
-                <div class="col-sm-4">
-                  <input type="text"
-                         data-bind="value: expYear, disable: isProcessing"
-                         size="4"
-                         class="form-control"
-                         placeholder="YYYY" />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="col-sm-offset-3 col-sm-9">
               <div class="checkbox">
                 <label>
                   <input type="checkbox" name="autopay" data-bind="checked: isAutopay, disable: isProcessing"/>
@@ -94,8 +47,7 @@
             {% trans 'Cancel' %}
           </button>
           <button type="button" class="btn btn-primary"
-                  data-bind="click: saveCard,
-                                       enable: !isProcessing()">
+                  data-bind="click: saveCard, enable: !isProcessing()">
             {% trans 'Save' %}
           </button>
         </div>

--- a/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
@@ -108,53 +108,8 @@
 
   <div data-bind="visible: showCardData">
     <div class="form-group">
-      <label class="control-label col-sm-3">
-        {% trans 'Card Number' %}
-      </label>
-      <div class="col-sm-9">
-        <input type="text"
-               data-bind="value: number"
-               size="20"
-               class="form-control"
-               placeholder="xxxx-xxxx-xxxx-xxxx" />
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label class="control-label col-sm-3">
-        {% trans 'CVC' %}
-      </label>
-
-      <div class="col-sm-2">
-        <input type="text"
-               data-bind="value: cvc"
-               size="4"
-               class="form-control"
-               placeholder="xxxx"/>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label class="control-label col-sm-3">
-        {% trans 'Expiration' %}
-      </label>
-      <div class="col-sm-9">
-        <div class="row">
-          <div class="col-sm-2">
-            <input type="text"
-                   data-bind="value: expMonth"
-                   size="2"
-                   class="form-control"
-                   placeholder="MM" />
-          </div>
-          <div class="col-sm-4">
-            <input type="text"
-                   data-bind="value: expYear"
-                   size="4"
-                   class="form-control"
-                   placeholder="YYYY" />
-          </div>
-        </div>
+      <div class="col-sm-9 col-sm-offset-3">
+        <div id="stripe-card-container"></div>{# populated by a card element from Stripe #}
       </div>
     </div>
     <div class="form-group">

--- a/corehq/apps/accounting/templates/accounting/plans.html
+++ b/corehq/apps/accounting/templates/accounting/plans.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main "accounting/js/software_plan_version_handler" %}
+{% js_entry_b3 "accounting/js/software_plan_version_handler" %}
 
 {% block page_content %}
   {% initial_page_data 'role' plan_version_form.role_dict %}

--- a/corehq/apps/accounting/templates/accounting/subscriptions.html
+++ b/corehq/apps/accounting/templates/accounting/subscriptions.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% load compress %}
 
-{% requirejs_main 'accounting/js/subscriptions_main' %}
+{% js_entry_b3 'accounting/js/subscriptions_main' %}
 
 {% block page_content %}
   {% initial_page_data 'current_version' subscription.plan_version.id %}

--- a/corehq/apps/domain/.eslintrc.js
+++ b/corehq/apps/domain/.eslintrc.js
@@ -1,7 +1,0 @@
-/* global module */
-// Temporary until weback migration is complete, requirejs is gone, and all of HQ can use the latest ecmaVersion
-module.exports = {
-    "parserOptions": {
-        "ecmaVersion": 6,
-    },
-};

--- a/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
@@ -1,4 +1,3 @@
-'use strict';
 hqDefine("domain/js/bootstrap3/billing_statements", [
     'jquery',
     'underscore',
@@ -6,7 +5,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
     'hqwebapp/js/initial_page_data',
     'accounting/js/payment_method_handler',
     'hqwebapp/js/bootstrap3/crud_paginated_list',
-    'stripe',
+    'commcarehq',
 ], function (
     $,
     _,
@@ -14,9 +13,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
     initialPageData,
     paymentMethodHandlers,
     CRUDPaginatedList,
-    Stripe
 ) {
-    Stripe.setPublishableKey(initialPageData.get("stripe_options").stripe_public_key);
     var wireInvoiceHandler = paymentMethodHandlers.wireInvoiceHandler;
     var paymentMethodHandler = paymentMethodHandlers.paymentMethodHandler;
     var invoice = paymentMethodHandlers.invoice;
@@ -30,7 +27,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
             statusCodeText: pagination.status_codes,
             allowItemCreation: initialPageData.get('item_creation_allowed'),
             createItemForm: pagination.create_item_form,
-        }
+        },
     );
 
     $(function () {
@@ -43,7 +40,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
             submitBtnText: gettext("Submit Payment"),
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_bulk_payment_url,
-        }
+        },
     );
 
     var bulkWirePaymentHandler = wireInvoiceHandler(
@@ -53,7 +50,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
             isWire: true,
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_wire_invoice_url,
-        }
+        },
     );
 
     var paymentHandler = paymentMethodHandler(
@@ -62,7 +59,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
             submitBtnText: gettext("Submit Payment"),
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_invoice_payment_url,
-        }
+        },
     );
 
     // A sign that the data model isn't exactly right - credit cards are shared data.
@@ -71,7 +68,7 @@ hqDefine("domain/js/bootstrap3/billing_statements", [
     for (var i = 0; i < handlers.length; i++) {
         handlers[i].handlers = handlers;
     }
-    var stripeCards = initialPageData.get("stripe_options").stripe_cards;
+    var stripeCards = initialPageData.get("stripe_cards");
     if (stripeCards) {
         bulkPaymentHandler.loadCards(stripeCards);
         paymentHandler.loadCards(stripeCards);

--- a/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/update_billing_contact_info.js
@@ -1,19 +1,16 @@
-'use strict';
 hqDefine('domain/js/bootstrap3/update_billing_contact_info', [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'accounting/js/stripe_card_manager',
-    'stripe',
     'accounting/js/widgets',
     'hqwebapp/js/bootstrap3/knockout_bindings.ko', // openModal
+    'commcarehq',
 ], function (
     $,
     initialPageData,
     stripeCardManager,
-    Stripe
 ) {
     $(function () {
-        Stripe.setPublishableKey(initialPageData.get("stripe_public_key"));
         var cardManager = stripeCardManager.stripeCardManager({
             cards: initialPageData.get("cards"),
             url: initialPageData.reverse("cards_view"),

--- a/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
@@ -1,4 +1,3 @@
-'use strict';
 hqDefine("domain/js/bootstrap5/billing_statements", [
     'jquery',
     'underscore',
@@ -6,7 +5,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
     'hqwebapp/js/initial_page_data',
     'accounting/js/payment_method_handler',
     'hqwebapp/js/bootstrap5/crud_paginated_list',
-    'stripe',
+    'commcarehq',
 ], function (
     $,
     _,
@@ -14,9 +13,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
     initialPageData,
     paymentMethodHandlers,
     CRUDPaginatedList,
-    Stripe
 ) {
-    Stripe.setPublishableKey(initialPageData.get("stripe_options").stripe_public_key);
     var wireInvoiceHandler = paymentMethodHandlers.wireInvoiceHandler;
     var paymentMethodHandler = paymentMethodHandlers.paymentMethodHandler;
     var invoice = paymentMethodHandlers.invoice;
@@ -30,7 +27,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
             statusCodeText: pagination.status_codes,
             allowItemCreation: initialPageData.get('item_creation_allowed'),
             createItemForm: pagination.create_item_form,
-        }
+        },
     );
 
     $(function () {
@@ -43,7 +40,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
             submitBtnText: gettext("Submit Payment"),
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_bulk_payment_url,
-        }
+        },
     );
 
     var bulkWirePaymentHandler = wireInvoiceHandler(
@@ -53,7 +50,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
             isWire: true,
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_wire_invoice_url,
-        }
+        },
     );
 
     var paymentHandler = paymentMethodHandler(
@@ -62,7 +59,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
             submitBtnText: gettext("Submit Payment"),
             errorMessages: initialPageData.get("payment_error_messages"),
             submitURL: initialPageData.get("payment_urls").process_invoice_payment_url,
-        }
+        },
     );
 
     // A sign that the data model isn't exactly right - credit cards are shared data.
@@ -71,7 +68,7 @@ hqDefine("domain/js/bootstrap5/billing_statements", [
     for (var i = 0; i < handlers.length; i++) {
         handlers[i].handlers = handlers;
     }
-    var stripeCards = initialPageData.get("stripe_options").stripe_cards;
+    var stripeCards = initialPageData.get("stripe_cards");
     if (stripeCards) {
         bulkPaymentHandler.loadCards(stripeCards);
         paymentHandler.loadCards(stripeCards);

--- a/corehq/apps/domain/static/domain/js/bootstrap5/update_billing_contact_info.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap5/update_billing_contact_info.js
@@ -1,19 +1,16 @@
-'use strict';
 hqDefine('domain/js/bootstrap5/update_billing_contact_info', [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'accounting/js/stripe_card_manager',
-    'stripe',
     'accounting/js/widgets',
     'hqwebapp/js/bootstrap5/knockout_bindings.ko', // openModal
+    'commcarehq',
 ], function (
     $,
     initialPageData,
     stripeCardManager,
-    Stripe
 ) {
     $(function () {
-        Stripe.setPublishableKey(initialPageData.get("stripe_public_key"));
         var cardManager = stripeCardManager.stripeCardManager({
             cards: initialPageData.get("cards"),
             url: initialPageData.reverse("cards_view"),

--- a/corehq/apps/domain/static/domain/js/confirm_billing_info.js
+++ b/corehq/apps/domain/static/domain/js/confirm_billing_info.js
@@ -1,17 +1,15 @@
-'use strict';
 hqDefine("domain/js/confirm_billing_info", [
     'jquery',
     'knockout',
     'hqwebapp/js/initial_page_data',
-    'stripe',
     'accounting/js/stripe_card_manager',
     'accounting/js/widgets',
+    'commcarehq',
 ], function (
     $,
     ko,
     initialPageData,
-    Stripe,
-    stripeCardManager
+    stripeCardManager,
 ) {
     $('a.breadcrumb-2').click(function (e) {
         e.preventDefault();
@@ -26,7 +24,6 @@ hqDefine("domain/js/confirm_billing_info", [
         document.getElementById('downgrade-email-note').value = initialPageData.get("downgrade_email_note");
     };
 
-    Stripe.setPublishableKey(initialPageData.get("stripe_public_key"));
     var cardManager = stripeCardManager.stripeCardManager({
         cards: initialPageData.get("cards"),
         url: initialPageData.reverse("cards_view"),

--- a/corehq/apps/domain/static/domain/js/current_subscription.js
+++ b/corehq/apps/domain/static/domain/js/current_subscription.js
@@ -1,19 +1,16 @@
-'use strict';
 hqDefine("domain/js/current_subscription", [
     'jquery',
     'hqwebapp/js/initial_page_data',
     'accounting/js/credits',
     'accounting/js/payment_method_handler',
-    'stripe',
+    'commcarehq',
 ], function (
     $,
     initialPageData,
     credits,
     paymentMethodHandler,
-    Stripe
 ) {
     $(function () {
-        Stripe.setPublishableKey(initialPageData.get('stripe_public_key'));
         var paymentHandler = paymentMethodHandler.paymentMethodHandler(
             "add-credit-form",
             {
@@ -22,7 +19,7 @@ hqDefine("domain/js/current_subscription", [
                 credit_card_url: initialPageData.reverse("domain_credits_payment"),
                 wire_url: initialPageData.reverse("domain_wire_payment"),
                 wire_email: initialPageData.get("user_email"),
-            }
+            },
         );
         var plan = initialPageData.get("plan");
         if (plan.cards) {
@@ -34,7 +31,7 @@ hqDefine("domain/js/current_subscription", [
             plan.products,
             plan.features,
             paymentHandler,
-            initialPageData.get("can_purchase_credits")
+            initialPageData.get("can_purchase_credits"),
         );
         $('#subscriptionSummary').koApplyBindings(creditsHandler);
         creditsHandler.init();

--- a/corehq/apps/domain/templates/domain/bootstrap3/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/billing_statements.html
@@ -2,11 +2,12 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main 'domain/js/bootstrap3/billing_statements' %}
+{% js_entry_b3 'domain/js/bootstrap3/billing_statements' %}
 
 {% block paginated_list_top %}
   {% initial_page_data 'pagination' pagination %}
-  {% initial_page_data 'stripe_options' stripe_options %}
+  {% initial_page_data 'stripe_cards' stripe_cards %}
+  {% initial_page_data 'stripe_public_key' stripe_public_key %}
   {% initial_page_data 'payment_urls' payment_urls %}
   {% initial_page_data 'payment_error_messages' payment_error_messages %}
   {% initial_page_data 'item_creation_allowed' pagination.create.is_allowed %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/confirm_billing_info.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/confirm_billing_info.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'domain/js/confirm_billing_info' %}
+{% js_entry_b3 'domain/js/confirm_billing_info' %}
 
 {% block form_content %}
   {% initial_page_data "plan" plan %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'domain/js/current_subscription' %}
+{% js_entry_b3 'domain/js/current_subscription' %}
 
 {% block page_content %}
   {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/update_billing_contact_info.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/update_billing_contact_info.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'domain/js/bootstrap3/update_billing_contact_info' %}
+{% js_entry_b3 'domain/js/bootstrap3/update_billing_contact_info' %}
 
 {% block additional_initial_page_data %}{{ block.super }}
   {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/billing_statements.html
@@ -2,11 +2,12 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main_b5 'domain/js/bootstrap5/billing_statements' %}
+{% js_entry 'domain/js/bootstrap5/billing_statements' %}
 
 {% block paginated_list_top %}
   {% initial_page_data 'pagination' pagination %}  {# todo B5: css-pagination #}
-  {% initial_page_data 'stripe_options' stripe_options %}
+  {% initial_page_data 'stripe_cards' stripe_cards %}
+  {% initial_page_data 'stripe_public_key' stripe_public_key %}
   {% initial_page_data 'payment_urls' payment_urls %}
   {% initial_page_data 'payment_error_messages' payment_error_messages %}
   {% initial_page_data 'item_creation_allowed' pagination.create.is_allowed %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/confirm_billing_info.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/confirm_billing_info.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'domain/js/confirm_billing_info' %}
+{% js_entry 'domain/js/confirm_billing_info' %}
 
 {% block form_content %}
   {% initial_page_data "plan" plan %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'domain/js/current_subscription' %}
+{% js_entry 'domain/js/current_subscription' %}
 
 {% block page_content %}
   {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/update_billing_contact_info.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/update_billing_contact_info.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main_b5 'domain/js/bootstrap5/update_billing_contact_info' %}
+{% js_entry 'domain/js/bootstrap5/update_billing_contact_info' %}
 
 {% block additional_initial_page_data %}{{ block.super }}
   {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -516,10 +516,8 @@ class DomainBillingStatementsView(DomainAccountingSettings, CRUDPaginatedViewMix
     def page_context(self):
         pagination_context = self.pagination_context
         pagination_context.update({
-            'stripe_options': {
-                'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
-                'stripe_cards': self.stripe_cards,
-            },
+            'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
+            'stripe_cards': self.stripe_cards,
             'payment_error_messages': PAYMENT_ERROR_MESSAGES,
             'payment_urls': {
                 'process_invoice_payment_url': reverse(

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -370,10 +370,8 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
     def page_context(self):
         pagination_context = self.pagination_context
         pagination_context.update({
-            'stripe_options': {
-                'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
-                'stripe_cards': self.stripe_cards,
-            },
+            'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
+            'stripe_cards': self.stripe_cards,
             'payment_error_messages': PAYMENT_ERROR_MESSAGES,
             'payment_urls': {
                 'process_invoice_payment_url': reverse(

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/billing_statements.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/billing_statements.html.diff.txt
@@ -6,16 +6,16 @@
  {% load i18n %}
  {% load hq_shared_tags %}
  
--{% requirejs_main 'domain/js/bootstrap3/billing_statements' %}
-+{% requirejs_main_b5 'domain/js/bootstrap5/billing_statements' %}
+-{% js_entry_b3 'domain/js/bootstrap3/billing_statements' %}
++{% js_entry 'domain/js/bootstrap5/billing_statements' %}
  
  {% block paginated_list_top %}
 -  {% initial_page_data 'pagination' pagination %}
 +  {% initial_page_data 'pagination' pagination %}  {# todo B5: css-pagination #}
-   {% initial_page_data 'stripe_options' stripe_options %}
+   {% initial_page_data 'stripe_cards' stripe_cards %}
+   {% initial_page_data 'stripe_public_key' stripe_public_key %}
    {% initial_page_data 'payment_urls' payment_urls %}
-   {% initial_page_data 'payment_error_messages' payment_error_messages %}
-@@ -21,8 +21,8 @@
+@@ -22,8 +22,8 @@
        <p data-bind="visible: hasInitialLoadFinished() && totalDue()">
          <button type="button"
                  class="btn btn-primary"
@@ -26,7 +26,7 @@
                  id="bulkPaymentBtn">
            {% trans 'Pay by Credit Card' %}
          </button>
-@@ -30,14 +30,14 @@
+@@ -31,14 +31,14 @@
        <p data-bind="visible: hasInitialLoadFinished() && totalDue()">
          <button type="button"
                  class="btn btn-primary"
@@ -44,7 +44,7 @@
              <i class="fa fa-info-circle"></i>
              {% trans "Not Billing Admin, Can't Make Payment" %}
          </span>
-@@ -62,33 +62,33 @@
+@@ -63,33 +63,33 @@
  
  {% block pagination_templates %}
    <script type="text/html" id="statement-row-template">
@@ -87,7 +87,7 @@
        <a class="btn btn-primary"
           data-bind="attr: { href: pdfUrl }"
           target="_blank">{% trans 'Download' %}</a>
-@@ -98,14 +98,14 @@
+@@ -99,14 +99,14 @@
    {% include 'accounting/partials/stripe_card_ko_template.html' %}
  
    <script type="text/html" id="cost-item-template">
@@ -105,7 +105,7 @@
          <div class="radio">
            <label>
              <input type="radio"
-@@ -129,7 +129,7 @@
+@@ -130,7 +130,7 @@
                Pay a portion of the balance:
              {% endblocktrans %}
              <div class="input-group">
@@ -114,7 +114,7 @@
                <input type="text"
                       class="form-control"
                       name="customPaymentAmount"
-@@ -187,12 +187,12 @@
+@@ -188,12 +188,12 @@
  
  {% block modals %}{{ block.super }}
    {% with process_invoice_payment_url as process_payment_url %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_billing_info.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_billing_info.html.diff.txt
@@ -7,8 +7,8 @@
  {% load hq_shared_tags %}
  {% load i18n %}
  
--{% requirejs_main 'domain/js/confirm_billing_info' %}
-+{% requirejs_main_b5 'domain/js/confirm_billing_info' %}
+-{% js_entry_b3 'domain/js/confirm_billing_info' %}
++{% js_entry 'domain/js/confirm_billing_info' %}
  
  {% block form_content %}
    {% initial_page_data "plan" plan %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
@@ -6,8 +6,8 @@
  {% load hq_shared_tags %}
  {% load i18n %}
  
--{% requirejs_main 'domain/js/current_subscription' %}
-+{% requirejs_main_b5 'domain/js/current_subscription' %}
+-{% js_entry_b3 'domain/js/current_subscription' %}
++{% js_entry 'domain/js/current_subscription' %}
  
  {% block page_content %}
    {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/update_billing_contact_info.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/update_billing_contact_info.html.diff.txt
@@ -7,8 +7,8 @@
  {% load hq_shared_tags %}
  {% load i18n %}
  
--{% requirejs_main 'domain/js/bootstrap3/update_billing_contact_info' %}
-+{% requirejs_main_b5 'domain/js/bootstrap5/update_billing_contact_info' %}
+-{% js_entry_b3 'domain/js/bootstrap3/update_billing_contact_info' %}
++{% js_entry 'domain/js/bootstrap5/update_billing_contact_info' %}
  
  {% block additional_initial_page_data %}{{ block.super }}
    {% initial_page_data "stripe_public_key" stripe_public_key %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/billing_statements.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/billing_statements.js.diff.txt
@@ -1,7 +1,6 @@
 --- 
 +++ 
-@@ -1,11 +1,11 @@
- 'use strict';
+@@ -1,10 +1,10 @@
 -hqDefine("domain/js/bootstrap3/billing_statements", [
 +hqDefine("domain/js/bootstrap5/billing_statements", [
      'jquery',
@@ -11,6 +10,6 @@
      'accounting/js/payment_method_handler',
 -    'hqwebapp/js/bootstrap3/crud_paginated_list',
 +    'hqwebapp/js/bootstrap5/crud_paginated_list',
-     'stripe',
+     'commcarehq',
  ], function (
      $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/update_billing_contact_info.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/domain/js/update_billing_contact_info.js.diff.txt
@@ -1,16 +1,14 @@
 --- 
 +++ 
-@@ -1,11 +1,11 @@
- 'use strict';
+@@ -1,9 +1,9 @@
 -hqDefine('domain/js/bootstrap3/update_billing_contact_info', [
 +hqDefine('domain/js/bootstrap5/update_billing_contact_info', [
      'jquery',
      'hqwebapp/js/initial_page_data',
      'accounting/js/stripe_card_manager',
-     'stripe',
      'accounting/js/widgets',
 -    'hqwebapp/js/bootstrap3/knockout_bindings.ko', // openModal
 +    'hqwebapp/js/bootstrap5/knockout_bindings.ko', // openModal
+     'commcarehq',
  ], function (
      $,
-     initialPageData,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "@mapbox/mapbox-gl-draw": "1.4.3",
         "@mapbox/mapbox-gl-geocoder": "5.0.2",
         "@popperjs/core": "npm:@popperjs/core#2.11.6",
+        "@stripe/stripe-js": "^6.1.0",
         "@turf/turf": "6.5.0",
         "At.js": "millerdev/At.js#master",
         "Caret.js": "INTELOGIE/Caret.js#0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -751,6 +751,11 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz#282046f03e886e352b2d5f5da5eb755e01457f3f"
   integrity sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==
 
+"@stripe/stripe-js@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-6.1.0.tgz#de6468e8d290da474d296f09baa1b02fda5f4f08"
+  integrity sha512-/5zxRol+MU4I7fjZXPxP2M6E1nuHOxAzoc0tOEC/TLnC31Gzc+5EE93mIjoAnu28O1Sqpl7/BkceDHwnGmn75A==
+
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"


### PR DESCRIPTION
Reverts dimagi/commcare-hq#36121, restoring https://github.com/dimagi/commcare-hq/pull/36073

I didn't realize there's a different UI for users who don't have any cards saved. This PR has a few additional commits to add support for that UI. The js is a bit finicky, as there are several knockout vars controlling the existence of the credit card inputs, and Stripe has to mount the UI whenever that area is made visible.

## Safety Assurance

### Safety story
Moderate risk due to affecting payments. Risk is limited to the updated pages.

### Automated test coverage

Accounting has tests, but I don't think it has javascript coverage.

### QA Plan
Using the same ticket as for the previous PR: https://dimagi.atlassian.net/browse/QA-7597

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change