### PR TITLE
Update codechecks script to reflect state of js in HQ

### DIFF
--- a/corehq/apps/hqadmin/management/commands/static_analysis.py
+++ b/corehq/apps/hqadmin/management/commands/static_analysis.py
@@ -86,16 +86,13 @@ class Command(BaseCommand):
     def show_js_dependencies(self):
         proc = subprocess.Popen(["./scripts/codechecks/hqDefine.sh", "static-analysis"], stdout=subprocess.PIPE)
         output = proc.communicate()[0].strip().decode("utf-8")
-        (step1, step2, step3) = output.split(" ")
+        (step1, step2) = output.split(" ")
 
         self.logger.log("commcare.static_analysis.hqdefine_file_count", int(step1), tags=[
-            'status:unmigrated',
+            'status:esm',
         ])
         self.logger.log("commcare.static_analysis.hqdefine_file_count", int(step2), tags=[
-            'status:hqdefine_only',
-        ])
-        self.logger.log("commcare.static_analysis.requirejs_file_count", int(step3), tags=[
-            'status:migrated',
+            'status:hqdefine',
         ])
 
     def show_toggles(self):

--- a/docs/js-guide/dependencies.rst
+++ b/docs/js-guide/dependencies.rst
@@ -323,8 +323,4 @@ un-migrated files. At the time of writing:
 
     $ ./scripts/codechecks/hqDefine.sh
 
-98%     (1352/1386) of HTML files are free of inline scripts
-97%     (533/555) of non-ESM JS files use hqDefine
-92%     (506/555) of non-ESM JS files specify their dependencies
-98%     (1355/1386) of HTML files are free of script tags
-13%     (82/637) of JS files use ESM format
+19%     (123/660) of JS files use ESM format

--- a/scripts/codechecks/hqDefine.sh
+++ b/scripts/codechecks/hqDefine.sh
@@ -51,6 +51,7 @@ help="Pass list-hqdefine, list-requirejs, or list-requirejs-html to list the fil
 
 jsTotalCount=$(echo $(list-js | wc -l))
 noEsmJsTotalCount=$(echo $(list-no-esm-js | wc -l))
+esmJsTotalCount=$((jsTotalCount - noEsmJsTotalCount))
 htmlTotalCount=$(echo $(list-html | wc -l))
 
 case $command in
@@ -77,9 +78,8 @@ case $command in
 
   # For use with static_analysis management command
   "static-analysis" )
-    withoutHqDefineCount=$(echo $(list-js-without-hqDefine | wc -l))
-    withoutRequireJsCount=$(echo $(list-js-without-requirejs | wc -l))
-    echo "$withoutHqDefineCount $(($withoutRequireJsCount - $withoutHqDefineCount)) $(($noEsmJsTotalCount - $withoutRequireJsCount))"
+    noEsmCount=$(echo $(list-no-esm-js | wc -l))
+    echo "$esmJsTotalCount $noEsmJsTotalCount"
     ;;
 
   "")

--- a/scripts/codechecks/hqDefine.sh
+++ b/scripts/codechecks/hqDefine.sh
@@ -16,12 +16,6 @@ function list-esm-js() {
   list-js | xargs grep -l '^import.*;'
 }
 
-## Count files that haven't met migration criteria
-
-function list-js-without-hqDefine() {
-  list-no-esm-js | xargs grep -L 'hqDefine'
-}
-
 ## Calculate migrated percentage for given statistic
 function percent() {
   result=$(echo "100 - $1 * 100 / $2" | bc)
@@ -32,7 +26,7 @@ function percent() {
 ## Main script
 
 command=${1:-""}
-help="Pass list-hqdefine to list the files that have yet to be migrated. list-esm to list ESM formatted files"
+help="Pass TODO to list the files that have yet to be migrated. list-esm to list ESM formatted files"
 
 jsTotalCount=$(echo $(list-js | wc -l))
 noEsmJsTotalCount=$(echo $(list-no-esm-js | wc -l))
@@ -45,11 +39,6 @@ case $command in
     list-esm-js | sed 's/^/  /'
     ;;
 
-  "list-hqdefine" )
-    echo "The following files do not use hqDefine:"
-    list-js-without-hqDefine | sed 's/^/  /'
-    ;;
-
   # For use with static_analysis management command
   "static-analysis" )
     noEsmCount=$(echo $(list-no-esm-js | wc -l))
@@ -59,9 +48,6 @@ case $command in
   "")
     # No command passed; print total migration progress
     echo
-
-    unmigratedCount=$(echo $(list-js-without-hqDefine | wc -l))
-    echo "$(percent $unmigratedCount $noEsmJsTotalCount) of non-ESM JS files use hqDefine"
 
     unmigratedCount=$(echo $(list-no-esm-js | wc -l))
     echo "$(percent $unmigratedCount $jsTotalCount) of JS files use ESM format"

--- a/scripts/codechecks/hqDefine.sh
+++ b/scripts/codechecks/hqDefine.sh
@@ -26,12 +26,6 @@ function list-js-without-hqDefine() {
   list-no-esm-js | xargs grep -L 'hqDefine'
 }
 
-# Partial indicator of RequireJS work left: how many js files don't yet use
-# the variation of hqDefine that specifies dependencies?
-function list-js-without-requirejs() {
-  list-no-esm-js | xargs grep -L 'hqDefine.*\['
-}
-
 # The other indicator of RequireJS work left: how many HTML files still have script tags?
 function list-html-with-external-scripts() {
   list-html | xargs grep -l 'script.*src='
@@ -47,7 +41,7 @@ function percent() {
 ## Main script
 
 command=${1:-""}
-help="Pass list-hqdefine, list-requirejs, or list-requirejs-html to list the files that have yet to be migrated. list-esm to list ESM formatted files"
+help="Pass list-hqdefine or list-requirejs-html to list the files that have yet to be migrated. list-esm to list ESM formatted files"
 
 jsTotalCount=$(echo $(list-js | wc -l))
 noEsmJsTotalCount=$(echo $(list-no-esm-js | wc -l))
@@ -64,11 +58,6 @@ case $command in
   "list-hqdefine" )
     echo "The following files do not use hqDefine:"
     list-js-without-hqDefine | sed 's/^/  /'
-    ;;
-
-  "list-requirejs" )
-    echo "The following modules do not specify their dependencies:"
-    list-js-without-requirejs | sed 's/^/  /'
     ;;
 
   "list-requirejs-html" )
@@ -89,9 +78,6 @@ case $command in
 
     unmigratedCount=$(echo $(list-js-without-hqDefine | wc -l))
     echo "$(percent $unmigratedCount $noEsmJsTotalCount) of non-ESM JS files use hqDefine"
-
-    unmigratedCount=$(echo $(list-js-without-requirejs | wc -l))
-    echo "$(percent $unmigratedCount $noEsmJsTotalCount) of non-ESM JS files specify their dependencies"
 
     unmigratedCount=$(echo $(list-html-with-external-scripts | wc -l))
     echo "$(percent $unmigratedCount $htmlTotalCount) of HTML files are free of script tags"

--- a/scripts/codechecks/hqDefine.sh
+++ b/scripts/codechecks/hqDefine.sh
@@ -26,7 +26,7 @@ function percent() {
 ## Main script
 
 command=${1:-""}
-help="Pass TODO to list the files that have yet to be migrated. list-esm to list ESM formatted files"
+help="Pass list-no-esm to list the files still using hqDefine, or list-esm to list ESM formatted files"
 
 jsTotalCount=$(echo $(list-js | wc -l))
 noEsmJsTotalCount=$(echo $(list-no-esm-js | wc -l))
@@ -37,6 +37,11 @@ case $command in
   "list-esm" )
     echo "These files use ESM syntax:"
     list-esm-js | sed 's/^/  /'
+    ;;
+
+  "list-no-esm" )
+    echo "These files do not use ESM syntax:"
+    list-no-esm-js | sed 's/^/  /'
     ;;
 
   # For use with static_analysis management command

--- a/scripts/codechecks/hqDefine.sh
+++ b/scripts/codechecks/hqDefine.sh
@@ -26,11 +26,6 @@ function list-js-without-hqDefine() {
   list-no-esm-js | xargs grep -L 'hqDefine'
 }
 
-# The other indicator of RequireJS work left: how many HTML files still have script tags?
-function list-html-with-external-scripts() {
-  list-html | xargs grep -l 'script.*src='
-}
-
 ## Calculate migrated percentage for given statistic
 function percent() {
   result=$(echo "100 - $1 * 100 / $2" | bc)
@@ -41,7 +36,7 @@ function percent() {
 ## Main script
 
 command=${1:-""}
-help="Pass list-hqdefine or list-requirejs-html to list the files that have yet to be migrated. list-esm to list ESM formatted files"
+help="Pass list-hqdefine to list the files that have yet to be migrated. list-esm to list ESM formatted files"
 
 jsTotalCount=$(echo $(list-js | wc -l))
 noEsmJsTotalCount=$(echo $(list-no-esm-js | wc -l))
@@ -60,11 +55,6 @@ case $command in
     list-js-without-hqDefine | sed 's/^/  /'
     ;;
 
-  "list-requirejs-html" )
-    echo "The following templates still have external script tags:"
-    list-html-with-external-scripts | sed 's/^/  /'
-    ;;
-
   # For use with static_analysis management command
   "static-analysis" )
     noEsmCount=$(echo $(list-no-esm-js | wc -l))
@@ -73,14 +63,10 @@ case $command in
 
   "")
     # No command passed; print total migration progress
-    # Don't bother printing the HTML external script percentage as a metric; it's misleading
     echo
 
     unmigratedCount=$(echo $(list-js-without-hqDefine | wc -l))
     echo "$(percent $unmigratedCount $noEsmJsTotalCount) of non-ESM JS files use hqDefine"
-
-    unmigratedCount=$(echo $(list-html-with-external-scripts | wc -l))
-    echo "$(percent $unmigratedCount $htmlTotalCount) of HTML files are free of script tags"
 
     unmigratedCount=$(echo $(list-no-esm-js | wc -l))
     echo "$(percent $unmigratedCount $jsTotalCount) of JS files use ESM format"

--- a/scripts/codechecks/hqDefine.sh
+++ b/scripts/codechecks/hqDefine.sh
@@ -16,10 +16,6 @@ function list-esm-js() {
   list-js | xargs grep -l '^import.*;'
 }
 
-function list-html() {
-  find corehq custom -name '*.html' | grep -v 'vellum'
-}
-
 ## Count files that haven't met migration criteria
 
 function list-js-without-hqDefine() {
@@ -41,7 +37,6 @@ help="Pass list-hqdefine to list the files that have yet to be migrated. list-es
 jsTotalCount=$(echo $(list-js | wc -l))
 noEsmJsTotalCount=$(echo $(list-no-esm-js | wc -l))
 esmJsTotalCount=$((jsTotalCount - noEsmJsTotalCount))
-htmlTotalCount=$(echo $(list-html | wc -l))
 
 case $command in
 

--- a/scripts/codechecks/hqDefine.sh
+++ b/scripts/codechecks/hqDefine.sh
@@ -22,10 +22,6 @@ function list-html() {
 
 ## Count files that haven't met migration criteria
 
-function list-html-with-inline-scripts() {
-  list-html | xargs grep -l '<script>'
-}
-
 function list-js-without-hqDefine() {
   list-no-esm-js | xargs grep -L 'hqDefine'
 }
@@ -51,18 +47,13 @@ function percent() {
 ## Main script
 
 command=${1:-""}
-help="Pass list-script, list-hqdefine, list-requirejs, or list-requirejs-html to list the files that have yet to be migrated. list-esm to list ESM formatted files"
+help="Pass list-hqdefine, list-requirejs, or list-requirejs-html to list the files that have yet to be migrated. list-esm to list ESM formatted files"
 
 jsTotalCount=$(echo $(list-js | wc -l))
 noEsmJsTotalCount=$(echo $(list-no-esm-js | wc -l))
 htmlTotalCount=$(echo $(list-html | wc -l))
 
 case $command in
-
-  "list-script" )
-    echo "The following templates still have inline script tags:"
-    list-html-with-inline-scripts | sed 's/^/  /'
-    ;;
 
   "list-esm" )
     echo "These files use ESM syntax:"
@@ -95,9 +86,6 @@ case $command in
     # No command passed; print total migration progress
     # Don't bother printing the HTML external script percentage as a metric; it's misleading
     echo
-
-    unmigratedCount=$(echo $(list-html-with-inline-scripts | wc -l))
-    echo "$(percent $unmigratedCount $htmlTotalCount) of HTML files are free of inline scripts"
 
     unmigratedCount=$(echo $(list-js-without-hqDefine | wc -l))
     echo "$(percent $unmigratedCount $noEsmJsTotalCount) of non-ESM JS files use hqDefine"


### PR DESCRIPTION
## Technical Summary
This script has been used to track javascript migration progress both ad hoc and on [datadog](https://app.datadoghq.com/dashboard/jmg-mcq-cy8/commcarehq-key-performance-indicators?fromUser=false&fullscreen_end_ts=1746123607061&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1714587607061&fullscreen_widget=6527196979379009&refresh_mode=sliding&from_ts=1714576796136&to_ts=1746112796136&live=true).

It used to check for the presence of script tags in HTML files, the usage of `hqDefine`, and the two-parameter vs three-parameter versions of `hqDefine`. None of those are relevant anymore. Instead, this script just tracks which js files are using ES6 modules versus still using `hqDefine`.

## Safety Assurance

### Safety story
These changes are developer-facing only.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
