### PR TITLE
[Data Cleaning] UI for Clean Selected Records Form

### DIFF
--- a/corehq/apps/data_cleaning/forms/cleaning.py
+++ b/corehq/apps/data_cleaning/forms/cleaning.py
@@ -10,6 +10,7 @@ from crispy_forms.helper import FormHelper
 from corehq.apps.data_cleaning.models import (
     EditActionType,
 )
+from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import AlpineSelect, BootstrapSwitchInput
 
 
@@ -89,6 +90,7 @@ class CleanSelectedRecordsForm(forms.Form):
         alpine_data_model = {
             "propId": initial_prop_id,
             "cleanAction": self.data.get('clean_action', EditActionType.CHOICES[0][0]),
+            "findActions": [EditActionType.FIND_REPLACE],
         }
 
         self.helper = FormHelper()
@@ -115,6 +117,16 @@ class CleanSelectedRecordsForm(forms.Form):
                         **({
                             "@select2change": "cleanAction = $event.detail;",
                         })
+                    ),
+                    crispy.Div(
+                        crispy.Div(
+                            'find_string',
+                            hqcrispy.CheckboxField('use_regex'),
+                            'replace_string',
+                            css_class="card-body",
+                        ),
+                        x_show="findActions.includes(cleanAction)",
+                        css_class="card mb-3",
                     ),
                     twbscrispy.StrictButton(
                         _("Preview Changes"),

--- a/corehq/apps/data_cleaning/forms/cleaning.py
+++ b/corehq/apps/data_cleaning/forms/cleaning.py
@@ -76,9 +76,11 @@ class CleanSelectedRecordsForm(forms.Form):
         self.editable_columns = self.session.columns.filter(is_system=False)
         self.is_form_visible = self.editable_columns.count() > 0
 
-        self.fields['clean_prop_id'].choices = [(None, None)] + [
+        property_choices = [(None, None)] + [
             (column.prop_id, column.choice_label) for column in self.editable_columns
         ]
+        self.fields['clean_prop_id'].choices = property_choices
+        self.fields['copy_from_prop_id'].choices = property_choices
 
         initial_prop_id = self.data.get('clean_prop_id')
 

--- a/corehq/apps/data_cleaning/forms/cleaning.py
+++ b/corehq/apps/data_cleaning/forms/cleaning.py
@@ -1,0 +1,123 @@
+import json
+
+from django import forms
+from django.utils.translation import gettext as _, gettext_lazy
+
+from crispy_forms import bootstrap as twbscrispy
+from crispy_forms import layout as crispy
+from crispy_forms.helper import FormHelper
+
+from corehq.apps.data_cleaning.models import (
+    EditActionType,
+)
+from corehq.apps.data_cleaning.utils.cases import (
+    get_case_property_details,
+)
+from corehq.apps.hqwebapp.widgets import AlpineSelect, BootstrapSwitchInput
+
+
+class CleanSelectedRecordsForm(forms.Form):
+    """
+    NOTE: While the related forms for this feature share similar properties (`prop_id`)
+    the `clean_` prefix is used here because all forms will be inserted into the same DOM, resulting
+    in the same css ids for each field (generated as `id_<field slug>`). Having multiple elements
+    with the same id is invalid HTML. Additionally, this scenario will result in select2s being
+    applied to only ONE field.
+    """
+    clean_prop_id = forms.ChoiceField(
+        label=gettext_lazy("Select a property to clean"),
+        required=False
+    )
+    clean_action = forms.ChoiceField(
+        label=gettext_lazy("Data cleaning action"),
+        widget=AlpineSelect,
+        choices=EditActionType.CHOICES,
+        required=False
+    )
+    find_string = forms.CharField(
+        label=gettext_lazy("Find:"),
+        strip=False,
+        required=False,
+    )
+    use_regex = forms.CharField(
+        label="",
+        required=False,
+        widget=BootstrapSwitchInput(
+            inline_label=gettext_lazy(
+                "Use regular expression"
+            ),
+        ),
+    )
+    replace_string = forms.CharField(
+        label=gettext_lazy("Replace with:"),
+        strip=False,
+        required=False,
+    )
+    replace_all_string = forms.CharField(
+        label=gettext_lazy("Replace existing value with:"),
+        strip=False,
+        required=False,
+    )
+    copy_from_prop_id = forms.ChoiceField(
+        label=gettext_lazy("Copy from property:"),
+        choices=(),
+        required=False,
+        help_text=gettext_lazy(
+            "The value from this property will replace the "
+            "value from the selected property at the top."
+        ),
+    )
+
+    def __init__(self, session, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.session = session
+
+        property_details = get_case_property_details(self.session.domain, self.session.identifier)
+        self.fields['clean_prop_id'].choices = [(None, None)] + [
+            (p, p) for p in sorted(property_details.keys())
+        ]
+
+        initial_prop_id = self.data.get('clean_prop_id')
+
+        offcanvas_selector = "#offcanvas-bulk-changes"
+
+        alpine_data_model = {
+            "propId": initial_prop_id,
+            "cleanAction": self.data.get('clean_action', EditActionType.CHOICES[0][0]),
+        }
+
+        self.helper = FormHelper()
+        self.helper.form_tag = False
+        self.helper.layout = crispy.Layout(
+            crispy.Div(
+                crispy.Field(
+                    'clean_prop_id',
+                    x_select2=json.dumps({
+                        "placeholder": _("Select a case property..."),
+                        "dropdownParent": offcanvas_selector,
+                    }),
+                    **({
+                        "@select2change": "propId = $event.detail;",
+                    })
+                ),
+                crispy.Div(
+                    crispy.Field(
+                        'clean_action',
+                        x_select2=json.dumps({
+                            "placeholder": _("Select a cleaning action..."),
+                            "dropdownParent": offcanvas_selector,
+                        }),
+                        **({
+                            "@select2change": "cleanAction = $event.detail;",
+                        })
+                    ),
+                    twbscrispy.StrictButton(
+                        _("Preview Changes"),
+                        type="submit",
+                        css_class="btn-primary",
+                    ),
+                    x_show="propId",
+                ),
+                x_data=json.dumps(alpine_data_model),
+            )
+        )

--- a/corehq/apps/data_cleaning/forms/cleaning.py
+++ b/corehq/apps/data_cleaning/forms/cleaning.py
@@ -92,6 +92,7 @@ class CleanSelectedRecordsForm(forms.Form):
             "cleanAction": self.data.get('clean_action', EditActionType.CHOICES[0][0]),
             "findActions": [EditActionType.FIND_REPLACE],
             "replaceActions": [EditActionType.REPLACE],
+            "copyActions": [EditActionType.COPY_REPLACE],
         }
 
         self.helper = FormHelper()
@@ -135,6 +136,20 @@ class CleanSelectedRecordsForm(forms.Form):
                             css_class="card-body",
                         ),
                         x_show="replaceActions.includes(cleanAction)",
+                        css_class="card mb-3",
+                    ),
+                    crispy.Div(
+                        crispy.Div(
+                            crispy.Field(
+                                'copy_from_prop_id',
+                                x_select2=json.dumps({
+                                    "placeholder": _("Select a case property..."),
+                                    "dropdownParent": offcanvas_selector,
+                                }),
+                            ),
+                            css_class="card-body",
+                        ),
+                        x_show="copyActions.includes(cleanAction)",
                         css_class="card mb-3",
                     ),
                     twbscrispy.StrictButton(

--- a/corehq/apps/data_cleaning/forms/cleaning.py
+++ b/corehq/apps/data_cleaning/forms/cleaning.py
@@ -91,6 +91,7 @@ class CleanSelectedRecordsForm(forms.Form):
             "propId": initial_prop_id,
             "cleanAction": self.data.get('clean_action', EditActionType.CHOICES[0][0]),
             "findActions": [EditActionType.FIND_REPLACE],
+            "replaceActions": [EditActionType.REPLACE],
         }
 
         self.helper = FormHelper()
@@ -126,6 +127,14 @@ class CleanSelectedRecordsForm(forms.Form):
                             css_class="card-body",
                         ),
                         x_show="findActions.includes(cleanAction)",
+                        css_class="card mb-3",
+                    ),
+                    crispy.Div(
+                        crispy.Div(
+                            'replace_all_string',
+                            css_class="card-body",
+                        ),
+                        x_show="replaceActions.includes(cleanAction)",
                         css_class="card mb-3",
                     ),
                     twbscrispy.StrictButton(

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -823,6 +823,13 @@ class BulkEditColumn(models.Model):
             is_system=is_system_property,
         )
 
+    @property
+    def choice_label(self):
+        """
+        Returns the human-readable option visible in a select field.
+        """
+        return self.label if self.label == self.prop_id else f"{self.label} ({self.prop_id})"
+
 
 class BulkEditRecord(models.Model):
     session = models.ForeignKey(BulkEditSession, related_name="records", on_delete=models.CASCADE)

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -6,5 +6,12 @@
   hx-swap="outerHTML"
   hq-hx-refresh-swap="#CleanCaseTable"
 >
-  # todo clean cases form goes here
+  <form
+    hx-post="{{ request.path_info }}"
+    hx-target="#{{ container_id }}"
+    hx-disabled-elt="find button"
+    hq-hx-action="create_bulk_edit_change"
+  >
+    {% crispy cleaning_form %}
+  </form>
 </div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/offcanvas.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/offcanvas.html
@@ -76,8 +76,9 @@
   </div>
   <div class="offcanvas-body">
     <div
+      id="hq-hx-clean-selected-records-form"
       hx-get="{% url "data_cleaning_clean_selected_records_form" domain session_id %}"
-      hx-trigger="load"
+      hx-trigger="load, dcCleanFormRefresh"
     >
       {% include "data_cleaning/partials/loading_indicator.html" %}
     </div>

--- a/corehq/apps/data_cleaning/views/cleaning.py
+++ b/corehq/apps/data_cleaning/views/cleaning.py
@@ -3,11 +3,12 @@ from django.utils.translation import gettext_lazy
 from django.views.generic import TemplateView
 
 from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
+from corehq.apps.data_cleaning.forms.cleaning import CleanSelectedRecordsForm
 from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
 from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.domain.views import DomainViewMixin
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
-from corehq.util.htmx_action import HqHtmxActionMixin
+from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 
 @method_decorator([
@@ -24,6 +25,14 @@ class CleanSelectedRecordsFormView(BulkEditSessionViewMixin,
         context = super().get_context_data(**kwargs)
         context.update({
             'container_id': 'clean-selected-records',
-            'session': self.session,  # temporarily calling this here so that access tests pass
+            'cleaning_form': kwargs.pop('cleaning_form', None) or CleanSelectedRecordsForm(self.session),
         })
         return context
+
+    @hq_hx_action('post')
+    def create_bulk_edit_change(self, request, *args, **kwargs):
+        cleaning_form = CleanSelectedRecordsForm(self.session, request.POST)
+        if cleaning_form.is_valid():
+            # todo
+            cleaning_form = None
+        return self.get(request, cleaning_form=cleaning_form, *args, **kwargs)


### PR DESCRIPTION
## Technical Summary
This implements the crispy forms UI (without form validation--that comes after this!) for the Clean Selected Records Form.

review commit-by-commit

related ticket:
https://dimagi.atlassian.net/browse/SAAS-16870

How it first appears:
<img width="405" alt="Screenshot 2025-04-10 at 9 07 28 AM" src="https://github.com/user-attachments/assets/09aaad08-cb13-4038-9d35-28ab35c095a5" />

Once a property is selected (replace option)
<img width="450" alt="Screenshot 2025-04-10 at 9 07 48 AM" src="https://github.com/user-attachments/assets/f92368c7-9561-4bf9-b10c-b15274ac5c62" />

Find and replace:
<img width="427" alt="Screenshot 2025-04-10 at 9 07 54 AM" src="https://github.com/user-attachments/assets/c14c581f-0e01-4899-ac0e-d46bfa3553eb" />

Copy and replace:
<img width="423" alt="Screenshot 2025-04-10 at 9 08 01 AM" src="https://github.com/user-attachments/assets/c2ed98c0-f38c-4f49-b721-e3f837618f94" />
<img width="419" alt="Screenshot 2025-04-10 at 9 08 06 AM" src="https://github.com/user-attachments/assets/4304004d-8fdf-49b5-babc-03b3063fa5ae" />

The remaining options:
<img width="394" alt="Screenshot 2025-04-10 at 9 08 51 AM" src="https://github.com/user-attachments/assets/efd89d4e-da76-4a35-83a7-e727d3148680" />
<img width="404" alt="Screenshot 2025-04-10 at 9 08 43 AM" src="https://github.com/user-attachments/assets/2a6ffcfa-1b60-4245-bc9b-a6069c5e904c" />
<img width="408" alt="Screenshot 2025-04-10 at 9 08 38 AM" src="https://github.com/user-attachments/assets/5aa8d5e0-f18d-4275-a4eb-5f58a1a2cb0f" />
<img width="404" alt="Screenshot 2025-04-10 at 9 08 32 AM" src="https://github.com/user-attachments/assets/94a4421c-631f-47dd-8c46-939beb16d65e" />
<img width="405" alt="Screenshot 2025-04-10 at 9 08 26 AM" src="https://github.com/user-attachments/assets/22bdf03a-582c-4509-914c-33e04d3f58c5" />
<img width="402" alt="Screenshot 2025-04-10 at 9 08 20 AM" src="https://github.com/user-attachments/assets/7011dbca-5017-41d0-a900-ec7d0c7fbdea" />
<img width="398" alt="Screenshot 2025-04-10 at 9 08 14 AM" src="https://github.com/user-attachments/assets/a69c477f-4b27-4096-96c4-84afdc2270c8" />



## Feature Flag
`DATA_CLEANING_CASES`


## Safety Assurance

### Safety story
just a ui change in a feature flagged workflow

### Automated test coverage
no, but important functionality is already covered

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
