### PR TITLE
Remove es6 prefix and bootstrap 5 loader module

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -4,7 +4,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
     'underscore',
     'DOMPurify',
     'hqwebapp/js/toggles',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'cloudcare/js/markdown',
     'cloudcare/js/utils',
     'cloudcare/js/form_entry/const',

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -4,7 +4,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
     'underscore',
     'DOMPurify',
     'hqwebapp/js/toggles',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'cloudcare/js/markdown',
     'cloudcare/js/utils',
     'cloudcare/js/form_entry/const',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -8,7 +8,7 @@ hqDefine("cloudcare/js/formplayer/app", [
     'backbone',
     'backbone.marionette',
     'markdown-it/dist/markdown-it',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'hqwebapp/js/initial_page_data',
     'analytix/js/appcues',
     'analytix/js/google',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -8,7 +8,7 @@ hqDefine("cloudcare/js/formplayer/app", [
     'backbone',
     'backbone.marionette',
     'markdown-it/dist/markdown-it',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'hqwebapp/js/initial_page_data',
     'analytix/js/appcues',
     'analytix/js/google',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -3,7 +3,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", [
     'underscore',
     'backbone',
     'DOMPurify',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
     'cloudcare/js/markdown',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -3,7 +3,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", [
     'underscore',
     'backbone',
     'DOMPurify',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
     'cloudcare/js/markdown',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -4,7 +4,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
     'backbone',
     'backbone.marionette',
     'DOMPurify',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
     'analytix/js/kissmetrix',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -4,7 +4,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
     'backbone',
     'backbone.marionette',
     'DOMPurify',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
     'analytix/js/kissmetrix',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -3,7 +3,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", [
     'underscore',
     'backbone',
     'DOMPurify',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
     "cloudcare/js/formplayer/constants",

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -3,7 +3,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", [
     'underscore',
     'backbone',
     'DOMPurify',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
     "cloudcare/js/formplayer/constants",

--- a/corehq/apps/commtrack/static/commtrack/js/base_list_view_model.js
+++ b/corehq/apps/commtrack/static/commtrack/js/base_list_view_model.js
@@ -3,7 +3,7 @@ hqDefine("commtrack/js/base_list_view_model", [
     'jquery',
     'knockout',
     'underscore',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
 ], function (
     $,
     ko,

--- a/corehq/apps/commtrack/static/commtrack/js/base_list_view_model.js
+++ b/corehq/apps/commtrack/static/commtrack/js/base_list_view_model.js
@@ -3,7 +3,7 @@ hqDefine("commtrack/js/base_list_view_model", [
     'jquery',
     'knockout',
     'underscore',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
 ], function (
     $,
     ko,

--- a/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
+++ b/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
@@ -1,10 +1,9 @@
-
 hqDefine('commtrack/js/products_and_programs_main', [
     'jquery',
     'knockout',
     'underscore',
     'hqwebapp/js/initial_page_data',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'commtrack/js/base_list_view_model',
     'hqwebapp/js/bootstrap5/widgets',   // "Additional Information" on product page uses a .hqwebapp-select2
     'hqwebapp/js/bootstrap5/knockout_bindings.ko',  // fadeVisible

--- a/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
+++ b/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
@@ -60,8 +60,8 @@ hqDefine('commtrack/js/products_and_programs_main', [
                         message = data.message || _.template(gettext("Could not <%= action %> product. Please try again later."))({action: $(button).text().toLowerCase()});
                     alertContainer.text(message);
                     alertContainer.removeClass("d-none");
-                    var $modal = $(button).closest(".modal"),
-                        bootstrap.Modal.getOrCreateInstance($modal);
+                    var $modal = $(button).closest(".modal");
+                    bootstrap.Modal.getOrCreateInstance($modal);
                     $modal.one('hidden.bs.modal', function () {
                         alertContainer.addClass("d-none");
                     });

--- a/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
+++ b/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
@@ -4,7 +4,7 @@ hqDefine('commtrack/js/products_and_programs_main', [
     'knockout',
     'underscore',
     'hqwebapp/js/initial_page_data',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'commtrack/js/base_list_view_model',
     'hqwebapp/js/bootstrap5/widgets',   // "Additional Information" on product page uses a .hqwebapp-select2
     'hqwebapp/js/bootstrap5/knockout_bindings.ko',  // fadeVisible

--- a/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
+++ b/corehq/apps/commtrack/static/commtrack/js/products_and_programs_main.js
@@ -61,7 +61,7 @@ hqDefine('commtrack/js/products_and_programs_main', [
                     alertContainer.text(message);
                     alertContainer.removeClass("d-none");
                     var $modal = $(button).closest(".modal"),
-                        modal = bootstrap.Modal.getOrCreateInstance($modal);
+                        bootstrap.Modal.getOrCreateInstance($modal);
                     $modal.one('hidden.bs.modal', function () {
                         alertContainer.addClass("d-none");
                     });

--- a/corehq/apps/export/static/export/js/customize_export_new.js
+++ b/corehq/apps/export/static/export/js/customize_export_new.js
@@ -1,7 +1,7 @@
 hqDefine('export/js/customize_export_new', [
     'jquery',
     'knockout',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'hqwebapp/js/initial_page_data',
     'export/js/models',
     'hqwebapp/js/toggles',

--- a/corehq/apps/export/static/export/js/customize_export_new.js
+++ b/corehq/apps/export/static/export/js/customize_export_new.js
@@ -1,7 +1,7 @@
 hqDefine('export/js/customize_export_new', [
     'jquery',
     'knockout',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'hqwebapp/js/initial_page_data',
     'export/js/models',
     'hqwebapp/js/toggles',

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -16,7 +16,7 @@ hqDefine("export/js/export_list", [
     'knockout',
     'underscore',
     'hqwebapp/js/assert_properties',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'clipboard/dist/clipboard',
     'analytix/js/google',
     'analytix/js/kissmetrix',

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -16,7 +16,7 @@ hqDefine("export/js/export_list", [
     'knockout',
     'underscore',
     'hqwebapp/js/assert_properties',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'clipboard/dist/clipboard',
     'analytix/js/google',
     'analytix/js/kissmetrix',

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -8,7 +8,7 @@ hqDefine('export/js/models', [
     'jquery',
     'knockout',
     'underscore',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
     'analytix/js/google',

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -8,7 +8,7 @@ hqDefine('export/js/models', [
     'jquery',
     'knockout',
     'underscore',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
     'analytix/js/google',

--- a/corehq/apps/groups/static/groups/js/all_groups.js
+++ b/corehq/apps/groups/static/groups/js/all_groups.js
@@ -1,7 +1,7 @@
 hqDefine("groups/js/all_groups", [
     'jquery',
     'analytix/js/google',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     // Just importing main.py so the post-link function is accessible, function parameter not needed
     'hqwebapp/js/bootstrap5/main',
     'commcarehq',

--- a/corehq/apps/groups/static/groups/js/all_groups.js
+++ b/corehq/apps/groups/static/groups/js/all_groups.js
@@ -1,8 +1,7 @@
-
 hqDefine("groups/js/all_groups", [
     'jquery',
     'analytix/js/google',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     // Just importing main.py so the post-link function is accessible, function parameter not needed
     'hqwebapp/js/bootstrap5/main',
     'commcarehq',

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -1,9 +1,8 @@
-
 hqDefine("groups/js/group_members", [
     "jquery",
     "underscore",
     "analytix/js/google",
-    "es6!hqwebapp/js/bootstrap5_loader",
+    "hqwebapp/js/bootstrap5_loader",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap5/alert_user",
     "hqwebapp/js/ui_elements/bootstrap5/ui-element-key-val-list",

--- a/corehq/apps/groups/static/groups/js/group_members.js
+++ b/corehq/apps/groups/static/groups/js/group_members.js
@@ -2,7 +2,7 @@ hqDefine("groups/js/group_members", [
     "jquery",
     "underscore",
     "analytix/js/google",
-    "hqwebapp/js/bootstrap5_loader",
+    "bootstrap5",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap5/alert_user",
     "hqwebapp/js/ui_elements/bootstrap5/ui-element-key-val-list",

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/500.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/500.js
@@ -1,6 +1,6 @@
 hqDefine("hqwebapp/js/500",[
     'jquery',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'commcarehq',
 ], function ($, bootstrap) {
     $(function () {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/500.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/500.js
@@ -1,6 +1,6 @@
 hqDefine("hqwebapp/js/500",[
     'jquery',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'commcarehq',
 ], function ($, bootstrap) {
     $(function () {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/common.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/common.js
@@ -3,7 +3,7 @@ hqDefine("hqwebapp/js/bootstrap5/common", [
     'knockout',
     'ko.mapping',
     'underscore',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
 ], function () {
     // nothing to do, this is just to define the major common dependencies for HQ
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/common.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/common.js
@@ -3,7 +3,6 @@ hqDefine("hqwebapp/js/bootstrap5/common", [
     'knockout',
     'ko.mapping',
     'underscore',
-    // the es6! loaders below (without the prefix) are necessary to fix build issues with these modules
     'hqwebapp/js/bootstrap5_loader',
 ], function () {
     // nothing to do, this is just to define the major common dependencies for HQ

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list.js
@@ -3,7 +3,7 @@ hqDefine("hqwebapp/js/bootstrap5/crud_paginated_list", [
     "jquery",
     "knockout",
     "underscore",
-    "es6!hqwebapp/js/bootstrap5_loader",
+    "hqwebapp/js/bootstrap5_loader",
     'hqwebapp/js/bootstrap5/knockout_bindings.ko',  // fadeVisible
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/crud_paginated_list.js
@@ -3,7 +3,7 @@ hqDefine("hqwebapp/js/bootstrap5/crud_paginated_list", [
     "jquery",
     "knockout",
     "underscore",
-    "hqwebapp/js/bootstrap5_loader",
+    "bootstrap5",
     'hqwebapp/js/bootstrap5/knockout_bindings.ko',  // fadeVisible
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
@@ -1,7 +1,7 @@
 hqDefine('hqwebapp/js/bootstrap5/email-request', [
     "jquery",
     "knockout",
-    "es6!hqwebapp/js/bootstrap5_loader",
+    "hqwebapp/js/bootstrap5_loader",
     "hqwebapp/js/bootstrap5/hq.helpers",
 ], function ($, ko, bootstrap) {
     var EmailRequest = function (modalId, formId) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
@@ -1,7 +1,7 @@
 hqDefine('hqwebapp/js/bootstrap5/email-request', [
     "jquery",
     "knockout",
-    "hqwebapp/js/bootstrap5_loader",
+    "bootstrap5",
     "hqwebapp/js/bootstrap5/hq.helpers",
 ], function ($, ko, bootstrap) {
     var EmailRequest = function (modalId, formId) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
@@ -3,7 +3,7 @@ hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
     'knockout',
     'underscore',
     'analytix/js/google',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'jquery.cookie/jquery.cookie',  // $.cookie
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
@@ -3,7 +3,7 @@ hqDefine("hqwebapp/js/bootstrap5/hq.helpers", [
     'knockout',
     'underscore',
     'analytix/js/google',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'jquery.cookie/jquery.cookie',  // $.cookie
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/inactivity.js
@@ -5,7 +5,7 @@
 hqDefine('hqwebapp/js/bootstrap5/inactivity', [
     'jquery',
     'underscore',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'hqwebapp/js/assert_properties',
     'hqwebapp/js/initial_page_data',
 ], function (

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/inactivity.js
@@ -5,7 +5,7 @@
 hqDefine('hqwebapp/js/bootstrap5/inactivity', [
     'jquery',
     'underscore',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'hqwebapp/js/assert_properties',
     'hqwebapp/js/initial_page_data',
 ], function (

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
@@ -2,7 +2,7 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
     'jquery',
     'underscore',
     'knockout',
-    "es6!hqwebapp/js/bootstrap5_loader",
+    "hqwebapp/js/bootstrap5_loader",
     'jquery-ui/ui/widgets/sortable',
     'langcodes/js/langcodes',   // $.langcodes
 ], function (

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
@@ -2,7 +2,7 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
     'jquery',
     'underscore',
     'knockout',
-    "hqwebapp/js/bootstrap5_loader",
+    "bootstrap5",
     'jquery-ui/ui/widgets/sortable',
     'langcodes/js/langcodes',   // $.langcodes
 ], function (

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
@@ -244,8 +244,8 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
                 } else {
                     // Clicking a row selects it for sorting and unselects all other rows.
                     $(this).addClass('last-clicked').siblings().removeClass('last-clicked');
-                    for (var i = 0; i < list().length; i++) {
-                        list()[i].selectedForSort(false);
+                    for (var j = 0; j < list().length; j++) {
+                        list()[j].selectedForSort(false);
                     }
                     getExportColumnByRow($(this)).selectedForSort(true);
                 }
@@ -343,7 +343,7 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
     };
 
     ko.bindingHandlers.modal = {
-        init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+        init: function (element, valueAccessor, allBindingsAccessor, viewModel) {
             viewModel.binding_modal = new bootstrap.Modal(element);
         },
         update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
@@ -420,7 +420,7 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
                 };
             ko.bindingHandlers.click.init(element, newValueAccessor, allBindingsAccessor, viewModel, bindingContext);
         },
-        update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+        update: function (element, valueAccessor) {
             $(element).data('ajaxSource', ko.utils.unwrapObservable(valueAccessor()));
         },
     };
@@ -537,7 +537,7 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
                 controlsDescendantBindings: true,
             };
         },
-        update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
+        update: function (element, valueAccessor) {
             $(element).empty();
             $(element).append(ko.unwrap(valueAccessor()));
         },
@@ -611,7 +611,6 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
     ko.bindingHandlers.paste = {
         init: function (element, valueAccessor) {
             ko.bindingHandlers.__copyPasteSharedInit();
-            var callback = valueAccessor();
             $(element).data('pasteCallback', valueAccessor());
         },
     };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
@@ -6,7 +6,7 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap5/alert_user",
     "analytix/js/google",
-    "es6!hqwebapp/js/bootstrap5_loader",
+    "hqwebapp/js/bootstrap5_loader",
     "hqwebapp/js/hq_extensions.jquery",
     "jquery.cookie/jquery.cookie",
 ], function (

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
@@ -6,7 +6,7 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/bootstrap5/alert_user",
     "analytix/js/google",
-    "hqwebapp/js/bootstrap5_loader",
+    "bootstrap5",
     "hqwebapp/js/hq_extensions.jquery",
     "jquery.cookie/jquery.cookie",
 ], function (

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/mobile_experience_warning.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/mobile_experience_warning.js
@@ -1,9 +1,8 @@
-
 hqDefine('hqwebapp/js/bootstrap5/mobile_experience_warning', [
     "jquery",
     "hqwebapp/js/initial_page_data",
     "analytix/js/kissmetrix",
-    "es6!hqwebapp/js/bootstrap5_loader",
+    "hqwebapp/js/bootstrap5_loader",
     "jquery.cookie/jquery.cookie",
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/mobile_experience_warning.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/mobile_experience_warning.js
@@ -2,7 +2,7 @@ hqDefine('hqwebapp/js/bootstrap5/mobile_experience_warning', [
     "jquery",
     "hqwebapp/js/initial_page_data",
     "analytix/js/kissmetrix",
-    "hqwebapp/js/bootstrap5_loader",
+    "bootstrap5",
     "jquery.cookie/jquery.cookie",
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/sticky_tabs.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/sticky_tabs.js
@@ -4,7 +4,7 @@
  */
 hqDefine("hqwebapp/js/bootstrap5/sticky_tabs", [
     "jquery",
-    "hqwebapp/js/bootstrap5_loader",    // needed for $.tab
+    "bootstrap5",
 ], function (
     $, bootstrap,
 ) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/sticky_tabs.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/sticky_tabs.js
@@ -4,7 +4,7 @@
  */
 hqDefine("hqwebapp/js/bootstrap5/sticky_tabs", [
     "jquery",
-    "es6!hqwebapp/js/bootstrap5_loader",    // needed for $.tab
+    "hqwebapp/js/bootstrap5_loader",    // needed for $.tab
 ], function (
     $, bootstrap,
 ) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5_loader.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5_loader.js
@@ -1,5 +1,0 @@
-hqDefine("hqwebapp/js/bootstrap5_loader", [
-    'bootstrap5',
-], function (bootstrap5) {
-    return bootstrap5;
-});

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5_loader.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5_loader.js
@@ -1,4 +1,4 @@
-hqDefine("es6!hqwebapp/js/bootstrap5_loader", [
+hqDefine("hqwebapp/js/bootstrap5_loader", [
     'bootstrap5',
 ], function (bootstrap5) {
     return bootstrap5;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -78,7 +78,7 @@ function hqDefine(path, dependencies, moduleAccessor) {
                 'hqwebapp/js/lib/modernizr': 'Modernizr',
             };
             if (window.USE_BOOTSTRAP5) {
-                thirdPartyGlobals['hqwebapp/js/bootstrap5_loader'] = 'bootstrap';
+                thirdPartyGlobals['bootstrap5'] = 'bootstrap';
                 thirdPartyGlobals['tempusDominus'] = 'tempusDominus';
             }
             var args = [];

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -78,7 +78,7 @@ function hqDefine(path, dependencies, moduleAccessor) {
                 'hqwebapp/js/lib/modernizr': 'Modernizr',
             };
             if (window.USE_BOOTSTRAP5) {
-                thirdPartyGlobals['es6!hqwebapp/js/bootstrap5_loader'] = 'bootstrap';
+                thirdPartyGlobals['hqwebapp/js/bootstrap5_loader'] = 'bootstrap';
                 thirdPartyGlobals['tempusDominus'] = 'tempusDominus';
             }
             var args = [];

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/common.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/common.js.diff.txt
@@ -8,7 +8,7 @@
      'ko.mapping',
      'underscore',
 -    'bootstrap',
-+    'hqwebapp/js/bootstrap5_loader',
++    'bootstrap5',
  ], function () {
      // nothing to do, this is just to define the major common dependencies for HQ
  });

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/common.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/common.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,9 +1,10 @@
+@@ -1,9 +1,9 @@
 -hqDefine("hqwebapp/js/bootstrap3/common", [
 +hqDefine("hqwebapp/js/bootstrap5/common", [
      'jquery',
@@ -8,7 +8,6 @@
      'ko.mapping',
      'underscore',
 -    'bootstrap',
-+    // the es6! loaders below (without the prefix) are necessary to fix build issues with these modules
 +    'hqwebapp/js/bootstrap5_loader',
  ], function () {
      // nothing to do, this is just to define the major common dependencies for HQ

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list.js.diff.txt
@@ -8,7 +8,7 @@
      "knockout",
      "underscore",
 -    "hqwebapp/js/bootstrap3/knockout_bindings.ko",  // fadeVisible
-+    "es6!hqwebapp/js/bootstrap5_loader",
++    "hqwebapp/js/bootstrap5_loader",
 +    'hqwebapp/js/bootstrap5/knockout_bindings.ko',  // fadeVisible
  ], function (
      $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/crud_paginated_list.js.diff.txt
@@ -8,7 +8,7 @@
      "knockout",
      "underscore",
 -    "hqwebapp/js/bootstrap3/knockout_bindings.ko",  // fadeVisible
-+    "hqwebapp/js/bootstrap5_loader",
++    "bootstrap5",
 +    'hqwebapp/js/bootstrap5/knockout_bindings.ko',  // fadeVisible
  ], function (
      $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/email-request.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/email-request.js.diff.txt
@@ -8,7 +8,7 @@
 -    "hqwebapp/js/bootstrap3/hq.helpers",
 -], function ($, ko) {
 -
-+    "hqwebapp/js/bootstrap5_loader",
++    "bootstrap5",
 +    "hqwebapp/js/bootstrap5/hq.helpers",
 +], function ($, ko, bootstrap) {
      var EmailRequest = function (modalId, formId) {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/email-request.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/email-request.js.diff.txt
@@ -8,7 +8,7 @@
 -    "hqwebapp/js/bootstrap3/hq.helpers",
 -], function ($, ko) {
 -
-+    "es6!hqwebapp/js/bootstrap5_loader",
++    "hqwebapp/js/bootstrap5_loader",
 +    "hqwebapp/js/bootstrap5/hq.helpers",
 +], function ($, ko, bootstrap) {
      var EmailRequest = function (modalId, formId) {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
@@ -8,7 +8,7 @@
      'underscore',
      'analytix/js/google',
 -    'bootstrap',  // for popover constructor override
-+    'es6!hqwebapp/js/bootstrap5_loader',
++    'hqwebapp/js/bootstrap5_loader',
      'jquery.cookie/jquery.cookie',  // $.cookie
  ], function (
      $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
@@ -8,7 +8,7 @@
      'underscore',
      'analytix/js/google',
 -    'bootstrap',  // for popover constructor override
-+    'hqwebapp/js/bootstrap5_loader',
++    'bootstrap5',
      'jquery.cookie/jquery.cookie',  // $.cookie
  ], function (
      $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/inactivity.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/inactivity.js.diff.txt
@@ -8,7 +8,7 @@
 +hqDefine('hqwebapp/js/bootstrap5/inactivity', [
      'jquery',
      'underscore',
-+    'es6!hqwebapp/js/bootstrap5_loader',
++    'hqwebapp/js/bootstrap5_loader',
      'hqwebapp/js/assert_properties',
      'hqwebapp/js/initial_page_data',
  ], function (

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/inactivity.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/inactivity.js.diff.txt
@@ -8,7 +8,7 @@
 +hqDefine('hqwebapp/js/bootstrap5/inactivity', [
      'jquery',
      'underscore',
-+    'hqwebapp/js/bootstrap5_loader',
++    'bootstrap5',
      'hqwebapp/js/assert_properties',
      'hqwebapp/js/initial_page_data',
  ], function (

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
@@ -17,14 +17,27 @@
  ) {
      // Need this due to https://github.com/knockout/knockout/pull/2324
      // so that ko.bindingHandlers.foreach.update works properly
-@@ -342,19 +344,15 @@
+@@ -242,8 +244,8 @@
+                 } else {
+                     // Clicking a row selects it for sorting and unselects all other rows.
+                     $(this).addClass('last-clicked').siblings().removeClass('last-clicked');
+-                    for (var i = 0; i < list().length; i++) {
+-                        list()[i].selectedForSort(false);
++                    for (var j = 0; j < list().length; j++) {
++                        list()[j].selectedForSort(false);
+                     }
+                     getExportColumnByRow($(this)).selectedForSort(true);
+                 }
+@@ -341,20 +343,16 @@
+     };
  
      ko.bindingHandlers.modal = {
-         init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+-        init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
 -            $(element).addClass('modal fade').modal({
 -                show: false,
 -            });
 -            //        ko.bindingHandlers['if'].init(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext);
++        init: function (element, valueAccessor, allBindingsAccessor, viewModel) {
 +            viewModel.binding_modal = new bootstrap.Modal(element);
          },
          update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
@@ -83,7 +96,7 @@
                      };
                      return clickAction;
                  };
-@@ -403,11 +408,13 @@
+@@ -403,17 +408,19 @@
  
      ko.bindingHandlers.openRemoteModal = {
          init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
@@ -100,7 +113,31 @@
                      };
                      return clickAction;
                  };
-@@ -643,7 +650,7 @@
+             ko.bindingHandlers.click.init(element, newValueAccessor, allBindingsAccessor, viewModel, bindingContext);
+         },
+-        update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
++        update: function (element, valueAccessor) {
+             $(element).data('ajaxSource', ko.utils.unwrapObservable(valueAccessor()));
+         },
+     };
+@@ -530,7 +537,7 @@
+                 controlsDescendantBindings: true,
+             };
+         },
+-        update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
++        update: function (element, valueAccessor) {
+             $(element).empty();
+             $(element).append(ko.unwrap(valueAccessor()));
+         },
+@@ -604,7 +611,6 @@
+     ko.bindingHandlers.paste = {
+         init: function (element, valueAccessor) {
+             ko.bindingHandlers.__copyPasteSharedInit();
+-            var callback = valueAccessor();
+             $(element).data('pasteCallback', valueAccessor());
+         },
+     };
+@@ -643,7 +649,7 @@
                  options.sanitize = false;
              }
              if (options.title || options.content) { // don't show empty popovers

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
@@ -6,7 +6,7 @@
      'jquery',
      'underscore',
      'knockout',
-+    "hqwebapp/js/bootstrap5_loader",
++    "bootstrap5",
      'jquery-ui/ui/widgets/sortable',
      'langcodes/js/langcodes',   // $.langcodes
  ], function (

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
@@ -6,7 +6,7 @@
      'jquery',
      'underscore',
      'knockout',
-+    "es6!hqwebapp/js/bootstrap5_loader",
++    "hqwebapp/js/bootstrap5_loader",
      'jquery-ui/ui/widgets/sortable',
      'langcodes/js/langcodes',   // $.langcodes
  ], function (

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
@@ -11,7 +11,7 @@
 -    "hqwebapp/js/bootstrap3/alert_user",
 +    "hqwebapp/js/bootstrap5/alert_user",
      "analytix/js/google",
-+    "hqwebapp/js/bootstrap5_loader",
++    "bootstrap5",
      "hqwebapp/js/hq_extensions.jquery",
      "jquery.cookie/jquery.cookie",
  ], function (

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
@@ -11,7 +11,7 @@
 -    "hqwebapp/js/bootstrap3/alert_user",
 +    "hqwebapp/js/bootstrap5/alert_user",
      "analytix/js/google",
-+    "es6!hqwebapp/js/bootstrap5_loader",
++    "hqwebapp/js/bootstrap5_loader",
      "hqwebapp/js/hq_extensions.jquery",
      "jquery.cookie/jquery.cookie",
  ], function (

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/mobile_experience_warning.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/mobile_experience_warning.js.diff.txt
@@ -1,13 +1,13 @@
 --- 
 +++ 
-@@ -1,47 +1,47 @@
- 
+@@ -1,47 +1,46 @@
+-
 -hqDefine('hqwebapp/js/bootstrap3/mobile_experience_warning', [
 +hqDefine('hqwebapp/js/bootstrap5/mobile_experience_warning', [
      "jquery",
      "hqwebapp/js/initial_page_data",
      "analytix/js/kissmetrix",
-+    "es6!hqwebapp/js/bootstrap5_loader",
++    "hqwebapp/js/bootstrap5_loader",
      "jquery.cookie/jquery.cookie",
  ], function (
      $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/mobile_experience_warning.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/mobile_experience_warning.js.diff.txt
@@ -7,7 +7,7 @@
      "jquery",
      "hqwebapp/js/initial_page_data",
      "analytix/js/kissmetrix",
-+    "hqwebapp/js/bootstrap5_loader",
++    "bootstrap5",
      "jquery.cookie/jquery.cookie",
  ], function (
      $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/sticky_tabs.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/sticky_tabs.js.diff.txt
@@ -8,7 +8,7 @@
 +hqDefine("hqwebapp/js/bootstrap5/sticky_tabs", [
      "jquery",
 -    "bootstrap",    // needed for $.tab
-+    "hqwebapp/js/bootstrap5_loader",    // needed for $.tab
++    "bootstrap5",
  ], function (
 -    $,
 +    $, bootstrap,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/sticky_tabs.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/sticky_tabs.js.diff.txt
@@ -8,7 +8,7 @@
 +hqDefine("hqwebapp/js/bootstrap5/sticky_tabs", [
      "jquery",
 -    "bootstrap",    // needed for $.tab
-+    "es6!hqwebapp/js/bootstrap5_loader",    // needed for $.tab
++    "hqwebapp/js/bootstrap5_loader",    // needed for $.tab
  ], function (
 -    $,
 +    $, bootstrap,

--- a/corehq/apps/hqwebapp/tests/test_requirejs.py
+++ b/corehq/apps/hqwebapp/tests/test_requirejs.py
@@ -64,7 +64,7 @@ class TestRequireJS(SimpleTestCase):
             if line:
                 match = re.search(r'^\s*hqDefine\([\'"]([^\'"]*)[\'"]', line)
                 if match:
-                    module = match.group(1).replace('es6!', '')
+                    module = match.group(1)
                     if not filename.endswith(module + ".js"):
                         errors.append("Module {} defined in file {}".format(module, filename))
 

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -266,7 +266,7 @@ def test_flag_changed_javascript_plugins_bootstrap5():
                 "\n\nAn EXAMPLE for how to apply this change is provided below.\nPlease see docs for "
                 "further details.\n\npreviously\n```\n$('#bugReport').modal('hide');\n```\n\nnow\n```\n"
                 "const bugReportModal = new bootstrap.Modal($('#bugReport'));\nbugReportModal.hide();\n```\n\n"
-                "Hint: make sure to list `hqwebapp/js/bootstrap5_loader` as a js dependency in the file where\n"
+                "Hint: make sure to list `bootstrap5` as a js dependency in the file where\n"
                 "bootstrap is referenced.\n\nOld docs: https://getbootstrap.com/docs/3.4/javascript/#modals\n"
                 "New docs: https://getbootstrap.com/docs/5.3/components/modal/#via-javascript\n"]])
 

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes_guide/js-modal.md
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes_guide/js-modal.md
@@ -18,7 +18,7 @@ const bugReportModal = new bootstrap.Modal($('#bugReport'));
 bugReportModal.hide();
 ```
 
-Hint: make sure to list `hqwebapp/js/bootstrap5_loader` as a js dependency in the file where
+Hint: make sure to list `bootstrap5` as a js dependency in the file where
 bootstrap is referenced.
 
 Old docs: https://getbootstrap.com/docs/3.4/javascript/#modals

--- a/corehq/apps/locations/static/locations/js/location.js
+++ b/corehq/apps/locations/static/locations/js/location.js
@@ -3,7 +3,7 @@ hqDefine("locations/js/location", [
     'jquery',
     'knockout',
     'underscore',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'hqwebapp/js/initial_page_data',
     'analytix/js/google',
     'locations/js/location_drilldown',

--- a/corehq/apps/locations/static/locations/js/location.js
+++ b/corehq/apps/locations/static/locations/js/location.js
@@ -3,7 +3,7 @@ hqDefine("locations/js/location", [
     'jquery',
     'knockout',
     'underscore',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'hqwebapp/js/initial_page_data',
     'analytix/js/google',
     'locations/js/location_drilldown',

--- a/corehq/apps/locations/static/locations/js/location_tree.js
+++ b/corehq/apps/locations/static/locations/js/location_tree.js
@@ -2,7 +2,7 @@ hqDefine('locations/js/location_tree', [
     'jquery',
     'knockout',
     'underscore',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/bootstrap5/alert_user',
     'analytix/js/google',

--- a/corehq/apps/locations/static/locations/js/location_tree.js
+++ b/corehq/apps/locations/static/locations/js/location_tree.js
@@ -2,7 +2,7 @@ hqDefine('locations/js/location_tree', [
     'jquery',
     'knockout',
     'underscore',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/bootstrap5/alert_user',
     'analytix/js/google',

--- a/corehq/apps/registry/static/registry/js/registry_edit.js
+++ b/corehq/apps/registry/static/registry/js/registry_edit.js
@@ -6,7 +6,7 @@ hqDefine("registry/js/registry_edit", [
     'registry/js/registry_text',
     'registry/js/registry_actions',
     'registry/js/registry_logs',
-    'hqwebapp/js/bootstrap5_loader',
+    'bootstrap5',
     'hqwebapp/js/select2_knockout_bindings.ko',
     'hqwebapp/js/bootstrap5/knockout_bindings.ko', // openModal
     'hqwebapp/js/bootstrap5/main', // makeHqHelp

--- a/corehq/apps/registry/static/registry/js/registry_edit.js
+++ b/corehq/apps/registry/static/registry/js/registry_edit.js
@@ -1,4 +1,3 @@
-
 hqDefine("registry/js/registry_edit", [
     'moment',
     'knockout',
@@ -7,7 +6,7 @@ hqDefine("registry/js/registry_edit", [
     'registry/js/registry_text',
     'registry/js/registry_actions',
     'registry/js/registry_logs',
-    'es6!hqwebapp/js/bootstrap5_loader',
+    'hqwebapp/js/bootstrap5_loader',
     'hqwebapp/js/select2_knockout_bindings.ko',
     'hqwebapp/js/bootstrap5/knockout_bindings.ko', // openModal
     'hqwebapp/js/bootstrap5/main', // makeHqHelp

--- a/corehq/apps/styleguide/static/styleguide/js/main.js
+++ b/corehq/apps/styleguide/static/styleguide/js/main.js
@@ -11,7 +11,7 @@ import 'ace-builds/src-min-noconflict/mode-python';
 import 'hqwebapp/js/bootstrap5/main';
 import 'hqwebapp/js/bootstrap5/widgets';
 import initialPageData from 'hqwebapp/js/initial_page_data';
-import { Tooltip } from 'hqwebapp/js/bootstrap5_loader';
+import { Tooltip } from 'bootstrap5';
 
 $(function () {
     ace.config.set('basePath', initialPageData.get('ace_base_path'));

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -56,14 +56,6 @@ module.exports = {
                     replace: 'define',
                 },
             },
-            {
-                test: /\.js$/,
-                loader: 'string-replace-loader',
-                options: {
-                    search: /\b(es6!)?hqwebapp\/js\/bootstrap5_loader\b/g,
-                    replace: 'bootstrap5',
-                },
-            },
 
             {
                 test: /modernizr\.js$/,


### PR DESCRIPTION
## Technical Summary
This was only necessary for requirejs.

## Safety Assurance

### Safety story
Any issues with this should be pretty obvious. This is deployed to staging, and I'll smoke test a few B5 pages there. Marking "don't merge" in the meantime.

### Automated test coverage

No

### QA Plan

No


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
