### PR TITLE
GA multimedia for web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1363,31 +1363,27 @@ hqDefine("cloudcare/js/form_entry/entries", [
                 entry = new InfoEntry(question, {});
                 break;
             case constants.BINARY:
-                if (!toggles.toggleEnabled('WEB_APPS_UPLOAD_QUESTIONS')) {
-                    // do nothing, fall through to unsupported
-                } else {
-                    switch (question.control()) {
-                        case constants.CONTROL_IMAGE_CHOOSE:
-                            if (question.stylesContains(constants.SIGNATURE)) {
-                                entry = new SignatureEntry(question, {});
-                                break;
-                            }
-                            entry = new ImageEntry(question, {
-                                broadcastStyles: broadcastStyles,
-                            });
+                switch (question.control()) {
+                    case constants.CONTROL_IMAGE_CHOOSE:
+                        if (question.stylesContains(constants.SIGNATURE)) {
+                            entry = new SignatureEntry(question, {});
                             break;
-                        case constants.CONTROL_AUDIO_CAPTURE:
-                            entry = new AudioEntry(question, {
-                                broadcastStyles: broadcastStyles,
-                            });
-                            break;
-                        case constants.CONTROL_VIDEO_CAPTURE:
-                            entry = new VideoEntry(question, {
-                                broadcastStyles: broadcastStyles,
-                            });
-                            break;
-                        // any other control types are unsupported
-                    }
+                        }
+                        entry = new ImageEntry(question, {
+                            broadcastStyles: broadcastStyles,
+                        });
+                        break;
+                    case constants.CONTROL_AUDIO_CAPTURE:
+                        entry = new AudioEntry(question, {
+                            broadcastStyles: broadcastStyles,
+                        });
+                        break;
+                    case constants.CONTROL_VIDEO_CAPTURE:
+                        entry = new VideoEntry(question, {
+                            broadcastStyles: broadcastStyles,
+                        });
+                        break;
+                    // any other control types are unsupported
                 }
         }
         if (!entry) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entries_spec.js
@@ -19,7 +19,6 @@ describe('Entries', function () {
         initialPageData.register(
             "toggles_dict",
             {
-                WEB_APPS_UPLOAD_QUESTIONS: true,
                 WEB_APPS_ANCHORED_SUBMIT: false,
             },
         );

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/form_ui_spec.js
@@ -17,7 +17,6 @@ describe('Fullform formUI', function () {
         initialPageData.register(
             "toggles_dict",
             {
-                WEB_APPS_UPLOAD_QUESTIONS: true,
                 WEB_APPS_ANCHORED_SUBMIT: false,
             },
         );

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -998,14 +998,6 @@ WEB_APPS_DOMAIN_BANNER = StaticToggle(
     help_link='https://confluence.dimagi.com/display/saas/USH%3A+Show+current+domain+in+web+apps+Login+As+banner',
 )
 
-WEB_APPS_UPLOAD_QUESTIONS = FeatureRelease(
-    'web_apps_upload_questions',
-    'USH: Support image, audio, and video questions in Web Apps',
-    TAG_RELEASE,
-    namespaces=[NAMESPACE_DOMAIN],
-    owner='Jenny Schweers',
-)
-
 LOCATION_FIELD_USER_PROVISIONING = FeatureRelease(
     'location_field_user_provisioning',
     'USH: Holding feature flag for various works relating to the location field',


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
GA use of multimedia for web apps. See [CMC](https://docs.google.com/document/d/1x4N3LpMKr4XlkLtSMb1wsVWCv9Q1km2yyafqfdGHH4k/edit?tab=t.0#heading=h.mqtes3dl75z)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-5882](https://dimagi.atlassian.net/browse/USH-5882)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
removes `WEB_APPS_UPLOAD_QUESTIONS` FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested and this change only removes the FF and FF checks.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no QA. This is identified as a "risk" medium label but i decided to not do QA because the code change involves only removing a feature flag and the portion of code that was gated behind the FF.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-5882]: https://dimagi.atlassian.net/browse/USH-5882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ