### PR TITLE
Updated Stripe UI selector to limit to the current form

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -1,7 +1,7 @@
 /**
  *  This module requires initial page data to provide "stripe_public_key".
- *  It also requires a container with the id stripe-card-container, which is where the credit card UI will be
- *  mounted.
+ *  It also requires the given form contain a div with the class stripe-card-container,
+ *  which is where the credit card UI will be  mounted.
  */
 hqDefine('accounting/js/payment_method_handler', [
     'jquery',
@@ -134,10 +134,10 @@ hqDefine('accounting/js/payment_method_handler', [
         self.cardElementMounted = false;
         self.showOrHideStripeUI = function (show) {
             self.cardElementPromise.then(function (cardElement) {
-                const containerId = 'stripe-card-container';
+                const stripeSelector = '#' + formId + ' .stripe-card-container';
                 if (show) {
-                    if (document.getElementById(containerId)) {
-                        cardElement.mount('#' + formId + ' #' + containerId);
+                    if ($(stripeSelector).length) {
+                        cardElement.mount(stripeSelector);
                         self.cardElementMounted = true;
                     }
                 } else {

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -137,7 +137,7 @@ hqDefine('accounting/js/payment_method_handler', [
                 const containerId = 'stripe-card-container';
                 if (show) {
                     if (document.getElementById(containerId)) {
-                        cardElement.mount('#' + containerId);
+                        cardElement.mount('#' + formId + ' #' + containerId);
                         self.cardElementMounted = true;
                     }
                 } else {

--- a/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe_card_manager.js
@@ -1,6 +1,6 @@
 /**
  *  This module requires initial page data to provide "stripe_public_key".
- *  It also requires a container with the id stripe-card-container, which is where the credit card UI will be
+ *  It also requires a container with the class stripe-card-container, which is where the credit card UI will be
  *  mounted.
  */
 hqDefine("accounting/js/stripe_card_manager", [
@@ -22,7 +22,7 @@ hqDefine("accounting/js/stripe_card_manager", [
         self.cardElementMounted = false;
         self.cardElementPromise = hqStripe.getCardElementPromise(initialPageData.get("stripe_public_key"));
         self.cardElementPromise.then(function (cardElement) {
-            cardElement.mount('#stripe-card-container');
+            cardElement.mount('.stripe-card-container');
             self.cardElementMounted = true;
         });
 

--- a/corehq/apps/accounting/templates/accounting/partials/new_stripe_card_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/new_stripe_card_template.html
@@ -22,7 +22,7 @@
                                     text: errorMsg">
           </div>
 
-          <div id="stripe-card-container"></div>{# populated by a card element from Stripe #}
+          <div class="stripe-card-container"></div>{# populated by a card element from Stripe #}
 
           <div class="form-group">
             <div class="col-sm-9">

--- a/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
@@ -109,7 +109,7 @@
   <div data-bind="visible: showCardData">
     <div class="form-group">
       <div class="col-sm-9 col-sm-offset-3">
-        <div id="stripe-card-container"></div>{# populated by a card element from Stripe #}
+        <div class="stripe-card-container"></div>{# populated by a card element from Stripe #}
       </div>
     </div>
     <div class="form-group">

--- a/corehq/apps/domain/templates/domain/bootstrap3/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/billing_statements.html
@@ -20,36 +20,29 @@
         data-bind="text: displayTotalDue, visible: hasInitialLoadFinished"
       ></span>
     </h2>
-    {% if not is_ops_user_but_not_admin %}
+    <p data-bind="visible: hasInitialLoadFinished() && totalDue()">
+      <button
+        type="button"
+        class="btn btn-primary"
+        data-toggle="modal"
+        data-target="#bulkPaymentModal"
+        id="bulkPaymentBtn"
+      >
+        {% trans 'Pay by Credit Card' %}
+      </button>
+    </p>
+    {% if can_pay_by_wire %}
       <p data-bind="visible: hasInitialLoadFinished() && totalDue()">
         <button
           type="button"
           class="btn btn-primary"
           data-toggle="modal"
-          data-target="#bulkPaymentModal"
-          id="bulkPaymentBtn"
+          data-target="#bulkWirePaymentModal"
+          id="bulkWirePaymentBtn"
         >
-          {% trans 'Pay by Credit Card' %}
+          {% trans 'Pay by Wire' %}
         </button>
       </p>
-      {% if can_pay_by_wire %}
-        <p data-bind="visible: hasInitialLoadFinished() && totalDue()">
-          <button
-            type="button"
-            class="btn btn-primary"
-            data-toggle="modal"
-            data-target="#bulkWirePaymentModal"
-            id="bulkWirePaymentBtn"
-          >
-            {% trans 'Pay by Wire' %}
-          </button>
-        </p>
-      {% endif %}
-    {% else %}
-      <span class="label label-default">
-        <i class="fa fa-info-circle"></i>
-        {% trans "Not Billing Admin, Can't Make Payment" %}
-      </span>
     {% endif %}
   </div>
   <h2>
@@ -98,21 +91,14 @@
         data-bind="text: payment_status, attr: {class: payment_class}"
       ></span>
       <!-- ko if: canMakePayment -->
-      {% if not is_ops_user_but_not_admin %}
-        <button
-          type="button"
-          class="btn btn-primary payment-button"
-          data-toggle="modal"
-          data-target="#paymentModal"
-        >
-          {% trans 'Make Payment' %}
-        </button>
-      {% else %}
-        <span class="label label-default">
-          <i class="fa fa-info-circle"></i>
-          {% trans "Not Billing Admin, Can't Make Payment" %}
-        </span>
-      {% endif %}
+      <button
+        type="button"
+        class="btn btn-primary payment-button"
+        data-toggle="modal"
+        data-target="#paymentModal"
+      >
+        {% trans 'Make Payment' %}
+      </button>
       <!-- /ko -->
     </td>
     <td class="col-sm-2">

--- a/corehq/apps/domain/templates/domain/bootstrap5/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/billing_statements.html
@@ -20,36 +20,29 @@
         data-bind="text: displayTotalDue, visible: hasInitialLoadFinished"
       ></span>
     </h2>
-    {% if not is_ops_user_but_not_admin %}
+    <p data-bind="visible: hasInitialLoadFinished() && totalDue()">
+      <button
+        type="button"
+        class="btn btn-primary"
+        data-bs-toggle="modal"
+        data-bs-target="#bulkPaymentModal"
+        id="bulkPaymentBtn"
+      >
+        {% trans 'Pay by Credit Card' %}
+      </button>
+    </p>
+    {% if can_pay_by_wire %}
       <p data-bind="visible: hasInitialLoadFinished() && totalDue()">
         <button
           type="button"
           class="btn btn-primary"
           data-bs-toggle="modal"
-          data-bs-target="#bulkPaymentModal"
-          id="bulkPaymentBtn"
+          data-bs-target="#bulkWirePaymentModal"
+          id="bulkWirePaymentBtn"
         >
-          {% trans 'Pay by Credit Card' %}
+          {% trans 'Pay by Wire' %}
         </button>
       </p>
-      {% if can_pay_by_wire %}
-        <p data-bind="visible: hasInitialLoadFinished() && totalDue()">
-          <button
-            type="button"
-            class="btn btn-primary"
-            data-bs-toggle="modal"
-            data-bs-target="#bulkWirePaymentModal"
-            id="bulkWirePaymentBtn"
-          >
-            {% trans 'Pay by Wire' %}
-          </button>
-        </p>
-      {% endif %}
-    {% else %}
-      <span class="badge text-bg-secondary">
-        <i class="fa fa-info-circle"></i>
-        {% trans "Not Billing Admin, Can't Make Payment" %}
-      </span>
     {% endif %}
   </div>
   <h2>
@@ -98,21 +91,14 @@
         data-bind="text: payment_status, attr: {class: payment_class}"
       ></span>
       <!-- ko if: canMakePayment -->
-      {% if not is_ops_user_but_not_admin %}
-        <button
-          type="button"
-          class="btn btn-primary payment-button"
-          data-bs-toggle="modal"
-          data-bs-target="#paymentModal"
-        >
-          {% trans 'Make Payment' %}
-        </button>
-      {% else %}
-        <span class="badge text-bg-secondary">
-          <i class="fa fa-info-circle"></i>
-          {% trans "Not Billing Admin, Can't Make Payment" %}
-        </span>
-      {% endif %}
+      <button
+        type="button"
+        class="btn btn-primary payment-button"
+        data-bs-toggle="modal"
+        data-bs-target="#paymentModal"
+      >
+        {% trans 'Make Payment' %}
+      </button>
       <!-- /ko -->
     </td>
     <td class="col-md-2">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/billing_statements.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/billing_statements.html.diff.txt
@@ -14,38 +14,29 @@
    {% initial_page_data 'stripe_cards' stripe_cards %}
    {% initial_page_data 'stripe_public_key' stripe_public_key %}
    {% initial_page_data 'payment_urls' payment_urls %}
-@@ -25,8 +25,8 @@
+@@ -24,8 +24,8 @@
+       <button
+         type="button"
+         class="btn btn-primary"
+-        data-toggle="modal"
+-        data-target="#bulkPaymentModal"
++        data-bs-toggle="modal"
++        data-bs-target="#bulkPaymentModal"
+         id="bulkPaymentBtn"
+       >
+         {% trans 'Pay by Credit Card' %}
+@@ -36,8 +36,8 @@
          <button
            type="button"
            class="btn btn-primary"
 -          data-toggle="modal"
--          data-target="#bulkPaymentModal"
+-          data-target="#bulkWirePaymentModal"
 +          data-bs-toggle="modal"
-+          data-bs-target="#bulkPaymentModal"
-           id="bulkPaymentBtn"
++          data-bs-target="#bulkWirePaymentModal"
+           id="bulkWirePaymentBtn"
          >
-           {% trans 'Pay by Credit Card' %}
-@@ -37,8 +37,8 @@
-           <button
-             type="button"
-             class="btn btn-primary"
--            data-toggle="modal"
--            data-target="#bulkWirePaymentModal"
-+            data-bs-toggle="modal"
-+            data-bs-target="#bulkWirePaymentModal"
-             id="bulkWirePaymentBtn"
-           >
-             {% trans 'Pay by Wire' %}
-@@ -46,7 +46,7 @@
-         </p>
-       {% endif %}
-     {% else %}
--      <span class="label label-default">
-+      <span class="badge text-bg-secondary">
-         <i class="fa fa-info-circle"></i>
-         {% trans "Not Billing Admin, Can't Make Payment" %}
-       </span>
-@@ -79,21 +79,21 @@
+           {% trans 'Pay by Wire' %}
+@@ -72,21 +72,21 @@
  {% block pagination_templates %}
    <script type="text/html" id="statement-row-template">
      <td
@@ -72,24 +63,17 @@
        <span
          data-bind="text: payment_status, attr: {class: payment_class}"
        ></span>
-@@ -102,20 +102,20 @@
-         <button
-           type="button"
-           class="btn btn-primary payment-button"
--          data-toggle="modal"
--          data-target="#paymentModal"
-+          data-bs-toggle="modal"
-+          data-bs-target="#paymentModal"
-         >
-           {% trans 'Make Payment' %}
-         </button>
-       {% else %}
--        <span class="label label-default">
-+        <span class="badge text-bg-secondary">
-           <i class="fa fa-info-circle"></i>
-           {% trans "Not Billing Admin, Can't Make Payment" %}
-         </span>
-       {% endif %}
+@@ -94,14 +94,14 @@
+       <button
+         type="button"
+         class="btn btn-primary payment-button"
+-        data-toggle="modal"
+-        data-target="#paymentModal"
++        data-bs-toggle="modal"
++        data-bs-target="#paymentModal"
+       >
+         {% trans 'Make Payment' %}
+       </button>
        <!-- /ko -->
      </td>
 -    <td class="col-sm-2">
@@ -97,7 +81,7 @@
        <a
          class="btn btn-primary"
          data-bind="attr: { href: pdfUrl }"
-@@ -128,16 +128,16 @@
+@@ -114,16 +114,16 @@
    {% include 'accounting/partials/stripe_card_ko_template.html' %}
  
    <script type="text/html" id="cost-item-template">
@@ -117,7 +101,7 @@
          <div class="radio">
            <label>
              <input
-@@ -163,7 +163,7 @@
+@@ -149,7 +149,7 @@
              />
              {% blocktrans %} Pay a portion of the balance: {% endblocktrans %}
              <div class="input-group">
@@ -126,7 +110,7 @@
                <input
                  type="text"
                  class="form-control"
-@@ -232,12 +232,12 @@
+@@ -218,12 +218,12 @@
  {% block modals %}
    {{ block.super }}
    {% with process_invoice_payment_url as process_payment_url %}


### PR DESCRIPTION
## Product Description
The "Pay by Credit Card" button on the billing statements page is not displaying the Stripe UI to input credit card info:

<img width="600" alt="Screenshot 2025-04-14 at 11 28 03 AM" src="https://github.com/user-attachments/assets/626e07d3-bdf6-478f-8638-36ae5490adeb" />

## Technical Summary
I think this is happening because there are multiple payment modals on the page. Happily, the relevant code already has an id of the form containing the UI.

## Feature Flag
This button is behind a `not is_ops_user_but_not_admin` check [here](https://github.com/dimagi/commcare-hq/blob/07e0862712570c058138407d841f248953da650f/corehq/apps/domain/templates/domain/billing_statements.html#L20-L39), but grepping for `is_ops_user_but_not_admin` turns up nothing. So it seems this is accessible to everyone but that may not be the intent - @jingcheng16 @nospame any idea if that's the intent?

## Safety Assurance

### Safety story
I can't reproduce this locally, but I tested that the billing info page, which uses the same js code, still displays the credit card UI. This is a pretty narrow change.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
