### PR TITLE
Update html_attr to accept translated strings

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -596,7 +596,11 @@ def trans_html_attr(value):
 def html_attr(value):
     if isinstance(value, bytes):
         value = value.decode('utf-8')
-    if not isinstance(value, str):
+    try:
+        # Call _ instead of instanceof(value, str) because value might be a translated string
+        _(value)
+    except AttributeError:
+        # Value is not a string, so JSON-encode it
         value = JSON(value)
     return conditional_escape(value)
 

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -12,6 +12,7 @@ from django.template.base import (
 )
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.functional import Promise
 from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
@@ -596,11 +597,8 @@ def trans_html_attr(value):
 def html_attr(value):
     if isinstance(value, bytes):
         value = value.decode('utf-8')
-    try:
-        # Call _ instead of instanceof(value, str) because value might be a translated string
-        _(value)
-    except AttributeError:
-        # Value is not a string, so JSON-encode it
+    if not isinstance(value, (str, Promise)):
+        # Value is not a string, or a lazily translated string, so JSON-encode it
         value = JSON(value)
     return conditional_escape(value)
 

--- a/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
+++ b/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
@@ -90,6 +90,18 @@ class TagTest(SimpleTestCase):
             "23"
         )
 
+    def test_html_attr_bool(self):
+        self.assertEqual(
+            self.render("""{% load hq_shared_tags %}{% html_attr True %}"""),
+            "true"
+        )
+
+    def test_html_attr_None(self):
+        self.assertEqual(
+            self.render("""{% load hq_shared_tags %}{% html_attr None %}"""),
+            "null"
+        )
+
     def test_html_attr_list(self):
         self.assertEqual(
             self.render("""{% load hq_shared_tags %}{% html_attr my_list %}""", {

--- a/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
+++ b/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
@@ -7,6 +7,7 @@ from django.template import Context, Template, TemplateSyntaxError
 from django.test import SimpleTestCase, override_settings
 
 from corehq.util.test_utils import make_make_path
+from corehq.apps.hqwebapp.exceptions import TemplateTagJSONException
 
 _make_path = make_make_path(__file__)
 
@@ -70,6 +71,46 @@ class TagTest(SimpleTestCase):
                 {'starling': 'murmuration'},
             ],
         })
+
+    def test_html_attr_string(self):
+        self.assertEqual(
+            self.render("""{% load hq_shared_tags %}{% html_attr "circus" %}"""),
+            "circus"
+        )
+
+    def test_html_attr_translated_string(self):
+        self.assertEqual(
+            self.render("""{% load hq_shared_tags %}{% html_attr _("toxic") %}"""),
+            "toxic"
+        )
+
+    def test_html_attr_number(self):
+        self.assertEqual(
+            self.render("""{% load hq_shared_tags %}{% html_attr "23" %}"""),
+            "23"
+        )
+
+    def test_html_attr_list(self):
+        self.assertEqual(
+            self.render("""{% load hq_shared_tags %}{% html_attr my_list %}""", {
+                "my_list": ["circus", "toxic", "stronger"],
+            }),
+            "[&quot;circus&quot;, &quot;toxic&quot;, &quot;stronger&quot;]"
+        )
+
+    def test_html_attr_dict(self):
+        self.assertEqual(
+            self.render("""{% load hq_shared_tags %}{% html_attr my_dict %}""", {
+                "my_dict": {"toxic": 2003, "circus": 2008}
+            }),
+            "{&quot;toxic&quot;: 2003, &quot;circus&quot;: 2008}"
+        )
+
+    def test_html_attr_obj(self):
+        with self.assertRaises(TemplateTagJSONException):
+            self.render("""{% load hq_shared_tags %}{% html_attr my_object %}""", {
+                "my_object": object(),
+            })
 
     def test_registerurl(self):
         # why does this test take 8s?

--- a/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
+++ b/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
@@ -78,6 +78,14 @@ class TagTest(SimpleTestCase):
             "circus"
         )
 
+    def test_html_attr_string_with_quotes(self):
+        self.assertEqual(
+            self.render("""{% load hq_shared_tags %}{% html_attr what_on_earth %}""", {
+                "what_on_earth": """cir'cus ci"rcus""",
+            }),
+            "cir&#x27;cus ci&quot;rcus",
+        )
+
     def test_html_attr_translated_string(self):
         self.assertEqual(
             self.render("""{% load hq_shared_tags %}{% html_attr _("toxic") %}"""),

--- a/corehq/apps/locations/templates/locations/manage/location_template.html
+++ b/corehq/apps/locations/templates/locations/manage/location_template.html
@@ -113,7 +113,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <h4 class="modal-title">{% trans "Delete Location:" %} <span data-bind="text: name" /></h4>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans_html_attr "Close" %}"></button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% html_attr _("Close") %}"></button>
           </div>
           <div class="modal-body">
             <p>
@@ -139,7 +139,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <h4 class="modal-title">{% trans "Archive Location:" %} <span data-bind="text: name" /></h4>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans_html_attr "Close" %}"></button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% html_attr _("Close") %}"></button>
           </div>
           <div class="modal-body">
             <p>


### PR DESCRIPTION
## Technical Summary
[trans_html_attr](https://github.com/dimagi/commcare-hq/blob/9cf2f94e5c8cad49215665a0841f7b087624a96e/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py#L586-L592) will translate the given string only if that string has been marked for translation in some other way.

You can pass translated strings in templates: https://docs.djangoproject.com/en/4.2/topics/i18n/translation/#string-literals-passed-to-tags-and-filters which makes me wonder why I wrote `trans_html_attr` in the first place. Maybe this behavior hasn't always been supported?

This PR updates the `html_attr` to accept translated strings. Previously, if passed a translated string, it would wrap quotes around the value.

Once this is merged, `trans_html_attr` can be phased out.

## Safety Assurance

### Safety story
This is used all over the place, including in knockout attributes, so the main risk is breaking javascript. I'm comfortable with the test coverage added in this PR.

### Automated test coverage

In PR.

### QA Plan

Not requesting QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
