### PR TITLE
Disable deleting invalid case properties

### DIFF
--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -1,4 +1,3 @@
-import inspect
 import re
 from collections import defaultdict
 
@@ -429,11 +428,11 @@ def delete_case_property(
     case_property: str,
 ):
     """
-    Delete the OpenMRS identifier on the case.
+    Drops the value of ``case_property`` on the case identified by
+    ``domain`` and ``case_id``.
     """
-    members = dict(inspect.getmembers(CaseBlock.__init__.__code__))
-    case_block_args = members['co_varnames']
-    if case_property in case_block_args:
+    deletable_case_block_kwargs = ('external_id', 'case_name')
+    if case_property in deletable_case_block_kwargs:
         case_block_kwargs = {case_property: None}
     else:
         case_block_kwargs = {"update": {case_property: None}}

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -725,17 +725,29 @@ class DeleteCasePropertyTests(SimpleTestCase):
         """)
         self.assert_expected_case_block(case_property, case_block_re)
 
-    def test_too_much_rope_error(self):
+    def test_deletable_kwargs_1(self):
         case_property = "case_id"
-        with self.assertRaises(TypeError):
-            delete_case_property(DOMAIN, "CASE_ID", case_property)
+        case_block_re = strip_xml(f"""
+            <case case_id="CASE_ID" »
+                  date_modified="{DATETIME_PATTERN}" »
+                  xmlns="http://commcarehq.org/case/transaction/v2">
+              <update>
+                <case_id />
+              </update>
+            </case>
+        """)
+        self.assert_expected_case_block(case_property, case_block_re)
 
-    def test_too_much_rope_no_error(self):
+    def test_deletable_kwargs_2(self):
         case_property = "update"
         case_block_re = strip_xml(f"""
             <case case_id="CASE_ID" »
                   date_modified="{DATETIME_PATTERN}" »
-                  xmlns="http://commcarehq.org/case/transaction/v2" />
+                  xmlns="http://commcarehq.org/case/transaction/v2">
+              <update>
+                <update />
+              </update>
+            </case>
         """)
         self.assert_expected_case_block(case_property, case_block_re)
 


### PR DESCRIPTION
## Technical Summary

Fixes a potential bug that the Python 3.13 migration brought to my attention.

The `delete_case_property()` function is for disconnecting a CommCare case from an associated OpenMRS Patient (for example, if that Patient instance was merged with another Patient instance). The case property name that is passed to the function is the one configured to store the ID of the OpenMRS patient. This change is to prevent a misconfigured integration from deleting system case properties. See the unit tests for examples.

## Feature Flag

openmrs_integration

## Safety Assurance

### Safety story

* This change has no effect on a correctly-configured OpenMRS integration.
* I checked all OpenMRS configurations in production, and all use valid case property names.

### Automated test coverage

Yes

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
