### PR TITLE
[Data Cleaning] Clean up commit task for BulkEditSessionView

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -308,6 +308,14 @@ class BulkEditSession(models.Model):
             selected_records = self.records.filter(is_selected=True)
             change.records.add(*selected_records)
 
+    @property
+    def num_changed_records(self):
+        if not self.committed_on:
+            raise RuntimeError(
+                "Session not committed yet. Please commit the session first or use get_change_counts()"
+            )
+        return self.result['record_count'] if self.completed_on else self.records.count()
+
     def get_change_counts(self):
         """
         Get the details of the number of records with changes, and the number

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -42,6 +42,9 @@ def commit_data_cleaning(bulk_edit_session_id):
     session.completed_on = datetime.now()
     session.save()
 
+    session.changes.all().delete()
+    session.records.all().delete()
+
     return form_ids
 
 

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -220,7 +220,7 @@ class CaseCleaningTasksTableView(BaseDataCleaningTableView):
             "committed_on": session.committed_on,
             "completed_on": session.completed_on,
             "case_type": session.identifier,
-            "case_count": session.records.count(),
+            "case_count": session.num_changed_records,
             "percent": session.percent_complete,
             "form_ids_url": reverse('download_form_ids', args=(session.domain, session.session_id)),
             "has_form_ids": bool(len(session.form_ids)),


### PR DESCRIPTION
## Technical Summary
This cleans up the `commit_data_cleaning` to purge related `BulkEditRecords` and `BulkEditChanges` from the session when done. This is due to the fact that a session could have as many as 100k `BulkEditRecords`, and it doesn't seem necessary to keep all those records around once the session has been committed. We could potentially keep a change history summary in a more condensed format elsewhere (like BulkEditSession's `result` `JSONField`)

In order to do this, I updated the task table view to reference `num_changed` instead of take the count of associated records. This number would also be previously incorrect if some of those records were selected but unchanged records.

https://dimagi.atlassian.net/browse/SAAS-17470

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
change is only made to a feature flagged area of the codebase

### Automated test coverage
i believe this functionality is covered in tests, but I will be updating those tests later

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
