### PR TITLE
[Data Cleaning] Add form validation to CleanSelectedRecordsForm

### DIFF
--- a/corehq/apps/data_cleaning/forms/cleaning.py
+++ b/corehq/apps/data_cleaning/forms/cleaning.py
@@ -90,8 +90,8 @@ class CleanSelectedRecordsForm(forms.Form):
         alpine_data_model = {
             "propId": initial_prop_id,
             "cleanAction": self.data.get('clean_action', EditActionType.CHOICES[0][0]),
-            "findActions": [EditActionType.FIND_REPLACE],
             "replaceActions": [EditActionType.REPLACE],
+            "findActions": [EditActionType.FIND_REPLACE],
             "copyActions": [EditActionType.COPY_REPLACE],
         }
 
@@ -122,20 +122,20 @@ class CleanSelectedRecordsForm(forms.Form):
                     ),
                     crispy.Div(
                         crispy.Div(
+                            'replace_all_string',
+                            css_class="card-body",
+                        ),
+                        x_show="replaceActions.includes(cleanAction)",
+                        css_class="card mb-3",
+                    ),
+                    crispy.Div(
+                        crispy.Div(
                             'find_string',
                             hqcrispy.CheckboxField('use_regex'),
                             'replace_string',
                             css_class="card-body",
                         ),
                         x_show="findActions.includes(cleanAction)",
-                        css_class="card mb-3",
-                    ),
-                    crispy.Div(
-                        crispy.Div(
-                            'replace_all_string',
-                            css_class="card-body",
-                        ),
-                        x_show="replaceActions.includes(cleanAction)",
                         css_class="card mb-3",
                     ),
                     crispy.Div(


### PR DESCRIPTION
## Technical Summary
Addresses: https://dimagi.atlassian.net/browse/SAAS-16871

Implements form validation for the `CleanSelectedRecordsForm`
![Screenshot 2025-04-15 at 3 06 32 PM](https://github.com/user-attachments/assets/d999a35f-0587-46c1-a8f1-12839e740a5e)
![Screenshot 2025-04-15 at 3 01 04 PM](https://github.com/user-attachments/assets/2a5a2393-cf4e-4981-b670-55052a7442e2)
![Screenshot 2025-04-15 at 2 57 38 PM](https://github.com/user-attachments/assets/4caaba07-0079-4be7-9039-9c437715a9e5)
![Screenshot 2025-04-15 at 2 57 27 PM](https://github.com/user-attachments/assets/409b53fd-79a0-422e-bd9f-0bd30be00c6d)



## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change. only affects feature flagged workflows

### Automated test coverage
I want to create tests against form validation later. since we already have tests for the data cleaning actions themselves, and I did a ui test of the validation, i will defer to writing these new tests until after feature release.
JIRA ticket for followup here: https://dimagi.atlassian.net/browse/SAAS-17402

### QA Plan
not yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
