### PR TITLE
Updated display condition of pagination of case properties on form se…

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -326,7 +326,7 @@
       </tbody>
     </table>
     <div data-bind="if: searchAndFilter">
-      <div class="pull-right" data-bind="visible: filtered_case_properties().length">
+      <div class="pull-right" data-bind="visible: filtered_case_properties().length > per_page()">
         <pagination data-apply-bindings="false"
                     params="goToPage: goToPage,
                             perPage: per_page,


### PR DESCRIPTION
…ttings page

## Product Description
https://dimagi.atlassian.net/browse/PROD-23

Update this pagination to only show if there are multiple pages:

<img width="1070" alt="Screenshot 2025-04-07 at 8 26 26 PM" src="https://github.com/user-attachments/assets/3ebc22e3-c3be-4959-ab40-cecaf20ce6d9" />

We often don't bother doing this because the number of items per page can change (although there's still an argument for not showing pagination if there are fewer items than the lowest "per page" option), but on this page there's no items per page dropdown so it's especially easy.

Note the screenshot is from my local environment, which is tweaked to use 2 items per page instead of the real value of 10.

## Safety Assurance

### Safety story
Pretty tiny. Tested locally.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
