### PR TITLE
[Data Cleaning] Fix get_edited_case_properties after changes are removed

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -1027,7 +1027,8 @@ class BulkEditRecord(models.Model):
         properties = {}
         for change in self.changes.all():
             if change.action_type == EditActionType.RESET:
-                del properties[change.prop_id]
+                if change.prop_id in properties:
+                    del properties[change.prop_id]
             else:
                 properties[change.prop_id] = change.edited_value(
                     case, edited_properties=properties


### PR DESCRIPTION
## Technical Summary
If changes are completely removed from the session (or a single record), then `get_edited_case_properties` still shows the "edited" state for that record because we never reset `calculated_properties` and `calculated_change_id` if there are no changes preset, but those values are not `None`.

This PR ensures we reset those field on a `BulkEditRecord` if `get_edited_case_properties` is called and there are no changes associated with the record, but `calculated_change_id` is not null.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change that only affects feature flagged workflows

### Automated test coverage
this particular use case is not yet tested, but I will cover outstanding tests once the feature is in QA.

### QA Plan
not yet for data cleaning actions

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
