### PR TITLE
Fixed typo for CouldNotAcquireLock exception

### DIFF
--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -102,7 +102,7 @@ class require_debug_true(ContextDecorator):
         pass
 
 
-class CouldNotAqcuireLock(Exception):
+class CouldNotAcquireLock(Exception):
     pass
 
 
@@ -164,9 +164,9 @@ def serial_task(unique_key, default_retry_delay=30, timeout=5 * 60, max_retries=
                 finally:
                     release_lock(lock, True)
             else:
-                msg = "Could not aquire lock '{}' for task '{}'.".format(
+                msg = "Could not acquire lock '{}' for task '{}'.".format(
                     key, fn.__name__)
-                self.retry(exc=CouldNotAqcuireLock(msg))
+                self.retry(exc=CouldNotAcquireLock(msg))
         return _inner
     return decorator
 


### PR DESCRIPTION
## Technical Summary
Quick PR to fix a typo in the error name and description. This error `CouldNotAqcuireLock` has been a frequent issue in Sentry, and it's unfortunate that correcting the typo will likely make it seem that these issues are new and haven't happened before, but we determined it was probably more likely that people would search for the correct spelling `CouldNotAcquireLock`, and be confused at not seeing any results.

## Safety Assurance

### Safety story
This is just a wording change that should not affect any logic

### Automated test coverage

No tests

### QA Plan
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
