### PR TITLE
[Data Cleaning] Diff view for edited columns + system column UI

### DIFF
--- a/corehq/apps/data_cleaning/records.py
+++ b/corehq/apps/data_cleaning/records.py
@@ -1,3 +1,6 @@
+from memoized import memoized
+
+from corehq.apps.data_cleaning.models import BulkEditRecord
 from corehq.apps.hqwebapp.tables.elasticsearch.records import CaseSearchElasticRecord
 
 
@@ -6,6 +9,21 @@ class EditableCaseSearchElasticRecord(CaseSearchElasticRecord):
     def __init__(self, record, request, **kwargs):
         super().__init__(record, request, **kwargs)
         self.session = kwargs.pop('session')
+
+    @property
+    @memoized
+    def edited_record(self):
+        try:
+            return self.session.records.get(doc_id=self.record.case.case_id)
+        except BulkEditRecord.DoesNotExist:
+            return None
+
+    @property
+    @memoized
+    def edited_properties(self):
+        if self.edited_record:
+            return self.edited_record.get_edited_case_properties(self.record.case)
+        return {}
 
     def __getitem__(self, item):
         return super().__getitem__(item)

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -23,6 +23,9 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
 
     class Meta(BaseHtmxTable.Meta):
         template_name = "data_cleaning/tables/table_with_controls.html"
+        attrs = {
+            "class": "table table-striped align-middle",
+        }
         row_attrs = {
             "x-data": "{ isRowSelected: $el.querySelector('input[type=checkbox]').checked }",
             ":class": "{ 'table-primary': isRowSelected }",

--- a/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_session.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_session.html
@@ -1,8 +1,20 @@
 {% extends "hqwebapp/bootstrap5/base_navigation.html" %}
 {% load hq_shared_tags %}
 {% load django_tables2 %}
+{% load compress %}
 {% load i18n %}
 {% js_entry "data_cleaning/js/clean_cases_session" %}
+
+{% block stylesheets %}
+  {% compress css %}
+    <link
+      type="text/scss"
+      rel="stylesheet"
+      media="all"
+      href="{% static "hqwebapp/scss/data_cleaning.scss" %}"
+    />
+  {% endcompress %}
+{% endblock stylesheets %}
 
 {% block content %}
   {% breadcrumbs current_page section current_page.parents %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -2,8 +2,73 @@
 {% load data_cleaning %}
 
 {% edited_value record column as edited_value %}
+<div
+  class="editable-column-container"
+  x-data="{
+    isEditing: false,
+    isSubmitting: false,
+  }"
+>
+  <div
+    class="dc-inline-edit-block"
+    x-show="!isEditing"
+    @dblclick="isEditing = !isSubmitting"
+  >
+    {% if edited_value|has_edits %}
+      <div class="d-flex align-items-center">
+        <div class="dc-diff-view">
+          <div class="dc-diff-before">
+            {{ value }}
+          </div>
+          <div class="dc-diff-after">
+            {{ edited_value }}
+          </div>
+        </div>
+        <div class="ms-2">
+          <button
+            class="btn btn-outline-danger btn-sm htmx-loading"
+            type="button"
+          >
+            <i class="fa fa-close"></i>
+          </button>
+        </div>
+      </div>
+    {% else %}
+      {{ value }}
+    {% endif %}
+    <button
+      class="btn btn-link btn-sm dc-inline-edit-action"
+      type="button"
+      @click="isEditing = true"
+      :disabled="isSubmitting"
+    >
+      <i class="fa fa-pencil"></i>
+      <span class="visually-hidden">{% trans "Edit Value" %}</span>
+    </button>
+  </div>
 
-{{ value }}
-{% if edited_value|has_edits %}
-{{ edited_value }}
-{% endif %}
+  <div x-show="isEditing">
+    <div class="input-group">
+      <input
+        class="form-control"
+        type="text"
+        name="newValue"
+      />
+      <button
+        class="btn btn-primary htmx-loading"
+        type="submit"
+        disabled="disabled"  {# todo implement inline edit submission #}
+        @click="isSubmitting = true"
+      >
+        <i class="fa fa-check"></i>
+      </button>
+      <button
+        class="btn btn-outline-danger"
+        type="button"
+        :disabled="isSubmitting"
+        @click="isEditing = false"
+      >
+        <i class="fa fa-close"></i>
+      </button>
+  </div>
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+{% load data_cleaning %}
+
+{% edited_value record column as edited_value %}
+
+{{ value }}
+{% if edited_value|has_edits %}
+{{ edited_value }}
+{% endif %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_main.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_main.html
@@ -1,3 +1,8 @@
 {% load i18n %}
+{% load data_cleaning %}
 
-{{ value }}
+{% if column|is_editable_column %}
+  {% include "data_cleaning/columns/column_editable.html" %}
+{% else %}
+  {% include "data_cleaning/columns/column_system.html" %}
+{% endif %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_system.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_system.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+{% load data_cleaning %}
+
+{# todo: system styling #}
+{{ value }}
+

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_system.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_system.html
@@ -1,6 +1,10 @@
 {% load i18n %}
 {% load data_cleaning %}
 
-{# todo: system styling #}
-{{ value }}
+<div class="dc-inline-edit-block">
+  {{ value }}
+  <div class="dc-inline-edit-action dc-inline-edit-action-text">
+    {% trans "System" %} <i class="fa fa-lock ms-1"></i>
+  </div>
+</div>
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/data_cleaning.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/data_cleaning.scss
@@ -1,0 +1,88 @@
+@import "functions";
+@import "commcarehq/variables";
+@import "variables";
+@import "variables-dark";
+
+.dc-diff-view {
+  font-family: $font-family-monospace;
+  letter-spacing: 1px;
+}
+
+.dc-diff-before,
+.dc-diff-after {
+  border: 1px solid white;
+  margin: $spacer *.13;
+  padding-right: $spacer *.5;
+  vertical-align: middle;
+
+  &::before {
+    display: inline-block;
+    color: $white;
+    line-height: 12px;
+    padding: $spacer *.25 $spacer *.5;
+  }
+}
+
+.dc-diff-before {
+  background-color: $red-100;
+  border-color: $red-500;
+
+  &::before {
+    background-color: $red-500;
+    content: "-";
+  }
+}
+
+.dc-diff-after {
+  background-color: $green-100;
+  border-color: $green-500;
+
+  &::before {
+    background-color: $green-500;
+    content: "+";
+  }
+}
+
+.dc-inline-edit-block {
+  display: block;
+  background-color: transparent;
+  cursor: text;
+  transition: background-color .5s ease-in-out;
+  position: relative;
+  padding: $spacer * 0.5;
+  margin: $spacer * -0.5;
+
+  .dc-inline-edit-action {
+    position: absolute;
+    right: 0;
+    top: calc(50% - 12px);
+    opacity: 0;
+    transition: opacity .5s ease-in-out;
+  }
+
+  .dc-inline-edit-action-text {
+    background-color: $white;
+    padding: $spacer * .25;
+    white-space: nowrap;
+    $_offset: $spacer * .6;
+    top: calc(50% - $_offset);
+    right: $spacer * 0.25;
+    font-size: 10px;
+    line-height: $spacer * .75;
+    text-transform: uppercase;
+    font-weight: bold;
+  }
+
+  &:hover {
+    background-color: rgba(0, 0, 0, .06);
+  }
+
+  &:hover .dc-inline-edit-action {
+    display: block;
+    opacity: 1;
+
+    &.dc-inline-edit-action-text {
+      opacity: 1;
+    }
+  }
+}


### PR DESCRIPTION
## Technical Summary
This PR introduces the diff view for edited columns.
<img width="758" alt="Screenshot 2025-04-22 at 10 02 44 AM" src="https://github.com/user-attachments/assets/7fa5d480-8227-4934-8a5b-891617267438" />

When you hover over system column values, you see "system" and the lock icon to indicate that this value is not editable.
<img width="366" alt="Screenshot 2025-04-22 at 10 02 49 AM" src="https://github.com/user-attachments/assets/aa5c914b-7293-4f01-ab0e-cc60f6aeba38" />

When you hover over editable columns, you see the pencil icon, indicating the value is editable. if you click on the pencil icon or double click on the column area, you enter the inline edit view.
<img width="277" alt="Screenshot 2025-04-22 at 10 03 00 AM" src="https://github.com/user-attachments/assets/3134bbb8-bddf-4792-98cc-6973a91d2db4" />
<img width="391" alt="Screenshot 2025-04-22 at 10 03 05 AM" src="https://github.com/user-attachments/assets/b92c1ee2-36e5-4c7d-b8e0-806162b42b3d" />
NOTE: this is a placeholder. Inline editing is still not supported, and the button to confirm the edit (the checkmark) is disabled.

There is also an X icon next to a diff view (indicating that the column has been editing). This will remove the edits for that column when clicked. In this PR, that functionality is not yet implemented. That will come in a future PR.

This PR introduces:
- the data cleaning stylesheet, as we will be adding custom styles for data cleaning as this feature progresses.
- template tags to check if a value is edited and retrieve the edited value from a record in the `DataCleaningHtmxColumn`.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
all changes only apply to feature flagged workflows.

### Automated test coverage
most important functionality is already tested

### QA Plan
not yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
