### PR TITLE
Lookup Fixture Missing on Restore Bug Fix

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -182,17 +182,18 @@ class ItemListsProvider(FixtureProvider):
                         io_stream = BytesIO(io_stream)
                 if io_stream is None:
                     record_datadog_metric('generate', key)
-                    item = self._get_global_item(global_type, domain)
+                    items = self._get_global_items(global_type, domain)
                     io_stream = BytesIO()
-                    io_stream.write(ElementTree.tostring(item, encoding='utf-8'))
+                    for item in items:
+                        io_stream.write(ElementTree.tostring(item, encoding='utf-8'))
                     io_stream.seek(0)
                     cache_fixture_items_data(io_stream, domain, '', key)
         return io_stream
 
-    def _get_global_item(self, global_type, domain):
+    def _get_global_items(self, global_type, domain):
         def get_items_by_type(data_type):
             return LookupTableRow.objects.iter_rows(domain, table_id=data_type.id)
-        return self._get_fixtures({global_type.id: global_type}, get_items_by_type, GLOBAL_USER_ID)[0]
+        return self._get_fixtures({global_type.id: global_type}, get_items_by_type, GLOBAL_USER_ID)
 
     def get_user_items_and_count(self, user_types, restore_user):
         user_items_count = 0

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -1,20 +1,24 @@
 from collections import defaultdict
-from functools import partial
 from operator import attrgetter
+from io import BytesIO
 from xml.etree import cElementTree as ElementTree
 
 from casexml.apps.phone.fixtures import FixtureProvider
 from casexml.apps.phone.utils import (
     GLOBAL_USER_ID,
-    get_or_cache_global_fixture,
+    record_datadog_metric,
+    get_cached_fixture_items,
+    cache_fixture_items_data,
+    combine_io_streams
 )
 from corehq.apps.fixtures.exceptions import FixtureTypeCheckError
-from corehq.apps.fixtures.models import FIXTURE_BUCKET, LookupTable, LookupTableRow
+from corehq.apps.fixtures.models import fixture_bucket, LookupTable, LookupTableRow
 from corehq.apps.products.fixtures import product_fixture_generator_json
 from corehq.apps.programs.fixtures import program_fixture_generator_json
 from corehq.util.metrics import metrics_histogram
 from corehq.util.xml_utils import serialize
 from .utils import clean_fixture_field_name, get_index_schema_node
+from dimagi.utils.couch import CriticalSection
 
 LOOKUP_TABLE_FIXTURE = 'lookup_table_fixture'
 REPORT_FIXTURE = 'report_fixture'
@@ -93,13 +97,8 @@ def item_lists_by_app(app, module):
 
 
 def get_global_items_by_domain(domain, case_id):
-    global_types = {}
-    for data_type in LookupTable.objects.by_domain(domain):
-        if data_type.is_global:
-            global_types[data_type.id] = data_type
-    if global_types:
-        data_fn = partial(ItemListsProvider()._get_global_items, global_types, domain)
-        return get_or_cache_global_fixture(domain, case_id, FIXTURE_BUCKET, '', data_fn)
+    global_types = LookupTable.objects.by_domain(domain).filter(is_global=True)
+    return ItemListsProvider().get_global_items(domain, global_types, case_id, False)
 
 
 class ItemListsProvider(FixtureProvider):
@@ -107,17 +106,25 @@ class ItemListsProvider(FixtureProvider):
 
     def __call__(self, restore_state):
         restore_user = restore_state.restore_user
-        global_types = {}
+        global_types = []
         user_types = {}
-        for data_type in LookupTable.objects.by_domain(restore_user.domain):
+        should_full_sync = not restore_state.last_sync_log or not restore_state.last_sync_log.date
+        if should_full_sync:
+            data_types = LookupTable.objects.by_domain(restore_user.domain)
+        else:
+            data_types = LookupTable.objects.get_tables_modified_since(restore_user.domain,
+                                                                       restore_state.last_sync_log.date)
+        for data_type in data_types:
             if data_type.is_global:
-                global_types[data_type.id] = data_type
+                global_types.append(data_type)
             else:
                 user_types[data_type.id] = data_type
         items = []
         user_items_count = 0
         if global_types:
-            global_items = self.get_global_items(global_types, restore_state)
+            global_items = self.get_global_items(restore_state.restore_user.domain, global_types,
+                                                 restore_state.restore_user.user_id,
+                                                 restore_state.overwrite_cache)
             items.extend(global_items)
         if user_types:
             user_items, user_items_count = self.get_user_items_and_count(user_types, restore_user)
@@ -135,21 +142,57 @@ class ItemListsProvider(FixtureProvider):
         )
         return items
 
-    def get_global_items(self, global_types, restore_state):
-        domain = restore_state.restore_user.domain
-        data_fn = partial(self._get_global_items, global_types, domain)
-        return get_or_cache_global_fixture(restore_state.restore_user.domain,
-                                           restore_state.restore_user.user_id,
-                                           FIXTURE_BUCKET,
-                                           '',
-                                           data_fn,
-                                           restore_state.overwrite_cache)
+    def get_global_items(self, domain, global_types, user_id, overwrite_cache):
+        """
+        :param user_id: User's id, if this is for case restore, then pass in case id
+        """
+        return combine_io_streams(
+            [self._get_or_cache_global_fixture(
+                domain,
+                global_type,
+                overwrite_cache,
+            ) for global_type in sorted(global_types, key=lambda global_type: global_type.tag)],
+            user_id
+        )
 
-    def _get_global_items(self, global_types, domain):
+    def _get_or_cache_global_fixture(self, domain, global_type, overwrite_cache=False):
+        """
+        Get the fixture data for a global fixture (one that does not vary by user).
+
+        :param domain: The domain to get or cache the fixture
+        :param user_id: User's id, if this is for case restore, then pass in case id
+        :param overwrite_cache: a boolean property from RestoreState object, default is False
+        :return: a byte string representation of the fixture
+        """
+        io_stream = None
+        key = fixture_bucket(global_type.id, domain)
+
+        if not overwrite_cache:
+            io_stream = get_cached_fixture_items(key)
+            record_datadog_metric('cache_miss' if io_stream is None else 'cache_hit', key)
+            if io_stream is not None:
+                io_stream = BytesIO(io_stream)
+
+        if io_stream is None:
+            with CriticalSection([key]):
+                if not overwrite_cache:
+                    # re-check cache to avoid re-computing it
+                    io_stream = get_cached_fixture_items(key)
+                    if io_stream is not None:
+                        io_stream = BytesIO(io_stream)
+                if io_stream is None:
+                    record_datadog_metric('generate', key)
+                    item = self._get_global_item(global_type, domain)
+                    io_stream = BytesIO()
+                    io_stream.write(ElementTree.tostring(item, encoding='utf-8'))
+                    io_stream.seek(0)
+                    cache_fixture_items_data(io_stream, domain, '', key)
+        return io_stream
+
+    def _get_global_item(self, global_type, domain):
         def get_items_by_type(data_type):
             return LookupTableRow.objects.iter_rows(domain, table_id=data_type.id)
-
-        return self._get_fixtures(global_types, get_items_by_type, GLOBAL_USER_ID)
+        return self._get_fixtures({global_type.id: global_type}, get_items_by_type, GLOBAL_USER_ID)[0]
 
     def get_user_items_and_count(self, user_types, restore_user):
         user_items_count = 0

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -12,7 +12,11 @@ from corehq.sql_db.fields import CharIdField
 from corehq.util.jsonattrs import AttrsDict, AttrsList, list_of
 from .exceptions import FixtureVersionError
 
-FIXTURE_BUCKET = 'domain-fixtures'
+FIXTURE_BUCKET_PREFIX = 'domain-fixtures'
+
+
+def fixture_bucket(lookup_table_id, domain):
+    return f'{FIXTURE_BUCKET_PREFIX}-{lookup_table_id}' + '/' + domain
 
 
 class LookupTableManager(models.Manager):
@@ -26,6 +30,9 @@ class LookupTableManager(models.Manager):
 
     def domain_tag_exists(self, domain_name, tag):
         return self.filter(domain=domain_name, tag=tag).exists()
+
+    def get_tables_modified_since(self, domain, since_datetime):
+        return self.filter(domain=domain, last_modified__gt=since_datetime)
 
 
 @define

--- a/corehq/apps/fixtures/tests/test_fixture_data.py
+++ b/corehq/apps/fixtures/tests/test_fixture_data.py
@@ -265,7 +265,7 @@ class FixtureDataTest(TestCase):
 
     def test_indexed_global_fixture(self):
         sandwich = self.make_data_type("sandwich", is_global=True)
-        sandwich.fields[0].is_indexed=True
+        sandwich.fields[0].is_indexed = True
         sandwich.save()
         self.make_data_item(sandwich, "7.39")
 
@@ -274,7 +274,7 @@ class FixtureDataTest(TestCase):
             [(node.tag, node.attrib['id']) for node in fixtures],
             [
                 ('schema', 'item-list:sandwich-index'),
-                # ('fixture', 'item-list:sandwich-index'),  # FIXME - this should show up here
+                ('fixture', 'item-list:sandwich-index'),
                 ('fixture', 'item-list:district'),
             ]
         )

--- a/corehq/apps/fixtures/tests/test_fixture_data.py
+++ b/corehq/apps/fixtures/tests/test_fixture_data.py
@@ -263,6 +263,22 @@ class FixtureDataTest(TestCase):
         fixtures = call_fixture_generator(sammy)
         self.assertEqual({item.attrib['user_id'] for item in fixtures}, {sammy.user_id})
 
+    def test_indexed_global_fixture(self):
+        sandwich = self.make_data_type("sandwich", is_global=True)
+        sandwich.fields[0].is_indexed=True
+        sandwich.save()
+        self.make_data_item(sandwich, "7.39")
+
+        fixtures = call_fixture_generator(self.user.to_ota_restore_user(self.domain))
+        self.assertEqual(
+            [(node.tag, node.attrib['id']) for node in fixtures],
+            [
+                ('schema', 'item-list:sandwich-index'),
+                # ('fixture', 'item-list:sandwich-index'),  # FIXME - this should show up here
+                ('fixture', 'item-list:district'),
+            ]
+        )
+
     def test_include_fixture_when_data_type_modified(self):
         fixture = call_fixture_generator(self.user.to_ota_restore_user(self.domain), self.sync_log)
         self.assertEqual(len(fixture), 0)

--- a/corehq/apps/fixtures/tests/test_fixture_data.py
+++ b/corehq/apps/fixtures/tests/test_fixture_data.py
@@ -24,9 +24,18 @@ from corehq.blobs import get_blob_db
 
 
 def call_fixture_generator(user, last_sync=None):
-    return [ElementTree.fromstring(f) if isinstance(f, bytes) else f
-            for f in call_fixture_generator_raw(fixturegenerators.item_lists, user,
-                                                last_sync=last_sync)]
+    raw = call_fixture_generator_raw(fixturegenerators.item_lists, user,
+                                    last_sync=last_sync)
+    res = []
+    for f in raw:
+        if isinstance(f, bytes):
+            wrapped_f = b'<root>' + f + b'</root>'
+            root = ElementTree.fromstring(wrapped_f)
+            for child in root:
+                res.append(child)
+        else:
+            res.append(f)
+    return res
 
 
 class FixtureDataTest(TestCase):

--- a/corehq/apps/fixtures/tests/test_fixture_data.py
+++ b/corehq/apps/fixtures/tests/test_fixture_data.py
@@ -1,14 +1,16 @@
 from xml.etree import cElementTree as ElementTree
+from datetime import datetime
 
 from django.test import TestCase
 
+from casexml.apps.phone.models import SimplifiedSyncLog
 from casexml.apps.case.tests.util import check_xml_line_by_line
 from casexml.apps.phone.tests.utils import \
     call_fixture_generator as call_fixture_generator_raw
 
 from corehq.apps.fixtures import fixturegenerators
 from corehq.apps.fixtures.models import (
-    FIXTURE_BUCKET,
+    fixture_bucket,
     Field,
     LookupTable,
     LookupTableRow,
@@ -16,13 +18,15 @@ from corehq.apps.fixtures.models import (
     OwnerType,
     TypeField,
 )
+from corehq.apps.fixtures.utils import clear_fixture_cache
 from corehq.apps.users.models import CommCareUser
 from corehq.blobs import get_blob_db
 
 
-def call_fixture_generator(user):
+def call_fixture_generator(user, last_sync=None):
     return [ElementTree.fromstring(f) if isinstance(f, bytes) else f
-            for f in call_fixture_generator_raw(fixturegenerators.item_lists, user)]
+            for f in call_fixture_generator_raw(fixturegenerators.item_lists, user,
+                                                last_sync=last_sync)]
 
 
 class FixtureDataTest(TestCase):
@@ -44,6 +48,7 @@ class FixtureDataTest(TestCase):
             item_attributes=[],
         )
         self.data_type.save()
+        self.addCleanup(get_blob_db().delete, key=fixture_bucket(self.data_type.id, self.domain))
 
         self.data_item = LookupTableRow(
             domain=self.domain,
@@ -75,7 +80,14 @@ class FixtureDataTest(TestCase):
             row_id=self.data_item.id,
         )
         self.ownership.save()
-        self.addCleanup(get_blob_db().delete, key=FIXTURE_BUCKET + '/' + self.domain)
+
+        self.sync_log = SimplifiedSyncLog(
+            date=datetime.utcnow(),
+            domain=self.domain,
+            user_id=self.user.user_id,
+            build_id='some-build-id'
+        )
+        self.sync_log.save()
 
     def test_xml(self):
         check_xml_line_by_line(self, """
@@ -246,10 +258,48 @@ class FixtureDataTest(TestCase):
 
         fixtures = call_fixture_generator(frank)
         self.assertEqual({item.attrib['user_id'] for item in fixtures}, {frank.user_id})
-        self.assertTrue(get_blob_db().exists(key=FIXTURE_BUCKET + '/' + self.domain))
+        self.assertTrue(get_blob_db().exists(key=fixture_bucket(sandwich.id, self.domain)))
 
         fixtures = call_fixture_generator(sammy)
         self.assertEqual({item.attrib['user_id'] for item in fixtures}, {sammy.user_id})
+
+    def test_include_fixture_when_data_type_modified(self):
+        fixture = call_fixture_generator(self.user.to_ota_restore_user(self.domain), self.sync_log)
+        self.assertEqual(len(fixture), 0)
+
+        self.data_type.save()
+        fixture, = call_fixture_generator(self.user.to_ota_restore_user(self.domain), self.sync_log)
+        check_xml_line_by_line(self, """
+        <fixture id="item-list:district" user_id="%s">
+            <district_list>
+                <district>
+                    <state_name>Delhi_state</state_name>
+                    <district_name lang="hin">Delhi_in_HIN</district_name>
+                    <district_name lang="eng">Delhi_in_ENG</district_name>
+                    <district_id>Delhi_id</district_id>
+                </district>
+            </district_list>
+        </fixture>
+        """ % self.user.user_id, ElementTree.tostring(fixture, encoding='utf-8'))
+
+    def test_include_fixture_when_cache_is_cleared(self):
+        fixture = call_fixture_generator(self.user.to_ota_restore_user(self.domain), self.sync_log)
+        self.assertEqual(len(fixture), 0)
+
+        clear_fixture_cache(self.domain, [self.data_type.id])
+        fixture, = call_fixture_generator(self.user.to_ota_restore_user(self.domain), self.sync_log)
+        check_xml_line_by_line(self, """
+        <fixture id="item-list:district" user_id="%s">
+            <district_list>
+                <district>
+                    <state_name>Delhi_state</state_name>
+                    <district_name lang="hin">Delhi_in_HIN</district_name>
+                    <district_name lang="eng">Delhi_in_ENG</district_name>
+                    <district_id>Delhi_id</district_id>
+                </district>
+            </district_list>
+        </fixture>
+        """ % self.user.user_id, ElementTree.tostring(fixture, encoding='utf-8'))
 
     def make_data_type(self, name, is_global):
         data_type = LookupTable(
@@ -263,6 +313,7 @@ class FixtureDataTest(TestCase):
             item_attributes=[],
         )
         data_type.save()
+        self.addCleanup(get_blob_db().delete, key=fixture_bucket(data_type.id, self.domain))
         return data_type
 
     def make_data_item(self, data_type, cost):

--- a/corehq/apps/fixtures/tests/test_upload.py
+++ b/corehq/apps/fixtures/tests/test_upload.py
@@ -684,6 +684,24 @@ class TestFixtureUpload(TestCase):
             self.upload([(None, 'N', 'orange')])
         clear_cache.assert_called_once()
 
+    def test_row_added_clears_its_table_cache(self):
+        self.upload([(None, 'N', 'apple')])
+        table = self.get_table()
+        apple_id = self.get_rows(None)[0].id.hex
+
+        with patch.object(mod, "clear_fixture_cache") as mock_clear:
+            self.upload([(apple_id, 'N', 'apple'), (None, 'N', 'banana')])
+            self.assertEqual(mock_clear.call_args[0][1], {table.id})
+
+    def test_row_deleted_clears_its_table_cache(self):
+        self.upload([(None, 'N', 'apple')])
+        table = self.get_table()
+        apple_id = self.get_rows(None)[0].id.hex
+
+        with patch.object(mod, "clear_fixture_cache") as mock_clear:
+            self.upload([(apple_id, 'Y', 'apple')])
+            self.assertEqual(mock_clear.call_args[0][1], {table.id})
+
 
 class TestLookupTableOwnershipUpload(TestCase):
     do_upload = _run_upload
@@ -806,6 +824,26 @@ class TestLookupTableOwnershipUpload(TestCase):
         result = self.upload([(None, 'N', 'apple', 3, 3, 3)], check_result=False)
         self.assertEqual(self.get_rows(), [('apple', {'3'}, {'3'}, {'3'})])
         self.assertFalse(result.errors)
+
+    def test_owner_added_clears_cache(self):
+        """Test that adding an owner to an existing row clears that table's cache"""
+        self.upload([(None, 'N', 'apple')])
+        table = LookupTable.objects.by_domain_tag(self.domain, 'things')
+        apple_id = self.get_rows(None)[0].id.hex
+
+        with patch.object(mod, "clear_fixture_cache") as mock_clear:
+            self.upload([(apple_id, 'N', 'apple', 'user1', 'G1', 'loc1')])
+            self.assertEqual(mock_clear.call_args[0][1], {table.id})
+
+    def test_owner_deleted_clears_cache(self):
+        """Test that removing an owner from an existing row clears that table's cache"""
+        self.upload([(None, 'N', 'apple', 'user1', 'G1', 'loc1')])
+        table = LookupTable.objects.by_domain_tag(self.domain, 'things')
+        apple_id = self.get_rows(None)[0].id.hex
+
+        with patch.object(mod, "clear_fixture_cache") as mock_clear:
+            self.upload([(apple_id, 'N', 'apple', None, None, None)])
+            self.assertEqual(mock_clear.call_args[0][1], {table.id})
 
     def upload(self, rows, *, check_result=True, **kw):
         data = self.make_rows(rows)

--- a/corehq/apps/fixtures/utils.py
+++ b/corehq/apps/fixtures/utils.py
@@ -59,8 +59,8 @@ def get_index_schema_node(fixture_id, attrs_to_index):
 
 
 def clear_fixture_cache(domain, data_type_ids):
-    from corehq.apps.fixtures.models import FIXTURE_BUCKET
     assert not isinstance(data_type_ids, (str, UUID)), f'expected list or set, got {type(data_type_ids).__name__}'
     LookupTable.objects.filter(id__in=data_type_ids).update(last_modified=datetime.utcnow())
-
-    get_blob_db().delete(key=FIXTURE_BUCKET + '/' + domain)
+    from corehq.apps.fixtures.models import fixture_bucket
+    for data_type_id in data_type_ids:
+        get_blob_db().delete(key=fixture_bucket(data_type_id, domain))

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -3,7 +3,7 @@ from corehq.blobs import get_blob_db
 from casexml.apps.phone.utils import MockDevice
 from corehq.apps.domain.models import Domain
 from corehq.apps.fixtures.models import (
-    FIXTURE_BUCKET,
+    fixture_bucket,
     Field,
     LookupTable,
     LookupTableRow,
@@ -37,11 +37,13 @@ class OtaFixtureTest(TestCase):
         cls.group2 = Group(domain=DOMAIN, name='group2', case_sharing=True, users=[])
         cls.group2.save()
 
-        make_item_lists(SA_PROVINCES, 'western cape'),
-        make_item_lists(FR_PROVINCES, 'burgundy', cls.group1),
-        make_item_lists(CA_PROVINCES, 'alberta', cls.group2),
+        sa_data_type, _ = make_item_lists(SA_PROVINCES, 'western cape')
+        fr_data_type, _ = make_item_lists(FR_PROVINCES, 'burgundy', cls.group1)
+        ca_data_type, _ = make_item_lists(CA_PROVINCES, 'alberta', cls.group2)
 
-        cls.addClassCleanup(get_blob_db().delete, key=FIXTURE_BUCKET + "/" + DOMAIN)
+        cls.addClassCleanup(get_blob_db().delete, key=fixture_bucket(sa_data_type.id, DOMAIN))
+        cls.addClassCleanup(get_blob_db().delete, key=fixture_bucket(fr_data_type.id, DOMAIN))
+        cls.addClassCleanup(get_blob_db().delete, key=fixture_bucket(ca_data_type.id, DOMAIN))
 
         cls.restore_user = cls.user.to_ota_restore_user(DOMAIN)
 

--- a/corehq/ex-submodules/casexml/apps/phone/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/utils.py
@@ -1,11 +1,8 @@
 import re
 import weakref
-from io import BytesIO
 from uuid import uuid4
 from xml.etree import cElementTree as ElementTree
 from collections import defaultdict
-
-import six
 
 from casexml.apps.case.mock import CaseBlock, CaseFactory, CaseStructure
 from casexml.apps.case.xml import V1, V2, V2_NAMESPACE
@@ -19,7 +16,6 @@ from memoized import memoized
 from corehq.blobs import get_blob_db, CODES, NotFound
 from corehq.blobs.models import BlobMeta
 from corehq.util.metrics import metrics_counter
-from dimagi.utils.couch import CriticalSection
 
 ITEMS_COMMENT_PREFIX = b'<!--items='
 ITESM_COMMENT_REGEX = re.compile(br'(<!--items=(\d+)-->)')
@@ -33,64 +29,27 @@ ITESM_COMMENT_REGEX = re.compile(br'(<!--items=(\d+)-->)')
 GLOBAL_USER_ID = 'global-user-id-7566F038-5000-4419-B3EF-5349FB2FF2E9'
 
 
-def get_or_cache_global_fixture(domain, user_id, cache_bucket_prefix,
-                                fixture_name, data_fn, overwrite_cache=False):
-    """
-    Get the fixture data for a global fixture (one that does not vary by user).
+def combine_io_streams(fixture_io_streams, user_id):
+    data = bytearray()
+    data.extend(ITEMS_COMMENT_PREFIX)
+    data.extend(str(len(fixture_io_streams)).encode('utf-8'))
+    data.extend(b'-->')
 
-    :param domain: The domain to get or cache the fixture
-    :param user_id: User's id, if this is for case restore, then pass in case id
-    :param cache_bucket_prefix: Fixture bucket prefix
-    :param fixture_name: Name of the fixture
-    :param data_fn: Function to generate the XML fixture elements
-    :param overwrite_cache: a boolean property from RestoreState object, default is False
-    :return: list containing byte string representation of the fixture
-    """
-
-    data = None
-    key = '{}/{}'.format(cache_bucket_prefix, domain)
-
-    if not overwrite_cache:
-        data = get_cached_fixture_items(domain, cache_bucket_prefix)
-        _record_datadog_metric('cache_miss' if data is None else 'cache_hit', key)
-
-    if data is None:
-        with CriticalSection([key]):
-            if not overwrite_cache:
-                # re-check cache to avoid re-computing it
-                data = get_cached_fixture_items(domain, cache_bucket_prefix)
-                if data is not None:
-                    return [data]
-
-            _record_datadog_metric('generate', key)
-            items = data_fn()
-            io_data = write_fixture_items_to_io(items)
-            data = io_data.read()
-            io_data.seek(0)
-            cache_fixture_items_data(io_data, domain, fixture_name, cache_bucket_prefix)
+    for fixture_stream in fixture_io_streams:
+        fixture_stream.seek(0)
+        data.extend(fixture_stream.read())
 
     global_id = GLOBAL_USER_ID.encode('utf-8')
     b_user_id = user_id.encode('utf-8')
-    return [data.replace(global_id, b_user_id)] if data else []
+    return [bytes(data).replace(global_id, b_user_id)] if data else []
 
 
-def write_fixture_items_to_io(items):
-    io = BytesIO()
-    io.write(ITEMS_COMMENT_PREFIX)
-    io.write(six.text_type(len(items)).encode('utf-8'))
-    io.write(b'-->')
-    for element in items:
-        io.write(ElementTree.tostring(element, encoding='utf-8'))
-    io.seek(0)
-    return io
-
-
-def cache_fixture_items_data(io_data, domain, fixure_name, key_prefix):
+def cache_fixture_items_data(io_data, domain, fixure_name, key):
     db = get_blob_db()
     try:
         kw = {"meta": db.metadb.get(
             parent_id=domain,
-            key=key_prefix + '/' + domain,
+            key=key,
         )}
     except BlobMeta.DoesNotExist:
         kw = {
@@ -98,25 +57,25 @@ def cache_fixture_items_data(io_data, domain, fixure_name, key_prefix):
             "parent_id": domain,
             "type_code": CODES.fixture,
             "name": fixure_name,
-            "key": key_prefix + '/' + domain,
+            "key": key,
         }
     db.put(io_data, **kw)
 
 
-def get_cached_fixture_items(domain, bucket_prefix):
+def get_cached_fixture_items(key):
     try:
-        return get_blob_db().get(key=bucket_prefix + '/' + domain, type_code=CODES.fixture).read()
+        return get_blob_db().get(key=key, type_code=CODES.fixture).read()
     except NotFound:
         return None
 
 
 def clear_fixture_cache(domain, bucket_prefix):
     key = bucket_prefix + '/' + domain
-    _record_datadog_metric('cache_clear', key)
+    record_datadog_metric('cache_clear', key)
     get_blob_db().delete(key=key)
 
 
-def _record_datadog_metric(name, cache_key):
+def record_datadog_metric(name, cache_key):
     metrics_counter('commcare.fixture.{}'.format(name), tags={
         'cache_key': cache_key,
     })


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
There exists a bug where if a fixture is configured with an index, the first related `schema` xml included in the restore but all following elements (including the fixture itself) is not. The resulted in app not being able to find the fixture. This PR fixes this bug.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Context for this PR:
There was a bug introduced [USH-5912](https://dimagi.atlassian.net/browse/USH-5912) as part of a [PR1](https://github.com/dimagi/commcare-hq/pull/36091). PR1 was partially reverted in [PR2](https://github.com/dimagi/commcare-hq/pull/36227). The functionalities reverted were: 1. filtering out for only last modified look up tables when constructing xml for the restore 2. caching fixtures individually instead of caching all global fixtures together.

Cause of the bug:
When getting the fixtures related to the data type, it was incorrectly returning only the first element in the list of elements. As a result, only the first element was written to the io stream.

This PR reintroduces the two changes that were reverted in PR2. Additionally:
- Since the cached XML for a fixture can contain multiple elements (e.g., both a schema and a fixture element), we add a comment indicating the number of elements so the restore includes the correct count for each fixture.
- This PR removes the step of aggregating all global fixtures into a single list with a comment indicating the total count. Instead, each component is returned as a separate element, which is appended to the restore in the same order.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Reproduced the bug locally and tested the change fixes the bug.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
A test was added that checks the fixture generator includes both the schema and fixture xml nodes. 

There exists tests that check: 
- fixture_generator creates the expected xml for non indexed fixtures
- fixture_generator correctly includes the fixtures that have been modified

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-5912]: https://dimagi.atlassian.net/browse/USH-5912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ