### PR TITLE
Fix : Payment report is not visible while assigning permission to roles 

### DIFF
--- a/corehq/apps/users/permissions.py
+++ b/corehq/apps/users/permissions.py
@@ -55,7 +55,7 @@ def get_extra_permissions():
     yield ReportPermission(
         PAYMENTS_REPORT_PERMISSION,
         PaymentsVerificationReportView.page_title,
-        lambda domain: toggles.MTN_MOBILE_WORKER_VERIFICATION.enabled(domain)
+        lambda domain: toggles.MTN_MOBILE_WORKER_VERIFICATION.enabled(domain.name)
     )
 
 

--- a/corehq/apps/users/permissions.py
+++ b/corehq/apps/users/permissions.py
@@ -40,22 +40,22 @@ def get_extra_permissions():
     from corehq.apps.integration.payments.views import PaymentsVerificationReportView
 
     yield ReportPermission(
-        FORM_EXPORT_PERMISSION, FormExportListView.page_title, lambda domain: True)
+        FORM_EXPORT_PERMISSION, FormExportListView.page_title, lambda domain_obj: True)
     yield ReportPermission(
         DEID_EXPORT_PERMISSION, gettext_noop("Export De-Identified Data"),
-        lambda domain: domain_has_privilege(domain, privileges.DEIDENTIFIED_DATA))
+        lambda domain_obj: domain_has_privilege(domain_obj, privileges.DEIDENTIFIED_DATA))
     yield ReportPermission(
         CASE_EXPORT_PERMISSION, CaseExportListView.page_title, lambda domain: True)
     yield ReportPermission(
         SMS_EXPORT_PERMISSION, DownloadNewSmsExportView.page_title, lambda domain: True)
     yield ReportPermission(
         ODATA_FEED_PERMISSION, ODataFeedListView.page_title,
-        lambda domain: domain_has_privilege(domain, privileges.ODATA_FEED)
+        lambda domain_obj: domain_has_privilege(domain_obj, privileges.ODATA_FEED)
     )
     yield ReportPermission(
         PAYMENTS_REPORT_PERMISSION,
         PaymentsVerificationReportView.page_title,
-        lambda domain: toggles.MTN_MOBILE_WORKER_VERIFICATION.enabled(domain.name)
+        lambda domain_obj: toggles.MTN_MOBILE_WORKER_VERIFICATION.enabled(domain_obj.name)
     )
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This is  a simple fix for Payment report not being visible while assigning permission to roles.
No UI facing change.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
The issue occurred because [domain instance was passed](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/permissions.py#L58) to `<toggle>.enabled` function which expects `domain name` instead.
Unfortunately it was not caught in testing as `<toggle>.enabled` function uses [string formatting internally](https://github.com/dimagi/commcare-hq/blob/master/corehq/toggles/shortcuts.py#L65) and for domain tested, the string formatted output of domain_obj instance (uses `display_name`) was exactly same as the domain name. However this is not true for all domains for obvious reasons.

Also naming was updated from `domain` to `domain_obj` for being explicit.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
MTN_MOBILE_WORKER_VERIFICATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Small and safe chnage. 
Tested on local and staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
