### PR TITLE
Log all restores over 5 minutes in sentry

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -100,6 +100,7 @@ def restore(request, domain, app_id=None):
 
     response, timing_context = get_restore_response(
         domain, request.couch_user, app_id, **get_restore_params(request, domain))
+    timing_context.add_to_sentry_breadcrumbs()
     return response
 
 

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -69,6 +69,7 @@ from corehq.form_processor.utils.xform import adjust_text_to_datetime
 from corehq.middleware import OPENROSA_VERSION_HEADER
 from corehq.util.metrics import limit_domains, metrics_histogram, limit_tags
 from corehq.util.quickcache import quickcache
+from corehq.util.timer import set_request_duration_reporting_threshold
 
 from .case_restore import get_case_restore_response
 from .models import DeviceLogRequest, MobileRecoveryMeasure, SerialIdBucket
@@ -90,6 +91,7 @@ PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 @handle_401_response
 @mobile_auth_or_formplayer
 @check_domain_mobile_access
+@set_request_duration_reporting_threshold(seconds=300)
 def restore(request, domain, app_id=None):
     """
     We override restore because we have to supply our own

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -102,7 +102,8 @@ def restore(request, domain, app_id=None):
 
     response, timing_context = get_restore_response(
         domain, request.couch_user, app_id, **get_restore_params(request, domain))
-    timing_context.add_to_sentry_breadcrumbs()
+    if timing_context:
+        timing_context.add_to_sentry_breadcrumbs()
     return response
 
 


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.atlassian.net/browse/USH-5948
This builds off `LogLongRequestMiddleware` to report on restores over 5 minutes in duration.

## Feature Flag


## Safety Assurance
Pretty simple change, just adds two minor utilities without modifying them.

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
