### PR TITLE
Safe URL Sanitization: Check Full URL instead of substring

### DIFF
--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -281,7 +281,7 @@ class OAuth2ClientGrantManager(AuthManager):
             # This is a workaround for a presumed issue with the MTN MoMo API sandbox where
             # the token type is not set to 'Bearer' as expected, but rather 'access_token'.
             # This is a temporary fix until more clarity can be gained around this.
-            is_mtn_momo_sandbox = self.base_url == 'https://sandbox.momodeveloper.mtn.com'
+            is_mtn_momo_sandbox = self.base_url.rstrip('/').lower() == 'https://sandbox.momodeveloper.mtn.com'
             token_type = self.last_token.get('token_type')
 
             if is_mtn_momo_sandbox and token_type == 'access_token':

--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -281,7 +281,7 @@ class OAuth2ClientGrantManager(AuthManager):
             # This is a workaround for a presumed issue with the MTN MoMo API sandbox where
             # the token type is not set to 'Bearer' as expected, but rather 'access_token'.
             # This is a temporary fix until more clarity can be gained around this.
-            is_mtn_momo_sandbox = 'sandbox.momodeveloper.mtn.com' in self.base_url
+            is_mtn_momo_sandbox = self.base_url == 'https://sandbox.momodeveloper.mtn.com'
             token_type = self.last_token.get('token_type')
 
             if is_mtn_momo_sandbox and token_type == 'access_token':

--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -1,7 +1,7 @@
 import re
 from corehq import toggles
 from typing import TYPE_CHECKING, Optional
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from django.utils.translation import gettext_lazy as _
 
@@ -281,7 +281,7 @@ class OAuth2ClientGrantManager(AuthManager):
             # This is a workaround for a presumed issue with the MTN MoMo API sandbox where
             # the token type is not set to 'Bearer' as expected, but rather 'access_token'.
             # This is a temporary fix until more clarity can be gained around this.
-            is_mtn_momo_sandbox = self.base_url.rstrip('/').lower() == 'https://sandbox.momodeveloper.mtn.com'
+            is_mtn_momo_sandbox = urlparse(self.base_url).hostname == 'sandbox.momodeveloper.mtn.com'
             token_type = self.last_token.get('token_type')
 
             if is_mtn_momo_sandbox and token_type == 'access_token':


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
A very small change the updates the check for MOMO URL to an equality instead of just substring. This makes the check better in terms of security. Please see [comment](https://github.com/dimagi/commcare-hq/pull/35966#discussion_r2045266851) for more details.

No UI change. 
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Follow up to https://github.com/dimagi/commcare-hq/security/code-scanning/437


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
MTN_MOBILE_WORKER_VERIFICATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Small and safe change. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
