### PR TITLE
Fix case type modal shrinking after selecting a case type

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/define_case_type_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/define_case_type_modal.html
@@ -53,7 +53,11 @@
               >
                 <option value=""></option>
               </select>
-              <div class="help-block" id="new-case-type-error"></div>
+              <div
+                class="help-block"
+                id="new-case-type-error"
+                style="display: none;"
+              ></div>
               <div class="help-block" id="new-case-type-help">
                 {% trans "* You can change the Case Type later by going to the menu settings page" %}
               </div>


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The shrinking:

https://github.com/user-attachments/assets/5f2a00ca-2aa4-4674-a677-54ab54fb61fa



## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Previously, the error block was rendered with zero height but retained vertical margins, which affected the layout of the modal. When the input value was updated and validated in JS, we used `$('#new-case-type-error').hide()` to remove the error element. This caused a subtle visual shift, as it removed both the element and its vertical margins, resulting in the modal shrinking slightly.

To avoid this layout jump, I now initialize the element with `display: none`

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
