### PR TITLE
Fix various broken help site links

### DIFF
--- a/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.html
+++ b/corehq/apps/accounting/templates/accounting/email/customer_subscription_ending_reminder_dimagi.html
@@ -8,7 +8,7 @@
   This account has a {{ plan }} subscription that is ending on {{ end_date }}. After that date, the subscription will automatically downgrade to the Free edition.
 </p>
 <p>
-  If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email <a href="https://confluence.dimagi.com/display/commcarehq/CommCare+HQ+Billing+-+Email+Templates#CommCareHQBilling-EmailTemplates-SubscriptionEnding">template</a> to follow up.
+  If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email <a href="https://dimagi.atlassian.net/wiki/spaces/saas/pages/2146603514/CommCare+Subscriptions+-+Account+Support+-+Email+templates">template</a> to follow up.
 </p>
 <p>
   Please note that the partner’s contacts ({{ contacts }}) will also receive a reminder on {{ client_reminder_email_date }} (30 days before their subscription end date, 30 days from today).

--- a/corehq/apps/accounting/templates/accounting/email/overdue_notice.html
+++ b/corehq/apps/accounting/templates/accounting/email/overdue_notice.html
@@ -54,7 +54,7 @@
     {% blocktrans %}
       You can also pre-pay for several months at any time by following
       <a
-        href="https://confluence.dimagi.com/display/commcarepublic/CommCare+Pricing+FAQs#CommCarePricingFAQs-Pre-payment"
+        href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#How-to-Prepay-by-Credit-or-Debit-Card"
         >these steps</a
       >.
     {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/overdue_notice.html
+++ b/corehq/apps/accounting/templates/accounting/email/overdue_notice.html
@@ -45,7 +45,7 @@
       As a reminder, payments can be made via credit card, Electronic Fund
       Transfer (EFT), or check by following these
       <a
-        href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment"
+        href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods"
         >instructions</a
       >.
     {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/subscription_ending_reminder_dimagi.html
+++ b/corehq/apps/accounting/templates/accounting/email/subscription_ending_reminder_dimagi.html
@@ -9,7 +9,7 @@
   This project has a subscription that is ending on {{ end_date }}. After that date, the subscription will automatically pause and this space will lose access to all features until it is re-subscribed to a new paid plan.
 </p>
 <p>
-  If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email <a href="https://confluence.dimagi.com/display/commcarehq/CommCare+HQ+Billing+-+Email+Templates#CommCareHQBilling-EmailTemplates-SubscriptionEnding">template</a> to follow up.
+  If you haven't already, can you follow up with the partner to confirm they are aware of this? If relevant, you can use the subscription with an upcoming end date email <a href="https://dimagi.atlassian.net/wiki/spaces/saas/pages/2146603514/CommCare+Subscriptions+-+Account+Support+-+Email+templates">template</a> to follow up.
 </p>
 <p>
   Please note that the partner’s contacts ({{ contacts }}) will also receive a reminder on {{ client_reminder_email_date }} (30 days before their subscription end date, 30 days from today).

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -50,7 +50,7 @@
           CommCare is billed on a monthly basis, and all subscriptions require a 30 day minimum commitment.
           You should expect your first invoice on {{ invoice_date }}, or you can prepay for your
           subscription by following the instructions
-          <a href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment">here</a>.
+          <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods">here</a>.
         {% endblocktrans %}
       </p>
       <p class="text-free">

--- a/corehq/apps/app_manager/add_ons.py
+++ b/corehq/apps/app_manager/add_ons.py
@@ -145,7 +145,9 @@ _ADD_ONS = {
         name=_("Register from case list"),
         description=_("Minimize duplicates by making registration forms available directly from the case list "
         "on the mobile device. Availabe in menu settings."),
-        help_link="https://confluence.dimagi.com/pages/viewpage.action?pageId=30605985",
+        help_link=("https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/"
+                   "2143951603/Case+List+and+Case+Detail+Configuration"
+                   "#Minimize-Duplicates%3A-Registration-From-the-Case-List"),
         used_in_module=lambda m: m.case_list_form.form_id,
     ),
     "subcases": AddOn(

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yml
@@ -151,7 +151,7 @@
 
 - id: mobile_ucr_restore_version
   name: Mobile UCR Restore Version
-  description: Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR+V2">Help Site</a>
+  description: Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://dimagi.atlassian.net/wiki/spaces/GS/pages/2146604299/Moving+to+Mobile+UCR+V2">Help Site</a>
   toggle: MOBILE_UCR
   values:
     - ['2.0', '2.0']

--- a/corehq/apps/app_manager/static_strings.py
+++ b/corehq/apps/app_manager/static_strings.py
@@ -194,7 +194,7 @@ STATICALLY_ANALYZABLE_TRANSLATIONS = [
     gettext_noop('Validate Multimedia'),
     gettext_noop('Version 1 translations (old)'),
     gettext_noop('Version 2 translations (recommended)'),
-    gettext_noop('Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://help.commcarehq.org/display/saas/Moving+to+Mobile+UCR+V2">Help Site</a>'),
+    gettext_noop('Version of mobile UCRs to use. Read more on the  <a target="_blank" href="https://dimagi.atlassian.net/wiki/spaces/GS/pages/2146604299/Moving+to+Mobile+UCR+V2">Help Site</a>'),
     gettext_noop('We frequently release new versions of CommCare Mobile. Use the latest version to take advantage of new features and bug fixes. Note that if you are using CommCare for Android you must also update your version of CommCare from the Google Play Store.'),
     gettext_noop('We suggest moving to CommCare 2.0 and above, unless your project is using referrals'),
     gettext_noop('Web App'),

--- a/corehq/apps/app_manager/templates/app_manager/odk_install.html
+++ b/corehq/apps/app_manager/templates/app_manager/odk_install.html
@@ -25,7 +25,7 @@
       </p>
       <p>
         {% trans "For help installing CommCare, visit " %}
-        <a href="https://help.commcarehq.org/display/commcarepublic/Install+CommCare+for+Android+Smartphones" target="_blank">
+        <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143946239/Installing+CommCare+on+Android+Devices" target="_blank">
           {% trans "Install CommCare" %}
         </a>
       </p>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_detail.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_detail.html
@@ -49,7 +49,7 @@
 
 <span class="hq-help-template"
       data-title="{% trans "Case Detail Tabs" %}"
-      data-content="{% blocktrans %}Do you have a lot of case properties? Try splitting them into tabs, which will appear as separate screens that mobile users can swipe through. Read more on the <a href='https://help.commcarehq.org/display/commcarepublic/Tabs+on+Case+Detail+Screen' target='_blank'>Help Site</a>.{% endblocktrans %}">
+      data-content="{% blocktrans %}Do you have a lot of case properties? Try splitting them into tabs, which will appear as separate screens that mobile users can swipe through. Read more on the <a href='https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143951603/Case+List+and+Case+Detail+Configuration#Add-Tabs-on-Case-Detail-Screen' target='_blank'>Help Site</a>.{% endblocktrans %}">
 </span>
 
 {% if request|toggle_enabled:"CASE_DETAIL_PRINT" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_form_setting.html
@@ -11,7 +11,7 @@
           {% trans "Form Accessible from Case List" %}
           <span class="hq-help-template"
                 data-title="{% trans "Forms Accessible from Case List" %}"
-                data-content="{% blocktrans %}Use Registration Forms to minimize duplicate registrations by requiring mobile workers to search the case list before registering a new case. Read more on the <a href='https://help.commcarehq.org/pages/viewpage.action?pageId=30605985'>Help Site</a>.
+                data-content="{% blocktrans %}Use Registration Forms to minimize duplicate registrations by requiring mobile workers to search the case list before registering a new case. Read more on the <a href='https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143951603/Case+List+and+Case+Detail+Configuration#Minimize-Duplicates%3A-Registration-From-the-Case-List'>Help Site</a>.
                 You can use followup forms for Parent Case button if this module uses Select Parent First workflow{% endblocktrans %}"
           ></span>
         {% else %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -57,7 +57,7 @@
                         data-content="{% blocktrans %}
                              Cases of these types will be displayed in Case List and Case Search screens, in addition to the Case Type inputted above.
                              <a target='_blank'
-                             href='https://confluence.dimagi.com/display/ccinternal/Case+Search+and+Claim'>(More   Information)</a>
+                             href='https://dimagi.atlassian.net/wiki/spaces/USH/pages/2146962056/Case+Search+Configuration'>(More   Information)</a>
                               {% endblocktrans %}">
                   </span>
                 </label>

--- a/corehq/apps/case_importer/templates/case_importer/partials/help_message.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/help_message.html
@@ -10,7 +10,7 @@
     {% blocktrans %}
       This tool can make changes to your data that might confuse your reports or applications.
       Please exercise caution and see the
-      <a href="https://help.commcarehq.org/display/commcarepublic/Importing+Cases+Using+Excel" target="_blank">
+      <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143946828/Case+Import+with+Excel" target="_blank">
         help pages for this feature.
       </a>
     {% endblocktrans %}

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -984,8 +984,8 @@ class PrivacySecurityForm(forms.Form):
             "Secure Submissions prevents others from impersonating your mobile workers. "
             "This setting requires all deployed applications to be using secure "
             "submissions as well. "
-            "<a href='https://help.commcarehq.org/display/commcarepublic/Project+Space+Settings'>"
-            "Read more about secure submissions here</a>"))
+            "<a href='https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2367226200/"
+            "Project+Settings+Overview'>Read more about secure submissions here</a>"))
     )
     secure_sessions = BooleanField(
         label=gettext_lazy("Shorten Inactivity Timeout"),

--- a/corehq/apps/domain/templates/domain/partials/bootstrap3/payment_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap3/payment_modal.html
@@ -234,7 +234,7 @@
                 instructions for wire payment. Please include the Invoice # in
                 the wire payment memo or note field.
                 <a
-                  href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment"
+                  href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods"
                   target="_blank"
                   >More information...</a
                 >

--- a/corehq/apps/domain/templates/domain/partials/bootstrap5/payment_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap5/payment_modal.html
@@ -234,7 +234,7 @@
                 instructions for wire payment. Please include the Invoice # in
                 the wire payment memo or note field.
                 <a
-                  href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment"
+                  href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods"
                   target="_blank"
                   >More information...</a
                 >

--- a/corehq/apps/export/templates/export/download_export.html
+++ b/corehq/apps/export/templates/export/download_export.html
@@ -60,7 +60,7 @@
             <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143947269/Publish+Your+Application"
                target="_blank">deploy</a>
             your application and submit data from a phone. You may also
-            <a href="https://help.commcarehq.org/display/commcarepublic/Web+Apps"
+            <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955161/Web+Applications"
                target="_blank">submit data via Web Apps
             </a>
             , depending on your project's

--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -20,7 +20,7 @@
           If you want timings for a cold cache, click Overwrite cache and run again.
         </div>
         <ul class="list-inline">
-          <li><a href="https://help.commcarehq.org/display/commcarepublic/CommCare+Sync+Data" target="_blank">Docs</a></li>
+          <li><a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143956128/CommCare+Sync+Data" target="_blank">Docs</a></li>
           <li><a href="{{request.get_full_path}}&raw=true">Raw</a></li>
           <li><a href="{{request.get_full_path}}&overwrite_cache=true">Overwrite Cache</a></li>
           <li><a href="?{% url_replace 'since' restore_id %}">Next Sync</a></li>

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -352,7 +352,8 @@ class ManageMultimediaPathsView(BaseMultimediaTemplateView):
                 "download_url": reverse('download_multimedia_paths', args=[self.domain, self.app.get_id]),
                 "adjective": _("multimedia paths"),
                 "plural_noun": _("multimedia paths"),
-                "help_link": "https://confluence.dimagi.com/display/ICDS/Multimedia+Path+Manager",
+                "help_link": ("https://dimagi.atlassian.net/wiki/spaces/IndiaDivision/"
+                              "pages/2145553380/Multimedia+Path+Manager"),
             },
         })
         context.update({

--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -20,7 +20,7 @@
           location's data or simply be used for aggregation. Once you've
           defined your organization structure types, you'll be able to define
           the organization structure for your project. Learn more about
-          Organizations on our <a href="https://help.commcarehq.org/display/commcarepublic/Organizations">Help Site</a>.
+          Organizations on our <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955032/Organizations+Locations" target="_blank">Help Site</a>.
         {% endblocktrans %}
       </p>
     </div>

--- a/corehq/apps/locations/templates/locations/manage/locations.html
+++ b/corehq/apps/locations/templates/locations/manage/locations.html
@@ -35,7 +35,7 @@
             The organization feature allows you to represent the real-world
             structure of your project (districts, facilities, frontline workers, etc.).
             Once this structure has been defined, you can use it for reporting and
-            case sharing. Learn more about Organizations on our <a href="https://help.commcarehq.org/display/commcarepublic/Organizations">Help Site</a>.
+            case sharing. Learn more about Organizations on our <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955032/Organizations+Locations" target="_blank">Help Site</a>.
           {% endblocktrans %}
         </p>
         {% if show_inactive %}

--- a/corehq/apps/saved_reports/README.md
+++ b/corehq/apps/saved_reports/README.md
@@ -2,7 +2,7 @@
 
 This app manages the backend components of the Saved Reports and Scheduled Email Reports
 features. For more information on this bundle of features, see
-https://confluence.dimagi.com/display/commcarepublic/Managing+Saved+and+Scheduled+Email+Reports.
+https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955322/Pre-Configured+Reports#Managing-Saved-and-Scheduled-Email-Reports.
 
 The UI (urls, view code, JS) for saved reports, which unlike the backend is tightly coupled with
 the rest of the reports UI, lives in the `reports` app. Otherwise `saved_reports` depends on

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3335,8 +3335,8 @@ class DeactivateMobileWorkerTrigger(models.Model):
 
 
 def check_and_send_limit_email(domain, plan_limit, user_count, prev_count):
-    ADDITIONAL_USERS_PRICING = ("https://confluence.dimagi.com/display/commcarepublic"
-                                "/CommCare+Pricing+FAQs#CommCarePricingFAQs-Feesforadditionalusers")
+    ADDITIONAL_USERS_PRICING = ("https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/"
+                                "2420015134/CommCare+Pricing+Overview#Additional-Mobile-Users-Fees")
     ENTERPRISE_LIMIT = -1
     if plan_limit == ENTERPRISE_LIMIT:
         return

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -113,7 +113,8 @@ ENUM_IMAGE = FeaturePreview(
         "For example, to show that a case is late, "
         'display a red square instead of "late: yes".'
     ),
-    help_link='https://help.commcarehq.org/display/commcarepublic/Adding+Icons+in+Case+List+and+Case+Detail+screen'
+    help_link=('https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143945372/'
+               'Application+Icons#Adding-Icons-in-Case-List-and-Case-Detail-screen')
 )
 
 CONDITIONAL_ENUM = FeaturePreview(

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1425,12 +1425,12 @@ COMMTRACK = StaticToggle(
     "CommCare Supply",
     TAG_DEPRECATED,
     description=(
-        '<a href="https://help.commcarehq.org/display/commtrack/CommCare+Supply+Home">CommCare Supply</a> '
+        '<a href="https://dimagi.atlassian.net/wiki/spaces/commtrack/overview">CommCare Supply</a> '
         "is a logistics and supply chain management module. It is designed "
         "to improve the management, transport, and resupply of a variety of "
         "goods and materials, from medication to food to bednets. <br/>"
     ),
-    help_link='https://help.commcarehq.org/display/commtrack/CommCare+Supply+Home',
+    help_link='https://dimagi.atlassian.net/wiki/spaces/commtrack/overview',
     namespaces=[NAMESPACE_DOMAIN],
     save_fn=_commtrackify,
 )

--- a/docs/api/bulk-upload-cases.rst
+++ b/docs/api/bulk-upload-cases.rst
@@ -4,7 +4,7 @@ Bulk Upload Case Data API
 Overview
 --------
 **Purpose**
-    Performs bulk imports of case data through the `Excel Case Data Importer <https://dimagi-dev.atlassian.net/wiki/display/commcarepublic/Importing+Cases+Using+Excel>`_ to either create or update cases.
+    Performs bulk imports of case data through the `Excel Case Data Importer <https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143946828/Case+Import+with+Excel>`_ to either create or update cases.
 
 **Base URL**
 

--- a/docs/overview/platform.rst
+++ b/docs/overview/platform.rst
@@ -230,7 +230,7 @@ in the system and enable highly-sophisticated integrations with CommCare.
 
 More details on CommCare's API can be found in the `API documentation`_.
 
-.. _API documentation: https://confluence.dimagi.com/display/commcarepublic/CommCare+HQ+APIs
+.. _API documentation: https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143958022/API+Access
 
 MOTECH Repeaters
 ~~~~~~~~~~~~~~~~

--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -2,7 +2,7 @@
 set -euo pipefail  # bash strict mode - exit on hard failures
 
 # Based on this confluence page:
-# https://confluence.dimagi.com/display/commcarehq/Internationalization+and+Localization+-+Transifex+Translations
+# https://dimagi.atlassian.net/wiki/spaces/saas/pages/2146607277/Internationalization+and+Localization+-+Transifex+Translations
 
 function abort () {
     echo $@
@@ -60,7 +60,7 @@ if [[ ! `command -v tx` || ! -f ~/.transifexrc ]]
 then
     echo "It looks like you haven't yet configured transifex."
     echo "Please visit the wiki page for instructions on how to do so:"
-    echo "https://confluence.dimagi.com/display/commcarehq/Internationalization+and+Localization+-+Transifex+Translations"
+    echo "https://dimagi.atlassian.net/wiki/spaces/saas/pages/2146607277/Internationalization+and+Localization+-+Transifex+Translations"
     abort
 fi
 


### PR DESCRIPTION
## Product Description
Fixes broken links.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-16807
Builds off that ticket by updating all of the broken (not able to redirect) `confluence.dimagi.com` and `help.commcarehq.org` links I was able to find, with the notable exception of help links that exist only for Feature Flags. I did not update any links that were already `dimagi.atlassian.net/wiki` (it's possible broken links do exist there) or where the page redirected correctly to its newer version. A couple of these were internal help site links that are already potentially user-facing and just moved to a different division, which seemed a bit odd but was noted in commit messages for those.

Also, many of these links are in html templates. I did not run Prettier on the templates because of the incredible number of changes it would introduce to this PR.

## Feature Flag
Some of these links are only shown when feature flags are enabled.

## Safety Assurance

### Safety story
These changes only affect already-broken help site links.

### Automated test coverage
Unlikely.

### QA Plan
No plan for it. Could test this on staging if reviewers think it's necessary, but I don't think it is.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
