### PR TITLE
Remove 'report' widget as an option while creating new widget.

### DIFF
--- a/corehq/apps/campaign/views.py
+++ b/corehq/apps/campaign/views.py
@@ -91,7 +91,11 @@ class DashboardView(BaseProjectReportSectionView, DashboardMapFilterMixin):
             'mapbox_access_token': settings.MAPBOX_ACCESS_TOKEN,
             'map_report_widgets': self.dashboard.get_map_report_widgets_by_tab(),
             'gauge_widgets': self._dashboard_gauge_configs(),
-            'widget_types': WidgetType.choices,
+            # Report widgets are not supported yet
+            'widget_types': [
+                (widget_type, label)
+                for widget_type, label in WidgetType.choices if widget_type != WidgetType.REPORT
+            ]
         })
         context.update(self.dashboard_map_case_filters_context())
         return context


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Remove 'report' widget as an option while creating new widget because [reports feature PR](https://github.com/dimagi/commcare-hq/pull/36226) was reverted so report widgets are no longer supported.

![image](https://github.com/user-attachments/assets/a5f38663-1692-46ea-9e60-58ce91f48a04)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
CAMPAIGN_DASHBOARD

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
