### PR TITLE
[Data Cleaning] uncheck header checkbox if the number of records on the page is zero

### DIFF
--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -51,7 +51,7 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
                 },
                 'th__input': {
                     # `pageNumRecordsSelected`, `pageTotalRecords`: defined in template
-                    ":checked": "pageNumRecordsSelected == pageTotalRecords",
+                    ":checked": "pageNumRecordsSelected == pageTotalRecords && pageTotalRecords > 0",
                 },
             },
         )


### PR DESCRIPTION
## Technical Summary
Make sure the header looks like this, when there are no results (unchecked checkbox)
![Screenshot 2025-04-10 at 6 51 08 PM](https://github.com/user-attachments/assets/2e088a40-1aef-40ef-8d29-1720e994a70c)


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
just a tiny ui fix to a feature flagged area on HQ

### Automated test coverage
n/a

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
