### PR TITLE
[Data Cleaning] Functionality to stage edits on selected records after CleanSelectedRecordsForm submission

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -6,6 +6,21 @@
   hx-swap="outerHTML"
   hq-hx-refresh-swap="#CleanCaseTable"
 >
+  {% if change %}
+    <div
+      class="alert alert-success alert-dismissible fade show"
+      role="alert"
+    >
+      {# todo: make this more descriptive #}
+      {% blocktrans with change.records.count as num_records %}
+        {{ num_records }} records have been cleaned.
+      {% endblocktrans %}
+      <button
+        type="button" class="btn-close" aria-label="{% trans "Close" %}"
+        data-bs-dismiss="alert"
+      ></button>
+    </div>
+  {% endif %}
   {% if cleaning_form.is_form_visible %}
     <form
       hx-post="{{ request.path_info }}"


### PR DESCRIPTION
## Technical Summary
This implements the functionality to stage edits on selected records (that are visible in the current filtered queryset) after a `CleanSelectedRecordsForm` submission.

I've purposely limited this functionality to local environments now until I finish the functionality to display the changes "diff" in the values displayed in the table. I do this as QA is actively looking at columns and filters. With the Clean Selected Records form now visible, I want to avoid creating a lot of `BulkEditChanges` that can't be viewed and removed in the UI yet...in case someone on the QA team submits that form.

I also have a simple placeholder message indicating that "x records have been cleaned."
I plan to make this statement more detailed (which will come with the changes summary work later).

![Screenshot 2025-04-17 at 7 06 56 PM](https://github.com/user-attachments/assets/ab905de7-9b9f-4c61-b61a-342b6ba4aee8)

Addresses this ticket:
https://dimagi.atlassian.net/browse/SAAS-16872


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
very safe change, most important bits are already tested. I've created a separate ticket to ensure I don't forget about needed tests here:
https://dimagi.atlassian.net/browse/SAAS-17416

### Automated test coverage
yes

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
