### PR TITLE
[Data Cleaning] "apply" changes functionality

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -1,6 +1,9 @@
 import re
 import uuid
 
+from celery import uuid as celery_uuid
+from datetime import datetime, timezone
+
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.db import models, transaction
@@ -354,6 +357,15 @@ class BulkEditSession(models.Model):
     def clear_all_changes(self):
         self.changes.all().delete()
         self.purge_records()
+
+    def prepare_session_for_commit(self):
+        """
+        Prepare the session for commit by generating a task id
+        and setting the committed_on date.
+        """
+        self.task_id = celery_uuid()
+        self.committed_on = datetime.now(timezone.utc).replace(tzinfo=None)
+        self.save()
 
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)

--- a/corehq/apps/data_cleaning/views/setup.py
+++ b/corehq/apps/data_cleaning/views/setup.py
@@ -1,4 +1,3 @@
-from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
@@ -80,8 +79,7 @@ class SetupCaseSessionFormView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActio
 
     def render_session_redirect(self, session):
         from corehq.apps.data_cleaning.views.main import CleanCasesSessionView
-        response = HttpResponse(_("Starting Data Cleaning Session..."))
-        response['HX-Redirect'] = reverse(
-            CleanCasesSessionView.urlname, args=(self.domain, session.session_id, )
+        return self.render_htmx_redirect(
+            reverse(CleanCasesSessionView.urlname, args=(self.domain, session.session_id, )),
+            response_message=_("Starting Data Cleaning Session...")
         )
-        return response

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -1,7 +1,10 @@
 import json
 
+from django.contrib import messages
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.translation import gettext as _
+
 from corehq.apps.data_cleaning.columns import DataCleaningHtmxColumn
 from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
 from corehq.apps.data_cleaning.models import BulkEditSession
@@ -9,6 +12,8 @@ from corehq.apps.data_cleaning.tables import (
     CleanCaseTable,
     CaseCleaningTasksTable,
 )
+from corehq.apps.data_cleaning.tasks import commit_data_cleaning
+from corehq.apps.data_cleaning.views.main import CleanCasesMainView
 from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
 from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.domain.views import DomainViewMixin
@@ -127,8 +132,18 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
 
     @hq_hx_action("post")
     def apply_all_changes(self, request, *args, **kwargs):
-        # todo: this is a placeholder
-        return self.get(request, *args, **kwargs)
+        self.session.prepare_session_for_commit()
+        commit_data_cleaning.apply_async(
+            args=(self.session.session_id,),
+            task_id=self.session.task_id
+        )
+        messages.success(
+            request,
+            _("Changes applied. Check the Recent Tasks table for progress.")
+        )
+        return self.render_htmx_redirect(
+            reverse(CleanCasesMainView.urlname, args=(self.domain,)),
+        )
 
     @hq_hx_action("post")
     def undo_last_change(self, request, *args, **kwargs):

--- a/corehq/util/htmx_action.py
+++ b/corehq/util/htmx_action.py
@@ -75,6 +75,11 @@ class HqHtmxActionMixin:
         """
         return self.default_htmx_error_template
 
+    def render_htmx_redirect(self, url, response_message=None):
+        response = HttpResponse(response_message or "")
+        response['HX-Redirect'] = url
+        return response
+
     def render_htmx_no_response(self, request, *args, **kwargs):
         """
         Return this when the HTMX triggering element uses


### PR DESCRIPTION
## Technical Summary
This PR actually implements the functionality for applying all changes. This is the action taken when the user hits "apply" and then confirms that action on the apply confirmation modal (ui for that modal is a separate PR)
<img width="334" alt="Screenshot 2025-04-24 at 12 29 08 PM" src="https://github.com/user-attachments/assets/d64d0a09-bae3-4b8c-8cd8-74091b94aeb7" />

This also adds a `render_htmx_redirect` option to `HqHtmxActionMixin` to make setting up an HTMX redirect more straightforward when using that mixin. I've updated the other usage of the `HX-Redirect` header in `SetupCaseSessionFormView`

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change, only affects feature flagged code.

### Automated test coverage
yes, most important parts are tested

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
