### PR TITLE
Upgrade to pip==25.1.1 and setuptools==80.3.1

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -775,9 +775,9 @@ zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==25.1.1
     # via pip-tools
-setuptools==75.4.0
+setuptools==80.3.1
     # via
     #   django-websocket-redis
     #   pip-tools

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -633,7 +633,7 @@ zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.4.0
+setuptools==80.3.1
     # via
     #   django-websocket-redis
     #   zope-event

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -626,9 +626,9 @@ zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==25.1.1
     # via -r prod-requirements.in
-setuptools==75.4.0
+setuptools==80.3.1
     # via
     #   django-websocket-redis
     #   zope-event

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -578,7 +578,7 @@ zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.4.0
+setuptools==80.3.1
     # via
     #   django-websocket-redis
     #   zope-event

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -644,9 +644,9 @@ zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==25.1.1
     # via pip-tools
-setuptools==75.4.0
+setuptools==80.3.1
     # via
     #   django-websocket-redis
     #   pip-tools


### PR DESCRIPTION
Upgrade multi-major outdated installer requirements.

## Safety Assurance

### Safety story

Perhaps the most widely used dependencies of all. Used mainly during installation.

### Automated test coverage

Indirect.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
