### PR TITLE
[Data Cleaning] Placeholder UI for the "edits bar"

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -304,7 +304,12 @@ class BulkEditSession(models.Model):
             change.records.add(*selected_records)
 
     def get_num_edited_records(self):
-        return self.records.filter(changes__isnull=False).count()
+        return (
+            self.records.filter(changes__isnull=False)
+            .values("doc_id")
+            .distinct()
+            .count()
+        )
 
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -14,6 +14,12 @@ Alpine.data('wiggleButtonModel', wiggleButton);
 
 Alpine.store('isCleaningAllowed', false);
 Alpine.store('showWhitespaces', false);
+Alpine.store('editDetails', {
+    numEditedRecords: 0,
+    update(numEditedRecords) {
+        this.numEditedRecords = numEditedRecords;
+    },
+});
 
 import Alpine from 'alpinejs';
 Alpine.start();
@@ -21,4 +27,8 @@ Alpine.start();
 document.body.addEventListener("showDataCleaningModal", function (event) {
     const modal = new Modal(event.detail.elt);
     modal.show();
+});
+
+document.body.addEventListener("updateEditDetails", function (event) {
+    Alpine.store('editDetails').update(event.detail.numEditedRecords);
 });

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -14,6 +14,7 @@
     },
   }"
   x-init="
+    $store.editDetails.update({{ table.num_edited_records }});
     updateCleaningStatus(numRecordsSelected);
     $watch('numRecordsSelected', updateCleaningStatus);
   "
@@ -35,6 +36,36 @@
 
 {% block before_table %}
   <div class="d-flex align-items-center pb-2">
+
+    <div
+      class="pe-2"
+      x-show="$store.editDetails.numEditedRecords > 0"
+    >
+      <div class="input-group">
+        <div class="input-group-text">
+          <i class="fa-solid fa-pencil me-2"></i>
+          {% trans "Edits" %}
+          <span
+            class="ms-2 badge text-bg-secondary"
+            data-bs-title="{% trans "number of cases edited" %}"
+            x-tooltip=""
+            x-text="$store.editDetails.numEditedRecords"
+          ></span>
+        </div>
+        <button class="btn btn-outline-danger" type="button">
+          <i class="fa-solid fa-close"></i>
+          {% trans "Clear" %}
+        </button>
+        <button class="btn btn-outline-secondary" type="button">
+          <i class="fa-solid fa-undo"></i>
+          {% trans "Undo" %}
+        </button>
+        <button class="btn btn-success" type="button">
+          <i class="fa-solid fa-check-double"></i>
+          {% trans "Apply" %}
+        </button>
+      </div>
+    </div>
 
     {% if table.has_any_filtering %}
       <div class="pe-2">

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -402,18 +402,26 @@ class BulkEditSessionChangesTests(BaseBulkEditSessionTest):
     def test_get_num_edited_records(self):
         doc_ids = self._get_list_of_doc_ids(5)
         selected_edited_doc_ids = self._get_list_of_doc_ids(5)
+        records = []
+        changes = []
         for doc_id in doc_ids + selected_edited_doc_ids:
             record = BulkEditRecord.objects.create(
                 session=self.session,
                 doc_id=doc_id,
                 is_selected=doc_id in selected_edited_doc_ids,
             )
+            records.append(record)
             change = BulkEditChange.objects.create(
                 session=self.session,
                 prop_id='name',
                 action_type=EditActionType.STRIP,
             )
             change.records.add(record)
+            changes.append(change)
+
+        # ensure that if a record has multiple changes, those changes aren't counted
+        changes[1].records.add(records[0], records[5])
+        changes[4].records.add(records[2])
         selected_doc_ids = self._get_list_of_doc_ids(40)
         self.session.select_multiple_records(selected_doc_ids)
         num_edited_records = self.session.get_num_edited_records()

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -141,9 +141,18 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
             record,
             table,
         )
-        return self.render_htmx_partial_response(
+        response = self.render_htmx_partial_response(
             request, DataCleaningHtmxColumn.template_name, context
         )
+        response["HX-Trigger"] = json.dumps(
+            {
+                "updateEditDetails": {
+                    "target": "body",
+                    "numEditedRecords": self.session.get_num_edited_records(),
+                },
+            }
+        )
+        return response
 
     def _get_cell_request_details(self, request):
         """


### PR DESCRIPTION
## Product Description
This adds the placeholder UI for the edits bar, and sets up the `Alpine.store` that HTMX requests can update to make sure the number of edited records stays the same.

<img width="334" alt="Screenshot 2025-04-24 at 12 29 08 PM" src="https://github.com/user-attachments/assets/52f0cd88-d88b-415b-8b0e-5586ca794d98" />
<img width="334" alt="Screenshot 2025-04-24 at 12 29 13 PM" src="https://github.com/user-attachments/assets/e32354ff-d395-4e4a-85b4-730ee9de8a51" />


## Technical Summary
This also updates the `get_num_edited_records` method on `BulkEditSession`, as it wasn't actually fetching the number of edited records, but the number of changes for all edited records. I also updated the related test to account for this.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
very safe small UI change that only affects feature flagged workflows
QA has not yet tested this area of the feature flag, and will be testing it in a couple weeks.

### Automated test coverage
yes, and updated a relevant test to improve

### QA Plan
QA finished testing columns + filters functionality,
QA tbd on the changes/edits functionality

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
