### PR TITLE
Print pillow id instead of class name

### DIFF
--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -102,7 +102,7 @@ class PillowBase(metaclass=ABCMeta):
         """
         Main entry point for running pillows forever.
         """
-        pillow_logging.info("Starting pillow %s" % self.__class__)
+        pillow_logging.info("Starting pillow %s" % self.pillow_id)
         scope = Scope.get_current_scope()
         scope.set_tag("pillow_name", self.get_name())
         if self.is_dedicated_migration_process:

--- a/corehq/ex-submodules/pillowtop/run_pillowtop.py
+++ b/corehq/ex-submodules/pillowtop/run_pillowtop.py
@@ -35,6 +35,6 @@ def start_pillows(pillows=None):
 
 def start_pillow(pillow_instance):
     while True:
-        print("Starting pillow %s.run()" % pillow_instance.__class__)
+        print("Starting pillow %s.run()" % pillow_instance.pillow_id)
         pillow_instance.run()
-        print("Pillow %s.run() completed, restarting" % pillow_instance.__class__)
+        print("Pillow %s.run() completed, restarting" % pillow_instance.pillow_id)


### PR DESCRIPTION
All pillows are the same ConstructedPillow class, which isn't very useful when looking at logs. Print the pillow id instead.

## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
These logs aren't very useful. All pillows are ConstructedPillow classes, which have a pillow_id property. Let's use that instead.
```
2025-04-04 03:42:21,475 INFO interface Starting pillow <class 'pillowtop.pillow.interface.ConstructedPillow'>
2025-04-04 03:42:31,492 INFO interface Starting pillow <class 'pillowtop.pillow.interface.ConstructedPillow'>
2025-04-04 03:42:40,628 INFO interface Starting pillow <class 'pillowtop.pillow.interface.ConstructedPillow'>
```
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
