### PR TITLE
Add FCM Analytics Label for Connect messages

### DIFF
--- a/corehq/messaging/smsbackends/connectid/backend.py
+++ b/corehq/messaging/smsbackends/connectid/backend.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import ConnectIDUserLink, CouchUser
 
+FCM_ANALYTICS_LABEL = "commcare-hq-message-notification"
 
 class ConnectBackend:
     couch_id = "connectid"
@@ -32,6 +33,7 @@ class ConnectBackend:
                 "channel": user_link.messaging_channel,
                 "content": content,
                 "message_id": str(message.message_id),
+                "fcm_analytics_label": FCM_ANALYTICS_LABEL
             },
             auth=(settings.CONNECTID_CLIENT_ID, settings.CONNECTID_SECRET_KEY)
         )

--- a/corehq/messaging/smsbackends/connectid/backend.py
+++ b/corehq/messaging/smsbackends/connectid/backend.py
@@ -34,7 +34,7 @@ class ConnectBackend:
                 "channel": user_link.messaging_channel,
                 "content": content,
                 "message_id": str(message.message_id),
-                "fcm_analytics_label": FCM_ANALYTICS_LABEL
+                "fcm_options": {"analytics_label": FCM_ANALYTICS_LABEL}
             },
             auth=(settings.CONNECTID_CLIENT_ID, settings.CONNECTID_SECRET_KEY)
         )

--- a/corehq/messaging/smsbackends/connectid/backend.py
+++ b/corehq/messaging/smsbackends/connectid/backend.py
@@ -9,6 +9,7 @@ from corehq.apps.users.models import ConnectIDUserLink, CouchUser
 
 FCM_ANALYTICS_LABEL = "commcare-hq-message-notification"
 
+
 class ConnectBackend:
     couch_id = "connectid"
     opt_out_keywords = []


### PR DESCRIPTION
## Product Description
No user-facing changes.

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-777)

This PR adds an FCM Analytics Label to the ConnectID API for sending messages. This label helps us identify the source of messages in FCM.

## Feature Flag
commcare_connect

## Safety Assurance

### Safety story


### Automated test coverage

### QA Plan




### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
