### PR TITLE
[Data Cleaning] fix 404 error when filtering cases on page > 1

### DIFF
--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -12,7 +12,10 @@ from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
 from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.domain.views import DomainViewMixin
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
-from corehq.apps.hqwebapp.tables.pagination import SelectablePaginatedTableView
+from corehq.apps.hqwebapp.tables.pagination import (
+    HtmxInvalidPageRedirectMixin,
+    SelectablePaginatedTableView,
+)
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 
@@ -24,9 +27,14 @@ class BaseDataCleaningTableView(LoginAndDomainMixin, DomainViewMixin, Selectable
     pass
 
 
-class CleanCasesTableView(BulkEditSessionViewMixin, HqHtmxActionMixin, BaseDataCleaningTableView):
+class CleanCasesTableView(BulkEditSessionViewMixin,
+                          HtmxInvalidPageRedirectMixin, HqHtmxActionMixin, BaseDataCleaningTableView):
     urlname = "data_cleaning_cases_table"
     table_class = CleanCaseTable
+
+    def get_host_url(self):
+        from corehq.apps.data_cleaning.views.main import CleanCasesSessionView
+        return reverse(CleanCasesSessionView.urlname, args=(self.domain, self.session_id,))
 
     def get_table_kwargs(self):
         extra_columns = [(

--- a/corehq/apps/hqwebapp/tables/pagination.py
+++ b/corehq/apps/hqwebapp/tables/pagination.py
@@ -1,4 +1,5 @@
-from django.core.paginator import Paginator
+from django.core.paginator import Paginator, InvalidPage
+from django.http import Http404, QueryDict
 from django.views.generic.list import ListView
 
 from django_tables2 import SingleTableMixin
@@ -37,6 +38,76 @@ class SelectablePaginatedTableMixin(SingleTableMixin):
 
     def get_paginate_by(self, table_data):
         return self.current_paginate_by
+
+
+class HtmxInvalidPageRedirectMixin:
+    """
+    This mixin is used to handle the case when the page number served by
+    the view is out of range (perhaps when the queryset's filter changes).
+
+    The default behavior of `paginate_queryset` on a `ListView` raises
+    an `Http404` exception. This mixin will catch that exception and
+    redirect to the first page of the TableView instead.
+
+    IMPORTANT: THIS MIXIN MUST BE THE FIRST IN THE CLASS HIERARCHY.
+    Specifically, before `SelectablePaginatedTableView`, which it is often
+    used with.
+
+    e.g.:
+        class MyTableView(HtmxInvalidPageRedirectMixin, SelectablePaginatedTableView):
+            ...
+    """
+
+    def paginate_queryset(self, queryset, page_size):
+        try:
+            return super().paginate_queryset(queryset, page_size)
+        except Http404:
+            # This is a workaround for the case when the queryset is empty.
+            # The default behavior of `paginate_queryset` raises an Http404
+            # exception when the page number is out of range.
+            raise InvalidPage
+
+    def get_host_url(self):
+        """
+        This is used to set the `HX-Push-Url` header in the `get_first_page` response.
+
+        :return: str
+            The url of the view that is hosting the table view.
+        """
+        raise NotImplementedError(
+            "please return a URL of the view hosting the table view in the "
+            "get_host_url() method"
+        )
+
+    def get_first_page(self, request, *args, **kwargs):
+        """
+        We re-render the response instead of a redirect (HttpResponseRedirect)
+        because the HX-Push-Url header is ignored by the browser when a redirect
+        occurs.
+        """
+        # sort is the only GET parameter we want to keep
+        # when redirecting to the first page
+        sort = request.GET.get('sort')
+        params = f"sort={sort}" if sort else ""
+
+        # reset the GET parameters to only include sort, no `page` information
+        request.GET = QueryDict(params)
+
+        # re-fetch the get response with the modified request
+        response = super().get(request, *args, **kwargs)
+        params = f"?{params}" if params else ""
+
+        # get the host page url
+        host_url = self.get_host_url() + params
+        response['HX-Push-Url'] = request.build_absolute_uri(host_url)
+
+        return response
+
+    def get(self, request, *args, **kwargs):
+        try:
+            return super().get(request, *args, **kwargs)
+        except InvalidPage:
+            return self.get_first_page(request, *args, **kwargs)
 
 
 class SelectablePaginatedTableView(SelectablePaginatedTableMixin, ListView):


### PR DESCRIPTION
## Technical Summary
Previously, if I added filters anywhere except the first page and the resulting queryset had less than one page of results, I would get an HTMX error popping up that read 404 instead of 500. After some digging, I realized that `ListView` (which the table view inherits from) raises an `Http404` when its paginator encounters an `InvalidPage`. This makes sense in a pre-`HTMX` world, however if the table is an `HTMX` partial, this can cause some confusion because refreshing the URL (without manually removing the page parameter) will always throw the 404.

This is obviously a terrible user experience and once that I expect to be quite common, so I prioritized fixing this before flagging QA to test the filters and columns functionality.

Here is the ticket:
https://dimagi.atlassian.net/browse/SAAS-17376

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
very safe change, only affects feature flagged workflows

### Automated test coverage
not for this one yet (I plan to investigate adding tests later)

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
