### PR TITLE
[Data Cleaning] Make commit_data_cleaning task more robust

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -481,7 +481,7 @@ class BulkEditSession(models.Model):
             result['percent'] = result['record_count'] * 100 / self.records.count()
 
         self.result = result
-        self.save()
+        self.save(update_fields=['result'])
 
 
 class DataType:

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -462,7 +462,7 @@ class BulkEditSession(models.Model):
         # the most potentially expensive query is below:
         return num_records + self._get_num_unrecorded() <= MAX_RECORDED_LIMIT
 
-    def update_result(self, record_count, form_id=None):
+    def update_result(self, record_count, form_id=None, error=None):
         result = self.result or {}
 
         if 'form_ids' not in result:
@@ -471,9 +471,13 @@ class BulkEditSession(models.Model):
             result['record_count'] = 0
         if 'percent' not in result:
             result['percent'] = 0
+        if 'errors' not in result:
+            result['errors'] = []
 
         if form_id:
             result['form_ids'].append(form_id)
+        if error:
+            result['errors'].append(error)
         result['record_count'] += record_count
         if self.records.count() == 0:
             result['percent'] = 100

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -1,9 +1,6 @@
 import re
 import uuid
 
-from celery import uuid as celery_uuid
-from datetime import datetime, timezone
-
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.db import models, transaction
@@ -392,15 +389,6 @@ class BulkEditSession(models.Model):
     def clear_all_changes(self):
         self.changes.all().delete()
         self.purge_records()
-
-    def prepare_session_for_commit(self):
-        """
-        Prepare the session for commit by generating a task id
-        and setting the committed_on date.
-        """
-        self.task_id = celery_uuid()
-        self.committed_on = datetime.now(timezone.utc).replace(tzinfo=None)
-        self.save()
 
     def is_record_selected(self, doc_id):
         return BulkEditRecord.is_record_selected(self, doc_id)

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -100,9 +100,11 @@ def _purge_ui_data_from_session(session):
     session.purge_records()
 
 
+@transaction.atomic
 def _prune_completed_records(session, completed_doc_ids, errored_doc_ids):
     ids_to_delete = set(completed_doc_ids) - set(errored_doc_ids)
     session.records.filter(doc_id__in=ids_to_delete).delete()
+    session.changes.filter(records__isnull=True).delete()
 
 
 def _create_case_blocks(session, records):

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -56,6 +56,13 @@ def commit_data_cleaning(self, bulk_edit_session_id):
     record_iter = session.records.order_by('pk').iterator()
     for record_batch in chunked(record_iter, CASEBLOCK_CHUNKSIZE):
         blocks = _create_case_blocks(session, record_batch)
+        if not blocks:
+            logger.info("commit_data_cleaning: no cases needed an update in a batch", extra={
+                'session_id': session.session_id,
+                'domain': session.domain,
+                'record_batch': [record.doc_id for record in record_batch],
+            })
+            continue
         xform = _submit_case_blocks(session, blocks)
         num_records = len(record_batch)
         count_cases(value=num_records * 2)       # 1 read + 1 write per case

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -8,7 +8,6 @@ from django.db.models import Q, Count
 from dimagi.utils.chunked import chunked
 
 from casexml.apps.case.mock import CaseBlock
-from corehq.apps.data_cleaning.utils.decorators import retry_on_integrity_error
 from corehq.apps.data_cleaning.models import (
     BulkEditSession,
 )
@@ -95,7 +94,6 @@ def _purge_ui_data_from_session(session):
     session.purge_records()
 
 
-@retry_on_integrity_error(max_retries=3, delay=0.1)
 @transaction.atomic
 def _prune_records_and_complete_session(session, errored_doc_ids):
     # remove errored records from session

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -53,7 +53,6 @@ def commit_data_cleaning(self, bulk_edit_session_id):
         count_cases(value=len(records) * 2)       # 1 read + 1 write per case
         form_ids.append(xform.form_id)
         session.update_result(len(records), xform.form_id)
-        session.save()
 
     session.completed_on = timezone.now()
     session.save()

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -41,6 +41,11 @@ def commit_data_cleaning(self, bulk_edit_session_id):
 
     session = BulkEditSession.objects.get(session_id=bulk_edit_session_id)
 
+    logger.info("commit_data_cleaning: starting", extra={
+        'session_id': session.session_id,
+        'domain': session.domain,
+    })
+
     session.deselect_all_records_in_queryset()  # already in an atomic, retry block
     _purge_ui_data_from_session(session)
 

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -87,6 +87,10 @@ def commit_data_cleaning(self, bulk_edit_session_id):
         form_ids.append(xform.form_id)
 
     _prune_records_and_complete_session(session, errored_doc_ids)
+    logger.info("commit_data_cleaning: completed", extra={
+        'session_id': session.session_id,
+        'domain': session.domain,
+    })
 
     return form_ids
 

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -21,7 +21,7 @@ from corehq.util.metrics.load_counters import case_load_counter
 logger = logging.getLogger(__name__)
 
 
-@task(bind=True, queue='case_import_queue', acks_late=True)
+@task(bind=True, queue='case_import_queue')
 def commit_data_cleaning(self, bulk_edit_session_id):
     updated = BulkEditSession.objects.filter(
         session_id=bulk_edit_session_id,

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -46,7 +46,6 @@ def commit_data_cleaning(self, bulk_edit_session_id):
         'domain': session.domain,
     })
 
-    session.deselect_all_records_in_queryset()  # already in an atomic, retry block
     _purge_ui_data_from_session(session)
 
     form_ids = []
@@ -87,9 +86,9 @@ def commit_data_cleaning(self, bulk_edit_session_id):
     return form_ids
 
 
-@retry_on_integrity_error(max_retries=3, delay=0.1)
 @transaction.atomic
 def _purge_ui_data_from_session(session):
+    session.deselect_all_records_in_queryset()
     session.filters.all().delete()
     session.pinned_filters.all().delete()
     session.columns.all().delete()

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from corehq.apps.celery import task
 
 from django.utils import timezone
@@ -56,7 +55,7 @@ def commit_data_cleaning(self, bulk_edit_session_id):
         session.update_result(len(records), xform.form_id)
         session.save()
 
-    session.completed_on = datetime.now()
+    session.completed_on = timezone.now()
     session.save()
 
     session.changes.all().delete()

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -82,9 +82,9 @@ def commit_data_cleaning(self, bulk_edit_session_id):
             continue
 
         num_records = len(record_batch)
-        count_cases(value=num_records * 2)       # 1 read + 1 write per case
-        form_ids.append(xform.form_id)
+        count_cases(value=num_records * 2)  # 1 read + 1 write per case
         session.update_result(num_records, xform.form_id)
+        form_ids.append(xform.form_id)
 
     session.completed_on = timezone.now()
     session.save()

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -42,11 +42,7 @@ def commit_data_cleaning(self, bulk_edit_session_id):
     for record_batch in chunked(record_iter, CASEBLOCK_CHUNKSIZE):
         blocks = _create_case_blocks(session, record_batch)
         if not blocks:
-            logger.info("commit_data_cleaning: no cases needed an update in a batch", extra={
-                'session_id': session.session_id,
-                'domain': session.domain,
-                'record_batch': [record.doc_id for record in record_batch],
-            })
+            _log_unusual_empty_case_block(session, record_batch)
             continue
 
         try:
@@ -134,6 +130,14 @@ def _submit_case_blocks(session, blocks):
         username_to_user_id(session.user.username),
         device_id=__name__ + ".data_cleaning",
     )[0]
+
+
+def _log_unusual_empty_case_block(session, record_batch):
+    logger.info("commit_data_cleaning: no cases needed an update in a batch", extra={
+        'session_id': session.session_id,
+        'domain': session.domain,
+        'record_batch': [record.doc_id for record in record_batch],
+    })
 
 
 def _record_case_block_creation_error(session, error, doc_id):

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -38,7 +38,7 @@ def commit_data_cleaning(self, bulk_edit_session_id):
     session.update_result(0)
     count_cases = case_load_counter("bulk_case_cleaning", session.domain)
 
-    record_iter = session.records.order_by('pk').iterator()
+    record_iter = session.records.iterator()
     for record_batch in chunked(record_iter, CASEBLOCK_CHUNKSIZE):
         blocks = _create_case_blocks(session, record_batch)
         if not blocks:

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -124,18 +124,9 @@ def _create_case_blocks(session, records, errored_doc_ids):
         case = cases[record.doc_id]
         try:
             update = record.get_edited_case_properties(case)
-        except Exception as e:
+        except Exception as error:  # todo: catch specific errors seen with case interactions
             errored_doc_ids.append(record.doc_id)
-            session.update_result(0, error={
-                'error': str(e),
-                'doc_id': record.doc_id,
-            })
-            logger.error("commit_data_cleaning: error getting edited case properties", extra={
-                'session_id': session.session_id,
-                'domain': session.domain,
-                'error': str(e),
-                'doc_id': record.doc_id,
-            })
+            _record_case_block_creation_error(session, error, record.doc_id)
             continue
         if update:
             blocks.append(CaseBlock(
@@ -156,3 +147,16 @@ def _submit_case_blocks(session, blocks):
         username_to_user_id(session.user.username),
         device_id=__name__ + ".data_cleaning",
     )[0]
+
+
+def _record_case_block_creation_error(session, error, doc_id):
+    session.update_result(0, error={
+        'error': str(error),
+        'doc_id': doc_id,
+    })
+    logger.error("commit_data_cleaning: error getting edited case properties", extra={
+        'session_id': session.session_id,
+        'domain': session.domain,
+        'error': str(error),
+        'doc_id': doc_id,
+    })

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -16,9 +16,7 @@ from corehq.apps.data_cleaning.models import (
 )
 from corehq.apps.data_cleaning.tasks import commit_data_cleaning
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.es.case_search import (
-    case_search_adapter,
-)
+from corehq.apps.es import case_search_adapter, user_adapter
 from corehq.apps.es.tests.utils import (
     case_search_es_setup,
     es_test,
@@ -32,7 +30,7 @@ from corehq.util.test_utils import flag_enabled
 
 
 @flag_enabled('DATA_CLEANING_CASES')
-@es_test(requires=[case_search_adapter], setup_class=True)
+@es_test(requires=[case_search_adapter, user_adapter], setup_class=True)
 class CommitCasesTest(TestCase):
     case_type = 'song'
     domain_name = 'the-loveliest-time'

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -136,6 +136,7 @@ class CommitCasesTest(TestCase):
 
         self._refresh_session()
         self.assertDictEqual(self.session.result, {
+            'errors': [],
             'form_ids': form_ids,
             'record_count': 1,
             'percent': 100,

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -132,11 +132,7 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
 
     @hq_hx_action("post")
     def apply_all_changes(self, request, *args, **kwargs):
-        self.session.prepare_session_for_commit()
-        commit_data_cleaning.apply_async(
-            args=(self.session.session_id,),
-            task_id=self.session.task_id
-        )
+        commit_data_cleaning.delay(self.session.session_id)
         messages.success(
             request,
             _("Changes applied. Check the Recent Tasks table for progress.")


### PR DESCRIPTION
## Technical Summary
This ensures the `commit_data_cleaning` task is more robust by
- adding logging to troubleshoot any issues
- catching partial errors, so that the entire task doesn't fail
- ensuring only one task can "claim" processing of the bulk cleaning session
- populating task_id and committed_on from within the task, rather than outside of it

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
existing tests already test the functionality of `commit_data_cleaning`, these changes improve overall safety and error handling.

### Automated test coverage
yes, with room for improvements in a followup

### QA Plan
not yet (QA starting on overall feature this week, does not block PR)


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
