### PR TITLE
[Data Cleaning] Add functionality to reset changes on a single table cell

### DIFF
--- a/corehq/apps/data_cleaning/columns.py
+++ b/corehq/apps/data_cleaning/columns.py
@@ -1,4 +1,8 @@
-from django_tables2.columns import TemplateColumn, CheckBoxColumn
+from django_tables2.columns import (
+    TemplateColumn,
+    CheckBoxColumn,
+    BoundColumn,
+)
 from django_tables2.utils import AttributeDict
 
 from corehq.toggles import mark_safe
@@ -22,6 +26,25 @@ class DataCleaningHtmxColumn(TemplateColumn):
             *args, **kwargs
         )
         self.column_spec = column_spec
+
+    @classmethod
+    def get_htmx_partial_response_context(cls, column_spec, record, table):
+        """
+        Returns the context needed for rendering the
+        `DataCleaningHtmxColumn` template as an HTMX partial response.
+
+        :param column_spec: BulkEditColumn
+        :param record: EditableCaseSearchElasticRecord (or similar)
+        :param table: CleanCaseTable (or similar)
+        """
+        column = cls(column_spec)
+        bound_column = BoundColumn(table, column, column_spec.slug)
+        value = record[column_spec.prop_id]
+        return {
+            "column": bound_column,
+            "record": record,
+            "value": value,
+        }
 
 
 class DataCleaningHtmxSelectionColumn(CheckBoxColumn):

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -998,6 +998,16 @@ class BulkEditRecord(models.Model):
             self.calculated_change_id is None or self.changes.last().change_id != self.calculated_change_id
         )
 
+    @retry_on_integrity_error(max_retries=3, delay=0.1)
+    @transaction.atomic
+    def reset_changes(self, prop_id):
+        change = BulkEditChange.objects.create(
+            session=self.session,
+            prop_id=prop_id,
+            action_type=EditActionType.RESET,
+        )
+        change.records.add(self)
+
     def get_edited_case_properties(self, case):
         """
         Returns a dictionary of properties that have been edited by related BulkEditChanges.

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -1021,7 +1021,12 @@ class BulkEditRecord(models.Model):
 
         properties = {}
         for change in self.changes.all():
-            properties[change.prop_id] = change.edited_value(case, edited_properties=properties)
+            if change.action_type == EditActionType.RESET:
+                del properties[change.prop_id]
+            else:
+                properties[change.prop_id] = change.edited_value(
+                    case, edited_properties=properties
+                )
         self.calculated_properties = properties
         self.calculated_change_id = self.changes.last().change_id
         self.save()

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -861,6 +861,13 @@ class BulkEditColumn(models.Model):
         )
 
     @property
+    def slug(self):
+        """
+        Returns a slugified version of the prop_id.
+        """
+        return self.prop_id.replace("@", "")
+
+    @property
     def choice_label(self):
         """
         Returns the human-readable option visible in a select field.

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -251,6 +251,16 @@ class BulkEditSession(models.Model):
         query = BulkEditPinnedFilter.apply_filters_to_query(self, query)
         return query
 
+    def get_document_from_queryset(self, doc_id):
+        """
+        Get the CaseES doc from the queryset for this session.
+        # todo update for FormES later
+
+        :param doc_id: the id of the document (case / form)
+        :return: the raw document from elasticsearch
+        """
+        return self.get_queryset().case_ids([doc_id]).run().hits[0]
+
     def get_num_selected_records(self):
         return self.records.filter(is_selected=True).count()
 

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -65,8 +65,9 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
     def get_columns_from_session(cls, session):
         visible_columns = []
         for column_spec in session.columns.all():
-            slug = column_spec.prop_id.replace('@', '')
-            visible_columns.append((slug, DataCleaningHtmxColumn(column_spec)))
+            visible_columns.append(
+                (column_spec.slug, DataCleaningHtmxColumn(column_spec))
+            )
         return visible_columns
 
     @property

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load django_tables2 %}
 {% load data_cleaning %}
 
 {% edited_value record column as edited_value %}
@@ -28,6 +29,12 @@
           <button
             class="btn btn-outline-danger btn-sm htmx-loading"
             type="button"
+            hx-post="{{ request.path_info }}{% querystring %}"
+            hq-hx-action="cell_reset_changes"
+            hx-vals="{% cell_request_params record column %}"
+            hx-target="closest .editable-column-container"
+            hx-swap="outerHTML"
+            hx-disabled-elt="this"
           >
             <i class="fa fa-close"></i>
           </button>

--- a/corehq/apps/data_cleaning/templatetags/data_cleaning.py
+++ b/corehq/apps/data_cleaning/templatetags/data_cleaning.py
@@ -80,10 +80,15 @@ def has_edits(edited_value):
     return edited_value is not Ellipsis
 
 
-@register.filter
-def is_editable_column(bound_column):
+def _validate_htmx_column(bound_column):
     if not isinstance(bound_column.column, DataCleaningHtmxColumn):
         raise template.TemplateSyntaxError(
-            f"Expected a DataCleaningHtmxColumn, got {type(bound_column.column)}"
+            f"Expected bound_column.column to be a DataCleaningHtmxColumn, "
+            f"got {type(bound_column.column)} instead."
         )
+
+
+@register.filter
+def is_editable_column(bound_column):
+    _validate_htmx_column(bound_column)
     return not bound_column.column.column_spec.is_system

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -159,7 +159,8 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
         Effectively resets/removes any changes made to a record's prop_id.
         """
         doc_id, column = self._get_cell_request_details(request)
-        # todo actually reset the changes
+        edit_record = self.session.records.get(doc_id=doc_id)
+        edit_record.reset_changes(column.prop_id)
         return self._render_table_cell_response(
             doc_id, column, request, *args, **kwargs
         )

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -2,6 +2,7 @@ import json
 
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from corehq.apps.data_cleaning.columns import DataCleaningHtmxColumn
 from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
 from corehq.apps.data_cleaning.models import BulkEditSession
 from corehq.apps.data_cleaning.tables import (
@@ -123,6 +124,45 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
             },
         })
         return response
+
+    def _render_table_cell_response(self, doc_id, column, request, *args, **kwargs):
+        """
+        Returns an a partial HttpResponse for the table cell,
+        using the `DataCleaningHtmxColumn` template and context.
+        """
+        record = self.table_class.record_class(
+            self.session.get_document_from_queryset(doc_id),
+            self.request,
+            session=self.session,
+        )
+        table = self.table_class(session=self.session, data=self.session.get_queryset())
+        context = DataCleaningHtmxColumn.get_htmx_partial_response_context(
+            column,
+            record,
+            table,
+        )
+        return self.render_htmx_partial_response(
+            request, DataCleaningHtmxColumn.template_name, context
+        )
+
+    def _get_cell_request_details(self, request):
+        """
+        Returns the details of the cell request.
+        """
+        doc_id = request.POST["record_id"]
+        column = self.session.columns.get(column_id=request.POST["column_id"])
+        return doc_id, column
+
+    @hq_hx_action("post")
+    def cell_reset_changes(self, request, *args, **kwargs):
+        """
+        Effectively resets/removes any changes made to a record's prop_id.
+        """
+        doc_id, column = self._get_cell_request_details(request)
+        # todo actually reset the changes
+        return self._render_table_cell_response(
+            doc_id, column, request, *args, **kwargs
+        )
 
 
 class CaseCleaningTasksTableView(BaseDataCleaningTableView):

--- a/corehq/apps/hqwebapp/tables/elasticsearch/records.py
+++ b/corehq/apps/hqwebapp/tables/elasticsearch/records.py
@@ -39,6 +39,15 @@ class BaseElasticRecord(ABC):
         :return: string
         """
 
+    @property
+    @abstractmethod
+    def record_id(self):
+        """
+        Return the primary id of the record
+
+        :return: string
+        """
+
     @staticmethod
     def get_sorted_query(query, accessors):
         """
@@ -80,6 +89,15 @@ class CaseSearchElasticRecord(BaseElasticRecord):
         Used by the built-in CheckBoxColumn from django_tables2.
         """
         return "selected_case"
+
+    @property
+    def record_id(self):
+        """
+        Return the primary id of the record
+
+        :return: string
+        """
+        return self.record.case.case_id
 
     @staticmethod
     def get_sorted_query(query, accessors):


### PR DESCRIPTION
## Product Description
This adds the functionality to reset changes on a single table cell. It's the action that happens when you click the "x" button next to the edited value diff:
![Screenshot 2025-04-22 at 8 29 21 PM](https://github.com/user-attachments/assets/3e9be330-602b-4507-a4fc-3fe6bffb9648)

Here is a video of the interaction:

https://github.com/user-attachments/assets/bb567799-29f7-48fb-afd1-a5a02720999f

## Technical Summary
This also adds the ability to return a standard partial htmx response for cell-related HTMX interactions with a table.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
small changes made to a feature flagged area of the codebase

### Automated test coverage
most important logic is tested, but i will be adding additional tests once the main part of the feature is in QA

### QA Plan
not yet / pending for this part of the code

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
