### PR TITLE
Restrict optimizations to calculated properties only

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1932,7 +1932,7 @@ class DetailColumn(IndexedSchema):
         return self.format == 'invisible'
 
     def supports_optimizations(self):
-        return self.format in FORMATS_SUPPORTING_CASE_LIST_OPTIMIZATIONS
+        return self.useXpathExpression and self.format in FORMATS_SUPPORTING_CASE_LIST_OPTIMIZATIONS
 
 
 class SortElement(IndexedSchema):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1931,6 +1931,7 @@ class DetailColumn(IndexedSchema):
     def invisible(self):
         return self.format == 'invisible'
 
+    @property
     def supports_optimizations(self):
         return self.useXpathExpression and self.format in FORMATS_SUPPORTING_CASE_LIST_OPTIMIZATIONS
 

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -296,6 +296,7 @@ hqDefine("app_manager/js/details/column", [
         self.setSupportOptimizations = function () {
             let optimizationsSupported = (
                 screen.showCaseListOptimizations &&
+                self.useXpathExpression &&
                 self.format.val() &&
                 initialPageData.get('formats_supporting_case_list_optimizations').includes(self.format.val())
             );

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -314,6 +314,7 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
                 header={'en': 'CachedProperty'},
                 model='case',
                 field="prop1",
+                format="plain",
                 useXpathExpression=True,
                 optimization='cache',
 
@@ -362,6 +363,7 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
                 header={'en': 'CachedProperty'},
                 model='case',
                 field="prop1",
+                format="plain",
                 useXpathExpression=True,
                 optimization='cache',
             )
@@ -410,6 +412,7 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
                 header={'en': 'CachedProperty'},
                 model='case',
                 field="prop1",
+                format="plain",
                 useXpathExpression=True,
                 optimization='cache',
             )
@@ -448,6 +451,55 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
         self.assertIn('<detail id="m0_case_short">', str(suite))
 
     @flag_enabled('CASE_LIST_OPTIMIZATIONS')
+    def test_case_list_optimizations_for_non_supported_format_property(self):
+        factory = AppFactory(build_version='2.56.0')
+        module, form = factory.new_basic_module('m0', 'case')
+        module.show_case_list_optimization_options = True
+
+        module.case_details.short.columns = [
+            DetailColumn(
+                header={'en': 'CachedProperty'},
+                model='case',
+                field="prop1",
+                format="unsupported_format",
+                useXpathExpression=True,
+                optimization='cache',
+            )
+        ]
+
+        suite = factory.app.create_suite()
+
+        cached_property_template = """
+        <partial>
+          <field>
+            <header>
+              <text>
+                <locale id="m0.case_short.case_calculated_property_1.header"/>
+              </text>
+            </header>
+            <template>
+              <text>
+                <xpath function="$calculated_property">
+                  <variable name="calculated_property">
+                    <xpath function="prop1"/>
+                  </variable>
+                </xpath>
+              </text>
+            </template>
+          </field>
+        </partial>
+        """
+
+        self.assertXmlPartialEqual(
+            cached_property_template,
+            suite,
+            './detail[@id="m0_case_short"]/field[1]'
+        )
+
+        # No optimizations added on detail as well
+        self.assertIn('<detail id="m0_case_short">', str(suite))
+
+    @flag_enabled('CASE_LIST_OPTIMIZATIONS')
     def test_case_list_optimizations(self):
         factory = AppFactory(build_version='2.56.0')
         module, form = factory.new_basic_module('m0', 'case')
@@ -458,6 +510,7 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
                 header={'en': 'CachedProperty'},
                 model='case',
                 field="prop1",
+                format="plain",
                 useXpathExpression=True,
                 optimization='cache',
             ),
@@ -465,6 +518,7 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
                 header={'en': 'lazyLoadedProperty'},
                 model='case',
                 field="prop2",
+                format="plain",
                 useXpathExpression=True,
                 optimization='lazy_load',
             ),
@@ -472,6 +526,7 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
                 header={'en': 'Cached&LazyLoadedProperty'},
                 model='case',
                 field="prop3",
+                format="plain",
                 useXpathExpression=True,
                 optimization='cache_and_lazy_load',
             ),

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -500,6 +500,51 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
         self.assertIn('<detail id="m0_case_short">', str(suite))
 
     @flag_enabled('CASE_LIST_OPTIMIZATIONS')
+    def test_case_list_optimizations_for_non_calculated_property(self):
+        factory = AppFactory(build_version='2.56.0')
+        module, form = factory.new_basic_module('m0', 'case')
+        module.show_case_list_optimization_options = True
+
+        module.case_details.short.columns = [
+            DetailColumn(
+                header={'en': 'CachedProperty'},
+                model='case',
+                field="prop1",
+                format="plain",
+                useXpathExpression=False,
+                optimization='cache',
+            )
+        ]
+
+        suite = factory.app.create_suite()
+
+        cached_property_template = """
+            <partial>
+              <field>
+                <header>
+                  <text>
+                    <locale id="m0.case_short.case_prop1_1.header"/>
+                  </text>
+                </header>
+                <template>
+                  <text>
+                    <xpath function="prop1"/>
+                  </text>
+                </template>
+              </field>
+            </partial>
+            """
+
+        self.assertXmlPartialEqual(
+            cached_property_template,
+            suite,
+            './detail[@id="m0_case_short"]/field[1]'
+        )
+
+        # No optimizations added on detail as well
+        self.assertIn('<detail id="m0_case_short">', str(suite))
+
+    @flag_enabled('CASE_LIST_OPTIMIZATIONS')
     def test_case_list_optimizations(self):
         factory = AppFactory(build_version='2.56.0')
         module, form = factory.new_basic_module('m0', 'case')

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -314,7 +314,9 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
                 header={'en': 'CachedProperty'},
                 model='case',
                 field="prop1",
+                useXpathExpression=True,
                 optimization='cache',
+
             )
         ]
 
@@ -325,12 +327,16 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
           <field>
             <header>
               <text>
-                <locale id="m0.case_short.case_prop1_1.header"/>
+                <locale id="m0.case_short.case_calculated_property_1.header"/>
               </text>
             </header>
             <template>
               <text>
-                <xpath function="prop1"/>
+                <xpath function="$calculated_property">
+                  <variable name="calculated_property">
+                    <xpath function="prop1"/>
+                  </variable>
+                </xpath>
               </text>
             </template>
           </field>
@@ -356,6 +362,7 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
                 header={'en': 'CachedProperty'},
                 model='case',
                 field="prop1",
+                useXpathExpression=True,
                 optimization='cache',
             )
         ]
@@ -367,12 +374,16 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
           <field>
             <header>
               <text>
-                <locale id="m0.case_short.case_prop1_1.header"/>
+                <locale id="m0.case_short.case_calculated_property_1.header"/>
               </text>
             </header>
             <template>
               <text>
-                <xpath function="prop1"/>
+                <xpath function="$calculated_property">
+                  <variable name="calculated_property">
+                    <xpath function="prop1"/>
+                  </variable>
+                </xpath>
               </text>
             </template>
           </field>
@@ -399,6 +410,7 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
                 header={'en': 'CachedProperty'},
                 model='case',
                 field="prop1",
+                useXpathExpression=True,
                 optimization='cache',
             )
         ]
@@ -410,12 +422,16 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
               <field>
                 <header>
                   <text>
-                    <locale id="m0.case_short.case_prop1_1.header"/>
+                    <locale id="m0.case_short.case_calculated_property_1.header"/>
                   </text>
                 </header>
                 <template>
                   <text>
-                    <xpath function="prop1"/>
+                    <xpath function="$calculated_property">
+                      <variable name="calculated_property">
+                        <xpath function="prop1"/>
+                      </variable>
+                    </xpath>
                   </text>
                 </template>
               </field>
@@ -442,18 +458,21 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
                 header={'en': 'CachedProperty'},
                 model='case',
                 field="prop1",
+                useXpathExpression=True,
                 optimization='cache',
             ),
             DetailColumn(
                 header={'en': 'lazyLoadedProperty'},
                 model='case',
                 field="prop2",
+                useXpathExpression=True,
                 optimization='lazy_load',
             ),
             DetailColumn(
                 header={'en': 'Cached&LazyLoadedProperty'},
                 model='case',
                 field="prop3",
+                useXpathExpression=True,
                 optimization='cache_and_lazy_load',
             ),
         ]
@@ -465,12 +484,16 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
           <field cache_enabled="true">
             <header>
               <text>
-                <locale id="m0.case_short.case_prop1_1.header"/>
+                <locale id="m0.case_short.case_calculated_property_1.header"/>
               </text>
             </header>
             <template>
               <text>
-                <xpath function="prop1"/>
+                <xpath function="$calculated_property">
+                  <variable name="calculated_property">
+                    <xpath function="prop1"/>
+                  </variable>
+                </xpath>
               </text>
             </template>
           </field>
@@ -488,12 +511,16 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
           <field lazy_loading="true">
             <header>
               <text>
-                <locale id="m0.case_short.case_prop2_2.header"/>
+                <locale id="m0.case_short.case_calculated_property_2.header"/>
               </text>
             </header>
             <template>
               <text>
-                <xpath function="prop2"/>
+                <xpath function="$calculated_property">
+                  <variable name="calculated_property">
+                    <xpath function="prop2"/>
+                  </variable>
+                </xpath>
               </text>
             </template>
           </field>
@@ -511,12 +538,16 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
           <field cache_enabled="true" lazy_loading="true">
             <header>
               <text>
-                <locale id="m0.case_short.case_prop3_3.header"/>
+                <locale id="m0.case_short.case_calculated_property_3.header"/>
               </text>
             </header>
             <template>
               <text>
-                <xpath function="prop3"/>
+                <xpath function="$calculated_property">
+                  <variable name="calculated_property">
+                    <xpath function="prop3"/>
+                  </variable>
+                </xpath>
               </text>
             </template>
           </field>


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
https://dimagi.atlassian.net/browse/SC-4421
Restrict optimizations to calculated properties only. Some performance testing revealed that optimizations were not really of use for non calculated properties.
Originally feature added in https://github.com/dimagi/commcare-hq/pull/35755.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`CASE_LIST_OPTIMIZATIONS`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Covered by tests and tested locally as well.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Well covered by suite tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi.atlassian.net/browse/QA-7672


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
