### PR TITLE
[Data Cleaning] Select / De-Select page of records

### DIFF
--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -1,5 +1,6 @@
 import 'commcarehq';
 import 'hqwebapp/js/htmx_base';
+import 'hqwebapp/js/htmx_utils/hq_hx_select_all';
 import 'hqwebapp/js/alpinejs/directives/select2';
 import 'hqwebapp/js/alpinejs/directives/report_select2';
 import 'hqwebapp/js/alpinejs/directives/datepicker';

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -30,6 +30,8 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
             session, request, select_record_action, select_page_action, accessor="case_id",
             attrs={
                 'td__input': {
+                    # `pageNumRecordsSelected` defined in template
+                    "x-init": "if($el.checked) { pageNumRecordsSelected++ }",
                     "@click": (
                         "if ($el.checked !== isRowSelected) {"
                         # `numRecordsSelected` defined in template

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -31,14 +31,14 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
             attrs={
                 'td__input': {
                     "@click": (
-                        "if ($event.target.checked !== isRowSelected) {"
+                        "if ($el.checked !== isRowSelected) {"
                         # `numRecordsSelected` defined in template
-                        "  $event.target.checked ? numRecordsSelected++ : numRecordsSelected--;"
+                        "  $el.checked ? numRecordsSelected++ : numRecordsSelected--;"
                         # `pageNumRecordsSelected` defined in template
-                        "  $event.target.checked ? pageNumRecordsSelected++ : pageNumRecordsSelected--; "
+                        "  $el.checked ? pageNumRecordsSelected++ : pageNumRecordsSelected--; "
                         "} "
                         # `isRowSelected` defined in `row_attrs` in `class Meta`
-                        "isRowSelected = $event.target.checked;"
+                        "isRowSelected = $el.checked;"
                     ),
                 },
                 'th__input': {

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
@@ -5,7 +5,7 @@
   hq-hx-action="{{ hq_hx_action }}"
   hx-trigger="change from:#{{ css_id }}"
   hx-swap="none"
-  hx-disable-elt="#{{ css_id }}"
+  hx-disabled-elt=" #{{ css_id }}"
 >
   <input
     type="hidden"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
@@ -15,7 +15,7 @@
   />
   <input
     id="{{ css_id }}"
-    class="form-check-input htmx-disable-on-select-page"
+    class="form-check-input htmx-disable-on-select-page js-select-record-checkbox"
     type="checkbox"
     {% if is_checked %}
       checked="checked"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection.html
@@ -9,6 +9,7 @@
 >
   <input
     type="hidden"
+    class="js-select-record"
     name="record_id"
     value="{{ value }}"
   />

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection_header.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection_header.html
@@ -9,5 +9,8 @@
   hq-hx-action="{{ hq_hx_action }}"
   hx-swap="none"
   hx-disabled-elt=".htmx-disable-on-select-page"
+  hx-vals='js:{
+    recordIds: [...document.querySelectorAll(".js-select-record")].map(input => input.value)
+  }'
   {{ attrs.as_html }}
 />

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection_header.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection_header.html
@@ -7,6 +7,10 @@
   name="select_page"
   hx-post="{{ request.path_info }}{% querystring %}"
   hq-hx-action="{{ hq_hx_action }}"
+  hq-hx-select-all='{
+    "selector": ".js-select-record-checkbox",
+    "triggerEvent": "click"
+  }'
   hx-swap="none"
   hx-disabled-elt=".htmx-disable-on-select-page"
   hx-vals='js:{

--- a/corehq/apps/data_cleaning/tests/test_records.py
+++ b/corehq/apps/data_cleaning/tests/test_records.py
@@ -73,3 +73,57 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
 
         self.assertFalse(self.session.is_record_selected(case_id))
         self.assertTrue(self.session.records.filter(doc_id=case_id).exists())
+
+    def test_select_multiple_records(self):
+        case_ids = [self._get_case_id() for _ in range(10)]
+        self.session.select_multiple_records(case_ids)
+        for case_id in case_ids:
+            record = self.session.records.get(doc_id=case_id)
+            self.assertTrue(record.is_selected)
+            self.assertEqual(record.session, self.session)
+            self.assertEqual(record.doc_id, case_id)
+        self.assertEqual(self.session.records.count(), len(case_ids))
+        self.assertEqual(self.session.get_num_selected_records(), len(case_ids))
+
+    def test_select_multiple_records_some_existing(self):
+        case_ids = [self._get_case_id() for _ in range(10)]
+        self.session.select_record(case_ids[3])
+        BulkEditRecord.objects.create(
+            session=self.session,
+            doc_id=case_ids[5],
+            calculated_change_id=uuid.uuid4(),
+            is_selected=False,
+        )
+        BulkEditRecord.objects.create(
+            session=self.session,
+            doc_id=self._get_case_id(),
+            calculated_change_id=uuid.uuid4(),
+            is_selected=False,
+        )
+        self.assertEqual(self.session.records.count(), 3)
+        self.assertEqual(self.session.get_num_selected_records(), 1)
+        self.session.select_multiple_records(case_ids)
+        self.assertEqual(self.session.records.count(), len(case_ids) + 1)
+        self.assertEqual(self.session.get_num_selected_records(), len(case_ids))
+
+    def test_deselect_multiple_records(self):
+        case_ids = [self._get_case_id() for _ in range(10)]
+        self.session.select_record(self._get_case_id())  # record not in case_ids
+        self.session.select_multiple_records(case_ids)
+        self.assertEqual(self.session.get_num_selected_records(), len(case_ids) + 1)
+        self.session.deselect_multiple_records(case_ids)
+        self.assertEqual(self.session.records.count(), 1)
+        self.assertEqual(self.session.get_num_selected_records(), 1)
+
+    def test_deselect_multiple_records_some_edited(self):
+        case_ids = [self._get_case_id() for _ in range(10)]
+        self.session.select_multiple_records(case_ids)
+        edited_record = self.session.records.get(doc_id=case_ids[5])
+        edited_record.calculated_change_id = uuid.uuid4()
+        edited_record.save()
+        self.assertEqual(self.session.get_num_selected_records(), len(case_ids))
+        self.session.deselect_multiple_records(case_ids)
+        self.assertEqual(self.session.records.count(), 1)
+        self.assertEqual(self.session.get_num_selected_records(), 0)
+        edited_record = self.session.records.get(doc_id=case_ids[5])
+        self.assertFalse(edited_record.is_selected)

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -82,8 +82,13 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
         """
         Selects all records on the current page.
         """
-        # todo
-        return self.get(request, *args, **kwargs)
+        select_page = request.POST.get('select_page') is not None
+        doc_ids = request.POST.getlist('recordIds')
+        if select_page:
+            self.session.select_multiple_records(doc_ids)
+        else:
+            self.session.deselect_multiple_records(doc_ids)
+        return self.render_htmx_no_response(request, *args, **kwargs)
 
 
 class CaseCleaningTasksTableView(BaseDataCleaningTableView):

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -67,7 +67,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
     @hq_hx_action('post')
     def select_record(self, request, *args, **kwargs):
         """
-        Selects a single record.
+        Selects (or de-selects) a single record.
         """
         doc_id = request.POST['record_id']
         is_selected = request.POST.get('is_selected') is not None
@@ -80,7 +80,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
     @hq_hx_action('post')
     def select_page(self, request, *args, **kwargs):
         """
-        Selects all records on the current page.
+        Selects (or de-selects) all records on the current page.
         """
         select_page = request.POST.get('select_page') is not None
         doc_ids = request.POST.getlist('recordIds')

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_select_all.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_select_all.js
@@ -1,0 +1,24 @@
+/*
+    The attribute `hq-hx-select-all` is used to select all checkboxes with the class name
+    provideded in the config object passed as a string in the attribute value.
+
+    Example:
+    hx-hx-select-all='{
+        "selector": <string - class name of the checkboxes>,
+        "triggerEvent": <string - name of the event to trigger on each checkbox>
+    }'
+
+*/
+import htmx from 'htmx.org';
+
+document.body.addEventListener('htmx:configRequest', (event) => {
+    if (event.detail.elt.hasAttribute('hq-hx-select-all')) {
+        const config = JSON.parse(event.detail.elt.getAttribute('hq-hx-select-all'));
+        document.querySelectorAll(config.selector).forEach((el) => {
+            el.checked = event.detail.elt.checked;
+            if (config.triggerEvent) {
+                htmx.trigger(el, config.triggerEvent);
+            }
+        });
+    }
+});


### PR DESCRIPTION
## Technical Summary
This implements the page select / de-select functionality. Adds two methods to select/deselect a batch of doc_ids (which will also be useful when applying this selection / deselection to records in the session)

https://dimagi.atlassian.net/browse/SAAS-16865


https://github.com/user-attachments/assets/cbfc63c9-0748-4dd5-ac92-328bcd1a61c5





## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
changes only applicable to feature behind feature flag

### Automated test coverage
yes

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
