### PR TITLE
Only include BHA index on SaaS environments

### DIFF
--- a/corehq/apps/es/__init__.py
+++ b/corehq/apps/es/__init__.py
@@ -1,3 +1,6 @@
+from django.conf import settings
+from memoized import memoized
+
 from . import (  # noqa: F401
     # "utility" modules
     aggregations,
@@ -43,14 +46,22 @@ sms_adapter = sms.sms_adapter
 user_adapter = users.user_adapter
 case_search_bha_adapter = case_search_bha.case_search_bha_adapter
 
-CANONICAL_NAME_ADAPTER_MAP = {
-    app_adapter.canonical_name: app_adapter,
-    case_adapter.canonical_name: case_adapter,
-    case_search_bha_adapter.canonical_name: case_search_bha_adapter,
-    case_search_adapter.canonical_name: case_search_adapter,
-    domain_adapter.canonical_name: domain_adapter,
-    form_adapter.canonical_name: form_adapter,
-    group_adapter.canonical_name: group_adapter,
-    sms_adapter.canonical_name: sms_adapter,
-    user_adapter.canonical_name: user_adapter,
-}
+
+@memoized
+def canonical_name_adapter_map():
+    """
+    Due to custom indices created in SaaS environments, we need this to by dynamic.
+    """
+    adapter_map = {
+        app_adapter.canonical_name: app_adapter,
+        case_adapter.canonical_name: case_adapter,
+        case_search_adapter.canonical_name: case_search_adapter,
+        domain_adapter.canonical_name: domain_adapter,
+        form_adapter.canonical_name: form_adapter,
+        group_adapter.canonical_name: group_adapter,
+        sms_adapter.canonical_name: sms_adapter,
+        user_adapter.canonical_name: user_adapter,
+    }
+    if settings.IS_SAAS_ENVIRONMENT:
+        adapter_map[case_search_bha_adapter.canonical_name] = case_search_bha_adapter
+    return adapter_map

--- a/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
+++ b/corehq/apps/es/management/commands/elastic_sync_multiplexed.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from corehq.apps.es import CANONICAL_NAME_ADAPTER_MAP
+from corehq.apps.es import canonical_name_adapter_map
 
 import corehq.apps.es.const as es_consts
 from corehq.apps.es.client import ElasticMultiplexAdapter, get_client
@@ -335,7 +335,7 @@ class ESSyncUtil:
 
     def _get_index_name_cname_map(self, ignore_subindices=False):
         index_name_cname_map = {}
-        for cname, adapter in CANONICAL_NAME_ADAPTER_MAP.items():
+        for cname, adapter in canonical_name_adapter_map().items():
             if ignore_subindices and adapter.parent_index_cname:
                 continue
             index_name_cname_map[adapter.index_name] = cname
@@ -391,9 +391,9 @@ class ESSyncUtil:
             print("No residual indices found on the environment")
 
     def _get_all_known_index_names(self):
-        # get index name from CANONICAL_NAME_ADAPTER_MAP
+        # get index name from canonical_name_adapter_map()
         known_indices = set()
-        for cname in CANONICAL_NAME_ADAPTER_MAP.keys():
+        for cname in canonical_name_adapter_map().keys():
             known_indices.update(self._get_current_and_older_index_name(cname))
         return [index for index in known_indices if index]
 

--- a/corehq/apps/es/management/commands/ensure_indices_reindexed.py
+++ b/corehq/apps/es/management/commands/ensure_indices_reindexed.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 
-from corehq.apps.es import CANONICAL_NAME_ADAPTER_MAP, const
+from corehq.apps.es import const
 from corehq.apps.es.client import manager
 from corehq.apps.es.transient_util import doc_adapter_from_cname
 
@@ -32,6 +32,7 @@ class Command(BaseCommand):
         parser.add_argument('changelog', help="Changelog entry for the upgrade that outlines reindex steps")
 
     def handle(self, current_es_version, changelog, **kwargs):
+        from corehq.apps.es import canonical_name_adapter_map
         if manager.elastic_major_version != current_es_version:
             print(f"""
                 Skipping Reindex verify checks!
@@ -52,7 +53,7 @@ class Command(BaseCommand):
             return
 
         inconsistent_doc_count = []
-        for index_cname in CANONICAL_NAME_ADAPTER_MAP.keys():
+        for index_cname in canonical_name_adapter_map().keys():
             if not self.is_doc_count_difference_reasonable(index_cname):
                 inconsistent_doc_count.append(index_cname)
 
@@ -105,9 +106,10 @@ class Command(BaseCommand):
         """
         Returns a tuple of missing primary and secondary index names
         """
+        from corehq.apps.es import canonical_name_adapter_map
         missing_primary = []
         missing_secondary = []
-        for cname in CANONICAL_NAME_ADAPTER_MAP.keys():
+        for cname in canonical_name_adapter_map().keys():
             primary_adapter, secondary_adapter = cls.get_both_adapters_for_cname(cname)
             if not manager.index_exists(primary_adapter.index_name):
                 missing_primary.append(primary_adapter.index_name)

--- a/corehq/apps/es/management/commands/ensure_indices_reindexed.py
+++ b/corehq/apps/es/management/commands/ensure_indices_reindexed.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 
-from corehq.apps.es import const
+from corehq.apps.es import canonical_name_adapter_map, const
 from corehq.apps.es.client import manager
 from corehq.apps.es.transient_util import doc_adapter_from_cname
 
@@ -32,7 +32,6 @@ class Command(BaseCommand):
         parser.add_argument('changelog', help="Changelog entry for the upgrade that outlines reindex steps")
 
     def handle(self, current_es_version, changelog, **kwargs):
-        from corehq.apps.es import canonical_name_adapter_map
         if manager.elastic_major_version != current_es_version:
             print(f"""
                 Skipping Reindex verify checks!
@@ -106,7 +105,6 @@ class Command(BaseCommand):
         """
         Returns a tuple of missing primary and secondary index names
         """
-        from corehq.apps.es import canonical_name_adapter_map
         missing_primary = []
         missing_secondary = []
         for cname in canonical_name_adapter_map().keys():

--- a/corehq/apps/es/transient_util.py
+++ b/corehq/apps/es/transient_util.py
@@ -26,8 +26,8 @@ def doc_adapter_from_cname(index_cname, for_export=False):
     :param for_export: ``bool`` used to instantiate the adapter instance
     :returns: instance of an ``ElasticDocumentAdapter`` subclass
     """
-    from corehq.apps.es import CANONICAL_NAME_ADAPTER_MAP
-    return _get_doc_adapter(CANONICAL_NAME_ADAPTER_MAP[index_cname], for_export)
+    from corehq.apps.es import canonical_name_adapter_map
+    return _get_doc_adapter(canonical_name_adapter_map()[index_cname], for_export)
 
 
 def doc_adapter_from_index_name(index_name, for_export=False):
@@ -48,13 +48,13 @@ def _get_doc_adapter(adapter, for_export):
 
 
 def iter_doc_adapters():
-    from corehq.apps.es import CANONICAL_NAME_ADAPTER_MAP
-    yield from CANONICAL_NAME_ADAPTER_MAP.values()
+    from corehq.apps.es import canonical_name_adapter_map
+    yield from canonical_name_adapter_map().values()
 
 
 def iter_index_cnames():
-    from corehq.apps.es import CANONICAL_NAME_ADAPTER_MAP
-    yield from CANONICAL_NAME_ADAPTER_MAP
+    from corehq.apps.es import canonical_name_adapter_map
+    yield from canonical_name_adapter_map
 
 
 def populate_doc_adapter_map():

--- a/corehq/apps/es/transient_util.py
+++ b/corehq/apps/es/transient_util.py
@@ -54,7 +54,7 @@ def iter_doc_adapters():
 
 def iter_index_cnames():
     from corehq.apps.es import canonical_name_adapter_map
-    yield from canonical_name_adapter_map
+    yield from canonical_name_adapter_map()
 
 
 def populate_doc_adapter_map():

--- a/corehq/pillows/utils.py
+++ b/corehq/pillows/utils.py
@@ -2,7 +2,6 @@ from couchdbkit.exceptions import ResourceNotFound
 from jsonobject.exceptions import WrappingAttributeError
 
 from corehq.apps.commtrack.const import COMMTRACK_USERNAME
-from corehq.apps.es import CANONICAL_NAME_ADAPTER_MAP
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.util import SYSTEM_USER_ID, DEMO_USER_ID
 from corehq.const import ONE_DAY
@@ -83,7 +82,8 @@ def get_user_type_deep_cache_for_unknown_users(user_id):
 
 
 def get_all_expected_es_indices(ignore_subindices=False):
-    all_es_adapters = CANONICAL_NAME_ADAPTER_MAP.values()
+    from corehq.apps.es import canonical_name_adapter_map
+    all_es_adapters = canonical_name_adapter_map().values()
     if ignore_subindices:
         return [adapter for adapter in all_es_adapters if not adapter.parent_index_cname]
     return all_es_adapters

--- a/corehq/pillows/utils.py
+++ b/corehq/pillows/utils.py
@@ -2,6 +2,7 @@ from couchdbkit.exceptions import ResourceNotFound
 from jsonobject.exceptions import WrappingAttributeError
 
 from corehq.apps.commtrack.const import COMMTRACK_USERNAME
+from corehq.apps.es import canonical_name_adapter_map
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.util import SYSTEM_USER_ID, DEMO_USER_ID
 from corehq.const import ONE_DAY
@@ -82,7 +83,6 @@ def get_user_type_deep_cache_for_unknown_users(user_id):
 
 
 def get_all_expected_es_indices(ignore_subindices=False):
-    from corehq.apps.es import canonical_name_adapter_map
     all_es_adapters = canonical_name_adapter_map().values()
     if ignore_subindices:
         return [adapter for adapter in all_es_adapters if not adapter.parent_index_cname]

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.test import SimpleTestCase, override_settings
 
+from corehq.apps.es import canonical_name_adapter_map
 from corehq.apps.es.migration_operations import CreateIndex
 from corehq.apps.es.tests.utils import es_test
 from corehq.pillows.utils import get_all_expected_es_indices
@@ -19,6 +20,8 @@ class ProdIndexManagementTest(SimpleTestCase):
         if not settings.PILLOWTOPS:
             # assumes HqTestSuiteRunner, which blanks this out and saves a copy here
             settings.PILLOWTOPS = settings._PILLOWTOPS
+        canonical_name_adapter_map.reset_cache()
+        cls.addClassCleanup(canonical_name_adapter_map.reset_cache)
 
     @classmethod
     def tearDownClass(cls):

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 from corehq.apps.es.migration_operations import CreateIndex
 from corehq.apps.es.tests.utils import es_test
@@ -7,6 +7,7 @@ from corehq.pillows.utils import get_all_expected_es_indices
 
 
 @es_test
+@override_settings(IS_SAAS_ENVIRONMENT=True)
 class ProdIndexManagementTest(SimpleTestCase):
 
     maxDiff = None  # show the entire diff for test failures


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15796

Followup to the migration added in https://github.com/dimagi/commcare-hq/pull/36260. We should avoid including indices that are custom to SaaS environments by default, since most environments do not have those indices setup. In this case, we need to exclude the case search bha index when obtaining the list of indices to iterate over for the migration to enable slow logs on each index.

The specific migration function is
```
def _configure_slowlogs(apps, schema_editor):
    for adapter in iter_doc_adapters():
        manager.index_configure_for_standard_ops(adapter.index_name)
```

I'm hoping this change is "deep enough" that we won't run into this problem again.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Currently the migration added in https://github.com/dimagi/commcare-hq/pull/36260 fails on non-SaaS environments. Without merging this, that will continue to be true. I've had one person test this change locally on an environment that did not have the bha adapter setup and it worked, but if this does cause issues, it should be very obvious in tests, which pass.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
