### PR TITLE
Increase Timing Granularity for Building Fixture Elements

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -813,14 +813,16 @@ class RestoreConfig(object):
             extra_tags = {}
             if timer.name in RESTORE_SEGMENTS:
                 segment = RESTORE_SEGMENTS[timer.name]
+                segment_timer_buckets = timer_buckets
             elif timer.name.startswith('fixture:'):
                 segment = 'fixture'
+                segment_timer_buckets = (0.25, 0.5, 1, 5, 20, 60, 120, 300, 600)
                 extra_tags = {'fixture': timer.name.split(':')[1]}
 
             if segment:
                 metrics_histogram(
                     'commcare.restores.{}.duration.seconds'.format(segment), timer.duration,
-                    bucket_tag='duration', buckets=timer_buckets, bucket_unit='s',
+                    bucket_tag='duration', buckets=segment_timer_buckets, bucket_unit='s',
                     tags={**tags, **extra_tags}
                 )
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
no user facing effects.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-5895](https://dimagi.atlassian.net/browse/USH-5895)
We are seeing increased in submission timing for BHA in the past couple months and suspect it is related to increased in CSQL fixture timings. We are increasing the granularity in the timing to have better visibility on performance impact of changes going forward. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Only adds timing buckets

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-5895]: https://dimagi.atlassian.net/browse/USH-5895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ