### PR TITLE
[Data Cleaning] Address remaining data cleaning cleanup and open for QA

### DIFF
--- a/corehq/apps/data_cleaning/forms/cleaning.py
+++ b/corehq/apps/data_cleaning/forms/cleaning.py
@@ -217,22 +217,25 @@ class CleanSelectedRecordsForm(forms.Form):
     def create_bulk_edit_change(self):
         prop_id = self.cleaned_data["clean_prop_id"]
         action_type = self.cleaned_data["clean_action"]
-        change_kwargs = {
-            EditActionType.REPLACE: {
+        if action_type == EditActionType.REPLACE:
+            action_options = {
                 "replace_string": self.cleaned_data["replace_all_string"],
-            },
-            EditActionType.FIND_REPLACE: {
+            }
+        elif action_type == EditActionType.FIND_REPLACE:
+            action_options = {
                 "find_string": self.cleaned_data["find_string"],
                 "replace_string": self.cleaned_data["replace_string"],
                 "use_regex": self.cleaned_data["use_regex"],
-            },
-            EditActionType.COPY_REPLACE: {
+            }
+        elif action_type == EditActionType.COPY_REPLACE:
+            action_options = {
                 "copy_from_prop_id": self.cleaned_data["copy_from_prop_id"],
-            },
-        }.get(action_type, {})
+            }
+        else:
+            action_options = {}
         return BulkEditChange.objects.create(
             session=self.session,
             prop_id=prop_id,
             action_type=action_type,
-            **change_kwargs,
+            **action_options,
         )

--- a/corehq/apps/data_cleaning/forms/cleaning.py
+++ b/corehq/apps/data_cleaning/forms/cleaning.py
@@ -214,7 +214,7 @@ class CleanSelectedRecordsForm(forms.Form):
 
         return cleaned_data
 
-    def create_bulk_edit_change(self):
+    def get_bulk_edit_change(self):
         prop_id = self.cleaned_data["clean_prop_id"]
         action_type = self.cleaned_data["clean_action"]
         if action_type == EditActionType.REPLACE:
@@ -233,7 +233,7 @@ class CleanSelectedRecordsForm(forms.Form):
             }
         else:
             action_options = {}
-        return BulkEditChange.objects.create(
+        return BulkEditChange(
             session=self.session,
             prop_id=prop_id,
             action_type=action_type,

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -314,6 +314,7 @@ class BulkEditSession(models.Model):
         Apply a change to the selected records in the current queryset.
         :param change: BulkEditChange - an UNSAVED instance
         """
+        assert change.session == self
         change.save()  # save the change in the atomic block, rather than the form
         if self.has_any_filtering:
             self._apply_operation_on_queryset(

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -309,10 +309,10 @@ class BulkEditSession(models.Model):
         change.records.add(*selected_records)
 
     @transaction.atomic
-    def apply_change_to_selected_records_in_queryset(self, change):
+    def apply_change_to_selected_records(self, change):
         """
-        Apply a change to the selected records in the current queryset.
         :param change: BulkEditChange - an UNSAVED instance
+        :return: BulkEditChange - the saved instance
         """
         assert change.session == self
         change.save()  # save the change in the atomic block, rather than the form
@@ -324,6 +324,7 @@ class BulkEditSession(models.Model):
             # If there are no filters, we can just apply the change to all selected records
             # this will be a faster operation for larger data sets
             self._attach_change_to_records(change)
+        return change
 
     @property
     def num_changed_records(self):

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -296,6 +296,7 @@ class BulkEditSession(models.Model):
         record = BulkEditRecord.get_record_for_inline_editing(self, doc_id)
         BulkEditChange.apply_inline_edit(record, prop_id, value)
 
+    @retry_on_integrity_error(max_retries=3, delay=0.1)
     def _attach_change_to_records(self, change, doc_ids=None):
         """
         :param change: BulkEditChange
@@ -307,7 +308,6 @@ class BulkEditSession(models.Model):
             selected_records = self.records.filter(doc_id__in=doc_ids, is_selected=True)
         change.records.add(*selected_records)
 
-    @retry_on_integrity_error(max_retries=3, delay=0.1)
     @transaction.atomic
     def apply_change_to_selected_records_in_queryset(self, change):
         """

--- a/corehq/apps/data_cleaning/views/cleaning.py
+++ b/corehq/apps/data_cleaning/views/cleaning.py
@@ -35,13 +35,7 @@ class CleanSelectedRecordsFormView(BulkEditSessionViewMixin,
         cleaning_form = CleanSelectedRecordsForm(self.session, request.POST)
         change = None
         if cleaning_form.is_valid():
-            from django.conf import settings
-
-            # temporarily disallow QA to accidentally create bulk edit changes
-            # that they cannot see
-            if settings.SERVER_ENVIRONMENT == settings.LOCAL_SERVER_ENVIRONMENT:
-                change = cleaning_form.create_bulk_edit_change()
-                self.session.apply_change_to_selected_records_in_queryset(change)
-
+            change = cleaning_form.create_bulk_edit_change()
+            self.session.apply_change_to_selected_records_in_queryset(change)
             cleaning_form = None
         return self.get(request, cleaning_form=cleaning_form, change=change, *args, **kwargs)

--- a/corehq/apps/data_cleaning/views/cleaning.py
+++ b/corehq/apps/data_cleaning/views/cleaning.py
@@ -35,7 +35,8 @@ class CleanSelectedRecordsFormView(BulkEditSessionViewMixin,
         cleaning_form = CleanSelectedRecordsForm(self.session, request.POST)
         change = None
         if cleaning_form.is_valid():
-            change = cleaning_form.get_bulk_edit_change()
-            self.session.apply_change_to_selected_records_in_queryset(change)
+            change = self.session.apply_change_to_selected_records(
+                cleaning_form.get_bulk_edit_change()
+            )
             cleaning_form = None
         return self.get(request, cleaning_form=cleaning_form, change=change, *args, **kwargs)

--- a/corehq/apps/data_cleaning/views/cleaning.py
+++ b/corehq/apps/data_cleaning/views/cleaning.py
@@ -35,7 +35,7 @@ class CleanSelectedRecordsFormView(BulkEditSessionViewMixin,
         cleaning_form = CleanSelectedRecordsForm(self.session, request.POST)
         change = None
         if cleaning_form.is_valid():
-            change = cleaning_form.create_bulk_edit_change()
+            change = cleaning_form.get_bulk_edit_change()
             self.session.apply_change_to_selected_records_in_queryset(change)
             cleaning_form = None
         return self.get(request, cleaning_form=cleaning_form, change=change, *args, **kwargs)


### PR DESCRIPTION
## Technical Summary
This PR:
- addresses concurrency issues with creating a `BulkEditChange` and assigning it to a `BulkEditSession`'s `records`
- improves bulk creation of `M2M` relationships between changes and records
- small renaming and reorganization refactors
- ensures the bulk data cleaning functionality is available to QA, allowing the clean selected cases form to be submitted on non-local environments (the whole feature is still behind a feature flag in this PR)

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change applied to feature flagged workflows only

### Automated test coverage
most important logic is unit tested, and there are pending tickets to address any missed tests

### QA Plan
not yet

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
