### PR TITLE
Add zero-width spaces after underscores in custom data field labels

### DIFF
--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from collections import OrderedDict
 
@@ -109,6 +110,7 @@ class CustomDataEditor(object):
 
     def _make_field(self, field):
         safe_label = escape(field.label)
+        safe_label = re.sub(r"([_-])", "\\1\u200B", safe_label)  # add zero-width spaces for nicer line breaks
         is_required_field = self.field_view.is_field_required(field)
         if field.regex:
             validator = RegexValidator(field.regex, field.regex_msg)


### PR DESCRIPTION
## Product Description
Adds zero-width spaces after underscores in custom data field labels, for better line breaks on long names.
Before:
![image](https://github.com/user-attachments/assets/29a9d37a-cdcd-46d3-acdb-8bec055ad9ec)


After:
![image](https://github.com/user-attachments/assets/f76dcf25-71d8-488c-b413-03fe70923cd4)


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-16571


## Safety Assurance

### Safety story
We use zero-width spaces in the same manner in other places in HQ already, this just adds them to the custom data field labels. This only affects the display name for the field, not its value.

### Automated test coverage
Not likely.

### QA Plan
Not planning on it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
