### PR TITLE
Fix the character that was causing issues in translations

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -51331,7 +51331,7 @@ msgstr "Ubicación Padre"
 
 #: corehq/ex-submodules/couchforms/openrosa_response.py:67
 msgid "   √   "
-msgstr "      "
+msgstr "  √    "
 
 #: corehq/ex-submodules/dimagi/utils/dates.py:306
 msgid "You have to specify both dates!"

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -54298,7 +54298,7 @@ msgstr "Location parente "
 
 #: corehq/ex-submodules/couchforms/openrosa_response.py:67
 msgid "   √   "
-msgstr "      "
+msgstr "  √    "
 
 #: corehq/ex-submodules/dimagi/utils/dates.py:306
 msgid "You have to specify both dates!"

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -51172,7 +51172,7 @@ msgstr "Localização Principal"
 
 #: corehq/ex-submodules/couchforms/openrosa_response.py:67
 msgid "   √   "
-msgstr "      "
+msgstr "  √    "
 
 #: corehq/ex-submodules/dimagi/utils/dates.py:306
 msgid "You have to specify both dates!"


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The translation for `√ ` was generated as non UTF-8 character which caused the following error -  `ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters`

The PR fixes that.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Non trivial change, affects only translations for Spanish, Portuguese and French.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
