### PR TITLE
Show timing profile for Case List Explorer

### DIFF
--- a/corehq/apps/case_search/tests/test_utils.py
+++ b/corehq/apps/case_search/tests/test_utils.py
@@ -1,6 +1,10 @@
 from unittest.mock import patch
 
-from corehq.apps.case_search.utils import get_expanded_case_results
+from corehq.apps.case_search.utils import (
+    CaseSearchProfiler,
+    get_expanded_case_results,
+)
+from corehq.apps.es import CaseSearchES
 from corehq.form_processor.models import CommCareCase
 
 
@@ -16,3 +20,8 @@ def test_get_expanded_case_results(get_cases_mock):
     helper = None
     get_expanded_case_results(helper, "potential_duplicate_id", cases)
     get_cases_mock.assert_called_with(helper, {"123", "456"})
+
+
+def test_profiler_search_class():
+    profiler = CaseSearchProfiler()
+    assert profiler.search_class == CaseSearchES

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -37,7 +37,7 @@ from corehq.apps.case_search.models import (
     CaseSearchConfig,
     extract_search_request_config,
 )
-from corehq.apps.es import case_search
+from corehq.apps.es import HQESQuery, case_search
 from corehq.apps.es import cases as case_es
 from corehq.apps.es import filters, queries
 from corehq.apps.es.case_search import (
@@ -59,15 +59,10 @@ from corehq.util.quickcache import quickcache
 
 @dataclass
 class CaseSearchProfiler(ESQueryProfiler):
+    search_class: HQESQuery = CaseSearchES
     name: str = 'Case Search'
     primary_count: int = 0
     related_count: int = 0
-
-    def __post_init__(self):
-        super().__post_init__()
-        # For some reason defining the default value in the dataclass doesn't work
-        # so we do it here
-        self.search_class = CaseSearchES
 
 
 def time_function():

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -16,7 +16,6 @@ from dimagi.utils.logging import notify_exception
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_app_cached
 from corehq.apps.app_manager.util import module_offers_search
-from corehq.apps.es import cases as case_es
 from corehq.apps.case_search.const import (
     CASE_SEARCH_MAX_RESULTS,
     COMMCARE_PROJECT,
@@ -27,7 +26,10 @@ from corehq.apps.case_search.exceptions import (
     CaseSearchUserError,
     TooManyRelatedCasesError,
 )
-from corehq.apps.case_search.filter_dsl import build_filter_from_xpath, SearchFilterContext
+from corehq.apps.case_search.filter_dsl import (
+    SearchFilterContext,
+    build_filter_from_xpath,
+)
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     CASE_SEARCH_XPATH_QUERY_KEY,
@@ -35,22 +37,24 @@ from corehq.apps.case_search.models import (
     CaseSearchConfig,
     extract_search_request_config,
 )
-from corehq.apps.es import case_search, filters, queries
+from corehq.apps.es import case_search
+from corehq.apps.es import cases as case_es
+from corehq.apps.es import filters, queries
 from corehq.apps.es.case_search import (
     CaseSearchES,
+    case_property_date_range,
     case_property_missing,
     case_property_query,
-    case_property_date_range,
     reverse_index_case_query,
     wrap_case_search_hit,
 )
+from corehq.apps.es.profiling import ESQueryProfiler
 from corehq.apps.registry.exceptions import (
     RegistryAccessException,
     RegistryNotFound,
 )
 from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.util.quickcache import quickcache
-from corehq.apps.es.profiling import ESQueryProfiler
 
 
 @dataclass

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -156,7 +156,7 @@ class QueryHelper:
 
     def get_base_queryset(self, slug=None):
         # slug is only informational, used for profiling
-        _CaseSearchES = self.profiler.get_search_class(slug)
+        _CaseSearchES = self.profiler.get_profiled_search_class(slug)
         # See case_search_bha.py docstring for context on index_name
         return _CaseSearchES(index=self.config.index_name or None).domain(self.domain)
 
@@ -185,7 +185,7 @@ class RegistryQueryHelper(QueryHelper):
         self._registry_helper = registry_helper
 
     def get_base_queryset(self, slug=None):
-        _CaseSearchES = self.profiler.get_search_class(slug)
+        _CaseSearchES = self.profiler.get_profiled_search_class(slug)
         return _CaseSearchES().domain(self._registry_helper.visible_domains)
 
     def wrap_case(self, es_hit, include_score=False):

--- a/corehq/apps/es/README.rst
+++ b/corehq/apps/es/README.rst
@@ -614,3 +614,6 @@ Code Documentation
 
 .. automodule:: corehq.apps.es.client
    :members:
+
+.. automodule:: corehq.apps.es.profiling
+   :members:

--- a/corehq/apps/es/profiling.py
+++ b/corehq/apps/es/profiling.py
@@ -41,7 +41,7 @@ class ESQueryProfiler:
         """
         self.timing_context = TimingContext(self.name)
 
-    def get_search_class(self, slug=None):
+    def get_profiled_search_class(self, slug=None):
         """
         Returns a wrapped version of the search class that automatically
         profiles query execution times.

--- a/corehq/apps/es/profiling.py
+++ b/corehq/apps/es/profiling.py
@@ -6,24 +6,27 @@ from corehq.apps.es.es_query import HQESQuery
 @dataclass
 class ESQueryProfiler:
     """
-    A profiler for gathering timing and profiling data on functions that may or may not contain
-    Elasticsearch queries.
+    A profiler for gathering timing and profiling data on functions that
+    may or may not contain Elasticsearch queries.
 
-    This is particularly useful for profiling workflows involving multiple ES queries
-    and other operations. For profiling a single ES query, you can simply use `query.enable_profiling`.
-    However, when profiling a broader workflow, the outermost `with timing_context` block
-    should be chosen carefully, as it represents the total evaluation time being measured.
+    This is particularly useful for profiling workflows involving
+    multiple ES queries and other operations. For profiling a single ES
+    query, you can simply use ``query.enable_profiling``. However, when
+    profiling a broader workflow, the outermost ``with timing_context``
+    block should be chosen carefully, as it represents the total
+    evaluation time being measured.
 
     Attributes:
-        search_class (HQESQuery): The ES query class to be profiled (any subclass of HQESQuery).
-        name (str): A label for the profiler instance, defaults to 'Query Profiler'.
-        debug_mode (bool): Enables ES profiling details when set to True.
-        queries (list): Stores profiling data for individual queries when in debug mode.
-        _query_number (int): Tracks the number of queries executed within the profiler.
-
-    Methods:
-        get_search_class(slug=None): Returns a wrapped version of the search class
-            that automatically profiles query execution times.
+        search_class (HQESQuery):
+            The ES query class to be profiled (any subclass of HQESQuery).
+        name (str):
+            A label for the profiler instance, defaults to 'Query Profiler'.
+        debug_mode (bool):
+            Enables ES profiling details when set to True.
+        queries (list):
+            Stores profiling data for individual queries when in debug mode.
+        _query_number (int):
+            Tracks the number of queries executed within the profiler.
     """
 
     search_class: HQESQuery = HQESQuery
@@ -33,13 +36,31 @@ class ESQueryProfiler:
     _query_number: int = 0
 
     def __post_init__(self):
+        """
+        Initialize the timing context for the profiler.
+        """
         self.timing_context = TimingContext(self.name)
 
     def get_search_class(self, slug=None):
+        """
+        Returns a wrapped version of the search class that automatically
+        profiles query execution times.
+
+        :param slug: Optional identifier for the query being profiled
+        :return: A subclass of the original search class with profiling
+                 capabilities
+        """
         profiler = self
 
         class ProfiledSearchClass(self.search_class):
             def run(self):
+                """
+                Overrides the run method of the search class to add profiling
+                capabilities.
+
+                :return: The query results with profiling data if debug_mode
+                         is enabled
+                """
                 profiler._query_number += 1
                 if profiler.debug_mode:
                     self.es_query['profile'] = True

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
@@ -398,7 +398,7 @@
 -            var html = '<div class="timing-block">';
 -
 -            // Sort sub-nodes by duration (descending)
--            node.subs.sort(function(a, b) {
+-            node.subs.sort(function (a, b) {
 -                return b.duration - a.duration;
 +        }
 +        applyBootstrapMagic();
@@ -691,7 +691,7 @@
 +        var html = '<div class="timing-block">';
 +
 +        // Sort sub-nodes by duration (descending)
-+        node.subs.sort(function(a, b) {
++        node.subs.sort(function (a, b) {
 +            return b.duration - a.duration;
 +        });
 +

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,340 +1,308 @@
+@@ -1,402 +1,370 @@
 -hqDefine("reports/js/bootstrap3/datatables_config", [
 -    'jquery',
 -    'underscore',
@@ -32,6 +32,61 @@
 -        if (self.loadingTemplateSelector !== undefined) {
 -            var loadingTemplate = _.template($(self.loadingTemplateSelector).html() || self.loadingText);
 -            self.loadingText = loadingTemplate({});
+-        }
+-        self.emptyText = options.emptyText || gettext("No data available to display. " +
+-                                                      "Please try changing your filters.");
+-        self.errorText = options.errorText || "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
+-                         gettext("There was an error with your query, it has been logged, please try another query.");
+-        self.badRequestErrorText = options.badRequestErrorText || options.errorText ||
+-                                   "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
+-                                   gettext("Your search query is invalid, please adjust the formatting and try again.");
+-        self.fixColumns = !!(options.fixColumns);
+-        self.fixColsNumLeft = options.fixColsNumLeft || 1;
+-        self.fixColsWidth = options.fixColsWidth || 100;
+-        self.show_pagination = (options.show_pagination === undefined) ? true : options.bPaginate;
+-        self.aaSorting = options.aaSorting || null;
+-        // a list of functions to call back to after ajax.
+-        // see user configurable charts for an example usage
+-        self.successCallbacks = options.successCallbacks;
+-        self.errorCallbacks = options.errorCallbacks;
+-        self.includeFilter = options.includeFilter || false;
+-        self.datatable = null;
+-        self.rendered = false;
+-
+-        self.render_footer_row = (function () {
+-            var $dataTableElem = $(self.dataTableElem);
+-            return function (id, row) {
+-                if ($dataTableElem.find('tfoot').length === 0) {
+-                    var $row = $dataTableElem.find('#' + id);
+-                    if ($row.length === 0) {
+-                        $row = $('<tfoot />');
+-                        $dataTableElem.append($row);
+-                    }
+-                    $row.html('');
+-                    for (var i = 0; i < row.length; i++) {
+-                        $row.append('<td>' + row[i] + '</td>');
+-                    }
+-                }
+-            };
+-        })();
+-
+-        self.render = function () {
+-            if (self.rendered) {
+-                $(self.dataTableElem).each(function () {
+-                    if ($.fn.dataTable.versionCheck) {
+-                        // $.fn.dataTable.versionCheck does not exist prior to 1.10
+-                        $(this).DataTable().ajax.reload();
+-                    } else {
+-                        $(this).dataTable().fnReloadAjax();
+-                    }
+-                });
+-                return;
+-            }
+-
+-            self.rendered = true;
+-
+-            $('[data-datatable-highlight-closest]').each(function () {
+-                $(this).closest($(this).attr('data-datatable-highlight-closest')).addClass('active');
 +import $ from 'jquery';
 +
 +import 'datatables.net/js/jquery.dataTables';
@@ -102,64 +157,7 @@
 +                } else {
 +                    $(this).dataTable().fnReloadAjax();
 +                }
-+            });
-+            return;
-         }
--        self.emptyText = options.emptyText || gettext("No data available to display. " +
--                                                      "Please try changing your filters.");
--        self.errorText = options.errorText || "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
--                         gettext("There was an error with your query, it has been logged, please try another query.");
--        self.badRequestErrorText = options.badRequestErrorText || options.errorText ||
--                                   "<span class='label label-danger'>" + gettext("Sorry!") + "</span> " +
--                                   gettext("Your search query is invalid, please adjust the formatting and try again.");
--        self.fixColumns = !!(options.fixColumns);
--        self.fixColsNumLeft = options.fixColsNumLeft || 1;
--        self.fixColsWidth = options.fixColsWidth || 100;
--        self.show_pagination = (options.show_pagination === undefined) ? true : options.bPaginate;
--        self.aaSorting = options.aaSorting || null;
--        // a list of functions to call back to after ajax.
--        // see user configurable charts for an example usage
--        self.successCallbacks = options.successCallbacks;
--        self.errorCallbacks = options.errorCallbacks;
--        self.includeFilter = options.includeFilter || false;
--        self.datatable = null;
--        self.rendered = false;
--
--        self.render_footer_row = (function () {
--            var $dataTableElem = $(self.dataTableElem);
--            return function (id, row) {
--                if ($dataTableElem.find('tfoot').length === 0) {
--                    var $row = $dataTableElem.find('#' + id);
--                    if ($row.length === 0) {
--                        $row = $('<tfoot />');
--                        $dataTableElem.append($row);
--                    }
--                    $row.html('');
--                    for (var i = 0; i < row.length; i++) {
--                        $row.append('<td>' + row[i] + '</td>');
--                    }
--                }
--            };
--        })();
--
--        self.render = function () {
--            if (self.rendered) {
--                $(self.dataTableElem).each(function () {
--                    if ($.fn.dataTable.versionCheck) {
--                        // $.fn.dataTable.versionCheck does not exist prior to 1.10
--                        $(this).DataTable().ajax.reload();
--                    } else {
--                        $(this).dataTable().fnReloadAjax();
--                    }
--                });
--                return;
--            }
--
--            self.rendered = true;
--
--            $('[data-datatable-highlight-closest]').each(function () {
--                $(this).closest($(this).attr('data-datatable-highlight-closest')).addClass('active');
--            });
+             });
 -            function applyBootstrapMagic() {
 -                $('[data-datatable-tooltip]').each(function () {
 -                    $(this).tooltip({
@@ -227,6 +225,9 @@
 -                                for (i = 0; i < data.statistics_rows.length; i++) {
 -                                    self.render_footer_row('ajax_stat_row-' + i, data.statistics_rows[i]);
 -                                }
+-                            }
+-                            if ('report_timing_profile' in data) {
+-                                self.renderTimingProfile(data.report_timing_profile);
 -                            }
 -                            applyBootstrapMagic();
 -                            if (self.successCallbacks) {
@@ -349,6 +350,8 @@
 -                }
 -                $(".dataTables_length select").change(function () {
 -                    $(self.dataTableElem).trigger('hqreport.tabular.lengthChange', $(this).val());
++            return;
++        }
 +
 +        self.rendered = true;
 +
@@ -364,27 +367,40 @@
              });
 -        };  // end of self.render
 -
--        return self;
--    };
+-        self.renderTimingProfile = function (reportTimingProfile) {
+-            var $timingProfile = $('#report-timing-profile');
+-            if (!reportTimingProfile) {
+-                $timingProfile.empty();
+-                return;
+-            }
+-            // Create the main container
+-            var html = `
+-                <div class="panel panel-default">
+-                  <div class="panel-heading">
+-                    <h4 class="panel-title">
+-                      Report Timing Profile:
+-                      ${reportTimingProfile.name}
+-                      (${reportTimingProfile.duration.toFixed(2)}s)
+-                    </h4>
+-                  </div>
+-                  <div class="panel-body">
+-                    ${renderTimingNode(reportTimingProfile)}
+-                  </div>
+-                </div>`;
+-            $timingProfile.html(html);
+-        };
 -
--    $.extend($.fn.dataTableExt.oStdClasses, {
--        "sSortAsc": "header headerSortAsc",
--        "sSortDesc": "header headerSortDesc",
--        "sSortable": "header headerSort",
--    });
+-        function renderTimingNode(node) {
+-            if (!node.subs || node.subs.length === 0) {
+-                return '';
+-            }
 -
--    // For sorting rows
+-            var html = '<div class="timing-block">';
 -
--    function sortSpecial(a, b, asc, convert) {
--        var x = convert(a);
--        var y = convert(b);
--
--        // sort nulls at end regardless of current sort direction
--        if (x === null && y === null) {
--            return 0;
-         }
--        if (x === null) {
--            return 1;
+-            // Sort sub-nodes by duration (descending)
+-            node.subs.sort(function(a, b) {
+-                return b.duration - a.duration;
++        }
 +        applyBootstrapMagic();
 +
 +        var dataTablesDom = "frt<'d-flex mb-1'<'p-2 ps-3'i><'p-2 ps-0'l><'ms-auto p-2 pe-3'p>>";
@@ -454,6 +470,9 @@
 +                            self.render_footer_row('ajax_stat_row-' + i, data.statistics_rows[i]);
 +                        }
 +                    }
++                    if ('report_timing_profile' in data) {
++                        self.renderTimingProfile(data.report_timing_profile);
++                    }
 +                };
 +
 +                params.drawCallback = function () {
@@ -520,8 +539,33 @@
 +                    datatable.fnAdjustColumnSizing();
 +                    self._lengthsSeen.push(length);
 +                }
-+            });
-+
+             });
+ 
+-            for (var i = 0; i < node.subs.length; i++) {
+-                var sub = node.subs[i];
+-                // Ensure reasonable width
+-                var percentWidth = Math.max(Math.min(sub.percent_parent, 100), 10);
+-
+-                html += `
+-                    <div class="timing-node" style="width: ${percentWidth}%;">
+-                      <div class="timing-node-content">
+-                        <div class="timing-node-header">${sub.name}</div>
+-                        <div class="timing-node-details">
+-                          ${sub.duration.toFixed(3)}s
+-                          (${sub.percent_parent.toFixed(1)}% of parent,
+-                          ${sub.percent_total.toFixed(1)}% of total)
+-                        </div>`;
+-
+-                // Render children recursively
+-                if (sub.subs && sub.subs.length > 0) {
+-                    html += `<div class="timing-children">${renderTimingNode(sub)}</div>`;
+-                }
+-                html += '</div></div>';
+-            }
+-            return html + '</div>';
+-        }
+-
+-        return self;
 +            var $dataTablesFilter = $(".dataTables_filter");
 +            if ($dataTablesFilter && $("#extra-filter-info")) {
 +                if ($dataTablesFilter.length > 1) {
@@ -559,36 +603,48 @@
 +        });
 +    };  // end of self.render
 +
-+    return self;
-+};
-+
-+// For sorting rows
-+
-+function sortSpecial(a, b, asc, convert) {
-+    var x = convert(a);
-+    var y = convert(b);
-+
-+    // sort nulls at end regardless of current sort direction
-+    if (x === null && y === null) {
-+        return 0;
-+    }
-+    if (x === null) {
-+        return 1;
-+    }
-+    if (y === null) {
-+        return -1;
-+    }
-+
-+    return (asc ? 1 : -1) * ((x < y) ? -1 : ((x > y) ?  1 : 0));
-+}
-+
-+function convertNum(k) {
-+    var m = k.match(/title="*([-+.0-9eE]+)/);
-+    if (m !== null) {
-+        m = +m[1];
-+        if (isNaN(m)) {
-+            m = null;
-         }
++    self.renderTimingProfile = function (reportTimingProfile) {
++        var $timingProfile = $('#report-timing-profile');
++        if (!reportTimingProfile) {
++            $timingProfile.empty();
++            return;
++        }
++        // Create the main container
++        var html = `
++            <div class="panel panel-default">
++              <div class="panel-heading">
++                <h4 class="panel-title">
++                  Report Timing Profile:
++                  ${reportTimingProfile.name}
++                  (${reportTimingProfile.duration.toFixed(2)}s)
++                </h4>
++              </div>
++              <div class="panel-body">
++                ${renderTimingNode(reportTimingProfile)}
++              </div>
++            </div>`;
++        $timingProfile.html(html);
+     };
+ 
+-    $.extend($.fn.dataTableExt.oStdClasses, {
+-        "sSortAsc": "header headerSortAsc",
+-        "sSortDesc": "header headerSortDesc",
+-        "sSortable": "header headerSort",
+-    });
+-
+-    // For sorting rows
+-
+-    function sortSpecial(a, b, asc, convert) {
+-        var x = convert(a);
+-        var y = convert(b);
+-
+-        // sort nulls at end regardless of current sort direction
+-        if (x === null && y === null) {
+-            return 0;
+-        }
+-        if (x === null) {
+-            return 1;
+-        }
 -        if (y === null) {
 -            return -1;
 -        }
@@ -627,6 +683,72 @@
 -        HQReportDataTables: function (options) { return new HQReportDataTables(options); },
 -    };
 -});
++    function renderTimingNode(node) {
++        if (!node.subs || node.subs.length === 0) {
++            return '';
++        }
++
++        var html = '<div class="timing-block">';
++
++        // Sort sub-nodes by duration (descending)
++        node.subs.sort(function(a, b) {
++            return b.duration - a.duration;
++        });
++
++        for (var i = 0; i < node.subs.length; i++) {
++            var sub = node.subs[i];
++            // Ensure reasonable width
++            var percentWidth = Math.max(Math.min(sub.percent_parent, 100), 10);
++
++            html += `
++                <div class="timing-node" style="width: ${percentWidth}%;">
++                  <div class="timing-node-content">
++                    <div class="timing-node-header">${sub.name}</div>
++                    <div class="timing-node-details">
++                      ${sub.duration.toFixed(3)}s
++                      (${sub.percent_parent.toFixed(1)}% of parent,
++                      ${sub.percent_total.toFixed(1)}% of total)
++                    </div>`;
++
++            // Render children recursively
++            if (sub.subs && sub.subs.length > 0) {
++                html += `<div class="timing-children">${renderTimingNode(sub)}</div>`;
++            }
++            html += '</div></div>';
++        }
++        return html + '</div>';
++    }
++
++    return self;
++};
++
++// For sorting rows
++
++function sortSpecial(a, b, asc, convert) {
++    var x = convert(a);
++    var y = convert(b);
++
++    // sort nulls at end regardless of current sort direction
++    if (x === null && y === null) {
++        return 0;
++    }
++    if (x === null) {
++        return 1;
++    }
++    if (y === null) {
++        return -1;
++    }
++
++    return (asc ? 1 : -1) * ((x < y) ? -1 : ((x > y) ?  1 : 0));
++}
++
++function convertNum(k) {
++    var m = k.match(/title="*([-+.0-9eE]+)/);
++    if (m !== null) {
++        m = +m[1];
++        if (isNaN(m)) {
++            m = null;
++        }
 +    }
 +    return m;
 +}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/standard/base_template.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,24 +1,26 @@
+@@ -1,28 +1,32 @@
 -{% extends "hqwebapp/bootstrap3/two_column.html" %}
 +{% extends "hqwebapp/bootstrap5/two_column.html" %}
  {% load compress %}
@@ -27,16 +27,26 @@
 -          rel="stylesheet"
 -          media="all"
 -          href="{% static 'reports/less/reports.less' %}" />
+-    <link type="text/css"
+-          rel="stylesheet"
+-          media="all"
+-          href="{% static 'reports/css/timing-profile.css' %}" />
 +    <link
 +      type="text/scss"
 +      rel="stylesheet"
 +      media="all"
 +      href="{% static 'reports/scss/reports.scss' %}"
 +    />
++    <link
++      type="text/css"
++      rel="stylesheet"
++      media="all"
++      href="{% static 'reports/css/timing-profile.css' %}"
++    />
    {% endcompress %}
    {% include 'reports/partials/filters_css.html' %}
  
-@@ -28,22 +30,33 @@
+@@ -32,22 +36,33 @@
  {% block title %}{{ report.title|default:"Project Reports" }}{% endblock %}
  
  {% block page_breadcrumbs %}
@@ -86,7 +96,7 @@
  {% endblock %}
  
  {% block page_content %}
-@@ -68,19 +81,18 @@
+@@ -72,19 +87,18 @@
    {% initial_page_data 'slug' report.slug %}
  
    {% block filter_panel %}
@@ -112,7 +122,7 @@
              <h4 class="modal-title">
                {% trans "Email report:" %}
                {{ datespan.startdate|date:"Y-m-d" }}
-@@ -89,15 +101,21 @@
+@@ -93,15 +107,21 @@
                {% endif %}
                {{ datespan.enddate|date:"Y-m-d" }}
              </h4>
@@ -136,7 +146,7 @@
        <h4>{% trans 'Notice' %}</h4>
        <p>{{ report.special_notice }}</p>
      </div>
-@@ -107,7 +125,7 @@
+@@ -111,7 +131,7 @@
        {% block reportcontent %}
        {% endblock %}
      {% else %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/tabular.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/tabular.html.diff.txt
@@ -125,7 +125,7 @@
                {% for stats in report_table.statistics_rows %}
                  <tr>
                    {% for col in stats %}
-@@ -91,26 +118,17 @@
+@@ -91,13 +118,12 @@
                    {% endfor %}
                  </tr>
                {% endfor %}
@@ -142,7 +142,9 @@
 +      {% endif %}
 +    {% endblock reporttable %}
    </div>
-   {% block posttable %}{% endblock posttable %}
+   {% block posttable %}
+     <div id="report-timing-profile"></div>
+@@ -105,14 +131,6 @@
  {% endblock reportcontent %}
  
  {% block js-inline %} {{ block.super }}

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -12,15 +12,13 @@ from django.http import (
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.urls import NoReverseMatch
+from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
-from django.utils.html import conditional_escape
 
 from celery.utils.log import get_task_logger
 from memoized import memoized
 
-from corehq.apps.hqwebapp.utils.bootstrap.paths import get_bootstrap5_path
-from corehq.util.timezones.utils import get_timezone
 from couchexport.export import export_from_tables, get_writer
 from couchexport.shortcuts import export_response
 from dimagi.utils.modules import to_function
@@ -34,6 +32,7 @@ from corehq.apps.hqwebapp.decorators import (
     use_daterangepicker,
     use_jquery_ui,
 )
+from corehq.apps.hqwebapp.utils.bootstrap.paths import get_bootstrap5_path
 from corehq.apps.reports.cache import request_cache
 from corehq.apps.reports.const import EXPORT_PAGE_LIMIT
 from corehq.apps.reports.datatables import DataTablesHeader
@@ -46,6 +45,7 @@ from corehq.apps.reports.util import (
 )
 from corehq.apps.saved_reports.models import ReportConfig
 from corehq.apps.users.models import CouchUser
+from corehq.util.timezones.utils import get_timezone
 from corehq.util.view_utils import absolute_reverse, request_as_dict, reverse
 
 CHART_SPAN_MAP = {1: '10', 2: '6', 3: '4', 4: '3', 5: '2', 6: '2'}

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -1049,6 +1049,9 @@ class GenericTabularReport(GenericReportView):
         if self.statistics_rows:
             ret["statistics_rows"] = list(self.statistics_rows)
 
+        if self.profiler_enabled and self.profiler.debug_mode:
+            ret["report_timing_profile"] = self.profiler.timing_context.to_dict()
+
         return ret
 
     def _get_datatables_json_dict(self, records_total, records_filtered, data):

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -1049,6 +1049,7 @@ class GenericTabularReport(GenericReportView):
         if self.statistics_rows:
             ret["statistics_rows"] = list(self.statistics_rows)
 
+        # Not necessarily the best place to put this
         if self.profiler_enabled and self.profiler.debug_mode:
             ret["report_timing_profile"] = self.profiler.timing_context.to_dict()
 

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -1049,10 +1049,6 @@ class GenericTabularReport(GenericReportView):
         if self.statistics_rows:
             ret["statistics_rows"] = list(self.statistics_rows)
 
-        # Not necessarily the best place to put this
-        if self.profiler_enabled and self.profiler.debug_mode:
-            ret["report_timing_profile"] = self.profiler.timing_context.to_dict()
-
         return ret
 
     def _get_datatables_json_dict(self, records_total, records_filtered, data):

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -362,7 +362,11 @@ class ESQueryProfilerMixin(object):
                 search_class=self.search_class,
                 debug_mode=self.debug_mode,
             )
-            self.search_class = self.profiler.get_search_class(slug=self.__class__.__name__)
+            # Replace the report's search_class so that queries are
+            # profiled when the report executes searches. Use the report
+            # class's name to identify the profile.
+            identifier = self.__class__.__name__
+            self.search_class = self.profiler.get_profiled_search_class(identifier)
         else:
             self.profiler = None
 

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -9,9 +9,9 @@ from django.utils.translation import gettext_noop
 import dateutil
 from memoized import memoized
 
+from corehq import toggles
 from dimagi.utils.dates import DateSpan
 from dimagi.utils.logging import notify_exception
-from dimagi.utils.parsing import string_to_boolean
 
 from corehq.apps.casegroups.models import CommCareCaseGroup
 from corehq.apps.es.profiling import ESQueryProfiler
@@ -368,7 +368,10 @@ class ESQueryProfilerMixin(object):
 
     @property
     def debug_mode(self):
-        debug_enabled = string_to_boolean(self.request.GET.get('debug'))
+        debug_enabled = toggles.REPORT_TIMING_PROFILING.enabled(
+            self.request.couch_user.username,
+            namespace=toggles.NAMESPACE_USER,
+        )
         return debug_enabled and self.request.couch_user.is_superuser
 
     @property

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -349,21 +349,18 @@ class ESQueryProfilerMixin(object):
     profiler_enabled = False
     profiler_name = 'Case List'
     search_class = None
-    _profiler = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.profiler_enabled:
-            self._profiler = ESQueryProfiler(
+            self.profiler = ESQueryProfiler(
                 name=self.profiler_name,
                 search_class=self._get_search_class(),
                 debug_mode=self.debug_mode,
             )
             self.search_class = self.profiler.get_search_class(slug=self.__class__.__name__)
-
-    @property
-    def profiler(self):
-        return self._profiler
+        else:
+            self.profiler = None
 
     @property
     def debug_mode(self):

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -10,6 +10,7 @@ import dateutil
 from memoized import memoized
 
 from dimagi.utils.dates import DateSpan
+from dimagi.utils.parsing import string_to_boolean
 
 from corehq.apps.casegroups.models import CommCareCaseGroup
 from corehq.apps.es.profiling import ESQueryProfiler
@@ -370,8 +371,8 @@ class ESQueryProfilerMixin(object):
 
     @property
     def debug_mode(self):
-        debug_enabled = self.request.GET.get('debug', 'false')
-        return debug_enabled == 'true' and self.request.couch_user.is_superuser
+        debug_enabled = string_to_boolean(self.request.GET.get('debug'))
+        return debug_enabled and self.request.couch_user.is_superuser
 
     def _get_search_class(self):
         if not self.search_class:

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -356,6 +356,7 @@ class ESQueryProfilerMixin(object):
             self._profiler = ESQueryProfiler(
                 name=self.profiler_name,
                 search_class=self._get_search_class(),
+                debug_mode=self.debug_mode,
             )
             self.search_class = self.profiler.get_search_class(slug=self.__class__.__name__)
 
@@ -366,6 +367,11 @@ class ESQueryProfilerMixin(object):
     @property
     def should_profile(self):
         return self.profiler_enabled and self.profiler
+
+    @property
+    def debug_mode(self):
+        debug_enabled = self.request.GET.get('debug', 'false')
+        return debug_enabled == 'true' and self.request.couch_user.is_superuser
 
     def _get_search_class(self):
         if not self.search_class:

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -349,7 +349,7 @@ class ESQueryProfilerMixin(object):
 
     """
     profiler_enabled = False
-    profiler_name = 'Case List'
+    profiler_name = 'Elasticsearch Query Profiler'
     search_class = None
 
     def __init__(self, *args, **kwargs):

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -354,7 +354,7 @@ class ESQueryProfilerMixin(object):
         super().__init__(*args, **kwargs)
         if self.profiler_enabled:
             if not self.search_class:
-                raise NotImplementedError("You must define a search_class attribute.")
+                raise ValueError("You must define a search_class attribute.")
             self.profiler = ESQueryProfiler(
                 name=self.profiler_name,
                 search_class=self.search_class,

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -8,11 +8,11 @@ from django.utils.translation import gettext_noop
 
 import dateutil
 from memoized import memoized
-from corehq.apps.reports.forms import EmailReportForm
 
 from dimagi.utils.dates import DateSpan
 
 from corehq.apps.casegroups.models import CommCareCaseGroup
+from corehq.apps.es.profiling import ESQueryProfiler
 from corehq.apps.groups.models import Group
 from corehq.apps.reports import util
 from corehq.apps.reports.dispatcher import (
@@ -22,11 +22,11 @@ from corehq.apps.reports.dispatcher import (
 from corehq.apps.reports.exceptions import BadRequestError
 from corehq.apps.reports.filters.select import MonthFilter, YearFilter
 from corehq.apps.reports.filters.users import UserTypeFilter
+from corehq.apps.reports.forms import EmailReportForm
 from corehq.apps.reports.generic import GenericReportView
 from corehq.apps.reports.models import HQUserType
 from corehq.apps.users.models import CommCareUser
 from corehq.util.timezones.conversions import ServerTime
-from corehq.apps.es.profiling import ESQueryProfiler
 
 
 class ProjectReport(GenericReportView):

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -310,32 +310,40 @@ class MonthYearMixin(object):
 
 
 class ESQueryProfilerMixin(object):
-    """Mixin for profiling Elasticsearch queries.
+    """
+    Mixin for profiling Elasticsearch queries.
 
-    This mixin provides timing and profiling capabilities methods in report classes.
+    This mixin provides timing and profiling capabilities for methods in
+    report classes. The report class must have ``profiler_enabled`` and
+    ``profiler_name`` attributes set for the profiling functionality to
+    work.
 
     Attributes:
-        profiler_enabled (bool): Must be set to True to enable profiling
-        profiler_name (str): Name of the report to be used in profiling output
+        profiler_enabled (bool):
+            Set to ``True`` to enable profiling
+        profiler_name (str):
+            Name of the report to be used in profiling output
 
-    Usage:
-        There are two ways to capture timing information:
+    There are two ways to capture timing information:
 
-        1. Using the decorator:
-            >>> from corehq.apps.reports.standard import profile
-            >>> class MyReport(...):
-            ...     @profile('Method Name')
-            ...     def my_method(self):
-            ...         pass
+    1. Using the decorator::
 
-        2. Using the context manager:
-            >>> def my_method(self):
-            ...     with self.profiler.timing_context('Method Name'):
-            ...         pass
+           >>> from corehq.apps.reports.standard import (
+           ...     ESQueryProfilerMixin,
+           ...     profile,
+           ... )
+           >>> class MyReport(ESQueryProfilerMixin):
+           ...     @profile('Method Name')
+           ...     def my_method(self):
+           ...         pass
 
-    Notes:
-        The appropriate report class must have profiler_enabled and profiler_name
-        attributes set for the profiling functionality to work.
+    2. Using the context manager::
+
+           >>> class MyReport(ESQueryProfilerMixin):
+           ...     def my_method(self):
+           ...         with self.profiler.timing_context('Method Name'):
+           ...             pass
+
     """
     profiler_enabled = False
     profiler_name = 'Case List'

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -366,10 +366,6 @@ class ESQueryProfilerMixin(object):
         return self._profiler
 
     @property
-    def should_profile(self):
-        return self.profiler_enabled and self.profiler
-
-    @property
     def debug_mode(self):
         debug_enabled = string_to_boolean(self.request.GET.get('debug'))
         return debug_enabled and self.request.couch_user.is_superuser
@@ -388,7 +384,7 @@ def profile(name=None):
     def decorator(func):
         @wraps(func)
         def wrapper(obj, *args, **kwargs):
-            if obj.should_profile:
+            if obj.profiler_enabled:
                 with obj.profiler.timing_context(name):
                     return func(obj, *args, **kwargs)
             return func(obj, *args, **kwargs)

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -353,9 +353,11 @@ class ESQueryProfilerMixin(object):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.profiler_enabled:
+            if not self.search_class:
+                raise NotImplementedError("You must define a search_class attribute.")
             self.profiler = ESQueryProfiler(
                 name=self.profiler_name,
-                search_class=self._get_search_class(),
+                search_class=self.search_class,
                 debug_mode=self.debug_mode,
             )
             self.search_class = self.profiler.get_search_class(slug=self.__class__.__name__)
@@ -366,11 +368,6 @@ class ESQueryProfilerMixin(object):
     def debug_mode(self):
         debug_enabled = string_to_boolean(self.request.GET.get('debug'))
         return debug_enabled and self.request.couch_user.is_superuser
-
-    def _get_search_class(self):
-        if not self.search_class:
-            raise NotImplementedError("You must define a search_class attribute.")
-        return self.search_class
 
 
 def profile(name=None):

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -1,14 +1,17 @@
 import contextlib
 from datetime import datetime
+
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
-from dimagi.utils.logging import notify_exception
 
 from memoized import memoized
+
+from dimagi.utils.logging import notify_exception
 
 from corehq.apps.es import cases as case_es
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.api import ReportDataSource
+from corehq.apps.reports.const import LONG_RUNNING_CLE_THRESHOLD
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.exceptions import BadRequestError
 from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
@@ -29,7 +32,6 @@ from corehq.apps.reports.standard.cases.utils import (
 )
 from corehq.elastic import ESError
 from corehq.util.es.elasticsearch import TransportError
-from corehq.apps.reports.const import LONG_RUNNING_CLE_THRESHOLD
 
 from .data_sources import CaseDisplayES
 

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -1,4 +1,3 @@
-import contextlib
 from datetime import datetime
 
 from django.utils.translation import gettext as _
@@ -259,7 +258,7 @@ class CaseListReport(CaseListMixin, ProjectReport, ReportDataSource):
             return super().json_response
 
         start_time = datetime.now()
-        with self.profiler.timing_context if self.should_profile else contextlib.nullcontext():
+        with self.profiler.timing_context:
             response = super().json_response
 
         elapsed_seconds = round((datetime.now() - start_time).total_seconds(), 1)

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -12,10 +12,8 @@ from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
 from corehq.apps.reports.filters.select import SelectOpenCloseFilter
 from corehq.apps.reports.generic import ElasticProjectInspectionReport
 from corehq.apps.reports.standard import (
-    ESQueryProfilerMixin,
     ProjectReport,
     ProjectReportParametersMixin,
-    profile,
 )
 from corehq.apps.reports.standard.cases.filters import CaseSearchFilter
 from corehq.apps.reports.standard.cases.utils import (
@@ -30,7 +28,7 @@ from corehq.util.es.elasticsearch import TransportError
 from .data_sources import CaseDisplayES
 
 
-class CaseListMixin(ESQueryProfilerMixin, ElasticProjectInspectionReport, ProjectReportParametersMixin):
+class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin):
     fields = [
         'corehq.apps.reports.filters.case_list.CaseListFilter',
         'corehq.apps.reports.filters.select.CaseTypeFilter',
@@ -122,7 +120,6 @@ class CaseListMixin(ESQueryProfilerMixin, ElasticProjectInspectionReport, Projec
                         raise BadRequestError()
             raise e
 
-    @profile("ES query")
     def _run_es_query(self):
         return self._build_query().run().raw
 

--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -20,7 +20,7 @@ from corehq.apps.reports.filters.select import (
     CaseTypeFilter,
     SelectOpenCloseFilter,
 )
-from corehq.apps.reports.standard import profile
+from corehq.apps.reports.standard import profile, ESQueryProfilerMixin
 from corehq.apps.reports.standard.cases.basic import CaseListReport
 from corehq.apps.reports.standard.cases.data_sources import SafeCaseDisplay
 from corehq.apps.reports.standard.cases.filters import (
@@ -55,7 +55,11 @@ class XpathCaseSearchFilterMixin(object):
 
 
 @location_safe
-class CaseListExplorer(CaseListReport, XpathCaseSearchFilterMixin):
+class CaseListExplorer(
+    ESQueryProfilerMixin,
+    CaseListReport,
+    XpathCaseSearchFilterMixin,
+):
     name = _('Case List Explorer')
     slug = 'case_list_explorer'
     search_class = CaseSearchES
@@ -93,6 +97,10 @@ class CaseListExplorer(CaseListReport, XpathCaseSearchFilterMixin):
         )
         with timer:
             return super(CaseListExplorer, self).es_results
+
+    @profile("ES query")
+    def _run_es_query(self):
+        return super()._run_es_query()
 
     def _build_query(self, sort=True):
         query = super(CaseListExplorer, self)._build_query()

--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -6,8 +6,8 @@ from memoized import memoized
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.case_search.const import (
     COMPUTED_METADATA,
-    INDEXED_METADATA_BY_KEY,
     DOCS_LINK_CASE_LIST_EXPLORER,
+    INDEXED_METADATA_BY_KEY,
 )
 from corehq.apps.case_search.exceptions import CaseFilterError
 from corehq.apps.case_search.utils import get_case_id_sort_block

--- a/corehq/apps/reports/standard/cases/duplicate_cases.py
+++ b/corehq/apps/reports/standard/cases/duplicate_cases.py
@@ -22,6 +22,8 @@ class DuplicateCasesExplorer(CaseListExplorer):
     description = _("Identify and manage duplicate cases")
     use_bootstrap5 = False
 
+    profiler_enabled = False
+
     fields = [
         DuplicateCaseRuleFilter,
         XPathCaseSearchFilter,

--- a/corehq/apps/reports/static/reports/css/timing-profile.css
+++ b/corehq/apps/reports/static/reports/css/timing-profile.css
@@ -1,0 +1,35 @@
+/**
+ * For Report Timing Profile
+ */
+.timing-block {
+    margin-bottom: 10px;
+}
+
+.timing-node {
+    margin-bottom: 5px;
+    background-color: #f5f5f5;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+}
+
+.timing-node-content {
+    padding: 8px;
+}
+
+.timing-children {
+    padding-left: 20px;
+}
+
+.timing-node-header {
+    font-weight: bold;
+    margin-bottom: 3px;
+    white-space: nowrap;
+    overflow: visible;
+}
+
+.timing-node-details {
+    font-size: 12px;
+    color: #666;
+    white-space: nowrap;
+    overflow: visible;
+}

--- a/corehq/apps/reports/static/reports/js/bootstrap3/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/datatables_config.js
@@ -312,7 +312,7 @@ hqDefine("reports/js/bootstrap3/datatables_config", [
             var html = '<div class="timing-block">';
 
             // Sort sub-nodes by duration (descending)
-            node.subs.sort(function(a, b) {
+            node.subs.sort(function (a, b) {
                 return b.duration - a.duration;
             });
 

--- a/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
@@ -154,6 +154,9 @@ var HQReportDataTables = function (options) {
                             self.render_footer_row('ajax_stat_row-' + i, data.statistics_rows[i]);
                         }
                     }
+                    if ('report_timing_profile' in data) {
+                        self.renderTimingProfile(data.report_timing_profile);
+                    }
                 };
 
                 params.drawCallback = function () {
@@ -258,6 +261,65 @@ var HQReportDataTables = function (options) {
             });
         });
     };  // end of self.render
+
+    self.renderTimingProfile = function (reportTimingProfile) {
+        var $timingProfile = $('#report-timing-profile');
+        if (!reportTimingProfile) {
+            $timingProfile.empty();
+            return;
+        }
+        // Create the main container
+        var html = `
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h4 class="panel-title">
+                  Report Timing Profile:
+                  ${reportTimingProfile.name}
+                  (${reportTimingProfile.duration.toFixed(2)}s)
+                </h4>
+              </div>
+              <div class="panel-body">
+                ${renderTimingNode(reportTimingProfile)}
+              </div>
+            </div>`;
+        $timingProfile.html(html);
+    };
+
+    function renderTimingNode(node) {
+        if (!node.subs || node.subs.length === 0) {
+            return '';
+        }
+
+        var html = '<div class="timing-block">';
+
+        // Sort sub-nodes by duration (descending)
+        node.subs.sort(function(a, b) {
+            return b.duration - a.duration;
+        });
+
+        for (var i = 0; i < node.subs.length; i++) {
+            var sub = node.subs[i];
+            // Ensure reasonable width
+            var percentWidth = Math.max(Math.min(sub.percent_parent, 100), 10);
+
+            html += `
+                <div class="timing-node" style="width: ${percentWidth}%;">
+                  <div class="timing-node-content">
+                    <div class="timing-node-header">${sub.name}</div>
+                    <div class="timing-node-details">
+                      ${sub.duration.toFixed(3)}s
+                      (${sub.percent_parent.toFixed(1)}% of parent,
+                      ${sub.percent_total.toFixed(1)}% of total)
+                    </div>`;
+
+            // Render children recursively
+            if (sub.subs && sub.subs.length > 0) {
+                html += `<div class="timing-children">${renderTimingNode(sub)}</div>`;
+            }
+            html += '</div></div>';
+        }
+        return html + '</div>';
+    }
 
     return self;
 };

--- a/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
@@ -293,7 +293,7 @@ var HQReportDataTables = function (options) {
         var html = '<div class="timing-block">';
 
         // Sort sub-nodes by duration (descending)
-        node.subs.sort(function(a, b) {
+        node.subs.sort(function (a, b) {
             return b.duration - a.duration;
         });
 

--- a/corehq/apps/reports/templates/reports/bootstrap3/tabular.html
+++ b/corehq/apps/reports/templates/reports/bootstrap3/tabular.html
@@ -99,7 +99,9 @@
       {% endblock reporttable %}
     </div>
   </div>
-  {% block posttable %}{% endblock posttable %}
+  {% block posttable %}
+    <div id="report-timing-profile"></div>
+  {% endblock posttable %}
 {% endblock reportcontent %}
 
 {% block js-inline %} {{ block.super }}

--- a/corehq/apps/reports/templates/reports/bootstrap5/tabular.html
+++ b/corehq/apps/reports/templates/reports/bootstrap5/tabular.html
@@ -125,7 +125,9 @@
       {% endif %}
     {% endblock reporttable %}
   </div>
-  {% block posttable %}{% endblock posttable %}
+  {% block posttable %}
+    <div id="report-timing-profile"></div>
+  {% endblock posttable %}
 {% endblock reportcontent %}
 
 {% block js-inline %} {{ block.super }}

--- a/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap3/base_template.html
@@ -19,6 +19,10 @@
           rel="stylesheet"
           media="all"
           href="{% static 'reports/less/reports.less' %}" />
+    <link type="text/css"
+          rel="stylesheet"
+          media="all"
+          href="{% static 'reports/css/timing-profile.css' %}" />
   {% endcompress %}
   {% include 'reports/partials/filters_css.html' %}
 

--- a/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/bootstrap5/base_template.html
@@ -21,6 +21,12 @@
       media="all"
       href="{% static 'reports/scss/reports.scss' %}"
     />
+    <link
+      type="text/css"
+      rel="stylesheet"
+      media="all"
+      href="{% static 'reports/css/timing-profile.css' %}"
+    />
   {% endcompress %}
   {% include 'reports/partials/filters_css.html' %}
 

--- a/corehq/apps/reports/tests/standard/test_mixins.py
+++ b/corehq/apps/reports/tests/standard/test_mixins.py
@@ -107,9 +107,7 @@ class TestESQueryProfilerMixin(SimpleTestCase):
                 super().__init__(*args, **kwargs)
 
         report = ProfiledReport()
-        assert report.should_profile is report.profiler
-        # Note assertion is the same when profiler_enabled = False (below)
-        assert report.profiler_enabled == bool(report.should_profile)
+        assert report.profiler is not None
 
     def test_profiler_enabled_false(self):
 
@@ -122,7 +120,4 @@ class TestESQueryProfilerMixin(SimpleTestCase):
                 super().__init__(*args, **kwargs)
 
         report = ProfiledReport()
-        assert report.should_profile is False
         assert report.profiler is None
-        # Note assertion is the same when profiler_enabled = True (above)
-        assert report.profiler_enabled == bool(report.should_profile)

--- a/corehq/apps/reports/tests/standard/test_mixins.py
+++ b/corehq/apps/reports/tests/standard/test_mixins.py
@@ -35,9 +35,11 @@ class TestESQueryProfilerMixin(SimpleTestCase):
                 super().__init__(*args, **kwargs)
 
         report = ProfiledReport()
+        # ESQueryProfilerMixin replaces `report.search_class` with one
+        # that wraps the original and profiles query execution times.
         assert report.search_class.__name__ == 'ProfiledSearchClass'
         assert isinstance(report.profiler, ESQueryProfiler)
-        assert report.profiler.search_class is CaseSearchES
+        assert report.profiler.search_class is ProfiledReport.search_class
         assert issubclass(report.search_class, report.profiler.search_class)
 
     @flag_enabled('REPORT_TIMING_PROFILING')

--- a/corehq/apps/reports/tests/standard/test_mixins.py
+++ b/corehq/apps/reports/tests/standard/test_mixins.py
@@ -1,0 +1,128 @@
+from unittest.mock import Mock
+from django.test import SimpleTestCase
+
+import pytest
+
+from corehq.apps.es.case_search import CaseSearchES
+from corehq.apps.es.profiling import ESQueryProfiler
+from corehq.apps.reports.standard import ESQueryProfilerMixin
+
+
+class TestESQueryProfilerMixin(SimpleTestCase):
+
+    def test_search_class_not_defined(self):
+
+        class ProfiledReport(ESQueryProfilerMixin):
+            profiler_enabled = True
+            # `search_class` is not defined
+
+        with pytest.raises(
+            NotImplementedError,
+            match='^You must define a search_class attribute.'
+        ):
+            ProfiledReport()
+
+    def test_search_class(self):
+
+        class ProfiledReport(ESQueryProfilerMixin):
+            profiler_enabled = True
+            search_class = CaseSearchES
+
+            def __init__(self, *args, **kwargs):
+                self.request = Mock(GET={})
+                super().__init__(*args, **kwargs)
+
+        report = ProfiledReport()
+        assert report.search_class.__name__ == 'ProfiledSearchClass'
+        assert isinstance(report.profiler, ESQueryProfiler)
+        assert report.profiler.search_class is CaseSearchES
+        assert issubclass(report.search_class, report.profiler.search_class)
+
+    def test_debug_mode_not_superuser(self):
+
+        class ProfiledReport(ESQueryProfilerMixin):
+            profiler_enabled = True
+            search_class = CaseSearchES
+
+            def __init__(self, *args, **kwargs):
+                self.request = Mock(
+                    GET={'debug': 'true'},
+                    couch_user=Mock(is_superuser=False),
+                )
+                super().__init__(*args, **kwargs)
+
+        report = ProfiledReport()
+        assert report.debug_mode is False
+
+    def test_debug_mode_true(self):
+
+        class ProfiledReport(ESQueryProfilerMixin):
+            profiler_enabled = True
+            search_class = CaseSearchES
+
+            def __init__(self, *args, **kwargs):
+                self.request = Mock(
+                    GET={'debug': 'true'},
+                    couch_user=Mock(is_superuser=True),
+                )
+                super().__init__(*args, **kwargs)
+
+        report = ProfiledReport()
+        assert report.debug_mode is True
+
+    def test_debug_mode_not_boolean(self):
+
+        class ProfiledReport(ESQueryProfilerMixin):
+            profiler_enabled = True
+            search_class = CaseSearchES
+
+            def __init__(self, *args, **kwargs):
+                self.request = Mock(GET={'debug': 'yeah-not-so-much-bro'})
+                super().__init__(*args, **kwargs)
+
+        with pytest.raises(ValueError):
+            ProfiledReport()
+
+    def test_profiler_none(self):
+
+        class ProfiledReport(ESQueryProfilerMixin):
+            profiler_enabled = False
+            search_class = CaseSearchES
+
+            def __init__(self, *args, **kwargs):
+                self.request = Mock(GET={})
+                super().__init__(*args, **kwargs)
+
+        report = ProfiledReport()
+        assert report.profiler is None
+
+    def test_profiler_enabled_true(self):
+
+        class ProfiledReport(ESQueryProfilerMixin):
+            profiler_enabled = True
+            search_class = CaseSearchES
+
+            def __init__(self, *args, **kwargs):
+                self.request = Mock(GET={})
+                super().__init__(*args, **kwargs)
+
+        report = ProfiledReport()
+        assert report.should_profile is report.profiler
+        # Note assertion is the same when profiler_enabled = False (below)
+        assert report.profiler_enabled == bool(report.should_profile)
+
+    def test_profiler_enabled_false(self):
+
+        class ProfiledReport(ESQueryProfilerMixin):
+            profiler_enabled = False
+            search_class = CaseSearchES
+
+            def __init__(self, *args, **kwargs):
+                self.request = Mock(GET={})
+                super().__init__(*args, **kwargs)
+
+        report = ProfiledReport()
+        assert report.should_profile is False
+        assert report.profiler is None
+        # Note assertion is the same when profiler_enabled = True (above)
+        assert report.profiler_enabled == bool(report.should_profile)

--- a/corehq/apps/reports/tests/standard/test_mixins.py
+++ b/corehq/apps/reports/tests/standard/test_mixins.py
@@ -17,7 +17,7 @@ class TestESQueryProfilerMixin(SimpleTestCase):
             # `search_class` is not defined
 
         with pytest.raises(
-            NotImplementedError,
+            ValueError,
             match='^You must define a search_class attribute.'
         ):
             ProfiledReport()

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2365,6 +2365,12 @@ USER_HISTORY_REPORT = StaticToggle(
     help_link="https://confluence.dimagi.com/display/saas/User+History+Report",
 )
 
+REPORT_TIMING_PROFILING = StaticToggle(
+    'report_timing_profiling',
+    'Report timing profiling is visible in reports that have a profiler enabled.',
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_USER],
+)
 
 COWIN_INTEGRATION = StaticToggle(
     'cowin_integration',


### PR DESCRIPTION
## Product Description

This change shows the report timing profile for the Case List Explorer for internal users who have it enabled.

![image](https://github.com/user-attachments/assets/477eddb4-3d0f-4489-9820-fec271ff8c60)

## Technical Summary

Context:
* [Product spec / design](https://docs.google.com/document/d/1z0K21vYzrOggzJYc9EOimxgx5OGHIHZT3QDncmxUhd8/edit?tab=t.0)
* [Tech spec](https://docs.google.com/document/d/1wVOwVb5bFC6xpLW-lHhbIWMVQBdR6sXgYr5DuynEdHA/edit?tab=t.0#heading=h.qvn5i9xk3am6)
* Jira: [SC-4182](https://dimagi.atlassian.net/browse/SC-4182)

This change is based on the work started in PR https://github.com/dimagi/commcare-hq/pull/36095

It adds tests, some refactoring, and front-end rendering.

Easier to review by commit. :blowfish: 

## Feature Flag

report_timing_profiling

## Safety Assurance

### Safety story

* Tested locally
* Only available for users with the feature flag enabled.

### Automated test coverage

Yes

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-4182]: https://dimagi.atlassian.net/browse/SC-4182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ