### PR TITLE
Pass case_id instead of entire case in run_case_update_rules_on_save

### DIFF
--- a/corehq/apps/data_interfaces/signals.py
+++ b/corehq/apps/data_interfaces/signals.py
@@ -11,7 +11,7 @@ def case_changed_receiver(sender, case, **kwargs):
         from corehq.apps.data_interfaces.tasks import run_case_update_rules_on_save
 
         if RUN_AUTO_CASE_UPDATES_ON_SAVE.enabled(case.domain):
-            run_case_update_rules_on_save.delay(case)
+            run_case_update_rules_on_save.delay(case.id, case.domain)
     except Exception as e:
         error_message = 'Exception in case update signal'
         notify_exception(None, "{msg}: {exc}".format(msg=error_message, exc=e))

--- a/corehq/apps/data_interfaces/signals.py
+++ b/corehq/apps/data_interfaces/signals.py
@@ -8,10 +8,10 @@ def case_changed_receiver(sender, case, **kwargs):
     Spawns a task to run auto update rules tied to the given case.
     """
     try:
-        from corehq.apps.data_interfaces.tasks import run_case_update_rules_on_save
+        from corehq.apps.data_interfaces.tasks import run_case_update_rules_on_save_ng
 
         if RUN_AUTO_CASE_UPDATES_ON_SAVE.enabled(case.domain):
-            run_case_update_rules_on_save.delay(case.case_id, case.domain)
+            run_case_update_rules_on_save_ng.delay(case.case_id)
     except Exception as e:
         error_message = 'Exception in case update signal'
         notify_exception(None, "{msg}: {exc}".format(msg=error_message, exc=e))

--- a/corehq/apps/data_interfaces/signals.py
+++ b/corehq/apps/data_interfaces/signals.py
@@ -11,7 +11,7 @@ def case_changed_receiver(sender, case, **kwargs):
         from corehq.apps.data_interfaces.tasks import run_case_update_rules_on_save
 
         if RUN_AUTO_CASE_UPDATES_ON_SAVE.enabled(case.domain):
-            run_case_update_rules_on_save.delay(case.id, case.domain)
+            run_case_update_rules_on_save.delay(case.case_id, case.domain)
     except Exception as e:
         error_message = 'Exception in case update signal'
         notify_exception(None, "{msg}: {exc}".format(msg=error_message, exc=e))

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -177,9 +177,14 @@ def run_case_update_rules_for_domain_and_db(domain, now, run_id, case_type, db=N
             rule.save(update_fields=['last_run'])
 
 
+@task(queue='background_queue', acks_late=True, ignore_result=True)
+def run_case_update_rules_on_save_ng(case_id):
+    case = CommCareCase.objects.get_case(case_id)
+    run_case_update_rules_on_save(case)
+
+
 @task(serializer='pickle', queue='background_queue', acks_late=True, ignore_result=True)
-def run_case_update_rules_on_save(case_id, domain):
-    case = CommCareCase.objects.get_case(case_id, domain)
+def run_case_update_rules_on_save(case):
     key = 'case-update-on-save-case-{case}'.format(case=case.case_id)
     with CriticalSection([key]):
         update_case = True

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -18,7 +18,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
 from corehq.apps.hqcase.utils import AUTO_UPDATE_XMLNS
 from corehq.apps.users.models import CouchUser
-from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.apps.case_importer.do_import import SubmitCaseBlockHandler, RowAndCase
 from corehq.motech.repeaters.const import State
 from corehq.motech.repeaters.models import RepeatRecord
@@ -178,7 +178,8 @@ def run_case_update_rules_for_domain_and_db(domain, now, run_id, case_type, db=N
 
 
 @task(serializer='pickle', queue='background_queue', acks_late=True, ignore_result=True)
-def run_case_update_rules_on_save(case):
+def run_case_update_rules_on_save(case_id, domain):
+    case = CommCareCase.objects.get_case(case_id, domain)
     key = 'case-update-on-save-case-{case}'.format(case=case.case_id)
     with CriticalSection([key]):
         update_case = True


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
It is expensive to serialize the entire case, plus you run the risk of the case being outdated once the task actually executes. This is just best practice.

For some added context, looking at a trace like [this one](https://app.datadoghq.com/apm/traces?query=env%3Aproduction%20resource_name%3A%2Areceiver%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=16619527041912270323&spanType=all&spanViewType=metadata&storage=hot&timeHint=1744722839969&trace=AwAAAZY5lcmhdrbCGQAAABhBWlk1bGNxQkFBQk1iVE5LQVZ5WXlzUWcAAABdMDE5NjM5ZWQtZDZhMC00YWIwLWJkMmUtOTUyNDBjMGYyNDM4LXN5bnRoZXRpYy10aW1lLTE3NDQ3MjIwMDAwMDAwMDAwMDBjLTE3NDQ3Mjg2MTA0NjQwMDAwMDFvAAv2Fg&traceID=67fe5b860000000020c4f0cafc08f808&view=spans&start=1744722600000&end=1744722840000&paused=true), we spend a good amount of time queueing this task to rabbit, which I imagine stems from serializing the case. Not to mention we do it for every case the form touches.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is a straightforward change, just passing the case id into this task instead of the full case.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Apparently there are tests in `corehq/apps/data_interfaces/tests/test_auto_case_updates.py`.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
