### PR TITLE
[Data Cleaning] Select / Deselect single record functionality

### DIFF
--- a/corehq/apps/data_cleaning/columns.py
+++ b/corehq/apps/data_cleaning/columns.py
@@ -29,20 +29,20 @@ class DataCleaningHtmxSelectionColumn(CheckBoxColumn):
     template_header = "data_cleaning/columns/selection_header.html"
     select_page_checkbox_id = "id-select-page-checkbox"
 
-    def __init__(self, session, request, select_row_action, select_page_action, *args, **kwargs):
+    def __init__(self, session, request, select_record_action, select_page_action, *args, **kwargs):
         """
         Defines a django_tables2 compatible column that handles selecting
         records in a data cleaning session.
 
         :param session: BulkEditSession instance
         :param request: a django request object from the session view
-        :param select_row_action: the hq_hx_action from the session view for selecting a row
+        :param select_record_action: the hq_hx_action from the session view for selecting a row
         :param select_page_action: the hq_hx_action from the session view for selecting all records in a page
         """
         super().__init__(*args, **kwargs)
         self.session = session
         self.request = request
-        self.select_row_action = select_row_action
+        self.select_record_action = select_record_action
         self.select_page_action = select_page_action
         self.attrs['th'] = {
             'class': 'select-header',
@@ -77,7 +77,7 @@ class DataCleaningHtmxSelectionColumn(CheckBoxColumn):
             render_to_string(
                 self.template_column,
                 {
-                    'hq_hx_action': self.select_row_action,
+                    'hq_hx_action': self.select_record_action,
                     'is_checked': self.is_checked(value, record),
                     'value': value,
                     'css_id': self.get_selected_record_checkbox_id(value),

--- a/corehq/apps/data_cleaning/columns.py
+++ b/corehq/apps/data_cleaning/columns.py
@@ -90,5 +90,4 @@ class DataCleaningHtmxSelectionColumn(CheckBoxColumn):
         )
 
     def is_checked(self, value, record):
-        # todo
-        return False
+        return self.session.is_record_selected(value)

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -234,6 +234,9 @@ class BulkEditSession(models.Model):
             query = pinned_filter.filter_query(query)
         return query
 
+    def get_num_selected_records(self):
+        return self.records.filter(is_selected=True).count()
+
     def update_result(self, record_count, form_id=None):
         result = self.result or {}
 

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -61,8 +61,7 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         """
         Return the number of selected records in the session.
         """
-        # todo
-        return 0
+        return self.session.get_num_selected_records()
 
 
 class CaseCleaningTasksTable(BaseHtmxTable, tables.Table):

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -25,9 +25,9 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         self.session = session
 
     @classmethod
-    def get_select_column(cls, session, request, select_row_action, select_page_action):
+    def get_select_column(cls, session, request, select_record_action, select_page_action):
         return DataCleaningHtmxSelectionColumn(
-            session, request, select_row_action, select_page_action, accessor='case_id',
+            session, request, select_record_action, select_page_action, accessor="case_id",
             attrs={
                 'td__input': {
                     "@click": (

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
@@ -1,17 +1,26 @@
 {% load django_tables2 %}
 
-<input
-  id="{{ css_id }}"
-  class="form-check-input htmx-disable-on-select-page"
-  type="checkbox"
-  {% if is_checked %}
-    checked="checked"
-  {% endif %}
-  name="selected_record"
-  value="{{ value }}"
+<form
   hx-post="{{ request.path_info }}{% querystring %}"
   hq-hx-action="{{ hq_hx_action }}"
+  hx-trigger="change from:#{{ css_id }}"
   hx-swap="none"
-  hx-disabled-elt="this"
-  {{ attrs.as_html }}
-/>
+  hx-disable-elt="#{{ css_id }}"
+>
+  <input
+    type="hidden"
+    name="record_id"
+    value="{{ value }}"
+  />
+  <input
+    id="{{ css_id }}"
+    class="form-check-input htmx-disable-on-select-page"
+    type="checkbox"
+    {% if is_checked %}
+      checked="checked"
+    {% endif %}
+    name="is_selected"
+    value="{{ value }}"
+    {{ attrs.as_html }}
+  />
+</form>

--- a/corehq/apps/data_cleaning/tests/test_records.py
+++ b/corehq/apps/data_cleaning/tests/test_records.py
@@ -1,0 +1,75 @@
+import uuid
+
+from corehq.apps.data_cleaning.models import BulkEditRecord
+from corehq.apps.data_cleaning.tests.test_session import BaseBulkEditSessionTest
+
+
+class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
+    domain_name = 'session-test-case-columns'
+
+    @staticmethod
+    def _get_case_id():
+        return str(uuid.uuid4())
+
+    def test_select_record(self):
+        case_id = self._get_case_id()
+        record = self.session.select_record(case_id)
+        self.assertEqual(record.session, self.session)
+        self.assertEqual(record.doc_id, case_id)
+        self.assertTrue(record.is_selected)
+        self.assertTrue(self.session.records.filter(doc_id=case_id).exists())
+
+    def test_deselect_record(self):
+        case_id = self._get_case_id()
+        self.session.select_record(case_id)
+        record = self.session.deselect_record(case_id)
+        self.assertIsNone(record)
+        self.assertFalse(self.session.records.filter(doc_id=case_id).exists())
+
+    def test_is_record_selected(self):
+        case_id = self._get_case_id()
+        self.session.select_record(case_id)
+        self.assertTrue(self.session.is_record_selected(case_id))
+        self.session.deselect_record(case_id)
+        self.assertFalse(self.session.is_record_selected(case_id))
+
+    def test_select_record_with_changes(self):
+        case_id = self._get_case_id()
+        change_id = uuid.uuid4()
+        BulkEditRecord.objects.create(
+            session=self.session,
+            doc_id=case_id,
+            calculated_change_id=change_id,
+            is_selected=False,
+        )
+        self.assertFalse(self.session.is_record_selected(case_id))
+
+        record = self.session.select_record(case_id)
+        self.assertEqual(record.session, self.session)
+        self.assertEqual(record.doc_id, case_id)
+        self.assertTrue(record.is_selected)
+        self.assertEqual(record.calculated_change_id, change_id)
+
+        self.assertTrue(self.session.is_record_selected(case_id))
+        self.assertTrue(self.session.records.filter(doc_id=case_id).exists())
+
+    def test_deselect_record_with_changes(self):
+        case_id = self._get_case_id()
+        change_id = uuid.uuid4()
+        BulkEditRecord.objects.create(
+            session=self.session,
+            doc_id=case_id,
+            calculated_change_id=change_id,
+            is_selected=True,
+        )
+        self.assertTrue(self.session.is_record_selected(case_id))
+
+        record = self.session.deselect_record(case_id)
+        self.assertIsNotNone(record)
+        self.assertEqual(record.session, self.session)
+        self.assertEqual(record.doc_id, case_id)
+        self.assertEqual(record.calculated_change_id, change_id)
+        self.assertFalse(record.is_selected)
+
+        self.assertFalse(self.session.is_record_selected(case_id))
+        self.assertTrue(self.session.records.filter(doc_id=case_id).exists())

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -1,9 +1,11 @@
 import datetime
+import uuid
 
 from django.contrib.auth.models import User
 from django.test import TestCase
 
 from corehq.apps.data_cleaning.models import (
+    BulkEditRecord,
     BulkEditSession,
     BulkEditSessionType,
     DataType,
@@ -363,3 +365,19 @@ class BulkEditSessionCaseColumnTests(BaseBulkEditSessionTest):
         self.assertEqual(new_column.label, "Owner ID")
         self.assertEqual(new_column.data_type, DataType.TEXT)
         self.assertTrue(new_column.is_system)
+
+
+class BulkEditSessionSelectionTests(BaseBulkEditSessionTest):
+    domain_name = 'session-test-selection'
+
+    def test_get_num_selected_records(self):
+        self.session.select_record(str(uuid.uuid4()))
+        self.session.select_record(str(uuid.uuid4()))
+        BulkEditRecord.objects.create(
+            session=self.session,
+            doc_id=str(uuid.uuid4()),
+            calculated_change_id=uuid.uuid4(),
+            is_selected=False,
+        )
+        num_selected_records = self.session.get_num_selected_records()
+        self.assertEqual(num_selected_records, 2)

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -313,8 +313,8 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         self.assertFalse(session.has_any_filtering)
 
 
-class BulkEditSessionCaseColumnTests(TestCase):
-    domain_name = 'session-test-case-columns'
+class BaseBulkEditSessionTest(TestCase):
+    domain_name = None
 
     @classmethod
     def setUpClass(cls):
@@ -336,9 +336,14 @@ class BulkEditSessionCaseColumnTests(TestCase):
         super().tearDownClass()
 
     def setUp(self):
+        super().setUp()
         self.session = BulkEditSession.new_case_session(
             self.django_user, self.domain_name, self.case_type
         )
+
+
+class BulkEditSessionCaseColumnTests(BaseBulkEditSessionTest):
+    domain_name = 'session-test-case-columns'
 
     def test_add_column(self):
         self.assertEqual(self.session.columns.count(), 6)

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -69,8 +69,13 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
         """
         Selects a single record.
         """
-        # todo
-        return self.get(request, *args, **kwargs)
+        doc_id = request.POST['record_id']
+        is_selected = request.POST.get('is_selected') is not None
+        if is_selected:
+            self.session.select_record(doc_id)
+        else:
+            self.session.deselect_record(doc_id)
+        return self.render_htmx_no_response(request, *args, **kwargs)
 
     @hq_hx_action('post')
     def select_page(self, request, *args, **kwargs):

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -34,7 +34,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
             self.table_class.get_select_column(
                 self.session,
                 self.request,
-                select_row_action="select_row",
+                select_record_action="select_record",
                 select_page_action="select_page",
             )
         )]
@@ -65,7 +65,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
         return response
 
     @hq_hx_action('post')
-    def select_row(self, request, *args, **kwargs):
+    def select_record(self, request, *args, **kwargs):
         """
         Selects a single record.
         """


### PR DESCRIPTION
## Technical Summary
This PR actually implements the logic for selecting/deselecting a single record by saving selection state through the session's `BulkEditRecord`s

https://dimagi.atlassian.net/browse/SAAS-16864

https://github.com/user-attachments/assets/edcf3ca8-88f5-4018-bb59-ab04813d8356

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
only touches code behind a feature flag. no production workflows affected

### Automated test coverage
yes

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
