### PR TITLE
[Data Cleaning] update undo changes summary modal UI

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -1124,6 +1124,39 @@ class BulkEditChange(models.Model):
     class Meta:
         ordering = ["created_on"]
 
+    @property
+    def action_title(self):
+        """
+        Returns a human-readable title of the action.
+        """
+        return dict(EditActionType.CHOICES).get(self.action_type, _("Unknown action"))
+
+    @property
+    def action_detail(self):
+        """
+        Returns a human-readable detail of the action.
+        To be read as {{ action_title }} {{ action_detail }}
+        """
+        if self.action_type == EditActionType.REPLACE:
+            return _('value with "{replace_string}".').format(
+                replace_string=self.replace_string,
+            )
+        elif self.action_type == EditActionType.FIND_REPLACE:
+            return _('"{find_string}" with "{replace_string}"{use_regex}.').format(
+                find_string=self.find_string,
+                replace_string=self.replace_string,
+                use_regex=_(" (using regex)") if self.use_regex else "",
+            )
+        elif self.action_type == EditActionType.COPY_REPLACE:
+            return _('from case property "{copy_from_prop_id}".').format(
+                copy_from_prop_id=self.copy_from_prop_id,
+            )
+        return ""
+
+    @property
+    def num_records(self):
+        return self.records.count()
+
     def edited_value(self, case, edited_properties=None):
         """
         Note: `BulkEditChange`s can be chained/layered. In order to properly chain

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/undo_changes.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/undo_changes.html
@@ -5,4 +5,30 @@
     The following edit will be undone:
   {% endblocktrans %}
 </p>
-{# todo list most recent edit #}
+{% if change %}
+  <div class="list-group">
+    <div class="list-group-item d-flex align-items-center">
+      <div
+        x-tooltip=""
+        data-bs-title="{% trans "the case property that was changed" %}"
+      >
+        <strong class="badge text-bg-secondary fs-6">
+          {{ change.prop_id }}
+        </strong>
+      </div>
+      <div class="flex-fill mx-2">
+        <strong>{{ change.action_title }}</strong>
+        {{ change.action_detail }}
+      </div>
+      <div
+        x-tooltip=""
+        data-bs-title="{% trans "number of records affected" %}"
+      >
+        {% blocktrans %}{{ change.num_records }}{% endblocktrans %}
+        <span class="badge text-bg-primary rounded-pill fs-6">
+          {{ change.num_records }}
+        </span>
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/corehq/apps/data_cleaning/views/summary.py
+++ b/corehq/apps/data_cleaning/views/summary.py
@@ -30,7 +30,9 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
         return self.render_htmx_partial_response(
             request,
             "data_cleaning/summary/undo_changes.html",
-            {},
+            {
+                "change": self.session.changes.last(),
+            },
         )
 
     @hq_hx_action('post')


### PR DESCRIPTION
## Product Description
This updates the "undo summary" to actually display the last change that will be undone when the confirmation modal shows.

Some screenshots
![Screenshot 2025-04-29 at 6 54 36 PM](https://github.com/user-attachments/assets/dd82538e-776b-4909-8103-88ffde7db0e9)
![Screenshot 2025-04-29 at 6 59 39 PM](https://github.com/user-attachments/assets/50b91877-0000-4c16-af34-13d8ce545a2e)
![Screenshot 2025-04-29 at 6 58 43 PM](https://github.com/user-attachments/assets/711521f1-e2b9-4b7a-a5a7-7fdcb70d65d7)
![Screenshot 2025-04-29 at 6 56 08 PM](https://github.com/user-attachments/assets/13168706-8140-454c-9236-b9312f615c77)
![Screenshot 2025-04-29 at 6 55 16 PM](https://github.com/user-attachments/assets/e9065a8c-887a-4eb5-abb7-f7375c874dd5)
![Screenshot 2025-04-29 at 6 54 44 PM](https://github.com/user-attachments/assets/4526bb2c-b619-4f83-a7e5-bb726513de23)
![Screenshot 2025-04-29 at 6 54 40 PM](https://github.com/user-attachments/assets/3d222471-55b7-4665-ab28-7c237ba7d48b)


## Technical Summary
adds some properties to `BulkEditChange` that can be accessed from the template.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change, only affects feature flagged ui

### Automated test coverage
most important logic is already tested

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
