### PR TITLE
Retry mounting Stripe UI after template containing it is rendered.

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -136,7 +136,7 @@ hqDefine('accounting/js/payment_method_handler', [
             self.cardElementPromise.then(function (cardElement) {
                 const stripeSelector = '#' + formId + ' .stripe-card-container';
                 if (show) {
-                    if ($(stripeSelector).length) {
+                    if ($(stripeSelector).length && !self.cardElementMounted) {
                         cardElement.mount(stripeSelector);
                         self.cardElementMounted = true;
                     }

--- a/corehq/apps/domain/templates/domain/partials/bootstrap3/payment_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap3/payment_modal.html
@@ -279,7 +279,8 @@
             data-bind="template: {
                            data: newCard,
                            name: 'select-new-stripe-card-template',
-                           if: mustCreateNewCard
+                           if: mustCreateNewCard,
+                           afterRender: showOrHideStripeUI,
                        }"
           ></div>
 
@@ -287,7 +288,8 @@
             data-bind="template: {
                            data: $data,
                            name: 'select-stripe-card-template',
-                           if: canSelectCard
+                           if: canSelectCard,
+                           afterRender: showOrHideStripeUI,
                        }"
           ></div>
           <!-- /ko -->

--- a/corehq/apps/domain/templates/domain/partials/bootstrap5/payment_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap5/payment_modal.html
@@ -279,7 +279,8 @@
             data-bind="template: {
                            data: newCard,
                            name: 'select-new-stripe-card-template',
-                           if: mustCreateNewCard
+                           if: mustCreateNewCard,
+                           afterRender: showOrHideStripeUI,
                        }"
           ></div>
 
@@ -287,7 +288,8 @@
             data-bind="template: {
                            data: $data,
                            name: 'select-stripe-card-template',
-                           if: canSelectCard
+                           if: canSelectCard,
+                           afterRender: showOrHideStripeUI,
                        }"
           ></div>
           <!-- /ko -->

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/partials/payment_modal.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/partials/payment_modal.html.diff.txt
@@ -160,7 +160,7 @@
                  <input
                    type="text"
                    data-bind="value: wireAdditionalEmails"
-@@ -304,8 +304,8 @@
+@@ -306,8 +306,8 @@
            <button
              type="button"
              data-bind="visible: paymentIsNotComplete"
@@ -171,7 +171,7 @@
            >
              {% trans "Cancel" %}
            </button>
-@@ -326,15 +326,15 @@
+@@ -328,15 +328,15 @@
              data-bind="text: submitBtnText"
              disabled="disabled"
            ></button>


### PR DESCRIPTION
## Product Description
Fix intermittent issue with credit card UI not appearing on billing statements page.

## Technical Summary
Related to https://github.com/dimagi/commcare-hq/pull/36073 and https://github.com/dimagi/commcare-hq/pull/36205

My theory is that depending on how long it takes to load the stripe js, [this code](https://github.com/dimagi/commcare-hq/blob/38caa24bccec7e3f5edb9c74afa664114bf997d2/corehq/apps/accounting/static/accounting/js/payment_method_handler.js#L137-L146) may run either before or after knockout bindings have been applied to the page. If it runs before bindings have been applied, it won't do anything because the stripe container is rendered as part of a `template` binding ([here](https://github.com/dimagi/commcare-hq/blob/38caa24bccec7e3f5edb9c74afa664114bf997d2/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html#L69-L83)) so it won't exist yet. Deal with this by re-running the stripe show/hide logic once the template has rendered.

## Safety Assurance

### Safety story
Risk is limited to this page. Tested locally and on staging.

### Automated test coverage

No

### QA Plan

No


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
