### PR TITLE
Fix issue with get app raising AppInDifferentDomainException

### DIFF
--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -15,6 +15,7 @@ from couchforms.analytics import get_exports_by_form
 
 from corehq.apps.app_manager.analytics import get_exports_by_application
 from corehq.apps.app_manager.dbaccessors import get_app, get_apps_in_domain
+from corehq.apps.app_manager.exceptions import AppInDifferentDomainException
 from corehq.apps.export.const import ALL_CASE_TYPE_EXPORT
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.registry.models import DataRegistry
@@ -337,7 +338,7 @@ class ApplicationDataRMIHelper(object):
                     if item not in self:
                         try:
                             self[item] = get_app(app_id=item, domain=self.domain)
-                        except Http404:
+                        except (Http404, AppInDifferentDomainException):
                             pass
                     return super(AppCache, self).__getitem__(item)
 

--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -12,6 +12,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_build_ids,
 )
 from corehq.apps.app_manager.exceptions import (
+    AppInDifferentDomainException,
     AppValidationError,
     SavedAppBuildException,
 )
@@ -88,8 +89,8 @@ def prune_auto_generated_builds(domain, app_id):
 def refresh_data_dictionary_from_app(domain, app_id):
     try:
         app = get_app(domain, app_id)
-    except Http404:
-        # If there's no app, trhere's nothing to do
+    except (Http404, AppInDifferentDomainException):
+        # If there's no app in the domain, there's nothing to do
         return
 
     from corehq.apps.app_manager.util import actions_use_usercase

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -33,6 +33,7 @@ from corehq.apps.app_manager.const import (
 )
 from corehq.apps.app_manager.dbaccessors import get_app, get_apps_in_domain
 from corehq.apps.app_manager.exceptions import (
+    AppInDifferentDomainException,
     AppManagerException,
     PracticeUserException,
     SuiteError,
@@ -650,7 +651,7 @@ def get_form_source_download_url(xform):
 
     try:
         app = get_app(xform.domain, xform.build_id)
-    except Http404:
+    except (Http404, AppInDifferentDomainException):
         return None
     if app.is_remote_app():
         return None

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -23,6 +23,7 @@ from jsonobject.exceptions import BadValueError
 from memoized import memoized
 
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
+from corehq.apps.app_manager.exceptions import AppInDifferentDomainException
 from couchexport.models import Format
 from couchexport.transforms import couch_to_excel_datetime
 from dimagi.ext.couchdbkit import (
@@ -1839,7 +1840,7 @@ class ExportDataSchema(Document):
     def _reorder_schema_from_app(cls, current_schema, app_id, identifier):
         try:
             app = get_app(current_schema.domain, app_id)
-        except Http404:
+        except (Http404, AppInDifferentDomainException):
             return current_schema
 
         if isinstance(app, RemoteApp):

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -11,6 +11,7 @@ import couchforms
 from couchforms.models import DefaultAuthContext
 
 from corehq.apps.app_manager.dbaccessors import get_app
+from corehq.apps.app_manager.exceptions import AppInDifferentDomainException
 from corehq.apps.app_manager.models import ApplicationBase
 from corehq.apps.receiverwrapper.exceptions import LocalSubmissionError
 from corehq.apps.receiverwrapper.rate_limiter import rate_limit_submission
@@ -91,7 +92,7 @@ def get_version_from_build_id(domain, build_id):
 
     try:
         build = get_app(domain, build_id)
-    except (ResourceNotFound, Http404):
+    except (ResourceNotFound, Http404, AppInDifferentDomainException):
         return None
     if not build.copy_of:
         return None

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -126,10 +126,10 @@ def strip_form_data(data):
     # remove all case, meta, attribute nodes from the top level
     for key in list(data.keys()):
         if (
-            not form_key_filter(key) or
-            key in ('meta', 'case', 'commcare_usercase') or
-            key.startswith('case_autoload_') or
-            key.startswith('case_load_')
+            not form_key_filter(key)
+            or key in ('meta', 'case', 'commcare_usercase')
+            or key.startswith('case_autoload_')
+            or key.startswith('case_load_')
         ):
             data.pop(key)
     return data

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -12,7 +12,7 @@ from corehq.apps.app_manager.app_schemas.app_case_metadata import (
     FormQuestionResponse,
 )
 from corehq.apps.app_manager.dbaccessors import get_app
-from corehq.apps.app_manager.exceptions import XFormException
+from corehq.apps.app_manager.exceptions import AppInDifferentDomainException, XFormException
 from corehq.apps.app_manager.models import Application
 from corehq.apps.reports.formdetails.exceptions import QuestionListNotFound
 from corehq.form_processor.exceptions import XFormQuestionValueNotFound
@@ -45,6 +45,10 @@ def get_questions(domain, app_id, xmlns):
     except Http404:
         raise QuestionListNotFound(
             _("No app could be found")
+        )
+    except AppInDifferentDomainException:
+        raise QuestionListNotFound(
+            _("App is in a different domain")
         )
     if not isinstance(app, Application):
         raise QuestionListNotFound(

--- a/corehq/ex-submodules/couchforms/management/commands/purge_forms_and_cases.py
+++ b/corehq/ex-submodules/couchforms/management/commands/purge_forms_and_cases.py
@@ -3,6 +3,7 @@ import csv
 from django.core.management.base import BaseCommand, CommandError
 from django.http import Http404
 
+from corehq.apps.app_manager.exceptions import AppInDifferentDomainException
 from corehq.apps.app_manager.models import Application
 from casexml.apps.case.xform import get_case_ids_from_form
 from corehq.form_processor.models import CommCareCase, XFormInstance
@@ -92,7 +93,7 @@ though deletion would be re-confirmed so dont panic
             if not version_from_mapping:
                 try:
                     get_app_version = get_app(self.domain, xform.build_id).version
-                except Http404:
+                except (Http404, AppInDifferentDomainException):
                     get_app_version = None
                 if get_app_version:
                     version_from_mapping = int(get_app_version)

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.http import Http404
 
 from corehq import toggles
+from corehq.apps.app_manager.exceptions import AppInDifferentDomainException
 from dimagi.utils.parsing import string_to_utc_datetime
 
 from corehq.apps.app_manager.dbaccessors import get_app
@@ -104,7 +105,7 @@ def mark_has_submission(domain, build_id):
     app = None
     try:
         app = get_app(domain, build_id)
-    except Http404:
+    except (Http404, AppInDifferentDomainException):
         pass
 
     if app and not app.has_submissions:

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -11,7 +11,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_app,
     get_latest_released_app,
 )
-from corehq.apps.app_manager.exceptions import FormNotFoundException
+from corehq.apps.app_manager.exceptions import AppInDifferentDomainException, FormNotFoundException
 from corehq.apps.data_interfaces.utils import property_references_parent
 from corehq.apps.formplayer_api.smsforms.api import TouchformsError
 from corehq.apps.reminders.util import get_one_way_number_for_recipient, get_two_way_number_for_recipient
@@ -584,7 +584,7 @@ class SurveyContent(Content):
                 app = get_latest_released_app(domain, self.app_id)
             form = app.get_form(self.form_unique_id)
             module = form.get_module()
-        except (Http404, FormNotFoundException):
+        except (Http404, FormNotFoundException, AppInDifferentDomainException):
             return None, None, None, None
 
         return app, module, form, form_requires_input(form)


### PR DESCRIPTION

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
While I was looking into Sentry today, I noticed couple of `AppInDifferentDomainException` [errors](https://dimagi.sentry.io/issues/?environment=production&project=136860&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20AppInDifferentDomainException&referrer=issue-stream&stream_index=1) in Sentry which might be blocking users to create exports.

The change in the PR is meant to keep the existing behaviour unchanged, so that all the places which were expecting 404 to be raised should also check for  `AppInDifferentDomainException`.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
Although this PR touches various components in HQ but it is essentially updating one thing which is pretty safe.

### Automated test coverage
na
<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
na
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
