### PR TITLE
Python 3.13 compatibility - part 1

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -10,6 +10,7 @@ Supports psuedo-tables using dls and real tables.
 
 import collections
 import datetime
+from collections.abc import Iterable
 
 import attr
 from django import template
@@ -48,7 +49,7 @@ register = template.Library()
 
 
 def _is_list_like(val):
-    return isinstance(val, collections.Iterable) and not isinstance(val, str)
+    return isinstance(val, Iterable) and not isinstance(val, str)
 
 
 def _parse_date_or_datetime(val):

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -1,5 +1,5 @@
-import collections
 import json
+from collections.abc import Sequence
 
 from django import forms
 from django.forms.utils import flatatt
@@ -69,7 +69,7 @@ class _Select2AjaxMixin():
         self._initial = val
 
     def _clean_initial(self, val):
-        if isinstance(val, collections.Sequence) and not isinstance(val, (str, str)):
+        if isinstance(val, Sequence) and not isinstance(val, (str, str)):
             # if its a tuple or list
             return {"id": val[0], "text": val[1]}
         elif val is None:

--- a/corehq/apps/registry/tests/test_helper.py
+++ b/corehq/apps/registry/tests/test_helper.py
@@ -45,20 +45,20 @@ class TestDataRegistryHelper(SimpleTestCase):
         with patch.object(CommCareCase.objects, 'get_case', return_value=mock_case), \
              self.assertRaisesMessage(RegistryAccessException, "'other-type' not available in registry"):
             self.helper.get_case("case1", _mock_user(), "app")
-        self.log_data_access.not_called()
+        self.log_data_access.assert_not_called()
 
     def test_get_case_not_found(self):
         with self.assertRaises(CaseNotFound), \
              patch.object(CommCareCase.objects, 'get_case', side_effect=CaseNotFound):
             self.helper.get_case("case1", _mock_user(), "app")
-        self.log_data_access.not_called()
+        self.log_data_access.assert_not_called()
 
     def test_get_case_domain_not_in_registry(self):
         mock_case = _mock_case("a", "other-domain")
         with self.assertRaisesMessage(RegistryAccessException, "Data not available in registry"), \
              patch.object(CommCareCase.objects, 'get_case', return_value=mock_case):
             self.helper.get_case("case1", _mock_user(), "app")
-        self.log_data_access.not_called()
+        self.log_data_access.assert_not_called()
 
     def test_get_case_access_to_current_domain_allowed_even_if_user_has_no_permission(self):
         mock_case = _mock_case("a", "domain1")
@@ -73,7 +73,7 @@ class TestDataRegistryHelper(SimpleTestCase):
     def test_get_case_access_to_other_domain_not_allowed_if_user_has_no_permission(self):
         mock_case = _mock_case("a", "domain2")
         mock_user = _mock_user(has_permission=False)
-        with self.assertRaisesMessage(RegistryAccessException, "User not permitted to access registry data"),\
+        with self.assertRaisesMessage(RegistryAccessException, "User not permitted to access registry data"), \
              patch.object(CommCareCase.objects, 'get_case', return_value=mock_case):
             self.helper.get_case("case1", mock_user, "app")
 

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -1,7 +1,7 @@
-import collections
 import hashlib
 import logging
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -55,7 +55,7 @@ def localize(value, lang):
     :param value: A dict-like object or string
     :param lang: A language code.
     """
-    if isinstance(value, collections.Mapping) and len(value):
+    if isinstance(value, Mapping) and len(value):
         return (
             value.get(lang, None)
             or value.get(default_language(), None)

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import MutableMapping
 
 from dateutil import parser
 from django.conf import settings
@@ -38,7 +38,7 @@ def flatten(d, parent_key='', delimiter='/'):
         if k in RESERVED_WORDS:
             continue
         new_key = parent_key + delimiter + k if parent_key else k
-        if isinstance(v, collections.MutableMapping):
+        if isinstance(v, MutableMapping):
             items.extend(list(flatten(v, new_key, delimiter).items()))
         elif not isinstance(v, list):
             items.append((new_key, v))

--- a/corehq/tests/pytest_plugins/patches.py
+++ b/corehq/tests/pytest_plugins/patches.py
@@ -28,7 +28,7 @@ def patch_unittest_TestCase_doClassCleanup():
 
     @classmethod
     def doClassCleanupAndRaiseLastError(cls):
-        doClassCleanups()
+        doClassCleanups(cls)
         errors = cls.tearDown_exceptions
         if errors:
             if len(errors) > 1:
@@ -41,7 +41,7 @@ def patch_unittest_TestCase_doClassCleanup():
     import sys
     from traceback import print_exception
     from unittest.case import TestCase
-    doClassCleanups = TestCase.doClassCleanups
+    doClassCleanups = TestCase.doClassCleanups.__func__
     TestCase.doClassCleanups = doClassCleanupAndRaiseLastError
 
 

--- a/corehq/util/signals.py
+++ b/corehq/util/signals.py
@@ -1,5 +1,5 @@
-import collections
 import signal
+from collections.abc import Iterable
 from functools import wraps
 
 from django.dispatch import Signal
@@ -23,7 +23,7 @@ class SignalHandlerContext(object):
     """
 
     def __init__(self, signals, handler, default_handler=signal.SIG_DFL):
-        if not isinstance(signals, collections.Iterable):
+        if not isinstance(signals, Iterable):
             signals = [signals]
         for sig in signals:
             if not isinstance(sig, int):

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -28,6 +28,7 @@ WHITELIST = [
     ("", "", RemovedInDjango51Warning),
 
     # warnings that can be resolved with HQ code changes
+    ("", "datetime.datetime.utcnow() is deprecated"),
     ("", "json_response is deprecated.  Use django.http.JsonResponse instead."),
     ("", "property_match are deprecated. Use boolean_expression instead."),
     ("corehq.util.validation", "metaschema specified by $schema was not found"),

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -36,14 +36,7 @@ function setup {
         install -dm0755 -o cchq -g cchq ./artifacts
     fi
 
-    # uv check, pip-sync, and symlink can be removed after the commcarehq_base
-    # Docker image containing uv has been published for use by Github Actions.
-    if which uv &> /dev/null; then
-        uv pip sync requirements/test-requirements.txt
-    else
-        pip-sync --user requirements/test-requirements.txt
-        ln -s /usr/bin/google-chrome-unstable /usr/bin/google-chrome-stable
-    fi
+    uv pip sync requirements/test-requirements.txt
     pip check  # make sure there are no incompatibilities in test-requirements.txt
     python_preheat  # preheat the python libs
 


### PR DESCRIPTION
Various changes in preparation for the upgrade to Python 3.13. See commit messages for more detail.

The [`docker/run.sh` change](https://github.com/dimagi/commcare-hq/commit/4294039e5398090ccec828d37d67d18534701228) is pure cleanup, not needed for any particular Python version, and it only affects tests.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

All changes are backward compatible with Python 3.9, and most only affect tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations