### PR TITLE
apply load styling to checkbox when checkbox triggers hx-post on parent form

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
@@ -1,6 +1,7 @@
 {% load django_tables2 %}
 
 <form
+  class="loading-checkbox-htmx-request"
   hx-post="{{ request.path_info }}{% querystring %}"
   hq-hx-action="{{ hq_hx_action }}"
   hx-trigger="change from:#{{ css_id }}"

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_htmx.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_htmx.scss
@@ -38,6 +38,7 @@ form.htmx-request {
   }
 }
 
+form.htmx-request.loading-checkbox-htmx-request input[type="checkbox"],
 .htmx-request[type="checkbox"] {
   position: relative;
 


### PR DESCRIPTION
## Technical Summary
Since the checkbox is triggering an `hx-post` on its parent `from` rather than triggering `hx-post` from itself, the loading style wasn't being applied to the triggering checkbox. This fixes that.

https://github.com/user-attachments/assets/ce7b6be2-37b6-44a1-974d-9687c1e744a8


## Safety Assurance

### Safety story
very safe style change that only appears on the data cleaning feature right now (feature flagged)

### Automated test coverage
n/a

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
