### PR TITLE
Return HTTP 403 on bad IP

### DIFF
--- a/corehq/apps/ip_access/middleware.py
+++ b/corehq/apps/ip_access/middleware.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse
+from django.core.exceptions import PermissionDenied
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import gettext_lazy as _
 
@@ -8,7 +8,11 @@ from corehq.toggles import IP_ACCESS_CONTROLS
 
 from .models import IPAccessConfig
 
-MSG = _("You cannot access this page from your current IP address")
+
+class IPPermissionDenied(PermissionDenied):
+    user_facing_message = _(
+        "You cannot access this page from your current IP address"
+    )
 
 
 class IPAccessMiddleware(MiddlewareMixin):
@@ -19,7 +23,7 @@ class IPAccessMiddleware(MiddlewareMixin):
 
         domain = view_kwargs['domain']
         if IP_ACCESS_CONTROLS.enabled(domain) and not is_valid_ip(request, domain):
-            return HttpResponse(MSG, status=451)
+            raise IPPermissionDenied()
 
 
 def is_valid_ip(request, domain):

--- a/corehq/apps/ip_access/tests/test_middleware.py
+++ b/corehq/apps/ip_access/tests/test_middleware.py
@@ -6,6 +6,7 @@ from django.urls import path
 
 from corehq.apps.users.models import WebUser
 from corehq.util.test_utils import flag_disabled, flag_enabled
+from urls import urlpatterns as base_urlpatterns
 
 from ..models import IPAccessConfig
 
@@ -21,7 +22,7 @@ def domain_view(request, domain):
 urlpatterns = [
     path('non_domain_view/', non_domain_view),
     path('a/<slug:domain>/', domain_view),
-]
+] + base_urlpatterns
 
 
 @override_settings(ROOT_URLCONF='corehq.apps.ip_access.tests.test_middleware')
@@ -56,7 +57,7 @@ class TestIPAccessMiddleware(TestCase):
     def test_disallowed_domain_view(self, is_allowed):
         is_allowed.return_value = False
         res = self.client.get(f'/a/{self.domain}/')
-        self.assertEqual(res.status_code, 451)
+        self.assertEqual(res.status_code, 403)
         is_allowed.assert_called_once()
 
     def test_other_domain(self, is_allowed):
@@ -139,5 +140,5 @@ class TestIPAccessMiddleware(TestCase):
         self.client.session.flush()
         self.client.login(username=self.username, password=self.password)
         res = self.client.get(f'/a/{self.domain}/')
-        self.assertEqual(res.status_code, 451)
+        self.assertEqual(res.status_code, 403)
         self.assertEqual(is_allowed.call_count, 2)


### PR DESCRIPTION
## Product Description


## Technical Summary
PRing into https://github.com/dimagi/commcare-hq/pull/36044

From a chat with @dannyroberts.  This seems like the more correct error code.  I also redid our `no_permissions` workflows to do some reporting to datadog that'll give us insights onto what triggered these types of errors.

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
