### PR TITLE
build_requirejs cleanup

### DIFF
--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -44,8 +44,6 @@ jobs:
           ./manage.py fix_less_imports_collectstatic
           echo "Starting compilejsi18n..."
           ./manage.py compilejsi18n
-          echo "Starting build_requirejs..."
-          ./manage.py build_requirejs
           echo "Starting generate_webpack_settings..."
           ./manage.py generate_webpack_settings
           echo "Starting yarn build..."


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
`build_requirejs` is removed in https://github.com/dimagi/commcare-hq/pull/36181

I receive [this error](https://github.com/dimagi/commcare-hq/actions/runs/14451043510) when deploy to staging. So removing `build_requirejs` from build static files...

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
`build_requirejs` command has already been deleted.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
