### PR TITLE
Fixed hqdefine_to_esm handling of single-line function params

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/hqdefine_to_esm.py
+++ b/corehq/apps/hqwebapp/management/commands/hqdefine_to_esm.py
@@ -15,7 +15,15 @@ class Command(BaseCommand):
     help = '''
         Attempts to migrate a JavaScript file from hqDefine to ESM syntax.
         Expects input file to be formatted with hqDefine on one line,
-        then one line per import, then one line per hqDefine argument.
+        then one line per import, then one line per argument:
+
+        hqDefine('this/is/my/module', [
+           'app1/js/m1/,
+           'app2/js/m2/,
+        ], function (
+           module1,      // this is used for xyz
+           module2,
+        ) {
 
         Also attempts to remove "use strict" directive, because modules automatically use strict.
     '''
@@ -54,7 +62,11 @@ class Command(BaseCommand):
 
             if self.update_parser_location(line, line_index):
                 if self.in_arguments:
-                    arguments.extend(self.parse_one_line_arguments(line, line_index))
+                    # Add blank "comments", which the loop below is expecting
+                    arguments.extend([
+                        (arg, '')
+                        for arg in self.parse_one_line_arguments(line, line_index)
+                    ])
                 continue
             if self.in_imports:
                 imports.append(self.parse_import(line))
@@ -76,8 +88,10 @@ class Command(BaseCommand):
                 fout.write('import "commcarehq";\n')
 
             # Add imports, ESM-style
+            # Dependency is a tuple of the module name and any inline comment
             for index, dependency_pair in enumerate(imports):
                 (dependency, comment) = dependency_pair
+                # Skip commcarehq, which has been handled above
                 if dependency is None or dependency == "commcarehq":
                     continue
 
@@ -125,6 +139,7 @@ class Command(BaseCommand):
     def parse_argument(self, line):
         return self.parse_item(ARGUMENT_PATTERN, line, "argument")
 
+    # Parses a single line, returning the relevant code (likely a module or variable name) and any inline comment
     def parse_item(self, pattern, line, description=""):
         match = re.search(r'^(.*\S)\s*\/\/\s*(.*)$', line)
         if match:
@@ -143,11 +158,22 @@ class Command(BaseCommand):
         logger.warning(f"Could not parse {description} from line: {line}")
 
     def parse_one_line_arguments(self, line, index):
+        '''
+        Most modules are formatted with one hqDefine param per line,
+        but some have a single line with all arguments, like this:
+
+        hqDefine('someModule', [
+           ...
+        ], function (module1, module2) {
+
+        This function grabs all the arguments from such a module.
+        Returns a list of arguments.
+        '''
         match = re.search(r'function\s*\((.*)\)', line)
         if match:
             self.update_parser_location(line, index)
             arguments = match.group(1)
-            return [(arg.strip(), '') for arg in arguments.split(',')]
+            return [arg.strip() for arg in arguments.split(',')]
         return []
 
     def init_parser(self):
@@ -166,6 +192,11 @@ class Command(BaseCommand):
         raise CommandError(f"Could not parse file. Ran out of code {status}.")
 
     def update_parser_location(self, line, index):
+        '''
+        The parser assumes there are three "blocks": the overall hqDefine area,
+        the imports block within that, and then the arguments block within that.
+        This is indicated via a couple of boolean flags.
+        '''
         if self.is_use_strict(line):
             return line
         if self.is_hqdefine_open(line):

--- a/corehq/apps/hqwebapp/management/commands/hqdefine_to_esm.py
+++ b/corehq/apps/hqwebapp/management/commands/hqdefine_to_esm.py
@@ -147,7 +147,7 @@ class Command(BaseCommand):
         if match:
             self.update_parser_location(line, index)
             arguments = match.group(1)
-            return [arg.strip() for arg in arguments.split(',')]
+            return [(arg.strip(), '') for arg in arguments.split(',')]
         return []
 
     def init_parser(self):


### PR DESCRIPTION
## Technical Summary
A while back I updated the script to handle comments in multi-line param lists:
```
hqDefine('blah', [
   ...
], function (
   module1,      // comments like this were getting swallowed
   module2,
) {
```

I missed updating the corresponding code for single-line param lists, which look like this:
```
hqDefine('blah', [
   ...
], function (module1, module2) {
```

## Safety Assurance

### Safety story
Minor change to an internal engineering tool

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
