### PR TITLE
Disable copy over of flags without edit permission while copying app

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -81,7 +81,9 @@ hqDefine("app_manager/js/app_view", [
             var $submit = $(this),
                 $form = $submit.closest("form"),
                 domain = $form.find("#id_domain").val(),
-                $modal = $("#copy-toggles");
+                $modal = $("#copy-toggles"),
+                selectAllText = gettext("Select All"),
+                selectNoneText = gettext("Select None");
 
             if (!isCopyApplicationFormValid($form)) {
                 return false;
@@ -99,10 +101,13 @@ hqDefine("app_manager/js/app_view", [
                         if (toggles.length) {
                             var template = _.template($modal.find("script").html()),
                                 $ul = $modal.find("ul").html(""),
-                                allSelected = false;
-                            $modal.find(".select-all").click(function (e) {
+                                allSelected = false,
+                                $selectAll = $modal.find(".select-all");
+
+                            $selectAll.text(selectAllText);
+                            $selectAll.click(function (e) {
                                 allSelected = !allSelected;
-                                $(e.currentTarget).text(allSelected ? gettext("Select None") : gettext("Select All"));
+                                $(e.currentTarget).text(allSelected ? selectNoneText : selectAllText);
                                 $ul.find("input:checkbox:enabled").prop('checked', allSelected);
                             });
                             _.each(toggles, function (toggle) {

--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -103,10 +103,14 @@ hqDefine("app_manager/js/app_view", [
                             $modal.find(".select-all").click(function (e) {
                                 allSelected = !allSelected;
                                 $(e.currentTarget).text(allSelected ? gettext("Select None") : gettext("Select All"));
-                                $ul.find("input:checkbox").prop('checked', allSelected);
+                                $ul.find("input:checkbox:enabled").prop('checked', allSelected);
                             });
                             _.each(toggles, function (toggle) {
-                                $ul.append(template(toggle));
+                                var $item = $(template(toggle));
+                                if (toggle.can_edit === false) {
+                                    $item.find('input').prop('disabled', true);
+                                }
+                                $ul.append($item);
                             });
                             $modal.modal().one("click", ".btn-primary", function () {
                                 $(this).disableButton();

--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -112,6 +112,11 @@ hqDefine("app_manager/js/app_view", [
                                 }
                                 $ul.append($item);
                             });
+
+                            if (_.any(toggles, t => !t.can_edit)) {
+                                $('#non_editable_flags').removeClass('d-none');
+                            }
+
                             $modal.modal().one("click", ".btn-primary", function () {
                                 $(this).disableButton();
                                 var slugs = _.map($modal.find(":checked"), function (c) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
@@ -12,16 +12,17 @@
       <div class="modal-body form-horizontal">
         <p>
           {% blocktrans %}
-            The following features are not turned on in the domain to which you're copying.
-            Select any that you wish to copy along with this application.
+            The following features are not turned on in the domain to which
+            you're copying. Select any that you wish to copy along with this
+            application.
           {% endblocktrans %}
         </p>
         <div id="non_editable_flags" class="alert alert-info d-none">
           <i class="fa fa-info-circle"></i>
-            {% blocktrans %}
-              You do not have permission to copy the disabled flags. Please contact
-              support if you require access to these flags.
-            {% endblocktrans %}
+          {% blocktrans %}
+            You do not have permission to copy the disabled flags. Please
+            contact support if you require access to these flags.
+          {% endblocktrans %}
         </div>
         <div>
           <button class="btn btn-default btn-xs select-all">
@@ -31,7 +32,9 @@
         <ul class="list-unstyled"></ul>
       </div>
       <div class="modal-footer">
-        <button class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
+        <button class="btn btn-default" data-dismiss="modal">
+          {% trans "Cancel" %}
+        </button>
         <button class="btn btn-primary">{% trans "Copy" %}</button>
       </div>
     </div>
@@ -40,7 +43,7 @@
     <li class="checkbox">
       <label>
         <input type="checkbox" data-slug="<%- slug %>" />
-        <span class='label label-<%- tag_css_class %>'><%- tag_name %></span>
+        <span class="label label-<%- tag_css_class %>"><%- tag_name %></span>
         <%- label %>
       </label>
     </li>

--- a/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
@@ -16,6 +16,13 @@
             Select any that you wish to copy along with this application.
           {% endblocktrans %}
         </p>
+        <div id="non_editable_flags" class="alert alert-info d-none">
+          <i class="fa fa-info-circle"></i>
+            {% blocktrans %}
+              You do not have permission to copy the disabled flags. Please contact
+              support if you require access to these flags.
+            {% endblocktrans %}
+        </div>
         <div>
           <button class="btn btn-default btn-xs select-all">
             {% trans "Select All" %}

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -443,7 +443,7 @@ def app_source(request, domain, app_id):
 def copy_app(request, domain):
     app_id = request.POST.get('app')
     app = get_app(domain, app_id)
-    form = CopyApplicationForm(domain, app, request.POST)
+    form = CopyApplicationForm(domain, app, request.POST, request_user=request.user)
     if not form.is_valid():
         from corehq.apps.app_manager.views.view_generic import view_generic
         return view_generic(request, domain, app_id, copy_app_form=form)

--- a/corehq/toggles/shortcuts.py
+++ b/corehq/toggles/shortcuts.py
@@ -111,3 +111,10 @@ def get_tags_with_edit_permission(username):
         if not permission or permission.is_user_enabled(username):
             allowed_tags.append(tag)
     return allowed_tags
+
+
+def get_toggles_with_edit_permission(username):
+    from corehq.toggles import all_toggles
+
+    allowed_tags = get_tags_with_edit_permission(username)
+    return [toggle for toggle in list(all_toggles()) if toggle.tag in allowed_tags]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
When an app is copied from one domain to another, it may use feature flags that aren’t enabled in the destination domain. In such cases, a superuser can choose to enable those flags as part of the copy process.

The changes in this PR check whether the superuser has permission to edit the feature flags. Flags for which the user does not have edit access are disabled, with an appropriate message displayed for clarity.

**Screenshot:**

![image](https://github.com/user-attachments/assets/1f40095d-5e22-463b-a130-c28b4501f509)


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
> Note: This PR currently builds on top of https://github.com/dimagi/commcare-hq/pull/36233 and the base will be updated later to master.

[Ticket](https://dimagi.atlassian.net/browse/SC-4434)
[Spec](https://docs.google.com/document/d/1arXfsgW7psnlimYwXqN27mCujdhGCrk_xOm8IlZbKJk/edit?tab=t.0#heading=h.ytrlro455iap)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local.  Changes only affect copying functionality for superuser.
(Staging testing pending to ensure a superuser has access to all the FFs)

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
