### PR TITLE
Don't fetch $0 invoices as "unpaid"

### DIFF
--- a/corehq/apps/accounting/utils/invoicing.py
+++ b/corehq/apps/accounting/utils/invoicing.py
@@ -20,6 +20,7 @@ def _get_all_unpaid_saas_invoices():
         is_hidden=False,
         subscription__service_type=SubscriptionType.PRODUCT,
         date_paid__isnull=True,
+        balance__gt=0,
     )
 
 


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-15321
Resolves a bug where the `run_auto_pause_process` task is failing because `subscriptions` on a `CustomerInvoice` object can be blank. This piece of code is trying to total up unpaid invoice dollar amounts that are associated with a particular software plan version -- if there is no subscription, there is no software plan version, so we can skip it in the calculation.

## Safety Assurance

### Safety story
This is a straightforward "check if the thing exists before getting a property of it" change. This code is reasonably well tested against regression.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
