### PR TITLE
Reset flag on DataSourceConfig

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/userreports/edit_data_source.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/userreports/edit_data_source.html.diff.txt
@@ -11,7 +11,22 @@
  
  {% block page_content %}
    {% if data_source.meta.build.is_rebuild_in_progress %}
-@@ -24,12 +24,12 @@
+@@ -12,24 +12,24 @@
+         {% if data_source.rebuild_failed %}
+           {% trans "Populating your report did not complete successfully." %}
+         {% elif data_source.meta.build.is_rebuilding %}
+-          {% trans "Please note that this data source is being rebuilt." %}
++          {% trans "Please note that this datasource is being rebuilt." %}
+         {% elif data_source.meta.build.is_rebuilding_in_place %}
+-          {% trans "Please note that this data source is being rebuilt in place." %}
++          {% trans "Please note that this datasource is being rebuilt in place." %}
+         {% endif %}
+       </h4>
+     </div>
+   {% elif data_source.meta.build.awaiting %}
+     <div class="alert alert-info">
+-      {% trans "Please note that this data source is yet to be built / rebuilt by CommCare HQ." %}
++      {% trans "Please note that this datasource is yet be built / rebuilt by CommCare HQ." %}
      </div>
    {% endif %}
    {% if data_source.get_id %}
@@ -135,8 +150,12 @@
    </ul>
  
    <div class="tab-content">
-@@ -241,7 +241,7 @@
-           {% trans "This datasource is read only, any changes made can not be saved." %}
+@@ -238,10 +238,10 @@
+     <div class="tab-pane fade in active" id="tabs-configuration">
+       {% if read_only %}
+         <div class="alert alert-info">
+-          {% trans "This data source is read only, any changes made can not be saved." %}
++          {% trans "This datasource is read only, any changes made can not be saved." %}
          </div>
        {% endif %}
 -      {% crispy form %}
@@ -144,6 +163,15 @@
      </div>
      <div class="tab-pane fade" id="tabs-usage">
        {% if not used_by_reports %}
+@@ -249,7 +249,7 @@
+           {% trans "Datasource currently unused" %}
+         </div>
+       {% else %}
+-        <p>{% trans "Reports dependent on this data source" %}</p>
++        <p>{% trans "Reports dependent on this datasource" %}</p>
+         <ul>
+           {% for report in used_by_reports %}
+             <li>
 @@ -276,8 +276,8 @@
                <div class="modal-header">
                  <button

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -52,11 +52,16 @@ from corehq.apps.cachehq.mixins import (
 )
 from corehq.apps.domain.models import AllowedUCRExpressionSettings
 from corehq.apps.registry.helper import DataRegistryHelper
-from corehq.apps.userreports.app_manager.data_source_meta import (
+from corehq.pillows.utils import get_deleted_doc_types
+from corehq.sql_db.connections import UCR_ENGINE_ID, connection_manager
+from corehq.util.couch import DocumentNotFound, get_document_or_not_found
+from corehq.util.quickcache import quickcache
+
+from .app_manager.data_source_meta import (
     REPORT_BUILDER_DATA_SOURCE_TYPE_VALUES,
 )
-from corehq.apps.userreports.columns import get_expanded_column_config
-from corehq.apps.userreports.const import (
+from .columns import get_expanded_column_config
+from .const import (
     ALL_EXPRESSION_TYPES,
     DATA_SOURCE_TYPE_AGGREGATE,
     DATA_SOURCE_TYPE_STANDARD,
@@ -66,7 +71,7 @@ from corehq.apps.userreports.const import (
     UCR_SQL_BACKEND,
     VALID_REFERENCED_DOC_TYPES,
 )
-from corehq.apps.userreports.dbaccessors import (
+from .dbaccessors import (
     get_all_registry_data_source_ids,
     get_datasources_for_domain,
     get_number_of_registry_report_configs_by_data_source,
@@ -75,7 +80,7 @@ from corehq.apps.userreports.dbaccessors import (
     get_registry_report_configs_for_domain,
     get_report_configs_for_domain,
 )
-from corehq.apps.userreports.exceptions import (
+from .exceptions import (
     BadSpecError,
     DataSourceConfigurationNotFoundError,
     DuplicateColumnIdError,
@@ -84,33 +89,29 @@ from corehq.apps.userreports.exceptions import (
     StaticDataSourceConfigurationNotFoundError,
     ValidationError,
 )
-from corehq.apps.userreports.expressions.factory import ExpressionFactory
-from corehq.apps.userreports.extension_points import (
+from .expressions.factory import ExpressionFactory
+from .extension_points import (
     static_ucr_data_source_paths,
     static_ucr_report_paths,
 )
-from corehq.apps.userreports.filters.factory import FilterFactory
-from corehq.apps.userreports.indicators import CompoundIndicator
-from corehq.apps.userreports.indicators.factory import IndicatorFactory
-from corehq.apps.userreports.reports.factory import (
+from .filters.factory import FilterFactory
+from .indicators import CompoundIndicator
+from .indicators.factory import IndicatorFactory
+from .reports.factory import (
     ChartFactory,
     ReportColumnFactory,
     ReportOrderByFactory,
 )
-from corehq.apps.userreports.reports.filters.factory import ReportFilterFactory
-from corehq.apps.userreports.reports.filters.specs import FilterSpec
-from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
-from corehq.apps.userreports.sql.util import decode_column_name
-from corehq.apps.userreports.util import (
+from .reports.filters.factory import ReportFilterFactory
+from .reports.filters.specs import FilterSpec
+from .specs import EvaluationContext, FactoryContext
+from .sql.util import decode_column_name
+from .util import (
     get_async_indicator_modify_lock_key,
     get_indicator_adapter,
     get_ucr_datasource_config_by_id,
     wrap_report_config_by_type,
 )
-from corehq.pillows.utils import get_deleted_doc_types
-from corehq.sql_db.connections import UCR_ENGINE_ID, connection_manager
-from corehq.util.couch import DocumentNotFound, get_document_or_not_found
-from corehq.util.quickcache import quickcache
 
 ID_REGEX_CHECK = re.compile(r"^[\w\-:]+$")
 
@@ -998,9 +999,7 @@ class ReportConfiguration(QuickCachedDocumentMixin, Document):
     @property
     @memoized
     def cached_data_source(self):
-        from corehq.apps.userreports.reports.data_source import (
-            ConfigurableReportDataSource,
-        )
+        from .reports.data_source import ConfigurableReportDataSource
         return ConfigurableReportDataSource.from_spec(self).data_source
 
     @property
@@ -1065,9 +1064,7 @@ class ReportConfiguration(QuickCachedDocumentMixin, Document):
         return langs
 
     def validate(self, required=True):
-        from corehq.apps.userreports.reports.data_source import (
-            ConfigurableReportDataSource,
-        )
+        from .reports.data_source import ConfigurableReportDataSource
 
         def _check_for_duplicates(supposedly_unique_list, error_msg):
             # http://stackoverflow.com/questions/9835762/find-and-list-duplicates-in-python-list

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -744,9 +744,9 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
 
     @cached_property
     def rebuild_failed(self):
-        # `has_died()` returns `None` if we can't use the Flower API,
-        # and so we don't know. Treating `None` as falsy allows calling
-        # code to give `rebuild_has_died` the benefit of the doubt.
+        # `DataSourceBuildInformation.rebuild_failed()` returns `None`
+        # if we don't know whether the rebuild has failed. Calling code
+        # can give the benefit of the doubt by treating `None` as falsy.
         return self.meta.build.rebuild_failed(self._id)
 
     @property

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -57,7 +57,7 @@ from corehq.sql_db.connections import UCR_ENGINE_ID, connection_manager
 from corehq.util.couch import DocumentNotFound, get_document_or_not_found
 from corehq.util.quickcache import quickcache
 
-from .alembic_diffs import DiffTypes
+from .alembic_diffs import get_tables_to_rebuild
 from .app_manager.data_source_meta import (
     REPORT_BUILDER_DATA_SOURCE_TYPE_VALUES,
 )
@@ -773,11 +773,7 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
             table_name = get_table_name(self.domain, self.table_id)
             engine_metadata = get_metadata(self.engine_id)
             diffs = get_table_diffs(engine, [table_name], engine_metadata)
-            tables_to_rebuild = {
-                diff.table_name
-                for diff in diffs
-                if diff.type in DiffTypes.TYPES_FOR_REBUILD
-            }
+            tables_to_rebuild = get_tables_to_rebuild(diffs)
             if table_name in tables_to_rebuild:
                 self.set_build_queued()
             else:

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -759,9 +759,16 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
         return self.meta.build.awaiting or (self.meta.build.is_rebuild_in_progress and not self.rebuild_failed)
 
     def set_rebuild_flags(self):
+        """
+        Sets rebuild flags based on whether a build is required.
+
+        If a build is in progress, and diffs require a rebuild, then the
+        awaiting flag is set. If a build is already awaiting, and diffs
+        do not require a rebuild, then the awaiting flag remains set.
+        """
         from .rebuild import get_table_diffs
 
-        if not self.rebuild_awaiting_or_in_progress:
+        if not self.meta.build.awaiting:
             engine = connection_manager.get_engine(self.engine_id)
             table_name = get_table_name(self.domain, self.table_id)
             engine_metadata = get_metadata(self.engine_id)

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -800,10 +800,6 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
                     current_config.meta.build.finished = True
             current_config.save()
 
-    def save_build_not_required(self):
-        self.meta.build.awaiting = False
-        self.save()
-
 
 class RegistryDataSourceConfiguration(DataSourceConfiguration):
     """This is a special data source that can contain data from

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -57,6 +57,7 @@ from corehq.sql_db.connections import UCR_ENGINE_ID, connection_manager
 from corehq.util.couch import DocumentNotFound, get_document_or_not_found
 from corehq.util.quickcache import quickcache
 
+from .alembic_diffs import DiffTypes
 from .app_manager.data_source_meta import (
     REPORT_BUILDER_DATA_SOURCE_TYPE_VALUES,
 )
@@ -105,10 +106,12 @@ from .reports.factory import (
 from .reports.filters.factory import ReportFilterFactory
 from .reports.filters.specs import FilterSpec
 from .specs import EvaluationContext, FactoryContext
+from .sql import get_metadata
 from .sql.util import decode_column_name
 from .util import (
     get_async_indicator_modify_lock_key,
     get_indicator_adapter,
+    get_table_name,
     get_ucr_datasource_config_by_id,
     wrap_report_config_by_type,
 )
@@ -755,11 +758,34 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
     def rebuild_awaiting_or_in_progress(self):
         return self.meta.build.awaiting or (self.meta.build.is_rebuild_in_progress and not self.rebuild_failed)
 
+    def set_rebuild_flags(self):
+        from .rebuild import get_table_diffs
+
+        if not self.rebuild_awaiting_or_in_progress:
+            engine = connection_manager.get_engine(self.engine_id)
+            table_name = get_table_name(self.domain, self.table_id)
+            engine_metadata = get_metadata(self.engine_id)
+            diffs = get_table_diffs(engine, [table_name], engine_metadata)
+            tables_to_rebuild = {
+                diff.table_name
+                for diff in diffs
+                if diff.type in DiffTypes.TYPES_FOR_REBUILD
+            }
+            if table_name in tables_to_rebuild:
+                self.set_build_queued()
+            else:
+                self.set_build_not_required()
+
     def set_build_queued(self, *, reset_init_fin=True):
         self.meta.build.awaiting = True
         if reset_init_fin:
             self.meta.build.initiated = None
             self.meta.build.finished = False
+
+    def set_build_not_required(self):
+        self.meta.build.awaiting = False
+        self.meta.build.initiated = None
+        self.meta.build.finished = False
 
     def save_build_started(self, *, in_place=False):
         # Save the start time now in case anything goes wrong. This way

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -800,6 +800,10 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
                     current_config.meta.build.finished = True
             current_config.save()
 
+    def save_build_not_required(self):
+        self.meta.build.awaiting = False
+        self.save()
+
 
 class RegistryDataSourceConfiguration(DataSourceConfiguration):
     """This is a special data source that can contain data from

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -468,7 +468,8 @@ class ConfigurableReportPillowProcessor(BulkPillowProcessor):
                                     async_configs_by_doc_id[doc['_id']].append(adapter.config._id)
                                 else:
                                     try:
-                                        rows_to_save_by_adapter[adapter].extend(adapter.get_all_values(doc, eval_context))
+                                        rows = adapter.get_all_values(doc, eval_context)
+                                        rows_to_save_by_adapter[adapter].extend(rows)
                                     except Exception as e:
                                         change_exceptions.append((change, e))
                                     eval_context.reset_iteration()
@@ -767,8 +768,13 @@ def get_location_pillow(pillow_id='location-ucr-pillow', include_ucrs=None,
 
 def get_kafka_ucr_registry_pillow(
     pillow_id='kafka-ucr-registry',
-    num_processes=1, process_num=0, dedicated_migration_process=False,
-    processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, ucr_configs=None, **kwargs):
+    num_processes=1,
+    process_num=0,
+    dedicated_migration_process=False,
+    processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE,
+    ucr_configs=None,
+    **kwargs,
+):
     """UCR pillow that reads from all 'case' Kafka topics and writes data into the UCR database tables
 
     Only UCRs backed by Data Registries are processed in this pillow.

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -6,35 +6,43 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 
-from corehq.apps.change_feed.consumer.feed import (
-    KafkaChangeFeed,
-    KafkaCheckpointEventHandler,
-)
-from corehq.apps.change_feed.topics import LOCATION as LOCATION_TOPIC, CASE_TOPICS
-from corehq.apps.domain.dbaccessors import get_domain_ids_by_names
-from corehq.apps.domain_migration_flags.api import all_domains_with_migrations_in_progress
-from corehq.apps.userreports.const import KAFKA_TOPICS
-from corehq.apps.userreports.data_source_providers import (
-    DynamicDataSourceProvider,
-    StaticDataSourceProvider, RegistryDataSourceProvider,
-)
-from corehq.apps.userreports.exceptions import (
-    UserReportsWarning,
-)
-from corehq.apps.userreports.models import AsyncIndicator
-from corehq.apps.userreports.pillow_utils import rebuild_sql_tables
-from corehq.apps.userreports.specs import EvaluationContext
-from corehq.apps.userreports.util import get_indicator_adapter
-from corehq.pillows.base import is_couch_change_for_sql_domain
-from corehq.util.metrics import metrics_counter, metrics_histogram_timer
-from corehq.util.timer import TimingContext
 from pillowtop.checkpoints.manager import KafkaPillowCheckpoint
 from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
 from pillowtop.exceptions import PillowConfigError
 from pillowtop.logger import pillow_logging
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import BulkPillowProcessor
-from pillowtop.utils import ensure_document_exists, ensure_matched_revisions, bulk_fetch_changes_docs
+from pillowtop.utils import (
+    bulk_fetch_changes_docs,
+    ensure_document_exists,
+    ensure_matched_revisions,
+)
+
+from corehq.apps.change_feed.consumer.feed import (
+    KafkaChangeFeed,
+    KafkaCheckpointEventHandler,
+)
+from corehq.apps.change_feed.topics import CASE_TOPICS
+from corehq.apps.change_feed.topics import LOCATION as LOCATION_TOPIC
+from corehq.apps.domain.dbaccessors import get_domain_ids_by_names
+from corehq.apps.domain_migration_flags.api import (
+    all_domains_with_migrations_in_progress,
+)
+from corehq.pillows.base import is_couch_change_for_sql_domain
+from corehq.util.metrics import metrics_counter, metrics_histogram_timer
+from corehq.util.timer import TimingContext
+
+from .const import KAFKA_TOPICS
+from .data_source_providers import (
+    DynamicDataSourceProvider,
+    RegistryDataSourceProvider,
+    StaticDataSourceProvider,
+)
+from .exceptions import UserReportsWarning
+from .models import AsyncIndicator
+from .pillow_utils import rebuild_sql_tables
+from .specs import EvaluationContext
+from .util import get_indicator_adapter
 
 REBUILD_CHECK_INTERVAL = 3 * 60 * 60  # in seconds
 LONG_UCR_LOGGING_THRESHOLD = 0.5

--- a/corehq/apps/userreports/pillow_utils.py
+++ b/corehq/apps/userreports/pillow_utils.py
@@ -1,13 +1,20 @@
 from collections import defaultdict
 
-from corehq.apps.userreports.exceptions import StaleRebuildError, TableRebuildError
 from couchdbkit import ResourceNotFound
-from corehq.apps.userreports.rebuild import migrate_tables, get_tables_rebuild_migrate, get_table_diffs
-from corehq.apps.userreports.sql import get_metadata
-from corehq.apps.userreports.tasks import rebuild_indicators
+
+from pillowtop.logger import pillow_logging
+
 from corehq.sql_db.connections import connection_manager
 from corehq.util.soft_assert import soft_assert
-from pillowtop.logger import pillow_logging
+
+from .exceptions import StaleRebuildError, TableRebuildError
+from .rebuild import (
+    get_table_diffs,
+    get_tables_rebuild_migrate,
+    migrate_tables,
+)
+from .sql import get_metadata
+from .tasks import rebuild_indicators
 
 
 def _is_datasource_active(adapter):

--- a/corehq/apps/userreports/pillow_utils.py
+++ b/corehq/apps/userreports/pillow_utils.py
@@ -103,10 +103,6 @@ def rebuild_table(adapter, diffs=None):
         adapter.log_table_rebuild_skipped(source='pillowtop', diffs=diff_dicts)
         return
 
-    if not config.is_static:
-        config.set_build_queued(reset_init_fin=False)
-        config.save()
-
     rebuild_indicators.delay(
         adapter.config.get_id,
         source='pillowtop',

--- a/corehq/apps/userreports/pillow_utils.py
+++ b/corehq/apps/userreports/pillow_utils.py
@@ -103,6 +103,10 @@ def rebuild_table(adapter, diffs=None):
         adapter.log_table_rebuild_skipped(source='pillowtop', diffs=diff_dicts)
         return
 
+    if not config.is_static:
+        config.set_build_queued(reset_init_fin=False)
+        config.save()
+
     rebuild_indicators.delay(
         adapter.config.get_id,
         source='pillowtop',

--- a/corehq/apps/userreports/pillow_utils.py
+++ b/corehq/apps/userreports/pillow_utils.py
@@ -78,8 +78,6 @@ def migrate_tables_with_logging(engine, diffs, table_names, adapters_by_table):
     migration_diffs = [diff for diff in diffs if diff.table_name in table_names]
     for table in table_names:
         adapter = adapters_by_table[table]
-        if not adapter.config.is_static:
-            adapter.config.save_build_not_required()
         pillow_logging.info("[rebuild] Using config: %r", adapter.config)
         pillow_logging.info("[rebuild] sqlalchemy metadata: %r", get_metadata(adapter.engine_id).tables[table])
         pillow_logging.info("[rebuild] sqlalchemy table: %r", adapter.get_table())

--- a/corehq/apps/userreports/pillow_utils.py
+++ b/corehq/apps/userreports/pillow_utils.py
@@ -78,6 +78,8 @@ def migrate_tables_with_logging(engine, diffs, table_names, adapters_by_table):
     migration_diffs = [diff for diff in diffs if diff.table_name in table_names]
     for table in table_names:
         adapter = adapters_by_table[table]
+        if not adapter.config.is_static:
+            adapter.config.save_build_not_required()
         pillow_logging.info("[rebuild] Using config: %r", adapter.config)
         pillow_logging.info("[rebuild] sqlalchemy metadata: %r", get_metadata(adapter.engine_id).tables[table])
         pillow_logging.info("[rebuild] sqlalchemy table: %r", adapter.get_table())

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -6,21 +6,22 @@ from django.utils.translation import gettext as _
 import psycopg2
 import sqlalchemy
 from memoized import memoized
-from sqlalchemy.exc import ProgrammingError, OperationalError
+from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.schema import Index, PrimaryKeyConstraint
 
-from corehq.apps.userreports.adapter import IndicatorAdapter
-from corehq.apps.userreports.exceptions import (
+from corehq.sql_db.connections import connection_manager
+from corehq.util.test_utils import unit_testing_only
+
+from ..adapter import IndicatorAdapter
+from ..exceptions import (
     ColumnNotFoundError,
     TableRebuildError,
     translate_programming_error,
 )
-from corehq.apps.userreports.sql.columns import column_to_sql
-from corehq.apps.userreports.util import get_table_name
-from corehq.sql_db.connections import connection_manager
-from corehq.util.test_utils import unit_testing_only
-from corehq.apps.userreports.util import register_data_source_row_change
+from ..util import get_table_name, register_data_source_row_change
+from .columns import column_to_sql
+
 logger = logging.getLogger(__name__)
 
 
@@ -349,7 +350,7 @@ class ErrorRaisingIndicatorSqlAdapter(IndicatorSqlAdapter):
         orig_exception = getattr(exception, 'orig', None)
         if orig_exception and isinstance(orig_exception, psycopg2.IntegrityError):
             if orig_exception.pgcode == psycopg2.errorcodes.NOT_NULL_VIOLATION:
-                from corehq.apps.userreports.models import InvalidUCRData
+                from ..models import InvalidUCRData
                 InvalidUCRData.objects.get_or_create(
                     doc_id=doc['_id'],
                     indicator_config_id=self.config._id,

--- a/corehq/apps/userreports/templates/userreports/bootstrap3/edit_data_source.html
+++ b/corehq/apps/userreports/templates/userreports/bootstrap3/edit_data_source.html
@@ -12,15 +12,15 @@
         {% if data_source.rebuild_failed %}
           {% trans "Populating your report did not complete successfully." %}
         {% elif data_source.meta.build.is_rebuilding %}
-          {% trans "Please note that this datasource is being rebuilt." %}
+          {% trans "Please note that this data source is being rebuilt." %}
         {% elif data_source.meta.build.is_rebuilding_in_place %}
-          {% trans "Please note that this datasource is being rebuilt in place." %}
+          {% trans "Please note that this data source is being rebuilt in place." %}
         {% endif %}
       </h4>
     </div>
   {% elif data_source.meta.build.awaiting %}
     <div class="alert alert-info">
-      {% trans "Please note that this datasource is yet be built / rebuilt by CommCare HQ." %}
+      {% trans "Please note that this data source is yet to be built / rebuilt by CommCare HQ." %}
     </div>
   {% endif %}
   {% if data_source.get_id %}
@@ -238,7 +238,7 @@
     <div class="tab-pane fade in active" id="tabs-configuration">
       {% if read_only %}
         <div class="alert alert-info">
-          {% trans "This datasource is read only, any changes made can not be saved." %}
+          {% trans "This data source is read only, any changes made can not be saved." %}
         </div>
       {% endif %}
       {% crispy form %}
@@ -249,7 +249,7 @@
           {% trans "Datasource currently unused" %}
         </div>
       {% else %}
-        <p>{% trans "Reports dependent on this datasource" %}</p>
+        <p>{% trans "Reports dependent on this data source" %}</p>
         <ul>
           {% for report in used_by_reports %}
             <li>

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -341,6 +341,21 @@ class DataSourceFilterInterpolationTest(SimpleTestCase):
 
 class DataSourceConfigurationTests(TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        for domain, table_id in [
+            ('foo', 'foo1'),
+            ('foo', 'foo2'),
+            ('bar', 'bar1')
+        ]:
+            config = DataSourceConfiguration(
+                domain=domain,
+                table_id=table_id,
+                referenced_doc_type='XFormInstance')
+            config.save()
+            cls.addClassCleanup(config.delete)
+
     def test_by_domain_returns_relevant_datasource_configs(self):
         results = DataSourceConfiguration.by_domain('foo')
         self.assertEqual(len(results), 2)
@@ -384,18 +399,6 @@ class DataSourceConfigurationTests(TestCase):
     def test_create_requires_doc_type(self):
         with self.assertRaises(BadValueError):
             DataSourceConfiguration(domain='domain', table_id='table').save()
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        for domain, table_id in [('foo', 'foo1'), ('foo', 'foo2'),
-                                 ('bar', 'bar1')]:
-            config = DataSourceConfiguration(
-                domain=domain,
-                table_id=table_id,
-                referenced_doc_type='XFormInstance')
-            config.save()
-            cls.addClassCleanup(config.delete)
 
 
 @patch('corehq.apps.userreports.models.AllowedUCRExpressionSettings.disallowed_ucr_expressions',

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -449,13 +449,35 @@ class DataSourceConfigurationRebuildTests(TestCase):
         diff = MagicMock(table_name=table_name, type=DiffTypes.MODIFY_TYPE)
         mock_get_table_diffs.return_value = [diff]
         self.config.set_rebuild_flags()
-        assert self.config.rebuild_awaiting_or_in_progress is True
+        assert self.config.meta.build.awaiting is True
 
     @patch('corehq.apps.userreports.rebuild.get_table_diffs')
     def test_set_rebuild_flags_not_required(self, mock_get_table_diffs):
         mock_get_table_diffs.return_value = []
         self.config.set_rebuild_flags()
-        assert self.config.rebuild_awaiting_or_in_progress is None
+        assert self.config.meta.build.awaiting is False
+
+    @patch('corehq.apps.userreports.rebuild.get_table_diffs')
+    def test_set_rebuild_flags_not_required_awaiting(self, mock_get_table_diffs):
+        # If a rebuild is already awaiting, it is not unset.
+        mock_get_table_diffs.return_value = []
+        self.config.meta.build.awaiting = True
+        self.config.set_rebuild_flags()
+        assert self.config.meta.build.awaiting is True
+
+    @patch('corehq.apps.userreports.rebuild.get_table_diffs')
+    def test_set_rebuild_flags_in_progress(self, mock_get_table_diffs):
+        # If a rebuild is in progress, it is set to awaiting.
+        table_name = get_table_name(self.config.domain, self.config.table_id)
+        diff = MagicMock(table_name=table_name, type=DiffTypes.MODIFY_TYPE)
+        mock_get_table_diffs.return_value = [diff]
+
+        self.config.meta.build.awaiting = False
+        self.config.meta.build.initiated = datetime.datetime.now()
+        self.config.meta.build.finished = False
+
+        self.config.set_rebuild_flags()
+        assert self.config.meta.build.awaiting is True
 
 
 @patch('corehq.apps.userreports.models.AllowedUCRExpressionSettings.disallowed_ucr_expressions',

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -180,7 +180,7 @@ class ConfigurableDataSourceEditForm(DocumentFormBase):
         required=False,
         label="",
         widget=forms.HiddenInput(),
-        help_text=help_text.ANALYTICS
+        help_text=help_text.COMMCARE_ANALYTICS
     )
 
     def __init__(self, domain, data_source_config, read_only, *args, **kwargs):

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -13,12 +13,13 @@ from corehq.apps.app_manager.fields import ApplicationDataSourceUIHelper
 from corehq.apps.domain.models import AllowedUCRExpressionSettings
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
-from corehq.apps.userreports.const import DATA_SOURCE_REBUILD_RESTRICTED_AT
-from corehq.apps.userreports.models import guess_data_source_type
-from corehq.apps.userreports.ui import help_text
-from corehq.apps.userreports.ui.fields import JsonField, ReportDataSourceField
-from corehq.apps.userreports.util import get_table_name
 from corehq.util.metrics import metrics_counter
+
+from ..const import DATA_SOURCE_REBUILD_RESTRICTED_AT
+from ..models import guess_data_source_type
+from ..util import get_table_name
+from . import help_text
+from .fields import JsonField, ReportDataSourceField
 
 
 class DocumentFormBase(forms.Form):

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -287,9 +287,7 @@ class ConfigurableDataSourceEditForm(DocumentFormBase):
                 )
 
     def save(self, commit=False):
-        self.instance.meta.build.finished = False
-        self.instance.meta.build.initiated = None
-        self.instance.meta.build.awaiting = True
+        self.instance.set_build_queued()
         instance = super(ConfigurableDataSourceEditForm, self).save(commit)
         self._report_edit_datasource_metrics()
         return instance

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -288,7 +288,7 @@ class ConfigurableDataSourceEditForm(DocumentFormBase):
                 )
 
     def save(self, commit=False):
-        self.instance.set_build_queued()
+        self.instance.set_rebuild_flags()
         instance = super(ConfigurableDataSourceEditForm, self).save(commit)
         self._report_edit_datasource_metrics()
         return instance

--- a/corehq/apps/userreports/ui/help_text.py
+++ b/corehq/apps/userreports/ui/help_text.py
@@ -41,6 +41,7 @@ NAMED_EXPRESSIONS = _(
     'wherever an expression goes using: <code>{"type": "named", "name": "myvarname"}</code>')
 NAMED_FILTER = _('These behave exactly like named expressions (see above), except the values '
                  'should be a valid filter, and they can be used wherever filters are used above.')
-ANALYTICS = _(
-    'Enabling this will let this data source and the data be imported into Analytics'
+COMMCARE_ANALYTICS = _(
+    'Enabling this will let this data source and the data be imported into '
+    'CommCare Analytics'
 )

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1212,7 +1212,11 @@ class BaseEditDataSourceView(BaseUserConfigReportsView):
                         'This data source will be built / rebuilt automatically by CommCare HQ.'
                     ))
                 else:
-                    message_list.append(_('This change does not require a rebuild.'))
+                    message_list.append(_(
+                        'CommCare HQ will not perform a data source rebuild '
+                        'for the changes made. Please initiate one manually '
+                        'if needed.'
+                    ))
                 messages.success(request, ' '.join(message_list))
                 if self.config_id is None:
                     return HttpResponseRedirect(reverse(

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1331,9 +1331,8 @@ def undelete_data_source(request, domain, config_id):
 def rebuild_data_source(request, domain, config_id):
     config, is_static = get_datasource_config_or_404(config_id, domain)
 
-    response = _redirect_response_if_build_awaiting(request, domain, config)
-    if response:
-        return response
+    if config.meta.build.awaiting:
+        return _build_awaiting_redirect_response(request, domain, config_id)
 
     if not config.asynchronous and toggles.RESTRICT_DATA_SOURCE_REBUILD.enabled(domain):
         number_of_records = number_of_records_to_be_processed(datasource_configuration=config)
@@ -1362,15 +1361,14 @@ def rebuild_data_source(request, domain, config_id):
     ))
 
 
-def _redirect_response_if_build_awaiting(request, domain, config):
-    if config.meta.build.awaiting:
-        messages.error(
-            request,
-            _('Rebuilding is not available until CommCare HQ finishes building / rebuilding.')
-        )
-        return HttpResponseRedirect(reverse(
-            EditDataSourceView.urlname, args=[domain, config.get_id]
-        ))
+def _build_awaiting_redirect_response(request, domain, config_id):
+    messages.error(
+        request,
+        _('Rebuilding is not available until CommCare HQ finishes building / rebuilding.')
+    )
+    return HttpResponseRedirect(reverse(
+        EditDataSourceView.urlname, args=[domain, config_id]
+    ))
 
 
 def _prep_data_source_for_rebuild(data_source_config, is_static):
@@ -1494,9 +1492,8 @@ def resume_building_data_source(request, domain, config_id):
 def build_data_source_in_place(request, domain, config_id):
     config, is_static = get_datasource_config_or_404(config_id, domain)
 
-    response = _redirect_response_if_build_awaiting(request, domain, config)
-    if response:
-        return response
+    if config.meta.build.awaiting:
+        return _build_awaiting_redirect_response(request, domain, config_id)
 
     _prep_data_source_for_rebuild(config, is_static)
 

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1374,7 +1374,7 @@ def _build_awaiting_redirect_response(request, domain, config_id):
 def _prep_data_source_for_rebuild(data_source_config, is_static):
     save_config = False
     if not is_static:
-        data_source_config.meta.build.awaiting = True
+        data_source_config.set_build_queued(reset_init_fin=False)
         save_config = True
     if data_source_config.is_deactivated:
         data_source_config.is_deactivated = False
@@ -1475,7 +1475,7 @@ def resume_building_data_source(request, domain, config_id):
         )
     else:
         if not is_static:
-            config.meta.build.awaiting = True
+            config.set_build_queued(reset_init_fin=False)
             config.save()
         messages.success(
             request,

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1204,12 +1204,16 @@ class BaseEditDataSourceView(BaseUserConfigReportsView):
         try:
             if self.edit_form.is_valid():
                 config = self.edit_form.save(commit=True)
-                messages.success(request, _('Data source "{}" saved!').format(
+                message_list = [_('Data source "{}" saved.').format(
                     config.display_name
-                ))
-                messages.success(request, _(
-                    'This data source will be built / rebuilt automatically by CommCare HQ.'
-                ))
+                )]
+                if config.meta.build.awaiting:
+                    message_list.append(_(
+                        'This data source will be built / rebuilt automatically by CommCare HQ.'
+                    ))
+                else:
+                    message_list.append(_('This change does not require a rebuild.'))
+                messages.success(request, ' '.join(message_list))
                 if self.config_id is None:
                     return HttpResponseRedirect(reverse(
                         EditDataSourceView.urlname, args=[self.domain, config._id])


### PR DESCRIPTION
## Technical Summary

Context:
* [Data Source rebuilding getting stuck for indefinite time after adding new Case Properties/Columns](https://dimagi.atlassian.net/browse/QA-7573)
* [Reset Data source build/rebuild flag when migrated instead of rebuild](https://dimagi.atlassian.net/browse/SC-4399)

This change determines which rebuild flags to set on `DataSourceConfiguration.meta.build`, based on whether the data source will automatically be rebuilt.

:fish: :tropical_fish: :blowfish: 

## Safety Assurance

### Safety story

* Tested locally:
  + Creating a new data source
  + Making changes that require rebuilds
  + Making changes that do not require rebuilds
  + Making changes when a rebuild is pending

### Automated test coverage

Yes.

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
