### PR TITLE
Upgrade to cffi==1.17.1

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -68,7 +68,7 @@ certifi==2025.1.31
     # via
     #   requests
     #   sentry-sdk
-cffi==1.14.3
+cffi==1.17.1
     # via
     #   cryptography
     #   csiphash

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -62,7 +62,7 @@ certifi==2025.1.31
     # via
     #   requests
     #   sentry-sdk
-cffi==1.14.3
+cffi==1.17.1
     # via
     #   cryptography
     #   csiphash

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -64,7 +64,7 @@ certifi==2025.1.31
     #   -r prod-requirements.in
     #   requests
     #   sentry-sdk
-cffi==1.14.3
+cffi==1.17.1
     # via
     #   cryptography
     #   csiphash

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -58,7 +58,7 @@ certifi==2025.1.31
     # via
     #   requests
     #   sentry-sdk
-cffi==1.14.3
+cffi==1.17.1
     # via
     #   cryptography
     #   csiphash

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -60,7 +60,7 @@ certifi==2025.1.31
     # via
     #   requests
     #   sentry-sdk
-cffi==1.14.3
+cffi==1.17.1
     # via
     #   cryptography
     #   csiphash


### PR DESCRIPTION
Minor version bump for better Python 3.13 compatibility. Reviewed [release notes](https://cffi.readthedocs.io/en/stable/whatsnew.html) and [recent issues](https://github.com/python-cffi/cffi/issues). The new version provides wheels for Python 3.13 (and older supported Pythons).

## Safety Assurance

### Safety story

`cffi` is a dependency of `cryptography` and `csiphash`, not used directly by HQ code.

### Automated test coverage

We have SSO tests and test utilities that use `cryptography` to generate X509 certificates. These tests use `cffi` indirectly.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations