### PR TITLE
Make v2 Locations API filterable

### DIFF
--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -30,6 +30,7 @@ class LocationResource(v0_5.LocationResource):
         max_limit = 5000
         queryset = SQLLocation.active_objects.all()
         detail_uri_name = 'location_id'
+        ordering = ['last_modified']
         authentication = RequirePermissionAuthentication(HqPermissions.edit_locations)
         list_allowed_methods = ['get', 'post', 'patch']
         detail_allowed_methods = ['get', 'put']

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -48,6 +48,7 @@ class LocationResource(v0_5.LocationResource):
         }
         filtering = {
             "domain": ['exact'],
+            'name': ['exact'],
             'site_code': ['exact'],
             'last_modified': ['gt', 'gte', 'lt', 'lte'],
         }

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -52,10 +52,19 @@ class LocationResource(v0_5.LocationResource):
         }
 
     def build_filters(self, filters=None, **kwargs):
-        if filters:
-            # Turn last_modified.gte to last_modified__gte
-            filters = {'__'.join(k.split('.')): v for k, v in filters.items()}
-        return super().build_filters(filters, **kwargs)
+        if not filters:
+            return {}
+
+        orm_filters = {}
+        if code := filters.get('location_type_code', None):
+            orm_filters['location_type__code'] = code
+
+        # Turn last_modified.gte to last_modified__gte
+        filters = {'__'.join(k.split('.')): v for k, v in filters.items()}
+        return {
+            **super().build_filters(filters, **kwargs),
+            **orm_filters,
+        }
 
     def dehydrate(self, bundle):
         if bundle.obj.parent:

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -57,14 +57,14 @@ class LocationResource(v0_5.LocationResource):
         if not filters:
             return {}
 
-        orm_filters = {}
-        if code := filters.get('location_type_code', None):
-            orm_filters['location_type__code'] = code
-        if parent_id := filters.get('parent_location_id', None):
-            orm_filters['parent__location_id'] = parent_id
-
         # Turn last_modified.gte to last_modified__gte
         filters = {'__'.join(k.split('.')): v for k, v in filters.items()}
+        orm_filters = {}
+        if code := filters.pop('location_type_code', None):
+            orm_filters['location_type__code'] = code
+        if parent_id := filters.pop('parent_location_id', None):
+            orm_filters['parent__location_id'] = parent_id
+
         return {
             **super().build_filters(filters, **kwargs),
             **orm_filters,

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -54,16 +54,14 @@ class LocationResource(v0_5.LocationResource):
         }
 
     def build_filters(self, filters=None, **kwargs):
-        if not filters:
-            return {}
-
-        # Turn last_modified.gte to last_modified__gte
-        filters = {'__'.join(k.split('.')): v for k, v in filters.items()}
         orm_filters = {}
-        if code := filters.pop('location_type_code', None):
-            orm_filters['location_type__code'] = code
-        if parent_id := filters.pop('parent_location_id', None):
-            orm_filters['parent__location_id'] = parent_id
+        if filters:
+            # Turn last_modified.gte to last_modified__gte
+            filters = {'__'.join(k.split('.')): v for k, v in filters.items()}
+            if code := filters.pop('location_type_code', None):
+                orm_filters['location_type__code'] = code
+            if parent_id := filters.pop('parent_location_id', None):
+                orm_filters['parent__location_id'] = parent_id
 
         return {
             **super().build_filters(filters, **kwargs),

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -46,8 +46,16 @@ class LocationResource(v0_5.LocationResource):
             'location_data',
         }
         filtering = {
-            "domain": ('exact',),
+            "domain": ['exact'],
+            'site_code': ['exact'],
+            'last_modified': ['gt', 'gte', 'lt', 'lte'],
         }
+
+    def build_filters(self, filters=None, **kwargs):
+        if filters:
+            # Turn last_modified.gte to last_modified__gte
+            filters = {'__'.join(k.split('.')): v for k, v in filters.items()}
+        return super().build_filters(filters, **kwargs)
 
     def dehydrate(self, bundle):
         if bundle.obj.parent:

--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -58,6 +58,8 @@ class LocationResource(v0_5.LocationResource):
         orm_filters = {}
         if code := filters.get('location_type_code', None):
             orm_filters['location_type__code'] = code
+        if parent_id := filters.get('parent_location_id', None):
+            orm_filters['parent__location_id'] = parent_id
 
         # Turn last_modified.gte to last_modified__gte
         filters = {'__'.join(k.split('.')): v for k, v in filters.items()}

--- a/corehq/apps/locations/tests/test_api_resources.py
+++ b/corehq/apps/locations/tests/test_api_resources.py
@@ -470,19 +470,21 @@ class TestV0_6LocationsList(APIResourceTest):
             cls.locations['Cambridge'].save()
 
     @generate_cases([
-        ('site_code=boston', ['boston']),
-        ('last_modified.gte=2025-03-31', ['boston', 'cambridge']),
+        ('name=boston', []),
+        ('name=Boston', ['Boston']),
+        ('site_code=boston', ['Boston']),
+        ('last_modified.gte=2025-03-31', ['Boston', 'Cambridge']),
         ('last_modified.gte=2020-01-01&last_modified.lt=2025-03-31', [
-            'massachusetts', 'middlesex', 'somerville', 'suffolk',
+            'Massachusetts', 'Middlesex', 'Somerville', 'Suffolk',
         ]),
         ('last_modified.gt=2025-03-31&last_modified.lte=2025-03-30', []),
-        ('location_type_code=county', ['middlesex', 'suffolk']),
-        ('parent_location_id=middlesex_uuid', ['cambridge', 'somerville']),
+        ('location_type_code=county', ['Middlesex', 'Suffolk']),
+        ('parent_location_id=middlesex_uuid', ['Cambridge', 'Somerville']),
     ])
     def test_api_filters(self, querystring, expected):
         url = f"{self.list_endpoint}?{querystring}"
         response = self._assert_auth_get_resource(url)
         self.assertEqual(response.status_code, 200)
         self.assertItemsEqual([
-            loc['site_code'] for loc in response.json()['objects']
+            loc['name'] for loc in response.json()['objects']
         ], expected)

--- a/corehq/apps/locations/tests/test_api_resources.py
+++ b/corehq/apps/locations/tests/test_api_resources.py
@@ -442,6 +442,8 @@ class TestV0_6LocationsList(APIResourceTest):
                 [],
                 cls.location_structure,
             )
+            cls.locations['Middlesex'].location_id = 'middlesex_uuid'
+            cls.locations['Middlesex'].save()
 
         with freeze_time(datetime(2025, 4, 1)):
             cls.locations['Boston'].save()
@@ -455,6 +457,7 @@ class TestV0_6LocationsList(APIResourceTest):
         ]),
         ('last_modified.gt=2025-03-31&last_modified.lte=2025-03-30', []),
         ('location_type_code=county', ['middlesex', 'suffolk']),
+        ('parent_location_id=middlesex_uuid', ['cambridge', 'somerville']),
     ])
     def test_api_filters(self, querystring, expected):
         url = f"{self.list_endpoint}?{querystring}"

--- a/corehq/apps/locations/tests/test_api_resources.py
+++ b/corehq/apps/locations/tests/test_api_resources.py
@@ -7,7 +7,7 @@ from corehq.apps.locations.models import LocationType, SQLLocation
 from corehq.apps.locations.resources import v0_5, v0_6
 from corehq.util.test_utils import generate_cases
 
-from .util import LocationHierarchyTestCase, setup_locations_and_types
+from .util import setup_locations_and_types
 
 
 class LocationTypeV0_5Test(APIResourceTest):

--- a/corehq/apps/locations/tests/test_api_resources.py
+++ b/corehq/apps/locations/tests/test_api_resources.py
@@ -415,6 +415,26 @@ class LocationV0_6Test(APIResourceTest):
                          {'error': "Could not update: could not find location with"
                                    f" given ID {unknown_location_id} on the domain."})
 
+    def test_ordering(self):
+
+        def assert_ordering(url, expected):
+            response = self._assert_auth_get_resource(url)
+            self.assertEqual([
+                loc['site_code'] for loc in response.json()['objects']
+            ], expected)
+
+        assert_ordering(f"{self.list_endpoint}?order_by=last_modified", [
+            'colorado', 'denver', 'south_park',
+        ])
+        assert_ordering(f"{self.list_endpoint}?order_by=-last_modified", [
+            'south_park', 'denver', 'colorado',
+        ])
+
+        self.location1.save()  # touch colorado so it comes last
+        assert_ordering(f"{self.list_endpoint}?order_by=last_modified", [
+            'denver', 'south_park', 'colorado',
+        ])
+
 
 class TestV0_6LocationsList(APIResourceTest):
     api_name = 'v0.6'

--- a/corehq/apps/locations/tests/test_api_resources.py
+++ b/corehq/apps/locations/tests/test_api_resources.py
@@ -1,8 +1,13 @@
+from datetime import datetime
+
+from freezegun import freeze_time
+
 from corehq.apps.api.tests.utils import APIResourceTest
 from corehq.apps.locations.models import LocationType, SQLLocation
 from corehq.apps.locations.resources import v0_5, v0_6
+from corehq.util.test_utils import generate_cases
 
-from .util import setup_locations_and_types
+from .util import LocationHierarchyTestCase, setup_locations_and_types
 
 
 class LocationTypeV0_5Test(APIResourceTest):
@@ -409,3 +414,51 @@ class LocationV0_6Test(APIResourceTest):
         self.assertEqual(response.json(),
                          {'error': "Could not update: could not find location with"
                                    f" given ID {unknown_location_id} on the domain."})
+
+
+class TestV0_6LocationsList(APIResourceTest):
+    api_name = 'v0.6'
+    resource = v0_6.LocationResource
+    location_type_names = ['state', 'county', 'city']
+    location_structure = [
+        ('Massachusetts', [
+            ('Middlesex', [
+                ('Cambridge', []),
+                ('Somerville', []),
+            ]),
+            ('Suffolk', [
+                ('Boston', []),
+            ])
+        ])
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        with freeze_time(datetime(2025, 1, 1)):
+            cls.location_types, cls.locations = setup_locations_and_types(
+                cls.domain.name,
+                cls.location_type_names,
+                [],
+                cls.location_structure,
+            )
+
+        with freeze_time(datetime(2025, 4, 1)):
+            cls.locations['Boston'].save()
+            cls.locations['Cambridge'].save()
+
+    @generate_cases([
+        ('site_code=boston', ['boston']),
+        ('last_modified.gte=2025-03-31', ['boston', 'cambridge']),
+        ('last_modified.gte=2020-01-01&last_modified.lt=2025-03-31', [
+            'massachusetts', 'middlesex', 'somerville', 'suffolk',
+        ]),
+        ('last_modified.gt=2025-03-31&last_modified.lte=2025-03-30', []),
+    ])
+    def test_api_filters(self, querystring, expected):
+        url = f"{self.list_endpoint}?{querystring}"
+        response = self._assert_auth_get_resource(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertItemsEqual([
+            loc['site_code'] for loc in response.json()['objects']
+        ], expected)

--- a/corehq/apps/locations/tests/test_api_resources.py
+++ b/corehq/apps/locations/tests/test_api_resources.py
@@ -454,6 +454,7 @@ class TestV0_6LocationsList(APIResourceTest):
             'massachusetts', 'middlesex', 'somerville', 'suffolk',
         ]),
         ('last_modified.gt=2025-03-31&last_modified.lte=2025-03-30', []),
+        ('location_type_code=county', ['middlesex', 'suffolk']),
     ])
     def test_api_filters(self, querystring, expected):
         url = f"{self.list_endpoint}?{querystring}"

--- a/docs/api/locations.rst
+++ b/docs/api/locations.rst
@@ -66,6 +66,12 @@ Locations can be filtered by the following attributes as request parameters:
      - Locations last modified on or before a specific date or datetime
      - ``?last_modified.lte=2024-01-01``
 
+v2 can also be ordered by ``last_modified`` from oldest to newest with the
+parameter ``order_by=last_modified``, or from newest to oldest with
+``order_by=-last_modified``. This can be used in conjunction with the
+``last_modified.gte`` parameter to only fetch locations modified since your last
+data pull.
+
 
 **Sample JSON Output (v1)**
 

--- a/docs/api/locations.rst
+++ b/docs/api/locations.rst
@@ -47,6 +47,9 @@ Locations can be filtered by the following attributes as request parameters:
    * - ``site_code``
      - Site code for the location
      - ``?site_code=boston``
+   * - ``name``
+     - The location's name (case sensitive)
+     - ``?name=Boston``
    * - ``location_type_code``
      - The location's type code
      - ``?location_type_code=city``

--- a/docs/api/locations.rst
+++ b/docs/api/locations.rst
@@ -89,6 +89,9 @@ Locations can be filtered by the following attributes as request parameters:
    * - ``location_type_code``
      - The location's type code
      - ``?location_type_code=city``
+   * - ``parent_location_id``
+     - The UUID of the location's direct parent
+     - ``?parent_location_id=5ce87caa-a739-4a61-a0cb-559f84a9b4b7``
    * - ``last_modified.gte``
      - Locations last modified on or after a specific date or datetime
      - ``?last_modified.gte=2024-01-01``

--- a/docs/api/locations.rst
+++ b/docs/api/locations.rst
@@ -86,6 +86,9 @@ Locations can be filtered by the following attributes as request parameters:
    * - ``site_code``
      - Site code for the location
      - ``?site_code=boston``
+   * - ``location_type_code``
+     - The location's type code
+     - ``?location_type_code=city``
    * - ``last_modified.gte``
      - Locations last modified on or after a specific date or datetime
      - ``?last_modified.gte=2024-01-01``

--- a/docs/api/locations.rst
+++ b/docs/api/locations.rst
@@ -70,10 +70,34 @@ Locations can be filtered by the following attributes as request parameters:
 
 **v2**
 
-The main distinctions between the v1 and v2 GET endpoints are that v2:
+The main distinction between the v1 and v2 GET endpoints is the serialization
+format. V2 Removes a few defunct fields and adds some new ones. It also provides
+IDs and/or codes of related locations and types, while v1 gave URLs that could
+be used to access those types.
 
-- Removes a few fields and adds a few fields from the response (there is no ``external_id`` with v2, for example, but there is ``parent_location_id``).
-- Currently does not allow filtering on the list endpoint.
+Locations can be filtered by the following attributes as request parameters:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Description
+     - Example
+   * - ``site_code``
+     - Site code for the location
+     - ``?site_code=boston``
+   * - ``last_modified.gte``
+     - Locations last modified on or after a specific date or datetime
+     - ``?last_modified.gte=2024-01-01``
+   * - ``last_modified.gt``
+     - Locations last modified after a specific date or datetime
+     - ``?last_modified.gt=2024-01-01``
+   * - ``last_modified.lt``
+     - Locations last modified before a specific date or datetime
+     - ``?last_modified.lt=2024-01-01``
+   * - ``last_modified.lte``
+     - Locations last modified on or before a specific date or datetime
+     - ``?last_modified.lte=2024-01-01``
 
 For the list endpoint, the "meta" section will look the same and the locations will still be in a list called "objects". But an individual location object will look like:
 

--- a/docs/api/locations.rst
+++ b/docs/api/locations.rst
@@ -14,9 +14,9 @@ List Locations
 
     GET https://www.commcarehq.org/a/[domain]/api/location/v1/
 
-**Input Parameters (v1)**
-
 Locations can be filtered by the following attributes as request parameters:
+
+**Input Parameters (v1)**
 
 .. list-table::
    :header-rows: 1
@@ -35,6 +35,37 @@ Locations can be filtered by the following attributes as request parameters:
      - Latitude coordinate of the location
    * - ``longitude``
      - Longitude coordinate of the location
+
+**Input Parameters (v2)**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Description
+     - Example
+   * - ``site_code``
+     - Site code for the location
+     - ``?site_code=boston``
+   * - ``location_type_code``
+     - The location's type code
+     - ``?location_type_code=city``
+   * - ``parent_location_id``
+     - The UUID of the location's direct parent
+     - ``?parent_location_id=5ce87caa-a739-4a61-a0cb-559f84a9b4b7``
+   * - ``last_modified.gte``
+     - Locations last modified on or after a specific date or datetime
+     - ``?last_modified.gte=2024-01-01``
+   * - ``last_modified.gt``
+     - Locations last modified after a specific date or datetime
+     - ``?last_modified.gt=2024-01-01``
+   * - ``last_modified.lt``
+     - Locations last modified before a specific date or datetime
+     - ``?last_modified.lt=2024-01-01``
+   * - ``last_modified.lte``
+     - Locations last modified on or before a specific date or datetime
+     - ``?last_modified.lte=2024-01-01``
+
 
 **Sample JSON Output (v1)**
 
@@ -74,36 +105,6 @@ The main distinction between the v1 and v2 GET endpoints is the serialization
 format. V2 Removes a few defunct fields and adds some new ones. It also provides
 IDs and/or codes of related locations and types, while v1 gave URLs that could
 be used to access those types.
-
-Locations can be filtered by the following attributes as request parameters:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Name
-     - Description
-     - Example
-   * - ``site_code``
-     - Site code for the location
-     - ``?site_code=boston``
-   * - ``location_type_code``
-     - The location's type code
-     - ``?location_type_code=city``
-   * - ``parent_location_id``
-     - The UUID of the location's direct parent
-     - ``?parent_location_id=5ce87caa-a739-4a61-a0cb-559f84a9b4b7``
-   * - ``last_modified.gte``
-     - Locations last modified on or after a specific date or datetime
-     - ``?last_modified.gte=2024-01-01``
-   * - ``last_modified.gt``
-     - Locations last modified after a specific date or datetime
-     - ``?last_modified.gt=2024-01-01``
-   * - ``last_modified.lt``
-     - Locations last modified before a specific date or datetime
-     - ``?last_modified.lt=2024-01-01``
-   * - ``last_modified.lte``
-     - Locations last modified on or before a specific date or datetime
-     - ``?last_modified.lte=2024-01-01``
 
 For the list endpoint, the "meta" section will look the same and the locations will still be in a list called "objects". But an individual location object will look like:
 


### PR DESCRIPTION
## Product Description
Make the v2 locations API filterable by:

* site_code
* parent_location_id
* last_modified
* location_type_code

Docs included with some more detail

## Technical Summary
https://dimagi.atlassian.net/browse/USH-2363

## Feature Flag


## Safety Assurance


### Safety story

I added tests for all the changes I made.  This is currently on staging, where I've manually played with the parameters.


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change