### PR TITLE
[Data Cleaning] Update the UI for the "clear" confirmation modal

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/modals/base_confirm.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/modals/base_confirm.html
@@ -8,7 +8,7 @@
   aria-hidden="true"
   data-bs-backdrop="static"
 >
-  <div class="modal-dialog" role="document">
+  <div class="modal-dialog modal-dialog-scrollable" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h4 id="{{ modal_id }}-label" class="modal-title">

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/clear_changes.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/clear_changes.html
@@ -1,8 +1,48 @@
 {% load i18n %}
 
-<p class="lead">
-  {% blocktrans %}
-    The following edits will be cleared:
-  {% endblocktrans %}
-</p>
-{# todo list summary of all session changes #}
+{% if changes %}
+  <p class="lead">
+    {# prettier-ignore-start #}
+    {% blocktrans count count=num_changes %}
+      One edit will be cleared.
+    {% plural %}
+      A total of {{ num_changes }} edits will be cleared.
+    {% endblocktrans %}
+    {# prettier-ignore-end #}
+  </p>
+  <div id="clear-changes-accordion-group" class="accordion">
+    <div class="accordion-item">
+      <h2 class="accordion-header">
+        <button
+          class="accordion-button collapsed"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#clear-changes-details"
+          aria-expanded="false"
+          aria-controls="clear-changes-details"
+        >
+          {% trans "Show edit history" %}
+        </button>
+      </h2>
+      <div
+        id="clear-changes-details"
+        class="accordion-collapse collapse"
+        data-bs-parent="#clear-changes-accordion-group"
+      >
+        <div class="accordion-body">
+          <div class="list-group list-group-flush">
+            {% for change in changes %}
+              {% include "data_cleaning/summary/partial/change_detail.html" with change=change %}
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% else %}
+  <p class="lead">
+    {% blocktrans %}
+      The following edits will be cleared...
+    {% endblocktrans %}
+  </p>
+{% endif %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/partial/change_detail.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/partial/change_detail.html
@@ -1,0 +1,25 @@
+{% load i18n %}
+
+<div class="list-group-item d-flex align-items-center">
+  <div
+    x-tooltip=""
+    data-bs-title="{% trans "the case property that was changed" %}"
+  >
+    <strong class="badge text-bg-secondary fs-6">
+      {{ change.prop_id }}
+    </strong>
+  </div>
+  <div class="flex-fill mx-2">
+    <strong>{{ change.action_title }}</strong>
+    {{ change.action_detail }}
+  </div>
+  <div
+    x-tooltip=""
+    data-bs-title="{% trans "number of records affected" %}"
+  >
+    {% blocktrans %}{{ change.num_records }}{% endblocktrans %}
+    <span class="badge text-bg-primary rounded-pill fs-6">
+      {{ change.num_records }}
+    </span>
+  </div>
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/undo_changes.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/undo_changes.html
@@ -7,28 +7,6 @@
 </p>
 {% if change %}
   <div class="list-group">
-    <div class="list-group-item d-flex align-items-center">
-      <div
-        x-tooltip=""
-        data-bs-title="{% trans "the case property that was changed" %}"
-      >
-        <strong class="badge text-bg-secondary fs-6">
-          {{ change.prop_id }}
-        </strong>
-      </div>
-      <div class="flex-fill mx-2">
-        <strong>{{ change.action_title }}</strong>
-        {{ change.action_detail }}
-      </div>
-      <div
-        x-tooltip=""
-        data-bs-title="{% trans "number of records affected" %}"
-      >
-        {% blocktrans %}{{ change.num_records }}{% endblocktrans %}
-        <span class="badge text-bg-primary rounded-pill fs-6">
-          {{ change.num_records }}
-        </span>
-      </div>
-    </div>
+    {% include "data_cleaning/summary/partial/change_detail.html" with change=change %}
   </div>
 {% endif %}

--- a/corehq/apps/data_cleaning/views/summary.py
+++ b/corehq/apps/data_cleaning/views/summary.py
@@ -36,11 +36,13 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
 
     @hq_hx_action('post')
     def clear_changes_summary(self, request, *args, **kwargs):
-        # todo: render summary context
         return self.render_htmx_partial_response(
             request,
             "data_cleaning/summary/clear_changes.html",
-            {},
+            {
+                "changes": self.session.changes.all(),
+                "num_changes": self.session.get_num_changes(),
+            },
         )
 
     @hq_hx_action('post')

--- a/corehq/apps/data_cleaning/views/summary.py
+++ b/corehq/apps/data_cleaning/views/summary.py
@@ -26,7 +26,6 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
 
     @hq_hx_action('post')
     def undo_changes_summary(self, request, *args, **kwargs):
-        # todo: render summary context
         return self.render_htmx_partial_response(
             request,
             "data_cleaning/summary/undo_changes.html",


### PR DESCRIPTION
## Product Description
This PR updates the UI for the "clear" confirmation modal that pops up when the user hits "clear" in the edits bar
<img width="334" alt="Screenshot 2025-04-24 at 12 29 08 PM" src="https://github.com/user-attachments/assets/cc3dc9c2-3a2f-4e12-96ba-4a32d04770ca" />

Here is what the modal looks like without the "show edit history" accordion open
![Screenshot 2025-04-30 at 12 10 53 PM](https://github.com/user-attachments/assets/b59b2b49-d950-4682-acfe-2540f5be1411)

Here is what the modal looks like with the "show edit history" accordion open
![Screenshot 2025-04-30 at 12 11 03 PM](https://github.com/user-attachments/assets/3a801945-81b6-4643-b886-f3373d96ad62)

Here is what the modal looks like with a long edit history
![Screenshot 2025-04-30 at 12 13 21 PM](https://github.com/user-attachments/assets/cffdc02e-2431-43f7-b1ea-a79b467c64c9)


## Technical Summary
- ensures the confirmation modals for data cleaning scroll when the content is long, so that the modal actions are always visible at the bottom

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
just a small UI update to a feature flagged ui

### Automated test coverage
not for this part, but most important logic is tested

### QA Plan
not yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
