### PR TITLE
Upgrade tar-fs subdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
         "mem": "^4.0.0",
         "minimist": "^1.2.6",
         "minimatch": "^3.0.5",
+        "mocha-headless-chrome/puppeteer/tar-fs": "^2.1.2",
         "moment-timezone": "^0.5.35",
         "qs": "^6.9.7",
         "set-value": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7623,10 +7623,10 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tar-fs@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
-  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+tar-fs@2.1.1, tar-fs@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.2.tgz#425f154f3404cb16cb8ff6e671d45ab2ed9596c5"
+  integrity sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"


### PR DESCRIPTION
Patch upgrade of a testing sub-depenedency.

https://dimagi.atlassian.net/browse/SAAS-17480

## Safety Assurance

### Safety story

Affects tests only.

### Automated test coverage

Unknown, but it does not matter because this is a test library dependency. HQ does not use it directly.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations