### PR TITLE
[Data Cleaning] Implement inline editing

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -2,7 +2,7 @@
 {% load django_tables2 %}
 {% load data_cleaning %}
 
-{% edited_value record column as edited_value %}
+{% get_edited_value record column as edited_value %}
 <div
   class="editable-column-container"
   x-data="{

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -75,12 +75,18 @@
     </button>
   </div>
 
-  <div x-show="isEditing">
+  <div
+    x-show="isEditing"
+    x-data="{
+      cellValue: {% get_cell_value value edited_value %},
+    }"
+  >
     <div class="input-group">
       <input
         class="form-control"
         type="text"
         name="newValue"
+        x-model="cellValue"
       />
       <button
         class="btn btn-primary"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -110,7 +110,10 @@
           class="btn btn-outline-danger"
           type="button"
           :disabled="isSubmitting"
-          @click="isEditing = false"
+          @click="
+            isEditing = false;
+            cellValue = initialValue;
+          "
         >
           <i class="fa fa-close"></i>
           <span class="visually-hidden">{% trans "Cancel Edit" %}</span>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -79,6 +79,7 @@
     x-show="isEditing"
     x-data="{
       cellValue: {% get_cell_value value edited_value %},
+      initialValue: {% get_cell_value value edited_value %},
     }"
   >
     <form
@@ -99,7 +100,7 @@
         <button
           class="btn btn-primary"
           type="submit"
-          disabled="disabled"  {# todo implement inline edit submission #}
+          :disabled="cellValue === initialValue"
           @click="isSubmitting = true"
         >
           <i class="fa fa-check"></i>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -81,31 +81,40 @@
       cellValue: {% get_cell_value value edited_value %},
     }"
   >
-    <div class="input-group">
-      <input
-        class="form-control"
-        type="text"
-        name="newValue"
-        x-model="cellValue"
-      />
-      <button
-        class="btn btn-primary"
-        type="submit"
-        disabled="disabled"  {# todo implement inline edit submission #}
-        @click="isSubmitting = true"
-      >
-        <i class="fa fa-check"></i>
-        <span class="visually-hidden">{% trans "Apply Edit" %}</span>
-      </button>
-      <button
-        class="btn btn-outline-danger"
-        type="button"
-        :disabled="isSubmitting"
-        @click="isEditing = false"
-      >
-        <i class="fa fa-close"></i>
-        <span class="visually-hidden">{% trans "Cancel Edit" %}</span>
-      </button>
-    </div>
+    <form
+      hx-post="{{ request.path_info }}{% querystring %}"
+      hq-hx-action="cell_inline_edit"
+      hx-vals="{% cell_request_params record column %}"
+      hx-target="closest .editable-column-container"
+      hx-swap="outerHTML"
+      hx-disabled-elt="find button"
+    >
+      <div class="input-group">
+        <input
+          class="form-control"
+          type="text"
+          name="newValue"
+          x-model="cellValue"
+        />
+        <button
+          class="btn btn-primary"
+          type="submit"
+          disabled="disabled"  {# todo implement inline edit submission #}
+          @click="isSubmitting = true"
+        >
+          <i class="fa fa-check"></i>
+          <span class="visually-hidden">{% trans "Apply Edit" %}</span>
+        </button>
+        <button
+          class="btn btn-outline-danger"
+          type="button"
+          :disabled="isSubmitting"
+          @click="isEditing = false"
+        >
+          <i class="fa fa-close"></i>
+          <span class="visually-hidden">{% trans "Cancel Edit" %}</span>
+        </button>
+      </div>
+    </form>
   </div>
 </div>

--- a/corehq/apps/data_cleaning/templatetags/data_cleaning.py
+++ b/corehq/apps/data_cleaning/templatetags/data_cleaning.py
@@ -57,7 +57,7 @@ def dc_data_type_icon(data_type):
 
 
 @register.simple_tag
-def edited_value(record, bound_column):
+def get_edited_value(record, bound_column):
     """
     Returns the Edited value of a record based on
     the `BoundColumn` information.

--- a/corehq/apps/data_cleaning/templatetags/data_cleaning.py
+++ b/corehq/apps/data_cleaning/templatetags/data_cleaning.py
@@ -128,6 +128,12 @@ def cell_request_params(record, bound_column):
 
 
 @register.simple_tag
+def get_cell_value(value, edited_value):
+    assigned_value = edited_value if has_edits(edited_value) else value
+    return json.dumps(assigned_value)
+
+
+@register.simple_tag
 def display_dc_value(value):
     """
     Returns a template that "styles" the value for display in the

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -204,6 +204,17 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
             doc_id, column, request, *args, **kwargs
         )
 
+    @hq_hx_action("post")
+    def cell_inline_edit(self, request, *args, **kwargs):
+        """
+        Commits the inline edit action for a cell.
+        """
+        doc_id, column = self._get_cell_request_details(request)
+        # placeholder
+        return self._render_table_cell_response(
+            doc_id, column, request, *args, **kwargs
+        )
+
 
 class CaseCleaningTasksTableView(BaseDataCleaningTableView):
     urlname = "case_data_cleaning_tasks_table"

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -210,7 +210,8 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
         Commits the inline edit action for a cell.
         """
         doc_id, column = self._get_cell_request_details(request)
-        # placeholder
+        value = request.POST["newValue"]
+        self.session.apply_inline_edit(doc_id, column.prop_id, value)
         return self._render_table_cell_response(
             doc_id, column, request, *args, **kwargs
         )


### PR DESCRIPTION
## Product Description
This PR implements the inline editing functionality for a and editable column cell in the data cleaning table:
![Screenshot 2025-05-01 at 3 58 10 PM](https://github.com/user-attachments/assets/dc829055-c967-4d6d-9ccb-61ef6254503d)
![Screenshot 2025-05-01 at 3 58 16 PM](https://github.com/user-attachments/assets/defc852e-7f90-4814-9e32-541323b859b3)

https://github.com/user-attachments/assets/8bb0f085-cb16-412e-8154-9a0ef1cc2bb6

## Technical Summary
Additional changes:
- renames the `edit_value` template tag to `get_edit_value` based on PR feedback received earlier

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change to feature flagged area of codebase

### Automated test coverage
most important logic is tested

### QA Plan
not yet, but QA will start for the data cleaning related features next week (does not block this PR)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
