### PR TITLE
Revert "Remove unused plan-notice custom styles"

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/plan_notice.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/plan_notice.less
@@ -1,0 +1,12 @@
+.plan-notice {
+  .column-icon {
+    text-align: center;
+    font-size: 200px;
+    color: @cc-brand-low;
+    line-height: 200px;
+  }
+
+  .column-text {
+    padding-top: 28px;
+  }
+}

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/style-imports.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/style-imports.less
@@ -30,6 +30,7 @@
 @import "_hq/notifications.less";
 @import "_hq/pagination.less";
 @import "_hq/panels.less";
+@import "_hq/plan_notice.less";
 @import "_hq/popovers.less";
 @import "_hq/report.less";
 @import "_hq/radio_select.less";

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq.scss
@@ -87,6 +87,7 @@
 @import "commcarehq/notifications";
 @import "commcarehq/pagination";
 @import "commcarehq/panels";
+@import "commcarehq/plan_notice";
 @import "commcarehq/radio_select";
 @import "commcarehq/readable_forms";
 @import "commcarehq/report";

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_plan_notice.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_plan_notice.scss
@@ -1,0 +1,12 @@
+.plan-notice {
+  .column-icon {
+    text-align: center;
+    font-size: 200px;
+    color: $cc-brand-low;
+    line-height: 200px;
+  }
+
+  .column-text {
+    padding-top: 28px;
+  }
+}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diff_config.json
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diff_config.json
@@ -232,6 +232,10 @@
           "_panels.scss"
         ],
         [
+          "plan_notice.less",
+          "_plan_notice.scss"
+        ],
+        [
           "popovers.less",
           "_popover.scss"
         ],

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/plan_notice._plan_notice.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/plan_notice._plan_notice.style.diff.txt
@@ -1,0 +1,11 @@
+--- 
++++ 
+@@ -2,7 +2,7 @@
+   .column-icon {
+     text-align: center;
+     font-size: 200px;
+-    color: @cc-brand-low;
++    color: $cc-brand-low;
+     line-height: 200px;
+   }
+ 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/style-imports.commcarehq.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/style-imports.commcarehq.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,43 +1,95 @@
+@@ -1,44 +1,96 @@
 -@import "_hq/includes/variables.less";
 -@import "_hq/includes/mixins.less";
  
@@ -33,6 +33,7 @@
 -@import "_hq/notifications.less";
 -@import "_hq/pagination.less";
 -@import "_hq/panels.less";
+-@import "_hq/plan_notice.less";
 -@import "_hq/popovers.less";
 -@import "_hq/report.less";
 -@import "_hq/radio_select.less";
@@ -132,6 +133,7 @@
 +@import "commcarehq/notifications";
 +@import "commcarehq/pagination";
 +@import "commcarehq/panels";
++@import "commcarehq/plan_notice";
 +@import "commcarehq/radio_select";
 +@import "commcarehq/readable_forms";
 +@import "commcarehq/report";


### PR DESCRIPTION
## Product Description
Fixes formatting in the Paused plan notice, which currently looks like this:
![image](https://github.com/user-attachments/assets/c9bbf3f1-c459-4054-9c03-3cf92be57682)

It should look like this:
![image](https://github.com/user-attachments/assets/49b34141-e9fa-42bf-9985-c605ef3a0ec8)


## Technical Summary
This reverts commit 119d7fb1cb522eb11c879169fddbb71ae88e3ffd.

These styles were not, in fact, unused. The `plan-notice` class is still applied on the Paused plan notice https://github.com/dimagi/commcare-hq/blob/f403e31e1fc33478d9f8eba534ab2af431f1cb22/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/paused_plan_notice.html#L3

## Safety Assurance

### Safety story
Just a revert to fix stylesheets.

### Automated test coverage
Nope.

### QA Plan
n/a


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
