### PR TITLE
[Data Cleaning] Prevent race conditions with filter remove and sort

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
@@ -9,6 +9,7 @@
   {% if active_filters %}
     <div class="mb-3">
       <form
+        class="htmx-disable-on-delete-filter"
         hx-post="{{ request.path_info }}"
         hx-target="#{{ container_id }}"
         hx-disabled-elt="find button"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/manage_filters_form.html
@@ -12,7 +12,7 @@
         class="htmx-disable-on-delete-filter"
         hx-post="{{ request.path_info }}"
         hx-target="#{{ container_id }}"
-        hx-disabled-elt="find button"
+        hx-disabled-elt=".htmx-disable-on-filter-sort"
         hq-hx-action="update_filter_order"
         hx-trigger="end"
       >

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/partials/filter_list_item.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/partials/filter_list_item.html
@@ -33,13 +33,13 @@
     </div>
     <div class="p-2 align-self-center">
       <button
-        class="btn btn-outline-danger btn-sm"
+        class="btn btn-outline-danger btn-sm htmx-disable-on-delete-filter"
         type="button"
         name="delete_id"
         value="{{ filter.filter_id }}"
         hx-post="{{ request.path_info }}"
         hq-hx-action="delete_filter"
-        hx-disabled-elt="this"
+        hx-disabled-elt=".htmx-disable-on-delete-filter"
         hx-target="#{{ container_id }}"
       >
         <i class="fa-solid fa-close"></i>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/partials/filter_list_item.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/partials/filter_list_item.html
@@ -33,7 +33,7 @@
     </div>
     <div class="p-2 align-self-center">
       <button
-        class="btn btn-outline-danger btn-sm htmx-disable-on-delete-filter"
+        class="btn btn-outline-danger btn-sm htmx-disable-on-delete-filter htmx-disable-on-filter-sort"
         type="button"
         name="delete_id"
         value="{{ filter.filter_id }}"


### PR DESCRIPTION
## Technical Summary
Does what the title says. Rapid fire removing and sorting of filters was leading to bad outcomes with the UI and the server side being out of alignment. This addresses that issue.

related ticket
https://dimagi.atlassian.net/browse/SAAS-17384

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
the power of css classes! also very safe and only on feature flagged area

### Automated test coverage
no

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
