### PR TITLE
Upgrade celery==5.4.0 (also upgrade related dependencies)

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -45,7 +45,7 @@ beaker==1.11.0
     # via oic
 beautifulsoup4==4.10.0
     # via -r base-requirements.in
-billiard==3.6.4.0
+billiard==4.2.1
     # via celery
 bleach==6.1.0
     # via -r base-requirements.in
@@ -59,7 +59,7 @@ build==1.2.2.post1
     # via pip-tools
 bytecode==0.14.2
     # via ddtrace
-celery==5.2.7
+celery==5.4.0
     # via
     #   -r base-requirements.in
     #   django-celery-results
@@ -76,7 +76,7 @@ chardet==5.2.0
     # via reportlab
 charset-normalizer==3.1.0
     # via requests
-click==8.0.3
+click==8.1.8
     # via
     #   celery
     #   click-didyoumean
@@ -517,6 +517,7 @@ python-dateutil==2.8.2
     # via
     #   -r base-requirements.in
     #   botocore
+    #   celery
     #   django-tastypie
     #   faker
     #   freezegun
@@ -532,7 +533,6 @@ pytz==2024.1
     # via
     #   -r base-requirements.in
     #   babel
-    #   celery
 pyyaml==6.0.2
     # via
     #   -r base-requirements.in
@@ -719,7 +719,9 @@ typing-extensions==4.12.2
     #   qrcode
     #   stripe
 tzdata==2025.1
-    # via kombu
+    # via
+    #   celery
+    #   kombu
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -41,7 +41,7 @@ babel==2.9.1
     # via sphinx
 beautifulsoup4==4.12.2
     # via -r base-requirements.in
-billiard==3.6.4.0
+billiard==4.2.1
     # via celery
 bleach==6.1.0
     # via -r base-requirements.in
@@ -53,7 +53,7 @@ botocore==1.27.96
     #   s3transfer
 bytecode==0.14.2
     # via ddtrace
-celery==5.2.7
+celery==5.4.0
     # via
     #   -r base-requirements.in
     #   django-celery-results
@@ -417,6 +417,7 @@ python-dateutil==2.8.2
     # via
     #   -r base-requirements.in
     #   botocore
+    #   celery
     #   django-tastypie
 python-dotenv==1.0.1
     # via pydantic-settings
@@ -430,7 +431,6 @@ pytz==2024.1
     # via
     #   -r base-requirements.in
     #   babel
-    #   celery
 pyyaml==6.0.2
     # via
     #   -r base-requirements.in
@@ -585,7 +585,9 @@ typing-extensions==4.12.2
     #   qrcode
     #   stripe
 tzdata==2025.1
-    # via kombu
+    # via
+    #   celery
+    #   kombu
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -41,7 +41,7 @@ backcall==0.2.0
     # via ipython
 beautifulsoup4==4.12.2
     # via -r base-requirements.in
-billiard==3.6.4.0
+billiard==4.2.1
     # via celery
 bleach==6.1.0
     # via -r base-requirements.in
@@ -53,7 +53,7 @@ botocore==1.27.96
     #   s3transfer
 bytecode==0.14.2
     # via ddtrace
-celery==5.2.7
+celery==5.4.0
     # via
     #   -r base-requirements.in
     #   django-celery-results
@@ -425,6 +425,7 @@ python-dateutil==2.8.2
     # via
     #   -r base-requirements.in
     #   botocore
+    #   celery
     #   django-tastypie
 python-dotenv==1.0.1
     # via pydantic-settings
@@ -439,7 +440,6 @@ python3-saml==1.12.0
 pytz==2024.1
     # via
     #   -r base-requirements.in
-    #   celery
     #   flower
 pyyaml==6.0.2
     # via -r base-requirements.in
@@ -577,7 +577,9 @@ typing-extensions==4.12.2
     #   qrcode
     #   stripe
 tzdata==2025.1
-    # via kombu
+    # via
+    #   celery
+    #   kombu
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -37,7 +37,7 @@ attrs==23.1.0
     #   jsonschema
 beautifulsoup4==4.12.2
     # via -r base-requirements.in
-billiard==3.6.4.0
+billiard==4.2.1
     # via celery
 bleach==6.1.0
     # via -r base-requirements.in
@@ -49,7 +49,7 @@ botocore==1.27.96
     #   s3transfer
 bytecode==0.14.2
     # via ddtrace
-celery==5.2.7
+celery==5.4.0
     # via
     #   -r base-requirements.in
     #   django-celery-results
@@ -389,6 +389,7 @@ python-dateutil==2.8.2
     # via
     #   -r base-requirements.in
     #   botocore
+    #   celery
     #   django-tastypie
 python-dotenv==1.0.1
     # via pydantic-settings
@@ -401,9 +402,7 @@ python-mimeparse==2.0.0
 python3-saml==1.12.0
     # via -r sso-requirements.in
 pytz==2024.1
-    # via
-    #   -r base-requirements.in
-    #   celery
+    # via -r base-requirements.in
 pyyaml==6.0.2
     # via -r base-requirements.in
 pyzxcvbn==0.8.0
@@ -530,7 +529,9 @@ typing-extensions==4.12.2
     #   qrcode
     #   stripe
 tzdata==2025.1
-    # via kombu
+    # via
+    #   celery
+    #   kombu
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -37,7 +37,7 @@ attrs==23.1.0
     #   jsonschema
 beautifulsoup4==4.10.0
     # via -r base-requirements.in
-billiard==3.6.4.0
+billiard==4.2.1
     # via celery
 bleach==6.1.0
     # via -r base-requirements.in
@@ -51,7 +51,7 @@ build==1.2.2.post1
     # via pip-tools
 bytecode==0.14.2
     # via ddtrace
-celery==5.2.7
+celery==5.4.0
     # via
     #   -r base-requirements.in
     #   django-celery-results
@@ -432,6 +432,7 @@ python-dateutil==2.8.2
     # via
     #   -r base-requirements.in
     #   botocore
+    #   celery
     #   django-tastypie
     #   faker
     #   freezegun
@@ -446,9 +447,7 @@ python-mimeparse==2.0.0
 python3-saml==1.12.0
     # via -r sso-requirements.in
 pytz==2024.1
-    # via
-    #   -r base-requirements.in
-    #   celery
+    # via -r base-requirements.in
 pyyaml==6.0.2
     # via -r base-requirements.in
 pyzxcvbn==0.8.0
@@ -594,7 +593,9 @@ typing-extensions==4.12.2
     #   qrcode
     #   stripe
 tzdata==2025.1
-    # via kombu
+    # via
+    #   celery
+    #   kombu
 ua-parser==0.10.0
     # via user-agents
 unidecode==1.2.0


### PR DESCRIPTION
Minor version bump for better Python 3.13 compatibility. Reviewed [release notes](https://docs.celeryq.dev/en/stable/changelog.html#version-5-4-0) and [recent issues](https://github.com/celery/celery/issues)...Celery has a lot of bugs, and the change logs are super long and verbose. Even though 5.4.0 does not officially support Python 3.13, in testing so far it is better than v5.2.7. Notably, one of the highlights of v5.4.0 is better test coverage.

Version 5.5 has been released and is compatible with Python 3.13, but it requires Kombu 5.5, which is [not yet stable](https://github.com/celery/kombu/issues/2258). It is unclear how many things are affected by the change from pycurl to urllib3, which is noted in both the Kombu and Celery change logs. Maybe v5.5.x or later, of both Celery and Kombu, will be stable enough that we can upgrade before we roll out Python 3.13 on production environments?

## Safety Assurance

### Safety story

Major version upgrades for Celery are a bit scary because it has so many features and varying usage patterns. It will be tested on staging before this PR is merged.

### Automated test coverage

Probably some, but probably not good enough that passing tests is an indication of upgrade safety.

### QA Plan

Since Celery is a backend service, it is not easy to QA directly. This new version will be deployed to staging and monitored for operational functionality.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations