### PR TITLE
[Data Cleaning] remove unused save case session view

### DIFF
--- a/corehq/apps/data_cleaning/urls.py
+++ b/corehq/apps/data_cleaning/urls.py
@@ -16,7 +16,6 @@ from corehq.apps.data_cleaning.views.main import (
     CleanCasesSessionView,
     clear_session_caches,
     download_form_ids,
-    save_case_session,
 )
 from corehq.apps.data_cleaning.views.tables import (
     CleanCasesTableView,
@@ -46,6 +45,5 @@ urlpatterns = [
         name=CleanSelectedRecordsFormView.urlname),
     url(r'^session/(?P<session_id>[\w\-]+)/clear/$', clear_session_caches,
         name="data_cleaning_clear_session_caches"),
-    url(r'^cases/save/(?P<session_id>[\w\-]+)/$', save_case_session, name='save_case_session'),
     url(r'^form_ids/(?P<session_id>[\w\-]+)/$', download_form_ids, name='download_form_ids'),
 ]


### PR DESCRIPTION
## Technical Summary
Remove a view that was previously used for testing purposes. It's now no longer needed.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change, removes a view that is unused

### Automated test coverage
not this part

### QA Plan
not yet


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
