### PR TITLE
[Data Cleaning] value styling and whitespaces

### DIFF
--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -13,6 +13,7 @@ import wiggleButton from 'hqwebapp/js/alpinejs/components/wiggle_button';
 Alpine.data('wiggleButtonModel', wiggleButton);
 
 Alpine.store('isCleaningAllowed', false);
+Alpine.store('showWhitespaces', false);
 
 import Alpine from 'alpinejs';
 Alpine.start();

--- a/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_session.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_session.html
@@ -23,6 +23,22 @@
     <div>
       {% include "data_cleaning/partials/button_bar.html" %}
     </div>
+    <div class="ps-3">
+      <div class="form-check form-switch">
+        <input
+          id="show-whitespaces-switch"
+          class="form-check-input"
+          type="checkbox"
+          role="switch"
+          name="show_whitespaces"
+          x-data=""  {# needed to activate x-model below #}
+          x-model="$store.showWhitespaces"
+        />
+        <label class="form-check-label" for="show-whitespaces-switch">
+          {% trans "Show Whitespaces" %}
+        </label>
+      </div>
+    </div>
   </div>
   <div
     class="mx-3"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_session.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_session.html
@@ -22,18 +22,6 @@
     <h1 class="fs-3 pe-3 py-3 m-0">{{ current_page.page_name }}</h1>
     <div>
       {% include "data_cleaning/partials/button_bar.html" %}
-      {% if show_temporary_save %}
-        <form
-          method="POST"
-          action="{% url "save_case_session" domain session_id %}"
-          class="float-end mx-3"
-        >
-          {% csrf_token %}
-          <button type="submit" class="btn btn-success">
-            <i class="fa fa-hippo"></i> Save
-          </button>
-        </form>
-      {% endif %}
     </div>
   </div>
   <div

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -28,7 +28,7 @@
               <i class="fa-solid fa-minus"></i>
             </div>
             <div class="align-self-center ms-1 me-2">
-              {{ value }}
+              {% display_dc_value value %}
             </div>
           </div>
           <div class="d-flex align-items-stretch dc-diff-after">
@@ -41,7 +41,7 @@
               <i class="fa-solid fa-plus"></i>
             </div>
             <div class="align-self-center ms-1 me-2">
-              {{ edited_value }}
+              {% display_dc_value edited_value %}
             </div>
           </div>
         </div>
@@ -62,7 +62,7 @@
         </div>
       </div>
     {% else %}
-      {{ value }}
+      {% display_dc_value value %}
     {% endif %}
     <button
       class="btn btn-link btn-sm dc-inline-edit-action"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -16,13 +16,33 @@
     @dblclick="isEditing = !isSubmitting"
   >
     {% if edited_value|has_edits %}
-      <div class="d-flex align-items-center">
+      <div class="d-flex align-items-center me-3">
         <div class="dc-diff-view">
-          <div class="dc-diff-before">
-            {{ value }}
+          <div class="d-flex align-items-stretch dc-diff-before">
+            <div
+              class="dc-diff-icon"
+              x-tooltip=""
+              data-bs-custom-class="fs-6"
+              data-bs-title="{% trans "stored value" %}"
+            >
+              <i class="fa-solid fa-minus"></i>
+            </div>
+            <div class="align-self-center ms-1 me-2">
+              {{ value }}
+            </div>
           </div>
-          <div class="dc-diff-after">
-            {{ edited_value }}
+          <div class="d-flex align-items-stretch dc-diff-after">
+            <div
+              class="dc-diff-icon"
+              x-tooltip=""
+              data-bs-custom-class="fs-6"
+              data-bs-title="{% trans "changed value" %}"
+            >
+              <i class="fa-solid fa-plus"></i>
+            </div>
+            <div class="align-self-center ms-1 me-2">
+              {{ edited_value }}
+            </div>
           </div>
         </div>
         <div class="ms-2">

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -80,5 +80,6 @@
         <i class="fa fa-close"></i>
         <span class="visually-hidden">{% trans "Cancel Edit" %}</span>
       </button>
+    </div>
   </div>
 </div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/values/empty.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/values/empty.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+
+<div class="dc-value dc-value-empty">
+  &nbsp;
+  <span class="dc-value-info" role="contentinfo">{% trans "EMPTY" %}</span>
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/values/null.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/values/null.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+
+<div class="dc-value dc-value-null">
+  ---
+  <span class="dc-value-info" role="contentinfo">{% trans "NULL" %}</span>
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/values/text.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/values/text.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+{% load data_cleaning %}
+
+<div
+  class="dc-value"
+  x-show="!$store.showWhitespaces"
+>
+  {{ value }}
+</div>
+
+<div
+  class="dc-value dc-value-whitespaces"
+  x-show="$store.showWhitespaces"
+>
+  {% whitespaces value %}
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/values/text.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/values/text.html
@@ -1,16 +1,8 @@
 {% load i18n %}
 {% load data_cleaning %}
 
-<div
-  class="dc-value"
-  x-show="!$store.showWhitespaces"
->
-  {{ value }}
-</div>
+<div class="dc-value" x-show="!$store.showWhitespaces">{{ value }}</div>
 
-<div
-  class="dc-value dc-value-whitespaces"
-  x-show="$store.showWhitespaces"
->
+<div class="dc-value dc-value-whitespaces" x-show="$store.showWhitespaces">
   {% whitespaces value %}
 </div>

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -89,10 +89,8 @@ class CleanCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
 
     @property
     def page_context(self):
-        from django.conf import settings
         return {
             "session_id": self.session_id,
-            "show_temporary_save": settings.SERVER_ENVIRONMENT == settings.LOCAL_SERVER_ENVIRONMENT,
         }
 
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/data_cleaning.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/data_cleaning.scss
@@ -3,6 +3,26 @@
 @import "variables";
 @import "variables-dark";
 
+.dc-value {
+  position: relative;
+
+  .dc-value-info {
+    background-color: $gray-800;
+    color: $white;
+    font-weight: bold;
+    position: absolute;
+    left: 0;
+    top: 0;
+    opacity: 0;
+    padding: 0 $spacer * 0.25;
+    transition: opacity 0.5s ease-in-out;
+  }
+  &:hover .dc-value-info {
+    display: block;
+    opacity: 1;
+  }
+}
+
 .dc-diff-view {
   font-family: $font-family-monospace;
   font-size: $font-size-base * .95;
@@ -19,6 +39,14 @@
     padding: $spacer * 0.15 $spacer * 0.4;
     cursor: help;
   }
+
+  .dc-value-null {
+    min-width: 38px;
+  }
+
+  .dc-value-empty {
+    min-width: 42px;
+  }
 }
 
 .dc-diff-before {
@@ -28,6 +56,15 @@
   .dc-diff-icon {
     background-color: $red-500;
   }
+
+  .dc-value-null {
+    color: $red-500;
+  }
+
+  .dc-value .dc-value-info {
+    background-color: $red-100;
+    color: $red-500;
+  }
 }
 
 .dc-diff-after {
@@ -36,6 +73,15 @@
 
   .dc-diff-icon {
     background-color: $green-500;
+  }
+
+  .dc-value-null {
+    color: $green-500;
+  }
+
+  .dc-value .dc-value-info {
+    background-color: $green-100;
+    color: $green-500;
   }
 }
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/data_cleaning.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/data_cleaning.scss
@@ -5,21 +5,19 @@
 
 .dc-diff-view {
   font-family: $font-family-monospace;
+  font-size: $font-size-base * .95;
   letter-spacing: 1px;
 }
 
 .dc-diff-before,
 .dc-diff-after {
   border: 1px solid white;
-  margin: $spacer * 0.13;
-  padding-right: $spacer * 0.5;
-  vertical-align: middle;
+  margin: $spacer * 0.15;
 
-  &::before {
-    display: inline-block;
+  .dc-diff-icon {
     color: $white;
-    line-height: 12px;
-    padding: $spacer * 0.25 $spacer * 0.5;
+    padding: $spacer * 0.15 $spacer * 0.4;
+    cursor: help;
   }
 }
 
@@ -27,9 +25,8 @@
   background-color: $red-100;
   border-color: $red-500;
 
-  &::before {
+  .dc-diff-icon {
     background-color: $red-500;
-    content: "-";
   }
 }
 
@@ -37,9 +34,8 @@
   background-color: $green-100;
   border-color: $green-500;
 
-  &::before {
+  .dc-diff-icon {
     background-color: $green-500;
-    content: "+";
   }
 }
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/data_cleaning.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/data_cleaning.scss
@@ -27,7 +27,7 @@
   border: 1px solid rgba(0, 0, 0, 0.1);
   display: inline-block;
   font-family: $font-family-monospace;
-  font-size: $font-size-base * .95;
+  font-size: $font-size-base * 0.95;
   letter-spacing: 1px;
   margin-right: $spacer * 1.5;
   padding: $spacer * 0.25 $spacer * 0.5;
@@ -48,13 +48,13 @@
     cursor: help;
     color: $white;
     background-color: rgba(0, 0, 0, 0.5);
-    opacity: 1.0;
+    opacity: 1;
   }
 }
 
 .dc-diff-view {
   font-family: $font-family-monospace;
-  font-size: $font-size-base * .95;
+  font-size: $font-size-base * 0.95;
   letter-spacing: 1px;
 }
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/data_cleaning.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/data_cleaning.scss
@@ -23,6 +23,35 @@
   }
 }
 
+.dc-value-whitespaces {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  display: inline-block;
+  font-family: $font-family-monospace;
+  font-size: $font-size-base * .95;
+  letter-spacing: 1px;
+  margin-right: $spacer * 1.5;
+  padding: $spacer * 0.25 $spacer * 0.5;
+  vertical-align: middle;
+  overflow-wrap: break-word;
+}
+
+.dc-spaces {
+  opacity: 0.5;
+  background-color: transparent;
+  font-weight: bold;
+  font-size: $font-size-base * 1.3;
+  line-height: $font-size-base * 1.3;
+  vertical-align: middle;
+  transition: 0.5s ease-in-out background-color;
+
+  &:hover {
+    cursor: help;
+    color: $white;
+    background-color: rgba(0, 0, 0, 0.5);
+    opacity: 1.0;
+  }
+}
+
 .dc-diff-view {
   font-family: $font-family-monospace;
   font-size: $font-size-base * .95;
@@ -46,6 +75,14 @@
 
   .dc-value-empty {
     min-width: 42px;
+  }
+
+  .dc-value-whitespaces {
+    border: 0;
+    letter-spacing: 1px;
+    line-height: $font-size-base * 1.3;
+    margin-right: 0;
+    padding: $spacer * 0.15 0;
   }
 }
 


### PR DESCRIPTION
## Product Description
This introduces the whitespaces toggle and additional styling for whitespaces, null values, and empty values:

whitespaces OFF (with diffs):
<img width="1255" alt="Screenshot 2025-04-24 at 10 58 58 AM" src="https://github.com/user-attachments/assets/82c82b57-a3ca-4ae3-a88c-0e2c2df75a0d" />

whitespaces ON (with diffs):
<img width="1250" alt="Screenshot 2025-04-24 at 10 59 08 AM" src="https://github.com/user-attachments/assets/b556b380-b80a-4ef5-8ac5-11405001c708" />

I addressed a few issues from the copied-over prototype styles. First, is an issue with non-breaking lines when whitespaces are turned on, which causes the table to overflow the page width. Here is an example of what that looked like:
![Screenshot 2025-04-23 at 9 23 35 PM](https://github.com/user-attachments/assets/172f7862-9b90-416f-b758-ebd682e50919)

Additionally, the diff view did not handle long diff lines very well at all:
![Screenshot 2025-04-23 at 9 23 40 PM](https://github.com/user-attachments/assets/f29f0a37-f32d-45a3-a500-8d1af5bbf3ea)

now, long lines are handled nicely (and whitespaces are broken up):
<img width="142" alt="Screenshot 2025-04-24 at 11 01 15 AM" src="https://github.com/user-attachments/assets/aab66e1a-2c45-445a-a24f-99cdad8c6996" />

this PR also:
- removes the hippo save button (as the whitespace toggle lives in its place) --- a forthcoming PR will introduce the apply changes bar
- adds styling for null and empty values (on hover)
  <img width="213" alt="Screenshot 2025-04-24 at 10 59 47 AM" src="https://github.com/user-attachments/assets/96a67295-c654-41ae-ba4d-636df52ecd3c" />
  <img width="286" alt="Screenshot 2025-04-24 at 10 59 58 AM" src="https://github.com/user-attachments/assets/28d24dc1-74d8-42ab-8246-f2dc3c9b71e8" />

- adds tooltips on the `+` and `-` icon in diffs to explain what the diffs mean
  <img width="226" alt="Screenshot 2025-04-24 at 10 59 31 AM" src="https://github.com/user-attachments/assets/104811c6-c128-44c1-89d8-9339732dec08" />
  <img width="272" alt="Screenshot 2025-04-24 at 10 59 34 AM" src="https://github.com/user-attachments/assets/a9bc75fe-50fd-4856-b869-6f5d86b879d4" />

Here are videos demoing a few of the changes

https://github.com/user-attachments/assets/c637ba5f-c4e8-4b99-80d2-4197b43cad0a
https://github.com/user-attachments/assets/5eaad35e-91a2-4bc8-af7d-ea359ba5ffe4



## Technical Summary
- introduces new template tags for consistent value styling
- fixes minor html issues (missing `<div>` closing tag)
- addresses multi-line diffs by utilizing bootstrap 5's flexbox utilities

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
very safe front-end changes made only to feature flagged areas of the codebase

### Automated test coverage
most crucial logic is already tested

### QA Plan
not yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
