### PR TITLE
Create migration to enable slow logs

### DIFF
--- a/corehq/apps/es/migrations/0014_enable_slowlogs.py
+++ b/corehq/apps/es/migrations/0014_enable_slowlogs.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+from corehq.apps.es.client import manager
+from corehq.apps.es.transient_util import iter_doc_adapters
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _configure_slowlogs(apps, schema_editor):
+    for adapter in iter_doc_adapters():
+        manager.index_configure_for_standard_ops(adapter.index_name)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('es', '0013_add_last_modifed'),
+    ]
+
+    operations = [migrations.RunPython(_configure_slowlogs, reverse_code=migrations.RunPython.noop)]

--- a/migrations.lock
+++ b/migrations.lock
@@ -456,6 +456,7 @@ es
  0011_add_indices_for_es5_reindex
  0012_add_new_index_for_bha
  0013_add_last_modifed
+ 0014_enable_slowlogs
 events
  0001_add_events_model
  0002_attendancetrackingconfig


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15796

Followup to https://github.com/dimagi/commcare-hq/pull/36030, this ensures that slow logs are enabled for existing indices.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
Depends on code changes in https://github.com/dimagi/commcare-hq/pull/36030, which is now merged, so this is safe to apply independently.
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
