### PR TITLE
[Data Cleaning] Address any concurrency issues (or potential issues) and performance imrovements

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -859,6 +859,13 @@ class BulkEditRecord(models.Model):
         # process inserts them concurrently:
         cls.objects.bulk_create(new_records, ignore_conflicts=True)
 
+        # re-update any records that might still not be marked if there
+        # were any conflicts above...
+        session.records.filter(
+            doc_id__in=doc_ids,
+            is_selected=False,
+        ).update(is_selected=True)
+
     @classmethod
     @transaction.atomic
     def deselect_multiple_records(cls, session, doc_ids):

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -854,7 +854,7 @@ class BulkEditRecord(models.Model):
         try:
             record = session.records.get(doc_id=doc_id)
         except cls.DoesNotExist:
-            return
+            return None
 
         if record.changes.count() > 0:
             record.is_selected = False

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -809,13 +809,11 @@ class BulkEditRecord(models.Model):
 
     @classmethod
     def select_record(cls, session, doc_id):
-        try:
-            record = session.records.get(doc_id=doc_id)
-        except cls.DoesNotExist:
-            record = cls.objects.create(
-                session=session,
-                doc_id=doc_id,
-            )
+        record, _ = cls.objects.get_or_create(
+            session=session,
+            doc_id=doc_id,
+            defaults={'is_selected': True}
+        )
         if not record.is_selected:
             record.is_selected = True
             record.save()

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -896,6 +896,7 @@ class BulkEditRecord(models.Model):
         ).update(is_selected=True)
 
     @classmethod
+    @retry_on_integrity_error(max_retries=3, delay=0.1)
     @transaction.atomic
     def deselect_multiple_records(cls, session, doc_ids):
         # update is_selected to False for all selected records that have changes

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -223,6 +223,7 @@ class BulkEditSession(models.Model):
         """
         self._delete_and_update_order(self.filters, 'filter_id', filter_id)
 
+    @retry_on_integrity_error(max_retries=3, delay=0.1)
     def remove_column(self, column_id):
         """
         Remove a BulkEditColumn from this session by its column_id,
@@ -230,7 +231,8 @@ class BulkEditSession(models.Model):
 
         :param column_id: UUID of the BulkEditColumn to remove
         """
-        self._delete_and_update_order(self.columns, 'column_id', column_id)
+        with transaction.atomic():
+            self._delete_and_update_order(self.columns, 'column_id', column_id)
 
     def get_queryset(self):
         query = CaseSearchES().domain(self.domain).case_type(self.identifier)

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -214,6 +214,7 @@ class BulkEditSession(models.Model):
         remaining_ids = related_manager.values_list(id_field, flat=True)
         self._update_order(related_manager, id_field, remaining_ids)
 
+    @retry_on_integrity_error(max_retries=3, delay=0.1)
     def remove_filter(self, filter_id):
         """
         Remove a BulkEditFilter from this session by its filter_id,
@@ -221,7 +222,8 @@ class BulkEditSession(models.Model):
 
         :param filter_id: UUID of the BulkEditFilter to remove
         """
-        self._delete_and_update_order(self.filters, 'filter_id', filter_id)
+        with transaction.atomic():
+            self._delete_and_update_order(self.filters, 'filter_id', filter_id)
 
     @retry_on_integrity_error(max_retries=3, delay=0.1)
     def remove_column(self, column_id):

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -174,10 +174,15 @@ class BulkEditSession(models.Model):
                 "Please provide a list of ALL existing object ids in the desired order."
             )
 
-        instance_map = {getattr(obj, id_field): obj for obj in related_manager.all()}
+        # NOTE: We cast the id_field to a string in the instance map to avoid UUID comparison
+        # as the forms will be sending the ids as strings, while the remove_method sends it
+        # as UUID objects.
+        instance_map = {str(getattr(obj, id_field)): obj for obj in related_manager.all()}
         for index, object_id in enumerate(provided_ids):
             try:
-                instance = instance_map[object_id]
+                # We need to cast the object_id to a string to match the instance_map keys
+                # in case the provided_ids are UUIDs.
+                instance = instance_map[str(object_id)]
             except KeyError:
                 raise ValueError(f"Object with {id_field} {object_id} not found.")
             instance.index = index

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -849,6 +849,7 @@ class BulkEditRecord(models.Model):
         return record
 
     @classmethod
+    @retry_on_integrity_error(max_retries=3, delay=0.1)
     def deselect_record(cls, session, doc_id):
         try:
             record = session.records.get(doc_id=doc_id)

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -182,7 +182,8 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         session.add_filter('pot_type', DataType.DATE, FilterMatchType.IS_EMPTY)
         session.add_filter('height_cm', DataType.DECIMAL, FilterMatchType.LESS_THAN_EQUAL, "11.0")
         filters = session.filters.all()
-        new_order = [filters[1].filter_id, filters[2].filter_id]
+        # the form that uses this method will always fetch a list of strings, and the field is a UUID
+        new_order = [str(filter_id) for filter_id in [filters[1].filter_id, filters[2].filter_id]]
         with self.assertRaises(ValueError):
             session.update_filter_order(new_order)
 
@@ -194,13 +195,14 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         session.add_filter('pot_type', DataType.DATE, FilterMatchType.IS_EMPTY)
         session.add_filter('height_cm', DataType.DECIMAL, FilterMatchType.LESS_THAN_EQUAL, "11.0")
         filters = session.filters.all()
-        new_order = [
+        # the form that uses this method will always fetch a list of strings, and the field is a UUID
+        new_order = [str(filter_id) for filter_id in [
             filters[1].filter_id,
             filters[0].filter_id,
             filters[2].filter_id,
             filters[4].filter_id,
             filters[3].filter_id,
-        ]
+        ]]
         session.update_filter_order(new_order)
         reordered_prop_ids = [c.prop_id for c in session.filters.all()]
         self.assertEqual(
@@ -211,21 +213,23 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
     def test_reorder_wrong_number_of_column_ids_raises_error(self):
         session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
         columns = session.columns.all()
-        new_order = [columns[1].column_id, columns[2].column_id]
+        # the form that uses this method will always fetch a list of strings, and the field is a UUID
+        new_order = [str(col_id) for col_id in [columns[1].column_id, columns[2].column_id]]
         with self.assertRaises(ValueError):
             session.update_column_order(new_order)
 
     def test_update_column_order(self):
         session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
         columns = session.columns.all()
-        new_order = [
+        # the form that uses this method will always fetch a list of strings, and the field is a UUID
+        new_order = [str(col_id) for col_id in [
             columns[1].column_id,
             columns[0].column_id,
             columns[2].column_id,
             columns[4].column_id,
             columns[5].column_id,
             columns[3].column_id,
-        ]
+        ]]
         session.update_column_order(new_order)
         reordered_prop_ids = [c.prop_id for c in session.columns.all()]
         self.assertEqual(

--- a/corehq/apps/data_cleaning/utils/decorators.py
+++ b/corehq/apps/data_cleaning/utils/decorators.py
@@ -1,0 +1,20 @@
+import time
+from django.db import IntegrityError
+
+
+def retry_on_integrity_error(max_retries=3, delay=0.1):
+    """
+    Decorator to retry a function call if an IntegrityError occurs.
+    """
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            for attempt in range(max_retries):
+                try:
+                    return func(*args, **kwargs)
+                except IntegrityError:
+                    if attempt < max_retries - 1:
+                        time.sleep(delay)
+                    else:
+                        raise
+        return wrapper
+    return decorator

--- a/corehq/apps/data_cleaning/utils/decorators.py
+++ b/corehq/apps/data_cleaning/utils/decorators.py
@@ -8,11 +8,12 @@ def retry_on_integrity_error(max_retries=3, delay=0.1):
     """
     def decorator(func):
         def wrapper(*args, **kwargs):
-            for attempt in range(max_retries):
+            # note: the zero-th 'attempt' is not a 'retry', it is the first call
+            for attempt in range(max_retries + 1):
                 try:
                     return func(*args, **kwargs)
                 except IntegrityError:
-                    if attempt < max_retries - 1:
+                    if attempt < max_retries:
                         time.sleep(delay)
                     else:
                         raise


### PR DESCRIPTION
## Technical Summary
In an HTMX world, we need to always be defensive against and robustly handle concurrency issues with the db because they absolutely will happen.

This PR addresses any potential concurrency issues in data cleaning models and implements a retry in case any action results in an `IntegrityError`.

should address this 🐞 
https://dimagi.atlassian.net/browse/SAAS-17358

Additionally, I've made a couple small performance improvements.


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
very safe change. tests still pass and all of changed logic is tested. only affects feature flagged workflows

### Automated test coverage
yes

### QA Plan
not yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
