### PR TITLE
Upgrade simpleeval==1.0.3

### DIFF
--- a/corehq/apps/userreports/expressions/evaluator/main.py
+++ b/corehq/apps/userreports/expressions/evaluator/main.py
@@ -6,6 +6,7 @@ from datetime import date, datetime
 from decimal import Decimal
 
 from corehq.util import eval_lazy
+from corehq.util.decorators import ignore_warning
 from simpleeval import (
     DEFAULT_OPERATORS,
     FeatureNotAvailable,
@@ -13,6 +14,7 @@ from simpleeval import (
     DISALLOW_FUNCTIONS,
     FunctionNotDefined,
     EvalWithCompoundTypes,
+    MultipleExpressions,
 )
 
 from .functions import FUNCTIONS, CONTEXT_PARAM_NAME, NEEDS_CONTEXT_PARAM_NAME
@@ -79,7 +81,8 @@ def eval_statements(statement, variable_context, execution_context=None):
 
     evaluator = CommCareEval(operators=SAFE_OPERATORS, names=variable_context, functions=FUNCTIONS)
     evaluator.set_context(execution_context)
-    return evaluator.eval(statement)
+    with ignore_warning(MultipleExpressions):
+        return evaluator.eval(statement)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/corehq/apps/userreports/expressions/evaluator/main.py
+++ b/corehq/apps/userreports/expressions/evaluator/main.py
@@ -37,6 +37,10 @@ class CommCareEval(EvalWithCompoundTypes):
     users less options to do crazy things that might get them / us into
     hard to back out of situations."""
 
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self.nodes.pop(ast.DictComp)  # disallow dict comprehensions
+
     def set_context(self, context):
         self._context = context.scope(self)
 

--- a/corehq/apps/userreports/expressions/evaluator/main.py
+++ b/corehq/apps/userreports/expressions/evaluator/main.py
@@ -5,20 +5,21 @@ import operator
 from datetime import date, datetime
 from decimal import Decimal
 
-from corehq.util import eval_lazy
-from corehq.util.decorators import ignore_warning
 from simpleeval import (
     DEFAULT_OPERATORS,
-    FeatureNotAvailable,
-    InvalidExpression,
     DISALLOW_FUNCTIONS,
-    FunctionNotDefined,
     EvalWithCompoundTypes,
+    FeatureNotAvailable,
+    FunctionNotDefined,
+    InvalidExpression,
     MultipleExpressions,
 )
 
-from .functions import FUNCTIONS, CONTEXT_PARAM_NAME, NEEDS_CONTEXT_PARAM_NAME
+from corehq.util import eval_lazy
+from corehq.util.decorators import ignore_warning
+
 from ...specs import EvaluationContext, FactoryContext
+from .functions import CONTEXT_PARAM_NAME, FUNCTIONS, NEEDS_CONTEXT_PARAM_NAME
 
 
 def safe_pow_fn(a, b):
@@ -52,7 +53,7 @@ class CommCareEval(EvalWithCompoundTypes):
             func = self.functions[node.func.id]
         except KeyError:
             raise FunctionNotDefined(node.func.id, self.expr)
-        except AttributeError as e:
+        except AttributeError:
             raise FeatureNotAvailable('Lambda Functions not implemented')
 
         if func in DISALLOW_FUNCTIONS:
@@ -94,7 +95,7 @@ class EvalExecutionContext:
     evaluation_context: EvaluationContext
     factory_context: FactoryContext
     evaluator: CommCareEval = None
-    
+
     @classmethod
     def empty(cls):
         return EvalExecutionContext(EvaluationContext.empty(), FactoryContext.empty())

--- a/requirements/base-requirements.in
+++ b/requirements/base-requirements.in
@@ -98,8 +98,7 @@ requests
 schema
 sentry-sdk
 sh
-# Package has an unfixed issue https://github.com/danthedeckie/simpleeval/issues/90 Can use that once https://github.com/danthedeckie/simpleeval/pull/91 is merged
-simpleeval @ git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+simpleeval
 simplejson
 six
 socketpool

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -598,7 +598,7 @@ sh==2.0.3
     #   -r base-requirements.in
     #   dependency-metrics
     #   git-build-branch
-simpleeval @ git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+simpleeval==1.0.3
     # via -r base-requirements.in
 simplejson==3.17.6
     # via

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -485,7 +485,7 @@ sentry-sdk==2.8.0
     # via -r base-requirements.in
 sh==2.0.3
     # via -r base-requirements.in
-simpleeval @ git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+simpleeval==1.0.3
     # via -r base-requirements.in
 simplejson==3.17.6
     # via

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -495,7 +495,7 @@ setproctitle==1.2.2
     # via -r prod-requirements.in
 sh==2.0.3
     # via -r base-requirements.in
-simpleeval @ git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+simpleeval==1.0.3
     # via -r base-requirements.in
 simplejson==3.17.6
     # via

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -456,7 +456,7 @@ sentry-sdk==2.8.0
     # via -r base-requirements.in
 sh==2.0.3
     # via -r base-requirements.in
-simpleeval @ git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+simpleeval==1.0.3
     # via -r base-requirements.in
 simplejson==3.17.6
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -506,7 +506,7 @@ sentry-sdk==2.8.0
     # via -r base-requirements.in
 sh==2.0.3
     # via -r base-requirements.in
-simpleeval @ git+https://github.com/dimagi/simpleeval.git@d85c5a9f972c0f0416a1716bb06d1a3ebc83e7ec
+simpleeval==1.0.3
     # via -r base-requirements.in
 simplejson==3.17.6
     # via


### PR DESCRIPTION
Version bump for Python 3.13 compatibility. Reviewed [releases](https://github.com/danthedeckie/simpleeval/releases), including [commits for 0.9.10...0.9.11](https://github.com/danthedeckie/simpleeval/compare/0.9.10...0.9.11), and [issues](https://github.com/danthedeckie/simpleeval/issues) (no concerns).

The previous version was a fork of v0.9.10 with a backported fix from v0.9.11, which had not yet been released at the time the fork was made.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

We have good test coverage for our usage of this library.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations