### PR TITLE
[Data Cleaning] Implement undo and clear functionality

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -343,8 +343,11 @@ class BulkEditSession(models.Model):
         """
         self.records.filter(is_selected=False, changes__isnull=True).delete()
 
+    @retry_on_integrity_error(max_retries=3, delay=0.1)
+    @transaction.atomic
     def undo_last_change(self):
         self.changes.last().delete()
+        self.purge_records()
 
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -23,6 +23,7 @@ from corehq.apps.es import CaseSearchES
 BULK_OPERATION_CHUNK_SIZE = 1000
 MAX_RECORDED_LIMIT = 100000
 MAX_RECORD_CHANGES = 20
+MAX_SESSION_CHANGES = 200
 
 
 class BulkEditSessionType:
@@ -324,6 +325,9 @@ class BulkEditSession(models.Model):
                 "pk", filter=models.Q(num_changes__gte=MAX_RECORD_CHANGES)
             ),
         )
+
+    def get_num_changes(self):
+        return self.changes.count()
 
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -337,6 +337,9 @@ class BulkEditSession(models.Model):
         last_change = self.changes.last()
         return last_change and last_change.records.count() > 1
 
+    def undo_last_change(self):
+        self.changes.last().delete()
+
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)
 

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -337,6 +337,12 @@ class BulkEditSession(models.Model):
         last_change = self.changes.last()
         return last_change and last_change.records.count() > 1
 
+    def purge_records(self):
+        """
+        Delete all records that do not have changes or are not selected.
+        """
+        self.records.filter(is_selected=False, changes__isnull=True).delete()
+
     def undo_last_change(self):
         self.changes.last().delete()
 

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -329,6 +329,14 @@ class BulkEditSession(models.Model):
     def get_num_changes(self):
         return self.changes.count()
 
+    def is_undo_multiple(self):
+        """
+        Check if the last change in the session affects multiple records.
+        :return: bool - True if the last change affects multiple records
+        """
+        last_change = self.changes.last()
+        return last_change and last_change.records.count() > 1
+
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)
 

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -17,9 +17,11 @@ Alpine.store('showWhitespaces', false);
 Alpine.store('editDetails', {
     numRecordsEdited: 0,
     showApplyWarning: false,
+    isSessionAtChangeLimit: false,
     update(details) {
         this.numRecordsEdited = details.numRecordsEdited;
         this.showApplyWarning = details.numRecordsOverLimit > 0;
+        this.isSessionAtChangeLimit = details.isSessionAtChangeLimit;
     },
 });
 

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -18,10 +18,12 @@ Alpine.store('editDetails', {
     numRecordsEdited: 0,
     showApplyWarning: false,
     isSessionAtChangeLimit: false,
+    isUndoMultiple: false,
     update(details) {
         this.numRecordsEdited = details.numRecordsEdited;
         this.showApplyWarning = details.numRecordsOverLimit > 0;
         this.isSessionAtChangeLimit = details.isSessionAtChangeLimit;
+        this.isUndoMultiple = details.isUndoMultiple;
     },
 });
 

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -15,9 +15,11 @@ Alpine.data('wiggleButtonModel', wiggleButton);
 Alpine.store('isCleaningAllowed', false);
 Alpine.store('showWhitespaces', false);
 Alpine.store('editDetails', {
-    numEditedRecords: 0,
-    update(numEditedRecords) {
-        this.numEditedRecords = numEditedRecords;
+    numRecordsEdited: 0,
+    showApplyWarning: false,
+    update(details) {
+        this.numRecordsEdited = details.numRecordsEdited;
+        this.showApplyWarning = details.numRecordsOverLimit > 0;
     },
 });
 
@@ -30,5 +32,5 @@ document.body.addEventListener("showDataCleaningModal", function (event) {
 });
 
 document.body.addEventListener("updateEditDetails", function (event) {
-    Alpine.store('editDetails').update(event.detail.numEditedRecords);
+    Alpine.store('editDetails').update(event.detail.editDetails);
 });

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -140,6 +140,7 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
             "numRecordsEdited": change_counts["num_records_edited"],
             "numRecordsOverLimit": change_counts["num_records_at_max_changes"],
             "isSessionAtChangeLimit": session.get_num_changes() >= MAX_SESSION_CHANGES,
+            "isUndoMultiple": session.is_undo_multiple(),
         }
 
     @property

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -97,12 +97,24 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         return self.num_selected_records
 
     @property
-    @memoized
     def num_edited_records(self):
         """
         Return the number of edited records in the session.
         """
-        return self.session.get_num_edited_records()
+        return self.change_counts["num_records_edited"]
+
+    @property
+    @memoized
+    def change_counts(self):
+        """
+        A dictionary of "change_counts" for the session.
+        This includes the number of records edited and the number of records
+        that have reached the maximum number of changes.
+        The keys are:
+            - num_records_edited: the number of records edited
+            - num_records_at_max_changes: the number of records that have reached the maximum number of changes
+        """
+        return self.session.get_change_counts()
 
 
 class CaseCleaningTasksTable(BaseHtmxTable, tables.Table):

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -11,6 +11,7 @@ from corehq.apps.data_cleaning.columns import (
 from corehq.apps.data_cleaning.models import (
     BULK_OPERATION_CHUNK_SIZE,
     MAX_RECORDED_LIMIT,
+    MAX_SESSION_CHANGES,
 )
 from corehq.apps.data_cleaning.records import EditableCaseSearchElasticRecord
 from corehq.apps.hqwebapp.tables.elasticsearch.tables import ElasticTable
@@ -132,11 +133,13 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         The keys are:
             - numRecordsEdited: the number of records edited
             - numRecordsOverLimit: the number of records that have reached the maximum number of changes
+            - isSessionAtChangeLimit: whether the session has reached the maximum number of changes
         """
         change_counts = change_counts or session.get_change_counts()
         return {
             "numRecordsEdited": change_counts["num_records_edited"],
             "numRecordsOverLimit": change_counts["num_records_at_max_changes"],
+            "isSessionAtChangeLimit": session.get_num_changes() >= MAX_SESSION_CHANGES,
         }
 
     @property

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -25,7 +25,7 @@
     <div
       class="alert alert-warning"
       role="alert"
-      x-show="$store.editDetails.showApplyWarning"
+      x-show="$store.editDetails.showApplyWarning && !$store.editDetails.isSessionAtChangeLimit"
     >
       <h5>
         {% trans "Performance might be impacted..." %}
@@ -42,9 +42,23 @@
       hx-target="#{{ container_id }}"
       hx-disabled-elt="find button"
       hq-hx-action="create_bulk_edit_change"
+      x-show="!$store.editDetails.isSessionAtChangeLimit"
     >
       {% crispy cleaning_form %}
     </form>
+    <div
+      class="alert alert-warning"
+      x-show="$store.editDetails.isSessionAtChangeLimit"
+    >
+      <h5>
+        {% trans "Edit history is too large..." %}
+      </h5>
+      <p>
+        {% blocktrans %}
+          The edit history for this session is too large to support new bulk edits.
+          You can either apply the current edits, undo edits, or clear the edit history to start over.
+        {% endblocktrans%}
+      </p>
   {% else %}
     <div class="alert alert-primary">
       <h5>{% trans "No editible case properties are visible" %}</h5>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -22,6 +22,21 @@
     </div>
   {% endif %}
   {% if cleaning_form.is_form_visible %}
+    <div
+      class="alert alert-warning"
+      role="alert"
+      x-show="$store.editDetails.showApplyWarning"
+    >
+      <h5>
+        {% trans "Performance might be impacted..." %}
+      </h5>
+      <p>
+        {% blocktrans %}
+          Some cases have a large number of edits. You can continue to preview new bulk edits,
+          but some pages may take longer to load.
+        {% endblocktrans %}
+      </p>
+    </div>
     <form
       hx-post="{{ request.path_info }}"
       hx-target="#{{ container_id }}"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -62,16 +62,34 @@
           <i class="fa-solid fa-close"></i>
           {% trans "Clear" %}
         </button>
+
         <button
           class="btn btn-outline-secondary"
           type="button"
           data-bs-toggle="modal"
           data-bs-target="#confirm-undo-modal"
+          x-show="$store.editDetails.isUndoMultiple"
           @click="$dispatch('updateUndoSummaryMessage');"
         >
           <i class="fa-solid fa-undo"></i>
           {% trans "Undo" %}
         </button>
+        <button
+          class="btn btn-outline-secondary"
+          type="button"
+          hx-post="{{ request.path_info }}{% querystring %}"
+          hq-hx-action="undo_last_change"
+          hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}.table-container{% endif %}"
+          hx-swap="outerHTML"
+          hq-hx-loading="{{ table.loading_indicator_id }}"
+          hx-disable-elt="this"
+          x-show="!$store.editDetails.isUndoMultiple"
+          @click="$dispatch('updateUndoSummaryMessage');"
+        >
+          <i class="fa-solid fa-undo"></i>
+          {% trans "Undo" %}
+        </button>
+
         <button
           class="btn btn-success"
           type="button"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -14,7 +14,7 @@
     },
   }"
   x-init="
-    $store.editDetails.update({{ table.num_edited_records }});
+    $store.editDetails.update({{ table.edit_details }});
     updateCleaningStatus(numRecordsSelected);
     $watch('numRecordsSelected', updateCleaningStatus);
   "
@@ -39,7 +39,7 @@
 
     <div
       class="pe-2"
-      x-show="$store.editDetails.numEditedRecords > 0"
+      x-show="$store.editDetails.numRecordsEdited > 0"
     >
       <div class="input-group">
         <div class="input-group-text">
@@ -49,7 +49,7 @@
             class="ms-2 badge text-bg-secondary"
             data-bs-title="{% trans "number of cases with an edit history" %}"
             x-tooltip=""
-            x-text="$store.editDetails.numEditedRecords"
+            x-text="$store.editDetails.numRecordsEdited"
           ></span>
         </div>
         <button

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -132,7 +132,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
 
     @hq_hx_action("post")
     def undo_last_change(self, request, *args, **kwargs):
-        # todo: this is a placeholder
+        self.session.undo_last_change()
         return self.get(request, *args, **kwargs)
 
     @hq_hx_action("post")

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -163,7 +163,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
             {
                 "updateEditDetails": {
                     "target": "body",
-                    "numEditedRecords": self.session.get_num_edited_records(),
+                    "editDetails": self.table_class.get_edit_details(self.session),
                 },
             }
         )


### PR DESCRIPTION
NOTE: this is in draft until blocking PRs are merged

## Technical Summary
This PR implements the undo and clear all changes functionality that happens when you click "undo" and "clear" in the edit changes bar:
<img width="334" alt="Screenshot 2025-04-24 at 12 29 08 PM" src="https://github.com/user-attachments/assets/bac231a7-ca26-4ddf-8926-bc6e0982ab6e" />

This PR does not include the updates to the "undo" and "clear" confirmation modals. That will come in a separate PR.


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change, only affects a feature flagged area of codebase

### Automated test coverage
most important bits are tested

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
