### PR TITLE
Constrain user input queries by domain

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -331,6 +331,7 @@ class LocationManager(LocationQueriesMixin, AdjListManager):
                     query = query.filter(
                         Q(name__icontains=part) | Q(site_code__icontains=part)
                     )
+                query = query.filter(domain=domain)
         return query
 
     def get_locations(self, location_ids):

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -149,13 +149,12 @@ class TestLocationScopedQueryset(BaseTestLocationQuerysetMethods):
     def test_filter_by_user_input(self):
         self.restrict_user_to_assigned_locations(self.web_user)
 
+        mass_locs = SQLLocation.objects.filter_by_user_input(self.domain, "Massachusetts/")
+        self.assertIn(f'"domain" = {self.domain})', str(mass_locs.query))
+
         # User searching for higher in the hierarchy is only given the items
         # they are allowed to see
-        middlesex_locs = (
-            SQLLocation.objects
-            .filter_by_user_input(self.domain, "Massachusetts/")
-            .accessible_to_user(self.domain, self.web_user)
-        )
+        middlesex_locs = mass_locs.accessible_to_user(self.domain, self.web_user)
         self.assertItemsEqual(
             ['Middlesex', 'Cambridge', 'Somerville'],
             [loc.name for loc in middlesex_locs]

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import WebUser
+from corehq.util.test_utils import generate_cases
 
 from ..models import (
     SQLLocation,
@@ -191,30 +192,39 @@ class TestFilterByUserInput(LocationHierarchyTestCase):
         ])
     ]
 
-    def test_path_queries(self):
-        for querystring, expected in [
-            ('', SQLLocation.objects.filter(domain=self.domain)
-                                    .values_list('name', flat=True)),
-            ('Suff', ['Suffolk']),
-            ('Suffolk', ['Suffolk']),
-            ('Cambridge', ['Cambridge', 'Cambridge']),
-            ('Massachusetts/Cambridge', ['Cambridge']),
-            ('"Copycat"/Cambridge', []),
-            ('"Middlesex"/Cambridge', ['Cambridge']),
-            ('"Middlesex/Cambridge', ['Cambridge', 'Cambridge']),
-            ('"Middlesex"/Somerville', ['Somerville', 'Evil Somerville']),
-            ('"Middlesex"/"Somer', ['Somerville', 'Evil Somerville']),
-            ('"Middlesex"/"Somerville"', ['Somerville']),
-            ('mass/mid/Som', ['Somerville', 'Evil Somerville']),
-            ('Middl', ['Middlesex', 'Evil Middlesex']),
-            ('Middl/', ['Cambridge', 'Somerville', 'Evil Somerville', 'Cambridge', 'Somerville']),
-            ('Middl/camb', ['Cambridge', 'Cambridge']),
-        ]:
-            actual = list(SQLLocation.objects
-                          .filter_by_user_input(self.domain, querystring)
-                          .values_list('name', flat=True))
-            error_msg = f"\nExpected '{querystring}' to yield\n{expected}\nbut got\n{actual}"
-            self.assertItemsEqual(actual, expected, error_msg)
+    def assert_query_has_results(self, querystring, expected):
+        actual = list(SQLLocation.objects
+                      .filter_by_user_input(self.domain, querystring)
+                      .values_list('name', flat=True))
+        error_msg = f"\nExpected '{querystring}' to yield\n{expected}\nbut got\n{actual}"
+        self.assertItemsEqual(actual, expected, error_msg)
+
+    def test_empty_path_query(self):
+        all_locations = (
+            SQLLocation.objects
+            .filter(domain=self.domain)
+            .values_list('name', flat=True)
+        )
+        self.assert_query_has_results('', all_locations)
+
+@generate_cases([  # noqa: E302
+    ('Suff', ['Suffolk']),
+    ('Suffolk', ['Suffolk']),
+    ('Cambridge', ['Cambridge', 'Cambridge']),
+    ('Massachusetts/Cambridge', ['Cambridge']),
+    ('"Copycat"/Cambridge', []),
+    ('"Middlesex"/Cambridge', ['Cambridge']),
+    ('"Middlesex/Cambridge', ['Cambridge', 'Cambridge']),
+    ('"Middlesex"/Somerville', ['Somerville', 'Evil Somerville']),
+    ('"Middlesex"/"Somer', ['Somerville', 'Evil Somerville']),
+    ('"Middlesex"/"Somerville"', ['Somerville']),
+    ('mass/mid/Som', ['Somerville', 'Evil Somerville']),
+    ('Middl', ['Middlesex', 'Evil Middlesex']),
+    ('Middl/', ['Cambridge', 'Somerville', 'Evil Somerville', 'Cambridge', 'Somerville']),
+    ('Middl/camb', ['Cambridge', 'Cambridge']),
+], TestFilterByUserInput)
+def test_path_query(self, querystring, expected):
+    self.assert_query_has_results(querystring, expected)
 
 
 @contextmanager


### PR DESCRIPTION
Small optimization. Previously the CTE query filtered on user input was doing a sequential scan on the full table. Now it can use the domain to eliminated more rows from the root nodes of the recursive query.

This removed one of two sequential scans. I don't understand yet why it's doing the second sequential scan. More research is required.

## Safety Assurance

### Safety story

This should not change the meaning of the query since all selected locations must belong to the domain.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations