### PR TITLE
[Data Cleaning] Show an alert to the user when there are selected records not visible in the current filtered view

### DIFF
--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -1,3 +1,5 @@
+from memoized import memoized
+
 from django.utils.translation import gettext_lazy
 from django_tables2 import columns, tables
 
@@ -65,6 +67,7 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         return visible_columns
 
     @property
+    @memoized
     def num_selected_records(self):
         """
         Return the number of selected records in the session.
@@ -72,6 +75,7 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         return self.session.get_num_selected_records()
 
     @property
+    @memoized
     def num_edited_records(self):
         """
         Return the number of edited records in the session.

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -68,6 +68,14 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
 
     @property
     @memoized
+    def has_any_filtering(self):
+        """
+        Return whether any filtering is applied to the session.
+        """
+        return self.session.has_any_filtering
+
+    @property
+    @memoized
     def num_selected_records(self):
         """
         Return the number of selected records in the session.

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -84,6 +84,16 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
 
     @property
     @memoized
+    def num_visible_selected_records(self):
+        """
+        Return the number of selected records visible with the current set of filters.
+        """
+        if self.has_any_filtering:
+            return self.session.get_num_selected_records_in_queryset()
+        return self.num_selected_records
+
+    @property
+    @memoized
     def num_edited_records(self):
         """
         Return the number of edited records in the session.

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -15,7 +15,7 @@
 {% block before_table %}
   <div class="d-flex align-items-center pb-2">
 
-    {% if table.session.has_any_filtering %}
+    {% if table.has_any_filtering %}
       <div class="pe-2">
         <div class="input-group">
           <div class="input-group-text">

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -5,7 +5,7 @@
 {% block table-container-attrs %}
   {{ block.super }}
   x-data="{
-    numRecordsSelected: {{ table.num_selected_records }},
+    numRecordsSelected: {{ table.num_visible_selected_records }},
     totalRecords: {{ table.page.paginator.count }},
     pageTotalRecords: {{ table.paginated_rows|length }},
     pageNumRecordsSelected: 0,

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -55,6 +55,16 @@
           {% blocktrans %}
             Records Selected
           {% endblocktrans %}
+          {% if table.num_visible_selected_records != table.num_selected_records %}
+            <div
+              class="ms-2 ps-2 border-start inline-block text-warning"
+              data-bs-custom-class="fs-6"
+              data-bs-title="{% trans 'Some records are selected in the session but not currently visible. They will not be part of cleaning actions until all filters are removed.' %}"
+              x-tooltip=""
+            >
+              <i class="fa-solid fa-triangle-exclamation"></i>
+            </div>
+          {% endif %}
         </div>
         <button
           class="btn btn-outline-danger"

--- a/corehq/apps/hqwebapp/tables/elasticsearch/tables.py
+++ b/corehq/apps/hqwebapp/tables/elasticsearch/tables.py
@@ -133,6 +133,13 @@ class ElasticTableData(TableData):
     @property
     @memoized
     def _total_records(self):
+        return self.get_total_records_in_query(self.query)
+
+    @classmethod
+    def get_total_records_in_query(cls, query):
+        """
+        Returns the total number of records in the ESQuery.
+        """
         res = cls.get_es_results(query.size(0))
         if res is not None:
             return res['hits'].get('total', 0)

--- a/corehq/apps/hqwebapp/tables/elasticsearch/tables.py
+++ b/corehq/apps/hqwebapp/tables/elasticsearch/tables.py
@@ -103,7 +103,7 @@ class ElasticTableData(TableData):
             raise ValueError("'stop' must be greater than 'start'")
         size = stop - start
         page_query = self.query.start(start).size(size)
-        results = self._get_es_results(page_query)
+        results = self.get_es_results(page_query)
         self.data = [self.table.record_class(record, self.table.request, **self.record_kwargs)
                      for record in results['hits'].get('hits', [])]
         return self.data
@@ -133,14 +133,14 @@ class ElasticTableData(TableData):
     @property
     @memoized
     def _total_records(self):
-        res = self._get_es_results(self.query.size(0))
+        res = cls.get_es_results(query.size(0))
         if res is not None:
             return res['hits'].get('total', 0)
         else:
             return 0
 
     @staticmethod
-    def _get_es_results(query):
+    def get_es_results(query):
         try:
             return query.run().raw
         except ESError as e:


### PR DESCRIPTION
## Technical Summary
When the user filters a the table with records selected, the number of selected records should show the number of selected records that are currently visible, as that's the number of records that will apply for the data cleaning action. If there are records selected outside of the current set of filters, I've created an alert to indicate this situation to the user and explain that those externally selected records will not me a part of the changes applied unless they remove the filters.

![Screenshot 2025-04-15 at 4 45 24 PM](https://github.com/user-attachments/assets/5288c72a-dcf1-4853-b777-9a24f0de96e6)


![Screenshot 2025-04-15 at 4 57 57 PM](https://github.com/user-attachments/assets/6fbe7f91-afab-4652-92a6-a9c99532e6a7)


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change only to feature flagged workflow

### Automated test coverage
most important bits are covered by tests. I've added a todo ticket to add a test for `BulkEditSession.get_num_selected_records_in_queryset()`
https://dimagi.atlassian.net/browse/SAAS-17406

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
