### PR TITLE
Update wording and styles for community/free banner and plan label

### DIFF
--- a/corehq/apps/accounting/user_text.py
+++ b/corehq/apps/accounting/user_text.py
@@ -1,11 +1,15 @@
 from django.utils.translation import gettext_lazy as _
 
 from corehq.apps.accounting.models import FeatureType, SoftwarePlanEdition
+from corehq.apps.hqwebapp.templatetags.hq_shared_tags import prelogin_url
 
 DESC_BY_EDITION = {
     SoftwarePlanEdition.COMMUNITY: {
         'name': _("Free"),
-        'description': _("For practice purposes. Not intended for live projects. {} users maximum."),
+        'description': _(
+            "Designed for practice purposes and not intended for live projects. Upgrade to access "
+            "full features and more users. Learn about "
+        ) + f'<a href="{prelogin_url("public_pricing")}" target="_blank">' + _("CommCare plans") + '</a>.',
     },
     SoftwarePlanEdition.STANDARD: {
         'name': _("Standard"),

--- a/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
@@ -43,7 +43,7 @@
                     The {{ trial_length }} Day Trial includes all the features present in the
                     {{ pn }} Software Plan, which is our full set of features.
                   {% endblocktrans %}
-                {% else %}{{ plan.description }}{% endif %}</p>
+                {% else %}{{ plan.description|safe }}{% endif %}</p>
             </div>
             {% if plan.do_not_invoice and not plan.is_paused %}
               <div class="alert alert-info">

--- a/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
@@ -43,7 +43,7 @@
                     The {{ trial_length }} Day Trial includes all the features present in the
                     {{ pn }} Software Plan, which is our full set of features.
                   {% endblocktrans %}
-                {% else %}{{ plan.description }}{% endif %}</p>
+                {% else %}{{ plan.description|safe }}{% endif %}</p>
             </div>
             {% if plan.do_not_invoice and not plan.is_paused %}
               <div class="alert alert-info">

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/alerts.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/alerts.less
@@ -52,10 +52,15 @@
   border: none;
   border-radius: 0;
   font-size: 1.1em;
-  font-weight: bold;
 
-  a, a:link, a:visited {
+  a,
+  a:link,
+  a:visited {
     color: white;
+    text-decoration: underline;
+  }
+  a:hover {
+    color: @color-purple-dark-inverse;
   }
 
   .btn-purple,

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/label.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/label.less
@@ -14,6 +14,13 @@
   padding: 10px;
   color: #ffffff;
   background-color: @cc-dark-cool-accent-low;
+  a {
+    color: @cc-neutral-hi;
+  }
+  a:hover {
+    color: #ffffff;
+    text-decoration: none;
+  }
 }
 
 .label-plan-enterprise {
@@ -33,7 +40,7 @@
 }
 
 .label-plan-community {
-  background-color: @cc-dark-cool-accent-mid;
+  background-color: @gray;
 }
 
 .label-flag {

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/label.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/label.less
@@ -53,7 +53,6 @@
 }
 .label-flag-disabled {
   margin: 25px 0;
-
 }
 table .label-flag {
   max-width: 100px;

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_alert.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_alert.scss
@@ -32,7 +32,11 @@
   }
 
   .btn-confirm {
-    @include button-variant(#ffffff, $color-purple-dark, darken($color-purple-dark, 5));
+    @include button-variant(
+      #ffffff,
+      $color-purple-dark,
+      darken($color-purple-dark, 5)
+    );
     border: 1px solid #ffffff;
 
     &:active,

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_alert.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_alert.scss
@@ -52,10 +52,15 @@
   border: none;
   border-radius: 0;
   font-size: 1.1em;
-  font-weight: bold;
 
-  a, a:link, a:visited {
+  a,
+  a:link,
+  a:visited {
     color: white;
+    text-decoration: underline;
+  }
+  a:hover {
+    color: $color-purple-dark-inverse;
   }
 
   .btn-purple,

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_label.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_label.scss
@@ -13,6 +13,13 @@
   padding: 10px;
   color: #ffffff;
   background-color: $cc-dark-cool-accent-low;
+  a {
+    color: $cc-neutral-hi;
+  }
+  a:hover {
+    color: #ffffff;
+    text-decoration: none;
+  }
 }
 
 .label-plan-enterprise {
@@ -32,7 +39,7 @@
 }
 
 .label-plan-community {
-  background-color: $cc-dark-cool-accent-mid;
+  background-color: $gray;
 }
 
 .label-flag {

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_label.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_label.scss
@@ -52,7 +52,6 @@
 }
 .label-flag-disabled {
   margin: 25px 0;
-
 }
 table .label-flag {
   max-width: 100px;

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/community_banner.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/community_banner.html
@@ -5,7 +5,8 @@
   <i class="fa fa-info-circle"></i>
   {% url 'domain_subscription_view' domain as url_sub %}
   {% blocktrans %}
-    You're using the free edition of CommCare. For practice purposes.
+    You're using the free edition of CommCare intended only for practice
+    purposes.
     <a href="{{ url_sub }}" id="cta-community-sub">Upgrade to a plan</a> for
     full access.
   {% endblocktrans %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/community_banner.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/community_banner.html
@@ -5,7 +5,8 @@
   <i class="fa fa-info-circle"></i>
   {% url 'domain_subscription_view' domain as url_sub %}
   {% blocktrans %}
-    You are on the CommCare Community Plan.
-    <a href="{{ url_sub }}" id="cta-community-sub">Subscribe to a professional plan</a>.
+    You're using the free edition of CommCare. For practice purposes.
+    <a href="{{ url_sub }}" id="cta-community-sub">Upgrade to a plan</a> for
+    full access.
   {% endblocktrans %}
 </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/alerts._alert.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/alerts._alert.style.diff.txt
@@ -23,7 +23,7 @@
    color: #ffffff;
    border: none;
  
-@@ -28,11 +28,11 @@
+@@ -28,11 +28,15 @@
    a:active,
    a:hover,
    a:link {
@@ -33,11 +33,15 @@
  
    .btn-confirm {
 -    .button-variant(#ffffff; @color-purple-dark; darken(@color-purple-dark, 5));
-+    @include button-variant(#ffffff, $color-purple-dark, darken($color-purple-dark, 5));
++    @include button-variant(
++      #ffffff,
++      $color-purple-dark,
++      darken($color-purple-dark, 5)
++    );
      border: 1px solid #ffffff;
  
      &:active,
-@@ -47,8 +47,8 @@
+@@ -47,8 +51,8 @@
  }
  
  .alert-trial {
@@ -48,7 +52,13 @@
    border: none;
    border-radius: 0;
    font-size: 1.1em;
-@@ -60,13 +60,13 @@
+@@ -60,18 +64,18 @@
+     text-decoration: underline;
+   }
+   a:hover {
+-    color: @color-purple-dark-inverse;
++    color: $color-purple-dark-inverse;
+   }
  
    .btn-purple,
    .btn-purple:focus {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/label._label.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/label._label.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -9,31 +9,30 @@
+@@ -9,13 +9,12 @@
  }
  
  .label-plan {
@@ -11,6 +11,13 @@
    color: #ffffff;
 -  background-color: @cc-dark-cool-accent-low;
 +  background-color: $cc-dark-cool-accent-low;
+   a {
+-    color: @cc-neutral-hi;
++    color: $cc-neutral-hi;
+   }
+   a:hover {
+     color: #ffffff;
+@@ -24,23 +23,23 @@
  }
  
  .label-plan-enterprise {
@@ -34,8 +41,8 @@
  }
  
  .label-plan-community {
--  background-color: @cc-dark-cool-accent-mid;
-+  background-color: $cc-dark-cool-accent-mid;
+-  background-color: @gray;
++  background-color: $gray;
  }
  
  .label-flag {


### PR DESCRIPTION
## Product Description
**Banner**
Before:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/aec953c7-8ab7-4572-8e1b-296d4bc0f060" />

After:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/a491d2cb-9098-4bbc-a0ee-c1f528a4e505" />


**Plan Label**
Before:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/38a633ad-1151-4b81-b709-ad98008d6fab" />

After:
<img width="810" alt="image" src="https://github.com/user-attachments/assets/8ec04978-7154-412b-ab3f-1b6d03ac3ba9" />



## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-16835: Banner
https://dimagi.atlassian.net/browse/SAAS-16836: Plan Label

The text used for the plan label is the same as would be used for the "Confirm Subscription" page - however since someone is never able to select/confirm the free edition and can only be defaulted to it, this only has the effect of changing the plan label text. 

## Safety Assurance

### Safety story
Just changes to text and styling, very safe kinds of changes.

### Automated test coverage
No, not for UI text and styling.

### QA Plan
Not planning on it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
