### PR TITLE
Fix bug in LocationManager.filter_by_user_input

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -322,7 +322,10 @@ class LocationManager(LocationQueriesMixin, AdjListManager):
         """
         query = None
         for part in user_input.split('/'):
-            query = self.get_queryset_descendants(query) if query is not None else self
+            if query is None:
+                query = self.filter(domain=domain)
+            else:
+                query = self.get_queryset_descendants(query)
             if part:
                 if part.startswith('"') and part.endswith('"'):
                     query = query.filter(name__iexact=part[1:-1])
@@ -331,7 +334,6 @@ class LocationManager(LocationQueriesMixin, AdjListManager):
                     query = query.filter(
                         Q(name__icontains=part) | Q(site_code__icontains=part)
                     )
-                query = query.filter(domain=domain)
         return query
 
     def get_locations(self, location_ids):

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -241,6 +241,7 @@ class TestFilterByUserInput(LocationHierarchyTestCase):
     ('Middl', ['Middlesex', 'Evil Middlesex']),
     ('Middl/', ['Cambridge', 'Somerville', 'Evil Somerville', 'Cambridge', 'Somerville']),
     ('Middl/camb', ['Cambridge', 'Cambridge']),
+    ('/evil', ['Evil Somerville', 'Evil Middlesex']),
 ], TestFilterByUserInput)
 def test_path_query(self, querystring, expected):
     self.assert_query_has_results(querystring, expected)


### PR DESCRIPTION
Iteration on https://github.com/dimagi/commcare-hq/pull/36216

Always and only filter the root query by domain, even when it has no user input. Lower query levels need not be filtered by domain since those levels are constrained by parent_id, where the parent should always be in the same domain as its children.

Fixes an issue with no user input on the first level, which caused

```py
query = self.get_queryset_descendants(query)
```

to raise

    AttributeError: 'LocationManager' object has no attribute 'id'

because `query` was `self` (a LocationManager object).

## Safety Assurance

### Safety story

Minor tweak to locations query.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations