### PR TITLE
Fix broken admin site form for CaseSearchConfig

### DIFF
--- a/corehq/apps/case_search/admin.py
+++ b/corehq/apps/case_search/admin.py
@@ -7,7 +7,7 @@ from .models import CaseSearchConfig
 
 
 class CaseSearchConfigForm(forms.ModelForm):
-    index_name = BooleanField(label="Use dedicated index")
+    index_name = BooleanField(label="Use dedicated index", required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Product Description


## Technical Summary
Make this field actually editable
Apparently leaving a checkbox unchecked counts as not answering. That prevents this form from being submitted unless the box is checked.

## Feature Flag


## Safety Assurance


### Safety story
Admin site only.  Local testing seems fine.

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
