### PR TITLE
[Data Cleaning] Change History performance limits

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -23,6 +23,7 @@ from corehq.apps.es import CaseSearchES
 BULK_OPERATION_CHUNK_SIZE = 1000
 MAX_RECORDED_LIMIT = 100000
 MAX_RECORD_CHANGES = 20
+MAX_SESSION_CHANGES = 200
 
 
 class BulkEditSessionType:
@@ -324,6 +325,9 @@ class BulkEditSession(models.Model):
                 "pk", filter=models.Q(num_changes__gte=MAX_RECORD_CHANGES)
             ),
         )
+
+    def get_num_changes(self):
+        return self.changes.count()
 
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -17,9 +17,11 @@ Alpine.store('showWhitespaces', false);
 Alpine.store('editDetails', {
     numRecordsEdited: 0,
     showApplyWarning: false,
+    isSessionAtChangeLimit: false,
     update(details) {
         this.numRecordsEdited = details.numRecordsEdited;
         this.showApplyWarning = details.numRecordsOverLimit > 0;
+        this.isSessionAtChangeLimit = details.isSessionAtChangeLimit;
     },
 });
 

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -15,9 +15,11 @@ Alpine.data('wiggleButtonModel', wiggleButton);
 Alpine.store('isCleaningAllowed', false);
 Alpine.store('showWhitespaces', false);
 Alpine.store('editDetails', {
-    numEditedRecords: 0,
-    update(numEditedRecords) {
-        this.numEditedRecords = numEditedRecords;
+    numRecordsEdited: 0,
+    showApplyWarning: false,
+    update(details) {
+        this.numRecordsEdited = details.numRecordsEdited;
+        this.showApplyWarning = details.numRecordsOverLimit > 0;
     },
 });
 
@@ -30,5 +32,5 @@ document.body.addEventListener("showDataCleaningModal", function (event) {
 });
 
 document.body.addEventListener("updateEditDetails", function (event) {
-    Alpine.store('editDetails').update(event.detail.numEditedRecords);
+    Alpine.store('editDetails').update(event.detail.editDetails);
 });

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -97,12 +97,24 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         return self.num_selected_records
 
     @property
-    @memoized
     def num_edited_records(self):
         """
         Return the number of edited records in the session.
         """
-        return self.session.get_num_edited_records()
+        return self.change_counts["num_records_edited"]
+
+    @property
+    @memoized
+    def change_counts(self):
+        """
+        A dictionary of "change_counts" for the session.
+        This includes the number of records edited and the number of records
+        that have reached the maximum number of changes.
+        The keys are:
+            - num_records_edited: the number of records edited
+            - num_records_at_max_changes: the number of records that have reached the maximum number of changes
+        """
+        return self.session.get_change_counts()
 
 
 class CaseCleaningTasksTable(BaseHtmxTable, tables.Table):

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -11,6 +11,7 @@ from corehq.apps.data_cleaning.columns import (
 from corehq.apps.data_cleaning.models import (
     BULK_OPERATION_CHUNK_SIZE,
     MAX_RECORDED_LIMIT,
+    MAX_SESSION_CHANGES,
 )
 from corehq.apps.data_cleaning.records import EditableCaseSearchElasticRecord
 from corehq.apps.hqwebapp.tables.elasticsearch.tables import ElasticTable
@@ -132,11 +133,13 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         The keys are:
             - numRecordsEdited: the number of records edited
             - numRecordsOverLimit: the number of records that have reached the maximum number of changes
+            - isSessionAtChangeLimit: whether the session has reached the maximum number of changes
         """
         change_counts = change_counts or session.get_change_counts()
         return {
             "numRecordsEdited": change_counts["num_records_edited"],
             "numRecordsOverLimit": change_counts["num_records_at_max_changes"],
+            "isSessionAtChangeLimit": session.get_num_changes() >= MAX_SESSION_CHANGES,
         }
 
     @property

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -25,7 +25,7 @@
     <div
       class="alert alert-warning"
       role="alert"
-      x-show="$store.editDetails.showApplyWarning"
+      x-show="$store.editDetails.showApplyWarning && !$store.editDetails.isSessionAtChangeLimit"
     >
       <h5>
         {% trans "Performance might be impacted..." %}
@@ -42,9 +42,23 @@
       hx-target="#{{ container_id }}"
       hx-disabled-elt="find button"
       hq-hx-action="create_bulk_edit_change"
+      x-show="!$store.editDetails.isSessionAtChangeLimit"
     >
       {% crispy cleaning_form %}
     </form>
+    <div
+      class="alert alert-warning"
+      x-show="$store.editDetails.isSessionAtChangeLimit"
+    >
+      <h5>
+        {% trans "Edit history is too large..." %}
+      </h5>
+      <p>
+        {% blocktrans %}
+          The edit history for this session is too large to support new bulk edits.
+          You can either apply the current edits, undo edits, or clear the edit history to start over.
+        {% endblocktrans%}
+      </p>
   {% else %}
     <div class="alert alert-primary">
       <h5>{% trans "No editible case properties are visible" %}</h5>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -22,6 +22,21 @@
     </div>
   {% endif %}
   {% if cleaning_form.is_form_visible %}
+    <div
+      class="alert alert-warning"
+      role="alert"
+      x-show="$store.editDetails.showApplyWarning"
+    >
+      <h5>
+        {% trans "Performance might be impacted..." %}
+      </h5>
+      <p>
+        {% blocktrans %}
+          Some cases have a large number of edits. You can continue to preview new bulk edits,
+          but some pages may take longer to load.
+        {% endblocktrans %}
+      </p>
+    </div>
     <form
       hx-post="{{ request.path_info }}"
       hx-target="#{{ container_id }}"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -59,6 +59,7 @@
           You can either apply the current edits, undo edits, or clear the edit history to start over.
         {% endblocktrans%}
       </p>
+    </div>
   {% else %}
     <div class="alert alert-primary">
       <h5>{% trans "No editible case properties are visible" %}</h5>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -14,7 +14,7 @@
     },
   }"
   x-init="
-    $store.editDetails.update({{ table.num_edited_records }});
+    $store.editDetails.update({{ table.edit_details }});
     updateCleaningStatus(numRecordsSelected);
     $watch('numRecordsSelected', updateCleaningStatus);
   "
@@ -39,7 +39,7 @@
 
     <div
       class="pe-2"
-      x-show="$store.editDetails.numEditedRecords > 0"
+      x-show="$store.editDetails.numRecordsEdited > 0"
     >
       <div class="input-group">
         <div class="input-group-text">
@@ -49,7 +49,7 @@
             class="ms-2 badge text-bg-secondary"
             data-bs-title="{% trans "number of cases edited" %}"
             x-tooltip=""
-            x-text="$store.editDetails.numEditedRecords"
+            x-text="$store.editDetails.numRecordsEdited"
           ></span>
         </div>
         <button class="btn btn-outline-danger" type="button">

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -148,7 +148,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
             {
                 "updateEditDetails": {
                     "target": "body",
-                    "numEditedRecords": self.session.get_num_edited_records(),
+                    "editDetails": self.table_class.get_edit_details(self.session),
                 },
             }
         )


### PR DESCRIPTION
## Product Description
This shows two alert messages to the user when the change history reaches two particular limits.

`MAX_RECORD_CHANGES`
- the number of "changes" that can be associated with a single record. This will show an alert above the clean selected cases form, but will not prevent additional bulk actions from being added. This is a soft limit as it will slightly affect performance for certain records if they are viewed on a page, but not all records, and no expected performance impacts when the user hits "apply changes" later
![Screenshot 2025-04-24 at 5 03 16 PM](https://github.com/user-attachments/assets/d23cecca-bba3-4f78-8517-f3483c2f2cdb)

`MAX_SESSION_CHANGES`
- This limits the number of session changes that can be made. After reaching or exceeding this limit (the limit can be exceeded with inline edit actions), the user will be prompted to either apply changes, undo changes, or clear changes.
![Screenshot 2025-04-24 at 5 05 31 PM](https://github.com/user-attachments/assets/26da64c6-6f91-4364-b7cc-b3517661fb35)


## Technical Summary
One last non-ui change is the update on how we retrieve the number of edited records in a session. Previously, that method was getting the number of changes for edited records in a session. This logic has been updated, and the relevant test has been updated to catch that.

https://dimagi.atlassian.net/browse/SAAS-17459

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change, with modified tests, only affects feature flagged areas of the codebase

### Automated test coverage
yes

### QA Plan
not yet. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
