### PR TITLE
[Data Cleaning] Implement undo functionality

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -343,8 +343,11 @@ class BulkEditSession(models.Model):
         """
         self.records.filter(is_selected=False, changes__isnull=True).delete()
 
+    @retry_on_integrity_error(max_retries=3, delay=0.1)
+    @transaction.atomic
     def undo_last_change(self):
         self.changes.last().delete()
+        self.purge_records()
 
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -337,6 +337,9 @@ class BulkEditSession(models.Model):
         last_change = self.changes.last()
         return last_change and last_change.records.count() > 1
 
+    def undo_last_change(self):
+        self.changes.last().delete()
+
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)
 

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -337,6 +337,12 @@ class BulkEditSession(models.Model):
         last_change = self.changes.last()
         return last_change and last_change.records.count() > 1
 
+    def purge_records(self):
+        """
+        Delete all records that do not have changes or are not selected.
+        """
+        self.records.filter(is_selected=False, changes__isnull=True).delete()
+
     def undo_last_change(self):
         self.changes.last().delete()
 

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -329,6 +329,14 @@ class BulkEditSession(models.Model):
     def get_num_changes(self):
         return self.changes.count()
 
+    def is_undo_multiple(self):
+        """
+        Check if the last change in the session affects multiple records.
+        :return: bool - True if the last change affects multiple records
+        """
+        last_change = self.changes.last()
+        return last_change and last_change.records.count() > 1
+
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)
 

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -18,10 +18,12 @@ Alpine.store('editDetails', {
     numRecordsEdited: 0,
     showApplyWarning: false,
     isSessionAtChangeLimit: false,
+    isUndoMultiple: false,
     update(details) {
         this.numRecordsEdited = details.numRecordsEdited;
         this.showApplyWarning = details.numRecordsOverLimit > 0;
         this.isSessionAtChangeLimit = details.isSessionAtChangeLimit;
+        this.isUndoMultiple = details.isUndoMultiple;
     },
 });
 

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -140,6 +140,7 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
             "numRecordsEdited": change_counts["num_records_edited"],
             "numRecordsOverLimit": change_counts["num_records_at_max_changes"],
             "isSessionAtChangeLimit": session.get_num_changes() >= MAX_SESSION_CHANGES,
+            "isUndoMultiple": session.is_undo_multiple(),
         }
 
     @property

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -72,7 +72,7 @@
           @click="$dispatch('updateUndoSummaryMessage');"
         >
           <i class="fa-solid fa-undo"></i>
-          {% trans "Undo" %}
+          {% trans "Undo" %} {# note: undo for multiple records #}
         </button>
         <button
           class="btn btn-outline-secondary"
@@ -86,7 +86,7 @@
           x-show="!$store.editDetails.isUndoMultiple"
         >
           <i class="fa-solid fa-undo"></i>
-          {% trans "Undo" %}
+          {% trans "Undo" %} {# note: undo for  single record #}
         </button>
 
         <button

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -86,7 +86,7 @@
           x-show="!$store.editDetails.isUndoMultiple"
         >
           <i class="fa-solid fa-undo"></i>
-          {% trans "Undo" %} {# note: undo for  single record #}
+          {% trans "Undo" %} {# note: undo for a single record #}
         </button>
 
         <button

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -62,16 +62,33 @@
           <i class="fa-solid fa-close"></i>
           {% trans "Clear" %}
         </button>
+
         <button
           class="btn btn-outline-secondary"
           type="button"
           data-bs-toggle="modal"
           data-bs-target="#confirm-undo-modal"
+          x-show="$store.editDetails.isUndoMultiple"
           @click="$dispatch('updateUndoSummaryMessage');"
         >
           <i class="fa-solid fa-undo"></i>
           {% trans "Undo" %}
         </button>
+        <button
+          class="btn btn-outline-secondary"
+          type="button"
+          hx-post="{{ request.path_info }}{% querystring %}"
+          hq-hx-action="undo_last_change"
+          hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}.table-container{% endif %}"
+          hx-swap="outerHTML"
+          hq-hx-loading="{{ table.loading_indicator_id }}"
+          hx-disable-elt="this"
+          x-show="!$store.editDetails.isUndoMultiple"
+        >
+          <i class="fa-solid fa-undo"></i>
+          {% trans "Undo" %}
+        </button>
+
         <button
           class="btn btn-success"
           type="button"

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -132,7 +132,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
 
     @hq_hx_action("post")
     def undo_last_change(self, request, *args, **kwargs):
-        # todo: this is a placeholder
+        self.session.undo_last_change()
         return self.get(request, *args, **kwargs)
 
     @hq_hx_action("post")


### PR DESCRIPTION
## Technical Summary
This PR implements the undo changes functionality that happens when you click "undo" in the edit changes bar:
<img width="334" alt="Screenshot 2025-04-24 at 12 29 08 PM" src="https://github.com/user-attachments/assets/bac231a7-ca26-4ddf-8926-bc6e0982ab6e" />

This PR does not include the updates to the "undo" confirmation modal. That will come in a separate PR.

This PR also removes the confirmation modal for the "undo" click when that action only affects a single record.


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change, only affects a feature flagged area of codebase

### Automated test coverage
most important bits are tested

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

