### PR TITLE
Restore build-essential to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update \
      libxmlsec1-openssl \
      make \
   && rm -rf /var/lib/apt/lists/* /src/*.deb
-# build-essential allows uv to build uwsgi; increases image size by 240 MB
+# build-essential allows uv to build dependencies; increases image size by 240 MB
 # libpq-dev is for make-requirements-test.sh; increases image size by ~20 MB
 # libpq-dev can be replaced with libpq5 if pip-tools is replaced with uv in make-requirements-test.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
+     build-essential \
      bzip2 \
      default-jre \
      gettext \
@@ -37,6 +38,7 @@ RUN apt-get update \
      libxmlsec1-openssl \
      make \
   && rm -rf /var/lib/apt/lists/* /src/*.deb
+# build-essential allows uv to build uwsgi; increases image size by 240 MB
 # libpq-dev is for make-requirements-test.sh; increases image size by ~20 MB
 # libpq-dev can be replaced with libpq5 if pip-tools is replaced with uv in make-requirements-test.sh
 


### PR DESCRIPTION
## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/35881

This is still necessary for `uv` to build `csiphash`. It's unknown if there are additional libraries that require it.

## Safety Assurance

### Safety story
Reverts a config change that broke the docker build. Does not impact users.

### Automated test coverage

I don't know if there are dedicated tests for this.

### QA Plan

No

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
