### PR TITLE
Drop "Gauges" and "Reports" headings

### DIFF
--- a/corehq/apps/campaign/templates/campaign/dashboard.html
+++ b/corehq/apps/campaign/templates/campaign/dashboard.html
@@ -63,7 +63,6 @@
       <!-- Cases tab content -->
       <!-- Gauges Section -->
       <div class="row">
-        <h2>{% trans "Gauges" %}</h2>
         <div id="gauges-container-cases">
           {% for widget in gauge_widgets.cases %}
             {% include 'campaign/partials/dashboard_gauge.html' %}
@@ -73,7 +72,6 @@
       <div class="spacer"></div>
       <!-- Report and Map Section -->
       <div class="row">
-        <h2>{% trans "Reports" %}</h2>
         <div id="map-reports-container-cases">
           {% for widget in map_report_widgets.cases %}
             {% if widget.widget_type == 'DashboardMap' %}
@@ -88,7 +86,6 @@
       <!-- Users tab content -->
       <!-- Gauges Section -->
       <div class="row">
-        <h2>{% trans "Gauges" %}</h2>
         <div id="gauges-container-mobile-workers">
           {% for widget in gauge_widgets.mobile_workers %}
             {% include 'campaign/partials/dashboard_gauge.html' %}
@@ -98,7 +95,6 @@
       <div class="spacer"></div>
       <!-- Report and Map Section -->
       <div class="row">
-        <h2>{% trans "Reports" %}</h2>
         <div id="map-reports-container-mobile-workers">
           {% for widget in map_report_widgets.mobile_workers %}
             {% if widget.widget_type == 'DashboardMap' %}


### PR DESCRIPTION
## Product Description

![image](https://github.com/user-attachments/assets/6620febb-8005-4294-8139-b03ed403618a)

## Technical Summary

Tiny change. Drops "Gauges" and "Reports" headings from the Campaign Dashboard

## Feature Flag

campaign_dashboard

## Safety Assurance

### Safety story

Tiny UI-only change. Tested locally.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
