### PR TITLE
[Data Cleaning] Improve user experience by drawing attention to buttons to fix common configuration issues

### DIFF
--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -9,6 +9,9 @@ import 'hqwebapp/js/alpinejs/directives/htmx_sortable';
 import 'hqwebapp/js/alpinejs/directives/tooltip';
 import 'data_cleaning/js/directives/dynamic_options_select2';
 
+import wiggleButton from 'hqwebapp/js/alpinejs/components/wiggle_button';
+Alpine.data('wiggleButtonModel', wiggleButton);
+
 import Alpine from 'alpinejs';
 Alpine.start();
 

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -6,12 +6,28 @@
   hx-swap="outerHTML"
   hq-hx-refresh-swap="#CleanCaseTable"
 >
-  <form
-    hx-post="{{ request.path_info }}"
-    hx-target="#{{ container_id }}"
-    hx-disabled-elt="find button"
-    hq-hx-action="create_bulk_edit_change"
-  >
-    {% crispy cleaning_form %}
-  </form>
+  {% if cleaning_form.is_form_visible %}
+    <form
+      hx-post="{{ request.path_info }}"
+      hx-target="#{{ container_id }}"
+      hx-disabled-elt="find button"
+      hq-hx-action="create_bulk_edit_change"
+    >
+      {% crispy cleaning_form %}
+    </form>
+  {% else %}
+    <div class="alert alert-primary">
+      <h5>{% trans "No editible case properties are visible" %}</h5>
+      {% blocktrans %}
+        Please
+        <a
+          href="#"
+          class="fw-bold"
+          data-bs-dismiss="offcanvas"
+        >Configure Columns</a>
+        to include editible case properties in the column list in
+        order to clean the selected cases.
+      {% endblocktrans %}
+    </div>
+  {% endif %}
 </div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -24,6 +24,7 @@
           href="#"
           class="fw-bold"
           data-bs-dismiss="offcanvas"
+          @click.prevent="$dispatch('wiggle-configure-columns-button');"
         >Configure Columns</a>
         to include editible case properties in the column list in
         order to clean the selected cases.

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/button_bar.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/button_bar.html
@@ -5,6 +5,9 @@
   type="button"
   data-bs-toggle="offcanvas"
   data-bs-target="#offcanvas-filter"
+  x-data="wiggleButtonModel"
+  @wiggle-filters-button.window="wiggleThatButton()"
+  :class="getWiggleClasses()"
 >
   <i class="fa-solid fa-filter"></i> {% trans "Filter Cases" %}
 </button>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/button_bar.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/button_bar.html
@@ -13,6 +13,9 @@
   type="button"
   data-bs-toggle="offcanvas"
   data-bs-target="#offcanvas-configure-columns"
+  x-data="wiggleButtonModel"
+  @wiggle-configure-columns-button.window="wiggleThatButton()"
+  :class="getWiggleClasses()"
 >
   <i class="fa-solid fa-table-columns"></i> {% trans "Configure Columns" %}
 </button>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -12,6 +12,20 @@
   }"
 {% endblock %}
 
+{% block no_results_table %}
+  <div class="alert alert-primary">
+    {% blocktrans %}
+      No cases were found that match the current filters. Please
+      <a
+        href="#"
+        class="fw-bold"
+        @click.prevent="$dispatch('wiggle-filters-button');"
+      >adjust your filters</a>
+      and try again.
+    {% endblocktrans %}
+  </div>
+{% endblock %}
+
 {% block before_table %}
   <div class="d-flex align-items-center pb-2">
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/components/wiggle_button.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/components/wiggle_button.js
@@ -1,0 +1,58 @@
+/**
+ * Use this model to create user delight!
+ * Encourage interaction with a button by making it wiggle
+ * when the user hovers over it, or clicks it.
+ *
+ * Use this by importing the model before Alpine.start() like this:
+ *
+ *   import wiggleButton from 'hqwebapp/js/alpinejs/components/wiggle_button';
+ *   Alpine.data('wiggleButtonModel', wiggleButton);
+ *
+ * Here is an example for a click-to-wiggle button on your page
+ * using this model:
+ *
+ *   Somewhere on the page you might have this text:
+ *
+ *     No records were found that match the current filters. Please
+ *     <a
+ *       href="#"
+ *       class="fw-bold"
+ *       @click.prevent="$dispatch('wiggle-filters-button');"
+ *     >adjust your filters</a> and try again.
+ *
+ *   Your filters button might look like this:
+ *
+ *     <button
+ *       type="button"
+ *       class="btn btn-outline-primary"
+ *       x-model="wiggleButtonModel"
+ *       @wiggle-filters-button.window="wiggleThatButton()"
+ *       :class="getWiggleClasses()"
+ *     >Filter Records</button>
+ *
+ *   Is your button not `btn-outline-primary`? No problem! Just pass in
+ *   the classes as arguments in your model:
+ *
+ *      x-model="wiggleButtonModel('btn-secondary', 'btn-outline-secondary')"
+ *
+ */
+export default (
+    onStateClasses = 'btn-primary',
+    offStateClasses = 'btn-outline-primary',
+) => ({
+    isWiggling: false,
+    onStateClasses: onStateClasses + ' btn-wiggle',
+    offStateClasses: offStateClasses,
+    wiggleThatButton() {
+        this.isWiggling = true;
+        setTimeout(() => {
+            this.isWiggling = false;
+        }, 1000);
+    },
+    getWiggleClasses() {
+        let cssClasses = {};
+        cssClasses[this.onStateClasses] = this.isWiggling;
+        cssClasses[this.offStateClasses] = !this.isWiggling;
+        return cssClasses;
+    },
+});


### PR DESCRIPTION
## Technical Summary
This introduces a mechanism for "wiggling" a button when a user clicks on hint text shown in an info message. The goal of this is to draw the user's attention to fix "issues" in the UI due to either current filters resulting in showing no cases or columns not including any "editable" case properties.

Here is the UX hint when there aren't any available case properties to clean:
![Screenshot 2025-04-15 at 1 40 34 PM](https://github.com/user-attachments/assets/60154ed4-c536-43d4-af4f-cef111126be1)

Here is the UX hint when filters applied resulted in an empty queryset:
![Screenshot 2025-04-15 at 1 41 08 PM](https://github.com/user-attachments/assets/1dab7169-2372-4fe0-99ec-0ed08935fda0)

Here is a video of the "wiggle" interaction to point out the configure columns button in the first scenario:

https://github.com/user-attachments/assets/94798272-918e-4065-916c-cac4adc28e13

Here is a video of the "wiggle" interaction to point out the filter button in the second scenario:

https://github.com/user-attachments/assets/dd652d9b-4c68-46ed-89fe-8e1e4eb31bcb

This introduces a `wiggle_button` alpine js component that can then be reused on other alpine.js pages!

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change that only affects feature flagged workflows

### Automated test coverage
most important functionality is already tested

### QA Plan
not yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
