### PR TITLE
Remove `query` param from docs

### DIFF
--- a/docs/api/cases-v2.rst
+++ b/docs/api/cases-v2.rst
@@ -287,14 +287,6 @@ described below.
 |                                  | those where it’s set to the      |
 |                                  | empty string.                    |
 +----------------------------------+----------------------------------+
-| query                            | Submit a valid `Case Search      |
-|                                  | Query                            |
-|                                  | Language <https://dimagi-de      |
-|                                  | v.atlassian.net/wiki/display/saa |
-|                                  | s/Case+Search+Query+Language>`__ |
-|                                  | query. Mirrors the “Search” box  |
-|                                  | in the Case List Explorer        |
-+----------------------------------+----------------------------------+
 
 Return value is a list of cases, each serialized as described in
 "`Single Case Serialization Format`_".


### PR DESCRIPTION
## Product Description
This parameter is just too unbound to recommend people use given our recommitted focus on stability and predictability.  May consider removing it from the back-end eventually, but for now I think this is fine.

## Technical Summary


## Feature Flag


## Safety Assurance
docs only

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
