### PR TITLE
Remove control character from translation files

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -51331,7 +51331,7 @@ msgstr "Ubicación Padre"
 
 #: corehq/ex-submodules/couchforms/openrosa_response.py:67
 msgid "   √   "
-msgstr "      "
+msgstr ""
 
 #: corehq/ex-submodules/dimagi/utils/dates.py:306
 msgid "You have to specify both dates!"

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -54298,7 +54298,7 @@ msgstr "Location parente "
 
 #: corehq/ex-submodules/couchforms/openrosa_response.py:67
 msgid "   √   "
-msgstr "      "
+msgstr ""
 
 #: corehq/ex-submodules/dimagi/utils/dates.py:306
 msgid "You have to specify both dates!"

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -51172,7 +51172,7 @@ msgstr "Localização Principal"
 
 #: corehq/ex-submodules/couchforms/openrosa_response.py:67
 msgid "   √   "
-msgstr "      "
+msgstr ""
 
 #: corehq/ex-submodules/dimagi/utils/dates.py:306
 msgid "You have to specify both dates!"


### PR DESCRIPTION
## Product Description
Fixes a bug where users in some languages are unable to update mobile worker location through the UI.

## Technical Summary
[SAAS-17336 ](https://dimagi.atlassian.net/browse/SAAS-17336)
Removes the control character `\x1a` shown below in `msgstr`, which was inadvertently added #36143:
![image](https://github.com/user-attachments/assets/2022028f-8312-4723-8044-a039a6776765)


## Safety Assurance

### Safety story
Just a fix to translation files and remove the `msgstr` contents for `"   √   "`, which is already empty for other language translations.

### Automated test coverage
Not for this particular fix. We should look at a test to ensure PO files don't contain invalid characters.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
