### PR TITLE
[Data Cleaning] Add placeholders for edit action confirmation modals.

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/modals/base_confirm.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/modals/base_confirm.html
@@ -34,7 +34,7 @@
         </button>
         {% block modal_continue_button %}
           <button
-            class="btn btn-primary"
+            class="btn {% if confirm_button_class %}{{ confirm_button_class }}{% else %}btn-primary{% endif %}"
             type="button"
             data-bs-dismiss="modal"
             {% block modal_continue_attrs %}{% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_apply.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_apply.html
@@ -1,0 +1,33 @@
+{% extends "data_cleaning/modals/base_confirm.html" %}
+{% load i18n %}
+{% load django_tables2 %}
+
+{% block modal_title %}
+  {% trans "Apply all edits?" %}
+{% endblock %}
+
+{% block modal_continue_attrs %}
+  hx-post="{{ request.path_info }}{% querystring %}"
+  hq-hx-action="apply_all_changes"
+  hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}.table-container{% endif %}"
+  hx-swap="outerHTML"
+  hq-hx-loading="{{ table.loading_indicator_id }}"
+  hx-disable-elt="this"
+{% endblock %}
+
+{% block modal_continue_text %}
+  <i class="fa-solid fa-check-double"></i>
+  {% trans "Apply All Edits" %}
+{% endblock %}
+
+{% block modal_body %}
+  <div
+    hx-trigger="updateApplySummaryMessage from:window"
+    hx-swap="innerHTML"
+    hx-post="{% url "data_cleaning_changes_summary" table.session.domain table.session.session_id %}"
+    hq-hx-action="apply_changes_summary"
+  >
+    {% include "data_cleaning/summary/apply_changes.html" %}
+    {% include "data_cleaning/partials/loading_indicator.html" %}
+  </div>
+{% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_clear.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_clear.html
@@ -1,0 +1,33 @@
+{% extends "data_cleaning/modals/base_confirm.html" %}
+{% load i18n %}
+{% load django_tables2 %}
+
+{% block modal_title %}
+  {% trans "Clear all edits?" %}
+{% endblock %}
+
+{% block modal_continue_attrs %}
+  hx-post="{{ request.path_info }}{% querystring %}"
+  hq-hx-action="clear_all_changes"
+  hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}.table-container{% endif %}"
+  hx-swap="outerHTML"
+  hq-hx-loading="{{ table.loading_indicator_id }}"
+  hx-disable-elt="this"
+{% endblock %}
+
+{% block modal_continue_text %}
+  <i class="fa-solid fa-close"></i>
+  {% trans "Clear" %}
+{% endblock %}
+
+{% block modal_body %}
+  <div
+    hx-trigger="updateClearSummaryMessage from:window"
+    hx-swap="innerHTML"
+    hx-post="{% url "data_cleaning_changes_summary" table.session.domain table.session.session_id %}"
+    hq-hx-action="clear_changes_summary"
+  >
+    {% include "data_cleaning/summary/clear_changes.html" %}
+    {% include "data_cleaning/partials/loading_indicator.html" %}
+  </div>
+{% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_undo.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_undo.html
@@ -1,0 +1,33 @@
+{% extends "data_cleaning/modals/base_confirm.html" %}
+{% load i18n %}
+{% load django_tables2 %}
+
+{% block modal_title %}
+  {% trans "Undo edit for multiple cases?" %}
+{% endblock %}
+
+{% block modal_continue_attrs %}
+  hx-post="{{ request.path_info }}{% querystring %}"
+  hq-hx-action="undo_last_change"
+  hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}.table-container{% endif %}"
+  hx-swap="outerHTML"
+  hq-hx-loading="{{ table.loading_indicator_id }}"
+  hx-disable-elt="this"
+{% endblock %}
+
+{% block modal_continue_text %}
+  <i class="fa-solid fa-undo"></i>
+  {% trans "Undo" %}
+{% endblock %}
+
+{% block modal_body %}
+  <div
+    hx-trigger="updateUndoSummaryMessage from:window"
+    hx-swap="innerHTML"
+    hx-post="{% url "data_cleaning_changes_summary" table.session.domain table.session.session_id %}"
+    hq-hx-action="undo_changes_summary"
+  >
+    {% include "data_cleaning/summary/undo_changes.html" %}
+    {% include "data_cleaning/partials/loading_indicator.html" %}
+  </div>
+{% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/apply_changes.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/apply_changes.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+
+<p class="lead">
+  {% blocktrans %}
+    The following edits will be applied:
+  {% endblocktrans %}
+</p>
+{# todo list summary of all session changes #}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/clear_changes.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/clear_changes.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+
+<p class="lead">
+  {% blocktrans %}
+    The following edits will be cleared:
+  {% endblocktrans %}
+</p>
+{# todo list summary of all session changes #}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/undo_changes.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/undo_changes.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+
+<p class="lead">
+  {% blocktrans %}
+    The following edit will be undone:
+  {% endblocktrans %}
+</p>
+{# todo list most recent edit #}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -56,7 +56,13 @@
           <i class="fa-solid fa-close"></i>
           {% trans "Clear" %}
         </button>
-        <button class="btn btn-outline-secondary" type="button">
+        <button
+          class="btn btn-outline-secondary"
+          type="button"
+          data-bs-toggle="modal"
+          data-bs-target="#confirm-undo-modal"
+          @click="$dispatch('updateUndoSummaryMessage');"
+        >
           <i class="fa-solid fa-undo"></i>
           {% trans "Undo" %}
         </button>
@@ -168,4 +174,5 @@
   {{ block.super }}
   {% include "data_cleaning/modals/confirm_select_all.html" with modal_id="confirm-select-all-modal" %}
   {% include "data_cleaning/modals/select_all_not_possible.html" with modal_id="select-all-not-possible-modal" %}
+  {% include "data_cleaning/modals/confirm_undo.html" with modal_id="confirm-undo-modal" confirm_button_class="btn-secondary" %}
 {% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -72,7 +72,13 @@
           <i class="fa-solid fa-undo"></i>
           {% trans "Undo" %}
         </button>
-        <button class="btn btn-success" type="button">
+        <button
+          class="btn btn-success"
+          type="button"
+          data-bs-toggle="modal"
+          data-bs-target="#confirm-apply-modal"
+          @click="$dispatch('updateApplySummaryMessage');"
+        >
           <i class="fa-solid fa-check-double"></i>
           {% trans "Apply" %}
         </button>
@@ -182,4 +188,5 @@
   {% include "data_cleaning/modals/select_all_not_possible.html" with modal_id="select-all-not-possible-modal" %}
   {% include "data_cleaning/modals/confirm_undo.html" with modal_id="confirm-undo-modal" confirm_button_class="btn-secondary" %}
   {% include "data_cleaning/modals/confirm_clear.html" with modal_id="confirm-clear-modal" confirm_button_class="btn-danger" %}
+  {% include "data_cleaning/modals/confirm_apply.html" with modal_id="confirm-apply-modal" confirm_button_class="btn-success" %}
 {% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -52,7 +52,13 @@
             x-text="$store.editDetails.numEditedRecords"
           ></span>
         </div>
-        <button class="btn btn-outline-danger" type="button">
+        <button
+          class="btn btn-outline-danger"
+          type="button"
+          data-bs-toggle="modal"
+          data-bs-target="#confirm-clear-modal"
+          @click="$dispatch('updateClearSummaryMessage');"
+        >
           <i class="fa-solid fa-close"></i>
           {% trans "Clear" %}
         </button>
@@ -175,4 +181,5 @@
   {% include "data_cleaning/modals/confirm_select_all.html" with modal_id="confirm-select-all-modal" %}
   {% include "data_cleaning/modals/select_all_not_possible.html" with modal_id="select-all-not-possible-modal" %}
   {% include "data_cleaning/modals/confirm_undo.html" with modal_id="confirm-undo-modal" confirm_button_class="btn-secondary" %}
+  {% include "data_cleaning/modals/confirm_clear.html" with modal_id="confirm-clear-modal" confirm_button_class="btn-danger" %}
 {% endblock %}

--- a/corehq/apps/data_cleaning/urls.py
+++ b/corehq/apps/data_cleaning/urls.py
@@ -1,5 +1,6 @@
 from django.urls import re_path as url
 
+from corehq.apps.data_cleaning.views.summary import ChangesSummaryView
 from corehq.apps.data_cleaning.views.cleaning import (
     CleanSelectedRecordsFormView,
 )
@@ -33,6 +34,8 @@ urlpatterns = [
         name=CleanCasesSessionView.urlname),
     url(r'^cases/(?P<session_id>[\w\-]+)/table/$', CleanCasesTableView.as_view(),
         name=CleanCasesTableView.urlname),
+    url(r'^cases/(?P<session_id>[\w\-]+)/summary/$', ChangesSummaryView.as_view(),
+        name=ChangesSummaryView.urlname),
     url(r'^session/(?P<session_id>[\w\-]+)/filters/$', ManageFiltersFormView.as_view(),
         name=ManageFiltersFormView.urlname),
     url(r'^session/(?P<session_id>[\w\-]+)/filters/pinned/$', PinnedFilterFormView.as_view(),

--- a/corehq/apps/data_cleaning/views/summary.py
+++ b/corehq/apps/data_cleaning/views/summary.py
@@ -8,7 +8,7 @@ from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
 from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.domain.views import DomainViewMixin
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
-from corehq.util.htmx_action import HqHtmxActionMixin
+from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 
 @method_decorator([
@@ -23,3 +23,12 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
     def get(self, request, *args, **kwargs):
         # this view can only be POSTed to and accessed at specific hq_hx_action endpoints
         raise Http404()
+
+    @hq_hx_action('post')
+    def undo_changes_summary(self, request, *args, **kwargs):
+        # todo: render summary context
+        return self.render_htmx_partial_response(
+            request,
+            "data_cleaning/summary/undo_changes.html",
+            {},
+        )

--- a/corehq/apps/data_cleaning/views/summary.py
+++ b/corehq/apps/data_cleaning/views/summary.py
@@ -41,3 +41,12 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
             "data_cleaning/summary/clear_changes.html",
             {},
         )
+
+    @hq_hx_action('post')
+    def apply_changes_summary(self, request, *args, **kwargs):
+        # todo: render summary context
+        return self.render_htmx_partial_response(
+            request,
+            "data_cleaning/summary/apply_changes.html",
+            {},
+        )

--- a/corehq/apps/data_cleaning/views/summary.py
+++ b/corehq/apps/data_cleaning/views/summary.py
@@ -1,0 +1,25 @@
+from django.http import Http404
+from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy
+from django.views.generic import TemplateView
+
+from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
+from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
+from corehq.apps.domain.decorators import LoginAndDomainMixin
+from corehq.apps.domain.views import DomainViewMixin
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.util.htmx_action import HqHtmxActionMixin
+
+
+@method_decorator([
+    use_bootstrap5,
+    require_bulk_data_cleaning_cases,
+], name='dispatch')
+class ChangesSummaryView(BulkEditSessionViewMixin,
+                         LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
+    urlname = "data_cleaning_changes_summary"
+    session_not_found_message = gettext_lazy("Cannot retrieve summary, session was not found.")
+
+    def get(self, request, *args, **kwargs):
+        # this view can only be POSTed to and accessed at specific hq_hx_action endpoints
+        raise Http404()

--- a/corehq/apps/data_cleaning/views/summary.py
+++ b/corehq/apps/data_cleaning/views/summary.py
@@ -32,3 +32,12 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
             "data_cleaning/summary/undo_changes.html",
             {},
         )
+
+    @hq_hx_action('post')
+    def clear_changes_summary(self, request, *args, **kwargs):
+        # todo: render summary context
+        return self.render_htmx_partial_response(
+            request,
+            "data_cleaning/summary/clear_changes.html",
+            {},
+        )

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -126,6 +126,11 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
         return response
 
     @hq_hx_action("post")
+    def apply_all_changes(self, request, *args, **kwargs):
+        # todo: this is a placeholder
+        return self.get(request, *args, **kwargs)
+
+    @hq_hx_action("post")
     def undo_last_change(self, request, *args, **kwargs):
         # todo: this is a placeholder
         return self.get(request, *args, **kwargs)

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -125,6 +125,11 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
         })
         return response
 
+    @hq_hx_action("post")
+    def undo_last_change(self, request, *args, **kwargs):
+        # todo: this is a placeholder
+        return self.get(request, *args, **kwargs)
+
     def _render_table_cell_response(self, doc_id, column, request, *args, **kwargs):
         """
         Returns an a partial HttpResponse for the table cell,

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -130,6 +130,11 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
         # todo: this is a placeholder
         return self.get(request, *args, **kwargs)
 
+    @hq_hx_action("post")
+    def clear_all_changes(self, request, *args, **kwargs):
+        # todo: this is a placeholder
+        return self.get(request, *args, **kwargs)
+
     def _render_table_cell_response(self, doc_id, column, request, *args, **kwargs):
         """
         Returns an a partial HttpResponse for the table cell,


### PR DESCRIPTION
## Technical Summary
This adds placeholders for the logic and UI surrounding presenting a user with a confirmation modal when they select "Clear", "Undo", or "Apply" in the edit actions toolbar
<img width="334" alt="Screenshot 2025-04-24 at 12 29 08 PM" src="https://github.com/user-attachments/assets/3b9e84ba-4c55-4372-89e5-b938dfe7d13c" />


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change that only affects the UI for a feature flagged part of the codebase

### Automated test coverage
most important logic is already tested

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
