### PR TITLE
Tag Permission entry is required for user to edit FFs

### DIFF
--- a/corehq/toggles/shortcuts.py
+++ b/corehq/toggles/shortcuts.py
@@ -107,8 +107,7 @@ def get_editable_toggle_tags_for_user(username):
     allowed_tags = []
     for tag in ALL_TAGS:
         permission = ToggleEditPermission.get_by_tag_slug(tag.slug)
-        # User has access to the tag if no entry exists
-        if not permission or permission.is_user_enabled(username):
+        if permission and permission.is_user_enabled(username):
             allowed_tags.append(tag)
     return allowed_tags
 
@@ -116,7 +115,6 @@ def get_editable_toggle_tags_for_user(username):
 def can_user_edit_tag(username, tag):
     from corehq.toggles.sql_models import ToggleEditPermission
     permission = ToggleEditPermission.get_by_tag_slug(tag.slug)
-    # User has access to the tag if no entry exists
-    if not permission or permission.is_user_enabled(username):
+    if permission and permission.is_user_enabled(username):
         return True
     return False

--- a/corehq/toggles/tests.py
+++ b/corehq/toggles/tests.py
@@ -443,8 +443,7 @@ class TestToggleEditPermissionShortcuts(TestCase):
 
     def test_get_tags_with_edit_permission(self):
         allowed_tags = get_editable_toggle_tags_for_user('arthur')
-        assert allowed_tags == ALL_TAGS
+        assert allowed_tags == [TAG_CUSTOM]
 
         allowed_tags = get_editable_toggle_tags_for_user('diane')
-        expected_tags = [tag for tag in ALL_TAGS if tag != TAG_CUSTOM]
-        assert allowed_tags == expected_tags
+        assert allowed_tags == []


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

If a permission entry did not exist in the database, it was previously assumed that all superusers would have access to edit the feature flags under the tag. This was done to ensure that superusers would retain the same access after deployment unless modified.

However, after discussions with stakeholders, this is no longer required, and only specific users will be granted access for each feature flag category.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This PR updates the logic to require an explicit permission entry with assigned users in order to access feature flags under a given tag.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
A small change. Tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Test  cases updated .

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA to be done

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
