### PR TITLE
change placement of popover to bottom

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -553,7 +553,7 @@ hqDefine('app_manager/js/app_manager', [
                     title: hoverHelpTexts[type].title,
                     content: hoverHelpTexts[type].content,
                     trigger: 'hover',
-                    placement: 'auto',
+                    placement: 'bottom',
                     container: 'body',
                     html: true,
                 });


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
I noticed when we have a lot of module in the left navigation area, the placement `auto` won't correctly place the popover. It placed the popover on `top` so part of the popover is covered by the browser
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/92375a1a-185f-40dd-8d91-7e54d0c2a8c4" />

This change will make sure the popover always show up on the bottom of the first two module option.
<img width="1072" alt="image" src="https://github.com/user-attachments/assets/5ed4475d-485e-46ad-a418-18500e3cb215" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
