### PR TITLE
Ignore demo user when rate limiting devices per user

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -317,8 +317,8 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
         msg = _('Invalid restore as user {}').format(as_user)
         return HttpResponse(msg, status=401), None
 
-    restoring_user_id = as_user_obj._id if uses_login_as else couch_user._id
-    should_limit = device_rate_limiter.rate_limit_device(domain, restoring_user_id, device_id)
+    user_to_limit_on = as_user_obj if uses_login_as else couch_user
+    should_limit = device_rate_limiter.rate_limit_device(domain, user_to_limit_on, device_id)
     if should_limit:
         return HttpNotAcceptable(DEVICE_RATE_LIMIT_MESSAGE), None
 
@@ -388,7 +388,7 @@ def heartbeat(request, domain, app_build_id):
         need any validation on it. This is pulled from @uniqueid from profile.xml
     """
     should_limit = device_rate_limiter.rate_limit_device(
-        domain, request.couch_user._id, request.GET.get('device_id')
+        domain, request.couch_user, request.GET.get('device_id')
     )
     if should_limit:
         return HttpNotAcceptable(DEVICE_RATE_LIMIT_MESSAGE)

--- a/corehq/apps/receiverwrapper/tests/test_audit_logging.py
+++ b/corehq/apps/receiverwrapper/tests/test_audit_logging.py
@@ -24,7 +24,7 @@ def return_submission_run_resp(*args, **kwargs):
 
 @patch('corehq.apps.receiverwrapper.views.couchforms.get_instance_and_attachment',
        new=Mock(return_value=(Mock(), Mock())))
-@patch('corehq.apps.receiverwrapper.views.convert_xform_to_json', new=Mock())
+@patch('corehq.apps.receiverwrapper.views.convert_xform_to_json', lambda _: {})
 @patch('corehq.apps.receiverwrapper.views._record_metrics', new=Mock())
 @patch('corehq.apps.receiverwrapper.views.SubmissionPost.run', new=return_submission_run_resp)
 class TestAuditLoggingForFormSubmission(TestCase):

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -52,6 +52,7 @@ from corehq.apps.receiverwrapper.util import (
     get_app_and_build_ids,
     should_ignore_submission,
 )
+from corehq.apps.users.models import CouchUser
 from corehq.form_processor.exceptions import XFormLockError
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.submission_post import SubmissionPost
@@ -147,7 +148,8 @@ def _process_form(request, domain, app_id, user_id, authenticated,
     else:
         device_id = instance_json.get('meta', {}).get('deviceID')
         submitting_user_id = instance_json.get('meta', {}).get('userID')
-        should_limit = device_rate_limiter.rate_limit_device(domain, submitting_user_id, device_id)
+        submitting_user = CouchUser.get_by_user_id(submitting_user_id) if submitting_user_id else None
+        should_limit = device_rate_limiter.rate_limit_device(domain, submitting_user, device_id)
         if should_limit:
             return HttpNotAcceptable(DEVICE_RATE_LIMIT_MESSAGE)
 

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -146,8 +146,9 @@ def _process_form(request, domain, app_id, user_id, authenticated,
         # let normal response handle invalid xml
         pass
     else:
-        device_id = instance_json.get('meta', {}).get('deviceID')
-        submitting_user_id = instance_json.get('meta', {}).get('userID')
+        meta = instance_json.get('meta', {})
+        device_id = meta.get('deviceID')
+        submitting_user_id = meta.get('userID')
         submitting_user = CouchUser.get_by_user_id(submitting_user_id) if submitting_user_id else None
         should_limit = device_rate_limiter.rate_limit_device(domain, submitting_user, device_id)
         if should_limit:

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -43,6 +43,10 @@ class DeviceRateLimiter:
             )
             return False
 
+        if user.is_commcare_user() and user.is_demo_user:
+            # demo users are intended to be used across devices
+            return False
+
         if self._is_formplayer(device_id):
             # do not track formplayer activity
             return False

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -31,14 +31,15 @@ class DeviceRateLimiter:
     def device_limit_per_user(self, domain):
         return SystemLimit.for_key(DEVICE_LIMIT_PER_USER_KEY, domain=domain) or DEVICE_LIMIT_PER_USER_DEFAULT
 
-    def rate_limit_device(self, domain, user_id, device_id):
+    def rate_limit_device(self, domain, user, device_id):
         """
         Returns boolean representing if this user_id + device_id combo is rate limited or not
         NOTE: calling this method will result in the device_id being added to the list of used device_ids
         """
-        if not device_id or not user_id:
+        if not device_id or not user:
             logger.info(
-                f"Unable to rate limit device activity for domain {domain}, user {user_id}, and device {device_id}"
+                f"Unable to rate limit device activity for domain {domain}, user {user.user_id if user else None},"
+                f" and device {device_id}"
             )
             return False
 
@@ -46,7 +47,7 @@ class DeviceRateLimiter:
             # do not track formplayer activity
             return False
 
-        key = self._get_redis_key(domain, user_id)
+        key = self._get_redis_key(domain, user.user_id)
 
         key_exists, device_exists, device_count = self._get_usage_for_device(key, device_id)
 
@@ -64,7 +65,7 @@ class DeviceRateLimiter:
         is_enabled = toggles.DEVICE_RATE_LIMITER.enabled(domain, toggles.NAMESPACE_DOMAIN)
         metrics_counter(
             'commcare.devices_per_user.rate_limited',
-            tags={'domain': domain, 'user_id': user_id, 'enabled': str(is_enabled)},
+            tags={'domain': domain, 'user_id': user.user_id, 'enabled': str(is_enabled)},
         )
         return is_enabled
 

--- a/corehq/apps/users/tests/test_device_rate_limiter.py
+++ b/corehq/apps/users/tests/test_device_rate_limiter.py
@@ -100,3 +100,11 @@ class TestDeviceRateLimiter(TestCase):
         device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
         device_rate_limiter.rate_limit_device('random-domain', self.user, 'random-device')
         self.assertTrue(device_rate_limiter.rate_limit_device('random-domain', self.user, 'existing-device-id'))
+
+    def test_demo_user_activity_is_not_limited(self):
+        demo_user = CommCareUser.create(self.domain, 'test-demo-user', 'abc123', None, None)
+        demo_user.is_demo_user = True
+        demo_user.save()
+        self.addCleanup(demo_user.delete, None, None)
+        device_rate_limiter.rate_limit_device(self.domain, demo_user, 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, demo_user, 'new-device-id'))

--- a/corehq/apps/users/tests/test_device_rate_limiter.py
+++ b/corehq/apps/users/tests/test_device_rate_limiter.py
@@ -3,6 +3,7 @@ from freezegun import freeze_time
 
 from corehq.apps.cloudcare.const import DEVICE_ID as CLOUDCARE_DEVICE_ID
 from corehq.apps.users.device_rate_limiter import DEVICE_LIMIT_PER_USER_KEY, REDIS_KEY_PREFIX, device_rate_limiter
+from corehq.apps.users.models import CommCareUser
 from corehq.project_limits.models import SystemLimit
 from corehq.util.test_utils import flag_disabled, flag_enabled
 
@@ -13,6 +14,12 @@ class TestDeviceRateLimiter(TestCase):
 
     domain = 'device-rate-limit-test'
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = CommCareUser.create(cls.domain, 'test-mobile-user', 'abc123', None, None)
+        cls.addClassCleanup(cls.user.delete, None, None)
+
     def setUp(self):
         SystemLimit.objects.create(key=DEVICE_LIMIT_PER_USER_KEY, limit=1)
         self.addCleanup(self._cleanup_redis)
@@ -22,72 +29,74 @@ class TestDeviceRateLimiter(TestCase):
             device_rate_limiter.client.delete(key.decode('utf-8'))
 
     def test_allowed_if_no_devices_have_been_used_yet(self):
-        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
 
     def test_allowed_if_device_count_is_under_limit(self):
         SystemLimit.objects.update_or_create(defaults={"limit": 2}, key=DEVICE_LIMIT_PER_USER_KEY)
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
-        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+        device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
 
     def test_rate_limited_if_device_count_exceeds_limit(self):
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
-        self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+        device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
+        self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
 
     def test_allowed_if_device_has_already_been_used(self):
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
-        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id'))
+        device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id'))
 
     def test_allowed_if_different_user(self):
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
-        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'new-user-id', 'existing-device-id'))
+        new_user = CommCareUser.create(self.domain, 'new-test-mobile-user', 'abc123', None, None)
+        self.addCleanup(new_user.delete, None, None)
+        device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, new_user, 'existing-device-id'))
 
     def test_allowed_after_waiting_one_minute(self):
         with freeze_time("2024-12-10 12:05:43") as frozen_time:
-            device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
-            self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+            device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
+            self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
             frozen_time.move_to("2024-12-10 12:06:15")
-            self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+            self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
 
     def test_formplayer_activity_is_always_allowed(self):
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
-        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'WebAppsLogin*newlogin'))
-        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', CLOUDCARE_DEVICE_ID))
+        device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, self.user, 'WebAppsLogin*newlogin'))
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, self.user, CLOUDCARE_DEVICE_ID))
 
     def test_formplayer_activity_does_not_count_towards_limit(self):
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'WebAppsLogin*newlogin')
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', CLOUDCARE_DEVICE_ID)
-        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+        device_rate_limiter.rate_limit_device(self.domain, self.user, 'WebAppsLogin*newlogin')
+        device_rate_limiter.rate_limit_device(self.domain, self.user, CLOUDCARE_DEVICE_ID)
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
 
     def test_domain_has_higher_limit(self):
         SystemLimit.objects.create(key=DEVICE_LIMIT_PER_USER_KEY, limit=2, domain=self.domain)
 
-        device_rate_limiter.rate_limit_device('random-domain', 'user-id', 'existing-device-id')
-        self.assertTrue(device_rate_limiter.rate_limit_device('random-domain', 'user-id', 'new-device-id'))
+        device_rate_limiter.rate_limit_device('random-domain', self.user, 'existing-device-id')
+        self.assertTrue(device_rate_limiter.rate_limit_device('random-domain', self.user, 'new-device-id'))
 
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
-        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+        device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
 
     def test_domain_has_lower_limit(self):
         SystemLimit.objects.update_or_create(defaults={"limit": 2}, key=DEVICE_LIMIT_PER_USER_KEY)
         SystemLimit.objects.create(key=DEVICE_LIMIT_PER_USER_KEY, limit=1, domain=self.domain)
 
-        device_rate_limiter.rate_limit_device('random-domain', 'user-id', 'existing-device-id')
-        self.assertFalse(device_rate_limiter.rate_limit_device('random-domain', 'user-id', 'new-device-id'))
+        device_rate_limiter.rate_limit_device('random-domain', self.user, 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device('random-domain', self.user, 'new-device-id'))
 
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
-        self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+        device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
+        self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
 
     @flag_disabled("DEVICE_RATE_LIMITER")
     def test_allowed_if_rate_limiter_is_disabled(self):
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
-        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'new-device-id'))
+        device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
 
-    def test_allowed_if_user_id_or_device_id_is_none(self):
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
-        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, 'user-id', None))
+    def test_allowed_if_user_or_device_id_is_none(self):
+        device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
+        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, self.user, None))
         self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, None, 'new-device-id'))
 
     def test_domains_do_not_conflict(self):
-        device_rate_limiter.rate_limit_device(self.domain, 'user-id', 'existing-device-id')
-        device_rate_limiter.rate_limit_device('random-domain', 'user-id', 'random-device')
-        self.assertTrue(device_rate_limiter.rate_limit_device('random-domain', 'user-id', 'existing-device-id'))
+        device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
+        device_rate_limiter.rate_limit_device('random-domain', self.user, 'random-device')
+        self.assertTrue(device_rate_limiter.rate_limit_device('random-domain', self.user, 'existing-device-id'))

--- a/corehq/apps/users/tests/test_device_rate_limiter.py
+++ b/corehq/apps/users/tests/test_device_rate_limiter.py
@@ -15,8 +15,9 @@ class TestDeviceRateLimiter(TestCase):
 
     def setUp(self):
         SystemLimit.objects.create(key=DEVICE_LIMIT_PER_USER_KEY, limit=1)
+        self.addCleanup(self._cleanup_redis)
 
-    def tearDown(self):
+    def _cleanup_redis(self):
         for key in device_rate_limiter.client.scan_iter(f"{REDIS_KEY_PREFIX}*"):
             device_rate_limiter.client.delete(key.decode('utf-8'))
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-16938

Demo users are intended to be used across many devices, and therefore should bypass the device rate limiting code. It is the case that by coincidence, already bypass device rate limiting code for restores by demo users, but this is to ensure that going forward we are always bypassing the rate limiter.

In restores and heartbeats, the full user object was already available, but I ended up needed to do a db hit for the form submission. However we do this same db hit when checking if we should ignore the form during processing [here](https://github.com/dimagi/commcare-hq/blob/70776b8784ef57dcfb1349295db1b1d1f00e4c87/corehq/apps/receiverwrapper/views.py#L131-L131), so this is only moving the db call up in the request flow and the `get_user_by_id` call is cached.
 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
