### PR TITLE
Support case-contact location SMS information

### DIFF
--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -59,6 +59,8 @@ from corehq.util.metrics import metrics_counter
 from corehq.util.metrics.load_counters import sms_load_counter
 from corehq.util.quickcache import quickcache
 from corehq.util.view_utils import absolute_reverse
+from corehq.form_processor.models import CommCareCase
+from corehq.apps.users.cases import get_owner_id, get_owner_location_id
 
 # A list of all keywords which allow registration via sms.
 # Meant to allow support for multiple languages.
@@ -120,6 +122,9 @@ def get_location_id_by_contact(domain, contact):
         return contact.location_id
     elif isinstance(contact, WebUser):
         return contact.get_location_id(domain)
+    elif isinstance(contact, CommCareCase):
+        owner_id = get_owner_id(contact)
+        return get_owner_location_id(owner_id, domain)
     else:
         return None
 

--- a/corehq/apps/users/cases.py
+++ b/corehq/apps/users/cases.py
@@ -54,3 +54,16 @@ def get_wrapped_owner(owner_id, support_deleted=False):
         return cls.wrap(owner_doc) if cls else None
 
     return None
+
+
+def get_owner_location_id(owner_id, domain):
+    owner = get_wrapped_owner(owner_id)
+    if not owner:
+        return None
+
+    if isinstance(owner, SQLLocation):
+        return owner.location_id
+    if isinstance(owner, CouchUser):
+        return owner.get_location_id(domain)
+
+    return None

--- a/corehq/apps/users/tests/test_cases.py
+++ b/corehq/apps/users/tests/test_cases.py
@@ -1,0 +1,51 @@
+from django.test import TestCase
+from unittest.mock import patch
+from corehq.apps.users.models import WebUser, CommCareUser, DomainMembership
+from corehq.apps.locations.models import SQLLocation
+from corehq.apps.groups.models import Group
+
+from corehq.apps.users import cases
+from corehq.apps.users.cases import get_owner_location_id
+
+
+class TestGetEntityLocation(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.entities = {}
+
+        def lookup(owner_id, support_deleted=False):
+            return self.entities.get(owner_id, None)
+
+        patcher = patch.object(cases, 'get_wrapped_owner', side_effect=lookup)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_retrieves_location_from_web_user(self):
+        entity = WebUser(_id='1')
+        entity.domain_memberships = [DomainMembership(domain='test-domain', location_id='123')]
+
+        self.entities['1'] = entity
+
+        self.assertEqual(get_owner_location_id(entity._id, 'test-domain'), '123')
+
+    def test_retrieves_location_from_mobile_user(self):
+        entity = CommCareUser(_id='2', domain='test-domain')
+        entity.domain_membership = DomainMembership(domain='test-domain', location_id='123')
+
+        self.entities['2'] = entity
+
+        self.assertEqual(get_owner_location_id(entity._id, 'test-domain'), '123')
+
+    def test_retrieves_location_from_location(self):
+        entity = SQLLocation(location_id='123')
+        self.entities['123'] = entity
+
+        self.assertEqual(get_owner_location_id(entity.location_id, 'test-domain'), '123')
+
+    def test_location_from_group_is_none(self):
+        entity = Group(_id='3')
+
+        self.entities['3'] = entity
+
+        self.assertIsNone(get_owner_location_id(entity._id, 'test-domain'))

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -9,7 +9,7 @@ from schema import And, Or, Schema, SchemaError
 from couchforms.const import TAG_FORM, TAG_META
 
 from corehq.apps.locations.models import SQLLocation
-from corehq.apps.users.cases import get_owner_id, get_wrapped_owner
+from corehq.apps.users.cases import get_owner_id, get_owner_location_id
 from corehq.form_processor.models import CommCareCase
 from corehq.motech.const import (  # noqa: F401
     COMMCARE_DATA_TYPE_DECIMAL,
@@ -681,12 +681,7 @@ def get_case_location(case):
 
 
 def get_owner_location(domain, owner_id):
-    owner = get_wrapped_owner(owner_id)
-    if not owner:
-        return None
-    if isinstance(owner, SQLLocation):
-        return owner
-    location_id = owner.get_location_id(domain)
+    location_id = get_owner_location_id(owner_id, domain)
     return SQLLocation.by_location_id(location_id) if location_id else None
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-16384

It was found that the Message Log's "Location Filter" was not working for messages sent to a "Contact Case". This was because the location filter filters based on the SMS message's `location_id`, and any message sent to anything but a `CommCareUser` or `WebUser` was not recording any location information.   This has been fixed so that the contact case will now attempt to pull location information from the case's owner.

In implementing this, I realized that we already had similar logic to get the location id from an owner inside `motech`. However, it appeared that this code did not gracefully handle Groups as case owners -- they would produce an error. I moved this code out to a more central location (so `sms` didn't need to depend on `motech`) and added code to correct the `Group`s issue.

Note that this will only partially fix the issue in the original ticket, as messages submitted prior to this change will still have no location information, and thus will not appear in the Message Log report. I've been told that the partner making this request is still in the testing phase, and therefore is fine with this. We could create a migration to handle older messages, but it doesn't appear necessary for them.

## Feature Flag
No feature flag

## Safety Assurance

### Safety story
Verified the SMS change by testing on staging. I created a conditional alert to send to a contact case and verified that this alert sent to my phone both as a mobile user and as a location. I did not perform any motech verification.

### Automated test coverage

A new test suite was created to cover the owner->location_id functionality.

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
