### PR TITLE
Change Campaign PDF Export Orientation

### DIFF
--- a/corehq/apps/campaign/static/campaign/js/dashboard.js
+++ b/corehq/apps/campaign/static/campaign/js/dashboard.js
@@ -122,7 +122,7 @@ function printActiveTabToPdf() {
         jsPDF: {
             unit: 'mm',
             format: 'a4',
-            orientation: 'portrait',
+            orientation: 'landscape',
         },
     };
 

--- a/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
+++ b/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
@@ -15,7 +15,7 @@
       {% include "campaign/partials/delete_widget_button.html" with widget_type='gauge' %}
     </div>
     <div
-      class="gauge-widget-card card-body p-0 d-flex justify-content-center align-items-center"
+      class="card-body p-0 d-flex justify-content-center align-items-center"
     >
       {% if widget.value %}
         <canvas id="gauge-widget-{{ widget.id }}"></canvas>

--- a/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
+++ b/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
@@ -14,7 +14,9 @@
       {% include "campaign/partials/edit_widget_button.html" with widget_type='gauge' %}
       {% include "campaign/partials/delete_widget_button.html" with widget_type='gauge' %}
     </div>
-    <div class="gauge-widget-card card-body p-0 d-flex justify-content-center align-items-center">
+    <div
+      class="gauge-widget-card card-body p-0 d-flex justify-content-center align-items-center"
+    >
       {% if widget.value %}
         <canvas id="gauge-widget-{{ widget.id }}"></canvas>
       {% else %}

--- a/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
+++ b/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
@@ -14,9 +14,7 @@
       {% include "campaign/partials/edit_widget_button.html" with widget_type='gauge' %}
       {% include "campaign/partials/delete_widget_button.html" with widget_type='gauge' %}
     </div>
-    <div
-      class="card-body p-0 d-flex justify-content-center align-items-center"
-    >
+    <div class="card-body p-0 d-flex justify-content-center align-items-center">
       {% if widget.value %}
         <canvas id="gauge-widget-{{ widget.id }}"></canvas>
       {% else %}

--- a/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
+++ b/corehq/apps/campaign/templates/campaign/partials/dashboard_gauge.html
@@ -14,7 +14,7 @@
       {% include "campaign/partials/edit_widget_button.html" with widget_type='gauge' %}
       {% include "campaign/partials/delete_widget_button.html" with widget_type='gauge' %}
     </div>
-    <div class="card-body p-0 d-flex">
+    <div class="gauge-widget-card card-body p-0 d-flex justify-content-center align-items-center">
       {% if widget.value %}
         <canvas id="gauge-widget-{{ widget.id }}"></canvas>
       {% else %}


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

The PDF export file has had it's orientation changed to be landscape now (from portrait) to better fit the content of the campaign dashboard. Additionally, some styling changes have been added to center the gauges so that they fit better on the export.

**Old:**
![Screenshot from 2025-04-03 11-23-43](https://github.com/user-attachments/assets/63bbfbb4-9ea7-461c-9dd8-4b33c02b00af)

**New:**
![Screenshot from 2025-04-03 11-26-16](https://github.com/user-attachments/assets/6c2d2060-35cc-4db5-8a77-bda3642a646a)


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This is a relatively small PR which only changes one of the PDF export options, as well as adds some additional B5 classes to the gauge template to help with centering the gauges.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`CAMPAIGN_DASHBOARD`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Unused feature flag
- Very small UI change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
