### PR TITLE
Removed most hqwebapp decorators

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/base_subscriptions_main.js
+++ b/corehq/apps/accounting/static/accounting/js/base_subscriptions_main.js
@@ -5,6 +5,7 @@ hqDefine('accounting/js/base_subscriptions_main', [
     'accounting/js/widgets',
     'accounting/js/credits_tab',
     'jquery-ui/ui/widgets/datepicker',
+    'jquery-ui-built-themes/redmond/jquery-ui.min.css',
     'commcarehq',
 ], function (
     $,

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -123,7 +123,7 @@ from corehq.apps.domain.views.accounting import (
     DomainBillingStatementsView,
 )
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
-from corehq.apps.hqwebapp.decorators import use_jquery_ui, use_multiselect
+from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.views import (
     BaseSectionPageView,
     CRUDPaginatedViewMixin,
@@ -587,10 +587,6 @@ class EditSoftwarePlanView(AccountingSectionView, AsyncHandlerMixin):
         FeatureRateAsyncHandler,
         SoftwareProductRateAsyncHandler,
     ]
-
-    @use_multiselect
-    def dispatch(self, request, *args, **kwargs):
-        return super(EditSoftwarePlanView, self).dispatch(request, *args, **kwargs)
 
     @property
     @memoized

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -123,7 +123,6 @@ from corehq.apps.domain.views.accounting import (
     DomainBillingStatementsView,
 )
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.views import (
     BaseSectionPageView,
     CRUDPaginatedViewMixin,
@@ -304,10 +303,6 @@ class NewSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
         Select2BillingInfoHandler,
     ]
 
-    @use_jquery_ui  # for datepicker
-    def dispatch(self, request, *args, **kwargs):
-        return super(NewSubscriptionView, self).dispatch(request, *args, **kwargs)
-
     @property
     @memoized
     def account_id(self):
@@ -376,10 +371,6 @@ class EditSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
     async_handlers = [
         Select2BillingInfoHandler,
     ]
-
-    @use_jquery_ui  # for datepicker
-    def dispatch(self, request, *args, **kwargs):
-        return super(EditSubscriptionView, self).dispatch(request, *args, **kwargs)
 
     @property
     @memoized
@@ -664,10 +655,6 @@ class SoftwarePlanVersionView(AccountingSectionView):
     urlname = 'software_plan_version'
     page_title = 'Plan Version'
     template_name = 'accounting/plan_version.html'
-
-    @use_jquery_ui  # for datepicker
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
         if self.upgrade_subscriptions_form.is_valid():

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -8,6 +8,7 @@ hqDefine("app_manager/js/forms/form_designer", [
     'app_manager/js/app_manager',
     'app_manager/js/forms/edit_form_details',
     'jquery-ui/ui/widgets/sortable',
+    'jquery-ui-built-themes/redmond/jquery-ui.min.css',
 ], function (
     $,
     _,

--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -37,9 +37,7 @@
   {{ block.super }}
   <!--
       jQuery UI needs to be included before Bootstrap's JavaScript, otherwise the two
-      tooltip widgets conflict. The B3 base template takes care of that when you use the
-      @use_jquery_ui decorator, but app manager doesn't, so instead include only the pieces
-      actually used in app manager (no tooltip).
+      tooltip widgets conflict. Include only the pieces actually used in app manager (no tooltip).
   -->
   {% compress js %}
     <!-- this defines jquery ui ($.ui) so this MUST come first -->

--- a/corehq/apps/app_manager/templates/app_manager/partials/apps_stylesheets.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/apps_stylesheets.html
@@ -2,10 +2,6 @@
 {% load hq_shared_tags %}
 
 {% compress css %}
-  {# Explicitly include this because app manager doesn't do class-based views, so it doesn't use @use_jquery_ui #}
-  <link type="text/css" rel="stylesheet" media="screen" href="{% static 'jquery-ui-built-themes/redmond/jquery-ui.min.css' %}"/>
-{% endcompress %}
-{% compress css %}
   <link type="text/less"
         rel="stylesheet"
         media="all"

--- a/corehq/apps/cloudcare/templates/cloudcare/preview_app_base.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/preview_app_base.html
@@ -24,15 +24,6 @@
           href="{% static 'cloudcare/scss/formplayer-common.scss' %}"/>
   {% endcompress %}
 
-  {% if request.use_daterangepicker %}
-    {% compress css %}
-      <link type="text/css"
-            rel="stylesheet"
-            media="screen"
-            href="{% static "bootstrap-daterangepicker/daterangepicker.css" %}" />
-    {% endcompress %}
-  {% endif %}
-
   {% block css %}{% endblock %}
 
   <link type="text/css"

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -75,7 +75,6 @@ from corehq.apps.formplayer_api.utils import get_formplayer_url
 from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.decorators import (
     use_bootstrap5,
-    use_tempusdominus,
     waf_allow,
 )
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import can_use_restore_as
@@ -102,7 +101,6 @@ class FormplayerMain(View):
 
     @xframe_options_sameorigin
     @use_bootstrap5
-    @use_tempusdominus
     @method_decorator(require_cloudcare_access)
     @method_decorator(requires_privilege_for_commcare_user(privileges.CLOUDCARE))
     def dispatch(self, request, *args, **kwargs):
@@ -259,7 +257,6 @@ class FormplayerMainPreview(FormplayerMain):
 
 
 @method_decorator(use_bootstrap5, name='dispatch')
-@method_decorator(use_tempusdominus, name='dispatch')
 class PreviewAppView(TemplateView):
     template_name = 'cloudcare/preview_app.html'
     urlname = 'preview_app'

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -15,7 +15,7 @@ from memoized import memoized
 from corehq.apps.commtrack.const import SUPPLY_POINT_CASE_TYPE
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.views.base import BaseDomainView
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_jquery_ui
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.locations.models import LocationType
 
 from .forms import CommTrackSettingsForm, ConsumptionForm
@@ -231,7 +231,3 @@ class SMSSettingsView(BaseCommTrackManageView):
         self.domain_object.commtrack_settings.save()
 
         return self.get(request, *args, **kwargs)
-
-    @use_jquery_ui
-    def dispatch(self, request, *args, **kwargs):
-        return super(SMSSettingsView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/custom_data_fields/edit_model.py
+++ b/corehq/apps/custom_data_fields/edit_model.py
@@ -15,7 +15,7 @@ from corehq import privileges
 from memoized import memoized
 from corehq.apps.callcenter.tasks import bulk_sync_usercases_if_applicable
 
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_jquery_ui
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.app_manager.helpers.validators import load_case_reserved_words
 from corehq.apps.users.models import SQLUserData, CouchUser
 
@@ -279,7 +279,6 @@ class CustomDataModelMixin(object):
     profile_required_for_options = []
 
     @use_bootstrap5
-    @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         return super(CustomDataModelMixin, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -40,7 +40,6 @@ from corehq.apps.data_dictionary.util import (
 )
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.geospatial.utils import get_geo_case_property
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.settings.views import BaseProjectDataView
 from corehq.apps.users.decorators import require_permission
@@ -492,7 +491,6 @@ class DataDictionaryView(BaseProjectDataView):
     urlname = 'data_dictionary'
 
     @method_decorator(login_and_domain_required)
-    @use_jquery_ui
     @method_decorator(requires_privilege_with_fallback(privileges.DATA_DICTIONARY))
     @method_decorator(require_permission(HqPermissions.edit_data_dict,
                                          view_only_permission=HqPermissions.view_data_dict))
@@ -522,7 +520,6 @@ class UploadDataDictionaryView(BaseProjectDataView):
     urlname = 'upload_data_dict'
 
     @method_decorator(login_and_domain_required)
-    @use_jquery_ui
     @method_decorator(requires_privilege(privileges.DATA_DICTIONARY))
     @method_decorator(require_permission(HqPermissions.edit_data_dict))
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -71,7 +71,6 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqcase.case_helper import CaseCopier
 from corehq.apps.hqcase.utils import get_case_by_identifier
-from corehq.apps.hqwebapp.decorators import use_daterangepicker
 from corehq.apps.hqwebapp.models import PageInfoContext
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import static
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
@@ -172,7 +171,6 @@ class ExploreCaseDataView(BaseDomainView):
     urlname = "explore_case_data"
     page_title = gettext_lazy("Explore Case Data")
 
-    @use_daterangepicker
     def dispatch(self, request, *args, **kwargs):
         if hasattr(request, 'couch_user') and not self.report_config.has_permission:
             raise Http404()

--- a/corehq/apps/domain/static/domain/js/internal_settings.js
+++ b/corehq/apps/domain/static/domain/js/internal_settings.js
@@ -12,7 +12,7 @@ hqDefine("domain/js/internal_settings", [
     ko,
     _,
     initialPageData,
-    multiselectUtils
+    multiselectUtils,
 ) {
     var areas = initialPageData.get('areas');
 
@@ -63,7 +63,7 @@ hqDefine("domain/js/internal_settings", [
         });
 
         var internalSettingsView = internalSettingsViewModel(
-            initialPageData.get("current_values")
+            initialPageData.get("current_values"),
         );
         $('#update-project-info').koApplyBindings(internalSettingsView);
 

--- a/corehq/apps/domain/static/domain/js/internal_settings.js
+++ b/corehq/apps/domain/static/domain/js/internal_settings.js
@@ -5,6 +5,7 @@ hqDefine("domain/js/internal_settings", [
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/multiselect_utils',
     'jquery-ui/ui/widgets/datepicker',
+    'jquery-ui-built-themes/redmond/jquery-ui.min.css',
     'commcarehq',
 ], function (
     $,

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -108,7 +108,6 @@ from corehq.apps.domain.views.settings import (
     BaseProjectSettingsView,
 )
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.views import BasePageView, CRUDPaginatedViewMixin
 from corehq.apps.users.decorators import require_permission
@@ -965,7 +964,6 @@ class InternalSubscriptionManagementView(BaseAdminProjectSettingsView):
 
     @method_decorator(always_allow_project_access)
     @method_decorator(require_superuser)
-    @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         return super(InternalSubscriptionManagementView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -41,7 +41,7 @@ from corehq.apps.domain.views.settings import (
     BaseAdminProjectSettingsView,
     BaseProjectSettingsView,
 )
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_jquery_ui
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.tasks import send_html_email_async, send_mail_async
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.receiverwrapper.rate_limiter import domain_case_rate_limiter, submission_rate_limiter
@@ -76,7 +76,6 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
     @method_decorator(login_and_domain_required)
     @method_decorator(require_superuser)
     @use_bootstrap5
-    @use_jquery_ui  # datepicker
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -41,7 +41,7 @@ from corehq.apps.domain.views.settings import (
     BaseAdminProjectSettingsView,
     BaseProjectSettingsView,
 )
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_jquery_ui, use_multiselect
+from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_jquery_ui
 from corehq.apps.hqwebapp.tasks import send_html_email_async, send_mail_async
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.receiverwrapper.rate_limiter import domain_case_rate_limiter, submission_rate_limiter
@@ -77,7 +77,6 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
     @method_decorator(require_superuser)
     @use_bootstrap5
     @use_jquery_ui  # datepicker
-    @use_multiselect
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -58,14 +58,13 @@ from corehq.apps.enterprise.tasks import email_enterprise_report
 from corehq.apps.export.utils import get_default_export_settings_if_available
 
 from corehq.apps.hqwebapp.context import get_page_context, Section
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_tempusdominus
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.users.decorators import require_can_edit_or_view_web_users
 
 from corehq.const import USER_DATE_FORMAT
 
 
-@use_tempusdominus
 @use_bootstrap5
 @always_allow_project_access
 @require_enterprise_admin
@@ -113,7 +112,6 @@ def platform_overview(request, domain):
     return render(request, "enterprise/project_dashboard.html", context)
 
 
-@use_tempusdominus
 @use_bootstrap5
 @always_allow_project_access
 @require_enterprise_admin

--- a/corehq/apps/events/static/events/js/new_event.js
+++ b/corehq/apps/events/static/events/js/new_event.js
@@ -6,6 +6,7 @@ hqDefine("events/js/new_event", [
     "locations/js/widgets",
     "hqwebapp/js/bootstrap3/widgets",
     "jquery-ui/ui/widgets/datepicker",
+    "jquery-ui-built-themes/redmond/jquery-ui.min.css",
     "commcarehq",
 ], function (
     $,

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -8,7 +8,6 @@ from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqcase.case_helper import CaseHelper
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
@@ -158,10 +157,6 @@ class EventCreateView(BaseEventView):
 
     page_title = _("Add Attendance Tracking Event")
 
-    @use_jquery_ui
-    def dispatch(self, request, *args, **kwargs):
-        return super(EventCreateView, self).dispatch(request, *args, **kwargs)
-
     @property
     def page_name(self):
         return _("Add New Event")
@@ -225,7 +220,6 @@ class EventEditView(EventCreateView):
     page_title = _("Edit Attendance Tracking Event")
     event_obj = None
 
-    @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         try:
             self.event_obj = Event.objects.get(
@@ -281,7 +275,6 @@ class AttendeesListView(JSONResponseMixin, BaseEventView):
     empty_notification = _("You have no attendees")
     loading_message = _("Loading attendees")
 
-    @use_jquery_ui
     def dispatch(self, *args, **kwargs):
         # The FF check is temporary till the full feature is released
         toggle_enabled = toggles.ATTENDANCE_TRACKING.enabled(self.domain)
@@ -340,7 +333,6 @@ class AttendeeEditView(BaseEventView):
     def page_url(self):
         return reverse(self.urlname, args=(self.domain, self.attendee_id))
 
-    @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         self.attendee_id = kwargs['attendee_id']
         return super().dispatch(request, *args, **kwargs)

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -8,7 +8,7 @@ from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqcase.case_helper import CaseHelper
-from corehq.apps.hqwebapp.decorators import use_jquery_ui, use_multiselect
+from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
@@ -158,7 +158,6 @@ class EventCreateView(BaseEventView):
 
     page_title = _("Add Attendance Tracking Event")
 
-    @use_multiselect
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         return super(EventCreateView, self).dispatch(request, *args, **kwargs)
@@ -226,7 +225,6 @@ class EventEditView(EventCreateView):
     page_title = _("Edit Attendance Tracking Event")
     event_obj = None
 
-    @use_multiselect
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         try:
@@ -342,7 +340,6 @@ class AttendeeEditView(BaseEventView):
     def page_url(self):
         return reverse(self.urlname, args=(self.domain, self.attendee_id))
 
-    @use_multiselect
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         self.attendee_id = kwargs['attendee_id']

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -61,7 +61,7 @@ from corehq.apps.export.views.utils import (
     ExportsPermissionsManager,
     case_type_or_app_limit_exceeded
 )
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_tempusdominus
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.widgets import DateRangePickerWidget
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.analytics.esaccessors import media_export_is_too_big
@@ -158,7 +158,6 @@ class BaseDownloadExportView(BaseProjectDataView):
     export_filter_class = None
 
     @use_bootstrap5
-    @use_tempusdominus
     @method_decorator(login_and_domain_required)
     def dispatch(self, request, *args, **kwargs):
         self.permissions = ExportsPermissionsManager(self.form_or_case, request.domain, request.couch_user)

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -38,7 +38,6 @@ from corehq.apps.geospatial.forms import GeospatialConfigForm
 from corehq.apps.geospatial.reports import CaseManagementMap
 from corehq.apps.geospatial.tasks import geo_cases_reassignment_update_owners
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.generic import get_filter_classes
 from corehq.apps.reports.standard.cases.basic import CaseListMixin
@@ -273,7 +272,6 @@ class GPSCaptureView(BaseGeospatialView):
         'corehq.apps.geospatial.filters.GPSDataFilter',
     ]
 
-    @use_jquery_ui
     @method_decorator(toggles.MICROPLANNING.required_decorator())
     def dispatch(self, *args, **kwargs):
         return super(GPSCaptureView, self).dispatch(*args, **kwargs)

--- a/corehq/apps/geospatial/views.py
+++ b/corehq/apps/geospatial/views.py
@@ -38,7 +38,7 @@ from corehq.apps.geospatial.forms import GeospatialConfigForm
 from corehq.apps.geospatial.reports import CaseManagementMap
 from corehq.apps.geospatial.tasks import geo_cases_reassignment_update_owners
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
-from corehq.apps.hqwebapp.decorators import use_datatables, use_jquery_ui
+from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.generic import get_filter_classes
 from corehq.apps.reports.standard.cases.basic import CaseListMixin
@@ -273,7 +273,6 @@ class GPSCaptureView(BaseGeospatialView):
         'corehq.apps.geospatial.filters.GPSDataFilter',
     ]
 
-    @use_datatables
     @use_jquery_ui
     @method_decorator(toggles.MICROPLANNING.required_decorator())
     def dispatch(self, *args, **kwargs):

--- a/corehq/apps/hqadmin/views/system.py
+++ b/corehq/apps/hqadmin/views/system.py
@@ -33,7 +33,6 @@ from corehq.apps.hqadmin.utils import get_celery_stats
 from corehq.apps.hqadmin.views.utils import (
     BaseAdminSectionView,
 )
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.receiverwrapper.rate_limiter import (
     global_submission_rate_limiter,
 )
@@ -45,7 +44,6 @@ class SystemInfoView(BaseAdminSectionView):
     urlname = 'system_info'
     template_name = "hqadmin/system_info.html"
 
-    @use_jquery_ui
     @method_decorator(require_superuser_or_contractor)
     def dispatch(self, request, *args, **kwargs):
         return super(SystemInfoView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/hqadmin/views/system.py
+++ b/corehq/apps/hqadmin/views/system.py
@@ -33,7 +33,7 @@ from corehq.apps.hqadmin.utils import get_celery_stats
 from corehq.apps.hqadmin.views.utils import (
     BaseAdminSectionView,
 )
-from corehq.apps.hqwebapp.decorators import use_datatables, use_jquery_ui
+from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.receiverwrapper.rate_limiter import (
     global_submission_rate_limiter,
 )
@@ -45,7 +45,6 @@ class SystemInfoView(BaseAdminSectionView):
     urlname = 'system_info'
     template_name = "hqadmin/system_info.html"
 
-    @use_datatables
     @use_jquery_ui
     @method_decorator(require_superuser_or_contractor)
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -61,20 +61,6 @@ def use_datatables(view_func):
     return set_request_flag(view_func, 'use_datatables')
 
 
-def use_timepicker(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to enable the inclusion of the timepicker library at the base template
-    level.
-
-    Example:
-
-    @use_timepicker
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-    return set_request_flag(view_func, 'use_timepicker')
-
-
 def use_bootstrap5(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable Boostrap 5 features for the included template.

--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -4,21 +4,6 @@ from functools import wraps
 from corehq.apps.hqwebapp.utils.bootstrap import set_bootstrap_version5
 
 
-def use_daterangepicker(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to enable the inclusion of the daterangepicker library at the base template
-    level.
-
-    Example:
-
-    @use_daterangepicker
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-
-    return set_request_flag(view_func, 'use_daterangepicker')
-
-
 def use_jquery_ui(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable the inclusion of the jquery-ui library at the base template

--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -33,20 +33,6 @@ def use_jquery_ui(view_func):
     return set_request_flag(view_func, 'use_jquery_ui')
 
 
-def use_multiselect(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to enable the inclusion of the multiselect library at the base template
-    level.
-
-    Example:
-
-    @use_multiselect
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-    return set_request_flag(view_func, 'use_multiselect')
-
-
 def use_datatables(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable the inclusion of the datatables library at the base template

--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -78,24 +78,6 @@ def use_bootstrap5(view_func):
     return get_wrapped_view(view_func, lambda r: set_bootstrap_version5())
 
 
-def use_tempusdominus(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to include CSS for Tempus Dominus (Date and/or Time picking widget).
-    NOTE: Only available for Bootstrap 5 pages!
-
-    Example:
-        @use_tempusdominus
-        def dispatch(self, request, *args, **kwargs):
-            return super().dispatch(request, *args, **kwargs)
-
-    Or alternatively:
-        @method_decorator(use_tempusdominus, name='dispatch')
-        class MyViewClass(MyViewSubclass):
-            ...
-    """
-    return set_request_flag(view_func, 'use_tempusdominus')
-
-
 def waf_allow(kind, hard_code_pattern=None):
     """
     Using this decorator simply registers a function for later use

--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -4,20 +4,6 @@ from functools import wraps
 from corehq.apps.hqwebapp.utils.bootstrap import set_bootstrap_version5
 
 
-def use_jquery_ui(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to enable the inclusion of the jquery-ui library at the base template
-    level.
-
-    Example:
-
-    @use_jquery_ui
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-    return set_request_flag(view_func, 'use_jquery_ui')
-
-
 def use_bootstrap5(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable Boostrap 5 features for the included template.

--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -18,20 +18,6 @@ def use_jquery_ui(view_func):
     return set_request_flag(view_func, 'use_jquery_ui')
 
 
-def use_datatables(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to enable the inclusion of the datatables library at the base template
-    level.
-
-    Example:
-
-    @use_datatables
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-    return set_request_flag(view_func, 'use_datatables')
-
-
 def use_bootstrap5(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable Boostrap 5 features for the included template.

--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -75,18 +75,6 @@ def use_timepicker(view_func):
     return set_request_flag(view_func, 'use_timepicker')
 
 
-def use_ko_validation(view_func):
-    """Use this decorator to use knockout validation in knockout forms
-
-    Example Tag Usage:
-
-    @use_ko_validation
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-    return set_request_flag(view_func, 'use_ko_validation')
-
-
 def use_bootstrap5(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable Boostrap 5 features for the included template.

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/knockout_bindings.ko.js
@@ -3,6 +3,7 @@ hqDefine("hqwebapp/js/bootstrap3/knockout_bindings.ko", [
     'underscore',
     'knockout',
     'jquery-ui/ui/widgets/sortable',
+    'jquery-ui-built-themes/redmond/jquery-ui.min.css',
     'langcodes/js/langcodes',   // $.langcodes
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/knockout_bindings.ko.js
@@ -243,8 +243,8 @@ hqDefine("hqwebapp/js/bootstrap3/knockout_bindings.ko", [
                 } else {
                     // Clicking a row selects it for sorting and unselects all other rows.
                     $(this).addClass('last-clicked').siblings().removeClass('last-clicked');
-                    for (var i = 0; i < list().length; i++) {
-                        list()[i].selectedForSort(false);
+                    for (var j = 0; j < list().length; j++) {
+                        list()[j].selectedForSort(false);
                     }
                     getExportColumnByRow($(this)).selectedForSort(true);
                 }
@@ -342,7 +342,7 @@ hqDefine("hqwebapp/js/bootstrap3/knockout_bindings.ko", [
     };
 
     ko.bindingHandlers.modal = {
-        init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+        init: function (element) {
             $(element).addClass('modal fade').modal({
                 show: false,
             });
@@ -414,7 +414,7 @@ hqDefine("hqwebapp/js/bootstrap3/knockout_bindings.ko", [
                 };
             ko.bindingHandlers.click.init(element, newValueAccessor, allBindingsAccessor, viewModel, bindingContext);
         },
-        update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+        update: function (element, valueAccessor) {
             $(element).data('ajaxSource', ko.utils.unwrapObservable(valueAccessor()));
         },
     };
@@ -531,7 +531,7 @@ hqDefine("hqwebapp/js/bootstrap3/knockout_bindings.ko", [
                 controlsDescendantBindings: true,
             };
         },
-        update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
+        update: function (element, valueAccessor) {
             $(element).empty();
             $(element).append(ko.unwrap(valueAccessor()));
         },
@@ -605,7 +605,6 @@ hqDefine("hqwebapp/js/bootstrap3/knockout_bindings.ko", [
     ko.bindingHandlers.paste = {
         init: function (element, valueAccessor) {
             ko.bindingHandlers.__copyPasteSharedInit();
-            var callback = valueAccessor();
             $(element).data('pasteCallback', valueAccessor());
         },
     };
@@ -706,7 +705,7 @@ hqDefine("hqwebapp/js/bootstrap3/knockout_bindings.ko", [
 
     ko.bindingHandlers.onEnterKey = {
         // calls a function when the enter key is pressed on an input
-        init: function (element, valueAccessor, allBindings, viewModel) {
+        init: function (element, valueAccessor) {
             $(element).keypress(function (event) {
                 if (event.key === "Enter" || event.keyCode === 13) {
                     valueAccessor()();

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/widgets.js
@@ -6,6 +6,7 @@ hqDefine("hqwebapp/js/bootstrap3/widgets",[
     'hqwebapp/js/initial_page_data',
     'select2/dist/js/select2.full.min',
     'jquery-ui/ui/widgets/datepicker',
+    'jquery-ui-built-themes/redmond/jquery-ui.min.css',
     "commcarehq",
 ], function ($, _, MapboxGeocoder, initialPageData) {
     var init = function () {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
@@ -712,7 +712,7 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
 
     ko.bindingHandlers.onEnterKey = {
         // calls a function when the enter key is pressed on an input
-        init: function (element, valueAccessor, allBindings, viewModel) {
+        init: function (element, valueAccessor) {
             $(element).keypress(function (event) {
                 if (event.key === "Enter" || event.keyCode === 13) {
                     valueAccessor()();

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
@@ -4,6 +4,7 @@ hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
     'knockout',
     "bootstrap5",
     'jquery-ui/ui/widgets/sortable',
+    'jquery-ui-built-themes/redmond/jquery-ui.min.css',
     'langcodes/js/langcodes',   // $.langcodes
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -1,10 +1,10 @@
-
 hqDefine("hqwebapp/js/daterangepicker.config", [
     'jquery',
     'underscore',
     'hqwebapp/js/initial_page_data',
     'moment/moment',
     'bootstrap-daterangepicker/daterangepicker',
+    'bootstrap-daterangepicker/daterangepicker.css',
 ], function (
     $,
     _,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -1,10 +1,11 @@
-
 hqDefine('hqwebapp/js/multiselect_utils', [
     "jquery",
     "knockout",
     "underscore",
     "hqwebapp/js/assert_properties",
     "multiselect/js/jquery.multi-select",
+    "multiselect/css/multi-select.css",
+    "hqwebapp/less/components/multiselect/multiselect.less",
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
@@ -10,6 +10,7 @@ hqDefine("hqwebapp/js/tempus_dominus", [
     'popper',
     'tempusDominus',
     'hqwebapp/js/initial_page_data',
+    '@eonasdan/tempus-dominus/dist/css/tempus-dominus.min.css',
 ], function (
     _,
     Popper,

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -137,41 +137,6 @@
           <script src="{% static 'jquery.cookie/jquery.cookie.js' %}"></script>
           <script src="{% static 'jquery.rmi/jquery.rmi.js' %}"></script>
       {% endcompress %}
-      {% if request.use_jquery_ui %}
-        {% compress js %}
-            <!-- this defines jquery ui ($.ui) so this MUST come first -->
-            <script src="{% static 'jquery-ui/ui/version.js' %}"></script>
-
-            <!-- all files originally in core.js, as that file now requires use of an AMD and it will be deprecated in 1.13 -->
-            <script src="{% static 'jquery-ui/ui/data.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/disable-selection.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/focusable.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/form.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/ie.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/keycode.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/labels.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/plugin.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/safe-active-element.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/safe-blur.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/scroll-parent.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/tabbable.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/unique-id.js' %}"></script>
-
-            <script src="{% static 'jquery-ui/ui/position.js' %}"></script>
-
-            <!-- Individual widgets and interactions -->
-            <script src="{% static 'jquery-ui/ui/widget.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/widgets/mouse.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/widgets/menu.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/widgets/autocomplete.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/widgets/button.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/widgets/datepicker.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/widgets/draggable.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/widgets/resizable.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/widgets/droppable.js' %}"></script>
-            <script src="{% static 'jquery-ui/ui/widgets/sortable.js' %}"></script>
-        {% endcompress %}
-      {% endif %}
       {% if use_bootstrap5 %}
         <script src="{% static "bootstrap5/dist/js/bootstrap.bundle.min.js" %}"></script>
       {% else %}
@@ -242,23 +207,6 @@
             <script src="{% static 'hqwebapp/js/bootstrap3/inactivity.js' %}"></script>
         {% endcompress %}
       {% endif %}
-    {% endif %}
-
-    {# Up here because if daterangepicker is called from within a form widget, #}
-    {# the javascript requiring the config file is run before js-inline #}
-    {% if request.use_daterangepicker and not use_js_bundler and not use_bootstrap5 %}
-      {% compress js %}
-        <script src="{% static 'moment/moment.js' %}"></script>
-        <script src="{% static 'bootstrap-daterangepicker/daterangepicker.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/daterangepicker.config.js' %}"></script>
-      {% endcompress %}
-    {% endif %}
-
-    {% if request.use_tempusdominus and not use_js_bundler and use_bootstrap5 %}
-      {% compress js %}
-        <script src="{% static '@popperjs/core/dist/umd/popper.min.js' %}"></script>
-        <script src="{% static '@eonasdan/tempus-dominus/dist/js/tempus-dominus.min.js' %}"></script>
-      {% endcompress %}
     {% endif %}
 
     {% block head %}
@@ -479,45 +427,6 @@
       {% compress js %}
         <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
       {% endcompress %}
-    {% endif %}
-
-    {% if request.use_datatables and not use_js_bundler %}
-      {% if use_bootstrap5 %}
-        {% compress js %}
-          <script src="{% static 'datatables.net/js/jquery.dataTables.min.js' %}"></script>
-          <script src="{% static 'datatables.net-bs5/js/dataTables.bootstrap5.min.js' %}"></script>
-          <script src="{% static 'datatables.net-fixedcolumns/js/dataTables.fixedColumns.min.js' %}"></script>
-          <script src="{% static 'datatables.net-fixedcolumns-bs5/js/fixedColumns.bootstrap5.min.js' %}"></script>
-        {% endcompress %}
-      {% else %}
-        {% compress js %}
-          <script src="{% static 'datatables.net/js/jquery.dataTables.min.js' %}"></script>
-          <script src="{% static 'datatables-fixedcolumns/js/dataTables.fixedColumns.js' %}"></script>
-          <script src="{% static 'datatables-bootstrap3/BS3/assets/js/datatables.js' %}"></script>
-        {% endcompress %}
-      {% endif %}
-    {% endif %}
-
-    {% if request.use_timepicker and not use_js_bundler and not use_bootstrap5 %}
-      {% compress js %}
-        <script src="{% static 'bootstrap-timepicker/js/bootstrap-timepicker.js' %}"></script>
-      {% endcompress %}
-    {% endif %}
-
-    {% if request.use_multiselect and not use_js_bundler %}
-      {% compress js %}
-        <script src="{% static 'multiselect/js/jquery.multi-select.js' %}"></script>
-        <script src="{% static 'hqwebapp/js/multiselect_utils.js' %}"></script>
-      {% endcompress %}
-    {% endif %}
-
-    {% if request.use_ko_validation and not use_js_bundler %}
-      <script src="{% static 'knockout-validation/dist/knockout.validation.min.js' %}"></script>
-      {% if use_bootstrap5 %}
-        <script src="{% static 'hqwebapp/js/bootstrap5/validators.ko.js' %}"></script>
-      {% else %}
-        <script src="{% static 'hqwebapp/js/bootstrap3/validators.ko.js' %}"></script>
-      {% endif %}
     {% endif %}
 
     {% if show_overdue_invoice_modal and not use_js_bundler %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -62,28 +62,6 @@
       {% endcompress %}
     {% endif %}
 
-    {% if request.use_datatables %}
-      {% if use_bootstrap5 %}
-        {% compress css %}
-          <link type="text/css"
-                rel="stylesheet"
-                media="all"
-                href="{% static 'datatables.net-bs5/css/dataTables.bootstrap5.min.css' %}" />
-          <link type="text/css"
-                rel="stylesheet"
-                media="all"
-                href="{% static 'datatables.net-fixedcolumns-bs5/css/fixedColumns.bootstrap5.min.css' %}" />
-        {% endcompress %}
-      {% else %}
-        {% compress css %}
-          <link type="text/css"
-                rel="stylesheet"
-                media="all"
-                href="{% static 'datatables-bootstrap3/BS3/assets/css/datatables.css' %}" />
-        {% endcompress %}
-      {% endif %}
-    {% endif %}
-
     <script>
       window.USE_BOOTSTRAP5 = {{ use_bootstrap5|BOOL }};
     </script>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -53,15 +53,6 @@
             href="{% static 'select2/dist/css/select2.min.css' %}" />
     {% endcompress %}
 
-    {% if request.use_jquery_ui %}
-      {% compress css %}
-        <link type="text/css"
-              rel="stylesheet"
-              media="screen"
-              href="{% static "jquery-ui-built-themes/redmond/jquery-ui.min.css" %}" />
-      {% endcompress %}
-    {% endif %}
-
     <script>
       window.USE_BOOTSTRAP5 = {{ use_bootstrap5|BOOL }};
     </script>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -62,15 +62,6 @@
       {% endcompress %}
     {% endif %}
 
-    {% if request.use_timepicker and not use_bootstrap5 %}
-      {% compress css %}
-        <link type="text/less"
-              rel="stylesheet"
-              media="screen"
-              href="{% static "bootstrap-timepicker/less/timepicker.less" %}" />
-      {% endcompress %}
-    {% endif %}
-
     {% if request.use_jquery_ui %}
       {% compress css %}
         <link type="text/css"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -93,15 +93,6 @@
       {% endif %}
     {% endif %}
 
-    {% if request.use_tempusdominus and use_bootstrap5 %}
-      {% compress css %}
-        <link type="text/css"
-              rel="stylesheet"
-              media="screen"
-              href="{% static "@eonasdan/tempus-dominus/dist/css/tempus-dominus.min.css" %}" />
-      {% endcompress %}
-    {% endif %}
-
     {% if request.use_multiselect %}
       {% compress css %}
         <link type="text/css"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -53,15 +53,6 @@
             href="{% static 'select2/dist/css/select2.min.css' %}" />
     {% endcompress %}
 
-    {% if request.use_daterangepicker and not use_bootstrap5 %}
-      {% compress css %}
-        <link type="text/css"
-              rel="stylesheet"
-              media="screen"
-              href="{% static "bootstrap-daterangepicker/daterangepicker.css" %}" />
-      {% endcompress %}
-    {% endif %}
-
     {% if request.use_jquery_ui %}
       {% compress css %}
         <link type="text/css"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -93,19 +93,6 @@
       {% endif %}
     {% endif %}
 
-    {% if request.use_multiselect %}
-      {% compress css %}
-        <link type="text/css"
-              rel="stylesheet"
-              media="screen"
-              href="{% static "multiselect/css/multi-select.css" %}" />
-        <link type="text/less"
-              rel="stylesheet"
-              media="screen"
-              href="{% static "hqwebapp/less/components/multiselect/multiselect.less" %}" />
-      {% endcompress %}
-    {% endif %}
-
     <script>
       window.USE_BOOTSTRAP5 = {{ use_bootstrap5|BOOL }};
     </script>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,13 +1,15 @@
+@@ -1,7 +1,8 @@
 -hqDefine("hqwebapp/js/bootstrap3/knockout_bindings.ko", [
 +hqDefine("hqwebapp/js/bootstrap5/knockout_bindings.ko", [
      'jquery',
@@ -8,8 +8,9 @@
      'knockout',
 +    "bootstrap5",
      'jquery-ui/ui/widgets/sortable',
+     'jquery-ui-built-themes/redmond/jquery-ui.min.css',
      'langcodes/js/langcodes',   // $.langcodes
- ], function (
+@@ -9,6 +10,7 @@
      $,
      _,
      ko,
@@ -17,22 +18,11 @@
  ) {
      // Need this due to https://github.com/knockout/knockout/pull/2324
      // so that ko.bindingHandlers.foreach.update works properly
-@@ -242,8 +244,8 @@
-                 } else {
-                     // Clicking a row selects it for sorting and unselects all other rows.
-                     $(this).addClass('last-clicked').siblings().removeClass('last-clicked');
--                    for (var i = 0; i < list().length; i++) {
--                        list()[i].selectedForSort(false);
-+                    for (var j = 0; j < list().length; j++) {
-+                        list()[j].selectedForSort(false);
-                     }
-                     getExportColumnByRow($(this)).selectedForSort(true);
-                 }
-@@ -341,20 +343,16 @@
+@@ -342,20 +344,16 @@
      };
  
      ko.bindingHandlers.modal = {
--        init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+-        init: function (element) {
 -            $(element).addClass('modal fade').modal({
 -                show: false,
 -            });
@@ -54,7 +44,7 @@
              }
          },
      };
-@@ -375,25 +373,32 @@
+@@ -376,25 +374,32 @@
           */
          init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
              let value = valueAccessor(),
@@ -96,7 +86,7 @@
                      };
                      return clickAction;
                  };
-@@ -403,17 +408,19 @@
+@@ -404,11 +409,13 @@
  
      ko.bindingHandlers.openRemoteModal = {
          init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
@@ -113,31 +103,7 @@
                      };
                      return clickAction;
                  };
-             ko.bindingHandlers.click.init(element, newValueAccessor, allBindingsAccessor, viewModel, bindingContext);
-         },
--        update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-+        update: function (element, valueAccessor) {
-             $(element).data('ajaxSource', ko.utils.unwrapObservable(valueAccessor()));
-         },
-     };
-@@ -530,7 +537,7 @@
-                 controlsDescendantBindings: true,
-             };
-         },
--        update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
-+        update: function (element, valueAccessor) {
-             $(element).empty();
-             $(element).append(ko.unwrap(valueAccessor()));
-         },
-@@ -604,7 +611,6 @@
-     ko.bindingHandlers.paste = {
-         init: function (element, valueAccessor) {
-             ko.bindingHandlers.__copyPasteSharedInit();
--            var callback = valueAccessor();
-             $(element).data('pasteCallback', valueAccessor());
-         },
-     };
-@@ -643,7 +649,7 @@
+@@ -643,7 +650,7 @@
                  options.sanitize = false;
              }
              if (options.title || options.content) { // don't show empty popovers

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/widgets.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/widgets.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,13 +1,13 @@
+@@ -1,14 +1,13 @@
  
 -hqDefine("hqwebapp/js/bootstrap3/widgets",[
 +hqDefine("hqwebapp/js/bootstrap5/widgets",[
@@ -11,6 +11,7 @@
 +    'tempusDominus',
      'select2/dist/js/select2.full.min',
 -    'jquery-ui/ui/widgets/datepicker',
+-    'jquery-ui-built-themes/redmond/jquery-ui.min.css',
 -    "commcarehq",
 -], function ($, _, MapboxGeocoder, initialPageData) {
 +    'commcarehq',
@@ -18,7 +19,7 @@
      var init = function () {
          var MAPBOX_ACCESS_TOKEN = initialPageData.get(
              "mapbox_access_token",
-@@ -110,7 +110,19 @@
+@@ -111,7 +110,19 @@
          });
  
          _.each($(".date-picker"), function (input) {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/datatables_config.js.diff.txt
@@ -1,12 +1,13 @@
 --- 
 +++ 
-@@ -1,402 +1,370 @@
+@@ -1,403 +1,334 @@
 -hqDefine("reports/js/bootstrap3/datatables_config", [
 -    'jquery',
 -    'underscore',
 -    'analytix/js/google',
 -    'datatables.bootstrap',
 -    'datatables.fixedColumns',
+-    'datatables-bootstrap3/BS3/assets/css/datatables.css',
 -], function (
 -    $,
 -    _,
@@ -92,6 +93,9 @@
 +import 'datatables.net/js/jquery.dataTables';
 +import 'datatables.net-fixedcolumns/js/dataTables.fixedColumns';
 +import 'datatables.net-fixedcolumns-bs5/js/fixedColumns.bootstrap5';
++
++import 'datatables.net-bs5/css/dataTables.bootstrap5.min.css';
++import 'datatables.net-fixedcolumns-bs5/css/fixedColumns.bootstrap5.min.css';
 +
 +import _ from 'underscore';
 +import googleAnalytics from 'analytix/js/google';
@@ -461,7 +465,7 @@
 +                    return data;
 +                };
 +
-+                params.footerCallback = function (row, data, start, end, display) {
++                params.footerCallback = function (row, data, start, end, display) {     // eslint-disable-line no-unused-vars
 +                    if ('total_row' in data) {
 +                        self.render_footer_row('ajax_total_row', data['total_row']);
 +                    }
@@ -650,39 +654,6 @@
 -        }
 -
 -        return (asc ? 1 : -1) * ((x < y) ? -1 : ((x > y) ?  1 : 0));
--    }
--
--    function convertNum(k) {
--        var m = k.match(/title="*([-+.0-9eE]+)/);
--        if (m !== null) {
--            m = +m[1];
--            if (isNaN(m)) {
--                m = null;
--            }
--        }
--        return m;
--    }
--
--    function convertDate(k) {
--        var m = k.match(/title="*(.+)"/);
--        if (m[1] === "None") {
--            return null;
--        }
--        return new Date(m[1]);
--    }
--
--    $.fn.dataTableExt.oSort['title-numeric-asc'] = function (a, b) { return sortSpecial(a, b, true, convertNum); };
--
--    $.fn.dataTableExt.oSort['title-numeric-desc'] = function (a, b) { return sortSpecial(a, b, false, convertNum); };
--
--    $.fn.dataTableExt.oSort['title-date-asc']  = function (a,b) { return sortSpecial(a, b, true, convertDate); };
--
--    $.fn.dataTableExt.oSort['title-date-desc']  = function (a,b) { return sortSpecial(a, b, false, convertDate); };
--
--    return {
--        HQReportDataTables: function (options) { return new HQReportDataTables(options); },
--    };
--});
 +    function renderTimingNode(node) {
 +        if (!node.subs || node.subs.length === 0) {
 +            return '';
@@ -717,49 +688,41 @@
 +            html += '</div></div>';
 +        }
 +        return html + '</div>';
-+    }
-+
+     }
+ 
+-    function convertNum(k) {
+-        var m = k.match(/title="*([-+.0-9eE]+)/);
+-        if (m !== null) {
+-            m = +m[1];
+-            if (isNaN(m)) {
+-                m = null;
+-            }
+-        }
+-        return m;
+-    }
+-
+-    function convertDate(k) {
+-        var m = k.match(/title="*(.+)"/);
+-        if (m[1] === "None") {
+-            return null;
+-        }
+-        return new Date(m[1]);
+-    }
+-
+-    $.fn.dataTableExt.oSort['title-numeric-asc'] = function (a, b) { return sortSpecial(a, b, true, convertNum); };
+-
+-    $.fn.dataTableExt.oSort['title-numeric-desc'] = function (a, b) { return sortSpecial(a, b, false, convertNum); };
+-
+-    $.fn.dataTableExt.oSort['title-date-asc']  = function (a,b) { return sortSpecial(a, b, true, convertDate); };
+-
+-    $.fn.dataTableExt.oSort['title-date-desc']  = function (a,b) { return sortSpecial(a, b, false, convertDate); };
+-
+-    return {
+-        HQReportDataTables: function (options) { return new HQReportDataTables(options); },
+-    };
+-});
 +    return self;
 +};
-+
-+// For sorting rows
-+
-+function sortSpecial(a, b, asc, convert) {
-+    var x = convert(a);
-+    var y = convert(b);
-+
-+    // sort nulls at end regardless of current sort direction
-+    if (x === null && y === null) {
-+        return 0;
-+    }
-+    if (x === null) {
-+        return 1;
-+    }
-+    if (y === null) {
-+        return -1;
-+    }
-+
-+    return (asc ? 1 : -1) * ((x < y) ? -1 : ((x > y) ?  1 : 0));
-+}
-+
-+function convertNum(k) {
-+    var m = k.match(/title="*([-+.0-9eE]+)/);
-+    if (m !== null) {
-+        m = +m[1];
-+        if (isNaN(m)) {
-+            m = null;
-+        }
-+    }
-+    return m;
-+}
-+
-+function convertDate(k) {
-+    var m = k.match(/title="*(.+)"/);
-+    if (m[1] === "None") {
-+        return null;
-+    }
-+    return new Date(m[1]);
-+}
 +
 +export default {
 +    HQReportDataTables: function (options) {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/edit_scheduled_report.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/reports/js/edit_scheduled_report.js.diff.txt
@@ -1,16 +1,19 @@
 --- 
 +++ 
-@@ -1,11 +1,11 @@
+@@ -1,13 +1,13 @@
 -hqDefine("reports/js/bootstrap3/edit_scheduled_report", [
 +hqDefine("reports/js/bootstrap5/edit_scheduled_report", [
      "jquery",
      "underscore",
      "analytix/js/google",
      "hqwebapp/js/initial_page_data",
-     "hqwebapp/js/toggles",
      "hqwebapp/js/multiselect_utils",
 -    "hqwebapp/js/bootstrap3/widgets",  // autocomplete widget for email recipient list
 +    "hqwebapp/js/bootstrap5/widgets",  // autocomplete widget for email recipient list
      "jquery-ui/ui/widgets/datepicker",
++    "jquery-ui-built-themes/redmond/jquery-ui.min.css",
      'hqwebapp/js/components/select_toggle',
+-    "jquery-ui-built-themes/redmond/jquery-ui.min.css",
      "commcarehq",
+ ], function (
+     $,

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -105,7 +105,6 @@ class DateRangePickerWidget(Input):
     usage:
     apply the following decorator to your view's dispatch method
 
-    @use_daterangepicker
     def dispatch(self, request, *args, **kwargs):
         super(self, MyView).dispatch(request, *args, **kwargs)
     """

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -30,7 +30,6 @@ from corehq.apps.domain.exceptions import DomainDoesNotExist
 from corehq.apps.domain.views.base import DomainViewMixin
 from corehq.apps.domain.views.settings import BaseProjectSettingsView
 from corehq.apps.fixtures.models import LookupTable
-from corehq.apps.hqwebapp.decorators import use_multiselect
 from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import pretty_doc_info
 from corehq.apps.linked_domain.const import (
@@ -270,10 +269,6 @@ class DomainLinkView(BaseProjectSettingsView):
     urlname = 'domain_links'
     page_title = gettext_lazy("Linked Project Spaces")
     template_name = 'linked_domain/domain_links.html'
-
-    @use_multiselect
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
 
     @property
     def page_context(self):

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -30,7 +30,7 @@ from corehq.apps.custom_data_fields.edit_model import CustomDataModelMixin
 from corehq.apps.domain.decorators import domain_admin_required, api_auth
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqwebapp.crispy import make_form_readonly
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_jquery_ui, use_multiselect, waf_allow
+from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_jquery_ui, waf_allow
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.hqwebapp.views import no_permissions
 from corehq.apps.locations.const import LOCK_LOCATIONS_TIMEOUT
@@ -686,7 +686,6 @@ class NewLocationView(BaseEditLocationView):
     urlname = 'create_location'
     page_title = gettext_noop("New Location")
 
-    @use_multiselect
     @method_decorator(require_can_edit_locations)
     @method_decorator(check_pending_locations_import(redirect=True))
     def dispatch(self, request, *args, **kwargs):
@@ -765,7 +764,6 @@ class EditLocationView(BaseEditLocationView):
     page_title = gettext_noop("Edit Location")
     creates_new_location = False
 
-    @use_multiselect
     @method_decorator(check_pending_locations_import(redirect=True))
     @method_decorator(can_edit_or_view_location)
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -30,7 +30,7 @@ from corehq.apps.custom_data_fields.edit_model import CustomDataModelMixin
 from corehq.apps.domain.decorators import domain_admin_required, api_auth
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqwebapp.crispy import make_form_readonly
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_jquery_ui, waf_allow
+from corehq.apps.hqwebapp.decorators import use_bootstrap5, waf_allow
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.hqwebapp.views import no_permissions
 from corehq.apps.locations.const import LOCK_LOCATIONS_TIMEOUT
@@ -201,7 +201,6 @@ class LocationsListView(BaseLocationView):
     page_title = gettext_noop("Organization Structure")
     template_name = 'locations/manage/locations.html'
 
-    @use_jquery_ui
     @method_decorator(use_bootstrap5)
     @method_decorator(check_pending_locations_import())
     @method_decorator(require_can_edit_or_view_locations)
@@ -314,7 +313,6 @@ class LocationTypesView(BaseDomainView):
     def section_url(self):
         return reverse(LocationsListView.urlname, args=[self.domain])
 
-    @use_jquery_ui
     @method_decorator(use_bootstrap5)
     @method_decorator(can_edit_location_types)
     @method_decorator(require_can_edit_locations)

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -9,6 +9,7 @@ hqDefine('registration/js/new_user.ko', [
     'intl-tel-input/build/js/intlTelInput.min',
     'jquery-ui/ui/effect',
     'jquery-ui/ui/effects/effect-slide',
+    'jquery-ui-built-themes/redmond/jquery-ui.min.css',
     'hqwebapp/js/password_validators.ko',
 ], function (
     $,

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -38,7 +38,6 @@ from corehq.apps.domain.exceptions import (
 )
 from corehq.apps.domain.extension_points import has_custom_clean_password
 from corehq.apps.domain.models import Domain, LicenseAgreement
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.registration.forms import (
     DomainRegistrationForm,
@@ -261,7 +260,6 @@ class UserRegistrationView(BasePageView):
     urlname = 'register_user'
     template_name = 'registration/register_new_user.html'
 
-    @use_jquery_ui
     @method_decorator(transaction.atomic)
     def dispatch(self, request, *args, **kwargs):
         if request.user.is_authenticated:

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -38,7 +38,7 @@ from corehq.apps.domain.exceptions import (
 )
 from corehq.apps.domain.extension_points import has_custom_clean_password
 from corehq.apps.domain.models import Domain, LicenseAgreement
-from corehq.apps.hqwebapp.decorators import use_jquery_ui, use_ko_validation
+from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.registration.forms import (
     DomainRegistrationForm,
@@ -262,7 +262,6 @@ class UserRegistrationView(BasePageView):
     template_name = 'registration/register_new_user.html'
 
     @use_jquery_ui
-    @use_ko_validation
     @method_decorator(transaction.atomic)
     def dispatch(self, request, *args, **kwargs):
         if request.user.is_authenticated:

--- a/corehq/apps/registry/views.py
+++ b/corehq/apps/registry/views.py
@@ -13,7 +13,7 @@ from corehq import toggles
 from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.data_dictionary.util import get_data_dict_case_types
 from corehq.apps.domain.models import Domain
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_multiselect, use_tempusdominus
+from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_multiselect
 from corehq.apps.registry.models import DataRegistry, RegistryInvitation
 from corehq.apps.registry.utils import (
     _get_registry_or_404,
@@ -93,7 +93,6 @@ def _registry_list_context(domain, registry):
 @toggles.DATA_REGISTRY.required_decorator()
 @use_bootstrap5
 @use_multiselect
-@use_tempusdominus
 def manage_registry(request, domain, registry_slug):
     registry = _get_registry_or_404(domain, registry_slug)
     if not RegistryPermissionCheck(domain, request.couch_user).can_manage_registry(registry.slug):

--- a/corehq/apps/registry/views.py
+++ b/corehq/apps/registry/views.py
@@ -13,7 +13,7 @@ from corehq import toggles
 from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.data_dictionary.util import get_data_dict_case_types
 from corehq.apps.domain.models import Domain
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_multiselect
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.registry.models import DataRegistry, RegistryInvitation
 from corehq.apps.registry.utils import (
     _get_registry_or_404,
@@ -92,7 +92,6 @@ def _registry_list_context(domain, registry):
 @require_GET
 @toggles.DATA_REGISTRY.required_decorator()
 @use_bootstrap5
-@use_multiselect
 def manage_registry(request, domain, registry_slug):
     registry = _get_registry_or_404(domain, registry_slug)
     if not RegistryPermissionCheck(domain, request.couch_user).can_manage_registry(registry.slug):

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -10,7 +10,7 @@ from memoized import memoized
 
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_multiselect
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.reminders.forms import NO_RESPONSE, KeywordForm
 from corehq.apps.reminders.util import get_combined_id, split_combined_id
@@ -281,7 +281,6 @@ class KeywordsListView(BaseMessagingSectionView, CRUDPaginatedViewMixin):
     loading_message = gettext_noop("Loading keywords...")
 
     @use_bootstrap5
-    @use_multiselect
     @method_decorator(requires_privilege_with_fallback(privileges.INBOUND_SMS))
     def dispatch(self, *args, **kwargs):
         return super(KeywordsListView, self).dispatch(*args, **kwargs)

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -28,7 +28,6 @@ from dimagi.utils.web import json_request, json_response
 from corehq.apps.domain.utils import normalize_domain_name
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import (
-    use_datatables,
     use_jquery_ui,
 )
 from corehq.apps.hqwebapp.utils.bootstrap.paths import get_bootstrap5_path
@@ -836,7 +835,6 @@ class GenericReportView(object):
         return []
 
     @use_jquery_ui
-    @use_datatables
     def decorator_dispatcher(self, request, *args, **kwargs):
         """
         Decorate this method in your report subclass and call super to make sure

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -29,7 +29,6 @@ from corehq.apps.domain.utils import normalize_domain_name
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import (
     use_datatables,
-    use_daterangepicker,
     use_jquery_ui,
 )
 from corehq.apps.hqwebapp.utils.bootstrap.paths import get_bootstrap5_path
@@ -838,7 +837,6 @@ class GenericReportView(object):
 
     @use_jquery_ui
     @use_datatables
-    @use_daterangepicker
     def decorator_dispatcher(self, request, *args, **kwargs):
         """
         Decorate this method in your report subclass and call super to make sure

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -27,9 +27,6 @@ from dimagi.utils.web import json_request, json_response
 
 from corehq.apps.domain.utils import normalize_domain_name
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
-from corehq.apps.hqwebapp.decorators import (
-    use_jquery_ui,
-)
 from corehq.apps.hqwebapp.utils.bootstrap.paths import get_bootstrap5_path
 from corehq.apps.reports.cache import request_cache
 from corehq.apps.reports.const import EXPORT_PAGE_LIMIT
@@ -834,19 +831,16 @@ class GenericReportView(object):
         """
         return []
 
-    @use_jquery_ui
     def decorator_dispatcher(self, request, *args, **kwargs):
         """
         Decorate this method in your report subclass and call super to make sure
-        appropriate decorators are used to render the page and its javascript
-        libraries.
+        appropriate decorators are used to render the page.
 
         example:
 
         class MyNewReport(GenericReport):
             ...
 
-            @use_jquery_ui
             def decorator_dispatcher(self, request, *args, **kwargs):
                 super(MyNewReport, self).decorator_dispatcher(request, *args, **kwargs)
 

--- a/corehq/apps/reports/standard/cases/case_data.py
+++ b/corehq/apps/reports/standard/cases/case_data.py
@@ -54,7 +54,6 @@ from corehq.apps.hqcase.utils import (
     resave_case,
     submit_case_blocks,
 )
-from corehq.apps.hqwebapp.decorators import use_datatables
 from corehq.apps.hqwebapp.templatetags.proptable_tags import (
     DisplayConfig,
     get_table_as_rows,
@@ -131,7 +130,6 @@ class CaseDataView(BaseProjectReportSectionView):
     http_method_names = ['get']
 
     @method_decorator(require_case_view_permission)
-    @use_datatables
     def dispatch(self, request, *args, **kwargs):
         if not self.case_instance:
             messages.info(request,

--- a/corehq/apps/reports/static/reports/js/bootstrap3/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/datatables_config.js
@@ -4,6 +4,7 @@ hqDefine("reports/js/bootstrap3/datatables_config", [
     'analytix/js/google',
     'datatables.bootstrap',
     'datatables.fixedColumns',
+    'datatables-bootstrap3/BS3/assets/css/datatables.css',
 ], function (
     $,
     _,

--- a/corehq/apps/reports/static/reports/js/bootstrap3/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap3/edit_scheduled_report.js
@@ -3,18 +3,17 @@ hqDefine("reports/js/bootstrap3/edit_scheduled_report", [
     "underscore",
     "analytix/js/google",
     "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/toggles",
     "hqwebapp/js/multiselect_utils",
     "hqwebapp/js/bootstrap3/widgets",  // autocomplete widget for email recipient list
     "jquery-ui/ui/widgets/datepicker",
     'hqwebapp/js/components/select_toggle',
+    "jquery-ui-built-themes/redmond/jquery-ui.min.css",
     "commcarehq",
 ], function (
     $,
     _,
     googleAnalytics,
     initialPageData,
-    toggles,
     multiselectUtils,
 ) {
     var addOptionsToSelect = function ($select, optList, selectedVal) {

--- a/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
@@ -4,6 +4,9 @@ import 'datatables.net/js/jquery.dataTables';
 import 'datatables.net-fixedcolumns/js/dataTables.fixedColumns';
 import 'datatables.net-fixedcolumns-bs5/js/fixedColumns.bootstrap5';
 
+import 'datatables.net-bs5/css/dataTables.bootstrap5.min.css';
+import 'datatables.net-fixedcolumns-bs5/css/fixedColumns.bootstrap5.min.css';
+
 import _ from 'underscore';
 import googleAnalytics from 'analytix/js/google';
 import {Tooltip} from 'bootstrap5';

--- a/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
@@ -327,45 +327,6 @@ var HQReportDataTables = function (options) {
     return self;
 };
 
-// For sorting rows
-
-function sortSpecial(a, b, asc, convert) {
-    var x = convert(a);
-    var y = convert(b);
-
-    // sort nulls at end regardless of current sort direction
-    if (x === null && y === null) {
-        return 0;
-    }
-    if (x === null) {
-        return 1;
-    }
-    if (y === null) {
-        return -1;
-    }
-
-    return (asc ? 1 : -1) * ((x < y) ? -1 : ((x > y) ?  1 : 0));
-}
-
-function convertNum(k) {
-    var m = k.match(/title="*([-+.0-9eE]+)/);
-    if (m !== null) {
-        m = +m[1];
-        if (isNaN(m)) {
-            m = null;
-        }
-    }
-    return m;
-}
-
-function convertDate(k) {
-    var m = k.match(/title="*(.+)"/);
-    if (m[1] === "None") {
-        return null;
-    }
-    return new Date(m[1]);
-}
-
 export default {
     HQReportDataTables: function (options) {
         return new HQReportDataTables(options);

--- a/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/datatables_config.js
@@ -148,7 +148,7 @@ var HQReportDataTables = function (options) {
                     return data;
                 };
 
-                params.footerCallback = function (row, data, start, end, display) {
+                params.footerCallback = function (row, data, start, end, display) {     // eslint-disable-line no-unused-vars
                     if ('total_row' in data) {
                         self.render_footer_row('ajax_total_row', data['total_row']);
                     }

--- a/corehq/apps/reports/static/reports/js/bootstrap5/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/bootstrap5/edit_scheduled_report.js
@@ -3,10 +3,10 @@ hqDefine("reports/js/bootstrap5/edit_scheduled_report", [
     "underscore",
     "analytix/js/google",
     "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/toggles",
     "hqwebapp/js/multiselect_utils",
     "hqwebapp/js/bootstrap5/widgets",  // autocomplete widget for email recipient list
     "jquery-ui/ui/widgets/datepicker",
+    "jquery-ui-built-themes/redmond/jquery-ui.min.css",
     'hqwebapp/js/components/select_toggle',
     "commcarehq",
 ], function (
@@ -14,7 +14,6 @@ hqDefine("reports/js/bootstrap5/edit_scheduled_report", [
     _,
     googleAnalytics,
     initialPageData,
-    toggles,
     multiselectUtils,
 ) {
     var addOptionsToSelect = function ($select, optList, selectedVal) {

--- a/corehq/apps/reports/static/reports/js/datepicker.js
+++ b/corehq/apps/reports/static/reports/js/datepicker.js
@@ -1,6 +1,7 @@
 hqDefine("reports/js/datepicker", [
     'jquery',
     'jquery-ui/ui/widgets/datepicker',
+    'jquery-ui-built-themes/redmond/jquery-ui.min.css',
 ], function (
     $,
 ) {

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -60,9 +60,6 @@ from corehq.apps.domain.decorators import (
 from corehq.apps.domain.models import Domain, DomainAuditRecordEntry
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.groups.models import Group
-from corehq.apps.hqwebapp.decorators import (
-    use_jquery_ui,
-)
 from corehq.apps.hqwebapp.doc_info import DocInfo, get_doc_info_by_id
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.hqwebapp.templatetags.proptable_tags import (
@@ -217,10 +214,6 @@ class MySavedReportsView(BaseProjectReportSectionView):
     urlname = 'saved_reports'
     page_title = gettext_noop("My Saved Reports")
     template_name = 'reports/bootstrap3/reports_home.html'
-
-    @use_jquery_ui
-    def dispatch(self, request, *args, **kwargs):
-        return super(MySavedReportsView, self).dispatch(request, *args, **kwargs)
 
     @property
     def language(self):
@@ -680,7 +673,6 @@ class ScheduledReportsView(BaseProjectReportSectionView):
     template_name = 'reports/bootstrap3/edit_scheduled_report.html'
 
     @method_decorator(require_permission(HqPermissions.download_reports))
-    @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         return super(ScheduledReportsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -64,7 +64,6 @@ from corehq.apps.hqwebapp.decorators import (
     use_datatables,
     use_daterangepicker,
     use_jquery_ui,
-    use_multiselect,
 )
 from corehq.apps.hqwebapp.doc_info import DocInfo, get_doc_info_by_id
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
@@ -685,7 +684,6 @@ class ScheduledReportsView(BaseProjectReportSectionView):
     template_name = 'reports/bootstrap3/edit_scheduled_report.html'
 
     @method_decorator(require_permission(HqPermissions.download_reports))
-    @use_multiselect
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         return super(ScheduledReportsView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -62,7 +62,6 @@ from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.decorators import (
     use_datatables,
-    use_daterangepicker,
     use_jquery_ui,
 )
 from corehq.apps.hqwebapp.doc_info import DocInfo, get_doc_info_by_id
@@ -222,7 +221,6 @@ class MySavedReportsView(BaseProjectReportSectionView):
 
     @use_jquery_ui
     @use_datatables
-    @use_daterangepicker
     def dispatch(self, request, *args, **kwargs):
         return super(MySavedReportsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -61,7 +61,6 @@ from corehq.apps.domain.models import Domain, DomainAuditRecordEntry
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.decorators import (
-    use_datatables,
     use_jquery_ui,
 )
 from corehq.apps.hqwebapp.doc_info import DocInfo, get_doc_info_by_id
@@ -220,7 +219,6 @@ class MySavedReportsView(BaseProjectReportSectionView):
     template_name = 'reports/bootstrap3/reports_home.html'
 
     @use_jquery_ui
-    @use_datatables
     def dispatch(self, request, *args, **kwargs):
         return super(MySavedReportsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -49,7 +49,7 @@ from corehq.apps.domain.extension_points import has_custom_clean_password
 from corehq.apps.domain.forms import clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_tempusdominus
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.utils import sign
 from corehq.apps.hqwebapp.utils.two_factor import user_can_use_phone
 from corehq.apps.hqwebapp.views import (
@@ -622,7 +622,6 @@ class ApiKeyView(BaseMyAccountView, CRUDPaginatedViewMixin):
     template_name = "settings/user_api_keys.html"
 
     @use_bootstrap5
-    @use_tempusdominus
     def dispatch(self, request, *args, **kwargs):
         return super(ApiKeyView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/sms/static/sms/js/chat_contacts.js
+++ b/corehq/apps/sms/static/sms/js/chat_contacts.js
@@ -10,12 +10,11 @@ hqDefine('sms/js/chat_contacts', [
     $,
     ko,
     _,
-    initialPageData
+    initialPageData,
 ) {
     var contactListTable = null;
 
     function filterViewModel() {
-        'use strict';
         var self = {};
 
         self.filterText = ko.observable();
@@ -41,7 +40,7 @@ hqDefine('sms/js/chat_contacts', [
                             '<a target="_blank" href="<%- href %>"><%- content %></a>' +
                             '<span class="btn btn-primary pull-right" ' +
                                   'onClick="window.open(\'<%- url %>\', \'_blank\', \'location=no,menubar=no,scrollbars=no,status=no,toolbar=no,height=400,width=400\');">' +
-                            '<%- chat %> <i class="fa fa-share"></i></span>'
+                            '<%- chat %> <i class="fa fa-share"></i></span>',
                         )({
                             href: row[4],
                             content: row[0],

--- a/corehq/apps/sms/static/sms/js/chat_contacts.js
+++ b/corehq/apps/sms/static/sms/js/chat_contacts.js
@@ -4,6 +4,7 @@ hqDefine('sms/js/chat_contacts', [
     'underscore',
     'hqwebapp/js/initial_page_data',
     'datatables.bootstrap',
+    'datatables-bootstrap3/BS3/assets/css/datatables.css',
     'commcarehq',
 ], function (
     $,

--- a/corehq/apps/sms/static/sms/js/compose.js
+++ b/corehq/apps/sms/static/sms/js/compose.js
@@ -2,6 +2,7 @@ hqDefine("sms/js/compose",[
     "jquery",
     "hqwebapp/js/bootstrap3/widgets",
     "jquery-ui/ui/widgets/sortable",
+    "jquery-ui-built-themes/redmond/jquery-ui.min.css",
     "commcarehq",
 ], function ($) {
     $(function () {

--- a/corehq/apps/sms/static/sms/js/settings.js
+++ b/corehq/apps/sms/static/sms/js/settings.js
@@ -12,11 +12,10 @@ hqDefine("sms/js/settings", [
     $,
     ko,
     initialPageData,
-    select2Handler
+    select2Handler,
 ) {
     $(function () {
         function dayTimeWindow(day, startTime, endTime, timeInputRelationship) {
-            'use strict';
             var self = {};
             self.day = ko.observable(day);
             self.start_time = ko.observable(startTime);
@@ -33,13 +32,12 @@ hqDefine("sms/js/settings", [
             };
 
             self.time_input_relationship = ko.observable(
-                timeInputRelationship || self.time_input_relationship_initial()
+                timeInputRelationship || self.time_input_relationship_initial(),
             );
             return self;
         }
 
         function settingsViewModel(initial) {
-            'use strict';
             var self = {};
 
             self.use_default_sms_response = ko.observable();
@@ -54,12 +52,12 @@ hqDefine("sms/js/settings", [
             self.sms_mobile_worker_registration_enabled = ko.observable();
             self.sms_case_registration_owner_id = settingsSelect2Handler(
                 initial.sms_case_registration_owner_id,
-                'sms_case_registration_owner_id'
+                'sms_case_registration_owner_id',
             );
             self.sms_case_registration_owner_id.init();
             self.sms_case_registration_user_id = settingsSelect2Handler(
                 initial.sms_case_registration_user_id,
-                'sms_case_registration_user_id'
+                'sms_case_registration_user_id',
             );
             self.sms_case_registration_user_id.init();
             self.override_daily_outbound_sms_limit = ko.observable();
@@ -152,8 +150,8 @@ hqDefine("sms/js/settings", [
                                 window.day,
                                 window.start_time,
                                 window.end_time,
-                                window.time_input_relationship
-                            )
+                                window.time_input_relationship,
+                            ),
                         );
                     }
                 } else {
@@ -168,8 +166,8 @@ hqDefine("sms/js/settings", [
                                 window.day,
                                 window.start_time,
                                 window.end_time,
-                                window.time_input_relationship
-                            )
+                                window.time_input_relationship,
+                            ),
                         );
                     }
                 } else {
@@ -207,7 +205,7 @@ hqDefine("sms/js/settings", [
         };
 
         var settingsModel = settingsViewModel(
-            initialPageData.get("current_values")
+            initialPageData.get("current_values"),
         );
         $('#sms-settings-form').koApplyBindings(settingsModel);
         settingsModel.init();

--- a/corehq/apps/sms/static/sms/js/settings.js
+++ b/corehq/apps/sms/static/sms/js/settings.js
@@ -7,6 +7,7 @@ hqDefine("sms/js/settings", [
     'bootstrap-timepicker/js/bootstrap-timepicker',
     'hqwebapp/js/bootstrap3/widgets', //multi-emails
     'commcarehq',
+    'bootstrap-timepicker/less/timepicker.less',
 ], function (
     $,
     ko,

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -63,9 +63,6 @@ from corehq.apps.domain.views.base import BaseDomainView, DomainViewMixin
 from corehq.apps.groups.models import Group
 from corehq.apps.hqadmin.views.users import BaseAdminSectionView
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
-from corehq.apps.hqwebapp.decorators import (
-    use_jquery_ui,
-)
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.reminders.util import get_two_way_number_for_recipient
@@ -1646,7 +1643,6 @@ class SMSLanguagesView(BaseMessagingSectionView):
     template_name = "sms/languages.html"
     page_title = gettext_noop("Languages")
 
-    @use_jquery_ui
     @method_decorator(domain_admin_required)
     def dispatch(self, *args, **kwargs):
         return super(SMSLanguagesView, self).dispatch(*args, **kwargs)

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -64,7 +64,6 @@ from corehq.apps.groups.models import Group
 from corehq.apps.hqadmin.views.users import BaseAdminSectionView
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.decorators import (
-    use_datatables,
     use_jquery_ui,
 )
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
@@ -626,10 +625,6 @@ class ChatOverSMSView(BaseMessagingSectionView):
     urlname = 'chat_contacts'
     template_name = 'sms/chat_contacts.html'
     page_title = _("Chat over SMS")
-
-    @use_datatables
-    def dispatch(self, *args, **kwargs):
-        return super(ChatOverSMSView, self).dispatch(*args, **kwargs)
 
 
 def get_case_contact_info(domain_obj, case_ids):

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -66,7 +66,6 @@ from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.decorators import (
     use_datatables,
     use_jquery_ui,
-    use_timepicker,
 )
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
@@ -1964,7 +1963,6 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
         return self.get(request, *args, **kwargs)
 
     @method_decorator(domain_admin_required)
-    @use_timepicker
     def dispatch(self, request, *args, **kwargs):
         return super(SMSSettingsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/sso/views/enterprise_admin.py
+++ b/corehq/apps/sso/views/enterprise_admin.py
@@ -8,7 +8,6 @@ from django.utils.translation import gettext as _, gettext_lazy
 
 from corehq.apps.enterprise.views import BaseEnterpriseAdminView
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
-from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.sso.async_handlers import SSOExemptUsersAdminAsyncHandler, SsoTestUserAdminAsyncHandler
 from corehq.apps.sso.certificates import get_certificate_response
 from corehq.apps.sso.forms import (
@@ -41,10 +40,6 @@ class EditIdentityProviderEnterpriseView(BaseEnterpriseAdminView, AsyncHandlerMi
         SSOExemptUsersAdminAsyncHandler,
         SsoTestUserAdminAsyncHandler,
     ]
-
-    @use_jquery_ui  # for datepicker
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
 
     @property
     def page_url(self):

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/dates_times.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/dates_times.html
@@ -46,10 +46,8 @@
     during the migration of a page from Bootstrap 3 to 5.
   </p>
   <div class="alert alert-primary">
-    <strong>Important Usage Note:</strong> To use Tempus Dominus on a page, you will need to apply the
-    <code>@use_tempusdominus</code> decorator to your view to ensure that the CSS is included.
-    Also make sure to import <code>TempusDominus</code> from <code>@eonasdan/tempus-dominus</code> in javascript,
-    as in the examples on this page.
+    <strong>Important Usage Note:</strong> Make sure to import <code>TempusDominus</code> from
+    <code>@eonasdan/tempus-dominus</code> in javascript, as in the examples on this page.
   </div>
 
   <h2 id="simple-date" class="pt-4">
@@ -59,8 +57,6 @@
     If you are in need of a simple date picker widget that returns a format in <code>YYYY-MM-DD</code>, then
     your best option is to add the <code>date-picker</code> CSS class to any text <code>input</code> and
     make sure that <code>hqwebapp/js/bootstrap5/widgets</code> is included as part of your javascript dependencies.
-    Additionally, you will want to use the <code>@use_tempusdominus</code> decorator on the view using the widget
-    to ensure the CSS is loaded to the page properly.
   </p>
   <p>
     The <code>hqwebapp/js/bootstrap5/widgets</code> module when loaded to a page will look for <code>input</code> fields

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/organisms/tables.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/organisms/tables.html
@@ -229,12 +229,11 @@
   </p>
 
   <div class="alert alert-primary">
-    <strong>Important Usage Note:</strong> To use Datatables on a page, you will need to apply the
-    <code>@use_datatables</code> decorator to your view to ensure that the CSS (on all views) and javascript
-    (on non-requirejs views) are included.
-    If you are using requirejs, make sure that <code>datatables.bootstrap</code> is in your list of dependencies.
+    <strong>Important Usage Note:</strong>
+    Make sure that <code>datatables.bootstrap</code> and the datatables CSS is in your list of dependencies.
     If you are using the <code>fixedColumns</code> extension, make sure that <code>datatables.fixedColumns.bootstrap</code>
     is in your list of dependencies.
+    It may be make sense to depend on <code>datatables_config.js</code>, which includes all of these.
   </div>
   {% registerurl "styleguide_datatables_data" %}
   {% include 'styleguide/bootstrap5/html_js_example.html' with content=examples.datatables %}

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -16,7 +16,6 @@ from couchforms.analytics import get_last_form_submission_received
 from soil import DownloadBase
 
 from corehq.apps.domain.decorators import require_superuser_or_contractor
-from corehq.apps.hqwebapp.decorators import use_datatables
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.toggle_ui.models import ToggleAudit
 from corehq.apps.toggle_ui.tasks import generate_toggle_csv_download
@@ -54,11 +53,6 @@ class ToggleListView(BasePageView):
     urlname = 'toggle_list'
     page_title = "Feature Flags"
     template_name = 'toggle/flags.html'
-
-    @use_datatables
-    @method_decorator(require_superuser_or_contractor)
-    def dispatch(self, request, *args, **kwargs):
-        return super(ToggleListView, self).dispatch(request, *args, **kwargs)
 
     @property
     def page_url(self):

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -32,7 +32,6 @@ from corehq.apps.domain.decorators import track_domain_request
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import (
-    use_datatables,
     use_jquery_ui,
 )
 from corehq.apps.locations.permissions import conditionally_location_safe
@@ -159,7 +158,6 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
         return super().domain
 
     @use_jquery_ui
-    @use_datatables
     @track_domain_request(calculated_prop='cp_n_viewed_ucr_reports')
     def dispatch(self, request, *args, **kwargs):
         if self.should_redirect_to_paywall(request):

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -31,9 +31,6 @@ from soil.util import get_download_context
 from corehq.apps.domain.decorators import track_domain_request
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
-from corehq.apps.hqwebapp.decorators import (
-    use_jquery_ui,
-)
 from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.apps.reports.datatables import DataTablesHeader
 from corehq.apps.reports.dispatcher import ReportDispatcher
@@ -157,7 +154,6 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             return self._domain
         return super().domain
 
-    @use_jquery_ui
     @track_domain_request(calculated_prop='cp_n_viewed_ucr_reports')
     def dispatch(self, request, *args, **kwargs):
         if self.should_redirect_to_paywall(request):

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -33,7 +33,6 @@ from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import (
     use_datatables,
-    use_daterangepicker,
     use_jquery_ui,
 )
 from corehq.apps.locations.permissions import conditionally_location_safe
@@ -159,7 +158,6 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             return self._domain
         return super().domain
 
-    @use_daterangepicker
     @use_jquery_ui
     @use_datatables
     @track_domain_request(calculated_prop='cp_n_viewed_ucr_reports')

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -60,9 +60,6 @@ from corehq.apps.domain.decorators import api_auth, login_and_domain_required
 from corehq.apps.domain.models import AllowedUCRExpressionSettings, Domain
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.es import CaseSearchES, FormES
-from corehq.apps.hqwebapp.decorators import (
-    use_jquery_ui,
-)
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.hqwebapp.utils.html import safe_replace
@@ -515,7 +512,6 @@ class ConfigureReport(ReportBuilderView):
     report_title = '{}'
     existing_report = None
 
-    @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         if self.existing_report:
             self.source_type = get_source_type_from_report_config(self.existing_report)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -62,7 +62,6 @@ from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.es import CaseSearchES, FormES
 from corehq.apps.hqwebapp.decorators import (
     use_datatables,
-    use_daterangepicker,
     use_jquery_ui,
 )
 from corehq.apps.hqwebapp.tasks import send_mail_async
@@ -343,7 +342,6 @@ class ReportBuilderView(BaseDomainView):
 
     @method_decorator(require_permission(HqPermissions.edit_reports))
     @cls_to_view_login_and_domain
-    @use_daterangepicker
     @use_datatables
     def dispatch(self, request, *args, **kwargs):
         return super(ReportBuilderView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -61,7 +61,6 @@ from corehq.apps.domain.models import AllowedUCRExpressionSettings, Domain
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.es import CaseSearchES, FormES
 from corehq.apps.hqwebapp.decorators import (
-    use_datatables,
     use_jquery_ui,
 )
 from corehq.apps.hqwebapp.tasks import send_mail_async
@@ -342,7 +341,6 @@ class ReportBuilderView(BaseDomainView):
 
     @method_decorator(require_permission(HqPermissions.edit_reports))
     @cls_to_view_login_and_domain
-    @use_datatables
     def dispatch(self, request, *args, **kwargs):
         return super(ReportBuilderView, self).dispatch(request, *args, **kwargs)
 
@@ -518,7 +516,6 @@ class ConfigureReport(ReportBuilderView):
     existing_report = None
 
     @use_jquery_ui
-    @use_datatables
     def dispatch(self, request, *args, **kwargs):
         if self.existing_report:
             self.source_type = get_source_type_from_report_config(self.existing_report)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -64,7 +64,6 @@ from corehq.apps.hqwebapp.decorators import (
     use_datatables,
     use_daterangepicker,
     use_jquery_ui,
-    use_multiselect,
 )
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
@@ -274,10 +273,6 @@ class UserConfigReportsHomeView(BaseUserConfigReportsView):
 
 class BaseEditConfigReportView(BaseUserConfigReportsView):
     template_name = 'userreports/bootstrap3/edit_report_config.html'
-
-    @use_multiselect
-    def dispatch(self, *args, **kwargs):
-        return super().dispatch(*args, **kwargs)
 
     @property
     def report_id(self):
@@ -526,7 +521,6 @@ class ConfigureReport(ReportBuilderView):
 
     @use_jquery_ui
     @use_datatables
-    @use_multiselect
     def dispatch(self, request, *args, **kwargs):
         if self.existing_report:
             self.source_type = get_source_type_from_report_config(self.existing_report)

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -996,10 +996,6 @@ class MultipleSelectionForm(forms.Form):
             {% crispy users_per_location_form %}
         </form>
 
-        @use_multiselect
-        def dispatch(self, request, *args, **kwargs):
-            return super(MyView, self).dispatch(request, *args, **kwargs)
-
         # javascript
         import multiselectUtils from "hqwebapp/js/multiselect_utils";
         $(function () {

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -16,7 +16,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.es.users import UserES
 from corehq.apps.groups.models import Group
-from corehq.apps.hqwebapp.decorators import use_bootstrap5, use_multiselect
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.reports.filters.api import MobileWorkersOptionsView
 from corehq.apps.reports.util import get_simplified_users
@@ -125,7 +125,6 @@ class BulkSMSVerificationView(BaseDomainView):
 class BaseGroupsView(BaseUserSettingsView):
 
     @method_decorator(require_can_edit_or_view_groups)
-    @use_multiselect
     def dispatch(self, request, *args, **kwargs):
         return super(BaseGroupsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -72,7 +72,7 @@ from corehq.apps.events.tasks import create_attendee_for_user
 from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.crispy import make_form_readonly
-from corehq.apps.hqwebapp.decorators import use_multiselect, waf_allow
+from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.locations.models import SQLLocation
@@ -192,7 +192,6 @@ class EditCommCareUserView(BaseEditUserView):
         else:
             return "users/edit_commcare_user.html"
 
-    @use_multiselect
     @method_decorator(require_can_edit_or_view_commcare_users)
     def dispatch(self, request, *args, **kwargs):
         return super(EditCommCareUserView, self).dispatch(request, *args, **kwargs)

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
@@ -3,6 +3,7 @@ import ko from "knockout";
 
 import "jquery-ui/ui/widgets/datepicker";
 import "bootstrap-timepicker/js/bootstrap-timepicker";
+import "bootstrap-timepicker/less/timepicker.less";
 
 import "hqwebapp/js/components/rich_text_knockout_bindings";
 import "hqwebapp/js/components/select_toggle";

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 import ko from "knockout";
 
 import "jquery-ui/ui/widgets/datepicker";
+import "jquery-ui-built-themes/redmond/jquery-ui.min.css";
 import "bootstrap-timepicker/js/bootstrap-timepicker";
 import "bootstrap-timepicker/less/timepicker.less";
 

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -34,9 +34,6 @@ from corehq.apps.accounting.decorators import (
 from corehq.apps.data_dictionary.util import get_data_dict_props_by_case_type
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
-from corehq.apps.hqwebapp.decorators import (
-    use_jquery_ui,
-)
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.sms.filters import EventStatusFilter, EventTypeFilter
 from corehq.apps.sms.models import (
@@ -446,7 +443,6 @@ class CreateScheduleView(BaseMessagingSectionView, AsyncHandlerMixin):
     read_only_mode = False
 
     @method_decorator(requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK))
-    @use_jquery_ui
     def dispatch(self, *args, **kwargs):
         return super(CreateScheduleView, self).dispatch(*args, **kwargs)
 
@@ -778,7 +774,6 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
         return format_html(_('For information on Conditional Alerts, see the {} help page.'), link)
 
     @method_decorator(requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK))
-    @use_jquery_ui
     def dispatch(self, *args, **kwargs):
         return super(CreateConditionalAlertView, self).dispatch(*args, **kwargs)
 

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -35,7 +35,6 @@ from corehq.apps.data_dictionary.util import get_data_dict_props_by_case_type
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.decorators import (
-    use_datatables,
     use_jquery_ui,
 )
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
@@ -317,7 +316,6 @@ class BroadcastListView(BaseMessagingSectionView):
     ACTION_DELETE_SCHEDULED_BROADCAST = 'delete_scheduled_broadcast'
 
     @method_decorator(requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK))
-    @use_datatables
     def dispatch(self, *args, **kwargs):
         return super(BroadcastListView, self).dispatch(*args, **kwargs)
 
@@ -619,10 +617,6 @@ class ConditionalAlertListView(ConditionalAlertBaseView):
     ACTION_DEACTIVATE = 'deactivate'
     ACTION_DELETE = 'delete'
     ACTION_RESTART = 'restart'
-
-    @use_datatables
-    def dispatch(self, *args, **kwargs):
-        return super(ConditionalAlertListView, self).dispatch(*args, **kwargs)
 
     @cached_property
     def limit_rule_restarts(self):

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -37,7 +37,6 @@ from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.decorators import (
     use_datatables,
     use_jquery_ui,
-    use_timepicker,
 )
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.sms.filters import EventStatusFilter, EventTypeFilter
@@ -450,7 +449,6 @@ class CreateScheduleView(BaseMessagingSectionView, AsyncHandlerMixin):
 
     @method_decorator(requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK))
     @use_jquery_ui
-    @use_timepicker
     def dispatch(self, *args, **kwargs):
         return super(CreateScheduleView, self).dispatch(*args, **kwargs)
 
@@ -787,7 +785,6 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
 
     @method_decorator(requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK))
     @use_jquery_ui
-    @use_timepicker
     def dispatch(self, *args, **kwargs):
         return super(CreateConditionalAlertView, self).dispatch(*args, **kwargs)
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "leaflet": "1.9.4",
         "leaflet-fullscreen": "^1.0.2",
         "less": "3.10.3",
+        "less-loader": "12.2.0",
         "mapbox-gl": "2.14.1",
         "mapbox.js": "3.3.1",
         "marionette.approuter": "^1.0.2",

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -21,6 +21,7 @@ const aliases = {
     "sentry_captureconsole": path.resolve(utils.getStaticFolderForApp('hqwebapp'),
         'sentry/js/sentry.captureconsole.7.28.0.min'),
     "tempusDominus": "@eonasdan/tempus-dominus",
+    "hqwebapp/less": path.resolve(utils.getStaticPathForApp('hqwebapp', 'less')),
     "ko.mapping": path.resolve(utils.getStaticPathForApp('hqwebapp', 'js/lib/knockout_plugins/'),
         'knockout_mapping.ko.min'),
 };

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -36,6 +36,10 @@ module.exports = {
                 use: ["style-loader", "css-loader"],
             },
             {
+                test: /\.less$/,
+                use: ["style-loader", "css-loader", "less-loader"],
+            },
+            {
                 test: /\.js$/,
                 loader: 'babel-loader',
                 exclude: /node_modules/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5117,6 +5117,11 @@ leaflet@1.9.4:
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.9.4.tgz#23fae724e282fa25745aff82ca4d394748db7d8d"
   integrity sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==
 
+less-loader@12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-12.2.0.tgz#e1e94522f6abe9e064ef396c29a3151bc6c1b6cc"
+  integrity sha512-MYUxjSQSBUQmowc0l5nPieOYwMzGPUaTzB6inNW/bdPEG9zOL3eAAD1Qw5ZxSPk7we5dMojHwNODYMV1hq4EVg==
+
 less@3.10.3:
   version "3.10.3"
   resolved "https://registry.yarnpkg.com/less/-/less-3.10.3.tgz#417a0975d5eeecc52cff4bcfa3c09d35781e6792"


### PR DESCRIPTION
## Technical Summary
This started out as removing unused script tags from `base.html` and grew a bit beyond that.

The first commit just removes script tags that are gated behind the `use_js_bundler` flag, which is true for all webpack pages. The only view left that doesn't use webpack is form designer, which doesn't use any of these decorators, so these script tags can be deleted. I considered moving all the remaining script tags in this file into `form_designer.html` but decided that wasn't worthwhile, they'll be gone soon enough.

The remaining commits remove the related decorators. Those that don't involve stylesheets are already dead code. For those that do involve stylesheets, they can be removed by moving the style references into the relevant js, which is a better place for it than python.

## Safety Assurance

### Safety story
I tested each removed decorator on at least one page using it to verify the styles are included properly. I have not loaded every single view this PR touches, I don't think that's necessary.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
