### PR TITLE
Automatically toggle fixtures for Priming Syncs

### DIFF
--- a/custom/bha/tasks.py
+++ b/custom/bha/tasks.py
@@ -6,7 +6,7 @@ from celery.schedules import crontab
 from dateutil.relativedelta import relativedelta
 
 from corehq.apps.celery import periodic_task
-from corehq.toggles import PRIME_FORMPLAYER_DBS_BHA
+from corehq.toggles import PRIME_FORMPLAYER_DBS_BHA, SKIP_FIXTURES_ON_RESTORE
 
 from corehq.apps.formplayer_api.tasks import (
     prime_formplayer_db_for_user,
@@ -23,13 +23,26 @@ SYNC_WINDOW_HOURS = 24 * 7
 # Don't allow tasks to run beyond then (2PM UTC).
 TASK_WINDOW_CUTOFF_HOUR = 14
 
+PRIME_FORMPLAYER_HOUR = 12
+REENABLE_FEATURE_FLAG_HOUR = PRIME_FORMPLAYER_HOUR + 1
+
 
 # Start priming at 12PM UTC (5AM GMT-7) so that the task is completed by 2PM UTC (7AM GMT-7).
-@periodic_task(run_every=crontab(minute=0, hour=12), queue='ush_background_tasks')
+@periodic_task(run_every=crontab(minute=0, hour=PRIME_FORMPLAYER_HOUR), queue='ush_background_tasks')
 def bha_prime_formplayer_dbs():
     domains = PRIME_FORMPLAYER_DBS_BHA.get_enabled_domains()
+    for domain in domains:
+        SKIP_FIXTURES_ON_RESTORE.set(domain, False, 'domain')
     date_window = datetime.utcnow() - relativedelta(hours=SYNC_WINDOW_HOURS)
     for domain in domains:
         users = get_users_for_priming(domain, date_window)
         for row in users:
             prime_formplayer_db_for_user.delay(domain, row[0], row[1], task_cutoff_hour=TASK_WINDOW_CUTOFF_HOUR)
+
+
+# This is temporary while investigating restore slowness caused by fixtures.
+@periodic_task(run_every=crontab(minute=0, hour=REENABLE_FEATURE_FLAG_HOUR), queue='ush_background_tasks')
+def reenable_skip_fixtures_feature_flag():
+    domains = PRIME_FORMPLAYER_DBS_BHA.get_enabled_domains()
+    for domain in domains:
+        SKIP_FIXTURES_ON_RESTORE.set(domain, True, 'domain')


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This is temporary while we invesitgate the cause of the slowness. We don't expect this to have user facing impacts as the fixturs should not need to be regularly updated. If it does, then the FF can be manually disabled until the next sync.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-5897](https://dimagi.atlassian.net/browse/USH-5897)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[prime_formplayer_dbs_bha](https://www.commcarehq.org/hq/flags/edit/prime_formplayer_dbs_bha/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-5897]: https://dimagi.atlassian.net/browse/USH-5897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ