### PR TITLE
[Data Cleaning] toggle enable/disable state of Clean Selected Cases button with selection state

### DIFF
--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -12,6 +12,8 @@ import 'data_cleaning/js/directives/dynamic_options_select2';
 import wiggleButton from 'hqwebapp/js/alpinejs/components/wiggle_button';
 Alpine.data('wiggleButtonModel', wiggleButton);
 
+Alpine.store('isCleaningAllowed', false);
+
 import Alpine from 'alpinejs';
 Alpine.start();
 

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/button_bar.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/button_bar.html
@@ -24,9 +24,16 @@
 </button>
 <button
   class="btn btn-outline-primary"
+  disabled="disabled"
   type="button"
   data-bs-toggle="offcanvas"
   data-bs-target="#offcanvas-bulk-changes"
+  x-data=""
+  :class="{
+    'btn-primary': $store.isCleaningAllowed,
+    'btn-outline-primary': !$store.isCleaningAllowed,
+  }"
+  :disabled="!$store.isCleaningAllowed"
 >
   <i class="fa-solid fa-shower"></i> {% trans "Clean Selected Cases" %}
 </button>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -9,7 +9,14 @@
     totalRecords: {{ table.page.paginator.count }},
     pageTotalRecords: {{ table.paginated_rows|length }},
     pageNumRecordsSelected: 0,
+    updateCleaningStatus(numSelected) {
+      $store.isCleaningAllowed = numSelected > 0;
+    },
   }"
+  x-init="
+    updateCleaningStatus(numRecordsSelected);
+    $watch('numRecordsSelected', updateCleaningStatus);
+  "
 {% endblock %}
 
 {% block no_results_table %}


### PR DESCRIPTION
## Technical Summary
When there are records selected (and visible) the Clean Selected Cases button should be enabled and `btn-primary`. When there aren't any records selected in the visible view, the Clean Selected Cases button should be disabled and `btn-outline-primary`.

![Apr-16-2025 16-45-57](https://github.com/user-attachments/assets/6361e149-474a-4db0-93aa-577306d3c6cc)


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
small UI change made to a feature flag ui

### Automated test coverage
yes, important logic is tested.

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
