### PR TITLE
Update links to payment info in downgrade emails

### DIFF
--- a/corehq/apps/accounting/templates/accounting/email/downgrade.html
+++ b/corehq/apps/accounting/templates/accounting/email/downgrade.html
@@ -25,7 +25,7 @@
       As a reminder, payments can be made via credit card, Electronic Fund
       Transfer (EFT), or check by following these
       <a
-        href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143956507/Payment+Methods+Instructions"
+        href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods"
         >instructions</a
       >.
     {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/downgrade.txt
+++ b/corehq/apps/accounting/templates/accounting/email/downgrade.txt
@@ -5,7 +5,7 @@ Dear {{ domain }} administrator,
 Your subscription has been paused for the CommCare project space {{ domain }}. You can regain access to your data and project space by re-subscribing to a plan.
 
 To see the full list of unpaid invoices you can follow this link: {{ statements_url }}
-As a reminder, payments can be made via credit card, Electronic Fund Transfer (EFT), or check by following the instructions at https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143956507/Payment+Methods+Instructions
+As a reminder, payments can be made via credit card, Electronic Fund Transfer (EFT), or check by following the instructions at https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods
 After you have paid the unpaid invoices you can re-subscribe to your plan here: {{ subscription_url }}
 
 If you have any questions, please don’t hesitate to contact {{ contact_email }}. Thank you for using CommCare.

--- a/corehq/apps/accounting/templates/accounting/email/downgrade_warning.html
+++ b/corehq/apps/accounting/templates/accounting/email/downgrade_warning.html
@@ -29,7 +29,7 @@
       As a reminder, payments can be made via credit card, Electronic Fund
       Transfer (EFT), or check by following these
       <a
-        href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143956507/Payment+Methods+Instructions"
+        href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods"
         >instructions</a
       >.
     {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/downgrade_warning.txt
+++ b/corehq/apps/accounting/templates/accounting/email/downgrade_warning.txt
@@ -6,7 +6,7 @@ Your CommCare {{ subscriptions_to_downgrade }} will be paused after tomorrow bec
 If you do not make a payment before tomorrow, your subscription will automatically be paused and you will lose access to your project space and data until you re-subscribe to a paid plan.
 
 To see the full list of unpaid invoices you can follow this link: {{ statements_url }}
-As a reminder, payments can be made via credit card, Electronic Fund Transfer (EFT), or check by following the instructions at https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143956507/Payment+Methods+Instructions
+As a reminder, payments can be made via credit card, Electronic Fund Transfer (EFT), or check by following the instructions at https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods
 You can also pre-pay for several months at any time by following the steps at https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143950358/CommCare+Subscriptions+Pricing+FAQs#Monthly-Billing
 
 If you have any questions, please don’t hesitate to contact {{ contact_email }}. Thank you for using CommCare.

--- a/corehq/apps/accounting/templates/accounting/email/overdue_notice.html
+++ b/corehq/apps/accounting/templates/accounting/email/overdue_notice.html
@@ -24,7 +24,7 @@
       As a reminder, payments can be made via credit card, Electronic Fund
       Transfer (EFT), or check by following these
       <a
-        href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143956507/Payment+Methods+Instructions"
+        href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods"
         >instructions</a
       >.
     {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/overdue_notice.txt
+++ b/corehq/apps/accounting/templates/accounting/email/overdue_notice.txt
@@ -5,7 +5,7 @@ Dear {{ domain_or_account }} administrator,
 Your billing account has unpaid CommCare Billing Statements which are more than {{ days_overdue }} days overdue. The balance currently owed is: ${{ total }}.
 
 To see the full list of unpaid invoices you can follow this link: {{  statements_url }}
-As a reminder, payments can be made via credit card, Electronic Fund Transfer (EFT), or check by following the instructions at https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143956507/Payment+Methods+Instructions
+As a reminder, payments can be made via credit card, Electronic Fund Transfer (EFT), or check by following the instructions at https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods
 You can also pre-pay for several months at any time by following the steps at https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143950358/CommCare+Subscriptions+Pricing+FAQs#Monthly-Billing
 
 Please make a payment as soon as possible for the amount due.


### PR DESCRIPTION
## Product Description
Fixes a link used in a few emails that, while not strictly broken, is not very useful as it goes to a page on Confluence that is no longer active.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17428

## Safety Assurance

### Safety story
Just updates a link to point to the correct page on Confluence, nothing risky here.

### Automated test coverage
Nope

### QA Plan
Nada

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
