### PR TITLE
Clear `get_data_dict_case_types()` cache

### DIFF
--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -96,7 +96,8 @@ def create_properties_for_case_types(domain, case_type_to_prop):
         try:
             case_type_obj = current_case_types[case_type]
         except KeyError:
-            case_type_obj = CaseType.objects.create(domain=domain, name=case_type)
+            case_type_obj = CaseType(domain=domain, name=case_type)
+            case_type_obj.save()  # save() method clears cache
 
         for prop in props:
             # don't add any properites to parent cases


### PR DESCRIPTION
## Technical Summary

The `refresh_data_dictionary_from_app()` background task calls `create_properties_for_case_types()`. It clears CaseProperty caches, but not the CaseType cache. This change is to clear the `get_data_dict_case_types()` cache when creating new case types.

## Safety Assurance

### Safety story

* Small change.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
