### PR TITLE
[Data Cleaning] Implement "clear" functionality

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -349,6 +349,12 @@ class BulkEditSession(models.Model):
         self.changes.last().delete()
         self.purge_records()
 
+    @retry_on_integrity_error(max_retries=3, delay=0.1)
+    @transaction.atomic
+    def clear_all_changes(self):
+        self.changes.all().delete()
+        self.purge_records()
+
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)
 

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -137,7 +137,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
 
     @hq_hx_action("post")
     def clear_all_changes(self, request, *args, **kwargs):
-        # todo: this is a placeholder
+        self.session.clear_all_changes()
         return self.get(request, *args, **kwargs)
 
     def _render_table_cell_response(self, doc_id, column, request, *args, **kwargs):


### PR DESCRIPTION
## Technical Summary
This PR is a quick one: implementing the "clear" functionality to clear all changes in the session after the user hits "clear" and confirms in the modal.

This PR does not introduce the UI updates to the "clear" modal—that will be a separate PR.

for reference, here is the clear button in the "edit" toolbar
<img width="334" alt="Screenshot 2025-04-24 at 12 29 08 PM" src="https://github.com/user-attachments/assets/37935b79-f507-4894-9eeb-58cd172856a1" />


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change, only applies to a feature flagged workflow that will eventually be QAd before release

### Automated test coverage
most important functionality is tested, but I will be introducing tests for this action once the core feature is in QA

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
