### PR TITLE
[Data Cleaning] Fix missing & empty filters

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -586,12 +586,6 @@ class BulkEditFilter(models.Model):
         return query
 
     @property
-    def is_editable_property(self):
-        from corehq.apps.data_cleaning.utils.cases import get_case_property_details
-        property_details = get_case_property_details(self.session.domain, self.session.identifier)
-        return property_details.get(self.prop_id, {}).get('is_editable', True)
-
-    @property
     def human_readable_match_type(self):
         category = DataType.get_filter_category(self.data_type)
         match_to_text = {
@@ -617,9 +611,7 @@ class BulkEditFilter(models.Model):
             FilterMatchType.IS_MISSING: lambda q: q.filter(case_property_missing(self.prop_id)),
             FilterMatchType.IS_NOT_MISSING: lambda q: q.NOT(case_property_missing(self.prop_id)),
         }
-        # if a property is not editable, then it can't be empty or missing
-        # we need the `is_editable_property` check to avoid elasticsearch RequestErrors on system fields
-        if self.match_type in filter_query_functions and self.is_editable_property:
+        if self.match_type in filter_query_functions:
             query = filter_query_functions[self.match_type](query)
         return query
 

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -244,12 +244,7 @@ class BulkEditSession(models.Model):
     def get_queryset(self):
         query = CaseSearchES().domain(self.domain).case_type(self.identifier)
         query = BulkEditFilter.apply_filters_to_query(self, query)
-        query = self._apply_pinned_filters(query)
-        return query
-
-    def _apply_pinned_filters(self, query):
-        for pinned_filter in self.pinned_filters.all():
-            query = pinned_filter.filter_query(query)
+        query = BulkEditPinnedFilter.apply_filters_to_query(self, query)
         return query
 
     def get_num_selected_records(self):
@@ -747,6 +742,12 @@ class BulkEditPinnedFilter(models.Model):
                 index=index,
                 filter_type=filter_type,
             )
+
+    @classmethod
+    def apply_filters_to_query(cls, session, query):
+        for pinned_filter in session.pinned_filters.all():
+            query = pinned_filter.filter_query(query)
+        return query
 
     def get_report_filter_class(self):
         from corehq.apps.data_cleaning.filters import (

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -153,17 +153,6 @@ class BulkEditFilterQueryTests(TestCase):
                     f"properly for FilterMatchType.IS_EMPTY"
             )
 
-    def test_filter_query_is_empty_system_property(self):
-        query = CaseSearchES().domain(self.domain)
-        active_filter = BulkEditFilter(
-            session=self.session,
-            prop_id='last_modified',
-            data_type=DataType.DATETIME,
-            match_type=FilterMatchType.IS_EMPTY,
-        )
-        filtered_query = active_filter.filter_query(query)
-        self.assertEqual(filtered_query, query)
-
     def test_filter_query_is_not_empty(self):
         query = CaseSearchES().domain(self.domain)
         for data_type, _ in DataType.CHOICES:
@@ -180,17 +169,6 @@ class BulkEditFilterQueryTests(TestCase):
                 msg=f"{data_type} failed to filter the query "
                     f"properly for FilterMatchType.IS_NOT_EMPTY"
             )
-
-    def test_filter_query_is_not_empty_system_property(self):
-        query = CaseSearchES().domain(self.domain)
-        active_filter = BulkEditFilter(
-            session=self.session,
-            prop_id='last_modified',
-            data_type=DataType.DATETIME,
-            match_type=FilterMatchType.IS_NOT_EMPTY,
-        )
-        filtered_query = active_filter.filter_query(query)
-        self.assertEqual(filtered_query, query)
 
     def test_filter_query_is_missing(self):
         query = CaseSearchES().domain(self.domain)
@@ -209,17 +187,6 @@ class BulkEditFilterQueryTests(TestCase):
                     f"properly for FilterMatchType.IS_MISSING"
             )
 
-    def test_filter_query_is_missing_system_property(self):
-        query = CaseSearchES().domain(self.domain)
-        active_filter = BulkEditFilter(
-            session=self.session,
-            prop_id='last_modified',
-            data_type=DataType.DATETIME,
-            match_type=FilterMatchType.IS_MISSING,
-        )
-        filtered_query = active_filter.filter_query(query)
-        self.assertEqual(filtered_query, query)
-
     def test_filter_query_is_not_missing(self):
         query = CaseSearchES().domain(self.domain)
         for data_type, _ in DataType.CHOICES:
@@ -236,17 +203,6 @@ class BulkEditFilterQueryTests(TestCase):
                 msg=f"{data_type} failed to filter the query "
                     f"properly for FilterMatchType.IS_NOT_MISSING"
             )
-
-    def test_filter_query_is_not_missing_system_property(self):
-        query = CaseSearchES().domain(self.domain)
-        active_filter = BulkEditFilter(
-            session=self.session,
-            prop_id='last_modified',
-            data_type=DataType.DATETIME,
-            match_type=FilterMatchType.IS_NOT_MISSING,
-        )
-        filtered_query = active_filter.filter_query(query)
-        self.assertEqual(filtered_query, query)
 
     def filter_query_remains_unchanged_for_other_match_types(self):
         query = CaseSearchES().domain(self.domain)

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -20,7 +20,11 @@ from corehq.apps.data_cleaning.models import (
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es import CaseSearchES, cases as case_es
-from corehq.apps.es.case_search import case_search_adapter
+from corehq.apps.es.case_search import (
+    case_property_missing,
+    case_search_adapter,
+    exact_case_property_text_query,
+)
 from corehq.apps.es.client import manager
 from corehq.apps.es.groups import group_adapter
 from corehq.apps.es.tests.utils import (
@@ -142,11 +146,11 @@ class BulkEditFilterQueryTests(TestCase):
                 match_type=FilterMatchType.IS_EMPTY,
             )
             filtered_query = active_filter.filter_query(query)
-            expected_query = query.empty('soil_contents')
+            expected_query = query.filter(exact_case_property_text_query('soil_contents', ''))
             self.assertEqual(
                 filtered_query.es_query, expected_query.es_query,
                 msg=f"{data_type} failed to filter the query "
-                    f"properly for FilterMatchType.is_empty"
+                    f"properly for FilterMatchType.IS_EMPTY"
             )
 
     def test_filter_query_is_empty_system_property(self):
@@ -170,11 +174,11 @@ class BulkEditFilterQueryTests(TestCase):
                 match_type=FilterMatchType.IS_NOT_EMPTY,
             )
             filtered_query = active_filter.filter_query(query)
-            expected_query = query.non_null('soil_contents')
+            expected_query = query.NOT(exact_case_property_text_query('soil_contents', ''))
             self.assertEqual(
                 filtered_query.es_query, expected_query.es_query,
                 msg=f"{data_type} failed to filter the query "
-                    f"properly for FilterMatchType.is_empty"
+                    f"properly for FilterMatchType.IS_NOT_EMPTY"
             )
 
     def test_filter_query_is_not_empty_system_property(self):
@@ -198,11 +202,11 @@ class BulkEditFilterQueryTests(TestCase):
                 match_type=FilterMatchType.IS_MISSING,
             )
             filtered_query = active_filter.filter_query(query)
-            expected_query = query.missing('soil_contents')
+            expected_query = query.filter(case_property_missing('soil_contents'))
             self.assertEqual(
                 filtered_query.es_query, expected_query.es_query,
                 msg=f"{data_type} failed to filter the query "
-                    f"properly for FilterMatchType.is_empty"
+                    f"properly for FilterMatchType.IS_MISSING"
             )
 
     def test_filter_query_is_missing_system_property(self):
@@ -226,11 +230,11 @@ class BulkEditFilterQueryTests(TestCase):
                 match_type=FilterMatchType.IS_NOT_MISSING,
             )
             filtered_query = active_filter.filter_query(query)
-            expected_query = query.exists('soil_contents')
+            expected_query = query.NOT(case_property_missing('soil_contents'))
             self.assertEqual(
                 filtered_query.es_query, expected_query.es_query,
                 msg=f"{data_type} failed to filter the query "
-                    f"properly for FilterMatchType.is_empty"
+                    f"properly for FilterMatchType.IS_NOT_MISSING"
             )
 
     def test_filter_query_is_not_missing_system_property(self):

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -15,7 +15,11 @@ from corehq.apps.data_cleaning.models import (
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es import CaseSearchES, user_adapter, group_adapter
-from corehq.apps.es.case_search import case_search_adapter
+from corehq.apps.es.case_search import (
+    case_property_missing,
+    case_search_adapter,
+    exact_case_property_text_query,
+)
 from corehq.apps.es.tests.utils import (
     case_search_es_setup,
     es_test,
@@ -249,8 +253,8 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             CaseSearchES()
             .domain(self.domain_name)
             .case_type(self.case_type)
-            .exists('watered_on')
-            .empty('pot_type')
+            .NOT(case_property_missing('watered_on'))
+            .filter(exact_case_property_text_query('pot_type', ''))
             .xpath_query(
                 self.domain_name,
                 "phonetic-match(name, 'lowkey') and num_leaves > 2 and height_cm <= 11.1"
@@ -267,7 +271,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             CaseSearchES()
             .domain(self.domain_name)
             .case_type(self.case_type)
-            .exists('watered_on')
+            .NOT(case_property_missing('watered_on'))
             .OR(all_project_data_filter(self.domain_name, ['project_data']))  # default Case Owners pinned filter
         )
         self.assertEqual(query.es_query, expected_query.es_query)


### PR DESCRIPTION
## Technical Summary
Turns out `CaseSearchES` handles missing and empty filters differently from the default ES Queries. Once I discovered the right filters to use, a quick update solved the issues. It even solved errors I was seeing with system properties (especially datetimes), which I had created a workaround for earlier.

I wanted to ensure this issue was addressed before handing the columns and filters portion of this feature off to QA!

review commit-by-commit

here is the ticket to the bug it fixes:
https://dimagi.atlassian.net/browse/SAAS-17375

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
super safe change, feature flagged workflow, has tests

### Automated test coverage
yes

### QA Plan
not yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
