### PR TITLE
[Data Cleaning] Add placeholder view for the data cleaning form

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+{% load crispy_forms_tags %}
+
+<div
+  id="{{ container_id }}"
+  hx-swap="outerHTML"
+  hq-hx-refresh-swap="#CleanCaseTable"
+>
+  # todo clean cases form goes here
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/offcanvas.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/offcanvas.html
@@ -75,6 +75,11 @@
     ></button>
   </div>
   <div class="offcanvas-body">
-    <p>todo</p>
+    <div
+      hx-get="{% url "data_cleaning_clean_selected_records_form" domain session_id %}"
+      hx-trigger="load"
+    >
+      {% include "data_cleaning/partials/loading_indicator.html" %}
+    </div>
   </div>
 </div>

--- a/corehq/apps/data_cleaning/tests/test_views.py
+++ b/corehq/apps/data_cleaning/tests/test_views.py
@@ -7,6 +7,9 @@ from corehq.apps.data_cleaning.models import (
     BulkEditSession,
 )
 from corehq.apps.data_cleaning.utils.cases import clear_caches_case_data_cleaning
+from corehq.apps.data_cleaning.views.cleaning import (
+    CleanSelectedRecordsFormView,
+)
 from corehq.apps.data_cleaning.views.columns import (
     ManageColumnsFormView,
 )
@@ -102,12 +105,16 @@ class CleanCasesViewAccessTest(TestCase):
             (ManageFiltersFormView, (cls.domain_name, cls.fake_session_id,)),
             (ManageColumnsFormView, (cls.domain_name, cls.real_session_id,)),
             (ManageColumnsFormView, (cls.domain_name, cls.fake_session_id,)),
+            (ManageFiltersFormView, (cls.domain_name, cls.fake_session_id,)),
+            (CleanSelectedRecordsFormView, (cls.domain_name, cls.real_session_id,)),
+            (CleanSelectedRecordsFormView, (cls.domain_name, cls.fake_session_id,)),
         ]
         cls.views_not_found_with_invalid_session = [
             CleanCasesTableView,
             PinnedFilterFormView,
             ManageFiltersFormView,
             ManageColumnsFormView,
+            CleanSelectedRecordsFormView,
         ]
 
         clear_caches_case_data_cleaning(cls.domain_name)

--- a/corehq/apps/data_cleaning/urls.py
+++ b/corehq/apps/data_cleaning/urls.py
@@ -1,5 +1,8 @@
 from django.urls import re_path as url
 
+from corehq.apps.data_cleaning.views.cleaning import (
+    CleanSelectedRecordsFormView,
+)
 from corehq.apps.data_cleaning.views.columns import (
     ManageColumnsFormView,
 )
@@ -36,6 +39,8 @@ urlpatterns = [
         name=PinnedFilterFormView.urlname),
     url(r'^session/(?P<session_id>[\w\-]+)/columns/$', ManageColumnsFormView.as_view(),
         name=ManageColumnsFormView.urlname),
+    url(r'^session/(?P<session_id>[\w\-]+)/clean/$', CleanSelectedRecordsFormView.as_view(),
+        name=CleanSelectedRecordsFormView.urlname),
     url(r'^session/(?P<session_id>[\w\-]+)/clear/$', clear_session_caches,
         name="data_cleaning_clear_session_caches"),
     url(r'^cases/save/(?P<session_id>[\w\-]+)/$', save_case_session, name='save_case_session'),

--- a/corehq/apps/data_cleaning/views/cleaning.py
+++ b/corehq/apps/data_cleaning/views/cleaning.py
@@ -1,0 +1,29 @@
+from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy
+from django.views.generic import TemplateView
+
+from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
+from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
+from corehq.apps.domain.decorators import LoginAndDomainMixin
+from corehq.apps.domain.views import DomainViewMixin
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.util.htmx_action import HqHtmxActionMixin
+
+
+@method_decorator([
+    use_bootstrap5,
+    require_bulk_data_cleaning_cases,
+], name='dispatch')
+class CleanSelectedRecordsFormView(BulkEditSessionViewMixin,
+                                   LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
+    urlname = "data_cleaning_clean_selected_records_form"
+    template_name = "data_cleaning/forms/clean_selected_records_form.html"
+    session_not_found_message = gettext_lazy("Cannot load clean selected records form, session was not found.")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update({
+            'container_id': 'clean-selected-records',
+            'session': self.session,  # temporarily calling this here so that access tests pass
+        })
+        return context


### PR DESCRIPTION
## Technical Summary
Quick and simple PR to add the placeholder view and template for the data cleaning form, `CleanSelectedRecordsFormView`.

<img width="641" alt="Screenshot 2025-04-09 at 2 56 34 PM" src="https://github.com/user-attachments/assets/b6e1cf7f-fe2e-459d-8c5c-b9ebb2261c42" />


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
very safe change, view access is tested, only affects feature flagged workflows

### Automated test coverage
yes, view access is tested

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
