### PR TITLE
Upgrade sqlagg==0.18.0

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -659,7 +659,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlagg==0.17.2
+sqlagg==0.18.0
     # via -r base-requirements.in
 sqlalchemy==1.3.19
     # via

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -541,7 +541,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlagg==0.17.2
+sqlagg==0.18.0
     # via -r base-requirements.in
 sqlalchemy==1.3.19
     # via

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -525,7 +525,7 @@ socketpool==0.5.3
     # via -r base-requirements.in
 soupsieve==2.5
     # via beautifulsoup4
-sqlagg==0.17.2
+sqlagg==0.18.0
     # via -r base-requirements.in
 sqlalchemy==1.3.19
     # via

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -486,7 +486,7 @@ socketpool==0.5.3
     # via -r base-requirements.in
 soupsieve==2.5
     # via beautifulsoup4
-sqlagg==0.17.2
+sqlagg==0.18.0
     # via -r base-requirements.in
 sqlalchemy==1.3.19
     # via

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -539,7 +539,7 @@ socketpool==0.5.3
     # via -r base-requirements.in
 soupsieve==2.0.1
     # via beautifulsoup4
-sqlagg==0.17.2
+sqlagg==0.18.0
     # via -r base-requirements.in
 sqlalchemy==1.3.19
     # via


### PR DESCRIPTION
sqlagg has been modernized for compatibility with recent versions of Python. See related sqlagg PRs for relevant changes:

- https://github.com/dimagi/sql-agg/pull/72
- https://github.com/dimagi/sql-agg/pull/73

## Safety Assurance

### Safety story

The changes to sqlagg are mostly to tests and packaging infrastructure, and should not change functional behavior.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations