### PR TITLE
Django Tables: add message beneath table if there are no rows on the page

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5.html
@@ -17,6 +17,14 @@
 
     {% block table %}{{ block.super }}{% endblock table %}
 
+    {% if table.page.paginator.count == 0 %}
+      {% block no_results_table %}
+        <div class="alert alert-primary">
+          {% blocktrans %}No results found.{% endblocktrans %}
+        </div>
+      {% endblock %}
+    {% endif %}
+
     <div class="pb-3 d-flex justify-content-between">
       <div>
         {% block num_entries %}


### PR DESCRIPTION
## Technical Summary
This was something that was frustrating me with the data cleaning table view. Django tables doesn't show a "no results" message by default, so I added one to our bootstrap 5 template. (I will be overriding this in the data cleaning table template with a more specific message later).

Very simple change for all future django tables everywhere on HQ!
![Screenshot 2025-04-10 at 6 58 49 PM](https://github.com/user-attachments/assets/001f343e-55a6-4364-96a5-c8a189612db1)



## Safety Assurance

### Safety story
safe ui change that just adds a message when there are no results.

### Automated test coverage
no

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
