### PR TITLE
[Data Cleaning] Hide temporary 'save' button on non-local environments

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_session.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_session.html
@@ -10,16 +10,18 @@
     <h1 class="fs-3 pe-3 py-3 m-0">{{ current_page.page_name }}</h1>
     <div>
       {% include "data_cleaning/partials/button_bar.html" %}
-      <form
-        method="POST"
-        action="{% url "save_case_session" domain session_id %}"
-        class="float-end mx-3"
-      >
-        {% csrf_token %}
-        <button type="submit" class="btn btn-success">
-          <i class="fa fa-hippo"></i> Save
-        </button>
-      </form>
+      {% if show_temporary_save %}
+        <form
+          method="POST"
+          action="{% url "save_case_session" domain session_id %}"
+          class="float-end mx-3"
+        >
+          {% csrf_token %}
+          <button type="submit" class="btn btn-success">
+            <i class="fa fa-hippo"></i> Save
+          </button>
+        </form>
+      {% endif %}
     </div>
   </div>
   <div

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -85,8 +85,10 @@ class CleanCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
 
     @property
     def page_context(self):
+        from django.conf import settings
         return {
             "session_id": self.session_id,
+            "show_temporary_save": settings.SERVER_ENVIRONMENT == settings.LOCAL_SERVER_ENVIRONMENT,
         }
 
 


### PR DESCRIPTION
## Technical Summary
While the hippo is a charming addition, I want to hide the temporary save button on non-local environments. This is to ensure QA doesn't accidentally click this button when they begin testing columns and filters soon.

![Screenshot 2025-04-07 at 7 16 39 PM](https://github.com/user-attachments/assets/e5e3e3b7-c448-4fae-ada0-36bcbf09fdf2)


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
tiny UI change on a feature flagged UI

### Automated test coverage
n/a for this, but yes data cleaning is tested

### QA Plan
Not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
