### PR TITLE
Call task after super.save() 

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4564,7 +4564,6 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
         if user and user.days_since_created == 0:
             track_workflow(user.get_email(), 'Saved the App Builder within first 24 hours')
         send_hubspot_form(HUBSPOT_SAVED_APP_FORM_ID, request)
-        refresh_data_dictionary_from_app.delay(self.domain, self.get_id)
         if self.copy_of:
             cache.delete('app_build_cache_{}_{}'.format(self.domain, self.get_id))
 
@@ -4573,6 +4572,8 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
         if increment_version:
             self.version = self.version + 1 if self.version else 1
         super(ApplicationBase, self).save(**params)
+
+        refresh_data_dictionary_from_app.delay(self.domain, self.get_id)
 
         if response_json is not None:
             if 'update' not in response_json:


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17440

`refresh_data_dictionary_from_app` is fired in the middle of the save function asynchronously.
If the queue is queued up and the function is executed after the save function, data dictionary will get correctly refreshed, with the latest info from the app.
But if the function is executed immediately, before the app is saved, it will refresh the data dictionary with the old data.

Move it after `super(ApplicationBase, self).save(**params)` will make sure the function is executed after the document is saved.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe, only move an async function several lines.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
