### PR TITLE
[Data Cleaning] Complete the UI for the "apply" confirmation modal

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/apply_changes.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/apply_changes.html
@@ -1,8 +1,20 @@
 {% load i18n %}
 
-<p class="lead">
-  {% blocktrans %}
-    The following edits will be applied:
-  {% endblocktrans %}
-</p>
-{# todo list summary of all session changes #}
+{% if changes %}
+  <p class="lead">
+    {# prettier-ignore-start #}
+    {% blocktrans count count=num_changes %}
+      One edit will be applied.
+    {% plural %}
+      A total of {{ num_changes }} edits will be applied.
+    {% endblocktrans %}
+    {# prettier-ignore-end #}
+  </p>
+  {% include "data_cleaning/summary/partial/change_history.html" with changes=changes group_id="apply-changes-accordion-group" accordion_id="apply-changes-details" %}
+{% else %}
+  <p class="lead">
+    {% blocktrans %}
+      The following edits will be applied...
+    {% endblocktrans %}
+  </p>
+{% endif %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/clear_changes.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/clear_changes.html
@@ -10,35 +10,7 @@
     {% endblocktrans %}
     {# prettier-ignore-end #}
   </p>
-  <div id="clear-changes-accordion-group" class="accordion">
-    <div class="accordion-item">
-      <h2 class="accordion-header">
-        <button
-          class="accordion-button collapsed"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#clear-changes-details"
-          aria-expanded="false"
-          aria-controls="clear-changes-details"
-        >
-          {% trans "Show edit history" %}
-        </button>
-      </h2>
-      <div
-        id="clear-changes-details"
-        class="accordion-collapse collapse"
-        data-bs-parent="#clear-changes-accordion-group"
-      >
-        <div class="accordion-body">
-          <div class="list-group list-group-flush">
-            {% for change in changes %}
-              {% include "data_cleaning/summary/partial/change_detail.html" with change=change %}
-            {% endfor %}
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+  {% include "data_cleaning/summary/partial/change_history.html" with changes=changes group_id="clear-changes-accordion-group" accordion_id="clear-changes-details" %}
 {% else %}
   <p class="lead">
     {% blocktrans %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/partial/change_detail.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/partial/change_detail.html
@@ -15,7 +15,7 @@
   </div>
   <div
     x-tooltip=""
-    data-bs-title="{% trans "number of records affected" %}"
+    data-bs-title="{% trans "number of cases affected" %}"
   >
     {% blocktrans %}{{ change.num_records }}{% endblocktrans %}
     <span class="badge text-bg-primary rounded-pill fs-6">

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/partial/change_history.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/partial/change_history.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+
+<div id="{{ group_id }}" class="accordion">
+  <div class="accordion-item">
+    <h2 class="accordion-header">
+      <button
+        class="accordion-button collapsed"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#{{ accordion_id }}"
+        aria-expanded="false"
+        aria-controls="{{ accordion_id }}"
+      >
+        {% trans "Show edit history" %}
+      </button>
+    </h2>
+    <div
+      id="{{ accordion_id }}"
+      class="accordion-collapse collapse"
+      data-bs-parent="#{{ group_id }}"
+    >
+      <div class="accordion-body">
+        <div class="list-group list-group-flush">
+          {% for change in changes %}
+            {% include "data_cleaning/summary/partial/change_detail.html" with change=change %}
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/corehq/apps/data_cleaning/views/summary.py
+++ b/corehq/apps/data_cleaning/views/summary.py
@@ -47,9 +47,11 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
 
     @hq_hx_action('post')
     def apply_changes_summary(self, request, *args, **kwargs):
-        # todo: render summary context
         return self.render_htmx_partial_response(
             request,
             "data_cleaning/summary/apply_changes.html",
-            {},
+            {
+                "changes": self.session.changes.all(),
+                "num_changes": self.session.get_num_changes(),
+            },
         )


### PR DESCRIPTION
## Product Description
This updates the confirmation modal shown to the user when the click on "apply" in the edits toolbar:
<img width="334" alt="Screenshot 2025-04-24 at 12 29 08 PM" src="https://github.com/user-attachments/assets/836f2248-7eb4-4470-9a83-433ceeafc638" />

What the modal looks like when it pops up:
![Screenshot 2025-04-30 at 5 41 04 PM](https://github.com/user-attachments/assets/b844eaab-2712-4e2f-8146-1d1612b2fe7e)

after expanding "show edit history"
![Screenshot 2025-04-30 at 5 41 11 PM](https://github.com/user-attachments/assets/ec8e89e3-233b-4fe5-83dc-217a20c29dbf)


## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
very simple, quick UI change to a feature flagged part of the codebase

### Automated test coverage
the ui isn't tested, but the logic behind it will be

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
