### PR TITLE
Drop `_repeater_type` class property

### DIFF
--- a/corehq/apps/zapier/tests/test_zapier_hooks.py
+++ b/corehq/apps/zapier/tests/test_zapier_hooks.py
@@ -8,7 +8,11 @@ from corehq.apps.zapier.consts import CASE_TYPE_REPEATER_CLASS_MAP, EventTypes
 from corehq.apps.zapier.models import ZapierSubscription
 from corehq.apps.zapier.tests.test_utils import bootrap_domain_for_zapier
 from corehq.apps.zapier.views import SubscribeView, UnsubscribeView
-from corehq.motech.repeaters.models import CreateCaseRepeater, FormRepeater
+from corehq.motech.repeaters.models import (
+    CreateCaseRepeater,
+    FormRepeater,
+    type_name,
+)
 
 ZAPIER_URL = "https://zapier.com/hooks/standard/1387607/5ccf35a5a1944fc9bfdd2c94c28c9885/"
 TEST_DOMAIN = 'test-domain'
@@ -142,7 +146,7 @@ class TestZapierIntegration(TestCase):
             self.assertNotEqual(subscription.repeater_id, '')
             self.assertEqual(
                 repeater_class.objects.get(id=subscription.repeater_id).repeater_type,
-                repeater_class.__name__,
+                type_name(repeater_class),
             )
 
     def test_subscribe_error(self):

--- a/corehq/apps/zapier/tests/test_zapier_hooks.py
+++ b/corehq/apps/zapier/tests/test_zapier_hooks.py
@@ -140,8 +140,10 @@ class TestZapierIntegration(TestCase):
             )
             self.assertIsNotNone(subscription.repeater_id)
             self.assertNotEqual(subscription.repeater_id, '')
-            self.assertEqual(repeater_class.objects.get(id=subscription.repeater_id).repeater_type,
-                             repeater_class._repeater_type)
+            self.assertEqual(
+                repeater_class.objects.get(id=subscription.repeater_id).repeater_type,
+                repeater_class.__name__,
+            )
 
     def test_subscribe_error(self):
         data = {

--- a/corehq/motech/management/commands/create_repeat_records.py
+++ b/corehq/motech/management/commands/create_repeat_records.py
@@ -4,10 +4,15 @@ import re
 from django.core.management import CommandError
 from django.core.management.base import BaseCommand
 
-from corehq.form_processor.models import CommCareCase, XFormInstance
-from corehq.motech.repeaters.models import Repeater, get_all_repeater_types
-from corehq.util.log import with_progress_bar
 from dimagi.utils.chunked import chunked
+
+from corehq.form_processor.models import CommCareCase, XFormInstance
+from corehq.motech.repeaters.models import (
+    Repeater,
+    get_all_repeater_types,
+    type_name,
+)
+from corehq.util.log import with_progress_bar
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -54,7 +59,7 @@ class Command(BaseCommand):
                     repeater_class = get_all_repeater_types()[repeater_type] if repeater_type else None
                     repeaters = get_repeaters_for_type_in_domain(
                         doc.domain,
-                        [repeater_class.__name__],
+                        [type_name(repeater_class)],
                     )
                     if repeater_name_re:
                         repeaters = [r for r in repeaters if repeater_name_re.match(r.name)]

--- a/corehq/motech/management/commands/create_repeat_records.py
+++ b/corehq/motech/management/commands/create_repeat_records.py
@@ -52,7 +52,10 @@ class Command(BaseCommand):
             def _get_repeaters(doc):
                 if doc.domain not in by_domain:
                     repeater_class = get_all_repeater_types()[repeater_type] if repeater_type else None
-                    repeaters = get_repeaters_for_type_in_domain(doc.domain, [repeater_class._repeater_type])
+                    repeaters = get_repeaters_for_type_in_domain(
+                        doc.domain,
+                        [repeater_class.__name__],
+                    )
                     if repeater_name_re:
                         repeaters = [r for r in repeaters if repeater_name_re.match(r.name)]
 

--- a/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
@@ -7,7 +7,7 @@ from django.core.management.base import BaseCommand
 from memoized import memoized
 
 from corehq.motech.repeaters.const import State
-from corehq.motech.repeaters.models import Repeater, RepeatRecord
+from corehq.motech.repeaters.models import Repeater, RepeatRecord, type_name
 
 
 class Command(BaseCommand):
@@ -72,7 +72,7 @@ class Command(BaseCommand):
         duplicates_log = self.resolve_duplicates(records_by_payload_id)
 
         filename = "cancelled_{}_records-{}.csv".format(
-            repeater.__class__.__name__,
+            type_name(repeater),
             datetime.datetime.utcnow().isoformat())
         print("Writing log of changes to {}".format(filename))
         with open(filename, 'w', encoding='utf-8') as f:

--- a/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/delete_duplicate_cancelled_records.py
@@ -72,7 +72,7 @@ class Command(BaseCommand):
         duplicates_log = self.resolve_duplicates(records_by_payload_id)
 
         filename = "cancelled_{}_records-{}.csv".format(
-            repeater._repeater_type,
+            repeater.__class__.__name__,
             datetime.datetime.utcnow().isoformat())
         print("Writing log of changes to {}".format(filename))
         with open(filename, 'w', encoding='utf-8') as f:

--- a/corehq/motech/repeaters/management/commands/update_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/update_cancelled_records.py
@@ -108,7 +108,7 @@ class Command(BaseCommand):
 
         filename = "{}_{}_records-{}.csv".format(
             action,
-            repeater._repeater_type,
+            repeater.__class__.__name__,
             datetime.datetime.utcnow().strftime('%Y-%m-%d_%H.%M.%S'))
         with open(filename, 'w', encoding='utf-8') as f:
             writer = csv.writer(f)

--- a/corehq/motech/repeaters/management/commands/update_cancelled_records.py
+++ b/corehq/motech/repeaters/management/commands/update_cancelled_records.py
@@ -6,7 +6,7 @@ import time
 from django.core.management.base import BaseCommand
 
 from corehq.motech.repeaters.const import State
-from corehq.motech.repeaters.models import Repeater, RepeatRecord
+from corehq.motech.repeaters.models import Repeater, RepeatRecord, type_name
 
 
 class Command(BaseCommand):
@@ -108,7 +108,7 @@ class Command(BaseCommand):
 
         filename = "{}_{}_records-{}.csv".format(
             action,
-            repeater.__class__.__name__,
+            type_name(repeater),
             datetime.datetime.utcnow().strftime('%Y-%m-%d_%H.%M.%S'))
         with open(filename, 'w', encoding='utf-8') as f:
             writer = csv.writer(f)

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -282,7 +282,7 @@ class RepeaterManager(models.Manager):
 
     def get_queryset(self):
         repeater_obj = self.model()
-        if type(repeater_obj).__name__ == "Repeater":  # TODO: Use `is`
+        if type(repeater_obj) is Repeater:
             return super().get_queryset().filter(is_deleted=False)
         else:
             return super().get_queryset().filter(

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -202,7 +202,7 @@ class RepeaterSuperProxy(models.Model):
 
     def save(self, *args, **kwargs):
         self.clear_caches()
-        self.repeater_type = self.__class__.__name__
+        self.repeater_type = type_name(self)
         self.name = self.name or self.connection_settings.name
         if 'update_fields' in kwargs:
             kwargs['update_fields'].extend(['repeater_type', 'name'])
@@ -286,7 +286,7 @@ class RepeaterManager(models.Manager):
             return super().get_queryset().filter(is_deleted=False)
         else:
             return super().get_queryset().filter(
-                repeater_type=repeater_obj.__class__.__name__,
+                repeater_type=type_name(repeater_obj),
                 is_deleted=False,
             )
 
@@ -620,7 +620,7 @@ class Repeater(RepeaterSuperProxy):
         (Most classes that extend CaseRepeater, and all classes that
         extend FormRepeater, use the same form.)
         """
-        return self.__class__.__name__
+        return type_name(self)
 
 
 class FormRepeater(Repeater):
@@ -1502,3 +1502,7 @@ def domain_can_forward_now(domain):
         domain_can_forward(domain)
         and not toggles.PAUSE_DATA_FORWARDING.enabled(domain)
     )
+
+
+def type_name(obj):
+    return obj.__name__ if type(obj) is type else obj.__class__.__name__

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -18,6 +18,7 @@ from corehq.motech.repeaters.models import (
     ReferCaseRepeater,
     UpdateCaseRepeater,
     domain_can_forward,
+    type_name,
 )
 from dimagi.utils.logging import notify_exception
 
@@ -61,19 +62,19 @@ def create_repeat_records(repeater_cls, payload):
             notify_exception(None, "create_repeat_records had an error resulting in a retry")
             metrics_counter('commcare.repeaters.error_creating_record', tags={
                 'domain': payload.domain,
-                'repeater_type': repeater_cls.__name__,
+                'repeater_type': type_name(repeater_cls),
             })
             time.sleep(sleep_length)
         else:
             return
     metrics_counter('commcare.repeaters.failed_to_create_record', tags={
         'domain': payload.domain,
-        'repeater_type': repeater_cls.__name__,
+        'repeater_type': type_name(repeater_cls),
     })
 
 
 def _create_repeat_records(repeater_cls, payload, fire_synchronously=False):
-    repeater_name = f'{repeater_cls.__module__}.{repeater_cls.__name__}'
+    repeater_name = f'{repeater_cls.__module__}.{type_name(repeater_cls)}'
     if settings.REPEATERS_WHITELIST is not None and repeater_name not in settings.REPEATERS_WHITELIST:
         return
     domain = payload.domain

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -61,19 +61,19 @@ def create_repeat_records(repeater_cls, payload):
             notify_exception(None, "create_repeat_records had an error resulting in a retry")
             metrics_counter('commcare.repeaters.error_creating_record', tags={
                 'domain': payload.domain,
-                'repeater_type': repeater_cls._repeater_type,
+                'repeater_type': repeater_cls.__name__,
             })
             time.sleep(sleep_length)
         else:
             return
     metrics_counter('commcare.repeaters.failed_to_create_record', tags={
         'domain': payload.domain,
-        'repeater_type': repeater_cls._repeater_type,
+        'repeater_type': repeater_cls.__name__,
     })
 
 
 def _create_repeat_records(repeater_cls, payload, fire_synchronously=False):
-    repeater_name = repeater_cls.__module__ + '.' + repeater_cls._repeater_type
+    repeater_name = f'{repeater_cls.__module__}.{repeater_cls.__name__}'
     if settings.REPEATERS_WHITELIST is not None and repeater_name not in settings.REPEATERS_WHITELIST:
         return
     domain = payload.domain

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -12,7 +12,6 @@ from django.utils import timezone
 
 from dateutil.parser import isoparse
 from freezegun import freeze_time
-from nose.tools import assert_in
 
 from corehq.motech.models import ConnectionSettings
 from corehq.motech.repeater_helpers import RepeaterResponse
@@ -33,6 +32,7 @@ from ..models import (
     get_all_repeater_types,
     is_response,
     is_success_response,
+    type_name,
 )
 
 DOMAIN = 'test-domain'
@@ -42,7 +42,20 @@ def test_get_all_repeater_types():
     types = get_all_repeater_types()
     for cls in settings.REPEATER_CLASSES:
         name = cls.split('.')[-1]
-        assert_in(name, types)
+        assert name in types
+
+
+class Foo:
+    pass
+
+
+def test_type_name_class():
+    assert type_name(Foo) == 'Foo'
+
+
+def test_type_name_instance():
+    foo = Foo()
+    assert type_name(foo) == 'Foo'
 
 
 class RepeaterTestCase(TestCase):

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -26,7 +26,7 @@ from corehq.motech.models import ConnectionSettings
 
 from ..const import RECORD_QUEUED_STATES, State
 from ..forms import CaseRepeaterForm, FormRepeaterForm, GenericRepeaterForm
-from ..models import Repeater, RepeatRecord, get_all_repeater_types
+from ..models import Repeater, RepeatRecord, get_all_repeater_types, type_name
 
 RepeaterTypeInfo = namedtuple('RepeaterTypeInfo',
                               'class_name friendly_name has_config instances')
@@ -57,7 +57,7 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
 
         return [
             RepeaterTypeInfo(
-                class_name=r.__class__.__name__,
+                class_name=type_name(r),
                 friendly_name=r.friendly_name,
                 has_config=r._has_config,
                 instances=get_repeaters_with_state_counts(r),

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -57,7 +57,7 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
 
         return [
             RepeaterTypeInfo(
-                class_name=r._repeater_type,
+                class_name=r.__class__.__name__,
                 friendly_name=r.friendly_name,
                 has_config=r._has_config,
                 instances=get_repeaters_with_state_counts(r),


### PR DESCRIPTION
## Technical Summary

I'm unsure that [using a Django function](https://github.com/dimagi/commcare-hq/pull/36176/commits/c37f54376c3cf241579db0fbe20b09b1430fe653) to preserve old Python behavior is ideal ... but maybe it is? I could be persuaded.

Opening as a draft PR for conversation. Tagging "Do not merge" to avoid a conflict for PR https://github.com/dimagi/commcare-hq/pull/36176 .

:blowfish: :fish: :tropical_fish: 

## Safety Assurance

No safety assurance. This PR is just for discussion. I haven't tested these changes or checked their test coverage yet.