### PR TITLE
Removed requirejs files from copy_required_static_files

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/copy_required_static_files.py
+++ b/corehq/apps/hqwebapp/management/commands/copy_required_static_files.py
@@ -44,8 +44,6 @@ class Command(BaseCommand):
         # Additional directories to copy
         additional_dirs = ['jsi18n', 'webpack', 'webpack_b3', 'CACHE']
 
-        files_to_copy = ['build.b3.js', 'build.b3.txt', 'build.b5.js', 'build.b5.txt', 'build.js', 'build.txt']
-
         def should_copy_directory(dir_name):
             return dir_name in installed_apps or dir_name in additional_dirs
 
@@ -64,12 +62,6 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(
             f'Successfully copied {copied_count} directories to {static_filtered}'
         ))
-
-        # copy files to copy
-        for file in files_to_copy:
-            src_path = os.path.join(static_root, file)
-            dst_path = os.path.join(static_filtered, file)
-            shutil.copy2(src_path, dst_path)
 
         # Print total size of copied files
         total_size = 0


### PR DESCRIPTION
## Technical Summary
Fix the workflow to build static files.

I missed this in https://github.com/dimagi/commcare-hq/pull/36181 - these are config files that used to get generated by the `build_requirejs` management comment. See here: https://github.com/dimagi/commcare-hq/pull/36181/files#diff-4745acd04bdcc1fc7244912f4eb09dd0e95e4437218016270513f7f4414695c0L179-L207

## Safety Assurance

### Safety story
This workflow isn't being used live yet.

### Automated test coverage

I don't think so.

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
