### PR TITLE
[Data Cleaning] Select / De-Select all records in current queryset

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -782,7 +782,7 @@ class BulkEditRecord(models.Model):
         except cls.DoesNotExist:
             return
 
-        if record.calculated_change_id is not None:
+        if record.changes.count() > 0:
             record.is_selected = False
             record.save()
         else:
@@ -818,13 +818,13 @@ class BulkEditRecord(models.Model):
         session.records.filter(
             doc_id__in=doc_ids,
             is_selected=True,
-            calculated_change_id__isnull=False,
+            changes__isnull=False,
         ).update(is_selected=False)
 
         # delete all records that have no changes
         session.records.filter(
             doc_id__in=doc_ids,
-            calculated_change_id__isnull=True,
+            changes__isnull=True,
         ).delete()
 
     @property

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -31,7 +31,7 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
             attrs={
                 'td__input': {
                     # `pageNumRecordsSelected` defined in template
-                    "x-init": "if($el.checked) { pageNumRecordsSelected++ }",
+                    "x-init": "if($el.checked) { pageNumRecordsSelected++; }",
                     "@click": (
                         "if ($el.checked !== isRowSelected) {"
                         # `numRecordsSelected` defined in template

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -57,6 +57,12 @@
           class="btn btn-outline-danger"
           type="button"
           x-show="numRecordsSelected > 0"
+          hx-post="{{ request.path_info }}{% querystring %}"
+          hq-hx-action="deselect_all"
+          hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"
+          hx-swap="outerHTML"
+          hq-hx-loading="{{ table.loading_indicator_id }}"
+          hx-disable-elt="this"
         >
           <i class="fa-solid fa-close"></i>
           <span class="visually-hidden">{% trans "Clear Selection" %}</span>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -53,6 +53,21 @@
             Records Selected
           {% endblocktrans %}
         </div>
+        <button
+          class="btn btn-outline-danger"
+          type="button"
+          x-show="numRecordsSelected > 0"
+        >
+          <i class="fa-solid fa-close"></i>
+          <span class="visually-hidden">{% trans "Clear Selection" %}</span>
+        </button>
+        <button
+          class="btn btn-outline-primary"
+          type="button"
+          x-show="numRecordsSelected > 0 && numRecordsSelected < totalRecords"
+        >
+          {% trans "Select All" %} ({{ table.page.paginator.count }})
+        </button>
       </div>
     </div>
 

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -43,7 +43,10 @@
 
     <div>
       <div class="input-group">
-        <div class="input-group-text rounded-end"> {# todo: selection UI #}
+        <div
+          class="input-group-text"
+          :class="(numRecordsSelected > 0) || 'rounded-end'"
+        >
           <i class="fa-solid fa-circle-check me-2"></i>
           <span
             class="me-1"
@@ -57,6 +60,7 @@
           class="btn btn-outline-danger"
           type="button"
           x-show="numRecordsSelected > 0"
+          :class="(numRecordsSelected > 0 && numRecordsSelected < totalRecords) || 'rounded-end'"
           hx-post="{{ request.path_info }}{% querystring %}"
           hq-hx-action="deselect_all"
           hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -71,6 +71,12 @@
           class="btn btn-outline-primary"
           type="button"
           x-show="numRecordsSelected > 0 && numRecordsSelected < totalRecords"
+          hx-post="{{ request.path_info }}{% querystring %}"
+          hq-hx-action="select_all"
+          hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}div.table-container{% endif %}"
+          hx-swap="outerHTML"
+          hq-hx-loading="{{ table.loading_indicator_id }}"
+          hx-disable-elt="this"
         >
           {% trans "Select All" %} ({{ table.page.paginator.count }})
         </button>

--- a/corehq/apps/data_cleaning/tests/test_records.py
+++ b/corehq/apps/data_cleaning/tests/test_records.py
@@ -1,6 +1,10 @@
 import uuid
 
-from corehq.apps.data_cleaning.models import BulkEditRecord
+from corehq.apps.data_cleaning.models import (
+    BulkEditChange,
+    BulkEditRecord,
+    EditActionType,
+)
 from corehq.apps.data_cleaning.tests.test_session import BaseBulkEditSessionTest
 
 
@@ -10,6 +14,15 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
     @staticmethod
     def _get_case_id():
         return str(uuid.uuid4())
+
+    def _add_change_to_record(self, record):
+        change = BulkEditChange.objects.create(
+            session=self.session,
+            prop_id='name',
+            action_type=EditActionType.STRIP,
+        )
+        change.records.add(record)
+        return change
 
     def test_select_record(self):
         case_id = self._get_case_id()
@@ -35,40 +48,40 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
 
     def test_select_record_with_changes(self):
         case_id = self._get_case_id()
-        change_id = uuid.uuid4()
-        BulkEditRecord.objects.create(
+        record = BulkEditRecord.objects.create(
             session=self.session,
             doc_id=case_id,
-            calculated_change_id=change_id,
             is_selected=False,
         )
+        change = self._add_change_to_record(record)
         self.assertFalse(self.session.is_record_selected(case_id))
 
         record = self.session.select_record(case_id)
         self.assertEqual(record.session, self.session)
         self.assertEqual(record.doc_id, case_id)
         self.assertTrue(record.is_selected)
-        self.assertEqual(record.calculated_change_id, change_id)
+        self.assertEqual(record.changes.count(), 1)
+        self.assertEqual(record.changes.first(), change)
 
         self.assertTrue(self.session.is_record_selected(case_id))
         self.assertTrue(self.session.records.filter(doc_id=case_id).exists())
 
     def test_deselect_record_with_changes(self):
         case_id = self._get_case_id()
-        change_id = uuid.uuid4()
-        BulkEditRecord.objects.create(
+        record = BulkEditRecord.objects.create(
             session=self.session,
             doc_id=case_id,
-            calculated_change_id=change_id,
             is_selected=True,
         )
+        change = self._add_change_to_record(record)
         self.assertTrue(self.session.is_record_selected(case_id))
 
         record = self.session.deselect_record(case_id)
         self.assertIsNotNone(record)
         self.assertEqual(record.session, self.session)
         self.assertEqual(record.doc_id, case_id)
-        self.assertEqual(record.calculated_change_id, change_id)
+        self.assertEqual(record.changes.count(), 1)
+        self.assertEqual(record.changes.first(), change)
         self.assertFalse(record.is_selected)
 
         self.assertFalse(self.session.is_record_selected(case_id))
@@ -88,18 +101,18 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
     def test_select_multiple_records_some_existing(self):
         case_ids = [self._get_case_id() for _ in range(10)]
         self.session.select_record(case_ids[3])
-        BulkEditRecord.objects.create(
+        record = BulkEditRecord.objects.create(
             session=self.session,
             doc_id=case_ids[5],
-            calculated_change_id=uuid.uuid4(),
             is_selected=False,
         )
-        BulkEditRecord.objects.create(
+        self._add_change_to_record(record)
+        record = BulkEditRecord.objects.create(
             session=self.session,
             doc_id=self._get_case_id(),
-            calculated_change_id=uuid.uuid4(),
             is_selected=False,
         )
+        self._add_change_to_record(record)
         self.assertEqual(self.session.records.count(), 3)
         self.assertEqual(self.session.get_num_selected_records(), 1)
         self.session.select_multiple_records(case_ids)
@@ -119,8 +132,7 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
         case_ids = [self._get_case_id() for _ in range(10)]
         self.session.select_multiple_records(case_ids)
         edited_record = self.session.records.get(doc_id=case_ids[5])
-        edited_record.calculated_change_id = uuid.uuid4()
-        edited_record.save()
+        self._add_change_to_record(edited_record)
         self.assertEqual(self.session.get_num_selected_records(), len(case_ids))
         self.session.deselect_multiple_records(case_ids)
         self.assertEqual(self.session.records.count(), 1)

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -95,7 +95,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
         """
         De-selects all records in the current filtered view.
         """
-        # todo
+        self.session.deselect_all_records_in_queryset()
         return self.get(request, *args, **kwargs)
 
     @hq_hx_action('post')
@@ -103,7 +103,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
         """
         Selects all records in the current filtered view.
         """
-        # todo
+        self.session.select_all_records_in_queryset()
         return self.get(request, *args, **kwargs)
 
 

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -98,6 +98,14 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
         # todo
         return self.get(request, *args, **kwargs)
 
+    @hq_hx_action('post')
+    def select_all(self, request, *args, **kwargs):
+        """
+        Selects all records in the current filtered view.
+        """
+        # todo
+        return self.get(request, *args, **kwargs)
+
 
 class CaseCleaningTasksTableView(BaseDataCleaningTableView):
     urlname = "case_data_cleaning_tasks_table"

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -90,6 +90,14 @@ class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataC
             self.session.deselect_multiple_records(doc_ids)
         return self.render_htmx_no_response(request, *args, **kwargs)
 
+    @hq_hx_action('post')
+    def deselect_all(self, request, *args, **kwargs):
+        """
+        De-selects all records in the current filtered view.
+        """
+        # todo
+        return self.get(request, *args, **kwargs)
+
 
 class CaseCleaningTasksTableView(BaseDataCleaningTableView):
     urlname = "case_data_cleaning_tasks_table"

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_select_all.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_select_all.js
@@ -1,6 +1,6 @@
 /*
     The attribute `hq-hx-select-all` is used to select all checkboxes with the class name
-    provideded in the config object passed as a string in the attribute value.
+    provided in the config object passed as a string in the attribute value.
 
     Example:
     hx-hx-select-all='{


### PR DESCRIPTION
## Technical Summary
This PR implements the "Select All" and "X" functionality from the selection toolbar that was present in the original DC prototype.
<img width="313" alt="Screenshot 2025-04-07 at 1 32 13 PM" src="https://github.com/user-attachments/assets/13d42d9c-1065-4a97-b408-508ebd9624a3" />

The logic selects and de-selects all records in the current queryset / filtered view. Basic tests included, which I hope to expand and clean up once the initial push for this feature is over.

Also, this PR introduces a new 'hq-hx-select-all` "HTMX to HQ" interaction plugin. I haven't included this as part of the main tools yet, as I want to write documentation for it before making it widely available by default.


https://github.com/user-attachments/assets/a1a82595-1dcd-4989-9da8-ef3ec6e43073



## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
Safe changes, do not affect any production workflows

### Automated test coverage
yes, and new tests added. Most important functionality is tested.

### QA Plan
Not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
