### PR TITLE
App manager ESM: form view and module view

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
@@ -1,151 +1,144 @@
-hqDefine("app_manager/js/case_config_utils", [
-    "jquery",
-    "underscore",
-    "hqwebapp/js/toggles",
-    "hqwebapp/js/initial_page_data",
-], function (
-    $,
-    _,
-    toggles,
-    initialPageData,
-) {
-    return {
-        getQuestions: function (questions, filter, excludeHidden, includeRepeat, excludeTrigger) {
-            // filter can be "all", or any of "select1", "select", or "input" separated by spaces
-            var i,
-                options = [],
-                q;
-            excludeHidden = excludeHidden || false;
-            excludeTrigger = excludeTrigger || false;
-            includeRepeat = includeRepeat || false;
-            filter = filter.split(" ");
-            if (!excludeHidden) {
-                filter.push('hidden');
-            }
-            if (!excludeTrigger) {
-                filter.push('trigger');
-            }
-            var allowAttachments = toggles.toggleEnabled('MM_CASE_PROPERTIES');
-            for (i = 0; i < questions.length; i += 1) {
-                q = questions[i];
-                if (filter[0] === "all" || filter.indexOf(q.tag) !== -1) {
-                    if (includeRepeat || !q.repeat) {
-                        if (!excludeTrigger || q.tag !== "trigger") {
-                            if (allowAttachments || q.tag !== "upload") {
-                                options.push(q);
-                            }
+import $ from "jquery";
+import _ from "underscore";
+import toggles from "hqwebapp/js/toggles";
+import initialPageData from "hqwebapp/js/initial_page_data";
+
+export default {
+    getQuestions: function (questions, filter, excludeHidden, includeRepeat, excludeTrigger) {
+        // filter can be "all", or any of "select1", "select", or "input" separated by spaces
+        var i,
+            options = [],
+            q;
+        excludeHidden = excludeHidden || false;
+        excludeTrigger = excludeTrigger || false;
+        includeRepeat = includeRepeat || false;
+        filter = filter.split(" ");
+        if (!excludeHidden) {
+            filter.push('hidden');
+        }
+        if (!excludeTrigger) {
+            filter.push('trigger');
+        }
+        var allowAttachments = toggles.toggleEnabled('MM_CASE_PROPERTIES');
+        for (i = 0; i < questions.length; i += 1) {
+            q = questions[i];
+            if (filter[0] === "all" || filter.indexOf(q.tag) !== -1) {
+                if (includeRepeat || !q.repeat) {
+                    if (!excludeTrigger || q.tag !== "trigger") {
+                        if (allowAttachments || q.tag !== "upload") {
+                            options.push(q);
                         }
                     }
                 }
             }
-            return options;
-        },
-        getAnswers: function (questions, condition) {
-            var i,
-                q,
-                o,
-                value = condition.question,
-                found = false,
-                options = [];
-            for (i = 0; i < questions.length; i += 1) {
-                q = questions[i];
-                if (q.value === value) {
-                    found = true;
-                    break;
-                }
+        }
+        return options;
+    },
+    getAnswers: function (questions, condition) {
+        var i,
+            q,
+            o,
+            value = condition.question,
+            found = false,
+            options = [];
+        for (i = 0; i < questions.length; i += 1) {
+            q = questions[i];
+            if (q.value === value) {
+                found = true;
+                break;
             }
-            if (found && q.options) {
-                for (i = 0; i < q.options.length; i += 1) {
-                    o = q.options[i];
-                    options.push(o);
-                }
+        }
+        if (found && q.options) {
+            for (i = 0; i < q.options.length; i += 1) {
+                o = q.options[i];
+                options.push(o);
             }
-            return options;
-        },
-        // This function depends on initial page data, so it should be called within a document ready handler
-        initRefreshQuestions: function (questionsObservable) {
-            const formUniqueId = initialPageData.get("form_unique_id");
-            if (formUniqueId) {
-                var currentAppUrl = initialPageData.reverse("current_app_version"),
-                    oldVersion = initialPageData.get("app_subset").version;
-                $(document).on("ajaxComplete", function (e, xhr, options) {
-                    if (options.url === currentAppUrl) {
-                        var newVersion = xhr.responseJSON.currentVersion;
-                        if (newVersion > oldVersion) {
-                            oldVersion = newVersion;
-                            $.get({
-                                url: initialPageData.reverse('get_form_questions'),
-                                data: {
-                                    form_unique_id: formUniqueId,
-                                },
-                                success: function (data) {
-                                    questionsObservable(data);
-                                },
-                            });
-                        }
-                    }
-                });
-            }
-        },
-        filteredSuggestedProperties: function (suggestedProperties, properties) {
-            var usedProperties = _.map(properties, function (x) {
-                return x.key();
-            });
-            return _(suggestedProperties).difference(usedProperties);
-        },
-        propertyDictToArray: function (required, propertyDict, caseConfig) {
-            var propertyArray = _(propertyDict).map(function (conditionalCaseUpdate, caseName) {
-                return {
-                    path: conditionalCaseUpdate.question_path,
-                    key: caseName,
-                    required: false,
-                    save_only_if_edited: conditionalCaseUpdate.update_mode === 'edit',
-                };
-            });
-            propertyArray = _(propertyArray).sortBy(function (property) {
-                return caseConfig.questionScores[property.path] * 2 + (property.required ? 0 : 1);
-            });
-            return required.concat(propertyArray);
-        },
-        propertyArrayToDict: function (required, propertyArray) {
-            var propertyDict = {},
-                extraDict = {};
-            _(propertyArray).each(function (caseProperty) {
-                var key = caseProperty.key;
-                var path = caseProperty.path;
-                var updateMode = caseProperty.save_only_if_edited ? 'edit' : 'always';
-                if (key || path) {
-                    if (_(required).contains(key) && caseProperty.required) {
-                        extraDict[key] = {question_path: path, update_mode: updateMode};
-                    } else {
-                        propertyDict[key] = {question_path: path, update_mode: updateMode};
+        }
+        return options;
+    },
+    // This function depends on initial page data, so it should be called within a document ready handler
+    initRefreshQuestions: function (questionsObservable) {
+        const formUniqueId = initialPageData.get("form_unique_id");
+        if (formUniqueId) {
+            var currentAppUrl = initialPageData.reverse("current_app_version"),
+                oldVersion = initialPageData.get("app_subset").version;
+            $(document).on("ajaxComplete", function (e, xhr, options) {
+                if (options.url === currentAppUrl) {
+                    var newVersion = xhr.responseJSON.currentVersion;
+                    if (newVersion > oldVersion) {
+                        oldVersion = newVersion;
+                        $.get({
+                            url: initialPageData.reverse('get_form_questions'),
+                            data: {
+                                form_unique_id: formUniqueId,
+                            },
+                            success: function (data) {
+                                questionsObservable(data);
+                            },
+                        });
                     }
                 }
             });
-            return [propertyDict, extraDict];
-        },
-        preloadDictToArray: function (propertyDict, caseConfig) {
-            var propertyArray = _(propertyDict).map(function (path, caseName) {
-                return {
-                    path: caseName,
-                    key: path,
-                    required: false,
-                    save_only_if_edited: false,
-                };
-            });
-            propertyArray = _(propertyArray).sortBy(function (property) {
-                return caseConfig.questionScores[property.path] * 2 + (property.required ? 0 : 1);
-            });
-            return propertyArray;
-        },
-        preloadArrayToDict: function (preloadArray) {
-            // i.e. {i.path: i.key for i in preloadArray if i.key or i.path}
-            return _.object(
-                _.map(
-                    _.filter(preloadArray, function (i) { return (i.key || i.path); }),
-                    function (i) { return [i.path, i.key]; },
-                ),
-            );
-        },
-    };
-});
+        }
+    },
+    filteredSuggestedProperties: function (suggestedProperties, properties) {
+        var usedProperties = _.map(properties, function (x) {
+            return x.key();
+        });
+        return _(suggestedProperties).difference(usedProperties);
+    },
+    propertyDictToArray: function (required, propertyDict, caseConfig) {
+        var propertyArray = _(propertyDict).map(function (conditionalCaseUpdate, caseName) {
+            return {
+                path: conditionalCaseUpdate.question_path,
+                key: caseName,
+                required: false,
+                save_only_if_edited: conditionalCaseUpdate.update_mode === 'edit',
+            };
+        });
+        propertyArray = _(propertyArray).sortBy(function (property) {
+            return caseConfig.questionScores[property.path] * 2 + (property.required ? 0 : 1);
+        });
+        return required.concat(propertyArray);
+    },
+    propertyArrayToDict: function (required, propertyArray) {
+        var propertyDict = {},
+            extraDict = {};
+        _(propertyArray).each(function (caseProperty) {
+            var key = caseProperty.key;
+            var path = caseProperty.path;
+            var updateMode = caseProperty.save_only_if_edited ? 'edit' : 'always';
+            if (key || path) {
+                if (_(required).contains(key) && caseProperty.required) {
+                    extraDict[key] = {question_path: path, update_mode: updateMode};
+                } else {
+                    propertyDict[key] = {question_path: path, update_mode: updateMode};
+                }
+            }
+        });
+        return [propertyDict, extraDict];
+    },
+    preloadDictToArray: function (propertyDict, caseConfig) {
+        var propertyArray = _(propertyDict).map(function (path, caseName) {
+            return {
+                path: caseName,
+                key: path,
+                required: false,
+                save_only_if_edited: false,
+            };
+        });
+        propertyArray = _(propertyArray).sortBy(function (property) {
+            return caseConfig.questionScores[property.path] * 2 + (property.required ? 0 : 1);
+        });
+        return propertyArray;
+    },
+    preloadArrayToDict: function (preloadArray) {
+        // i.e. {i.path: i.key for i in preloadArray if i.key or i.path}
+        return _.object(
+            _.map(
+                _.filter(preloadArray, function (i) { return (i.key || i.path); }),
+                function (i) { return [i.path, i.key]; },
+            ),
+        );
+    },
+};

--- a/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
@@ -1,76 +1,68 @@
-hqDefine('app_manager/js/custom_assertions', [
-    'jquery',
-    'knockout',
-    'hqwebapp/js/initial_page_data',
-    'hqwebapp/js/toggles',
-], function (
-    $,
-    ko,
-    initialPageData,
-    toggles,
-) {
-    var customAssertion = function (test, text) {
-        var self = {};
-        self.test = ko.observable(test || '');
-        self.text = ko.observable(text || '');
-        return self;
+import $ from "jquery";
+import ko from "knockout";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import toggles from "hqwebapp/js/toggles";
+
+var customAssertion = function (test, text) {
+    var self = {};
+    self.test = ko.observable(test || '');
+    self.text = ko.observable(text || '');
+    return self;
+};
+
+var customAssertions = function () {
+    var self = {};
+    self.customAssertions = ko.observableArray();
+
+    self.mapping = {
+        customAssertions: {
+            create: function (options) {
+                return customAssertion(options.data.test, options.data.text);
+            },
+        },
     };
 
-    var customAssertions = function () {
-        var self = {};
-        self.customAssertions = ko.observableArray();
+    self.wrap = function (assertions) {
+        let ret = ko.mapping.fromJS(assertions, self.mapping, self);
 
-        self.mapping = {
-            customAssertions: {
-                create: function (options) {
-                    return customAssertion(options.data.test, options.data.text);
-                },
-            },
-        };
-
-        self.wrap = function (assertions) {
-            let ret = ko.mapping.fromJS(assertions, self.mapping, self);
-
-            // after initialization, fire change event so save button works
-            self.customAssertions.subscribe(function () {
-                $("#custom-assertions input[name='custom_assertions']").change();
-            });
-
-            return ret;
-        };
-
-        self.unwrap = function () {
-            return ko.mapping.toJS(self);
-        };
-
-        self.addAssertion = function (assertion) {
-            assertion = assertion || {test: null, text: null};
-            self.customAssertions.push(
-                customAssertion(assertion.test, assertion.text),
-            );
-        };
-
-        self.removeAssertion = function (assertion) {
-            self.customAssertions.remove(assertion);
-        };
-
-        self.serializedCustomAssertions = ko.computed(function () {
-            return JSON.stringify(self.unwrap().customAssertions);
+        // after initialization, fire change event so save button works
+        self.customAssertions.subscribe(function () {
+            $("#custom-assertions input[name='custom_assertions']").change();
         });
 
-        return self;
+        return ret;
     };
 
-    $(function () {
-        if (toggles.toggleEnabled('CUSTOM_ASSERTIONS')) {
-            const $container = $('#custom-assertions');
-            if ($container.length) {
-                var assertions = customAssertions().wrap({
-                    'customAssertions': initialPageData.get('custom_assertions'),
-                });
-                $container.koApplyBindings(assertions);
-            }
-        }
+    self.unwrap = function () {
+        return ko.mapping.toJS(self);
+    };
+
+    self.addAssertion = function (assertion) {
+        assertion = assertion || {test: null, text: null};
+        self.customAssertions.push(
+            customAssertion(assertion.test, assertion.text),
+        );
+    };
+
+    self.removeAssertion = function (assertion) {
+        self.customAssertions.remove(assertion);
+    };
+
+    self.serializedCustomAssertions = ko.computed(function () {
+        return JSON.stringify(self.unwrap().customAssertions);
     });
 
+    return self;
+};
+
+$(function () {
+    if (toggles.toggleEnabled('CUSTOM_ASSERTIONS')) {
+        const $container = $('#custom-assertions');
+        if ($container.length) {
+            var assertions = customAssertions().wrap({
+                'customAssertions': initialPageData.get('custom_assertions'),
+            });
+            $container.koApplyBindings(assertions);
+        }
+    }
 });

--- a/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/custom_assertions.js
@@ -1,68 +1,76 @@
-import $ from "jquery";
-import ko from "knockout";
-import initialPageData from "hqwebapp/js/initial_page_data";
-import toggles from "hqwebapp/js/toggles";
-
-var customAssertion = function (test, text) {
-    var self = {};
-    self.test = ko.observable(test || '');
-    self.text = ko.observable(text || '');
-    return self;
-};
-
-var customAssertions = function () {
-    var self = {};
-    self.customAssertions = ko.observableArray();
-
-    self.mapping = {
-        customAssertions: {
-            create: function (options) {
-                return customAssertion(options.data.test, options.data.text);
-            },
-        },
+hqDefine('app_manager/js/custom_assertions', [
+    'jquery',
+    'knockout',
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/toggles',
+], function (
+    $,
+    ko,
+    initialPageData,
+    toggles,
+) {
+    var customAssertion = function (test, text) {
+        var self = {};
+        self.test = ko.observable(test || '');
+        self.text = ko.observable(text || '');
+        return self;
     };
 
-    self.wrap = function (assertions) {
-        let ret = ko.mapping.fromJS(assertions, self.mapping, self);
+    var customAssertions = function () {
+        var self = {};
+        self.customAssertions = ko.observableArray();
 
-        // after initialization, fire change event so save button works
-        self.customAssertions.subscribe(function () {
-            $("#custom-assertions input[name='custom_assertions']").change();
+        self.mapping = {
+            customAssertions: {
+                create: function (options) {
+                    return customAssertion(options.data.test, options.data.text);
+                },
+            },
+        };
+
+        self.wrap = function (assertions) {
+            let ret = ko.mapping.fromJS(assertions, self.mapping, self);
+
+            // after initialization, fire change event so save button works
+            self.customAssertions.subscribe(function () {
+                $("#custom-assertions input[name='custom_assertions']").change();
+            });
+
+            return ret;
+        };
+
+        self.unwrap = function () {
+            return ko.mapping.toJS(self);
+        };
+
+        self.addAssertion = function (assertion) {
+            assertion = assertion || {test: null, text: null};
+            self.customAssertions.push(
+                customAssertion(assertion.test, assertion.text),
+            );
+        };
+
+        self.removeAssertion = function (assertion) {
+            self.customAssertions.remove(assertion);
+        };
+
+        self.serializedCustomAssertions = ko.computed(function () {
+            return JSON.stringify(self.unwrap().customAssertions);
         });
 
-        return ret;
+        return self;
     };
 
-    self.unwrap = function () {
-        return ko.mapping.toJS(self);
-    };
-
-    self.addAssertion = function (assertion) {
-        assertion = assertion || {test: null, text: null};
-        self.customAssertions.push(
-            customAssertion(assertion.test, assertion.text),
-        );
-    };
-
-    self.removeAssertion = function (assertion) {
-        self.customAssertions.remove(assertion);
-    };
-
-    self.serializedCustomAssertions = ko.computed(function () {
-        return JSON.stringify(self.unwrap().customAssertions);
+    $(function () {
+        if (toggles.toggleEnabled('CUSTOM_ASSERTIONS')) {
+            const $container = $('#custom-assertions');
+            if ($container.length) {
+                var assertions = customAssertions().wrap({
+                    'customAssertions': initialPageData.get('custom_assertions'),
+                });
+                $container.koApplyBindings(assertions);
+            }
+        }
     });
 
-    return self;
-};
-
-$(function () {
-    if (toggles.toggleEnabled('CUSTOM_ASSERTIONS')) {
-        const $container = $('#custom-assertions');
-        if ($container.length) {
-            var assertions = customAssertions().wrap({
-                'customAssertions': initialPageData.get('custom_assertions'),
-            });
-            $container.koApplyBindings(assertions);
-        }
-    }
 });

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -1,523 +1,515 @@
-hqDefine("app_manager/js/details/case_claim", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/assert_properties",
-], function (
-    $,
-    ko,
-    _,
-    initialPageData,
-    assertProperties,
-) {
-    var generateSemiRandomId = function () {
-            // https://stackoverflow.com/a/2117523
-            return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, function (c) {
-                return (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16);
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import assertProperties from "hqwebapp/js/assert_properties";
+
+var generateSemiRandomId = function () {
+        // https://stackoverflow.com/a/2117523
+        return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, function (c) {
+            return (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16);
+        });
+    },
+    subscribeToSave = function (model, observableNames, saveButton) {
+        _.each(observableNames, function (name) {
+            model[name].subscribe(function () {
+                saveButton.fire('change');
             });
-        },
-        subscribeToSave = function (model, observableNames, saveButton) {
-            _.each(observableNames, function (name) {
-                model[name].subscribe(function () {
-                    saveButton.fire('change');
+        });
+        $(".hq-help").hqHelp();
+    },
+    itemsetValue = function (item) {
+        return "instance('" + item.id + "')" + item.path;
+    };
+
+var itemsetModel = function (options, saveButton) {
+    options = _.defaults(options, {
+        'instance_id': '',
+        'nodeset': null,
+        'label': '',
+        'value': '',
+        'sort': '',
+    });
+    var self = ko.mapping.fromJS(options);
+
+    self.lookupTableNodeset = ko.pureComputed({
+        write: function (value) {
+            if (value === undefined) {
+                self.nodeset(null);
+            } else {
+                self.instance_id(value);
+                var itemList = _.filter(initialPageData.get('js_options').item_lists, function (item) {
+                    return item.id === value;
                 });
-            });
-            $(".hq-help").hqHelp();
-        },
-        itemsetValue = function (item) {
-            return "instance('" + item.id + "')" + item.path;
-        };
-
-    var itemsetModel = function (options, saveButton) {
-        options = _.defaults(options, {
-            'instance_id': '',
-            'nodeset': null,
-            'label': '',
-            'value': '',
-            'sort': '',
-        });
-        var self = ko.mapping.fromJS(options);
-
-        self.lookupTableNodeset = ko.pureComputed({
-            write: function (value) {
-                if (value === undefined) {
-                    self.nodeset(null);
+                if (itemList && itemList.length === 1) {
+                    self.nodeset(itemsetValue(itemList[0]));
                 } else {
-                    self.instance_id(value);
-                    var itemList = _.filter(initialPageData.get('js_options').item_lists, function (item) {
-                        return item.id === value;
-                    });
-                    if (itemList && itemList.length === 1) {
-                        self.nodeset(itemsetValue(itemList[0]));
-                    } else {
-                        self.nodeset(null);
-                    }
+                    self.nodeset(null);
                 }
-            },
-            read: function () {
-                return self.instance_id();
-            },
+            }
+        },
+        read: function () {
+            return self.instance_id();
+        },
+    });
+    self.nodesetValid = ko.computed(function () {
+        if (self.nodeset() === null) {
+            return true;
+        }
+        var itemLists = _.map(initialPageData.get('js_options').item_lists, function (item) {
+            return itemsetValue(item);
         });
-        self.nodesetValid = ko.computed(function () {
-            if (self.nodeset() === null) {
+        if (self.nodeset().split("/").length === 0) {
+            return false;
+        }
+        var instancePart = self.nodeset().split("/")[0];
+        for (var i = itemLists.length - 1; i >= 0; i--) {
+            var groups = itemLists[i].split("/");
+            if (groups.length > 0 && groups[0] === instancePart) {
                 return true;
             }
-            var itemLists = _.map(initialPageData.get('js_options').item_lists, function (item) {
-                return itemsetValue(item);
-            });
-            if (self.nodeset().split("/").length === 0) {
-                return false;
-            }
-            var instancePart = self.nodeset().split("/")[0];
-            for (var i = itemLists.length - 1; i >= 0; i--) {
-                var groups = itemLists[i].split("/");
-                if (groups.length > 0 && groups[0] === instancePart) {
-                    return true;
-                }
-            }
-            return false;
-        });
-        subscribeToSave(self,
-            ['nodeset', 'label', 'value', 'sort'], saveButton);
+        }
+        return false;
+    });
+    subscribeToSave(self,
+        ['nodeset', 'label', 'value', 'sort'], saveButton);
 
-        return self;
-    };
+    return self;
+};
 
-    var searchPropertyModel = function (options, saveButton) {
-        options = _.defaults(options, {
-            name: '',
-            label: '',
-            hint: '',
-            appearance: '',
-            isMultiselect: false,
-            allowBlankValue: false,
-            defaultValue: '',
-            hidden: false,
-            receiverExpression: '',
-            itemsetOptions: {},
-            exclude: false,
-            requiredTest: '',
-            requiredText: '',
-            validationTest: '',
-            validationText: '',
-            isGroup: false,
-            groupKey: '',
-        });
-        var self = {};
-        self.uniqueId = generateSemiRandomId();
-        self.name = ko.observable(options.name);
-        self.label = ko.observable(options.label);
-        self.hint = ko.observable(options.hint);
-        self.appearance = ko.observable(options.appearance);
-        self.isMultiselect = ko.observable(options.isMultiselect);
-        self.allowBlankValue = ko.observable(options.allowBlankValue);
-        self.defaultValue = ko.observable(options.defaultValue);
-        self.hidden = ko.observable(options.hidden);
-        self.exclude = ko.observable(options.exclude);
-        self.requiredTest = ko.observable(options.requiredTest);
-        self.requiredText = ko.observable(options.requiredText);
-        self.validationTest = ko.observable(options.validationTest);
-        self.validationText = ko.observable(options.validationText);
-        self.appearanceFinal = ko.computed(function () {
-            var appearance = self.appearance();
-            if (appearance === 'report_fixture' || appearance === 'lookup_table_fixture') {
-                return 'fixture';
-            } else {
-                return appearance;
-            }
-        });
-        self.dropdownLabels = ko.computed(function () {
-            if (self.appearance() === 'report_fixture') {
+var searchPropertyModel = function (options, saveButton) {
+    options = _.defaults(options, {
+        name: '',
+        label: '',
+        hint: '',
+        appearance: '',
+        isMultiselect: false,
+        allowBlankValue: false,
+        defaultValue: '',
+        hidden: false,
+        receiverExpression: '',
+        itemsetOptions: {},
+        exclude: false,
+        requiredTest: '',
+        requiredText: '',
+        validationTest: '',
+        validationText: '',
+        isGroup: false,
+        groupKey: '',
+    });
+    var self = {};
+    self.uniqueId = generateSemiRandomId();
+    self.name = ko.observable(options.name);
+    self.label = ko.observable(options.label);
+    self.hint = ko.observable(options.hint);
+    self.appearance = ko.observable(options.appearance);
+    self.isMultiselect = ko.observable(options.isMultiselect);
+    self.allowBlankValue = ko.observable(options.allowBlankValue);
+    self.defaultValue = ko.observable(options.defaultValue);
+    self.hidden = ko.observable(options.hidden);
+    self.exclude = ko.observable(options.exclude);
+    self.requiredTest = ko.observable(options.requiredTest);
+    self.requiredText = ko.observable(options.requiredText);
+    self.validationTest = ko.observable(options.validationTest);
+    self.validationText = ko.observable(options.validationText);
+    self.appearanceFinal = ko.computed(function () {
+        var appearance = self.appearance();
+        if (appearance === 'report_fixture' || appearance === 'lookup_table_fixture') {
+            return 'fixture';
+        } else {
+            return appearance;
+        }
+    });
+    self.dropdownLabels = ko.computed(function () {
+        if (self.appearance() === 'report_fixture') {
+            return {
+                'labelPlaceholder': 'column_0',
+                'valuePlaceholder': 'column_0',
+                'optionsLabel': gettext("Mobile UCR Options"),
+                'tableLabel': gettext("Mobile UCR Report"),
+                'selectLabel': gettext("Select a Report..."),
+            };
+        } else {
+            return {
+                'labelPlaceholder': 'name',
+                'valuePlaceholder': 'id',
+                'optionsLabel': gettext("Lookup Table Options"),
+                'tableLabel': gettext("Lookup Table"),
+                'selectLabel': gettext("Select a Lookup Table..."),
+            };
+        }
+    });
+
+    self.receiverExpression = ko.observable(options.receiverExpression);
+    self.itemListOptions = ko.computed(function () {
+        var itemLists = initialPageData.get('js_options').item_lists;
+        return _.map(
+            _.filter(itemLists, function (p) {
+                return (
+                    p.fixture_type === self.appearance()
+                    || (p.fixture_type === 'lookup_table_fixture' && self.appearance() === 'checkbox')
+                );
+            }),
+            function (p) {
                 return {
-                    'labelPlaceholder': 'column_0',
-                    'valuePlaceholder': 'column_0',
-                    'optionsLabel': gettext("Mobile UCR Options"),
-                    'tableLabel': gettext("Mobile UCR Report"),
-                    'selectLabel': gettext("Select a Report..."),
+                    "value": p.id,
+                    "name": p.name,
                 };
-            } else {
-                return {
-                    'labelPlaceholder': 'name',
-                    'valuePlaceholder': 'id',
-                    'optionsLabel': gettext("Lookup Table Options"),
-                    'tableLabel': gettext("Lookup Table"),
-                    'selectLabel': gettext("Select a Lookup Table..."),
-                };
-            }
-        });
-
-        self.receiverExpression = ko.observable(options.receiverExpression);
-        self.itemListOptions = ko.computed(function () {
-            var itemLists = initialPageData.get('js_options').item_lists;
-            return _.map(
-                _.filter(itemLists, function (p) {
-                    return (
-                        p.fixture_type === self.appearance()
-                        || (p.fixture_type === 'lookup_table_fixture' && self.appearance() === 'checkbox')
-                    );
-                }),
-                function (p) {
-                    return {
-                        "value": p.id,
-                        "name": p.name,
-                    };
-                },
-            );
-        });
-        self.itemset = itemsetModel(options.itemsetOptions, saveButton);
-        self.isGroup = options.isGroup;
-        self.groupKey = options.groupKey;
-
-        subscribeToSave(self, [
-            'name', 'label', 'hint', 'appearance', 'defaultValue', 'hidden',
-            'receiverExpression', 'isMultiselect', 'allowBlankValue', 'exclude',
-            'requiredTest', 'requiredText', 'validationTest', 'validationText',
-        ], saveButton);
-        return self;
-    };
-
-    var defaultPropertyModel = function (options, saveButton) {
-        options = _.defaults(options, {
-            property: '',
-            defaultValue: '',
-        });
-        var self = ko.mapping.fromJS(options);
-
-        subscribeToSave(self, ['property', 'defaultValue'], saveButton);
-
-        return self;
-    };
-
-    var customSortPropertyModel = function (options, saveButton) {
-        options = _.defaults(options, {
-            property_name: '',
-            sort_type: '',
-            direction: '',
-        });
-        var self = ko.mapping.fromJS(options);
-
-        subscribeToSave(self, ['property_name', 'sort_type', 'direction'], saveButton);
-        return self;
-    };
-
-    var additionalRegistryCaseModel = function (xpath, saveButton) {
-        var self = {};
-        self.uniqueId = generateSemiRandomId();
-        self.caseIdXpath = ko.observable(xpath || '');
-        subscribeToSave(self, ['caseIdXpath'], saveButton);
-        return self;
-    };
-
-    var searchConfigKeys = [
-        'auto_launch', 'blacklisted_owner_ids_expression', 'default_search', 'search_again_label',
-        'title_label', 'description', 'search_button_display_condition', 'search_label', 'search_filter',
-        'additional_relevant', 'data_registry', 'data_registry_workflow', 'additional_registry_cases',
-        'custom_related_case_property', 'inline_search', 'instance_name', 'include_all_related_cases',
-        'search_on_clear',
-    ];
-    var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
-        assertProperties.assertRequired(options, searchConfigKeys);
-
-        options.search_label = options.search_label[lang] || "";
-        options.search_again_label = options.search_again_label[lang] || "";
-        options.title_label = options.title_label[lang] || "";
-        options.description = options.description[lang] || "";
-        var mapping = {
-            'additional_registry_cases': {
-                create: function (options) {
-                    return additionalRegistryCaseModel(options.data, saveButton);
-                },
             },
-        };
-        var self = ko.mapping.fromJS(options, mapping);
+        );
+    });
+    self.itemset = itemsetModel(options.itemsetOptions, saveButton);
+    self.isGroup = options.isGroup;
+    self.groupKey = options.groupKey;
 
-        self.restrictWorkflowForDataRegistry = ko.pureComputed(() => {
-            return self.data_registry() && self.data_registry_workflow() === 'load_case';
-        });
+    subscribeToSave(self, [
+        'name', 'label', 'hint', 'appearance', 'defaultValue', 'hidden',
+        'receiverExpression', 'isMultiselect', 'allowBlankValue', 'exclude',
+        'requiredTest', 'requiredText', 'validationTest', 'validationText',
+    ], saveButton);
+    return self;
+};
 
-        self.workflow = ko.computed({
-            read: function () {
-                if (self.restrictWorkflowForDataRegistry()) {
-                    if (self.auto_launch()) {
-                        if (self.default_search()) {
-                            return "es_only";
-                        }
-                    }
-                    return "auto_launch";
-                }
+var defaultPropertyModel = function (options, saveButton) {
+    options = _.defaults(options, {
+        property: '',
+        defaultValue: '',
+    });
+    var self = ko.mapping.fromJS(options);
+
+    subscribeToSave(self, ['property', 'defaultValue'], saveButton);
+
+    return self;
+};
+
+var customSortPropertyModel = function (options, saveButton) {
+    options = _.defaults(options, {
+        property_name: '',
+        sort_type: '',
+        direction: '',
+    });
+    var self = ko.mapping.fromJS(options);
+
+    subscribeToSave(self, ['property_name', 'sort_type', 'direction'], saveButton);
+    return self;
+};
+
+var additionalRegistryCaseModel = function (xpath, saveButton) {
+    var self = {};
+    self.uniqueId = generateSemiRandomId();
+    self.caseIdXpath = ko.observable(xpath || '');
+    subscribeToSave(self, ['caseIdXpath'], saveButton);
+    return self;
+};
+
+var searchConfigKeys = [
+    'auto_launch', 'blacklisted_owner_ids_expression', 'default_search', 'search_again_label',
+    'title_label', 'description', 'search_button_display_condition', 'search_label', 'search_filter',
+    'additional_relevant', 'data_registry', 'data_registry_workflow', 'additional_registry_cases',
+    'custom_related_case_property', 'inline_search', 'instance_name', 'include_all_related_cases',
+    'search_on_clear',
+];
+var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
+    assertProperties.assertRequired(options, searchConfigKeys);
+
+    options.search_label = options.search_label[lang] || "";
+    options.search_again_label = options.search_again_label[lang] || "";
+    options.title_label = options.title_label[lang] || "";
+    options.description = options.description[lang] || "";
+    var mapping = {
+        'additional_registry_cases': {
+            create: function (options) {
+                return additionalRegistryCaseModel(options.data, saveButton);
+            },
+        },
+    };
+    var self = ko.mapping.fromJS(options, mapping);
+
+    self.restrictWorkflowForDataRegistry = ko.pureComputed(() => {
+        return self.data_registry() && self.data_registry_workflow() === 'load_case';
+    });
+
+    self.workflow = ko.computed({
+        read: function () {
+            if (self.restrictWorkflowForDataRegistry()) {
                 if (self.auto_launch()) {
                     if (self.default_search()) {
                         return "es_only";
                     }
-                    return "auto_launch";
-                } else if (self.default_search()) {
-                    return "see_more";
                 }
-                return "classic";
-            },
-            write: function (value) {
-                self.auto_launch(_.contains(["es_only", "auto_launch"], value));
-                self.default_search(_.contains(["es_only", "see_more"], value));
-            },
-        });
-
-        self.inlineSearchVisible = ko.computed(() => {
-            return self.workflow() === "es_only" || self.workflow() === "auto_launch";
-        });
-
-        self.inlineSearchActive = ko.computed(() => {
-            return self.inlineSearchVisible() && self.inline_search();
-        });
-        self.exampleInstance = ko.computed(() => {
-            let name = self.instance_name() || 'inline';
-            return "instance('results:" + name + "')/results/case";
-        });
-
-
-        // Allow search filter to be copied from another part of the page
-        self.setSearchFilterVisible = ko.computed(function () {
-            return searchFilterObservable && searchFilterObservable();
-        });
-        self.setSearchFilterEnabled = ko.computed(function () {
-            return self.setSearchFilterVisible() && searchFilterObservable() !== self.search_filter();
-        });
-        self.setSearchFilter = function () {
-            self.search_filter(searchFilterObservable());
-        };
-
-        subscribeToSave(self, searchConfigKeys, saveButton);
-        // media image/audio buttons
-        $(".case-search-multimedia-input button").on("click", function () {
-            saveButton.fire('change');
-        });
-        // checkbox to select media for all languages
-        $(".case-search-multimedia-input input[type='checkbox']").on('change', function () {
-            saveButton.fire('change');
-        });
-
-        self.addRegistryQuery = function () {
-            self.additional_registry_cases.push(additionalRegistryCaseModel('', saveButton));
-        };
-
-        self.removeRegistryQuery = function (model) {
-            self.additional_registry_cases.remove(model);
-        };
-
-        self.serialize = function () {
-            var data = ko.mapping.toJS(self);
-            data.additional_registry_cases = data.data_registry_workflow === "load_case" ? _.pluck(data.additional_registry_cases, 'caseIdXpath') : [];
-            _.each(['search_label', 'search_again_label'], function (label) {
-                _.each(['image', 'audio'], function (media) {
-                    var key = label + "_" + media,
-                        selector = "#case_search-" + label + "_media_media_" + media + " input[type='hidden']";
-                    data[key] = $(selector + "[name='case_search-" + label + "_media_media_" + media + "']").val();
-                    data[key + "_for_all"] = $(selector + "[name='case_search-" + label + "_media_use_default_" + media + "_for_all']").val();
-                });
-            });
-            return data;
-        };
-
-        return self;
-    };
-
-    var _getAppearance = function (searchProperty) {
-        // init with blank string to avoid triggering save button
-        var appearance = searchProperty.appearance || "";
-        if (searchProperty.input_ === "select1" || searchProperty.input_ === "select") {
-            var instanceId = searchProperty.itemset.instance_id;
-            if (instanceId !== null && instanceId.includes("commcare-reports")) {
-                appearance = "report_fixture";
-            } else {
-                appearance = "lookup_table_fixture";
+                return "auto_launch";
             }
-        }
-        if (searchProperty.appearance === "address") {
-            appearance = "address";
-        }
-        if (["date", "daterange", "checkbox"].indexOf(searchProperty.input_) !== -1) {
-            appearance = searchProperty.input_;
-        }
-        return appearance;
+            if (self.auto_launch()) {
+                if (self.default_search()) {
+                    return "es_only";
+                }
+                return "auto_launch";
+            } else if (self.default_search()) {
+                return "see_more";
+            }
+            return "classic";
+        },
+        write: function (value) {
+            self.auto_launch(_.contains(["es_only", "auto_launch"], value));
+            self.default_search(_.contains(["es_only", "see_more"], value));
+        },
+    });
+
+    self.inlineSearchVisible = ko.computed(() => {
+        return self.workflow() === "es_only" || self.workflow() === "auto_launch";
+    });
+
+    self.inlineSearchActive = ko.computed(() => {
+        return self.inlineSearchVisible() && self.inline_search();
+    });
+    self.exampleInstance = ko.computed(() => {
+        let name = self.instance_name() || 'inline';
+        return "instance('results:" + name + "')/results/case";
+    });
+
+
+    // Allow search filter to be copied from another part of the page
+    self.setSearchFilterVisible = ko.computed(function () {
+        return searchFilterObservable && searchFilterObservable();
+    });
+    self.setSearchFilterEnabled = ko.computed(function () {
+        return self.setSearchFilterVisible() && searchFilterObservable() !== self.search_filter();
+    });
+    self.setSearchFilter = function () {
+        self.search_filter(searchFilterObservable());
     };
 
-    var searchViewModel = function (searchProperties, defaultProperties, customSortProperties, searchConfigOptions, lang, saveButton, searchFilterObservable) {
-        var self = {};
+    subscribeToSave(self, searchConfigKeys, saveButton);
+    // media image/audio buttons
+    $(".case-search-multimedia-input button").on("click", function () {
+        saveButton.fire('change');
+    });
+    // checkbox to select media for all languages
+    $(".case-search-multimedia-input input[type='checkbox']").on('change', function () {
+        saveButton.fire('change');
+    });
 
-        self.searchConfig = searchConfigModel(searchConfigOptions, lang, searchFilterObservable, saveButton);
-        self.default_properties = ko.observableArray();
-        self.custom_sort_properties = ko.observableArray();
+    self.addRegistryQuery = function () {
+        self.additional_registry_cases.push(additionalRegistryCaseModel('', saveButton));
+    };
 
-        // searchProperties is a list of CaseSearchProperty objects
-        var wrappedSearchProperties = _.map(searchProperties, function (searchProperty) {
-            // The model supports multiple validation conditions, but we don't need the UI for it yet
-            var validation = searchProperty.validations[0];
-            return searchPropertyModel({
-                name: searchProperty.name,
-                label: searchProperty.label[lang],
-                hint: searchProperty.hint[lang],
-                appearance: _getAppearance(searchProperty),
-                isMultiselect: searchProperty.input_ === "select",
-                allowBlankValue: searchProperty.allow_blank_value,
-                exclude: searchProperty.exclude,
-                requiredTest: searchProperty.required.test,
-                requiredText: searchProperty.required.text[lang],
-                validationTest: validation ? validation.test : '',
-                validationText: validation ? validation.text[lang] : '',
-                defaultValue: searchProperty.default_value,
-                hidden: searchProperty.hidden,
-                receiverExpression: searchProperty.receiver_expression,
-                itemsetOptions: searchProperty.itemset,
-                isGroup: searchProperty.is_group,
-                groupKey: searchProperty.group_key,
-            }, saveButton);
-        });
+    self.removeRegistryQuery = function (model) {
+        self.additional_registry_cases.remove(model);
+    };
 
-        self.search_properties = ko.observableArray(
-            wrappedSearchProperties.length > 0 ? wrappedSearchProperties : [searchPropertyModel({}, saveButton)],
-        );
-
-        self.search_properties.subscribe(function (newProperties) {
-            let groupKey = '';
-            ko.utils.arrayForEach(newProperties, function (property, index) {
-                if (property.isGroup) {
-                    groupKey = `group_header_${index}`;
-                    if (property.name !== groupKey) {
-                        property.name(groupKey);
-                    }
-                }
-                if (property.groupKey !== groupKey) {
-                    property.groupKey = groupKey;
-                }
+    self.serialize = function () {
+        var data = ko.mapping.toJS(self);
+        data.additional_registry_cases = data.data_registry_workflow === "load_case" ? _.pluck(data.additional_registry_cases, 'caseIdXpath') : [];
+        _.each(['search_label', 'search_again_label'], function (label) {
+            _.each(['image', 'audio'], function (media) {
+                var key = label + "_" + media,
+                    selector = "#case_search-" + label + "_media_media_" + media + " input[type='hidden']";
+                data[key] = $(selector + "[name='case_search-" + label + "_media_media_" + media + "']").val();
+                data[key + "_for_all"] = $(selector + "[name='case_search-" + label + "_media_use_default_" + media + "_for_all']").val();
             });
         });
+        return data;
+    };
 
-        self.addProperty = function () {
-            self.search_properties.push(searchPropertyModel({}, saveButton));
-        };
-        self.addGroupProperty = function () {
-            self.search_properties.push(searchPropertyModel({isGroup: true}, saveButton));
-        };
-        self.removeProperty = function (property) {
-            self.search_properties.remove(property);
-        };
-        self._getProperties = function () {
-            // i.e. [{'name': p.name, 'label': p.label} for p in self.search_properties if p.name]
-            return _.map(
-                _.filter(
-                    self.search_properties(),
-                    function (p) { return p.name().length > 0;},  // Skip properties where name is blank
-                ),
-                function (p) {
-                    var ifSupportsValidation = function (val) {
-                        return p.hidden() || p.appearance() === "address" ? "" : val;
-                    };
-                    return {
-                        name: p.name(),
-                        label: (p.label().length || p.isGroup) ? p.label() : p.name(),  // If label isn't set, use name
-                        hint: p.hint(),
-                        appearance: p.appearanceFinal(),
-                        is_multiselect: p.isMultiselect(),
-                        allow_blank_value: p.allowBlankValue(),
-                        exclude: p.exclude(),
-                        required_test: ifSupportsValidation(p.requiredTest()),
-                        required_text: ifSupportsValidation(p.requiredText()),
-                        validation_test: ifSupportsValidation(p.validationTest()),
-                        validation_text: ifSupportsValidation(p.validationText()),
-                        default_value: p.defaultValue(),
-                        hidden: p.hidden(),
-                        receiver_expression: p.receiverExpression(),
-                        fixture: ko.toJSON(p.itemset),
-                        is_group: p.isGroup,
-                        group_key: p.groupKey,
-                    };
-                },
-            );
-        };
+    return self;
+};
 
-        self.addDefaultProperty = function () {
-            self.default_properties.push(defaultPropertyModel({}, saveButton));
-        };
-        self.removeDefaultProperty = function (property) {
-            self.default_properties.remove(property);
-        };
-        self._getDefaultProperties = function () {
-            return _.map(
-                _.filter(
-                    self.default_properties(),
-                    function (p) { return p.property().length > 0; },  // Skip properties where property is blank
-                ),
-                function (prop) { return ko.mapping.toJS(prop); },
-            );
-        };
-
-        self.addCustomSortProperty = function () {
-            self.custom_sort_properties.push(customSortPropertyModel({}, saveButton));
-        };
-        self.removeCustomSortProperty = function (property) {
-            self.custom_sort_properties.remove(property);
-        };
-        self._getCustomSortProperties = function () {
-            return _.map(
-                _.filter(
-                    self.custom_sort_properties(),
-                    // Skip properties where property is blank
-                    function (p) { return p.property_name().length > 0; },
-                ),
-                function (prop) { return ko.mapping.toJS(prop); },
-            );
-        };
-
-        if (defaultProperties.length > 0) {
-            self.default_properties(_.map(defaultProperties, function (p) {
-                return defaultPropertyModel(p, saveButton);
-            }));
+var _getAppearance = function (searchProperty) {
+    // init with blank string to avoid triggering save button
+    var appearance = searchProperty.appearance || "";
+    if (searchProperty.input_ === "select1" || searchProperty.input_ === "select") {
+        var instanceId = searchProperty.itemset.instance_id;
+        if (instanceId !== null && instanceId.includes("commcare-reports")) {
+            appearance = "report_fixture";
         } else {
-            self.addDefaultProperty();
+            appearance = "lookup_table_fixture";
         }
+    }
+    if (searchProperty.appearance === "address") {
+        appearance = "address";
+    }
+    if (["date", "daterange", "checkbox"].indexOf(searchProperty.input_) !== -1) {
+        appearance = searchProperty.input_;
+    }
+    return appearance;
+};
 
-        if (customSortProperties.length > 0) {
-            self.custom_sort_properties(_.map(customSortProperties, function (p) {
-                return customSortPropertyModel(p, saveButton);
-            }));
-        }
+var searchViewModel = function (searchProperties, defaultProperties, customSortProperties, searchConfigOptions, lang, saveButton, searchFilterObservable) {
+    var self = {};
 
-        self.commonProperties = ko.computed(function () {
-            var defaultProperties = _.pluck(self._getDefaultProperties(), 'property');
-            var commonProperties = self.search_properties().filter(function (n) {
-                return n.name().length > 0 && defaultProperties.indexOf(n.name()) !== -1;
-            });
-            return _.map(
-                commonProperties,
-                function (p) {
-                    return p.name();
-                },
-            );
+    self.searchConfig = searchConfigModel(searchConfigOptions, lang, searchFilterObservable, saveButton);
+    self.default_properties = ko.observableArray();
+    self.custom_sort_properties = ko.observableArray();
+
+    // searchProperties is a list of CaseSearchProperty objects
+    var wrappedSearchProperties = _.map(searchProperties, function (searchProperty) {
+        // The model supports multiple validation conditions, but we don't need the UI for it yet
+        var validation = searchProperty.validations[0];
+        return searchPropertyModel({
+            name: searchProperty.name,
+            label: searchProperty.label[lang],
+            hint: searchProperty.hint[lang],
+            appearance: _getAppearance(searchProperty),
+            isMultiselect: searchProperty.input_ === "select",
+            allowBlankValue: searchProperty.allow_blank_value,
+            exclude: searchProperty.exclude,
+            requiredTest: searchProperty.required.test,
+            requiredText: searchProperty.required.text[lang],
+            validationTest: validation ? validation.test : '',
+            validationText: validation ? validation.text[lang] : '',
+            defaultValue: searchProperty.default_value,
+            hidden: searchProperty.hidden,
+            receiverExpression: searchProperty.receiver_expression,
+            itemsetOptions: searchProperty.itemset,
+            isGroup: searchProperty.is_group,
+            groupKey: searchProperty.group_key,
+        }, saveButton);
+    });
+
+    self.search_properties = ko.observableArray(
+        wrappedSearchProperties.length > 0 ? wrappedSearchProperties : [searchPropertyModel({}, saveButton)],
+    );
+
+    self.search_properties.subscribe(function (newProperties) {
+        let groupKey = '';
+        ko.utils.arrayForEach(newProperties, function (property, index) {
+            if (property.isGroup) {
+                groupKey = `group_header_${index}`;
+                if (property.name !== groupKey) {
+                    property.name(groupKey);
+                }
+            }
+            if (property.groupKey !== groupKey) {
+                property.groupKey = groupKey;
+            }
         });
+    });
 
-        self.isCommon = function (prop) {
-            return self.commonProperties().indexOf(prop) !== -1;
-        };
-
-        self.isEnabled = ko.computed(() => {
-            // match logic in corehq.apps.app_manager.util.module_offers_search
-            return self._getProperties().length > 0 || self._getDefaultProperties().length > 0;
-        });
-
-        self.serialize = function () {
-            return _.extend({
-                properties: self._getProperties(),
-                default_properties: self._getDefaultProperties(),
-                custom_sort_properties: self._getCustomSortProperties(),
-            }, self.searchConfig.serialize());
-        };
-
-        subscribeToSave(self, ['search_properties', 'default_properties', 'custom_sort_properties'], saveButton);
-        return self;
+    self.addProperty = function () {
+        self.search_properties.push(searchPropertyModel({}, saveButton));
+    };
+    self.addGroupProperty = function () {
+        self.search_properties.push(searchPropertyModel({isGroup: true}, saveButton));
+    };
+    self.removeProperty = function (property) {
+        self.search_properties.remove(property);
+    };
+    self._getProperties = function () {
+        // i.e. [{'name': p.name, 'label': p.label} for p in self.search_properties if p.name]
+        return _.map(
+            _.filter(
+                self.search_properties(),
+                function (p) { return p.name().length > 0;},  // Skip properties where name is blank
+            ),
+            function (p) {
+                var ifSupportsValidation = function (val) {
+                    return p.hidden() || p.appearance() === "address" ? "" : val;
+                };
+                return {
+                    name: p.name(),
+                    label: (p.label().length || p.isGroup) ? p.label() : p.name(),  // If label isn't set, use name
+                    hint: p.hint(),
+                    appearance: p.appearanceFinal(),
+                    is_multiselect: p.isMultiselect(),
+                    allow_blank_value: p.allowBlankValue(),
+                    exclude: p.exclude(),
+                    required_test: ifSupportsValidation(p.requiredTest()),
+                    required_text: ifSupportsValidation(p.requiredText()),
+                    validation_test: ifSupportsValidation(p.validationTest()),
+                    validation_text: ifSupportsValidation(p.validationText()),
+                    default_value: p.defaultValue(),
+                    hidden: p.hidden(),
+                    receiver_expression: p.receiverExpression(),
+                    fixture: ko.toJSON(p.itemset),
+                    is_group: p.isGroup,
+                    group_key: p.groupKey,
+                };
+            },
+        );
     };
 
-    return {
-        searchConfigKeys: searchConfigKeys,
-        searchViewModel: searchViewModel,
+    self.addDefaultProperty = function () {
+        self.default_properties.push(defaultPropertyModel({}, saveButton));
     };
-});
+    self.removeDefaultProperty = function (property) {
+        self.default_properties.remove(property);
+    };
+    self._getDefaultProperties = function () {
+        return _.map(
+            _.filter(
+                self.default_properties(),
+                function (p) { return p.property().length > 0; },  // Skip properties where property is blank
+            ),
+            function (prop) { return ko.mapping.toJS(prop); },
+        );
+    };
+
+    self.addCustomSortProperty = function () {
+        self.custom_sort_properties.push(customSortPropertyModel({}, saveButton));
+    };
+    self.removeCustomSortProperty = function (property) {
+        self.custom_sort_properties.remove(property);
+    };
+    self._getCustomSortProperties = function () {
+        return _.map(
+            _.filter(
+                self.custom_sort_properties(),
+                // Skip properties where property is blank
+                function (p) { return p.property_name().length > 0; },
+            ),
+            function (prop) { return ko.mapping.toJS(prop); },
+        );
+    };
+
+    if (defaultProperties.length > 0) {
+        self.default_properties(_.map(defaultProperties, function (p) {
+            return defaultPropertyModel(p, saveButton);
+        }));
+    } else {
+        self.addDefaultProperty();
+    }
+
+    if (customSortProperties.length > 0) {
+        self.custom_sort_properties(_.map(customSortProperties, function (p) {
+            return customSortPropertyModel(p, saveButton);
+        }));
+    }
+
+    self.commonProperties = ko.computed(function () {
+        var defaultProperties = _.pluck(self._getDefaultProperties(), 'property');
+        var commonProperties = self.search_properties().filter(function (n) {
+            return n.name().length > 0 && defaultProperties.indexOf(n.name()) !== -1;
+        });
+        return _.map(
+            commonProperties,
+            function (p) {
+                return p.name();
+            },
+        );
+    });
+
+    self.isCommon = function (prop) {
+        return self.commonProperties().indexOf(prop) !== -1;
+    };
+
+    self.isEnabled = ko.computed(() => {
+        // match logic in corehq.apps.app_manager.util.module_offers_search
+        return self._getProperties().length > 0 || self._getDefaultProperties().length > 0;
+    });
+
+    self.serialize = function () {
+        return _.extend({
+            properties: self._getProperties(),
+            default_properties: self._getDefaultProperties(),
+            custom_sort_properties: self._getCustomSortProperties(),
+        }, self.searchConfig.serialize());
+    };
+
+    subscribeToSave(self, ['search_properties', 'default_properties', 'custom_sort_properties'], saveButton);
+    return self;
+};
+
+export default {
+    searchConfigKeys: searchConfigKeys,
+    searchViewModel: searchViewModel,
+};

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_detail_print.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_detail_print.js
@@ -1,31 +1,25 @@
-hqDefine("app_manager/js/details/case_detail_print", [
-    "hqwebapp/js/initial_page_data",
-    "hqmedia/js/uploaders",
-    "hqmedia/js/media_reference_models",
-], function (
-    initialPageData,
-    uploaders,
-    mediaReferenceModels,
-) {
-    var printRef, printTemplateUploader;
-    const printUploader = initialPageData.get("print_uploader_js");
-    if (printUploader) {
-        printTemplateUploader = uploaders.uploader(
-            printUploader.slug,
-            printUploader.options,
-        );
-        printRef = mediaReferenceModels.BaseMediaReference(initialPageData.get('print_ref'));
-        printRef.upload_controller = printTemplateUploader;
-        printRef.setObjReference(initialPageData.get('print_media_info'));
-        printTemplateUploader.currentReference = printRef;
-    }
+import initialPageData from "hqwebapp/js/initial_page_data";
+import uploaders from "hqmedia/js/uploaders";
+import mediaReferenceModels from "hqmedia/js/media_reference_models";
 
-    return {
-        getPrintRef: function () {
-            return printRef;
-        },
-        getPrintTemplateUploader: function () {
-            return printTemplateUploader;
-        },
-    };
-});
+var printRef, printTemplateUploader;
+const printUploader = initialPageData.get("print_uploader_js");
+if (printUploader) {
+    printTemplateUploader = uploaders.uploader(
+        printUploader.slug,
+        printUploader.options,
+    );
+    printRef = mediaReferenceModels.BaseMediaReference(initialPageData.get('print_ref'));
+    printRef.upload_controller = printTemplateUploader;
+    printRef.setObjReference(initialPageData.get('print_media_info'));
+    printTemplateUploader.currentReference = printRef;
+}
+
+export default {
+    getPrintRef: function () {
+        return printRef;
+    },
+    getPrintTemplateUploader: function () {
+        return printTemplateUploader;
+    },
+};

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_list_callout.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_list_callout.js
@@ -1,235 +1,226 @@
-hqDefine("app_manager/js/details/case_list_callout", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "hqwebapp/js/bootstrap3/alert_user",
-    "hqwebapp/js/ui_elements/bootstrap3/ui-element-input",
-    "hqwebapp/js/ui_elements/ui-element-langcode-button",
-], function (
-    $,
-    ko,
-    _,
-    alertUser,
-    uiElementInput,
-    uiElementLangcodeButton,
-) {
-    var caseListLookupViewModel = function ($el, state, lang, saveButton) {
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import alertUser from "hqwebapp/js/bootstrap3/alert_user";
+import uiElementInput from "hqwebapp/js/ui_elements/bootstrap3/ui-element-input";
+import uiElementLangcodeButton from "hqwebapp/js/ui_elements/ui-element-langcode-button";
+
+var caseListLookupViewModel = function ($el, state, lang, saveButton) {
+    var self = {};
+    var detailType = $el.data('detail-type');
+
+    var observableKeyValue = function (obs) {
         var self = {};
-        var detailType = $el.data('detail-type');
-
-        var observableKeyValue = function (obs) {
-            var self = {};
-            self.key = ko.observable(obs.key);
-            self.value = ko.observable(obs.value);
-            return self;
-        };
-
-        var _fireChange = function () {
-            saveButton.fire('change');
-        };
-
-        self.initSaveButtonListeners = function ($el) {
-            $el.find('input[type=text], textarea').on('textchange', _fireChange);
-            $el.find('input[type=checkbox]').on('change', _fireChange);
-            $el.find(".case-list-lookup-icon button").on("click", _fireChange); // Trigger save button when icon upload buttons are clicked
-        };
-
-        var _removeEmpty = function (type) {
-            self[type].remove(function (t) {
-                return (!t.key() && !t.value());
-            });
-        };
-
-        self.addItem = function (type) {
-            _removeEmpty(type);
-            var data = (type === 'extras') ? {key: '', value: ''} : {key: ''};
-            self[type].push(observableKeyValue(data));
-        };
-
-        self.removeItem = function (type, item) {
-            self[type].remove(item);
-            if (self[type]().length === 0) {
-                self.addItem(type);
-            }
-            _fireChange();
-        };
-
-        var _trimmedExtras = function () {
-            return _.compact(_.map(self.extras(), function (extra) {
-                if (!(extra.key() === "" && extra.value() === "")) {
-                    return {key: extra.key(), value: extra.value()};
-                }
-            }));
-        };
-
-        var _trimmedResponses = function () {
-            return _.compact(_.map(self.responses(), function (response) {
-                if (response.key() !== "") {
-                    return {key: response.key()};
-                }
-            }));
-        };
-
-        self.serialize = function () {
-            var imagePath = $el.find(".case-list-lookup-icon input[type=hidden]").val() || null;
-
-            return {
-                lookup_enabled: self.lookup_enabled(),
-                lookup_autolaunch: self.lookup_autolaunch(),
-                lookup_action: self.lookup_action(),
-                lookup_name: self.lookup_name(),
-                lookup_extras: _trimmedExtras(),
-                lookup_responses: _trimmedResponses(),
-                lookup_image: imagePath,
-                lookup_display_results: self.lookup_display_results(),
-                lookup_field_header: self.lookup_field_header.val(),
-                lookup_field_template: self.lookup_field_template(),
-            };
-        };
-
-        var _validateInputs = function (errors) {
-            errors = errors || [];
-            $el.find('input[required]').each(function () {
-                var $this = $(this);
-                if ($this.val().trim().length === 0) {
-                    $this.closest('.form-group').addClass('has-error');
-                    var $help = $this.siblings('.help-block');
-                    $help.show();
-                    errors.push($help.text());
-                } else {
-                    $this.closest('.form-group').removeClass('has-error');
-                    $this.siblings('.help-block').hide();
-                }
-            });
-            return errors;
-        };
-
-        var _validateExtras = function (errors) {
-            errors = errors || [];
-            var $extras = $el.find("." + detailType + "-extras"),
-                $extraHelp = $extras.find(".help-block");
-
-            if (!_trimmedExtras().length) {
-                $extras.addClass('has-error');
-                $extraHelp.show();
-                errors.push($extraHelp.text());
-            } else {
-                $extras.removeClass('has-error');
-                $extraHelp.hide();
-            }
-            return errors;
-        };
-
-        var _validateResponses = function (errors) {
-            errors = errors || [];
-            var $responses = $el.find("." + detailType + "-responses"),
-                $responseHelp = $responses.find(".help-block");
-
-            if (!_trimmedResponses().length) {
-                $responses.addClass('has-error');
-                $responseHelp.show();
-                errors.push($responseHelp.text());
-            } else {
-                $responses.removeClass('has-error');
-                $responseHelp.hide();
-            }
-            return errors;
-        };
-
-        self.validate = function () {
-            var errors = [];
-
-            $("#message-alerts > div").each(function () {
-                $(this).alert('close');
-            });
-
-            if (self.lookup_enabled()) {
-                _validateInputs(errors);
-                _validateExtras(errors);
-                _validateResponses(errors);
-            }
-
-            if (errors.length) {
-                _.each(errors, function (error) {
-                    alertUser.alert_user(error, "danger");
-                });
-                return false;
-            }
-            return true;
-        };
-
-        self.$el = $el;
-        self.$form = $el.find('form');
-
-        self.lookup_enabled = ko.observable(state.lookup_enabled);
-        self.lookup_autolaunch = ko.observable(state.lookup_autolaunch);
-        self.lookup_action = ko.observable(state.lookup_action);
-        self.lookup_name = ko.observable(state.lookup_name);
-        self.extras = ko.observableArray(ko.utils.arrayMap(state.lookup_extras, function (extra) {
-            return observableKeyValue(extra);
-        }));
-        self.responses = ko.observableArray(ko.utils.arrayMap(state.lookup_responses, function (response) {
-            return observableKeyValue(response);
-        }));
-
-        if (self.extras().length === 0) {
-            self.addItem('extras');
-        }
-        if (self.responses().length === 0) {
-            self.addItem('responses');
-        }
-
-        self.lookup_display_results = ko.observable(state.lookup_display_results);
-        let invisible = "",
-            visible = "";
-        if (state.lookup_field_header[lang]) {
-            visible = invisible = state.lookup_field_header[lang];
-        } else {
-            _.each(_.keys(state.lookup_field_header), function (lang) {
-                if (state.lookup_field_header[lang]) {
-                    visible = state.lookup_field_header[lang]
-                        + uiElementLangcodeButton.LANG_DELIN
-                        + lang;
-                }
-            });
-        }
-
-        self.lookup_field_header = uiElementInput.new().val(invisible);
-        self.lookup_field_header.setVisibleValue(visible);
-        self.lookup_field_header.observableVal = ko.observable(self.lookup_field_header.val());
-        self.lookup_field_header.on('change', function () {
-            self.lookup_field_header.observableVal(self.lookup_field_header.val());
-            _fireChange();  // input node created too late for initSaveButtonListeners
-        });
-        self.lookup_field_template = ko.observable(state.lookup_field_template || '@case_id');
-
-        self.show_add_extra = ko.computed(function () {
-            if (self.extras().length) {
-                var lastKey = self.extras()[self.extras().length - 1].key(),
-                    lastValue = self.extras()[self.extras().length - 1].value();
-                return !(lastKey === "" && lastValue === "");
-            }
-            return true;
-        });
-
-        self.show_add_response = ko.computed(function () {
-            if (self.responses().length) {
-                var lastKey = self.responses()[self.responses().length - 1].key();
-                return lastKey !== "";
-            }
-            return true;
-        });
-
-        self.initSaveButtonListeners(self.$el);
-
+        self.key = ko.observable(obs.key);
+        self.value = ko.observable(obs.value);
         return self;
     };
 
-    var createCaseListLookupViewModel = function ($el, state, lang, saveButton) {
-        return caseListLookupViewModel($el, state, lang, saveButton);
+    var _fireChange = function () {
+        saveButton.fire('change');
     };
 
-    return {
-        caseListLookupViewModel: createCaseListLookupViewModel,
+    self.initSaveButtonListeners = function ($el) {
+        $el.find('input[type=text], textarea').on('textchange', _fireChange);
+        $el.find('input[type=checkbox]').on('change', _fireChange);
+        $el.find(".case-list-lookup-icon button").on("click", _fireChange); // Trigger save button when icon upload buttons are clicked
     };
-});
+
+    var _removeEmpty = function (type) {
+        self[type].remove(function (t) {
+            return (!t.key() && !t.value());
+        });
+    };
+
+    self.addItem = function (type) {
+        _removeEmpty(type);
+        var data = (type === 'extras') ? {key: '', value: ''} : {key: ''};
+        self[type].push(observableKeyValue(data));
+    };
+
+    self.removeItem = function (type, item) {
+        self[type].remove(item);
+        if (self[type]().length === 0) {
+            self.addItem(type);
+        }
+        _fireChange();
+    };
+
+    var _trimmedExtras = function () {
+        return _.compact(_.map(self.extras(), function (extra) {
+            if (!(extra.key() === "" && extra.value() === "")) {
+                return {key: extra.key(), value: extra.value()};
+            }
+        }));
+    };
+
+    var _trimmedResponses = function () {
+        return _.compact(_.map(self.responses(), function (response) {
+            if (response.key() !== "") {
+                return {key: response.key()};
+            }
+        }));
+    };
+
+    self.serialize = function () {
+        var imagePath = $el.find(".case-list-lookup-icon input[type=hidden]").val() || null;
+
+        return {
+            lookup_enabled: self.lookup_enabled(),
+            lookup_autolaunch: self.lookup_autolaunch(),
+            lookup_action: self.lookup_action(),
+            lookup_name: self.lookup_name(),
+            lookup_extras: _trimmedExtras(),
+            lookup_responses: _trimmedResponses(),
+            lookup_image: imagePath,
+            lookup_display_results: self.lookup_display_results(),
+            lookup_field_header: self.lookup_field_header.val(),
+            lookup_field_template: self.lookup_field_template(),
+        };
+    };
+
+    var _validateInputs = function (errors) {
+        errors = errors || [];
+        $el.find('input[required]').each(function () {
+            var $this = $(this);
+            if ($this.val().trim().length === 0) {
+                $this.closest('.form-group').addClass('has-error');
+                var $help = $this.siblings('.help-block');
+                $help.show();
+                errors.push($help.text());
+            } else {
+                $this.closest('.form-group').removeClass('has-error');
+                $this.siblings('.help-block').hide();
+            }
+        });
+        return errors;
+    };
+
+    var _validateExtras = function (errors) {
+        errors = errors || [];
+        var $extras = $el.find("." + detailType + "-extras"),
+            $extraHelp = $extras.find(".help-block");
+
+        if (!_trimmedExtras().length) {
+            $extras.addClass('has-error');
+            $extraHelp.show();
+            errors.push($extraHelp.text());
+        } else {
+            $extras.removeClass('has-error');
+            $extraHelp.hide();
+        }
+        return errors;
+    };
+
+    var _validateResponses = function (errors) {
+        errors = errors || [];
+        var $responses = $el.find("." + detailType + "-responses"),
+            $responseHelp = $responses.find(".help-block");
+
+        if (!_trimmedResponses().length) {
+            $responses.addClass('has-error');
+            $responseHelp.show();
+            errors.push($responseHelp.text());
+        } else {
+            $responses.removeClass('has-error');
+            $responseHelp.hide();
+        }
+        return errors;
+    };
+
+    self.validate = function () {
+        var errors = [];
+
+        $("#message-alerts > div").each(function () {
+            $(this).alert('close');
+        });
+
+        if (self.lookup_enabled()) {
+            _validateInputs(errors);
+            _validateExtras(errors);
+            _validateResponses(errors);
+        }
+
+        if (errors.length) {
+            _.each(errors, function (error) {
+                alertUser.alert_user(error, "danger");
+            });
+            return false;
+        }
+        return true;
+    };
+
+    self.$el = $el;
+    self.$form = $el.find('form');
+
+    self.lookup_enabled = ko.observable(state.lookup_enabled);
+    self.lookup_autolaunch = ko.observable(state.lookup_autolaunch);
+    self.lookup_action = ko.observable(state.lookup_action);
+    self.lookup_name = ko.observable(state.lookup_name);
+    self.extras = ko.observableArray(ko.utils.arrayMap(state.lookup_extras, function (extra) {
+        return observableKeyValue(extra);
+    }));
+    self.responses = ko.observableArray(ko.utils.arrayMap(state.lookup_responses, function (response) {
+        return observableKeyValue(response);
+    }));
+
+    if (self.extras().length === 0) {
+        self.addItem('extras');
+    }
+    if (self.responses().length === 0) {
+        self.addItem('responses');
+    }
+
+    self.lookup_display_results = ko.observable(state.lookup_display_results);
+    let invisible = "",
+        visible = "";
+    if (state.lookup_field_header[lang]) {
+        visible = invisible = state.lookup_field_header[lang];
+    } else {
+        _.each(_.keys(state.lookup_field_header), function (lang) {
+            if (state.lookup_field_header[lang]) {
+                visible = state.lookup_field_header[lang]
+                    + uiElementLangcodeButton.LANG_DELIN
+                    + lang;
+            }
+        });
+    }
+
+    self.lookup_field_header = uiElementInput.new().val(invisible);
+    self.lookup_field_header.setVisibleValue(visible);
+    self.lookup_field_header.observableVal = ko.observable(self.lookup_field_header.val());
+    self.lookup_field_header.on('change', function () {
+        self.lookup_field_header.observableVal(self.lookup_field_header.val());
+        _fireChange();  // input node created too late for initSaveButtonListeners
+    });
+    self.lookup_field_template = ko.observable(state.lookup_field_template || '@case_id');
+
+    self.show_add_extra = ko.computed(function () {
+        if (self.extras().length) {
+            var lastKey = self.extras()[self.extras().length - 1].key(),
+                lastValue = self.extras()[self.extras().length - 1].value();
+            return !(lastKey === "" && lastValue === "");
+        }
+        return true;
+    });
+
+    self.show_add_response = ko.computed(function () {
+        if (self.responses().length) {
+            var lastKey = self.responses()[self.responses().length - 1].key();
+            return lastKey !== "";
+        }
+        return true;
+    });
+
+    self.initSaveButtonListeners(self.$el);
+
+    return self;
+};
+
+var createCaseListLookupViewModel = function ($el, state, lang, saveButton) {
+    return caseListLookupViewModel($el, state, lang, saveButton);
+};
+
+export default {
+    caseListLookupViewModel: createCaseListLookupViewModel,
+};

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -570,4 +570,4 @@ export default function (col, screen) {
     };
 
     return self;
-};
+}

--- a/corehq/apps/app_manager/static/app_manager/js/details/column.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/column.js
@@ -10,580 +10,564 @@
  * set of properties that match python's DetailTab model. The screen model
  * is responsible for creating the tab "columns" and injecting them into itself.
  */
-hqDefine("app_manager/js/details/column", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/bootstrap3/main",
-    "app_manager/js/details/utils",
-    "hqwebapp/js/ui_elements/bootstrap3/ui-element-input",
-    "hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-mapping",
-    "hqwebapp/js/ui_elements/ui-element-langcode-button",
-    "hqwebapp/js/ui_elements/bootstrap3/ui-element-select",
-    "app_manager/js/details/detail_tab_nodeset",
-    "app_manager/js/details/graph_config",
-    "analytix/js/google",
-], function (
-    $,
-    ko,
-    _,
-    initialPageData,
-    main,
-    Utils,
-    uiElementInput,
-    uiElementKeyValueMapping,
-    uiElementLangcodeButton,
-    uiElementSelect,
-    detailTabNodeset,
-    graphConfig,
-    google,
-) {
-    const microCaseImageName = 'cc_case_image';
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import main from "hqwebapp/js/bootstrap3/main";
+import Utils from "app_manager/js/details/utils";
+import uiElementInput from "hqwebapp/js/ui_elements/bootstrap3/ui-element-input";
+import uiElementKeyValueMapping from "hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-mapping";
+import uiElementLangcodeButton from "hqwebapp/js/ui_elements/ui-element-langcode-button";
+import uiElementSelect from "hqwebapp/js/ui_elements/bootstrap3/ui-element-select";
+import detailTabNodeset from "app_manager/js/details/detail_tab_nodeset";
+import graphConfig from "app_manager/js/details/graph_config";
+import google from "analytix/js/google";
 
-    return function (col, screen) {
-        /*
-            column properties: model, field, header, format
-            column extras: enum, late_flag
-        */
-        const self = {};
-        self.$ = $;     // make $ available to data bindings, where it's used in sorting elements
-        main.eventize(self);
-        self.original = JSON.parse(JSON.stringify(col));
+const microCaseImageName = 'cc_case_image';
 
-        // Set defaults for normal (non-tab) column attributes
-        const defaults = {
-            calc_xpath: ".",
-            enum: [],
-            field: "",
-            filter_xpath: "",
-            format: "plain",
-            graph_configuration: {},
-            hasAutocomplete: false,
-            header: {},
-            model: screen.model,
-            date_format: "",
-            time_ago_interval: Utils.TIME_AGO.year,
-            horizontal_align: "left",
-            vertical_align: "start",
-            font_size: "medium",
-            show_border: false,
-            show_shading: false,
-        };
-        _.each(_.keys(defaults), function (key) {
-            self.original[key] = self.original[key] || defaults[key];
+export default function (col, screen) {
+    /*
+        column properties: model, field, header, format
+        column extras: enum, late_flag
+    */
+    const self = {};
+    self.$ = $;     // make $ available to data bindings, where it's used in sorting elements
+    main.eventize(self);
+    self.original = JSON.parse(JSON.stringify(col));
+
+    // Set defaults for normal (non-tab) column attributes
+    const defaults = {
+        calc_xpath: ".",
+        enum: [],
+        field: "",
+        filter_xpath: "",
+        format: "plain",
+        graph_configuration: {},
+        hasAutocomplete: false,
+        header: {},
+        model: screen.model,
+        date_format: "",
+        time_ago_interval: Utils.TIME_AGO.year,
+        horizontal_align: "left",
+        vertical_align: "start",
+        font_size: "medium",
+        show_border: false,
+        show_shading: false,
+    };
+    _.each(_.keys(defaults), function (key) {
+        self.original[key] = self.original[key] || defaults[key];
+    });
+    self.original.late_flag = _.isNumber(self.original.late_flag) ? self.original.late_flag : 30;
+
+    // Set up tab defaults
+    const tabDefaults = {
+        isTab: false,
+        hasNodeset: false,
+        nodeset: "",
+        nodesetCaseType: "",
+        nodesetFilter: "",
+        relevant: "",
+    };
+    self.original = _.defaults(self.original, tabDefaults);
+    let screenHasChildCaseTypes = screen.childCaseTypes && screen.childCaseTypes.length;
+    if (!self.original.nodeset && !self.original.nodesetCaseType && screenHasChildCaseTypes) {
+        // If there's no nodeset but there are child case types, default to showing a case type
+        self.original.nodesetCaseType = screen.childCaseTypes[0];
+    }
+    _.extend(self, _.pick(self.original, _.keys(tabDefaults)));
+
+    self.original.case_tile_field = ko.utils.unwrapObservable(self.original.case_tile_field) || "";
+    self.case_tile_field = ko.observable(self.original.case_tile_field);
+
+    self.coordinatesVisible = ko.observable(true);
+    self.tileRowMax = ko.observable(7); // set dynamically by screen
+    self.tileColumnMax = ko.observable(13);
+    self.tileRowStart = ko.observable(self.original.grid_y + 1 || 1); // converts from 0 to 1-based for UI
+    self.tileRowOptions = ko.computed(function () {
+        return _.range(1, self.tileRowMax());
+    });
+    self.tileColumnStart = ko.observable(self.original.grid_x + 1 || 1); // converts from 0 to 1-based for UI
+    self.tileColumnOptions = _.range(1, self.tileColumnMax());
+
+    let optimizationOptions = [
+        {
+            value: "",
+            label: "---",
+        },
+        {
+            value: "cache",
+            label: gettext('Cache'),
+        },
+        {
+            value: "lazy_load",
+            label: gettext('Lazy Load'),
+        },
+        {
+            value: "cache_and_lazy_load",
+            label: gettext('Cache & Lazy Load'),
+        },
+    ];
+    if (screen.showCaseListOptimizations) {
+        self.optimizationSelectElement = uiElementSelect.new(
+            optimizationOptions,
+        ).val(self.original.optimization || "");
+        self.$optimizationSelectElement = $('<div/>').append(self.optimizationSelectElement.ui);
+    }
+    self.tileWidth = ko.observable(self.original.width || self.tileRowMax() - 1);
+    self.tileWidthOptions = ko.computed(function () {
+        return _.range(1, self.tileColumnMax() + 1 - (self.tileColumnStart() || 1));
+    });
+    self.tileHeight = ko.observable(self.original.height || 1);
+    self.tileHeightOptions = ko.computed(function () {
+        return _.range(1, self.tileRowMax() + 1 - (self.tileRowStart() || 1));
+    });
+    self.horizontalAlign = ko.observable(self.original.horizontal_align || 'left');
+    self.horizontalAlignOptions = ['left', 'center', 'right'];
+
+    self.verticalAlign = ko.observable(self.original.vertical_align || 'start');
+    self.verticalAlignOptions = ['start', 'center', 'end'];
+
+    self.fontSize = ko.observable(self.original.font_size || 'medium');
+    self.fontSizeOptions = ['small', 'medium', 'large'];
+
+    self.showBorder = ko.observable(self.original.show_border || false);
+    self.showShading = ko.observable(self.original.show_shading || false);
+
+    self.openStyleModal = function () {
+        const $modalDiv = $(document.createElement("div"));
+        $modalDiv.attr("data-bind", "template: 'style_configuration_modal'");
+        $modalDiv.koApplyBindings(self);
+        const $modal = $modalDiv.find('.modal');
+        $modal.appendTo('body');
+        $modal.modal('show');
+        $modal.on('hidden.bs.modal', function () {
+            $modal.remove();
         });
-        self.original.late_flag = _.isNumber(self.original.late_flag) ? self.original.late_flag : 30;
+    };
 
-        // Set up tab defaults
-        const tabDefaults = {
-            isTab: false,
-            hasNodeset: false,
-            nodeset: "",
-            nodesetCaseType: "",
-            nodesetFilter: "",
-            relevant: "",
-        };
-        self.original = _.defaults(self.original, tabDefaults);
-        let screenHasChildCaseTypes = screen.childCaseTypes && screen.childCaseTypes.length;
-        if (!self.original.nodeset && !self.original.nodesetCaseType && screenHasChildCaseTypes) {
-            // If there's no nodeset but there are child case types, default to showing a case type
-            self.original.nodesetCaseType = screen.childCaseTypes[0];
-        }
-        _.extend(self, _.pick(self.original, _.keys(tabDefaults)));
+    self.tileRowEnd = ko.computed(function () {
+        return Number(self.tileRowStart()) + Number(self.tileHeight());
+    });
+    self.tileColumnEnd = ko.computed(function () {
+        return Number(self.tileColumnStart()) + Number(self.tileWidth());
+    });
+    self.showInTilePreview = ko.computed(function () {
+        return !self.isTab && self.coordinatesVisible() && self.tileRowStart() && self.tileColumnStart() && self.tileWidth() && self.tileHeight();
+    });
+    self.tileContent = ko.observable();
+    self.setTileContent = function () {
+        self.tileContent(self.header.val());
+    };
 
-        self.original.case_tile_field = ko.utils.unwrapObservable(self.original.case_tile_field) || "";
-        self.case_tile_field = ko.observable(self.original.case_tile_field);
+    self.screen = screen;
+    self.lang = screen.lang;
+    self.model = uiElementSelect.new([{
+        label: "Case",
+        value: "case",
+    }]).val(self.original.model);
 
-        self.coordinatesVisible = ko.observable(true);
-        self.tileRowMax = ko.observable(7); // set dynamically by screen
-        self.tileColumnMax = ko.observable(13);
-        self.tileRowStart = ko.observable(self.original.grid_y + 1 || 1); // converts from 0 to 1-based for UI
-        self.tileRowOptions = ko.computed(function () {
-            return _.range(1, self.tileRowMax());
-        });
-        self.tileColumnStart = ko.observable(self.original.grid_x + 1 || 1); // converts from 0 to 1-based for UI
-        self.tileColumnOptions = _.range(1, self.tileColumnMax());
+    const icon = Utils.isAttachmentProperty(self.original.field) ? 'fa fa-paperclip' : null;
+    self.field = undefined;
+    if (self.original.hasAutocomplete) {
+        self.field = uiElementSelect.new();
+    } else {
+        self.field = uiElementInput.new(self.original.field);
+    }
+    self.field.setIcon(icon);
+    self.getFieldHtml = function (value) {
+        return Utils.getFieldHtml(value);
+    };
 
-        let optimizationOptions = [
-            {
-                value: "",
-                label: "---",
-            },
-            {
-                value: "cache",
-                label: gettext('Cache'),
-            },
-            {
-                value: "lazy_load",
-                label: gettext('Lazy Load'),
-            },
-            {
-                value: "cache_and_lazy_load",
-                label: gettext('Cache & Lazy Load'),
-            },
-        ];
-        if (screen.showCaseListOptimizations) {
-            self.optimizationSelectElement = uiElementSelect.new(
-                optimizationOptions,
-            ).val(self.original.optimization || "");
-            self.$optimizationSelectElement = $('<div/>').append(self.optimizationSelectElement.ui);
-        }
-        self.tileWidth = ko.observable(self.original.width || self.tileRowMax() - 1);
-        self.tileWidthOptions = ko.computed(function () {
-            return _.range(1, self.tileColumnMax() + 1 - (self.tileColumnStart() || 1));
-        });
-        self.tileHeight = ko.observable(self.original.height || 1);
-        self.tileHeightOptions = ko.computed(function () {
-            return _.range(1, self.tileRowMax() + 1 - (self.tileRowStart() || 1));
-        });
-        self.horizontalAlign = ko.observable(self.original.horizontal_align || 'left');
-        self.horizontalAlignOptions = ['left', 'center', 'right'];
+    // Make it possible to observe changes to self.field
+    // note self observableVal is read only!
+    // Writing to it will not update the value of the self.field text input
+    self.field.observableVal = ko.observable(self.field.val());
+    self.field.on("change", function () {
+        self.field.observableVal(self.field.val());
+    });
 
-        self.verticalAlign = ko.observable(self.original.vertical_align || 'start');
-        self.verticalAlignOptions = ['start', 'center', 'end'];
-
-        self.fontSize = ko.observable(self.original.font_size || 'medium');
-        self.fontSizeOptions = ['small', 'medium', 'large'];
-
-        self.showBorder = ko.observable(self.original.show_border || false);
-        self.showShading = ko.observable(self.original.show_shading || false);
-
-        self.openStyleModal = function () {
-            const $modalDiv = $(document.createElement("div"));
-            $modalDiv.attr("data-bind", "template: 'style_configuration_modal'");
-            $modalDiv.koApplyBindings(self);
-            const $modal = $modalDiv.find('.modal');
-            $modal.appendTo('body');
-            $modal.modal('show');
-            $modal.on('hidden.bs.modal', function () {
-                $modal.remove();
-            });
-        };
-
-        self.tileRowEnd = ko.computed(function () {
-            return Number(self.tileRowStart()) + Number(self.tileHeight());
-        });
-        self.tileColumnEnd = ko.computed(function () {
-            return Number(self.tileColumnStart()) + Number(self.tileWidth());
-        });
-        self.showInTilePreview = ko.computed(function () {
-            return !self.isTab && self.coordinatesVisible() && self.tileRowStart() && self.tileColumnStart() && self.tileWidth() && self.tileHeight();
-        });
-        self.tileContent = ko.observable();
-        self.setTileContent = function () {
-            self.tileContent(self.header.val());
-        };
-
-        self.screen = screen;
-        self.lang = screen.lang;
-        self.model = uiElementSelect.new([{
-            label: "Case",
-            value: "case",
-        }]).val(self.original.model);
-
-        const icon = Utils.isAttachmentProperty(self.original.field) ? 'fa fa-paperclip' : null;
-        self.field = undefined;
-        if (self.original.hasAutocomplete) {
-            self.field = uiElementSelect.new();
+    (function () {
+        let i,
+            lang,
+            visibleVal = "",
+            invisibleVal = "";
+        if (self.original.header && self.original.header[self.lang]) {
+            visibleVal = invisibleVal = self.original.header[self.lang];
         } else {
-            self.field = uiElementInput.new(self.original.field);
+            for (i = 0; i < self.screen.langs.length; i += 1) {
+                lang = self.screen.langs[i];
+                if (self.original.header[lang]) {
+                    visibleVal = self.original.header[lang] +
+                        uiElementLangcodeButton.LANG_DELIN +
+                        lang;
+                    break;
+                }
+            }
         }
-        self.field.setIcon(icon);
-        self.getFieldHtml = function (value) {
-            return Utils.getFieldHtml(value);
-        };
+        self.header = uiElementInput.new().val(invisibleVal);
+        self.header.setVisibleValue(visibleVal);
 
-        // Make it possible to observe changes to self.field
-        // note self observableVal is read only!
-        // Writing to it will not update the value of the self.field text input
-        self.field.observableVal = ko.observable(self.field.val());
-        self.field.on("change", function () {
-            self.field.observableVal(self.field.val());
-        });
+        self.nodeset_extra = detailTabNodeset(_.extend({
+            caseTypes: self.screen.childCaseTypes,
+        }, _.pick(self.original, ['nodeset', 'nodesetCaseType', 'nodesetFilter'])));
 
-        (function () {
-            let i,
-                lang,
-                visibleVal = "",
-                invisibleVal = "";
-            if (self.original.header && self.original.header[self.lang]) {
-                visibleVal = invisibleVal = self.original.header[self.lang];
-            } else {
-                for (i = 0; i < self.screen.langs.length; i += 1) {
-                    lang = self.screen.langs[i];
-                    if (self.original.header[lang]) {
-                        visibleVal = self.original.header[lang] +
-                            uiElementLangcodeButton.LANG_DELIN +
-                            lang;
-                        break;
-                    }
-                }
+        self.relevant = uiElementInput.new().val(self.original.relevant);
+        if (self.isTab) {
+            self.header.ui.find("input[type='text']").attr("placeholder", gettext("Tab Name"));
+            self.relevant.ui.find("input[type='text']").attr("placeholder", gettext("Display Condition"));
+
+            if (self.original.relevant) {
+                self.relevant.observableVal = ko.observable(self.original.relevant);
+                self.relevant.on("change", function () {
+                    self.relevant.observableVal(self.relevant.val());
+                });
             }
-            self.header = uiElementInput.new().val(invisibleVal);
-            self.header.setVisibleValue(visibleVal);
+        }
+    }());
 
-            self.nodeset_extra = detailTabNodeset(_.extend({
-                caseTypes: self.screen.childCaseTypes,
-            }, _.pick(self.original, ['nodeset', 'nodesetCaseType', 'nodesetFilter'])));
-
-            self.relevant = uiElementInput.new().val(self.original.relevant);
-            if (self.isTab) {
-                self.header.ui.find("input[type='text']").attr("placeholder", gettext("Tab Name"));
-                self.relevant.ui.find("input[type='text']").attr("placeholder", gettext("Display Condition"));
-
-                if (self.original.relevant) {
-                    self.relevant.observableVal = ko.observable(self.original.relevant);
-                    self.relevant.on("change", function () {
-                        self.relevant.observableVal(self.relevant.val());
-                    });
-                }
-            }
-        }());
-
-        // TODO: use self.field.observableVal instead, and do something similar for header?
-        self.header.on("change", function () {
-            self.setTileContent();
-        });
-        self.field.on("change", function () {
-            self.setTileContent();
-        });
+    // TODO: use self.field.observableVal instead, and do something similar for header?
+    self.header.on("change", function () {
         self.setTileContent();
+    });
+    self.field.on("change", function () {
+        self.setTileContent();
+    });
+    self.setTileContent();
 
-        self.saveAttempted = ko.observable(false);
-        self.useXpathExpression = self.original.useXpathExpression;
-        self.warningText = Utils.fieldFormatWarningMessage;
-        self.showWarning = ko.computed(function () {
-            if (self.useXpathExpression) {
-                return false;
-            }
-            if (self.isTab) {
-                // Data tab missing its nodeset
-                return self.hasNodeset && !self.nodeset_extra.nodesetCaseType() && !self.nodeset_extra.nodeset();
-            }
-            // Invalid property name
-            return (self.field.observableVal() || self.saveAttempted()) && !Utils.isValidPropertyName(self.field.observableVal());
-        }, self);
-
-        // Add the graphing option if self is a graph so self we can set the value to graph
-        let menuOptions = Utils.getFieldFormats();
-        if (self.original.format === "graph") {
-            menuOptions = menuOptions.concat([{
-                value: "graph",
-                label: "",
-            }]);
-        }
-
+    self.saveAttempted = ko.observable(false);
+    self.useXpathExpression = self.original.useXpathExpression;
+    self.warningText = Utils.fieldFormatWarningMessage;
+    self.showWarning = ko.computed(function () {
         if (self.useXpathExpression) {
-            const menuOptionsToRemove = ['picture', 'audio'];
-            for (let i = 0; i < menuOptionsToRemove.length; i++) {
-                for (let j = 0; j < menuOptions.length; j++) {
-                    if (
-                        menuOptions[j].value !== self.original.format
-                        && menuOptions[j].value === menuOptionsToRemove[i]
-                    ) {
-                        menuOptions.splice(j, 1);
-                    }
+            return false;
+        }
+        if (self.isTab) {
+            // Data tab missing its nodeset
+            return self.hasNodeset && !self.nodeset_extra.nodesetCaseType() && !self.nodeset_extra.nodeset();
+        }
+        // Invalid property name
+        return (self.field.observableVal() || self.saveAttempted()) && !Utils.isValidPropertyName(self.field.observableVal());
+    }, self);
+
+    // Add the graphing option if self is a graph so self we can set the value to graph
+    let menuOptions = Utils.getFieldFormats();
+    if (self.original.format === "graph") {
+        menuOptions = menuOptions.concat([{
+            value: "graph",
+            label: "",
+        }]);
+    }
+
+    if (self.useXpathExpression) {
+        const menuOptionsToRemove = ['picture', 'audio'];
+        for (let i = 0; i < menuOptionsToRemove.length; i++) {
+            for (let j = 0; j < menuOptions.length; j++) {
+                if (
+                    menuOptions[j].value !== self.original.format
+                    && menuOptions[j].value === menuOptionsToRemove[i]
+                ) {
+                    menuOptions.splice(j, 1);
                 }
             }
-        } else {
-            // Restrict Translatable Text usage to Calculated Properties only
-            menuOptions.splice(-1);
         }
+    } else {
+        // Restrict Translatable Text usage to Calculated Properties only
+        menuOptions.splice(-1);
+    }
 
-        self.format = uiElementSelect.new(menuOptions).val(self.original.format || null);
-        self.supportsOptimizations = ko.observable(false);
-        self.setSupportOptimizations = function () {
-            let optimizationsSupported = (
-                screen.showCaseListOptimizations &&
-                self.useXpathExpression &&
-                self.format.val() &&
-                initialPageData.get('formats_supporting_case_list_optimizations').includes(self.format.val())
-            );
-            self.supportsOptimizations(optimizationsSupported);
-        };
-        self.setSupportOptimizations();
+    self.format = uiElementSelect.new(menuOptions).val(self.original.format || null);
+    self.supportsOptimizations = ko.observable(false);
+    self.setSupportOptimizations = function () {
+        let optimizationsSupported = (
+            screen.showCaseListOptimizations &&
+            self.useXpathExpression &&
+            self.format.val() &&
+            initialPageData.get('formats_supporting_case_list_optimizations').includes(self.format.val())
+        );
+        self.supportsOptimizations(optimizationsSupported);
+    };
+    self.setSupportOptimizations();
 
-        (function () {
-            const o = {
-                lang: self.lang,
-                langs: self.screen.langs,
-                module_id: self.screen.config.module_id,
-                items: self.original['enum'],
-                property_name: self.header,
-                multimedia: self.screen.config.multimedia,
-                values_are_icons: self.original.format === 'enum-image',
-                keys_are_conditions: self.original.format === 'conditional-enum',
-                values_are_translatable: self.original.format === 'translatable-enum',
-            };
-            self.enum_extra = uiElementKeyValueMapping.new(o);
-        }());
-        self.graph_extra = graphConfig.graphConfigurationUiElement({
-            childCaseTypes: self.screen.childCaseTypes,
-            fixtures: self.screen.fixtures,
+    (function () {
+        const o = {
             lang: self.lang,
             langs: self.screen.langs,
-            name: self.header.val(),
-        }, self.original.graph_configuration);
-        self.header.on("change", function () {
-            // The graph should always have the same name as the columnModel
-            self.graph_extra.setName(self.header.val());
-        });
+            module_id: self.screen.config.module_id,
+            items: self.original['enum'],
+            property_name: self.header,
+            multimedia: self.screen.config.multimedia,
+            values_are_icons: self.original.format === 'enum-image',
+            keys_are_conditions: self.original.format === 'conditional-enum',
+            values_are_translatable: self.original.format === 'translatable-enum',
+        };
+        self.enum_extra = uiElementKeyValueMapping.new(o);
+    }());
+    self.graph_extra = graphConfig.graphConfigurationUiElement({
+        childCaseTypes: self.screen.childCaseTypes,
+        fixtures: self.screen.fixtures,
+        lang: self.lang,
+        langs: self.screen.langs,
+        name: self.header.val(),
+    }, self.original.graph_configuration);
+    self.header.on("change", function () {
+        // The graph should always have the same name as the columnModel
+        self.graph_extra.setName(self.header.val());
+    });
 
-        const yyyy = new Date().getFullYear(),
-            yy = String(yyyy).substring(2);
-        self.date_extra = uiElementSelect.new([{
-            label: '31/10/' + yy,
-            value: '%d/%m/%y',
-        }, {
-            label: '31/10/' + yyyy,
-            value: '%d/%m/%Y',
-        }, {
-            label: '10/31/' + yyyy,
-            value: '%m/%d/%Y',
-        }, {
-            label: '10/31/' + yy,
-            value: '%m/%d/%y',
-        }, {
-            label: gettext('Oct 31, ') + yyyy,
-            value: '%b %d, %Y',
-        }]).val(self.original.date_format);
-        self.date_extra.ui.prepend($('<div/>').text(gettext(' Format ')));
+    const yyyy = new Date().getFullYear(),
+        yy = String(yyyy).substring(2);
+    self.date_extra = uiElementSelect.new([{
+        label: '31/10/' + yy,
+        value: '%d/%m/%y',
+    }, {
+        label: '31/10/' + yyyy,
+        value: '%d/%m/%Y',
+    }, {
+        label: '10/31/' + yyyy,
+        value: '%m/%d/%Y',
+    }, {
+        label: '10/31/' + yy,
+        value: '%m/%d/%y',
+    }, {
+        label: gettext('Oct 31, ') + yyyy,
+        value: '%b %d, %Y',
+    }]).val(self.original.date_format);
+    self.date_extra.ui.prepend($('<div/>').text(gettext(' Format ')));
 
-        self.endpointActionLabel = $('<span>Form to submit on click:</span>');
-        const formEndpointOptions = [{value: "-1", label: 'Select a form endpoint'}];
-        let moduleName = "";
-        const formEndpoints = Object.entries(initialPageData.get('form_endpoint_options'));
-        formEndpoints.forEach(([, endpoint]) => {
-            if (endpoint.module_name !== moduleName) {
-                moduleName = endpoint.module_name;
-                formEndpointOptions.push({groupName: `${moduleName} (${endpoint.module_case_type})`});
-            }
-            formEndpointOptions.push({value: endpoint.id, label: endpoint.form_name});
-        });
-        const selectedValue = self.original.endpoint_action_id ? self.original.endpoint_action_id : "-1";
-        self.action_form_extra = uiElementSelect.new(formEndpointOptions)
-            .val(selectedValue);
-
-        self.late_flag_extra = uiElementInput.new().val(self.original.late_flag.toString());
-        self.late_flag_extra.ui.find('input').css('width', 'auto').css("display", "inline-block");
-        self.late_flag_extra.ui.prepend($('<span>' + gettext(' Days late ') + '</span>'));
-
-        self.filter_xpath_extra = uiElementInput.new().val(self.original.filter_xpath.toString());
-        self.filter_xpath_extra.ui.prepend($('<div/>'));
-
-        self.calc_xpath_extra = uiElementInput.new().val(self.original.calc_xpath.toString());
-        self.calc_xpath_extra.ui.prepend($('<div/>'));
-
-        self.time_ago_extra = uiElementSelect.new([{
-            label: gettext('Years since date'),
-            value: Utils.TIME_AGO.year,
-        }, {
-            label: gettext('Months since date'),
-            value: Utils.TIME_AGO.month,
-        }, {
-            label: gettext('Weeks since date'),
-            value: Utils.TIME_AGO.week,
-        }, {
-            label: gettext('Days since date'),
-            value: Utils.TIME_AGO.day,
-        }, {
-            label: gettext('Days until date'),
-            value: -Utils.TIME_AGO.day,
-        }, {
-            label: gettext('Weeks until date'),
-            value: -Utils.TIME_AGO.week,
-        }, {
-            label: gettext('Months until date'),
-            value: -Utils.TIME_AGO.month,
-        }]).val(self.original.time_ago_interval.toString());
-        self.time_ago_extra.ui.prepend($('<div/>').text(gettext(' Measuring ')));
-
-        function fireChange() {
-            self.fire('change');
+    self.endpointActionLabel = $('<span>Form to submit on click:</span>');
+    const formEndpointOptions = [{value: "-1", label: 'Select a form endpoint'}];
+    let moduleName = "";
+    const formEndpoints = Object.entries(initialPageData.get('form_endpoint_options'));
+    formEndpoints.forEach(([, endpoint]) => {
+        if (endpoint.module_name !== moduleName) {
+            moduleName = endpoint.module_name;
+            formEndpointOptions.push({groupName: `${moduleName} (${endpoint.module_case_type})`});
         }
-        _.each([
-            'model',
-            'field',
-            'header',
-            'nodeset_extra',
-            'relevant',
-            'format',
-            'date_extra',
-            'enum_extra',
-            'action_form_extra',
-            'graph_extra',
-            'late_flag_extra',
-            'filter_xpath_extra',
-            'calc_xpath_extra',
-            'time_ago_extra',
-        ], function (element) {
-            self[element].on('change', fireChange);
-        });
-        if (self.optimizationSelectElement) {
-            self.optimizationSelectElement.on('change', fireChange);
+        formEndpointOptions.push({value: endpoint.id, label: endpoint.form_name});
+    });
+    const selectedValue = self.original.endpoint_action_id ? self.original.endpoint_action_id : "-1";
+    self.action_form_extra = uiElementSelect.new(formEndpointOptions)
+        .val(selectedValue);
+
+    self.late_flag_extra = uiElementInput.new().val(self.original.late_flag.toString());
+    self.late_flag_extra.ui.find('input').css('width', 'auto').css("display", "inline-block");
+    self.late_flag_extra.ui.prepend($('<span>' + gettext(' Days late ') + '</span>'));
+
+    self.filter_xpath_extra = uiElementInput.new().val(self.original.filter_xpath.toString());
+    self.filter_xpath_extra.ui.prepend($('<div/>'));
+
+    self.calc_xpath_extra = uiElementInput.new().val(self.original.calc_xpath.toString());
+    self.calc_xpath_extra.ui.prepend($('<div/>'));
+
+    self.time_ago_extra = uiElementSelect.new([{
+        label: gettext('Years since date'),
+        value: Utils.TIME_AGO.year,
+    }, {
+        label: gettext('Months since date'),
+        value: Utils.TIME_AGO.month,
+    }, {
+        label: gettext('Weeks since date'),
+        value: Utils.TIME_AGO.week,
+    }, {
+        label: gettext('Days since date'),
+        value: Utils.TIME_AGO.day,
+    }, {
+        label: gettext('Days until date'),
+        value: -Utils.TIME_AGO.day,
+    }, {
+        label: gettext('Weeks until date'),
+        value: -Utils.TIME_AGO.week,
+    }, {
+        label: gettext('Months until date'),
+        value: -Utils.TIME_AGO.month,
+    }]).val(self.original.time_ago_interval.toString());
+    self.time_ago_extra.ui.prepend($('<div/>').text(gettext(' Measuring ')));
+
+    function fireChange() {
+        self.fire('change');
+    }
+    _.each([
+        'model',
+        'field',
+        'header',
+        'nodeset_extra',
+        'relevant',
+        'format',
+        'date_extra',
+        'enum_extra',
+        'action_form_extra',
+        'graph_extra',
+        'late_flag_extra',
+        'filter_xpath_extra',
+        'calc_xpath_extra',
+        'time_ago_extra',
+    ], function (element) {
+        self[element].on('change', fireChange);
+    });
+    if (self.optimizationSelectElement) {
+        self.optimizationSelectElement.on('change', fireChange);
+    }
+    self.case_tile_field.subscribe(fireChange);
+    self.tileRowStart.subscribe(fireChange);
+    self.tileColumnStart.subscribe(fireChange);
+    self.tileWidth.subscribe(fireChange);
+    self.tileHeight.subscribe(fireChange);
+    self.horizontalAlign.subscribe(fireChange);
+    self.verticalAlign.subscribe(fireChange);
+    self.fontSize.subscribe(fireChange);
+    self.showBorder.subscribe(fireChange);
+    self.showShading.subscribe(fireChange);
+
+    self.$format = $('<div/>').append(self.format.ui);
+    self.$format.find("select").css("margin-bottom", "5px");
+    self.format.on('change', function () {
+        if (self.field.val() === microCaseImageName && self.format.val() !== 'image') {
+            // The field name input was disabled to enforce using the reserved micro image name.
+            // If the format is no longer an image then the user can edit the field input again
+            self.field.val('');
+            self.field.observableVal('');
+            self.field.ui.find('select').val('').change();
+            self.field.ui.find('select').prop('disabled', false);
         }
-        self.case_tile_field.subscribe(fireChange);
-        self.tileRowStart.subscribe(fireChange);
-        self.tileColumnStart.subscribe(fireChange);
-        self.tileWidth.subscribe(fireChange);
-        self.tileHeight.subscribe(fireChange);
-        self.horizontalAlign.subscribe(fireChange);
-        self.verticalAlign.subscribe(fireChange);
-        self.fontSize.subscribe(fireChange);
-        self.showBorder.subscribe(fireChange);
-        self.showShading.subscribe(fireChange);
 
-        self.$format = $('<div/>').append(self.format.ui);
-        self.$format.find("select").css("margin-bottom", "5px");
-        self.format.on('change', function () {
-            if (self.field.val() === microCaseImageName && self.format.val() !== 'image') {
-                // The field name input was disabled to enforce using the reserved micro image name.
-                // If the format is no longer an image then the user can edit the field input again
-                self.field.val('');
-                self.field.observableVal('');
-                self.field.ui.find('select').val('').change();
-                self.field.ui.find('select').prop('disabled', false);
-            }
-
-            self.coordinatesVisible(!_.contains(['address', 'address-popup', 'invisible'], self.format.val()));
-            self.setSupportOptimizations();
-            // Prevent self from running on page load before init
-            if (self.format.ui.parent().length > 0) {
-                self.date_extra.ui.detach();
-                self.enum_extra.ui.detach();
-                self.endpointActionLabel.detach();
-                self.action_form_extra.ui.detach();
-                self.graph_extra.ui.detach();
-                self.late_flag_extra.ui.detach();
-                self.filter_xpath_extra.ui.detach();
-                self.calc_xpath_extra.ui.detach();
-                self.time_ago_extra.ui.detach();
-                if (this.val() === "date") {
-                    self.format.ui.parent().append(self.date_extra.ui);
-                    var format = self.date_extra.ui.find('select');
-                    format.change(function () {
-                        self.date_extra.value = format.val();
-                        fireChange();
-                    });
+        self.coordinatesVisible(!_.contains(['address', 'address-popup', 'invisible'], self.format.val()));
+        self.setSupportOptimizations();
+        // Prevent self from running on page load before init
+        if (self.format.ui.parent().length > 0) {
+            self.date_extra.ui.detach();
+            self.enum_extra.ui.detach();
+            self.endpointActionLabel.detach();
+            self.action_form_extra.ui.detach();
+            self.graph_extra.ui.detach();
+            self.late_flag_extra.ui.detach();
+            self.filter_xpath_extra.ui.detach();
+            self.calc_xpath_extra.ui.detach();
+            self.time_ago_extra.ui.detach();
+            if (this.val() === "date") {
+                self.format.ui.parent().append(self.date_extra.ui);
+                var format = self.date_extra.ui.find('select');
+                format.change(function () {
                     self.date_extra.value = format.val();
-                } else if (this.val() === "enum" || this.val() === "enum-image"
-                           || this.val() === 'conditional-enum' || this.val() === 'translatable-enum') {
-                    self.enum_extra.values_are_icons(this.val() === 'enum-image');
-                    self.enum_extra.keys_are_conditions(this.val() === 'conditional-enum');
-                    self.enum_extra.values_are_translatable(this.val() === 'translatable-enum');
-                    self.format.ui.parent().append(self.enum_extra.ui);
-                } else if (this.val() === "clickable-icon") {
-                    self.enum_extra.values_are_icons(true);
-                    self.enum_extra.keys_are_conditions(true);
-                    self.format.ui.parent().append(self.enum_extra.ui);
-                    self.format.ui.parent().append(self.endpointActionLabel);
-                    self.format.ui.parent().append(self.action_form_extra.ui);
-                    const actionForm = self.action_form_extra.ui.find('select');
-                    actionForm.change(function () {
-                        self.action_form_extra.value = actionForm.val();
-                        fireChange();
-                    });
+                    fireChange();
+                });
+                self.date_extra.value = format.val();
+            } else if (this.val() === "enum" || this.val() === "enum-image"
+                       || this.val() === 'conditional-enum' || this.val() === 'translatable-enum') {
+                self.enum_extra.values_are_icons(this.val() === 'enum-image');
+                self.enum_extra.keys_are_conditions(this.val() === 'conditional-enum');
+                self.enum_extra.values_are_translatable(this.val() === 'translatable-enum');
+                self.format.ui.parent().append(self.enum_extra.ui);
+            } else if (this.val() === "clickable-icon") {
+                self.enum_extra.values_are_icons(true);
+                self.enum_extra.keys_are_conditions(true);
+                self.format.ui.parent().append(self.enum_extra.ui);
+                self.format.ui.parent().append(self.endpointActionLabel);
+                self.format.ui.parent().append(self.action_form_extra.ui);
+                const actionForm = self.action_form_extra.ui.find('select');
+                actionForm.change(function () {
                     self.action_form_extra.value = actionForm.val();
-                } else if (this.val() === "graph") {
-                    // Replace format select with edit button
-                    var parent = self.format.ui.parent();
-                    parent.empty();
-                    parent.append(self.graph_extra.ui);
-                } else if (this.val() === 'late-flag') {
-                    self.format.ui.parent().append(self.late_flag_extra.ui);
-                    var input = self.late_flag_extra.ui.find('input');
-                    input.change(function () {
-                        self.late_flag_extra.value = input.val();
-                        fireChange();
-                    });
-                } else if (this.val() === 'filter') {
-                    self.format.ui.parent().append(self.filter_xpath_extra.ui);
-                    var filter = self.filter_xpath_extra.ui.find('input');
-                    filter.change(function () {
-                        self.filter_xpath_extra.value = filter.val();
-                        fireChange();
-                    });
-                } else if (this.val() === 'time-ago') {
-                    self.format.ui.parent().append(self.time_ago_extra.ui);
-                    var interval = self.time_ago_extra.ui.find('select');
-                    interval.change(function () {
-                        self.time_ago_extra.value = interval.val();
-                        fireChange();
-                    });
-                } else if (this.val() === 'image') {
-                    // We are enforcing the reserved field name for the micro image format,
-                    // so don't allow a user to change this
-                    self.field.ui.find('select').val(microCaseImageName).change();
-                    self.field.val(microCaseImageName);
-                    self.field.observableVal(microCaseImageName);
-                    self.field.ui.find('select').prop('disabled', true);
-                }
+                    fireChange();
+                });
+                self.action_form_extra.value = actionForm.val();
+            } else if (this.val() === "graph") {
+                // Replace format select with edit button
+                var parent = self.format.ui.parent();
+                parent.empty();
+                parent.append(self.graph_extra.ui);
+            } else if (this.val() === 'late-flag') {
+                self.format.ui.parent().append(self.late_flag_extra.ui);
+                var input = self.late_flag_extra.ui.find('input');
+                input.change(function () {
+                    self.late_flag_extra.value = input.val();
+                    fireChange();
+                });
+            } else if (this.val() === 'filter') {
+                self.format.ui.parent().append(self.filter_xpath_extra.ui);
+                var filter = self.filter_xpath_extra.ui.find('input');
+                filter.change(function () {
+                    self.filter_xpath_extra.value = filter.val();
+                    fireChange();
+                });
+            } else if (this.val() === 'time-ago') {
+                self.format.ui.parent().append(self.time_ago_extra.ui);
+                var interval = self.time_ago_extra.ui.find('select');
+                interval.change(function () {
+                    self.time_ago_extra.value = interval.val();
+                    fireChange();
+                });
+            } else if (this.val() === 'image') {
+                // We are enforcing the reserved field name for the micro image format,
+                // so don't allow a user to change this
+                self.field.ui.find('select').val(microCaseImageName).change();
+                self.field.val(microCaseImageName);
+                self.field.observableVal(microCaseImageName);
+                self.field.ui.find('select').prop('disabled', true);
             }
-        }).fire('change');
-        // Note self bind to the $edit_view for self google analytics event
-        // (as opposed to the format object itself)
-        // because self way the events are not fired during the initialization
-        // of the page.
-        self.format.$edit_view.on("change", function (event) {
-            google.track.event('Case List Config', 'Display Format', event.target.value);
-        });
-        self.serialize = function () {
-            const column = self.original;
-            column.field = self.field.val();
-            column.header[self.lang] = self.header.val();
-            column.format = self.format.val();
-            column.optimization = self.supportsOptimizations() ? self.optimizationSelectElement.val() : null;
-            column.date_format = self.date_extra.val();
-            column.enum = self.enum_extra.getItems();
-            column.endpoint_action_id = self.action_form_extra.val() === "-1" ? null : self.action_form_extra.val();
-            column.grid_x = self.tileColumnStart() - 1;
-            column.grid_y = self.tileRowStart() - 1;
-            column.height = self.tileHeight();
-            column.width = self.tileWidth();
-            column.horizontal_align = self.horizontalAlign();
-            column.vertical_align = self.verticalAlign();
-            column.font_size = self.fontSize();
-            column.show_border = self.showBorder();
-            column.show_shading = self.showShading();
-            column.graph_configuration = self.format.val() === "graph" ? self.graph_extra.val() : null;
-            column.late_flag = parseInt(self.late_flag_extra.val(), 10);
-            column.time_ago_interval = parseFloat(self.time_ago_extra.val());
-            column.filter_xpath = self.filter_xpath_extra.val();
-            column.calc_xpath = self.calc_xpath_extra.val();
-            column.case_tile_field = self.case_tile_field();
-            if (self.isTab) {
-                // Note: starting_index is added by screenModel.serialize
-                let tab = {
-                    header: column.header,
-                    isTab: true,
-                    starting_index: self.starting_index,
-                    relevant: self.relevant.val(),
-                    has_nodeset: column.hasNodeset,
-                };
-                if (column.hasNodeset) {
-                    tab = _.extend(tab, {
-                        nodeset_case_type: self.nodeset_extra.nodesetCaseType(),
-                        nodeset: self.nodeset_extra.nodeset(),
-                        nodeset_filter: self.nodeset_extra.nodesetFilter(),
-                    });
-                }
-                return tab;
+        }
+    }).fire('change');
+    // Note self bind to the $edit_view for self google analytics event
+    // (as opposed to the format object itself)
+    // because self way the events are not fired during the initialization
+    // of the page.
+    self.format.$edit_view.on("change", function (event) {
+        google.track.event('Case List Config', 'Display Format', event.target.value);
+    });
+    self.serialize = function () {
+        const column = self.original;
+        column.field = self.field.val();
+        column.header[self.lang] = self.header.val();
+        column.format = self.format.val();
+        column.optimization = self.supportsOptimizations() ? self.optimizationSelectElement.val() : null;
+        column.date_format = self.date_extra.val();
+        column.enum = self.enum_extra.getItems();
+        column.endpoint_action_id = self.action_form_extra.val() === "-1" ? null : self.action_form_extra.val();
+        column.grid_x = self.tileColumnStart() - 1;
+        column.grid_y = self.tileRowStart() - 1;
+        column.height = self.tileHeight();
+        column.width = self.tileWidth();
+        column.horizontal_align = self.horizontalAlign();
+        column.vertical_align = self.verticalAlign();
+        column.font_size = self.fontSize();
+        column.show_border = self.showBorder();
+        column.show_shading = self.showShading();
+        column.graph_configuration = self.format.val() === "graph" ? self.graph_extra.val() : null;
+        column.late_flag = parseInt(self.late_flag_extra.val(), 10);
+        column.time_ago_interval = parseFloat(self.time_ago_extra.val());
+        column.filter_xpath = self.filter_xpath_extra.val();
+        column.calc_xpath = self.calc_xpath_extra.val();
+        column.case_tile_field = self.case_tile_field();
+        if (self.isTab) {
+            // Note: starting_index is added by screenModel.serialize
+            let tab = {
+                header: column.header,
+                isTab: true,
+                starting_index: self.starting_index,
+                relevant: self.relevant.val(),
+                has_nodeset: column.hasNodeset,
+            };
+            if (column.hasNodeset) {
+                tab = _.extend(tab, {
+                    nodeset_case_type: self.nodeset_extra.nodesetCaseType(),
+                    nodeset: self.nodeset_extra.nodeset(),
+                    nodeset_filter: self.nodeset_extra.nodesetFilter(),
+                });
             }
-            return column;
-        };
-        self.setGrip = function (grip) {
-            self.grip = grip;
-        };
-        self.copyCallback = function () {
-            const column = self.serialize();
-            // add a marker self self is copied for self purpose
-            return JSON.stringify({
-                type: 'detail-screen-config:Column',
-                contents: column,
-            });
-        };
-
-        return self;
+            return tab;
+        }
+        return column;
     };
-});
+    self.setGrip = function (grip) {
+        self.grip = grip;
+    };
+    self.copyCallback = function () {
+        const column = self.serialize();
+        // add a marker self self is copied for self purpose
+        return JSON.stringify({
+            type: 'detail-screen-config:Column',
+            contents: column,
+        });
+    };
+
+    return self;
+};

--- a/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
@@ -49,4 +49,4 @@ export default function (options) {
     });
 
     return self;
-};
+}

--- a/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/detail_tab_nodeset.js
@@ -1,59 +1,52 @@
-hqDefine("app_manager/js/details/detail_tab_nodeset", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "hqwebapp/js/bootstrap3/main",
-], function (
-    $,
-    ko,
-    _,
-    main,
-) {
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import main from "hqwebapp/js/bootstrap3/main";
+
 /**
  * This provides the UI for a case detail tab's nodeset.
  *
  * It contains a dropdown where to select the type of data,
  * currently either a child case type or a custom xpath expression.
  */
-    return function (options) {
-        var self = {};
+export default function (options) {
+    var self = {};
 
-        self.nodeset = ko.observable(options.nodeset);
-        self.nodesetCaseType = ko.observable(options.nodesetCaseType);
-        self.nodesetFilter = ko.observable(options.nodesetFilter);
+    self.nodeset = ko.observable(options.nodeset);
+    self.nodesetCaseType = ko.observable(options.nodesetCaseType);
+    self.nodesetFilter = ko.observable(options.nodesetFilter);
 
-        self.dropdownOptions = [{name: gettext("Data Tab: Custom Expression"), value: ""}].concat(
-            _.map(options.caseTypes, function (t) {
-                return {name: gettext("Data Tab: Child Cases: ") + t, value: t};
-            }),
-        );
+    self.dropdownOptions = [{name: gettext("Data Tab: Custom Expression"), value: ""}].concat(
+        _.map(options.caseTypes, function (t) {
+            return {name: gettext("Data Tab: Child Cases: ") + t, value: t};
+        }),
+    );
 
-        self.showXpath = ko.computed(function () {
-            return !self.nodesetCaseType();
-        });
+    self.showXpath = ko.computed(function () {
+        return !self.nodesetCaseType();
+    });
 
-        self.showFilter = ko.observable(!!self.nodesetFilter());    // show button if there's no saved filter
+    self.showFilter = ko.observable(!!self.nodesetFilter());    // show button if there's no saved filter
 
-        self.ui = $(_.template($("#module-case-detail-tab-nodeset-template").text())());
-        self.ui.koApplyBindings(self);
+    self.ui = $(_.template($("#module-case-detail-tab-nodeset-template").text())());
+    self.ui.koApplyBindings(self);
 
-        main.eventize(self);
-        self.nodeset.subscribe(function () {
-            self.fire('change');
-        });
-        self.nodesetCaseType.subscribe(function (newValue) {
-            self.fire('change');
-            if (newValue) {
-                self.nodeset("");
-            } else {
-                self.nodesetFilter("");
-                self.showFilter(false);
-            }
-        });
-        self.nodesetFilter.subscribe(function () {
-            self.fire('change');
-        });
+    main.eventize(self);
+    self.nodeset.subscribe(function () {
+        self.fire('change');
+    });
+    self.nodesetCaseType.subscribe(function (newValue) {
+        self.fire('change');
+        if (newValue) {
+            self.nodeset("");
+        } else {
+            self.nodesetFilter("");
+            self.showFilter(false);
+        }
+    });
+    self.nodesetFilter.subscribe(function () {
+        self.fire('change');
+    });
 
-        return self;
-    };
-});
+    return self;
+};

--- a/corehq/apps/app_manager/static/app_manager/js/details/filter.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/filter.js
@@ -1,8 +1,5 @@
-hqDefine("app_manager/js/details/filter", [
-    "knockout",
-], function (
-    ko,
-) {
+import ko from "knockout";
+
 /**
  * Model for the case list filter, which has a button to
  * "Add Filter" when there's no filter, and when clicked
@@ -11,24 +8,23 @@ hqDefine("app_manager/js/details/filter", [
  * @param filterText Initial text of the filter
  * @param saveButton Save button for case list config
  */
-    return function (filterText, saveButton) {
-        var self = {};
-        self.filterText = ko.observable(typeof filterText === "string" && filterText.length > 0 ? filterText : "");
-        self.showing = ko.observable(self.filterText() !== "");
+export default function (filterText, saveButton) {
+    var self = {};
+    self.filterText = ko.observable(typeof filterText === "string" && filterText.length > 0 ? filterText : "");
+    self.showing = ko.observable(self.filterText() !== "");
 
-        self.filterText.subscribe(function () {
-            saveButton.fire('change');
-        });
-        self.showing.subscribe(function () {
-            saveButton.fire('change');
-        });
+    self.filterText.subscribe(function () {
+        saveButton.fire('change');
+    });
+    self.showing.subscribe(function () {
+        saveButton.fire('change');
+    });
 
-        self.serialize = function () {
-            if (self.showing()) {
-                return self.filterText();
-            }
-            return null;
-        };
-        return self;
+    self.serialize = function () {
+        if (self.showing()) {
+            return self.filterText();
+        }
+        return null;
     };
-});
+    return self;
+};

--- a/corehq/apps/app_manager/static/app_manager/js/details/filter.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/filter.js
@@ -27,4 +27,4 @@ export default function (filterText, saveButton) {
         return null;
     };
     return self;
-};
+}

--- a/corehq/apps/app_manager/static/app_manager/js/details/fixture_select.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/fixture_select.js
@@ -17,4 +17,4 @@ export default function (init) {
         return defaultOption.concat(columns);
     });
     return self;
-};
+}

--- a/corehq/apps/app_manager/static/app_manager/js/details/fixture_select.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/fixture_select.js
@@ -1,24 +1,20 @@
 /**
  * Model for Lookup Table Case Selection in case list configuration.
  */
-hqDefine("app_manager/js/details/fixture_select", [
-    "knockout",
-], function (
-    ko,
-) {
-    return function (init) {
-        var self = {};
-        self.active = ko.observable(init.active);
-        self.fixtureType = ko.observable(init.fixtureType);
-        self.displayColumn = ko.observable(init.displayColumn);
-        self.localize = ko.observable(init.localize);
-        self.variableColumn = ko.observable(init.variableColumn);
-        self.xpath = ko.observable(init.xpath);
-        self.fixture_columns = ko.computed(function () {
-            var columns = init.fixture_columns_by_type[self.fixtureType()],
-                defaultOption = [gettext("Select One")];
-            return defaultOption.concat(columns);
-        });
-        return self;
-    };
-});
+import ko from "knockout";
+
+export default function (init) {
+    var self = {};
+    self.active = ko.observable(init.active);
+    self.fixtureType = ko.observable(init.fixtureType);
+    self.displayColumn = ko.observable(init.displayColumn);
+    self.localize = ko.observable(init.localize);
+    self.variableColumn = ko.observable(init.variableColumn);
+    self.xpath = ko.observable(init.xpath);
+    self.fixture_columns = ko.computed(function () {
+        var columns = init.fixture_columns_by_type[self.fixtureType()],
+            defaultOption = [gettext("Select One")];
+        return defaultOption.concat(columns);
+    });
+    return self;
+};

--- a/corehq/apps/app_manager/static/app_manager/js/details/graph_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/graph_config.js
@@ -13,197 +13,166 @@
  * Object corresponding to a graph configuration saved in couch.
  * @constructor
  */
-hqDefine("app_manager/js/details/graph_config", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "hqwebapp/js/bootstrap3/main",
-    "clipboard/dist/clipboard",
-    "hqwebapp/js/components/select_toggle",
-], function (
-    $,
-    ko,
-    _,
-    main,
-    ClipboardJS,
-) {
-    var graphConfigurationUiElement = function (moduleOptions, serverRepresentationOfGraph) {
-        var self = {};
-        moduleOptions = moduleOptions || {};
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import main from "hqwebapp/js/bootstrap3/main";
+import ClipboardJS from "clipboard/dist/clipboard";
+import "hqwebapp/js/components/select_toggle";
 
-        var $editButtonDiv = $(
-            '<div>' +
-            '<button class="btn btn-default" data-bind="click: openModal">' +
-            '<i class="fa fa-pencil"></i> ' +
-            gettext('Edit Graph') +
-            '</button>' +
-            '</div>',
-        );
+var graphConfigurationUiElement = function (moduleOptions, serverRepresentationOfGraph) {
+    var self = {};
+    moduleOptions = moduleOptions || {};
 
-        self.ui = $editButtonDiv;
-        self.graphView = graphViewModel(moduleOptions);
-        self.graphView.populate(getGraphViewJS(serverRepresentationOfGraph, moduleOptions));
+    var $editButtonDiv = $(
+        '<div>' +
+        '<button class="btn btn-default" data-bind="click: openModal">' +
+        '<i class="fa fa-pencil"></i> ' +
+        gettext('Edit Graph') +
+        '</button>' +
+        '</div>',
+    );
 
-        self.openModal = function (uiElementViewModel) {
+    self.ui = $editButtonDiv;
+    self.graphView = graphViewModel(moduleOptions);
+    self.graphView.populate(getGraphViewJS(serverRepresentationOfGraph, moduleOptions));
 
-            // make a copy of the view model
-            var graphViewCopy = graphViewModel(moduleOptions);
-            graphViewCopy.populate(ko.toJS(uiElementViewModel.graphView));
-            // Replace the original with the copy if save is clicked, otherwise discard it
-            graphViewCopy.onSave = function () {
-                uiElementViewModel.graphView = graphViewCopy;
-                self.fire("change");
-            };
+    self.openModal = function (uiElementViewModel) {
 
-            // Load the modal with the copy
-            var $modalDiv = $(document.createElement("div"));
-            $modalDiv.attr("data-bind", "template: 'graph_configuration_modal'");
-
-            $modalDiv.koApplyBindings(graphViewCopy);
-
-            var $modal = $modalDiv.find('.modal');
-            $modal.appendTo('body');
-            $modal.modal('show');
-            $modal.on('hidden.bs.modal', function () {
-                $modal.remove();
-            });
-        };
-        self.setName = function (name) {
-            self.graphView.graphDisplayName(name);
+        // make a copy of the view model
+        var graphViewCopy = graphViewModel(moduleOptions);
+        graphViewCopy.populate(ko.toJS(uiElementViewModel.graphView));
+        // Replace the original with the copy if save is clicked, otherwise discard it
+        graphViewCopy.onSave = function () {
+            uiElementViewModel.graphView = graphViewCopy;
+            self.fire("change");
         };
 
-        self.ui.koApplyBindings(self);
-        main.eventize(self);
+        // Load the modal with the copy
+        var $modalDiv = $(document.createElement("div"));
+        $modalDiv.attr("data-bind", "template: 'graph_configuration_modal'");
+
+        $modalDiv.koApplyBindings(graphViewCopy);
+
+        var $modal = $modalDiv.find('.modal');
+        $modal.appendTo('body');
+        $modal.modal('show');
+        $modal.on('hidden.bs.modal', function () {
+            $modal.remove();
+        });
+    };
+    self.setName = function (name) {
+        self.graphView.graphDisplayName(name);
+    };
+
+    self.ui.koApplyBindings(self);
+    main.eventize(self);
+
+    /**
+     * Return an object representing this graph configuration that is suitable
+     * for sending to and saving on the server.
+     * @returns {{}}
+     */
+    self.val = function () {
+        var graphViewAsPOJS = ko.toJS(self.graphView);
+        var ret = {};
 
         /**
-         * Return an object representing this graph configuration that is suitable
-         * for sending to and saving on the server.
+         * Convert objects like {'en': null, 'fra': 'baguette'} to {'fra': 'baguette'}
+         * @param obj
          * @returns {{}}
          */
-        self.val = function () {
-            var graphViewAsPOJS = ko.toJS(self.graphView);
+        var omitNulls = function (obj) {
+            var keys = _.keys(obj);
             var ret = {};
-
-            /**
-             * Convert objects like {'en': null, 'fra': 'baguette'} to {'fra': 'baguette'}
-             * @param obj
-             * @returns {{}}
-             */
-            var omitNulls = function (obj) {
-                var keys = _.keys(obj);
-                var ret = {};
-                for (var i = 0; i < keys.length; i++) {
-                    if (obj[keys[i]] !== null) {
-                        ret[keys[i]] = obj[keys[i]];
-                    }
+            for (var i = 0; i < keys.length; i++) {
+                if (obj[keys[i]] !== null) {
+                    ret[keys[i]] = obj[keys[i]];
                 }
-                return ret;
-            };
+            }
+            return ret;
+        };
 
-            ret.graph_name = graphViewAsPOJS.graphDisplayName;
-            ret.graph_type = graphViewAsPOJS.selectedGraphType;
-            ret.series = _.map(graphViewAsPOJS.series, function (s) {
-                var series = {};
-                // Only take the keys from the series that we care about
-                series.data_path = s.dataPath;
-                series.x_function = s.xFunction;
-                series.y_function = s.yFunction;
-                if (s.radiusFunction !== undefined) {
-                    series.radius_function = s.radiusFunction;
-                }
-                series.locale_specific_config = _.reduce(
-                    s.localeSpecificConfigurations,
-                    function (memo, conf) {
-                        memo[conf.property] = omitNulls(conf.values);
-                        return memo;
-                    }, {});
-                // convert the list of config objects to a single object (since
-                // order no longer matters)
-                series.config = _.reduce(s.configPairs, function (memo, pair) {
-                    memo[pair.property] = pair.value;
-                    return memo;
-                }, {});
-                return series;
-            });
-            ret.annotations = _.map(graphViewAsPOJS.annotations, function (obj) {
-                obj.display_text = omitNulls(obj.values);
-                delete obj.displayText;
-                return obj;
-            });
-            ret.locale_specific_config = _.reduce(
-                graphViewAsPOJS.axisTitleConfigurations,
+        ret.graph_name = graphViewAsPOJS.graphDisplayName;
+        ret.graph_type = graphViewAsPOJS.selectedGraphType;
+        ret.series = _.map(graphViewAsPOJS.series, function (s) {
+            var series = {};
+            // Only take the keys from the series that we care about
+            series.data_path = s.dataPath;
+            series.x_function = s.xFunction;
+            series.y_function = s.yFunction;
+            if (s.radiusFunction !== undefined) {
+                series.radius_function = s.radiusFunction;
+            }
+            series.locale_specific_config = _.reduce(
+                s.localeSpecificConfigurations,
                 function (memo, conf) {
                     memo[conf.property] = omitNulls(conf.values);
                     return memo;
                 }, {});
-            ret.config = _.reduce(graphViewAsPOJS.configPairs, function (memo, pair) {
+            // convert the list of config objects to a single object (since
+            // order no longer matters)
+            series.config = _.reduce(s.configPairs, function (memo, pair) {
                 memo[pair.property] = pair.value;
                 return memo;
             }, {});
-            return ret;
-        };
+            return series;
+        });
+        ret.annotations = _.map(graphViewAsPOJS.annotations, function (obj) {
+            obj.display_text = omitNulls(obj.values);
+            delete obj.displayText;
+            return obj;
+        });
+        ret.locale_specific_config = _.reduce(
+            graphViewAsPOJS.axisTitleConfigurations,
+            function (memo, conf) {
+                memo[conf.property] = omitNulls(conf.values);
+                return memo;
+            }, {});
+        ret.config = _.reduce(graphViewAsPOJS.configPairs, function (memo, pair) {
+            memo[pair.property] = pair.value;
+            return memo;
+        }, {});
+        return ret;
+    };
 
-        /**
-         * Returns an object in in the same form as that returned by
-         * ko.toJS(graphViewModel_instance).
-         * @param serverGraphObject
-         * An object in the form returned of that returned by self.val(). That is,
-         * in the same form as the the graph configuration saved in couch.
-         * @param moduleOptions
-         * Additional options that are derived from the module (or app) like lang,
-         * langs, childCaseTypes, and fixtures.
-         * @returns {{}}
-         */
-        function getGraphViewJS(serverGraphObject, moduleOptions) {
-            // This line is needed because old Columns that don't have a
-            // graph_configuration will still call:
-            //      this.graph_extra = graphConfigurationUiElement(..., this.original.graph_configuration)
-            serverGraphObject = serverGraphObject || {};
-            var ret = {};
+    /**
+     * Returns an object in in the same form as that returned by
+     * ko.toJS(graphViewModel_instance).
+     * @param serverGraphObject
+     * An object in the form returned of that returned by self.val(). That is,
+     * in the same form as the the graph configuration saved in couch.
+     * @param moduleOptions
+     * Additional options that are derived from the module (or app) like lang,
+     * langs, childCaseTypes, and fixtures.
+     * @returns {{}}
+     */
+    function getGraphViewJS(serverGraphObject, moduleOptions) {
+        // This line is needed because old Columns that don't have a
+        // graph_configuration will still call:
+        //      this.graph_extra = graphConfigurationUiElement(..., this.original.graph_configuration)
+        serverGraphObject = serverGraphObject || {};
+        var ret = {};
 
-            ret.graphDisplayName = serverRepresentationOfGraph.graph_name;
-            ret.selectedGraphType = serverGraphObject.graph_type;
-            ret.series = _.map(serverGraphObject.series, function (s) {
-                var series = {};
+        ret.graphDisplayName = serverRepresentationOfGraph.graph_name;
+        ret.selectedGraphType = serverGraphObject.graph_type;
+        ret.series = _.map(serverGraphObject.series, function (s) {
+            var series = {};
 
-                series.selectedSource = {
-                    'text': 'custom',
-                    'value': 'custom',
-                };
-                series.dataPath = s.data_path;
-                series.dataPathPlaceholder = s.data_path_placeholder;
-                series.xFunction = s.x_function;
-                series.xPlaceholder = s.x_placeholder;
-                series.yFunction = s.y_function;
-                series.yPlaceholder = s.y_placeholder;
-                if (s.radius_function !== undefined) {
-                    series.radiusFunction = s.radius_function;
-                }
-                series.localeSpecificConfigurations = _.map(_.pairs(s.locale_specific_config), function (pair) {
-                    return {
-                        'lang': moduleOptions.lang,
-                        'langs': moduleOptions.langs,
-                        'property': pair[0],
-                        'values': pair[1],
-                    };
-                });
-                series.localeSpecificConfigurations = _.sortBy(series.localeSpecificConfigurations, 'property');
-                series.configPairs = _.map(_.pairs(s.config), function (pair) {
-                    return {
-                        'property': pair[0],
-                        'value': pair[1],
-                    };
-                });
-                return series;
-            });
-            ret.annotations = _.map(serverGraphObject.annotations, function (obj) {
-                obj.values = obj.display_text;
-                delete obj.display_text;
-                obj.lang = moduleOptions.lang;
-                obj.langs = moduleOptions.langs;
-                return obj;
-            });
-            ret.axisTitleConfigurations = _.map(_.pairs(serverGraphObject.locale_specific_config), function (pair) {
+            series.selectedSource = {
+                'text': 'custom',
+                'value': 'custom',
+            };
+            series.dataPath = s.data_path;
+            series.dataPathPlaceholder = s.data_path_placeholder;
+            series.xFunction = s.x_function;
+            series.xPlaceholder = s.x_placeholder;
+            series.yFunction = s.y_function;
+            series.yPlaceholder = s.y_placeholder;
+            if (s.radius_function !== undefined) {
+                series.radiusFunction = s.radius_function;
+            }
+            series.localeSpecificConfigurations = _.map(_.pairs(s.locale_specific_config), function (pair) {
                 return {
                     'lang': moduleOptions.lang,
                     'langs': moduleOptions.langs,
@@ -211,488 +180,511 @@ hqDefine("app_manager/js/details/graph_config", [
                     'values': pair[1],
                 };
             });
-            ret.configPairs = _.map(_.pairs(serverGraphObject.config), function (pair) {
+            series.localeSpecificConfigurations = _.sortBy(series.localeSpecificConfigurations, 'property');
+            series.configPairs = _.map(_.pairs(s.config), function (pair) {
                 return {
                     'property': pair[0],
                     'value': pair[1],
                 };
             });
-            ret.childCaseTypes = moduleOptions.childCaseTypes;
-            ret.fixtures = moduleOptions.fixtures;
+            return series;
+        });
+        ret.annotations = _.map(serverGraphObject.annotations, function (obj) {
+            obj.values = obj.display_text;
+            delete obj.display_text;
+            obj.lang = moduleOptions.lang;
+            obj.langs = moduleOptions.langs;
+            return obj;
+        });
+        ret.axisTitleConfigurations = _.map(_.pairs(serverGraphObject.locale_specific_config), function (pair) {
+            return {
+                'lang': moduleOptions.lang,
+                'langs': moduleOptions.langs,
+                'property': pair[0],
+                'values': pair[1],
+            };
+        });
+        ret.configPairs = _.map(_.pairs(serverGraphObject.config), function (pair) {
+            return {
+                'property': pair[0],
+                'value': pair[1],
+            };
+        });
+        ret.childCaseTypes = moduleOptions.childCaseTypes;
+        ret.fixtures = moduleOptions.fixtures;
 
-            return ret;
-        }
+        return ret;
+    }
 
-        return self;
+    return self;
+};
+
+// private
+var pairConfiguration = function (original) {
+    var self = {};
+    original = original || {};
+
+    self.configPairs = ko.observableArray(_.map(original.configPairs || [], function (pair) {
+        return configPropertyValuePair(pair);
+    }));
+    self.configPropertyOptions = [''];
+    self.configPropertyHints = {};
+
+    self.removeConfigPair = function (configPair) {
+        self.configPairs.remove(configPair);
+    };
+    self.addConfigPair = function () {
+        self.configPairs.push(configPropertyValuePair());
     };
 
-    // private
-    var pairConfiguration = function (original) {
-        var self = {};
-        original = original || {};
+    return self;
+};
 
-        self.configPairs = ko.observableArray(_.map(original.configPairs || [], function (pair) {
-            return configPropertyValuePair(pair);
+// private
+var configPropertyValuePair = function (original) {
+    var self = {};
+    original = original || {};
+
+    self.property = ko.observable(original.property === undefined ? "" : original.property);
+    self.value = ko.observable(original.value === undefined ? "" : original.value);
+
+    return self;
+};
+
+// private
+// TODO: Rename values to value (throughout the stack) to maintain consistency with enums!!
+var localizableValue = function (original) {
+    var self = {};
+    original = original || {};
+
+    // These values should always be provided
+    self.lang = original.lang;
+    self.langs = original.langs;
+
+    self.values = original.values || {};
+    // Make the value for the current language observable
+    self.values[self.lang] = ko.observable(
+        self.values[self.lang] === undefined ? null : ko.unwrap(self.values[self.lang]),
+    );
+
+    /**
+     * Return the backup value for self.lang.
+     * ex: self.values = {'en': 'foo', 'it': 'bar'}
+     *     self.langs = ['en', 'fra', 'it']
+     *
+     *     self.lang = 'fra'
+     *     self.getBackup() === 'foo'
+     *
+     *     self.lang = 'it'
+     *     self.getBackup() === 'bar'
+     *
+     * @returns {object}
+     */
+    self.getBackup = function () {
+        var backup = {
+            'value': null,
+            'lang': null,
+        };
+        var modLangs = [self.lang].concat(self.langs);
+        for (var i = 0; i < modLangs.length; i++) {
+            var possibleBackup = ko.unwrap(self.values[modLangs[i]]);
+            if (possibleBackup !== undefined && possibleBackup !== null) {
+                backup = {
+                    'value': possibleBackup,
+                    'lang': modLangs[i],
+                };
+                break;
+            }
+        }
+        return backup;
+    };
+
+    return self;
+};
+
+// private
+var localizedConfigPropertyValuePair = function (original) {
+    var self = localizableValue(original);
+    original = original || {};
+
+    // This should always be provided
+    self.property = original.property;
+
+    return self;
+};
+
+// private
+var graphViewModel = function (moduleOptions) {
+    var self = pairConfiguration();
+    moduleOptions = moduleOptions || {};
+
+    self.lang = moduleOptions.lang;
+    self.langs = moduleOptions.langs;
+
+    self.graphDisplayName = ko.observable(moduleOptions.name || "Graph");
+    self.availableGraphTypes = ko.observableArray(["xy", "bar", "bubble", "time"]);
+    self.selectedGraphType = ko.observable("xy");
+    self.series = ko.observableArray([]);
+    self.annotations = ko.observableArray([]);
+    self.axisTitleConfigurations = ko.observableArray(_.map(
+        // If you add to this list, don't forget to update theOrder in populate() (I know this is gross)
+        ['x-title', 'y-title', 'secondary-y-title'],
+        function (s) {
+            return localizedConfigPropertyValuePair({
+                'property': s,
+                'lang': self.lang,
+                'langs': self.langs,
+            });
+        },
+    ));
+
+    self.configPropertyOptions = [
+        '',
+        // Axis min and max:
+        'x-min',
+        'x-max',
+        'y-min',
+        'y-max',
+        'secondary-y-min',
+        'secondary-y-max',
+        // Axis labels:
+        'x-labels',
+        'x-labels-time-format',
+        'y-labels',
+        'secondary-y-labels',
+        // other:
+        'show-axes',
+        'show-data-labels',
+        'show-grid',
+        'show-legend',
+        'bar-orientation',
+        'stack',
+    ];
+    // Note: I don't like repeating the list of property options in the hints map.
+    // I could use configPropertyHints.keys() to generate the options, but that
+    // doesn't guarantee order...
+    // I could make these be lists of lists and have the bindings be functions
+    // instead of just the name of the property
+    self.configPropertyHints = {
+        // Axis min and max:
+        'x-min': 'ex: 0',
+        'x-max': 'ex: 100',
+        'y-min': 'ex: 0',
+        'y-max': 'ex: 100',
+        'secondary-y-min': 'ex: 0',
+        'secondary-y-max': 'ex: 100',
+        // Axis labels:
+        'x-labels': 'ex: 3 or \'[1,3,5]\' or \'{"0":"freezing"}\'',
+        'x-labels-time-format': 'ex: \'%Y-%m\'',
+        'y-labels': 'ex: 3 or \'[1,3,5]\' or \'{"0":"freezing"}\'',
+        'secondary-y-labels': 'ex: 3 or [1,3,5] or {"0":"freezing"}',
+        // other:
+        'show-axes': 'true() or false()',
+        'show-data-labels': 'true() or false()',
+        'show-grid': 'true() or false()',
+        'show-legend': 'true() or false()',
+        'bar-orientation': '\'horizontal\' or \'vertical\'',
+        'stack': 'true() or false()',
+    };
+    self.childCaseTypes = moduleOptions.childCaseTypes || [];
+    self.fixtures = moduleOptions.fixtures || [];
+    self.lang = moduleOptions.lang;
+    self.langs = moduleOptions.langs;
+
+    self.selectedGraphType.subscribe(function () {
+        // Recreate the series objects to be of the correct type.
+        self.series(_.map(self.series(), function (series) {
+            return self.createSeries(ko.toJS(series), self.childCaseTypes, self.fixtures, self.lang, self.langs);
         }));
-        self.configPropertyOptions = [''];
-        self.configPropertyHints = {};
+    });
 
-        self.removeConfigPair = function (configPair) {
-            self.configPairs.remove(configPair);
-        };
-        self.addConfigPair = function () {
-            self.configPairs.push(configPropertyValuePair());
-        };
+    self.populate = function (obj) {
+        self.graphDisplayName(obj.graphDisplayName);
+        self.selectedGraphType(obj.selectedGraphType);
+        self.series(_.map(obj.series, function (o) {
+            return self.createSeries(o, self.childCaseTypes, self.fixtures, self.lang, self.langs);
+        }));
+        self.annotations(_.map(obj.annotations, function (o) {
+            return annotation(o);
+        }));
 
-        return self;
-    };
-
-    // private
-    var configPropertyValuePair = function (original) {
-        var self = {};
-        original = original || {};
-
-        self.property = ko.observable(original.property === undefined ? "" : original.property);
-        self.value = ko.observable(original.value === undefined ? "" : original.value);
-
-        return self;
-    };
-
-    // private
-    // TODO: Rename values to value (throughout the stack) to maintain consistency with enums!!
-    var localizableValue = function (original) {
-        var self = {};
-        original = original || {};
-
-        // These values should always be provided
-        self.lang = original.lang;
-        self.langs = original.langs;
-
-        self.values = original.values || {};
-        // Make the value for the current language observable
-        self.values[self.lang] = ko.observable(
-            self.values[self.lang] === undefined ? null : ko.unwrap(self.values[self.lang]),
-        );
-
-        /**
-         * Return the backup value for self.lang.
-         * ex: self.values = {'en': 'foo', 'it': 'bar'}
-         *     self.langs = ['en', 'fra', 'it']
-         *
-         *     self.lang = 'fra'
-         *     self.getBackup() === 'foo'
-         *
-         *     self.lang = 'it'
-         *     self.getBackup() === 'bar'
-         *
-         * @returns {object}
-         */
-        self.getBackup = function () {
-            var backup = {
-                'value': null,
-                'lang': null,
-            };
-            var modLangs = [self.lang].concat(self.langs);
-            for (var i = 0; i < modLangs.length; i++) {
-                var possibleBackup = ko.unwrap(self.values[modLangs[i]]);
-                if (possibleBackup !== undefined && possibleBackup !== null) {
-                    backup = {
-                        'value': possibleBackup,
-                        'lang': modLangs[i],
-                    };
-                    break;
-                }
-            }
-            return backup;
-        };
-
-        return self;
-    };
-
-    // private
-    var localizedConfigPropertyValuePair = function (original) {
-        var self = localizableValue(original);
-        original = original || {};
-
-        // This should always be provided
-        self.property = original.property;
-
-        return self;
-    };
-
-    // private
-    var graphViewModel = function (moduleOptions) {
-        var self = pairConfiguration();
-        moduleOptions = moduleOptions || {};
-
-        self.lang = moduleOptions.lang;
-        self.langs = moduleOptions.langs;
-
-        self.graphDisplayName = ko.observable(moduleOptions.name || "Graph");
-        self.availableGraphTypes = ko.observableArray(["xy", "bar", "bubble", "time"]);
-        self.selectedGraphType = ko.observable("xy");
-        self.series = ko.observableArray([]);
-        self.annotations = ko.observableArray([]);
-        self.axisTitleConfigurations = ko.observableArray(_.map(
-            // If you add to this list, don't forget to update theOrder in populate() (I know this is gross)
-            ['x-title', 'y-title', 'secondary-y-title'],
-            function (s) {
-                return localizedConfigPropertyValuePair({
-                    'property': s,
-                    'lang': self.lang,
-                    'langs': self.langs,
-                });
-            },
-        ));
-
-        self.configPropertyOptions = [
-            '',
-            // Axis min and max:
-            'x-min',
-            'x-max',
-            'y-min',
-            'y-max',
-            'secondary-y-min',
-            'secondary-y-max',
-            // Axis labels:
-            'x-labels',
-            'x-labels-time-format',
-            'y-labels',
-            'secondary-y-labels',
-            // other:
-            'show-axes',
-            'show-data-labels',
-            'show-grid',
-            'show-legend',
-            'bar-orientation',
-            'stack',
-        ];
-        // Note: I don't like repeating the list of property options in the hints map.
-        // I could use configPropertyHints.keys() to generate the options, but that
-        // doesn't guarantee order...
-        // I could make these be lists of lists and have the bindings be functions
-        // instead of just the name of the property
-        self.configPropertyHints = {
-            // Axis min and max:
-            'x-min': 'ex: 0',
-            'x-max': 'ex: 100',
-            'y-min': 'ex: 0',
-            'y-max': 'ex: 100',
-            'secondary-y-min': 'ex: 0',
-            'secondary-y-max': 'ex: 100',
-            // Axis labels:
-            'x-labels': 'ex: 3 or \'[1,3,5]\' or \'{"0":"freezing"}\'',
-            'x-labels-time-format': 'ex: \'%Y-%m\'',
-            'y-labels': 'ex: 3 or \'[1,3,5]\' or \'{"0":"freezing"}\'',
-            'secondary-y-labels': 'ex: 3 or [1,3,5] or {"0":"freezing"}',
-            // other:
-            'show-axes': 'true() or false()',
-            'show-data-labels': 'true() or false()',
-            'show-grid': 'true() or false()',
-            'show-legend': 'true() or false()',
-            'bar-orientation': '\'horizontal\' or \'vertical\'',
-            'stack': 'true() or false()',
-        };
-        self.childCaseTypes = moduleOptions.childCaseTypes || [];
-        self.fixtures = moduleOptions.fixtures || [];
-        self.lang = moduleOptions.lang;
-        self.langs = moduleOptions.langs;
-
-        self.selectedGraphType.subscribe(function () {
-            // Recreate the series objects to be of the correct type.
-            self.series(_.map(self.series(), function (series) {
-                return self.createSeries(ko.toJS(series), self.childCaseTypes, self.fixtures, self.lang, self.langs);
-            }));
-        });
-
-        self.populate = function (obj) {
-            self.graphDisplayName(obj.graphDisplayName);
-            self.selectedGraphType(obj.selectedGraphType);
-            self.series(_.map(obj.series, function (o) {
-                return self.createSeries(o, self.childCaseTypes, self.fixtures, self.lang, self.langs);
-            }));
-            self.annotations(_.map(obj.annotations, function (o) {
-                return annotation(o);
-            }));
-
-            if (obj.axisTitleConfigurations.length !== 0) {
-                self.axisTitleConfigurations(_.map(obj.axisTitleConfigurations, function (o) {
-                    return localizedConfigPropertyValuePair(o);
-                }));
-            }
-            // This is dumb:
-            // might make more sense to sort this in getGraphViewModelJS. Either way it's annoying.
-            var theOrder = {
-                'x-title': 0,
-                'y-title': 1,
-                'secondary-y-title': 2,
-            };
-            self.axisTitleConfigurations.sort(function (a, b) {
-                return theOrder[a.property] - theOrder[b.property];
-            });
-
-            self.configPairs(_.map(obj.configPairs, function (pair) {
-                return configPropertyValuePair(pair);
-            }));
-
-            self.childCaseTypes = obj.childCaseTypes.slice(0);
-            self.fixtures = obj.fixtures.slice(0);
-        };
-
-        self.removeSeries = function (series) {
-            self.series.remove(series);
-        };
-        self.addSeries = function () {
-            self.series.push(self.createSeries({}, self.childCaseTypes, self.fixtures, self.lang, self.langs));
-        };
-        /**
-         * Return the proper Series object constructor based on the current state
-         * of the view model.
-         */
-        self.createSeries = function () {
-            if (!_.contains(self.availableGraphTypes(), self.selectedGraphType())) {
-                throw new Error("Invalid selectedGraphType: " + self.selectedGraphType());
-            }
-            if (self.selectedGraphType() === "bubble") {
-                return bubbleGraphSeries.apply(undefined, arguments);
-            } else if (self.selectedGraphType() === "bar") {
-                return barGraphSeries.apply(undefined, arguments);
-            } else {
-                return xyGraphSeries.apply(undefined, arguments);
-            }
-        };
-
-        self.removeAnnotation = function (annotation) {
-            self.annotations.remove(annotation);
-        };
-        self.addAnnotation = function () {
-            self.annotations.push(annotation({
-                lang: self.lang,
-                langs: self.langs,
-            }));
-        };
-
-        return self;
-    };
-
-    // private
-    var annotation = function (original) {
-        var self = localizableValue(original);
-        original = original || {};
-
-        self.x = ko.observable(original.x === undefined ? undefined : original.x);
-        self.y = ko.observable(original.y === undefined ? undefined : original.y);
-
-        return self;
-    };
-
-    // private
-    var graphSeries = function (original, childCaseTypes, fixtures, lang, langs) {
-        var self = pairConfiguration(original);
-        original = original || {};
-        childCaseTypes = childCaseTypes || [];
-        fixtures = fixtures || [];
-        self.lang = lang;
-        self.langs = langs;
-
-        function origOrDefault(prop, fallback) {
-            return original[prop] === undefined ? fallback : original[prop];
-        }
-
-        self.getFixtureInstanceId = function (fixtureName) {
-            return "item-list:" + fixtureName;
-        };
-
-        /**
-         * Return the default value for the data path field based on the given source.
-         * This is used to change the data path field when a new source type is selected.
-         * @param source
-         * @returns {string}
-         */
-        self.getDefaultDataPath = function (source) {
-            if (source.type === "custom") {
-                return "instance('name')/root/path-to-point/point";
-            } else if (source.type === 'case') {
-                return "instance('casedb')/casedb/case[@case_type='" + source.name + "'][@status='open'][index/parent=current()/@case_id]";
-            } else if (source.type === 'fixture') {
-                return "instance('" + self.getFixtureInstanceId(source.name) + "')/" + source.name + "_list/" + source.name;
-            }
-        };
-
-        self.sourceOptions = ko.observableArray(origOrDefault(
-            'sourceOptions',
-            _.map(childCaseTypes, function (s) {
-                return {
-                    'text': "Child case: " + s,
-                    'value': {
-                        'type': 'case',
-                        'name': s,
-                    },
-                };
-            }).concat(_.map(fixtures, function (s) {
-                return {
-                    'text': "Lookup table: " + s,
-                    'value': {
-                        type: 'fixture',
-                        name: s,
-                    },
-                };
-            })).concat([{
-                'text': 'custom',
-                'value': 'custom',
-            }]),
-        ));
-
-        self.selectedSource = ko.observable(origOrDefault('selectedSource', self.sourceOptions()[0]));
-        // Fix selectedSource reference:
-        //  (selectedSource has to be a reference to an object in sourceOptions.
-        //   Thus, when original specifies a selectedSource we must find the matching
-        //   object in sourceOptions.)
-        if (!_.contains(self.sourceOptions(), self.selectedSource())) {
-            var curSource = self.selectedSource();
-            var source = _.find(self.sourceOptions(), function (opt) {
-                return _.isEqual(opt, curSource);
-            });
-            self.selectedSource(source);
-        }
-        self.dataPath = ko.observable(origOrDefault('dataPath', self.getDefaultDataPath(self.selectedSource().value)));
-        self.dataPathPlaceholder = ko.observable(origOrDefault('dataPathPlaceholder', ""));
-        self.showDataPath = ko.observable(origOrDefault('showDataPath', false));
-        self.xFunction = ko.observable(origOrDefault('xFunction', ""));
-        self.xPlaceholder = ko.observable(origOrDefault('xPlaceholder', ""));
-        self.yFunction = ko.observable(origOrDefault('yFunction', ""));
-        self.yPlaceholder = ko.observable(origOrDefault('yPlaceholder', ""));
-        self.copyPlaceholder = function (series, e) {
-            var $button = $(e.currentTarget);
-            var clipboard = new ClipboardJS($button[0], {
-                text: function () {
-                    return $button.closest(".input-group").find("input").val();
-                },
-            });
-            $button.tooltip({
-                title: gettext('Copied!'),
-            });
-            clipboard.on('success', function () {
-                $button.tooltip('show');
-                window.setTimeout(function () {
-                    $button.tooltip('hide');
-                }, 1000);
-            });
-            clipboard.onClick(e);
-        };
-
-        var seriesValidationWarning = gettext(
-            "It is recommended that you leave this value blank. Future changes to your report's " +
-            "chart configuration will not be reflected here.",
-        );
-        self.dataPathWarning = ko.computed(function () {
-            if (!self.dataPathPlaceholder() || !self.dataPath()) {
-                return;
-            }
-            self.showDataPath(true);
-            return seriesValidationWarning;
-        });
-        self.xWarning = ko.computed(function () {
-            if (!self.xPlaceholder() || !self.xFunction()) {
-                return;
-            }
-            return seriesValidationWarning;
-        });
-        self.yWarning = ko.computed(function () {
-            if (!self.yPlaceholder() || !self.yFunction()) {
-                return;
-            }
-            return seriesValidationWarning;
-        });
-        self.showDataPathCopy = ko.computed(function () {
-            return self.dataPathPlaceholder() && !self.dataPathWarning();
-        });
-        self.showXCopy = ko.computed(function () {
-            return self.xPlaceholder() && !self.xWarning();
-        });
-        self.showYCopy = ko.computed(function () {
-            return self.yPlaceholder() && !self.yWarning();
-        });
-        self.xLabel = "X";
-        self.yLabel = "Y";
-        self.configPropertyOptions = [
-            '',
-            'fill-below',
-            'line-color',
-            'name',
-            'x-name',
-        ];
-        self.configPropertyHints = {
-            'fill-below': "ex: '#aarrggbb'",
-            'line-color': "ex: '#aarrggbb'",
-            'name': "ex: 'My Y-Values 1'",
-            'x-name': "ex: 'My X-Values'",
-        };
-        self.localeSpecificConfigurations = ko.observableArray(_.map(
-            ['name', 'x-name'],
-            function (s) {
-                return localizedConfigPropertyValuePair({
-                    'property': s,
-                    'lang': self.lang,
-                    'langs': self.langs,
-                });
-            },
-        ));
-        if (original.localeSpecificConfigurations && original.localeSpecificConfigurations.length !== 0) {
-            self.localeSpecificConfigurations(_.map(original.localeSpecificConfigurations, function (o) {
+        if (obj.axisTitleConfigurations.length !== 0) {
+            self.axisTitleConfigurations(_.map(obj.axisTitleConfigurations, function (o) {
                 return localizedConfigPropertyValuePair(o);
             }));
         }
-        self.localeSpecificConfigurations.sort();
-
-        self.toggleShowDataPath = function () {
-            self.showDataPath(!self.showDataPath());
+        // This is dumb:
+        // might make more sense to sort this in getGraphViewModelJS. Either way it's annoying.
+        var theOrder = {
+            'x-title': 0,
+            'y-title': 1,
+            'secondary-y-title': 2,
         };
-        self.selectedSource.subscribe(function (newValue) {
-            if (newValue.value === "custom") {
-                self.showDataPath(true);
-            }
-            self.dataPath(self.getDefaultDataPath(newValue.value));
+        self.axisTitleConfigurations.sort(function (a, b) {
+            return theOrder[a.property] - theOrder[b.property];
         });
 
-        return self;
+        self.configPairs(_.map(obj.configPairs, function (pair) {
+            return configPropertyValuePair(pair);
+        }));
+
+        self.childCaseTypes = obj.childCaseTypes.slice(0);
+        self.fixtures = obj.fixtures.slice(0);
     };
 
-    // private
-    var xyGraphSeries = function (original, childCaseTypes, fixtures, lang, langs) {
-        var self = graphSeries(original, childCaseTypes, fixtures, lang, langs);
-        self.configPropertyOptions = self.configPropertyOptions.concat(['is-data', 'point-style', 'secondary-y']);
-        self.configPropertyHints['is-data'] = 'true() or false()';
-        // triangle-up and triangle-down are also options
-        self.configPropertyHints['point-style'] = "'none', 'circle', 'cross', 'diamond', ...";
-        self.configPropertyHints['secondary-y'] = 'true() or false()';
-        return self;
+    self.removeSeries = function (series) {
+        self.series.remove(series);
+    };
+    self.addSeries = function () {
+        self.series.push(self.createSeries({}, self.childCaseTypes, self.fixtures, self.lang, self.langs));
+    };
+    /**
+     * Return the proper Series object constructor based on the current state
+     * of the view model.
+     */
+    self.createSeries = function () {
+        if (!_.contains(self.availableGraphTypes(), self.selectedGraphType())) {
+            throw new Error("Invalid selectedGraphType: " + self.selectedGraphType());
+        }
+        if (self.selectedGraphType() === "bubble") {
+            return bubbleGraphSeries.apply(undefined, arguments);
+        } else if (self.selectedGraphType() === "bar") {
+            return barGraphSeries.apply(undefined, arguments);
+        } else {
+            return xyGraphSeries.apply(undefined, arguments);
+        }
     };
 
-    // private
-    var barGraphSeries = function (original, childCaseTypes, fixtures, lang, langs) {
-        var self = graphSeries(original, childCaseTypes, fixtures, lang, langs);
-
-        self.xLabel = "Label";
-        self.yLabel = "Value";
-        self.configPropertyOptions = self.configPropertyOptions.concat(['bar-color']);
-        self.configPropertyHints['bar-color'] = "if(x > 100, '#55ff00ff', 'ffff00ff')";
-
-        return self;
+    self.removeAnnotation = function (annotation) {
+        self.annotations.remove(annotation);
+    };
+    self.addAnnotation = function () {
+        self.annotations.push(annotation({
+            lang: self.lang,
+            langs: self.langs,
+        }));
     };
 
-    // private
-    var bubbleGraphSeries = function (original, childCaseTypes, fixtures, lang, langs) {
-        var self = xyGraphSeries(original, childCaseTypes, fixtures, lang, langs);
+    return self;
+};
 
-        self.radiusFunction = ko.observable(original.radiusFunction === undefined ? "" : original.radiusFunction);
-        self.configPropertyOptions = self.configPropertyOptions.concat(['max-radius']);
-        self.configPropertyHints['max-radius'] = 'ex: 7';
+// private
+var annotation = function (original) {
+    var self = localizableValue(original);
+    original = original || {};
 
-        return self;
+    self.x = ko.observable(original.x === undefined ? undefined : original.x);
+    self.y = ko.observable(original.y === undefined ? undefined : original.y);
+
+    return self;
+};
+
+// private
+var graphSeries = function (original, childCaseTypes, fixtures, lang, langs) {
+    var self = pairConfiguration(original);
+    original = original || {};
+    childCaseTypes = childCaseTypes || [];
+    fixtures = fixtures || [];
+    self.lang = lang;
+    self.langs = langs;
+
+    function origOrDefault(prop, fallback) {
+        return original[prop] === undefined ? fallback : original[prop];
+    }
+
+    self.getFixtureInstanceId = function (fixtureName) {
+        return "item-list:" + fixtureName;
     };
 
-    return {
-        graphConfigurationUiElement: graphConfigurationUiElement,
+    /**
+     * Return the default value for the data path field based on the given source.
+     * This is used to change the data path field when a new source type is selected.
+     * @param source
+     * @returns {string}
+     */
+    self.getDefaultDataPath = function (source) {
+        if (source.type === "custom") {
+            return "instance('name')/root/path-to-point/point";
+        } else if (source.type === 'case') {
+            return "instance('casedb')/casedb/case[@case_type='" + source.name + "'][@status='open'][index/parent=current()/@case_id]";
+        } else if (source.type === 'fixture') {
+            return "instance('" + self.getFixtureInstanceId(source.name) + "')/" + source.name + "_list/" + source.name;
+        }
     };
-});
+
+    self.sourceOptions = ko.observableArray(origOrDefault(
+        'sourceOptions',
+        _.map(childCaseTypes, function (s) {
+            return {
+                'text': "Child case: " + s,
+                'value': {
+                    'type': 'case',
+                    'name': s,
+                },
+            };
+        }).concat(_.map(fixtures, function (s) {
+            return {
+                'text': "Lookup table: " + s,
+                'value': {
+                    type: 'fixture',
+                    name: s,
+                },
+            };
+        })).concat([{
+            'text': 'custom',
+            'value': 'custom',
+        }]),
+    ));
+
+    self.selectedSource = ko.observable(origOrDefault('selectedSource', self.sourceOptions()[0]));
+    // Fix selectedSource reference:
+    //  (selectedSource has to be a reference to an object in sourceOptions.
+    //   Thus, when original specifies a selectedSource we must find the matching
+    //   object in sourceOptions.)
+    if (!_.contains(self.sourceOptions(), self.selectedSource())) {
+        var curSource = self.selectedSource();
+        var source = _.find(self.sourceOptions(), function (opt) {
+            return _.isEqual(opt, curSource);
+        });
+        self.selectedSource(source);
+    }
+    self.dataPath = ko.observable(origOrDefault('dataPath', self.getDefaultDataPath(self.selectedSource().value)));
+    self.dataPathPlaceholder = ko.observable(origOrDefault('dataPathPlaceholder', ""));
+    self.showDataPath = ko.observable(origOrDefault('showDataPath', false));
+    self.xFunction = ko.observable(origOrDefault('xFunction', ""));
+    self.xPlaceholder = ko.observable(origOrDefault('xPlaceholder', ""));
+    self.yFunction = ko.observable(origOrDefault('yFunction', ""));
+    self.yPlaceholder = ko.observable(origOrDefault('yPlaceholder', ""));
+    self.copyPlaceholder = function (series, e) {
+        var $button = $(e.currentTarget);
+        var clipboard = new ClipboardJS($button[0], {
+            text: function () {
+                return $button.closest(".input-group").find("input").val();
+            },
+        });
+        $button.tooltip({
+            title: gettext('Copied!'),
+        });
+        clipboard.on('success', function () {
+            $button.tooltip('show');
+            window.setTimeout(function () {
+                $button.tooltip('hide');
+            }, 1000);
+        });
+        clipboard.onClick(e);
+    };
+
+    var seriesValidationWarning = gettext(
+        "It is recommended that you leave this value blank. Future changes to your report's " +
+        "chart configuration will not be reflected here.",
+    );
+    self.dataPathWarning = ko.computed(function () {
+        if (!self.dataPathPlaceholder() || !self.dataPath()) {
+            return;
+        }
+        self.showDataPath(true);
+        return seriesValidationWarning;
+    });
+    self.xWarning = ko.computed(function () {
+        if (!self.xPlaceholder() || !self.xFunction()) {
+            return;
+        }
+        return seriesValidationWarning;
+    });
+    self.yWarning = ko.computed(function () {
+        if (!self.yPlaceholder() || !self.yFunction()) {
+            return;
+        }
+        return seriesValidationWarning;
+    });
+    self.showDataPathCopy = ko.computed(function () {
+        return self.dataPathPlaceholder() && !self.dataPathWarning();
+    });
+    self.showXCopy = ko.computed(function () {
+        return self.xPlaceholder() && !self.xWarning();
+    });
+    self.showYCopy = ko.computed(function () {
+        return self.yPlaceholder() && !self.yWarning();
+    });
+    self.xLabel = "X";
+    self.yLabel = "Y";
+    self.configPropertyOptions = [
+        '',
+        'fill-below',
+        'line-color',
+        'name',
+        'x-name',
+    ];
+    self.configPropertyHints = {
+        'fill-below': "ex: '#aarrggbb'",
+        'line-color': "ex: '#aarrggbb'",
+        'name': "ex: 'My Y-Values 1'",
+        'x-name': "ex: 'My X-Values'",
+    };
+    self.localeSpecificConfigurations = ko.observableArray(_.map(
+        ['name', 'x-name'],
+        function (s) {
+            return localizedConfigPropertyValuePair({
+                'property': s,
+                'lang': self.lang,
+                'langs': self.langs,
+            });
+        },
+    ));
+    if (original.localeSpecificConfigurations && original.localeSpecificConfigurations.length !== 0) {
+        self.localeSpecificConfigurations(_.map(original.localeSpecificConfigurations, function (o) {
+            return localizedConfigPropertyValuePair(o);
+        }));
+    }
+    self.localeSpecificConfigurations.sort();
+
+    self.toggleShowDataPath = function () {
+        self.showDataPath(!self.showDataPath());
+    };
+    self.selectedSource.subscribe(function (newValue) {
+        if (newValue.value === "custom") {
+            self.showDataPath(true);
+        }
+        self.dataPath(self.getDefaultDataPath(newValue.value));
+    });
+
+    return self;
+};
+
+// private
+var xyGraphSeries = function (original, childCaseTypes, fixtures, lang, langs) {
+    var self = graphSeries(original, childCaseTypes, fixtures, lang, langs);
+    self.configPropertyOptions = self.configPropertyOptions.concat(['is-data', 'point-style', 'secondary-y']);
+    self.configPropertyHints['is-data'] = 'true() or false()';
+    // triangle-up and triangle-down are also options
+    self.configPropertyHints['point-style'] = "'none', 'circle', 'cross', 'diamond', ...";
+    self.configPropertyHints['secondary-y'] = 'true() or false()';
+    return self;
+};
+
+// private
+var barGraphSeries = function (original, childCaseTypes, fixtures, lang, langs) {
+    var self = graphSeries(original, childCaseTypes, fixtures, lang, langs);
+
+    self.xLabel = "Label";
+    self.yLabel = "Value";
+    self.configPropertyOptions = self.configPropertyOptions.concat(['bar-color']);
+    self.configPropertyHints['bar-color'] = "if(x > 100, '#55ff00ff', 'ffff00ff')";
+
+    return self;
+};
+
+// private
+var bubbleGraphSeries = function (original, childCaseTypes, fixtures, lang, langs) {
+    var self = xyGraphSeries(original, childCaseTypes, fixtures, lang, langs);
+
+    self.radiusFunction = ko.observable(original.radiusFunction === undefined ? "" : original.radiusFunction);
+    self.configPropertyOptions = self.configPropertyOptions.concat(['max-radius']);
+    self.configPropertyHints['max-radius'] = 'ex: 7';
+
+    return self;
+};
+
+export default {
+    graphConfigurationUiElement: graphConfigurationUiElement,
+};

--- a/corehq/apps/app_manager/static/app_manager/js/details/parent_select.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/parent_select.js
@@ -87,4 +87,4 @@ export default function (init) {
         return options;
     });
     return self;
-};
+}

--- a/corehq/apps/app_manager/static/app_manager/js/details/parent_select.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/parent_select.js
@@ -15,82 +15,76 @@
  * first case. This first case will just be available to forms.
  * This is used for deduplication workflows.
  */
-hqDefine("app_manager/js/details/parent_select", [
-    'knockout',
-    'underscore',
-    'hqwebapp/js/toggles',
-], function (
-    ko,
-    _,
-    toggles,
-) {
-    return function (init) {
-        var self = {};
-        var defaultModule = _(init.parentModules).findWhere({
-            is_parent: true,
-        });
-        self.moduleId = ko.observable(init.moduleId || (defaultModule ? defaultModule.unique_id : null));
-        self.allCaseModules = ko.observable(init.allCaseModules);
-        self.parentModules = ko.observable(init.parentModules);
-        self.lang = ko.observable(init.lang);
-        self.langs = ko.observable(init.langs);
-        self.enableOtherOption = toggles.toggleEnabled('NON_PARENT_MENU_SELECTION');
+import ko from "knockout";
+import _ from "underscore";
+import toggles from "hqwebapp/js/toggles";
 
-        self.selectOptions = [
-            {id: 'none', text: gettext('None')},
-            {id: 'parent', text: gettext('Parent')},
-        ];
-        if (self.enableOtherOption) {
-            self.selectOptions.push(
-                {id: 'other', text: gettext('Other')},
-            );
-        }
-        var selectMode = init.active ? (init.relationship === 'parent' ? 'parent' : 'other') : 'none';
-        if (self.enableOtherOption) {
-            self.selectMode = ko.observable(selectMode);
-            self.active = ko.computed(function () {
-                return (self.selectMode() !== 'none');
-            });
-        } else {
-            self.active = ko.observable(init.active);
-            self.selectMode = ko.computed(function () {
-                return self.active ? 'parent' : 'none';
-            });
-        }
-        self.relationship = ko.computed(function () {
-            return (self.selectMode() === 'parent' || self.selectMode() === 'none') ? 'parent' : null ;
-        });
+export default function (init) {
+    var self = {};
+    var defaultModule = _(init.parentModules).findWhere({
+        is_parent: true,
+    });
+    self.moduleId = ko.observable(init.moduleId || (defaultModule ? defaultModule.unique_id : null));
+    self.allCaseModules = ko.observable(init.allCaseModules);
+    self.parentModules = ko.observable(init.parentModules);
+    self.lang = ko.observable(init.lang);
+    self.langs = ko.observable(init.langs);
+    self.enableOtherOption = toggles.toggleEnabled('NON_PARENT_MENU_SELECTION');
 
-        function getTranslation(name, langs) {
-            var firstLang = _(langs).find(function (lang) {
-                return name[lang];
+    self.selectOptions = [
+        {id: 'none', text: gettext('None')},
+        {id: 'parent', text: gettext('Parent')},
+    ];
+    if (self.enableOtherOption) {
+        self.selectOptions.push(
+            {id: 'other', text: gettext('Other')},
+        );
+    }
+    var selectMode = init.active ? (init.relationship === 'parent' ? 'parent' : 'other') : 'none';
+    if (self.enableOtherOption) {
+        self.selectMode = ko.observable(selectMode);
+        self.active = ko.computed(function () {
+            return (self.selectMode() !== 'none');
+        });
+    } else {
+        self.active = ko.observable(init.active);
+        self.selectMode = ko.computed(function () {
+            return self.active ? 'parent' : 'none';
+        });
+    }
+    self.relationship = ko.computed(function () {
+        return (self.selectMode() === 'parent' || self.selectMode() === 'none') ? 'parent' : null ;
+    });
+
+    function getTranslation(name, langs) {
+        var firstLang = _(langs).find(function (lang) {
+            return name[lang];
+        });
+        return name[firstLang];
+    }
+    self.dropdownModules = ko.computed(function () {
+        return (self.selectMode() === 'parent') ? self.parentModules() : self.allCaseModules();
+    });
+    self.hasError = ko.computed(function () {
+        return !_.contains(_.pluck(self.dropdownModules(), 'unique_id'), self.moduleId());
+    });
+    self.moduleOptions = ko.computed(function () {
+        var options = _(self.dropdownModules()).map(function (module) {
+            var STAR = '\u2605',
+                SPACE = '\u3000';
+            var marker = (module.is_parent ? STAR : SPACE);
+            return {
+                value: module.unique_id,
+                label: marker + ' ' + getTranslation(module.name, [self.lang()].concat(self.langs())),
+            };
+        });
+        if (self.hasError()) {
+            options.unshift({
+                value: '',
+                label: gettext('Unknown menu'),
             });
-            return name[firstLang];
         }
-        self.dropdownModules = ko.computed(function () {
-            return (self.selectMode() === 'parent') ? self.parentModules() : self.allCaseModules();
-        });
-        self.hasError = ko.computed(function () {
-            return !_.contains(_.pluck(self.dropdownModules(), 'unique_id'), self.moduleId());
-        });
-        self.moduleOptions = ko.computed(function () {
-            var options = _(self.dropdownModules()).map(function (module) {
-                var STAR = '\u2605',
-                    SPACE = '\u3000';
-                var marker = (module.is_parent ? STAR : SPACE);
-                return {
-                    value: module.unique_id,
-                    label: marker + ' ' + getTranslation(module.name, [self.lang()].concat(self.langs())),
-                };
-            });
-            if (self.hasError()) {
-                options.unshift({
-                    value: '',
-                    label: gettext('Unknown menu'),
-                });
-            }
-            return options;
-        });
-        return self;
-    };
-});
+        return options;
+    });
+    return self;
+};

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -719,4 +719,4 @@ export default function (spec, config, options) {
     };
 
     return self;
-};
+}

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -11,726 +11,712 @@
  * @param config A detailScreenConfig object.
  * @param options
  */
-hqDefine("app_manager/js/details/screen", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "app_manager/js/details/utils",
-    "app_manager/js/details/column",
-    "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list",
-    "hqwebapp/js/bootstrap3/main",
-    "hqwebapp/js/toggles",
-    "app_manager/js/app_manager",
-    "analytix/js/google",
-    "hqwebapp/js/components/select_toggle",
-    "hqwebapp/js/bootstrap3/knockout_bindings.ko",  // sortable binding
-], function (
-    $,
-    ko,
-    _,
-    Utils,
-    ColumnModel,
-    initialPageData,
-    uiMapList,
-    main,
-    toggles,
-    appManager,
-    google,
-) {
-    const getPropertyTitle = function (property) {
-        // Strip "<prefix>:" before converting to title case.
-        // This is aimed at prefixes like ledger: and attachment:
-        property = property || '';
-        const i = property.indexOf(":");
-        return Utils.toTitleCase(property.substring(i + 1));
-    };
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import Utils from "app_manager/js/details/utils";
+import ColumnModel from "app_manager/js/details/column";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import uiMapList from "hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list";
+import main from "hqwebapp/js/bootstrap3/main";
+import toggles from "hqwebapp/js/toggles";
+import appManager from "app_manager/js/app_manager";
+import google from "analytix/js/google";
+import "hqwebapp/js/components/select_toggle";
+import "hqwebapp/js/bootstrap3/knockout_bindings.ko";  // sortable binding
 
-    return function (spec, config, options) {
-        var self = {};
-        var i,
-            columns;
-        main.eventize(self);
-        self.moduleId = options.moduleId;
-        self.type = spec.type;
-        self.saveUrl = options.saveUrl;
-        self.config = config;
-        self.columns = ko.observableArray([]);
-        self.model = config.model;
-        self.lang = options.lang;
-        self.langs = options.langs || [];
-        self.properties = options.properties;
-        self.childCaseTypes = options.childCaseTypes;
-        self.fixtures = options.fixtures;
-        // The column key is used to retrieve the columns from the spec and
-        // as the name of the key in the data object that is sent to the
-        // server on save.
-        self.columnKey = options.columnKey;
-        let detail = spec[self.columnKey];
+const getPropertyTitle = function (property) {
+    // Strip "<prefix>:" before converting to title case.
+    // This is aimed at prefixes like ledger: and attachment:
+    property = property || '';
+    const i = property.indexOf(":");
+    return Utils.toTitleCase(property.substring(i + 1));
+};
 
-        // Not all screenModel instances will handle sorting, parent selection,
-        // and filtering. E.g The "Case Detail" tab only handles the module's
-        // "long" case details. These flags will make sure this instance
-        // doesn't try to save these configurations if it is not in charge
-        // of these configurations.
-        self.containsSortConfiguration = options.containsSortConfiguration;
-        self.containsParentConfiguration = options.containsParentConfiguration;
-        self.containsFixtureConfiguration = options.containsFixtureConfiguration;
-        self.containsFilterConfiguration = options.containsFilterConfiguration;
-        self.containsCaseListLookupConfiguration = options.containsCaseListLookupConfiguration;
-        self.containsSearchConfiguration = options.containsSearchConfiguration;
-        self.containsCustomXMLConfiguration = options.containsCustomXMLConfiguration;
-        self.allowsTabs = options.allowsTabs;
-        self.allowsCustomXML = toggles.toggleEnabled('CASE_LIST_CUSTOM_XML');
+export default function (spec, config, options) {
+    var self = {};
+    var i,
+        columns;
+    main.eventize(self);
+    self.moduleId = options.moduleId;
+    self.type = spec.type;
+    self.saveUrl = options.saveUrl;
+    self.config = config;
+    self.columns = ko.observableArray([]);
+    self.model = config.model;
+    self.lang = options.lang;
+    self.langs = options.langs || [];
+    self.properties = options.properties;
+    self.childCaseTypes = options.childCaseTypes;
+    self.fixtures = options.fixtures;
+    // The column key is used to retrieve the columns from the spec and
+    // as the name of the key in the data object that is sent to the
+    // server on save.
+    self.columnKey = options.columnKey;
+    let detail = spec[self.columnKey];
 
-        let baseCaseTileTemplateOptions = [[null, gettext("Don't Use Case Tiles")]];
-        if (toggles.toggleEnabled('CASE_LIST_TILE_CUSTOM')) {
-            baseCaseTileTemplateOptions = baseCaseTileTemplateOptions.concat([["custom", gettext("Manually configure Case Tiles")]]);
-        }
-        if (self.columnKey === 'short') {
-            baseCaseTileTemplateOptions = baseCaseTileTemplateOptions.concat(options.caseTileTemplateOptions);
-        }
+    // Not all screenModel instances will handle sorting, parent selection,
+    // and filtering. E.g The "Case Detail" tab only handles the module's
+    // "long" case details. These flags will make sure this instance
+    // doesn't try to save these configurations if it is not in charge
+    // of these configurations.
+    self.containsSortConfiguration = options.containsSortConfiguration;
+    self.containsParentConfiguration = options.containsParentConfiguration;
+    self.containsFixtureConfiguration = options.containsFixtureConfiguration;
+    self.containsFilterConfiguration = options.containsFilterConfiguration;
+    self.containsCaseListLookupConfiguration = options.containsCaseListLookupConfiguration;
+    self.containsSearchConfiguration = options.containsSearchConfiguration;
+    self.containsCustomXMLConfiguration = options.containsCustomXMLConfiguration;
+    self.allowsTabs = options.allowsTabs;
+    self.allowsCustomXML = toggles.toggleEnabled('CASE_LIST_CUSTOM_XML');
 
-        self.caseTileTemplateOptions = baseCaseTileTemplateOptions;
-        self.caseTileTemplateOptions = self.caseTileTemplateOptions.map(function (templateOption) {
-            return {templateValue: templateOption[0], templateName: templateOption[1]};
-        });
-        self.caseTileTemplate = ko.observable(detail.case_tile_template || null);
-        self.caseTileTemplateConfigs = options.caseTileTemplateConfigs;
-        self.caseTileFieldsForTemplate = ko.computed(function () {
-            return (self.caseTileTemplateConfigs[self.caseTileTemplate()] || {}).fields;
-        });
-        self.caseTilePreviewColumns = ko.computed(function () {
-            const grid = (self.caseTileTemplateConfigs[self.caseTileTemplate()] || {}).grid;
-            if (grid) {
-                return _.map(grid, function (value, key) {
-                    return {
-                        showInTilePreview: true,
-                        horizontalAlign: value["horz-align"],
-                        verticalAlign: value["vert-align"],
-                        tileRowStart: value.y + 1,
-                        tileRowEnd: value.y + value.height + 1,
-                        tileColumnStart: value.x + 1,
-                        tileColumnEnd: value.x + value.width + 1,
-                        tileContent: key,
-                    };
-                });
-            }
+    let baseCaseTileTemplateOptions = [[null, gettext("Don't Use Case Tiles")]];
+    if (toggles.toggleEnabled('CASE_LIST_TILE_CUSTOM')) {
+        baseCaseTileTemplateOptions = baseCaseTileTemplateOptions.concat([["custom", gettext("Manually configure Case Tiles")]]);
+    }
+    if (self.columnKey === 'short') {
+        baseCaseTileTemplateOptions = baseCaseTileTemplateOptions.concat(options.caseTileTemplateOptions);
+    }
 
-            return self.columns();
-        });
-        self.showCaseTileConfigColumns = ko.computed(function () {
-            const featureFlag = toggles.toggleEnabled('CASE_LIST_TILE_CUSTOM');
-            const template = self.caseTileTemplate();
-            return featureFlag && template === "custom";
-        });
-        self.showCaseTileMappingColumn = ko.computed(function () {
-            const featureFlag = toggles.toggleEnabled('CASE_LIST_TILE');
-            const caseTileTemplate = self.caseTileTemplate() && self.caseTileTemplate() !== "custom";
-            return caseTileTemplate && featureFlag;
-        });
-        self.showCaseListOptimizations = (
-            self.columnKey === 'short' &&
-            initialPageData.get('app_supports_case_list_optimizations') &&
-            initialPageData.get('show_case_list_optimization_options')
-        );
-        self.persistCaseContext = ko.observable(detail.persist_case_context || false);
-        self.persistentCaseContextXML = ko.observable(detail.persistent_case_context_xml || 'case_name');
-
-        self.caseTileGrouped = ko.observable(!!detail.case_tile_group.index_identifier || false);
-        self.caseTileGroupBy = ko.observable(detail.case_tile_group.index_identifier);
-        self.caseTileGroupHeaderRows = ko.observable(detail.case_tile_group.header_rows);
-
-        self.customVariablesViewModel = {
-            enabled: toggles.toggleEnabled('CASE_LIST_CUSTOM_VARIABLES'),
-            dict: detail.custom_variables_dict || {},
-        };
-        const customDataEditor = uiMapList.new(`${ self.moduleId }-${self.columnKey}`, gettext("Edit Custom Variables"));
-        customDataEditor.val(self.customVariablesViewModel.dict);
-        customDataEditor.on("change", function () {
-            self.customVariablesViewModel.dict = this.val();
-            self.fireChange();
-        });
-        $(`#custom-variables-editor-${self.columnKey}`).append(customDataEditor.ui);
-
-        self.multiSelectEnabled = ko.observable(detail.multi_select);
-        self.multiSelectEnabled.subscribe(function () {
-            self.autoSelectEnabled(self.multiSelectEnabled() && self.autoSelectEnabled());
-            self.fireChange();
-        });
-        self.maxSelectValue = ko.observable(detail.max_select_value);
-        self.maxSelectValue.subscribe(function () {
-            self.fireChange();
-        });
-        self.autoSelectEnabled = ko.observable(detail.auto_select);
-        self.autoSelectEnabled.subscribe(function () {
-            self.fireChange();
-        });
-        self.persistTileOnForms = ko.observable(detail.persist_tile_on_forms || false);
-        self.enableTilePullDown = ko.observable(detail.pull_down_tile || false);
-        self.resetCaseTilePreview = function () {   // TODO: probably want to move this
-            // On click, make each cell height 1, width 1-4 depending on number of columns, x and y top left to bottom right
-            _.each(self.columns(), function (column, index) {
-                if (index >= 12) {
-                    return;
-                }
-                column.tileRowStart(Math.ceil((index + 1) / 4));
-                column.tileColumnStart((index % 4) * 3 + 1);
-                column.tileHeight(1);
-                column.tileWidth(3);
-            });
-        };
-
-        // Given a column model, return a boolean indicating whether the column is on an odd
-        // or an even tab, for the sake of being able to differentiate in the case tile preview
-        // which rows go with which tab.
-        self.tabPolarity = function (column) {
-            const self = this;
-            let flag = false;
-            _.find(self.columns(), function (c) {
-                if (c.isTab) {
-                    flag = !flag;
-                }
-                return c === column;
-            });
-            return flag;
-        };
-
-        self.adjustTileGridArea = function (activeColumnIndex, rowDelta, columnDelta, widthDelta, heightDelta) {
-            let matrix = self._buildMatrix();
-            matrix = self._adjustTileGridArea(matrix, activeColumnIndex, rowDelta, columnDelta, widthDelta, heightDelta);
-            self._parseMatrix(matrix);
-        };
-
-        // TODO: replace rowDelta, columnDelta, widthDelta, heightDelta with a single action param
-        self._adjustTileGridArea = function (matrix, activeColumnIndex, rowDelta, columnDelta, widthDelta, heightDelta) {
-            let activeColumn = self.columns()[activeColumnIndex];
-
-            // Validate column still has size
-            if (activeColumn.tileWidth() + widthDelta < 1 || activeColumn.tileHeight() + heightDelta < 1) {
-                throw new Error("tile shrank to nothing");
-            }
-
-            // Validate boundaries
-            const newRowStart = activeColumn.tileRowStart() + rowDelta,
-                newColumnStart = activeColumn.tileColumnStart() + columnDelta,
-                newRowEnd = newRowStart + activeColumn.tileHeight() + heightDelta,
-                newColumnEnd = newColumnStart + activeColumn.tileWidth() + widthDelta;
-            if (newRowStart < 1 || newRowEnd > activeColumn.tileRowMax ||
-                newColumnStart < 1 || newColumnEnd > activeColumn.tileColumnMax()) {
-                throw new Error("cannot move tile out of bounds");
-            }
-
-            // Identify matrix points to null out
-            if (rowDelta === 1) {
-                matrix = self._nullMatrixRow(matrix, activeColumn.tileRowStart(), activeColumn.tileColumnStart(), activeColumn.tileColumnEnd());
-            } else if (rowDelta === -1 || heightDelta === -1) {
-                matrix = self._nullMatrixRow(matrix, activeColumn.tileRowEnd() - 1, activeColumn.tileColumnStart(), activeColumn.tileColumnEnd());
-            } else if (columnDelta === 1) {
-                matrix = self._nullMatrixColumn(matrix, activeColumn.tileColumnStart(), activeColumn.tileRowStart(), activeColumn.tileRowEnd());
-            } else if (columnDelta === -1 || widthDelta === -1) {
-                matrix = self._nullMatrixColumn(matrix, activeColumn.tileColumnEnd() - 1, activeColumn.tileRowStart(), activeColumn.tileRowEnd());
-            }
-
-            // Identify matrix points to fill in
-            if (rowDelta === 1 || heightDelta === 1) {
-                matrix = self._replaceMatrixRow(matrix, activeColumnIndex, activeColumn.tileRowEnd(), activeColumn.tileColumnStart(), activeColumn.tileColumnEnd());
-            } else if (rowDelta === -1) {
-                matrix = self._replaceMatrixRow(matrix, activeColumnIndex, activeColumn.tileRowStart() - 1, activeColumn.tileColumnStart(), activeColumn.tileColumnEnd());
-            } else if (columnDelta === 1 || widthDelta === 1) {
-                matrix = self._replaceMatrixColumn(matrix, activeColumnIndex, activeColumn.tileColumnEnd(), activeColumn.tileRowStart(), activeColumn.tileRowEnd());
-            } else if (columnDelta === -1) {
-                matrix = self._replaceMatrixColumn(matrix, activeColumnIndex, activeColumn.tileColumnStart() - 1, activeColumn.tileRowStart(), activeColumn.tileRowEnd());
-            }
-
-            return matrix;
-        };
-
-        // TODO: combine these into 2 functions instead of 4
-        self._nullMatrixRow = function (matrix, row, col1, col2) {
-            for (let i = col1 - 1; i < col2 - 1; i++) {
-                matrix[row - 1][i] = null;
-            }
-            return matrix;
-        };
-        self._nullMatrixColumn = function (matrix, column, row1, row2) {
-            for (let i = row1 - 1; i < row2 - 1; i++) {
-                matrix[i][column - 1] = null;
-            }
-            return matrix;
-        };
-
-        self._replaceMatrixRow = function (matrix, newValue, row, col1, col2) {
-            for (let i = col1 - 1; i < col2 - 1; i++) {
-                const oldValue = matrix[row - 1][i];
-                if (oldValue !== null) {
-                    try {
-                        // Attempt to move. If the row above is newValue, move down, otherwise move up.
-                        const rowDelta = row > 1 && matrix[row - 2][i] === newValue ? 1 : -1;
-                        console.log("Attempt to move #" + oldValue + " " + (rowDelta === 1 ? "down" : "up"));
-                        matrix = self._adjustTileGridArea(matrix, oldValue, rowDelta, 0, 0, 0);
-                    } catch (e) {
-                        try {
-                            // attempt to shrink height
-                            console.log("Attempt to shrink height of #" + oldValue);
-                            matrix = self._adjustTileGridArea(matrix, oldValue, 0, 0, 0, -1);
-                        } catch (e) {
-                            throw new Error("cannot _replaceMatrixRow");
-                        }
-                    }
-                }
-                matrix[row - 1][i] = newValue;
-            }
-            return matrix;
-        };
-        self._replaceMatrixColumn = function (matrix, newValue, column, row1, row2) {
-            for (let i = row1 - 1; i < row2 - 1; i++) {
-                const oldValue = matrix[i][column - 1];
-                if (oldValue !== null) {
-                    try {
-                        // Attempt to move. If the column to the left is newValue, move right, otherwise move left.
-                        const columnDelta = column > 1 && matrix[i][column - 2] === newValue ? 1 : -1;
-                        console.log("Attempt to move #" + oldValue + " " + (columnDelta === 1 ? "right" : "left"));
-                        matrix = self._adjustTileGridArea(matrix, oldValue, 0, columnDelta, 0, 0);
-                    } catch (e) {
-                        try {
-                            // attempt to shrink width
-                            console.log("Attempt to shrink width of #" + oldValue);
-                            matrix = self._adjustTileGridArea(matrix, oldValue, 0, 0, -1, 0);
-                        } catch (e) {
-                            throw new Error("cannot _replaceMatrixColumn");
-                        }
-                    }
-                }
-                matrix[i][column - 1] = newValue;
-            }
-            return matrix;
-        };
-
-        self._buildMatrix = function () {
-            let matrix = [
-                [null, null, null, null, null, null, null, null, null, null, null, null],
-                [null, null, null, null, null, null, null, null, null, null, null, null],
-                [null, null, null, null, null, null, null, null, null, null, null, null],
-            ];
-            _.each(self.columns(), function (column, columnIndex) {
-                if (!column.showInTilePreview()) {
-                    return;
-                }
-                for (let i = 0; i < column.tileHeight(); i++) {
-                    for (let j = 0; j < column.tileWidth(); j++) {
-                        matrix[i + column.tileRowStart() - 1][j + column.tileColumnStart() - 1] = columnIndex;
-                    }
-                }
-            });
-            return matrix;
-        };
-        self._parseMatrix = function (matrix) {
-            let columns = _.map(_.range(self.columns().length), function () {
+    self.caseTileTemplateOptions = baseCaseTileTemplateOptions;
+    self.caseTileTemplateOptions = self.caseTileTemplateOptions.map(function (templateOption) {
+        return {templateValue: templateOption[0], templateName: templateOption[1]};
+    });
+    self.caseTileTemplate = ko.observable(detail.case_tile_template || null);
+    self.caseTileTemplateConfigs = options.caseTileTemplateConfigs;
+    self.caseTileFieldsForTemplate = ko.computed(function () {
+        return (self.caseTileTemplateConfigs[self.caseTileTemplate()] || {}).fields;
+    });
+    self.caseTilePreviewColumns = ko.computed(function () {
+        const grid = (self.caseTileTemplateConfigs[self.caseTileTemplate()] || {}).grid;
+        if (grid) {
+            return _.map(grid, function (value, key) {
                 return {
-                    rowStart: null,
-                    rowEnd: null,
-                    columnStart: null,
-                    columnEnd: null,
+                    showInTilePreview: true,
+                    horizontalAlign: value["horz-align"],
+                    verticalAlign: value["vert-align"],
+                    tileRowStart: value.y + 1,
+                    tileRowEnd: value.y + value.height + 1,
+                    tileColumnStart: value.x + 1,
+                    tileColumnEnd: value.x + value.width + 1,
+                    tileContent: key,
                 };
             });
-
-            for (let i = 0; i < 3; i++) {
-                for (let j = 0; j < 12; j++) {
-                    const columnIndex = matrix[i][j];
-                    if (columnIndex === null) {
-                        continue;
-                    }
-                    if (columns[columnIndex].rowStart === null) {
-                        columns[columnIndex].rowStart = i;
-                    }
-                    columns[columnIndex].rowEnd = i;
-                    if (columns[columnIndex].columnStart === null) {
-                        columns[columnIndex].columnStart = j;
-                    }
-                    columns[columnIndex].columnEnd = j;
-                }
-            }
-
-            _.each(columns, function (c, i) {
-                if (c.rowStart !== null) {
-                    self.columns()[i].tileRowStart(c.rowStart + 1);
-                    self.columns()[i].tileWidth(c.columnEnd - c.columnStart + 1);
-                    self.columns()[i].tileColumnStart(c.columnStart + 1);
-                    self.columns()[i].tileHeight(c.rowEnd - c.rowStart + 1);
-                }
-            });
-        };
-        self.allowsEmptyColumns = options.allowsEmptyColumns;
-        self.persistentCaseTileFromModule = ko.observable(detail.persistent_case_tile_from_module || "");
-        self.fireChange = function () {
-            self.fire('change');
-        };
-
-        self.initColumnAsColumn = function (column) {
-            column.model.setEdit(false);
-            column.field.setEdit(true);
-            column.header.setEdit(true);
-            column.format.setEdit(true);
-            column.date_extra.setEdit(true);
-            column.enum_extra.setEdit(true);
-            column.late_flag_extra.setEdit(true);
-            column.filter_xpath_extra.setEdit(true);
-            column.calc_xpath_extra.setEdit(true);
-            column.time_ago_extra.setEdit(true);
-            column.setGrip(true);
-            column.on('change', self.fireChange);
-
-            column.field.on('change', function () {
-                if (!column.useXpathExpression) {
-                    const oldVal = column.header.val(),
-                        newVal = getPropertyTitle(this.val());
-                    column.header.val(newVal);
-                    column.header.fire("change", {oldVal: oldVal, newVal: newVal});
-                }
-            });
-            if (column.original.hasAutocomplete) {
-                var options = self.properties;
-                if (column.original.field && !_.contains(column.original.field)) {
-                    options = [column.original.field].concat(options);
-                }
-                column.field.setOptions(options);
-                column.field.val(column.original.field);
-                column.field.observableVal(column.original.field);
-                Utils.setUpAutocomplete(column.field, self.properties);
-            }
-            column.header.on('change', function (e) {
-                if (e.oldValue !== e.newValue) {
-                    self.fire("columnChange", [{
-                        "value": column,
-                        "index": self.columns.indexOf(column),
-                        "status": "edited",
-                    }]);
-                }
-            });
-            return column;
-        };
-
-        columns = detail.columns;
-        // Inject tabs into the columns list:
-        var tabs = detail.tabs || [];
-        for (i = 0; i < tabs.length; i++) {
-            columns.splice(
-                tabs[i].starting_index + i,
-                0,
-                _.extend({
-                    hasNodeset: tabs[i].has_nodeset,
-                    nodeset: tabs[i].nodeset,
-                    nodesetCaseType: tabs[i].nodeset_case_type,
-                    nodesetFilter: tabs[i].nodeset_filter,
-                }, _.pick(tabs[i], ["header", "isTab", "relevant"])),
-            );
-        }
-        if (self.columnKey === 'long') {
-            self.addTab = function (hasNodeset) {
-                var col = self.initColumnAsColumn(ColumnModel({
-                    isTab: true,
-                    hasNodeset: hasNodeset,
-                    model: 'tab',
-                }, self));
-                self.columns.splice(0, 0, col);
-            };
         }
 
-        // Filters are a type of DetailColumn on the server. Don't display
-        // them with the other columns though
-        columns = _.filter(columns, function (col) {
-            return col.format !== "filter";
-        });
+        return self.columns();
+    });
+    self.showCaseTileConfigColumns = ko.computed(function () {
+        const featureFlag = toggles.toggleEnabled('CASE_LIST_TILE_CUSTOM');
+        const template = self.caseTileTemplate();
+        return featureFlag && template === "custom";
+    });
+    self.showCaseTileMappingColumn = ko.computed(function () {
+        const featureFlag = toggles.toggleEnabled('CASE_LIST_TILE');
+        const caseTileTemplate = self.caseTileTemplate() && self.caseTileTemplate() !== "custom";
+        return caseTileTemplate && featureFlag;
+    });
+    self.showCaseListOptimizations = (
+        self.columnKey === 'short' &&
+        initialPageData.get('app_supports_case_list_optimizations') &&
+        initialPageData.get('show_case_list_optimization_options')
+    );
+    self.persistCaseContext = ko.observable(detail.persist_case_context || false);
+    self.persistentCaseContextXML = ko.observable(detail.persistent_case_context_xml || 'case_name');
 
-        // set up the columns
-        for (i = 0; i < columns.length; i += 1) {
-            self.columns.push(ColumnModel(columns[i], self));
-            self.initColumnAsColumn(self.columns()[i]);
-        }
+    self.caseTileGrouped = ko.observable(!!detail.case_tile_group.index_identifier || false);
+    self.caseTileGroupBy = ko.observable(detail.case_tile_group.index_identifier);
+    self.caseTileGroupHeaderRows = ko.observable(detail.case_tile_group.header_rows);
 
-        self.caseTileRowMax = ko.computed(() => _.max([self.columns().length + 1, 7]));
-        self.caseTileRowMax.subscribe(function (newValue) {
-            self.updateTileRowMaxForColumns(newValue);
-        });
-
-        self.updateTileRowMaxForColumns = function (newValue) {
-            _.each(self.columns(), function (column) {
-                column.tileRowMax(newValue);
-            });
-        };
-        self.updateTileRowMaxForColumns(self.caseTileRowMax());
-
-        self.saveButton = main.initSaveButton({
-            unsavedMessage: gettext('You have unsaved detail screen configurations.'),
-            save: function () {
-                self.save();
-            },
-        });
-        let saveButtonFire = () => self.saveButton.fire('change');
-        self.on('change', saveButtonFire);
-        self.caseTileTemplate.subscribe(saveButtonFire);
-        self.persistCaseContext.subscribe(saveButtonFire);
-        self.persistentCaseContextXML.subscribe(saveButtonFire);
-        self.persistTileOnForms.subscribe(saveButtonFire);
-        self.persistentCaseTileFromModule.subscribe(saveButtonFire);
-        self.enableTilePullDown.subscribe(saveButtonFire);
-        self.caseTileGrouped.subscribe(saveButtonFire);
-        self.caseTileGroupBy.subscribe(saveButtonFire);
-        self.caseTileGroupHeaderRows.subscribe(saveButtonFire);
-        self.columns.subscribe(function (changes) {
-            self.saveButton.fire('change');
-
-            // create events when rows (column objects) are moved and fire a special event that allows us to update
-            // dependent UI elements (sort properties)
-            const events = changes
-                // remove the 2nd event for column moves
-                .filter(c => !(c.status === 'deleted' && c.moved !== undefined));
-
-            // there should only be one 'change' now.
-            const change = events[0];
-
-            // for "moved" and "deleted" we need to add events for all the other columns that have changed their index
-            let affectedColumns, move;  // 'move' is an index diff to calculate the previous index
-            if (change.moved !== undefined) {
-                const moveFrom = change.moved,
-                    movedTo = change.index;
-                if (movedTo > moveFrom) {
-                    move = 1;
-                    affectedColumns = self.columns.slice(moveFrom, movedTo);
-                } else {
-                    move = -1;
-                    affectedColumns = self.columns.slice(movedTo + 1, moveFrom + 1);
-                }
-            } else if (change.status === 'deleted') {
-                move = 1;
-                affectedColumns = self.columns.slice(change.index);
-            }
-            if (affectedColumns) {
-                affectedColumns.forEach(c => {
-                    let index = self.columns.indexOf(c);
-                    events.push({
-                        value: c, index: index, status: "added", moved: index + move,
-                    });
-                });
-            }
-
-            self.fire("columnChange", events);
-        }, null, 'arrayChange');
-
-        self.save = function () {
-            // Only save if property names are valid
-            var errors = [],
-                containsTab = false,
-                imageColumnCount = 0;
-            _.each(self.columns(), function (column) {
-                column.saveAttempted(true);
-                if (column.isTab) {
-                    containsTab = true;
-                    if (column.showWarning()) {
-                        errors.push(gettext("There is an error in your tab: ") + column.field.value);
-                    }
-                } else if (column.showWarning()) {
-                    errors.push(gettext("There is an error in your property name: ") + column.field.value);
-                } else if (column.format.value === 'image') {
-                    imageColumnCount += 1;
-                }
-            });
-
-            if (imageColumnCount > 1) {
-                errors.push(gettext("You can only have one property with the 'Image' format"));
-            }
-            if (containsTab) {
-                if (!self.columns()[0].isTab) {
-                    errors.push(gettext("All properties must be below a tab."));
-                }
-            }
-            if (self.config.search.commonProperties().length > 0) {
-                var msg = gettext("Search Properties and Default Search Filters can't have common properties. " +
-                    "Please update following properties: ");
-                errors.push(msg + self.config.search.commonProperties());
-            }
-            if (errors.length) {
-                alert(gettext("There are errors in your configuration.") + "\n" + errors.join("\n"));
-                return;
-            }
-
-            if (self.containsSortConfiguration) {
-                var sortRows = self.config.sortRows.sortRows();
-                for (var i = 0; i < sortRows.length; i++) {
-                    var row = sortRows[i];
-                    if (!row.hasValidPropertyName()) {
-                        row.showWarning(true);
-                    }
-                }
-            }
-            if (self.validate()) {
-                self.saveButton.ajax({
-                    url: self.saveUrl,
-                    type: "POST",
-                    data: self.serialize(),
-                    dataType: 'json',
-                    success: function (data) {
-                        appManager.updateDOM(data.update);
-                    },
-                });
-            }
-        };
-        self.validate = function () {
-            if (self.containsCaseListLookupConfiguration) {
-                return self.config.caseListLookup.validate();
-            }
-            return true;
-        };
-        self.serialize = function () {
-            var columns = self.columns();
-            var data = {
-                type: JSON.stringify(self.type),
-            };
-
-            // Add columns
-            data[self.columnKey] = JSON.stringify(_.map(
-                _.filter(columns, function (c) {
-                    return !c.isTab;
-                }),
-                function (c) {
-                    return c.serialize();
-                },
-            ));
-
-            // Add tabs
-            // calculate the starting index for each Tab
-            var acc = 0;
-            for (var j = 0; j < columns.length; j++) {
-                var c = columns[j];
-                if (c.isTab) {
-                    c.starting_index = acc;
-                } else {
-                    acc++;
-                }
-            }
-            data.tabs = JSON.stringify(_.map(
-                _.filter(columns, function (c) {
-                    return c.isTab;
-                }),
-                function (c) {
-                    return c.serialize();
-                },
-            ));
-
-            data.caseTileTemplate = self.caseTileTemplate();
-            data.persistCaseContext = self.persistCaseContext();
-            data.persistentCaseContextXML = self.persistentCaseContextXML();
-            data.persistTileOnForms = self.persistTileOnForms();
-            data.persistentCaseTileFromModule = self.persistentCaseTileFromModule();
-            data.enableTilePullDown = self.persistTileOnForms() ? self.enableTilePullDown() : false;
-
-            data.case_tile_group = JSON.stringify({
-                index_identifier: self.caseTileGrouped() ? self.caseTileGroupBy() : null,
-                header_rows: self.caseTileGroupHeaderRows(),
-            });
-
-            if (self.containsParentConfiguration) {
-                var parentSelect;
-                if (_.has(self.config, 'parentSelect')) {
-                    parentSelect = {
-                        module_id: self.config.parentSelect.moduleId(),
-                        relationship: self.config.parentSelect.relationship(),
-                        active: self.config.parentSelect.active(),
-                    };
-                }
-                data.parent_select = JSON.stringify(parentSelect);
-            }
-            if (self.containsFixtureConfiguration) {
-                var fixtureSelect;
-                if (_.has(self.config, 'fixtureSelect')) {
-                    fixtureSelect = {
-                        active: self.config.fixtureSelect.active(),
-                        fixture_type: self.config.fixtureSelect.fixtureType(),
-                        display_column: self.config.fixtureSelect.displayColumn(),
-                        localize: self.config.fixtureSelect.localize(),
-                        variable_column: self.config.fixtureSelect.variableColumn(),
-                        xpath: self.config.fixtureSelect.xpath(),
-                    };
-                }
-                data.fixture_select = JSON.stringify(fixtureSelect);
-            }
-            if (self.containsSortConfiguration) {
-                data.sort_elements = JSON.stringify(_.map(self.config.sortRows.sortRows(), function (row) {
-                    return {
-                        field: row.selectField.val(),
-                        type: row.type(),
-                        direction: row.direction(),
-                        blanks: row.blanks(),
-                        display: row.display(),
-                        sort_calculation: row.sortCalculation(),
-                    };
-                }));
-            }
-            if (self.containsFilterConfiguration) {
-                data.filter = JSON.stringify(self.config.filter.serialize());
-            }
-            if (self.containsCaseListLookupConfiguration) {
-                data.case_list_lookup = JSON.stringify(self.config.caseListLookup.serialize());
-            }
-            if (self.containsCustomXMLConfiguration) {
-                data.custom_xml = self.config.customXMLViewModel.xml();
-            }
-            data[self.columnKey + '_custom_variables_dict'] = JSON.stringify(self.customVariablesViewModel.dict);
-            data.multi_select = self.multiSelectEnabled();
-            data.auto_select = self.autoSelectEnabled();
-            data.max_select_value = self.maxSelectValue();
-            if (self.containsSearchConfiguration) {
-                data.search_properties = JSON.stringify(self.config.search.serialize());
-            }
-            return data;
-        };
-        self.addItem = function (columnConfiguration, index) {
-            var column = self.initColumnAsColumn(
-                ColumnModel(columnConfiguration, self),
-            );
-            if (index === undefined) {
-                self.columns.push(column);
-            } else {
-                self.columns.splice(index, 0, column);
-            }
-            column.useXpathExpression = !!columnConfiguration.useXpathExpression;
-        };
-        self.pasteCallback = function (data, index) {
-            try {
-                data = JSON.parse(data);
-            } catch (e) {
-                // just ignore pasting non-json
-                return;
-            }
-            if (data.type === 'detail-screen-config:Column' && data.contents) {
-                self.addItem(data.contents, index);
-            }
-        };
-        self.addProperty = function () {
-            var type = self.columnKey === "short" ? "List" : "Detail";
-            google.track.event('Case Management', 'Module Level Case ' + type, 'Add Property');
-            self.addItem({
-                hasAutocomplete: true,
-            });
-        };
-
-        self.hasGraphing = appManager.checkCommcareVersion("2.17");
-        self.addGraph = function () {
-            self.addItem({
-                hasAutocomplete: false,
-                format: 'graph',
-            });
-        };
-
-        self.hasXpathExpressions = initialPageData.get("add_ons").calc_xpaths;
-        self.addXpathExpression = function () {
-            self.addItem({
-                hasAutocomplete: false,
-                useXpathExpression: true,
-            });
-        };
-
-        return self;
+    self.customVariablesViewModel = {
+        enabled: toggles.toggleEnabled('CASE_LIST_CUSTOM_VARIABLES'),
+        dict: detail.custom_variables_dict || {},
     };
-});
+    const customDataEditor = uiMapList.new(`${ self.moduleId }-${self.columnKey}`, gettext("Edit Custom Variables"));
+    customDataEditor.val(self.customVariablesViewModel.dict);
+    customDataEditor.on("change", function () {
+        self.customVariablesViewModel.dict = this.val();
+        self.fireChange();
+    });
+    $(`#custom-variables-editor-${self.columnKey}`).append(customDataEditor.ui);
+
+    self.multiSelectEnabled = ko.observable(detail.multi_select);
+    self.multiSelectEnabled.subscribe(function () {
+        self.autoSelectEnabled(self.multiSelectEnabled() && self.autoSelectEnabled());
+        self.fireChange();
+    });
+    self.maxSelectValue = ko.observable(detail.max_select_value);
+    self.maxSelectValue.subscribe(function () {
+        self.fireChange();
+    });
+    self.autoSelectEnabled = ko.observable(detail.auto_select);
+    self.autoSelectEnabled.subscribe(function () {
+        self.fireChange();
+    });
+    self.persistTileOnForms = ko.observable(detail.persist_tile_on_forms || false);
+    self.enableTilePullDown = ko.observable(detail.pull_down_tile || false);
+    self.resetCaseTilePreview = function () {   // TODO: probably want to move this
+        // On click, make each cell height 1, width 1-4 depending on number of columns, x and y top left to bottom right
+        _.each(self.columns(), function (column, index) {
+            if (index >= 12) {
+                return;
+            }
+            column.tileRowStart(Math.ceil((index + 1) / 4));
+            column.tileColumnStart((index % 4) * 3 + 1);
+            column.tileHeight(1);
+            column.tileWidth(3);
+        });
+    };
+
+    // Given a column model, return a boolean indicating whether the column is on an odd
+    // or an even tab, for the sake of being able to differentiate in the case tile preview
+    // which rows go with which tab.
+    self.tabPolarity = function (column) {
+        const self = this;
+        let flag = false;
+        _.find(self.columns(), function (c) {
+            if (c.isTab) {
+                flag = !flag;
+            }
+            return c === column;
+        });
+        return flag;
+    };
+
+    self.adjustTileGridArea = function (activeColumnIndex, rowDelta, columnDelta, widthDelta, heightDelta) {
+        let matrix = self._buildMatrix();
+        matrix = self._adjustTileGridArea(matrix, activeColumnIndex, rowDelta, columnDelta, widthDelta, heightDelta);
+        self._parseMatrix(matrix);
+    };
+
+    // TODO: replace rowDelta, columnDelta, widthDelta, heightDelta with a single action param
+    self._adjustTileGridArea = function (matrix, activeColumnIndex, rowDelta, columnDelta, widthDelta, heightDelta) {
+        let activeColumn = self.columns()[activeColumnIndex];
+
+        // Validate column still has size
+        if (activeColumn.tileWidth() + widthDelta < 1 || activeColumn.tileHeight() + heightDelta < 1) {
+            throw new Error("tile shrank to nothing");
+        }
+
+        // Validate boundaries
+        const newRowStart = activeColumn.tileRowStart() + rowDelta,
+            newColumnStart = activeColumn.tileColumnStart() + columnDelta,
+            newRowEnd = newRowStart + activeColumn.tileHeight() + heightDelta,
+            newColumnEnd = newColumnStart + activeColumn.tileWidth() + widthDelta;
+        if (newRowStart < 1 || newRowEnd > activeColumn.tileRowMax ||
+            newColumnStart < 1 || newColumnEnd > activeColumn.tileColumnMax()) {
+            throw new Error("cannot move tile out of bounds");
+        }
+
+        // Identify matrix points to null out
+        if (rowDelta === 1) {
+            matrix = self._nullMatrixRow(matrix, activeColumn.tileRowStart(), activeColumn.tileColumnStart(), activeColumn.tileColumnEnd());
+        } else if (rowDelta === -1 || heightDelta === -1) {
+            matrix = self._nullMatrixRow(matrix, activeColumn.tileRowEnd() - 1, activeColumn.tileColumnStart(), activeColumn.tileColumnEnd());
+        } else if (columnDelta === 1) {
+            matrix = self._nullMatrixColumn(matrix, activeColumn.tileColumnStart(), activeColumn.tileRowStart(), activeColumn.tileRowEnd());
+        } else if (columnDelta === -1 || widthDelta === -1) {
+            matrix = self._nullMatrixColumn(matrix, activeColumn.tileColumnEnd() - 1, activeColumn.tileRowStart(), activeColumn.tileRowEnd());
+        }
+
+        // Identify matrix points to fill in
+        if (rowDelta === 1 || heightDelta === 1) {
+            matrix = self._replaceMatrixRow(matrix, activeColumnIndex, activeColumn.tileRowEnd(), activeColumn.tileColumnStart(), activeColumn.tileColumnEnd());
+        } else if (rowDelta === -1) {
+            matrix = self._replaceMatrixRow(matrix, activeColumnIndex, activeColumn.tileRowStart() - 1, activeColumn.tileColumnStart(), activeColumn.tileColumnEnd());
+        } else if (columnDelta === 1 || widthDelta === 1) {
+            matrix = self._replaceMatrixColumn(matrix, activeColumnIndex, activeColumn.tileColumnEnd(), activeColumn.tileRowStart(), activeColumn.tileRowEnd());
+        } else if (columnDelta === -1) {
+            matrix = self._replaceMatrixColumn(matrix, activeColumnIndex, activeColumn.tileColumnStart() - 1, activeColumn.tileRowStart(), activeColumn.tileRowEnd());
+        }
+
+        return matrix;
+    };
+
+    // TODO: combine these into 2 functions instead of 4
+    self._nullMatrixRow = function (matrix, row, col1, col2) {
+        for (let i = col1 - 1; i < col2 - 1; i++) {
+            matrix[row - 1][i] = null;
+        }
+        return matrix;
+    };
+    self._nullMatrixColumn = function (matrix, column, row1, row2) {
+        for (let i = row1 - 1; i < row2 - 1; i++) {
+            matrix[i][column - 1] = null;
+        }
+        return matrix;
+    };
+
+    self._replaceMatrixRow = function (matrix, newValue, row, col1, col2) {
+        for (let i = col1 - 1; i < col2 - 1; i++) {
+            const oldValue = matrix[row - 1][i];
+            if (oldValue !== null) {
+                try {
+                    // Attempt to move. If the row above is newValue, move down, otherwise move up.
+                    const rowDelta = row > 1 && matrix[row - 2][i] === newValue ? 1 : -1;
+                    console.log("Attempt to move #" + oldValue + " " + (rowDelta === 1 ? "down" : "up"));
+                    matrix = self._adjustTileGridArea(matrix, oldValue, rowDelta, 0, 0, 0);
+                } catch (e) {
+                    try {
+                        // attempt to shrink height
+                        console.log("Attempt to shrink height of #" + oldValue);
+                        matrix = self._adjustTileGridArea(matrix, oldValue, 0, 0, 0, -1);
+                    } catch (e) {
+                        throw new Error("cannot _replaceMatrixRow");
+                    }
+                }
+            }
+            matrix[row - 1][i] = newValue;
+        }
+        return matrix;
+    };
+    self._replaceMatrixColumn = function (matrix, newValue, column, row1, row2) {
+        for (let i = row1 - 1; i < row2 - 1; i++) {
+            const oldValue = matrix[i][column - 1];
+            if (oldValue !== null) {
+                try {
+                    // Attempt to move. If the column to the left is newValue, move right, otherwise move left.
+                    const columnDelta = column > 1 && matrix[i][column - 2] === newValue ? 1 : -1;
+                    console.log("Attempt to move #" + oldValue + " " + (columnDelta === 1 ? "right" : "left"));
+                    matrix = self._adjustTileGridArea(matrix, oldValue, 0, columnDelta, 0, 0);
+                } catch (e) {
+                    try {
+                        // attempt to shrink width
+                        console.log("Attempt to shrink width of #" + oldValue);
+                        matrix = self._adjustTileGridArea(matrix, oldValue, 0, 0, -1, 0);
+                    } catch (e) {
+                        throw new Error("cannot _replaceMatrixColumn");
+                    }
+                }
+            }
+            matrix[i][column - 1] = newValue;
+        }
+        return matrix;
+    };
+
+    self._buildMatrix = function () {
+        let matrix = [
+            [null, null, null, null, null, null, null, null, null, null, null, null],
+            [null, null, null, null, null, null, null, null, null, null, null, null],
+            [null, null, null, null, null, null, null, null, null, null, null, null],
+        ];
+        _.each(self.columns(), function (column, columnIndex) {
+            if (!column.showInTilePreview()) {
+                return;
+            }
+            for (let i = 0; i < column.tileHeight(); i++) {
+                for (let j = 0; j < column.tileWidth(); j++) {
+                    matrix[i + column.tileRowStart() - 1][j + column.tileColumnStart() - 1] = columnIndex;
+                }
+            }
+        });
+        return matrix;
+    };
+    self._parseMatrix = function (matrix) {
+        let columns = _.map(_.range(self.columns().length), function () {
+            return {
+                rowStart: null,
+                rowEnd: null,
+                columnStart: null,
+                columnEnd: null,
+            };
+        });
+
+        for (let i = 0; i < 3; i++) {
+            for (let j = 0; j < 12; j++) {
+                const columnIndex = matrix[i][j];
+                if (columnIndex === null) {
+                    continue;
+                }
+                if (columns[columnIndex].rowStart === null) {
+                    columns[columnIndex].rowStart = i;
+                }
+                columns[columnIndex].rowEnd = i;
+                if (columns[columnIndex].columnStart === null) {
+                    columns[columnIndex].columnStart = j;
+                }
+                columns[columnIndex].columnEnd = j;
+            }
+        }
+
+        _.each(columns, function (c, i) {
+            if (c.rowStart !== null) {
+                self.columns()[i].tileRowStart(c.rowStart + 1);
+                self.columns()[i].tileWidth(c.columnEnd - c.columnStart + 1);
+                self.columns()[i].tileColumnStart(c.columnStart + 1);
+                self.columns()[i].tileHeight(c.rowEnd - c.rowStart + 1);
+            }
+        });
+    };
+    self.allowsEmptyColumns = options.allowsEmptyColumns;
+    self.persistentCaseTileFromModule = ko.observable(detail.persistent_case_tile_from_module || "");
+    self.fireChange = function () {
+        self.fire('change');
+    };
+
+    self.initColumnAsColumn = function (column) {
+        column.model.setEdit(false);
+        column.field.setEdit(true);
+        column.header.setEdit(true);
+        column.format.setEdit(true);
+        column.date_extra.setEdit(true);
+        column.enum_extra.setEdit(true);
+        column.late_flag_extra.setEdit(true);
+        column.filter_xpath_extra.setEdit(true);
+        column.calc_xpath_extra.setEdit(true);
+        column.time_ago_extra.setEdit(true);
+        column.setGrip(true);
+        column.on('change', self.fireChange);
+
+        column.field.on('change', function () {
+            if (!column.useXpathExpression) {
+                const oldVal = column.header.val(),
+                    newVal = getPropertyTitle(this.val());
+                column.header.val(newVal);
+                column.header.fire("change", {oldVal: oldVal, newVal: newVal});
+            }
+        });
+        if (column.original.hasAutocomplete) {
+            var options = self.properties;
+            if (column.original.field && !_.contains(column.original.field)) {
+                options = [column.original.field].concat(options);
+            }
+            column.field.setOptions(options);
+            column.field.val(column.original.field);
+            column.field.observableVal(column.original.field);
+            Utils.setUpAutocomplete(column.field, self.properties);
+        }
+        column.header.on('change', function (e) {
+            if (e.oldValue !== e.newValue) {
+                self.fire("columnChange", [{
+                    "value": column,
+                    "index": self.columns.indexOf(column),
+                    "status": "edited",
+                }]);
+            }
+        });
+        return column;
+    };
+
+    columns = detail.columns;
+    // Inject tabs into the columns list:
+    var tabs = detail.tabs || [];
+    for (i = 0; i < tabs.length; i++) {
+        columns.splice(
+            tabs[i].starting_index + i,
+            0,
+            _.extend({
+                hasNodeset: tabs[i].has_nodeset,
+                nodeset: tabs[i].nodeset,
+                nodesetCaseType: tabs[i].nodeset_case_type,
+                nodesetFilter: tabs[i].nodeset_filter,
+            }, _.pick(tabs[i], ["header", "isTab", "relevant"])),
+        );
+    }
+    if (self.columnKey === 'long') {
+        self.addTab = function (hasNodeset) {
+            var col = self.initColumnAsColumn(ColumnModel({
+                isTab: true,
+                hasNodeset: hasNodeset,
+                model: 'tab',
+            }, self));
+            self.columns.splice(0, 0, col);
+        };
+    }
+
+    // Filters are a type of DetailColumn on the server. Don't display
+    // them with the other columns though
+    columns = _.filter(columns, function (col) {
+        return col.format !== "filter";
+    });
+
+    // set up the columns
+    for (i = 0; i < columns.length; i += 1) {
+        self.columns.push(ColumnModel(columns[i], self));
+        self.initColumnAsColumn(self.columns()[i]);
+    }
+
+    self.caseTileRowMax = ko.computed(() => _.max([self.columns().length + 1, 7]));
+    self.caseTileRowMax.subscribe(function (newValue) {
+        self.updateTileRowMaxForColumns(newValue);
+    });
+
+    self.updateTileRowMaxForColumns = function (newValue) {
+        _.each(self.columns(), function (column) {
+            column.tileRowMax(newValue);
+        });
+    };
+    self.updateTileRowMaxForColumns(self.caseTileRowMax());
+
+    self.saveButton = main.initSaveButton({
+        unsavedMessage: gettext('You have unsaved detail screen configurations.'),
+        save: function () {
+            self.save();
+        },
+    });
+    let saveButtonFire = () => self.saveButton.fire('change');
+    self.on('change', saveButtonFire);
+    self.caseTileTemplate.subscribe(saveButtonFire);
+    self.persistCaseContext.subscribe(saveButtonFire);
+    self.persistentCaseContextXML.subscribe(saveButtonFire);
+    self.persistTileOnForms.subscribe(saveButtonFire);
+    self.persistentCaseTileFromModule.subscribe(saveButtonFire);
+    self.enableTilePullDown.subscribe(saveButtonFire);
+    self.caseTileGrouped.subscribe(saveButtonFire);
+    self.caseTileGroupBy.subscribe(saveButtonFire);
+    self.caseTileGroupHeaderRows.subscribe(saveButtonFire);
+    self.columns.subscribe(function (changes) {
+        self.saveButton.fire('change');
+
+        // create events when rows (column objects) are moved and fire a special event that allows us to update
+        // dependent UI elements (sort properties)
+        const events = changes
+            // remove the 2nd event for column moves
+            .filter(c => !(c.status === 'deleted' && c.moved !== undefined));
+
+        // there should only be one 'change' now.
+        const change = events[0];
+
+        // for "moved" and "deleted" we need to add events for all the other columns that have changed their index
+        let affectedColumns, move;  // 'move' is an index diff to calculate the previous index
+        if (change.moved !== undefined) {
+            const moveFrom = change.moved,
+                movedTo = change.index;
+            if (movedTo > moveFrom) {
+                move = 1;
+                affectedColumns = self.columns.slice(moveFrom, movedTo);
+            } else {
+                move = -1;
+                affectedColumns = self.columns.slice(movedTo + 1, moveFrom + 1);
+            }
+        } else if (change.status === 'deleted') {
+            move = 1;
+            affectedColumns = self.columns.slice(change.index);
+        }
+        if (affectedColumns) {
+            affectedColumns.forEach(c => {
+                let index = self.columns.indexOf(c);
+                events.push({
+                    value: c, index: index, status: "added", moved: index + move,
+                });
+            });
+        }
+
+        self.fire("columnChange", events);
+    }, null, 'arrayChange');
+
+    self.save = function () {
+        // Only save if property names are valid
+        var errors = [],
+            containsTab = false,
+            imageColumnCount = 0;
+        _.each(self.columns(), function (column) {
+            column.saveAttempted(true);
+            if (column.isTab) {
+                containsTab = true;
+                if (column.showWarning()) {
+                    errors.push(gettext("There is an error in your tab: ") + column.field.value);
+                }
+            } else if (column.showWarning()) {
+                errors.push(gettext("There is an error in your property name: ") + column.field.value);
+            } else if (column.format.value === 'image') {
+                imageColumnCount += 1;
+            }
+        });
+
+        if (imageColumnCount > 1) {
+            errors.push(gettext("You can only have one property with the 'Image' format"));
+        }
+        if (containsTab) {
+            if (!self.columns()[0].isTab) {
+                errors.push(gettext("All properties must be below a tab."));
+            }
+        }
+        if (self.config.search.commonProperties().length > 0) {
+            var msg = gettext("Search Properties and Default Search Filters can't have common properties. " +
+                "Please update following properties: ");
+            errors.push(msg + self.config.search.commonProperties());
+        }
+        if (errors.length) {
+            alert(gettext("There are errors in your configuration.") + "\n" + errors.join("\n"));
+            return;
+        }
+
+        if (self.containsSortConfiguration) {
+            var sortRows = self.config.sortRows.sortRows();
+            for (var i = 0; i < sortRows.length; i++) {
+                var row = sortRows[i];
+                if (!row.hasValidPropertyName()) {
+                    row.showWarning(true);
+                }
+            }
+        }
+        if (self.validate()) {
+            self.saveButton.ajax({
+                url: self.saveUrl,
+                type: "POST",
+                data: self.serialize(),
+                dataType: 'json',
+                success: function (data) {
+                    appManager.updateDOM(data.update);
+                },
+            });
+        }
+    };
+    self.validate = function () {
+        if (self.containsCaseListLookupConfiguration) {
+            return self.config.caseListLookup.validate();
+        }
+        return true;
+    };
+    self.serialize = function () {
+        var columns = self.columns();
+        var data = {
+            type: JSON.stringify(self.type),
+        };
+
+        // Add columns
+        data[self.columnKey] = JSON.stringify(_.map(
+            _.filter(columns, function (c) {
+                return !c.isTab;
+            }),
+            function (c) {
+                return c.serialize();
+            },
+        ));
+
+        // Add tabs
+        // calculate the starting index for each Tab
+        var acc = 0;
+        for (var j = 0; j < columns.length; j++) {
+            var c = columns[j];
+            if (c.isTab) {
+                c.starting_index = acc;
+            } else {
+                acc++;
+            }
+        }
+        data.tabs = JSON.stringify(_.map(
+            _.filter(columns, function (c) {
+                return c.isTab;
+            }),
+            function (c) {
+                return c.serialize();
+            },
+        ));
+
+        data.caseTileTemplate = self.caseTileTemplate();
+        data.persistCaseContext = self.persistCaseContext();
+        data.persistentCaseContextXML = self.persistentCaseContextXML();
+        data.persistTileOnForms = self.persistTileOnForms();
+        data.persistentCaseTileFromModule = self.persistentCaseTileFromModule();
+        data.enableTilePullDown = self.persistTileOnForms() ? self.enableTilePullDown() : false;
+
+        data.case_tile_group = JSON.stringify({
+            index_identifier: self.caseTileGrouped() ? self.caseTileGroupBy() : null,
+            header_rows: self.caseTileGroupHeaderRows(),
+        });
+
+        if (self.containsParentConfiguration) {
+            var parentSelect;
+            if (_.has(self.config, 'parentSelect')) {
+                parentSelect = {
+                    module_id: self.config.parentSelect.moduleId(),
+                    relationship: self.config.parentSelect.relationship(),
+                    active: self.config.parentSelect.active(),
+                };
+            }
+            data.parent_select = JSON.stringify(parentSelect);
+        }
+        if (self.containsFixtureConfiguration) {
+            var fixtureSelect;
+            if (_.has(self.config, 'fixtureSelect')) {
+                fixtureSelect = {
+                    active: self.config.fixtureSelect.active(),
+                    fixture_type: self.config.fixtureSelect.fixtureType(),
+                    display_column: self.config.fixtureSelect.displayColumn(),
+                    localize: self.config.fixtureSelect.localize(),
+                    variable_column: self.config.fixtureSelect.variableColumn(),
+                    xpath: self.config.fixtureSelect.xpath(),
+                };
+            }
+            data.fixture_select = JSON.stringify(fixtureSelect);
+        }
+        if (self.containsSortConfiguration) {
+            data.sort_elements = JSON.stringify(_.map(self.config.sortRows.sortRows(), function (row) {
+                return {
+                    field: row.selectField.val(),
+                    type: row.type(),
+                    direction: row.direction(),
+                    blanks: row.blanks(),
+                    display: row.display(),
+                    sort_calculation: row.sortCalculation(),
+                };
+            }));
+        }
+        if (self.containsFilterConfiguration) {
+            data.filter = JSON.stringify(self.config.filter.serialize());
+        }
+        if (self.containsCaseListLookupConfiguration) {
+            data.case_list_lookup = JSON.stringify(self.config.caseListLookup.serialize());
+        }
+        if (self.containsCustomXMLConfiguration) {
+            data.custom_xml = self.config.customXMLViewModel.xml();
+        }
+        data[self.columnKey + '_custom_variables_dict'] = JSON.stringify(self.customVariablesViewModel.dict);
+        data.multi_select = self.multiSelectEnabled();
+        data.auto_select = self.autoSelectEnabled();
+        data.max_select_value = self.maxSelectValue();
+        if (self.containsSearchConfiguration) {
+            data.search_properties = JSON.stringify(self.config.search.serialize());
+        }
+        return data;
+    };
+    self.addItem = function (columnConfiguration, index) {
+        var column = self.initColumnAsColumn(
+            ColumnModel(columnConfiguration, self),
+        );
+        if (index === undefined) {
+            self.columns.push(column);
+        } else {
+            self.columns.splice(index, 0, column);
+        }
+        column.useXpathExpression = !!columnConfiguration.useXpathExpression;
+    };
+    self.pasteCallback = function (data, index) {
+        try {
+            data = JSON.parse(data);
+        } catch (e) {
+            // just ignore pasting non-json
+            return;
+        }
+        if (data.type === 'detail-screen-config:Column' && data.contents) {
+            self.addItem(data.contents, index);
+        }
+    };
+    self.addProperty = function () {
+        var type = self.columnKey === "short" ? "List" : "Detail";
+        google.track.event('Case Management', 'Module Level Case ' + type, 'Add Property');
+        self.addItem({
+            hasAutocomplete: true,
+        });
+    };
+
+    self.hasGraphing = appManager.checkCommcareVersion("2.17");
+    self.addGraph = function () {
+        self.addItem({
+            hasAutocomplete: false,
+            format: 'graph',
+        });
+    };
+
+    self.hasXpathExpressions = initialPageData.get("add_ons").calc_xpaths;
+    self.addXpathExpression = function () {
+        self.addItem({
+            hasAutocomplete: false,
+            useXpathExpression: true,
+        });
+    };
+
+    return self;
+};

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -1,256 +1,240 @@
 /**
  * Model for the entire case list + case detail configuration UI.
  */
-hqDefine("app_manager/js/details/screen_config", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "app_manager/js/details/parent_select",
-    "app_manager/js/details/fixture_select",
-    "app_manager/js/details/screen",
-    "hqwebapp/js/toggles",
-    "app_manager/js/details/filter",
-    "app_manager/js/details/sort_rows",
-    "app_manager/js/details/case_list_callout",
-    "app_manager/js/details/case_claim",
-    "app_manager/js/details/case_detail_print",
-    "hqwebapp/js/initial_page_data",
-], function (
-    $,
-    ko,
-    _,
-    parentSelect,
-    fixtureSelect,
-    screenModule,
-    toggles,
-    filterModule,
-    sortRows,
-    caseListCallout,
-    caseClaimModels,
-    printModule,
-    initialPageData,
-) {
-    const module = function (spec) {
-        var self = {};
-        self.properties = spec.properties;
-        self.sortProperties = Array.from(spec.properties);
-        self.screens = [];
-        self.model = spec.model || 'case';
-        self.lang = spec.lang;
-        self.langs = spec.langs || [];
-        self.multimedia = spec.multimedia || {};
-        self.module_id = spec.module_id || '';
-        if (_.has(spec, 'parentSelect') && spec.parentSelect) {
-            self.parentSelect = parentSelect({
-                active: spec.parentSelect.active,
-                moduleId: spec.parentSelect.module_id,
-                relationship: spec.parentSelect.relationship,
-                parentModules: spec.parentModules,
-                allCaseModules: spec.allCaseModules,
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import parentSelect from "app_manager/js/details/parent_select";
+import fixtureSelect from "app_manager/js/details/fixture_select";
+import screenModule from "app_manager/js/details/screen";
+import toggles from "hqwebapp/js/toggles";
+import filterModule from "app_manager/js/details/filter";
+import sortRows from "app_manager/js/details/sort_rows";
+import caseListCallout from "app_manager/js/details/case_list_callout";
+import caseClaimModels from "app_manager/js/details/case_claim";
+import printModule from "app_manager/js/details/case_detail_print";
+import initialPageData from "hqwebapp/js/initial_page_data";
+
+const module = function (spec) {
+    var self = {};
+    self.properties = spec.properties;
+    self.sortProperties = Array.from(spec.properties);
+    self.screens = [];
+    self.model = spec.model || 'case';
+    self.lang = spec.lang;
+    self.langs = spec.langs || [];
+    self.multimedia = spec.multimedia || {};
+    self.module_id = spec.module_id || '';
+    if (_.has(spec, 'parentSelect') && spec.parentSelect) {
+        self.parentSelect = parentSelect({
+            active: spec.parentSelect.active,
+            moduleId: spec.parentSelect.module_id,
+            relationship: spec.parentSelect.relationship,
+            parentModules: spec.parentModules,
+            allCaseModules: spec.allCaseModules,
+            lang: self.lang,
+            langs: self.langs,
+        });
+    }
+
+    if (_.has(spec, 'fixtureSelect') && spec.fixtureSelect) {
+        self.fixtureSelect = fixtureSelect({
+            active: spec.fixtureSelect.active,
+            fixtureType: spec.fixtureSelect.fixture_type,
+            displayColumn: spec.fixtureSelect.display_column,
+            localize: spec.fixtureSelect.localize,
+            variableColumn: spec.fixtureSelect.variable_column,
+            xpath: spec.fixtureSelect.xpath,
+            fixture_columns_by_type: spec.fixture_columns_by_type,
+        });
+    }
+    self.saveUrl = spec.saveUrl;
+
+    /**
+     * Add a screenModel to self detailScreenConfig
+     * @param pair
+     * @param columnType
+     * The type of case properties self self screenModel will be displaying,
+     * either "short" or "long".
+     */
+    function addScreen(pair, columnType) {
+
+        var screen = screenModule(
+            pair,
+            self, {
                 lang: self.lang,
                 langs: self.langs,
+                properties: self.properties,
+                saveUrl: self.saveUrl,
+                moduleId: self.module_id,
+                columnKey: columnType,
+                childCaseTypes: spec.childCaseTypes,
+                fixtures: _.keys(spec.fixture_columns_by_type),
+                containsSortConfiguration: columnType === "short",
+                containsParentConfiguration: columnType === "short",
+                containsFixtureConfiguration: (columnType === "short" && toggles.toggleEnabled('FIXTURE_CASE_SELECTION')),
+                containsFilterConfiguration: columnType === "short",
+                containsCaseListLookupConfiguration: (columnType === "short" && (toggles.toggleEnabled('CASE_LIST_LOOKUP') || toggles.toggleEnabled('BIOMETRIC_INTEGRATION'))),
+                containsSearchConfiguration: (columnType === "short" && initialPageData.get('case_search_enabled')),
+                containsCustomXMLConfiguration: columnType === "short",
+                allowsTabs: columnType === 'long',
+                allowsEmptyColumns: columnType === 'long',
+                caseTileTemplateOptions: spec.caseTileTemplateOptions,
+                caseTileTemplateConfigs: spec.caseTileTemplateConfigs,
+            },
+        );
+        self.screens.push(screen);
+        return screen;
+    }
+
+    const calculatedColName = (index) => `_cc_calculated_${index}`;
+    const calculatedColLabel = (index, col) => {
+        return _.template(gettext('<%- name %> (Calculated Property #<%- index %>)'))({
+            name: col.header.val(), index: index + 1,
+        });
+    };
+
+    function bindCalculatedPropsWithSortCols() {
+        // This links the calculated properties in the case list with the options available for sorting.
+        // Updates to the calculated properties are propagated to the sort rows.
+
+        // update the available sort properties with existing calculated properties
+        let calculatedCols = self.shortScreen.columns()
+            .filter(col => col.useXpathExpression)
+            .map(col => {
+                let index = self.shortScreen.columns.indexOf(col),
+                    label = calculatedColLabel(index, col);
+                return {value: calculatedColName(index), label: label};
             });
-        }
+        self.sortProperties.push(...calculatedCols);
 
-        if (_.has(spec, 'fixtureSelect') && spec.fixtureSelect) {
-            self.fixtureSelect = fixtureSelect({
-                active: spec.fixtureSelect.active,
-                fixtureType: spec.fixtureSelect.fixture_type,
-                displayColumn: spec.fixtureSelect.display_column,
-                localize: spec.fixtureSelect.localize,
-                variableColumn: spec.fixtureSelect.variable_column,
-                xpath: spec.fixtureSelect.xpath,
-                fixture_columns_by_type: spec.fixture_columns_by_type,
-            });
-        }
-        self.saveUrl = spec.saveUrl;
-
-        /**
-         * Add a screenModel to self detailScreenConfig
-         * @param pair
-         * @param columnType
-         * The type of case properties self self screenModel will be displaying,
-         * either "short" or "long".
-         */
-        function addScreen(pair, columnType) {
-
-            var screen = screenModule(
-                pair,
-                self, {
-                    lang: self.lang,
-                    langs: self.langs,
-                    properties: self.properties,
-                    saveUrl: self.saveUrl,
-                    moduleId: self.module_id,
-                    columnKey: columnType,
-                    childCaseTypes: spec.childCaseTypes,
-                    fixtures: _.keys(spec.fixture_columns_by_type),
-                    containsSortConfiguration: columnType === "short",
-                    containsParentConfiguration: columnType === "short",
-                    containsFixtureConfiguration: (columnType === "short" && toggles.toggleEnabled('FIXTURE_CASE_SELECTION')),
-                    containsFilterConfiguration: columnType === "short",
-                    containsCaseListLookupConfiguration: (columnType === "short" && (toggles.toggleEnabled('CASE_LIST_LOOKUP') || toggles.toggleEnabled('BIOMETRIC_INTEGRATION'))),
-                    containsSearchConfiguration: (columnType === "short" && initialPageData.get('case_search_enabled')),
-                    containsCustomXMLConfiguration: columnType === "short",
-                    allowsTabs: columnType === 'long',
-                    allowsEmptyColumns: columnType === 'long',
-                    caseTileTemplateOptions: spec.caseTileTemplateOptions,
-                    caseTileTemplateConfigs: spec.caseTileTemplateConfigs,
-                },
-            );
-            self.screens.push(screen);
-            return screen;
-        }
-
-        const calculatedColName = (index) => `_cc_calculated_${index}`;
-        const calculatedColLabel = (index, col) => {
-            return _.template(gettext('<%- name %> (Calculated Property #<%- index %>)'))({
-                name: col.header.val(), index: index + 1,
-            });
-        };
-
-        function bindCalculatedPropsWithSortCols() {
-            // This links the calculated properties in the case list with the options available for sorting.
-            // Updates to the calculated properties are propagated to the sort rows.
-
-            // update the available sort properties with existing calculated properties
-            let calculatedCols = self.shortScreen.columns()
-                .filter(col => col.useXpathExpression)
-                .map(col => {
-                    let index = self.shortScreen.columns.indexOf(col),
-                        label = calculatedColLabel(index, col);
-                    return {value: calculatedColName(index), label: label};
-                });
-            self.sortProperties.push(...calculatedCols);
-
-            // propagate changes in calculated columns to the sort properties
-            self.shortScreen.on("columnChange", changes => {
-                let sortProps = [...self.sortProperties];
-                let valueMapping = {};  // used to handle value changes and deletions
-                changes.forEach(change => {
-                    if (!change.value.useXpathExpression) {
-                        return;
-                    }
-                    const colValue = calculatedColName(change.index);
-                    const colLabel = calculatedColLabel(change.index, change.value);
-                    if (change.status === "edited") {
-                        let prop = sortProps.find(p => {
-                            return p.value === colValue;
-                        });
-                        if (prop) {
-                            prop.label = colLabel;
-                        }
-                    } else if (change.status === "added" && change.moved !== undefined) {
-                        // re-order
-                        const oldValue = calculatedColName(change.moved);
-                        let prop = sortProps.find(p => p.value === oldValue);
-                        if (prop) {
-                            prop.value = colValue;
-                            prop.label = colLabel;
-                        }
-                        valueMapping[oldValue] = colValue;
-                    } else if (change.status === "added") {
-                        sortProps.push({value: colValue, label: colLabel});
-                    } else if (change.status === "deleted") {
-                        sortProps = sortProps.filter(p => p.value !== colValue);
-                        valueMapping[colValue] = "";  // set selection to blank
-                    }
-                });
-
-                // update values for next time and for new sort-cols
-                self.sortProperties = sortProps;
-                self.sortRows.updateSortProperties(self.sortProperties, valueMapping);
-            });
-        }
-
-        if (spec.state.short !== undefined) {
-            self.shortScreen = addScreen(spec.state, "short");
-            bindCalculatedPropsWithSortCols();
-            // Set up filter
-            var filterXpath = spec.state.short.filter;
-            self.filter = filterModule(filterXpath ? filterXpath : null, self.shortScreen.saveButton);
-            // Set up sortRows
-            self.sortRows = sortRows(self.sortProperties, self.shortScreen.saveButton);
-            if (spec.sortRows) {
-                for (var j = 0; j < spec.sortRows.length; j++) {
-                    self.sortRows.addSortRow(
-                        spec.sortRows[j].field,
-                        spec.sortRows[j].type,
-                        spec.sortRows[j].direction,
-                        spec.sortRows[j].blanks,
-                        spec.sortRows[j].display[self.lang],
-                        false,
-                        spec.sortRows[j].sort_calculation,
-                    );
+        // propagate changes in calculated columns to the sort properties
+        self.shortScreen.on("columnChange", changes => {
+            let sortProps = [...self.sortProperties];
+            let valueMapping = {};  // used to handle value changes and deletions
+            changes.forEach(change => {
+                if (!change.value.useXpathExpression) {
+                    return;
                 }
+                const colValue = calculatedColName(change.index);
+                const colLabel = calculatedColLabel(change.index, change.value);
+                if (change.status === "edited") {
+                    let prop = sortProps.find(p => {
+                        return p.value === colValue;
+                    });
+                    if (prop) {
+                        prop.label = colLabel;
+                    }
+                } else if (change.status === "added" && change.moved !== undefined) {
+                    // re-order
+                    const oldValue = calculatedColName(change.moved);
+                    let prop = sortProps.find(p => p.value === oldValue);
+                    if (prop) {
+                        prop.value = colValue;
+                        prop.label = colLabel;
+                    }
+                    valueMapping[oldValue] = colValue;
+                } else if (change.status === "added") {
+                    sortProps.push({value: colValue, label: colLabel});
+                } else if (change.status === "deleted") {
+                    sortProps = sortProps.filter(p => p.value !== colValue);
+                    valueMapping[colValue] = "";  // set selection to blank
+                }
+            });
+
+            // update values for next time and for new sort-cols
+            self.sortProperties = sortProps;
+            self.sortRows.updateSortProperties(self.sortProperties, valueMapping);
+        });
+    }
+
+    if (spec.state.short !== undefined) {
+        self.shortScreen = addScreen(spec.state, "short");
+        bindCalculatedPropsWithSortCols();
+        // Set up filter
+        var filterXpath = spec.state.short.filter;
+        self.filter = filterModule(filterXpath ? filterXpath : null, self.shortScreen.saveButton);
+        // Set up sortRows
+        self.sortRows = sortRows(self.sortProperties, self.shortScreen.saveButton);
+        if (spec.sortRows) {
+            for (var j = 0; j < spec.sortRows.length; j++) {
+                self.sortRows.addSortRow(
+                    spec.sortRows[j].field,
+                    spec.sortRows[j].type,
+                    spec.sortRows[j].direction,
+                    spec.sortRows[j].blanks,
+                    spec.sortRows[j].display[self.lang],
+                    false,
+                    spec.sortRows[j].sort_calculation,
+                );
             }
-            self.customXMLViewModel = {
-                enabled: toggles.toggleEnabled('CASE_LIST_CUSTOM_XML'),
-                xml: ko.observable(spec.state.short.custom_xml || ""),
-            };
-            self.customXMLViewModel.xml.subscribe(function () {
-                self.shortScreen.saveButton.fire("change");
-            });
-            var $caseListLookup = $("#" + spec.state.type + "-list-callout-configuration");
-            self.caseListLookup = caseListCallout.caseListLookupViewModel(
-                $caseListLookup,
-                spec.state.short,
-                spec.lang,
-                self.shortScreen.saveButton,
-            );
-            // Set up case search
-            self.search = caseClaimModels.searchViewModel(
-                spec.search_properties || [],
-                spec.default_properties,
-                spec.custom_sort_properties,
-                _.pick(spec, caseClaimModels.searchConfigKeys),
-                spec.lang,
-                self.shortScreen.saveButton,
-                self.filter.filterText,
-            );
         }
-        if (spec.state.long !== undefined) {
-            var printRef = printModule.getPrintRef(),
-                printTemplateUploader = printModule.getPrintTemplateUploader();
-            self.longScreen = addScreen(spec.state, "long");
-            self.printTemplateReference = _.extend(printRef, {
-                removePrintTemplate: function () {
-                    $.post(
-                        initialPageData.reverse("hqmedia_remove_detail_print_template"), {
-                            module_unique_id: spec.moduleUniqueId,
-                        },
-                        function (data, status) {
-                            if (status === 'success') {
-                                printRef.setObjReference({
-                                    path: printRef.path,
-                                });
-                                printRef.is_matched(false);
-                                printTemplateUploader.updateUploadFormUI();
-                            }
-                        },
-                    );
-                },
+        self.customXMLViewModel = {
+            enabled: toggles.toggleEnabled('CASE_LIST_CUSTOM_XML'),
+            xml: ko.observable(spec.state.short.custom_xml || ""),
+        };
+        self.customXMLViewModel.xml.subscribe(function () {
+            self.shortScreen.saveButton.fire("change");
+        });
+        var $caseListLookup = $("#" + spec.state.type + "-list-callout-configuration");
+        self.caseListLookup = caseListCallout.caseListLookupViewModel(
+            $caseListLookup,
+            spec.state.short,
+            spec.lang,
+            self.shortScreen.saveButton,
+        );
+        // Set up case search
+        self.search = caseClaimModels.searchViewModel(
+            spec.search_properties || [],
+            spec.default_properties,
+            spec.custom_sort_properties,
+            _.pick(spec, caseClaimModels.searchConfigKeys),
+            spec.lang,
+            self.shortScreen.saveButton,
+            self.filter.filterText,
+        );
+    }
+    if (spec.state.long !== undefined) {
+        var printRef = printModule.getPrintRef(),
+            printTemplateUploader = printModule.getPrintTemplateUploader();
+        self.longScreen = addScreen(spec.state, "long");
+        self.printTemplateReference = _.extend(printRef, {
+            removePrintTemplate: function () {
+                $.post(
+                    initialPageData.reverse("hqmedia_remove_detail_print_template"), {
+                        module_unique_id: spec.moduleUniqueId,
+                    },
+                    function (data, status) {
+                        if (status === 'success') {
+                            printRef.setObjReference({
+                                path: printRef.path,
+                            });
+                            printRef.is_matched(false);
+                            printTemplateUploader.updateUploadFormUI();
+                        }
+                    },
+                );
+            },
+        });
+    }
+    return self;
+};
+
+ko.bindingHandlers.DetailScreenConfig_notifyShortScreenOnChange = {
+    init: function (element, valueAccessor) {
+        var $root = valueAccessor();
+        setTimeout(function () {
+            $(element).on('change', '*', function () {
+                $root.shortScreen.fire('change');
             });
-        }
-        return self;
-    };
+        }, 0);
+    },
+};
 
-    ko.bindingHandlers.DetailScreenConfig_notifyShortScreenOnChange = {
-        init: function (element, valueAccessor) {
-            var $root = valueAccessor();
-            setTimeout(function () {
-                $(element).on('change', '*', function () {
-                    $root.shortScreen.fire('change');
-                });
-            }, 0);
-        },
-    };
+ko.bindingHandlers.addSaveButtonListener = {
+    init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
+        bindingContext.$parent.initSaveButtonListeners($(element).parent());
+    },
+};
 
-    ko.bindingHandlers.addSaveButtonListener = {
-        init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
-            bindingContext.$parent.initSaveButtonListeners($(element).parent());
-        },
-    };
-
-    return module;
-});
+export default module;

--- a/corehq/apps/app_manager/static/app_manager/js/details/sort_rows.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/sort_rows.js
@@ -5,7 +5,6 @@
  * each map to a display property column and have
  * sorting-related attributes like direction.
  */
-import $ from "jquery";
 import ko from "knockout";
 import uiElementSelect from "hqwebapp/js/ui_elements/bootstrap3/ui-element-select";
 import Utils from "app_manager/js/details/utils";

--- a/corehq/apps/app_manager/static/app_manager/js/details/sort_rows.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/sort_rows.js
@@ -5,162 +5,155 @@
  * each map to a display property column and have
  * sorting-related attributes like direction.
  */
-hqDefine("app_manager/js/details/sort_rows", [
-    "jquery",
-    "knockout",
-    "hqwebapp/js/ui_elements/bootstrap3/ui-element-select",
-    "app_manager/js/details/utils",
-], function (
-    $,
-    ko,
-    uiElementSelect,
-    Utils,
-) {
-    var sortRow = function (params, saveButton) {
-        var self = {};
-        params = params || {};
+import $ from "jquery";
+import ko from "knockout";
+import uiElementSelect from "hqwebapp/js/ui_elements/bootstrap3/ui-element-select";
+import Utils from "app_manager/js/details/utils";
 
-        self.selectField = uiElementSelect.new(params.properties).val(typeof params.field !== 'undefined' ? params.field : "");
-        Utils.setUpAutocomplete(self.selectField, params.properties);
-        self.sortCalculation = ko.observable(typeof params.sortCalculation !== 'undefined' ? params.sortCalculation : "");
+var sortRow = function (params, saveButton) {
+    var self = {};
+    params = params || {};
 
-        self.showWarning = ko.observable(false);
-        self.warningText = Utils.fieldFormatWarningMessage;
-        self.hasValidPropertyName = function () {
-            let name = self.selectField.val();
-            // changes here should also be made in
-            // corehq.apps.app_manager.helpers.validators.ModuleDetailValidatorMixin._validate_detail_screen_field
-            if (new RegExp('^_cc_calculated_(\\d+)$').test(name)) {
-                // special case for calculated properties
-                return true;
-            }
-            return Utils.isValidPropertyName(name);
-        };
-        self.display = ko.observable(typeof params.display !== 'undefined' ? params.display : "");
-        self.display.subscribe(function () {
+    self.selectField = uiElementSelect.new(params.properties).val(typeof params.field !== 'undefined' ? params.field : "");
+    Utils.setUpAutocomplete(self.selectField, params.properties);
+    self.sortCalculation = ko.observable(typeof params.sortCalculation !== 'undefined' ? params.sortCalculation : "");
+
+    self.showWarning = ko.observable(false);
+    self.warningText = Utils.fieldFormatWarningMessage;
+    self.hasValidPropertyName = function () {
+        let name = self.selectField.val();
+        // changes here should also be made in
+        // corehq.apps.app_manager.helpers.validators.ModuleDetailValidatorMixin._validate_detail_screen_field
+        if (new RegExp('^_cc_calculated_(\\d+)$').test(name)) {
+            // special case for calculated properties
+            return true;
+        }
+        return Utils.isValidPropertyName(name);
+    };
+    self.display = ko.observable(typeof params.display !== 'undefined' ? params.display : "");
+    self.display.subscribe(function () {
+        self.notifyButton();
+    });
+    self.toTitleCase = Utils.toTitleCase;
+    self.selectField.on('change', function () {
+        if (!self.hasValidPropertyName()) {
+            self.showWarning(true);
+        } else {
+            self.showWarning(false);
+            let display = self.toTitleCase(this.valLabel()).split('(')[0].trim();
+            self.display(display);
             self.notifyButton();
-        });
-        self.toTitleCase = Utils.toTitleCase;
-        self.selectField.on('change', function () {
-            if (!self.hasValidPropertyName()) {
-                self.showWarning(true);
+        }
+    });
+
+    self.type = ko.observable(typeof params.type !== 'undefined' ? params.type : "");
+    self.type.subscribe(function () {
+        self.notifyButton();
+    });
+    self.direction = ko.observable(params.direction || "ascending");
+    self.blanks = ko.observable(params.blanks || (params.direction === "descending" ? "last" : "first"));
+    self.direction.subscribe(function () {
+        self.notifyButton();
+    });
+    self.blanks.subscribe(function () {
+        self.notifyButton();
+    });
+    self.sortCalculation.subscribe(function () {
+        self.notifyButton();
+    });
+
+    self.notifyButton = function () {
+        saveButton.fire('change');
+    };
+
+    self.ascendText = ko.computed(function () {
+        var type = self.type();
+        // This is here for the CACHE_AND_INDEX feature
+        if (type === 'plain' || type === 'index') {
+            return gettext('Increasing (a, b, c)');
+        } else if (type === 'date') {
+            return gettext('Increasing (May 1st, May 2nd)');
+        } else if (type === 'int') {
+            return gettext('Increasing (1, 2, 3)');
+        } else if (type === 'double' || type === 'distance') {
+            return gettext('Increasing (1.1, 1.2, 1.3)');
+        }
+    });
+
+    self.descendText = ko.computed(function () {
+        var type = self.type();
+        if (type === 'plain' || type === 'index') {
+            return gettext('Decreasing (c, b, a)');
+        } else if (type === 'date') {
+            return gettext('Decreasing (May 2nd, May 1st)');
+        } else if (type === 'int') {
+            return gettext('Decreasing (3, 2, 1)');
+        } else if (type === 'double' || type === 'distance') {
+            return gettext('Decreasing (1.3, 1.2, 1.1)');
+        }
+    });
+
+    return self;
+};
+
+/**
+ *
+ * @param properties
+ * @param saveButton
+ * The button that should be activated when something changes
+ * @constructor
+ */
+var sortRows = function (properties, saveButton) {
+    var self = {};
+    self.sortRows = ko.observableArray([]);
+    self.properties = properties;
+
+    self.addSortRow = function (field, type, direction, blanks, display, notify, sortCalculation) {
+        self.sortRows.push(sortRow({
+            field: field,
+            type: type,
+            direction: direction,
+            blanks: blanks,
+            display: display,
+            properties: [...self.properties],  // clone list here to avoid updates from select2 leaking out
+            sortCalculation: sortCalculation,
+        }, saveButton));
+        if (notify) {
+            saveButton.fire('change');
+        }
+    };
+    self.removeSortRow = function (row) {
+        self.sortRows.remove(row);
+        saveButton.fire('change');
+    };
+
+    self.rowCount = ko.computed(function () {
+        return self.sortRows().length;
+    });
+
+    self.showing = ko.computed(function () {
+        return self.rowCount() > 0;
+    });
+
+    self.updateSortProperties = function (newProperties, changedValues) {
+        self.properties = newProperties;
+
+        // update existing sort rows with the new options
+        // and re-apply the selected value
+        self.sortRows().forEach((row) => {
+            let oldSelection = row.selectField.val();
+            row.selectField.setOptions(newProperties);
+            if (changedValues[oldSelection] !== undefined) {
+                // handle changed values and deletions
+                row.selectField.val(changedValues[oldSelection]);
             } else {
-                self.showWarning(false);
-                let display = self.toTitleCase(this.valLabel()).split('(')[0].trim();
-                self.display(display);
-                self.notifyButton();
+                row.selectField.val(oldSelection);
             }
+            row.selectField.fire("change");
         });
-
-        self.type = ko.observable(typeof params.type !== 'undefined' ? params.type : "");
-        self.type.subscribe(function () {
-            self.notifyButton();
-        });
-        self.direction = ko.observable(params.direction || "ascending");
-        self.blanks = ko.observable(params.blanks || (params.direction === "descending" ? "last" : "first"));
-        self.direction.subscribe(function () {
-            self.notifyButton();
-        });
-        self.blanks.subscribe(function () {
-            self.notifyButton();
-        });
-        self.sortCalculation.subscribe(function () {
-            self.notifyButton();
-        });
-
-        self.notifyButton = function () {
-            saveButton.fire('change');
-        };
-
-        self.ascendText = ko.computed(function () {
-            var type = self.type();
-            // This is here for the CACHE_AND_INDEX feature
-            if (type === 'plain' || type === 'index') {
-                return gettext('Increasing (a, b, c)');
-            } else if (type === 'date') {
-                return gettext('Increasing (May 1st, May 2nd)');
-            } else if (type === 'int') {
-                return gettext('Increasing (1, 2, 3)');
-            } else if (type === 'double' || type === 'distance') {
-                return gettext('Increasing (1.1, 1.2, 1.3)');
-            }
-        });
-
-        self.descendText = ko.computed(function () {
-            var type = self.type();
-            if (type === 'plain' || type === 'index') {
-                return gettext('Decreasing (c, b, a)');
-            } else if (type === 'date') {
-                return gettext('Decreasing (May 2nd, May 1st)');
-            } else if (type === 'int') {
-                return gettext('Decreasing (3, 2, 1)');
-            } else if (type === 'double' || type === 'distance') {
-                return gettext('Decreasing (1.3, 1.2, 1.1)');
-            }
-        });
-
-        return self;
     };
 
-    /**
-     *
-     * @param properties
-     * @param saveButton
-     * The button that should be activated when something changes
-     * @constructor
-     */
-    var sortRows = function (properties, saveButton) {
-        var self = {};
-        self.sortRows = ko.observableArray([]);
-        self.properties = properties;
+    return self;
+};
 
-        self.addSortRow = function (field, type, direction, blanks, display, notify, sortCalculation) {
-            self.sortRows.push(sortRow({
-                field: field,
-                type: type,
-                direction: direction,
-                blanks: blanks,
-                display: display,
-                properties: [...self.properties],  // clone list here to avoid updates from select2 leaking out
-                sortCalculation: sortCalculation,
-            }, saveButton));
-            if (notify) {
-                saveButton.fire('change');
-            }
-        };
-        self.removeSortRow = function (row) {
-            self.sortRows.remove(row);
-            saveButton.fire('change');
-        };
-
-        self.rowCount = ko.computed(function () {
-            return self.sortRows().length;
-        });
-
-        self.showing = ko.computed(function () {
-            return self.rowCount() > 0;
-        });
-
-        self.updateSortProperties = function (newProperties, changedValues) {
-            self.properties = newProperties;
-
-            // update existing sort rows with the new options
-            // and re-apply the selected value
-            self.sortRows().forEach((row) => {
-                let oldSelection = row.selectField.val();
-                row.selectField.setOptions(newProperties);
-                if (changedValues[oldSelection] !== undefined) {
-                    // handle changed values and deletions
-                    row.selectField.val(changedValues[oldSelection]);
-                } else {
-                    row.selectField.val(oldSelection);
-                }
-                row.selectField.fire("change");
-            });
-        };
-
-        return self;
-    };
-
-    return sortRows;
-});
+export default sortRows;

--- a/corehq/apps/app_manager/static/app_manager/js/details/utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/utils.js
@@ -4,7 +4,6 @@
  *
  * Depends on `add_ons` being available in initial page data
  */
-import $ from "jquery";
 import _ from "underscore";
 import DOMPurify from "DOMPurify";
 import toggles from "hqwebapp/js/toggles";

--- a/corehq/apps/app_manager/static/app_manager/js/details/utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/utils.js
@@ -4,191 +4,183 @@
  *
  * Depends on `add_ons` being available in initial page data
  */
-hqDefine("app_manager/js/details/utils", [
-    "jquery",
-    "underscore",
-    "DOMPurify",
-    "hqwebapp/js/toggles",
-    "hqwebapp/js/initial_page_data",
-    "select2/dist/js/select2.full.min",
-], function (
-    $,
-    _,
-    DOMPurify,
-    toggles,
-    initialPageData,
-) {
-    var module = {};
+import $ from "jquery";
+import _ from "underscore";
+import DOMPurify from "DOMPurify";
+import toggles from "hqwebapp/js/toggles";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import "select2/dist/js/select2.full.min";
 
-    module.fieldFormatWarningMessage = gettext("Must begin with a letter and contain only letters, numbers, '-', and '_'");
+var module = {};
 
-    module.getFieldFormats = function () {
-        var formats = [{
-            value: "plain",
-            label: gettext('Plain'),
-        }, {
-            value: "date",
-            label: gettext('Date'),
-        }, {
-            value: "time-ago",
-            label: gettext('Time Since or Until Date'),
-        }, {
-            value: "phone",
-            label: gettext('Phone Number'),
-        }, {
-            value: "enum",
-            label: gettext('ID Mapping'),
-        }, {
-            value: "late-flag",
-            label: gettext('Late Flag'),
-        }, {
-            value: "invisible",
-            label: gettext('Search Only'),
-        }, {
-            value: "address",
-            label: gettext('Address'),
-        }, {
-            value: "distance",
-            label: gettext('Distance from current location'),
-        }, {
-            value: "markdown",
-            label: gettext('Markdown'),
-        }];
+module.fieldFormatWarningMessage = gettext("Must begin with a letter and contain only letters, numbers, '-', and '_'");
 
-        if (toggles.toggleEnabled('CASE_LIST_MAP')) {
-            formats.push({
-                value: "address-popup",
-                label: gettext('Address Popup (Web Apps only)'),
-            });
-        }
+module.getFieldFormats = function () {
+    var formats = [{
+        value: "plain",
+        label: gettext('Plain'),
+    }, {
+        value: "date",
+        label: gettext('Date'),
+    }, {
+        value: "time-ago",
+        label: gettext('Time Since or Until Date'),
+    }, {
+        value: "phone",
+        label: gettext('Phone Number'),
+    }, {
+        value: "enum",
+        label: gettext('ID Mapping'),
+    }, {
+        value: "late-flag",
+        label: gettext('Late Flag'),
+    }, {
+        value: "invisible",
+        label: gettext('Search Only'),
+    }, {
+        value: "address",
+        label: gettext('Address'),
+    }, {
+        value: "distance",
+        label: gettext('Distance from current location'),
+    }, {
+        value: "markdown",
+        label: gettext('Markdown'),
+    }];
 
-        if (toggles.toggleEnabled('CASE_LIST_CLICKABLE_ICON')) {
-            formats.push({
-                value: "clickable-icon",
-                label: gettext('Clickable Icon (Web Apps only)'),
-            });
-        }
-
-        if (toggles.toggleEnabled('MM_CASE_PROPERTIES')) {
-            formats.push({
-                value: "picture",
-                label: gettext('Picture'),
-            }, {
-                value: "audio",
-                label: gettext('Audio'),
-            });
-        }
-
-        var addOns = initialPageData.get("add_ons");
-        if (addOns.enum_image) {
-            formats.push({
-                value: "enum-image",
-                label: gettext('Icon'),
-            });
-        }
-        if (addOns.conditional_enum) {
-            formats.push({
-                value: "conditional-enum",
-                label: gettext('Conditional ID Mapping'),
-            });
-        }
-        if (addOns.calc_xpaths) {
-            formats.push({
-                value: "translatable-enum",
-                label: gettext('Translatable Text'),
-            });
-        }
-
-        if (toggles.toggleEnabled('VELLUM_CASE_MICRO_IMAGE')) {
-            formats.push({
-                value: "image",
-                label: gettext('Image'),
-            });
-        }
-
-        return formats;
-    };
-
-    module.getFieldHtml = function (field) {
-        var text = field || '';
-        if (module.isAttachmentProperty(text)) {
-            text = text.substring(text.indexOf(":") + 1);
-        }
-        var parts = text.split('/');
-        // wrap all parts but the last in a label style
-        for (var j = 0; j < parts.length - 1; j++) {
-            parts[j] = ('<span class="label label-info">' +
-                parts[j] + '</span>');
-        }
-        if (parts[j][0] === '#') {
-            parts[j] = ('<span class="label label-info">' +
-                module.toTitleCase(parts[j]) + '</span>');
-        } else {
-            parts[j] = ('<code style="display: inline-block;">' +
-                parts[j] + '</code>');
-        }
-        return parts.join('<span style="color: #DDD;">/</span>');
-    };
-
-    module.isAttachmentProperty = function (value) {
-        return value && value.indexOf("attachment:") === 0;
-    };
-
-    module.isValidPropertyName = function (name) {
-        var word = '[a-zA-Z][\\w_-]*';
-        var regex = new RegExp('^(' + word + ':)*(' + word + '\\/)*#?' + word + '$');
-        return regex.test(name);
-    };
-
-    module.TIME_AGO = {
-        year: 365.25,
-        month: 365.25 / 12,
-        week: 7,
-        day: 1,
-    };
-
-    module.toTitleCase = function (str) {
-        return (str
-            .replace(/[_/-]/g, ' ')
-            .replace(/#/g, '')
-        ).replace(/\w\S*/g, function (txt) {
-            return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+    if (toggles.toggleEnabled('CASE_LIST_MAP')) {
+        formats.push({
+            value: "address-popup",
+            label: gettext('Address Popup (Web Apps only)'),
         });
-    };
+    }
 
-    /**
-     * Enable autocomplete on the given jquery element with the given autocomplete
-     * options.
-     * @param $elem
-     * @param options: Array of strings.
-     */
-    module.setUpAutocomplete = function ($elem, options) {
-        if (!_.contains(options, $elem.value)) {
-            options.unshift($elem.value);
-        }
-        $elem.$edit_view.select2({
-            minimumInputLength: 0,
-            width: '100%',
-            tags: true,
-            escapeMarkup: function (m) {
-                return DOMPurify.sanitize(m);
-            },
-            templateResult: function (result) {
-                var formatted = result.text;
-                if (module.isAttachmentProperty(result.id)) {
-                    formatted = (
-                        '<i class="fa fa-paperclip"></i> ' +
-                        result.id.substring(result.id.indexOf(":") + 1)
-                    );
-                }
-                return DOMPurify.sanitize(formatted);
-            },
-        }).on('change', function () {
-            $elem.val($elem.$edit_view.value);
-            $elem.fire('change');
+    if (toggles.toggleEnabled('CASE_LIST_CLICKABLE_ICON')) {
+        formats.push({
+            value: "clickable-icon",
+            label: gettext('Clickable Icon (Web Apps only)'),
         });
-        return $elem;
-    };
+    }
 
-    return module;
-});
+    if (toggles.toggleEnabled('MM_CASE_PROPERTIES')) {
+        formats.push({
+            value: "picture",
+            label: gettext('Picture'),
+        }, {
+            value: "audio",
+            label: gettext('Audio'),
+        });
+    }
+
+    var addOns = initialPageData.get("add_ons");
+    if (addOns.enum_image) {
+        formats.push({
+            value: "enum-image",
+            label: gettext('Icon'),
+        });
+    }
+    if (addOns.conditional_enum) {
+        formats.push({
+            value: "conditional-enum",
+            label: gettext('Conditional ID Mapping'),
+        });
+    }
+    if (addOns.calc_xpaths) {
+        formats.push({
+            value: "translatable-enum",
+            label: gettext('Translatable Text'),
+        });
+    }
+
+    if (toggles.toggleEnabled('VELLUM_CASE_MICRO_IMAGE')) {
+        formats.push({
+            value: "image",
+            label: gettext('Image'),
+        });
+    }
+
+    return formats;
+};
+
+module.getFieldHtml = function (field) {
+    var text = field || '';
+    if (module.isAttachmentProperty(text)) {
+        text = text.substring(text.indexOf(":") + 1);
+    }
+    var parts = text.split('/');
+    // wrap all parts but the last in a label style
+    for (var j = 0; j < parts.length - 1; j++) {
+        parts[j] = ('<span class="label label-info">' +
+            parts[j] + '</span>');
+    }
+    if (parts[j][0] === '#') {
+        parts[j] = ('<span class="label label-info">' +
+            module.toTitleCase(parts[j]) + '</span>');
+    } else {
+        parts[j] = ('<code style="display: inline-block;">' +
+            parts[j] + '</code>');
+    }
+    return parts.join('<span style="color: #DDD;">/</span>');
+};
+
+module.isAttachmentProperty = function (value) {
+    return value && value.indexOf("attachment:") === 0;
+};
+
+module.isValidPropertyName = function (name) {
+    var word = '[a-zA-Z][\\w_-]*';
+    var regex = new RegExp('^(' + word + ':)*(' + word + '\\/)*#?' + word + '$');
+    return regex.test(name);
+};
+
+module.TIME_AGO = {
+    year: 365.25,
+    month: 365.25 / 12,
+    week: 7,
+    day: 1,
+};
+
+module.toTitleCase = function (str) {
+    return (str
+        .replace(/[_/-]/g, ' ')
+        .replace(/#/g, '')
+    ).replace(/\w\S*/g, function (txt) {
+        return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+    });
+};
+
+/**
+ * Enable autocomplete on the given jquery element with the given autocomplete
+ * options.
+ * @param $elem
+ * @param options: Array of strings.
+ */
+module.setUpAutocomplete = function ($elem, options) {
+    if (!_.contains(options, $elem.value)) {
+        options.unshift($elem.value);
+    }
+    $elem.$edit_view.select2({
+        minimumInputLength: 0,
+        width: '100%',
+        tags: true,
+        escapeMarkup: function (m) {
+            return DOMPurify.sanitize(m);
+        },
+        templateResult: function (result) {
+            var formatted = result.text;
+            if (module.isAttachmentProperty(result.id)) {
+                formatted = (
+                    '<i class="fa fa-paperclip"></i> ' +
+                    result.id.substring(result.id.indexOf(":") + 1)
+                );
+            }
+            return DOMPurify.sanitize(formatted);
+        },
+    }).on('change', function () {
+        $elem.val($elem.$edit_view.value);
+        $elem.fire('change');
+    });
+    return $elem;
+};
+
+export default module;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
@@ -1,786 +1,775 @@
-hqDefine("app_manager/js/forms/advanced/actions", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "app_manager/js/case_config_utils",
-    "app_manager/js/forms/advanced/case_properties",
-    "hqwebapp/js/toggles",
-    "hqwebapp/js/privileges",
-    "hqwebapp/js/bootstrap3/main",
-    "app_manager/js/forms/case_knockout_bindings",  // withPrevious
-], function (
-    $,
-    ko,
-    _,
-    caseConfigUtils,
-    caseProperties,
-    toggles,
-    privileges,
-    main,
-) {
-    var caseIndex = {
-        mapping: {
-            include: ['tag', 'reference_id', 'relationship', 'relationship_question'],
-        },
-        wrap: function (data) {
-            var self = ko.mapping.fromJS(data, caseIndex.mapping);
-            self.relationship.subscribe(function (value) {
-                if (value === 'extension' && self.reference_id() !== 'host') {
-                    self.reference_id('host');
-                } else if (value === 'child' && self.reference_id() !== 'parent') {
-                    self.reference_id('parent');
-                } else if (value === 'question') {
-                    self.reference_id('');
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import caseConfigUtils from "app_manager/js/case_config_utils";
+import caseProperties from "app_manager/js/forms/advanced/case_properties";
+import toggles from "hqwebapp/js/toggles";
+import privileges from "hqwebapp/js/privileges";
+import main from "hqwebapp/js/bootstrap3/main";
+import "app_manager/js/forms/case_knockout_bindings";  // withPrevious
+
+var caseIndex = {
+    mapping: {
+        include: ['tag', 'reference_id', 'relationship', 'relationship_question'],
+    },
+    wrap: function (data) {
+        var self = ko.mapping.fromJS(data, caseIndex.mapping);
+        self.relationship.subscribe(function (value) {
+            if (value === 'extension' && self.reference_id() !== 'host') {
+                self.reference_id('host');
+            } else if (value === 'child' && self.reference_id() !== 'parent') {
+                self.reference_id('parent');
+            } else if (value === 'question') {
+                self.reference_id('');
+            }
+        });
+
+        return self;
+    },
+};
+
+var actionBase = {
+    validate: function (self, caseType, caseTag) {
+        if (!self.caseConfig.caseConfigViewModel) {
+            return;
+        }
+        if (!caseType) {
+            return gettext("Case Type required");
+        } else if (!caseTag || (self.warn_blank_case_tag() && !toggles.toggleEnabled('ALLOW_BLANK_CASE_TAGS'))) {
+            return gettext("Case Tag required");
+        }
+        if (!/^[a-zA-Z][\w_-]*(\/[a-zA-Z][\w_-]*)*$/.test(caseTag)) {
+            return gettext("Case Tag: only letters, numbers, '-', and '_' allowed");
+        }
+        var tags = self.caseConfig.caseConfigViewModel.getCaseTags('all');
+        if (_.where(tags, { value: caseTag }).length > 1) {
+            return gettext("Case Tag already in use");
+        }
+        return null;
+    },
+    close_case: function (self) {
+        return {
+            read: function () {
+                if (self.close_condition) {
+                    return self.close_condition.type() !== 'never';
+                } else {
+                    return false;
                 }
-            });
+            },
+            write: function (value) {
+                self.close_condition.type(value ? 'always' : 'never');
+                self.caseConfig.saveButton.fire('change');
+            },
+        };
+    },
+    case_tag: function (self) {
+        self.case_tag.extend({
+            withPrevious: 1,
+        });
 
-            return self;
-        },
-    };
-
-    var actionBase = {
-        validate: function (self, caseType, caseTag) {
-            if (!self.caseConfig.caseConfigViewModel) {
+        self.case_tag.subscribe(function (tag) {
+            if (!self.auto_select && !tag) {
+                // Don't allow user to blank out case tag
+                self.warn_blank_case_tag(true);
+                if (!toggles.toggleEnabled('ALLOW_BLANK_CASE_TAGS')) {
+                    self.case_tag(self.case_tag.previous());
+                }
                 return;
             }
-            if (!caseType) {
-                return gettext("Case Type required");
-            } else if (!caseTag || (self.warn_blank_case_tag() && !toggles.toggleEnabled('ALLOW_BLANK_CASE_TAGS'))) {
-                return gettext("Case Tag required");
+            if (self.case_tag.previous()) {
+                self.warn_blank_case_tag(false);
             }
-            if (!/^[a-zA-Z][\w_-]*(\/[a-zA-Z][\w_-]*)*$/.test(caseTag)) {
-                return gettext("Case Tag: only letters, numbers, '-', and '_' allowed");
+            self.caseConfig.caseConfigViewModel.renameCaseTag(self.case_tag.previous(), tag, true);
+        });
+
+        return self.case_tag;
+    },
+    propertyCounts: function (self) {
+        return function () {
+            var count = {};
+            _(self.case_properties()).each(function (p) {
+                var key = p.key();
+                if (!_.has(count, key)) {
+                    count[key] = 0;
+                }
+                return count[key] += 1;
+            });
+            return count;
+        };
+    },
+    clean_condition: function (condition) {
+        if (condition.type() !== 'if') {
+            condition.question(null);
+            condition.answer(null);
+            condition.operator(null);
+        }
+    },
+    header: function (action) {
+        var nameSnip = "<i class=\"fa fa-tag\"></i> <%- action.case_tag() %> (<%- action.case_type() %>)";
+        var closeSnip = "<% if (action.close_case()) { %> : close<% }%>";
+        var spanSnip = '<span class="text-muted" style="font-weight: normal;">';
+        if (action.actionType === 'open') {
+            return _.template(
+                nameSnip + spanSnip +
+                '<% if (action.parent_tags()) { %> : ' +
+                gettext('subcase of') + '<span style="font-weight: bold;"><%- action.parent_tags() %></span>' +
+                '<% } %>' + closeSnip + "</span>")({
+                action: action,
+            });
+        } else {
+            if (action.auto_select) {
+                nameSnip = "<i class=\"fa fa-tag\"></i> <%- action.case_tag() %> (" + gettext("autoselect mode: ") + "<%- action.auto_select.mode() %>)";
             }
-            var tags = self.caseConfig.caseConfigViewModel.getCaseTags('all');
-            if (_.where(tags, { value: caseTag }).length > 1) {
-                return gettext("Case Tag already in use");
+            if (action.load_case_from_fixture) {
+                nameSnip += gettext(" (from fixture)");
             }
-            return null;
-        },
-        close_case: function (self) {
-            return {
-                read: function () {
-                    if (self.close_condition) {
-                        return self.close_condition.type() !== 'never';
+            return _.template(nameSnip + spanSnip +
+                "<% if (action.hasPreload()) { %> : load<% } %>" +
+                "<% if (action.hasCaseProperties()) { %> : update<% } %>" +
+                closeSnip + "</span>")({
+                action: action,
+            });
+        }
+    },
+    suggestedProperties: function (action, allowParent) {
+        var properties = [];
+        var propertiesMap = action.caseConfig.propertiesMap;
+        var caseType = action.case_type();
+        if (_(propertiesMap).has(caseType)) {
+            properties = _.filter(propertiesMap[caseType](), function (p) {
+                return allowParent ? true : p.indexOf('/') === -1;
+            });
+        }
+        return properties;
+    },
+    relationshipTypes: ['child', 'extension', 'question'],
+};
+
+var loadUpdateAction = {
+    mapping: function (self) {
+        return {
+            include: [
+                'case_type',
+                'details_module',
+                'case_tag',
+                'close_condition',
+                'show_product_stock',
+                'product_program',
+            ],
+            preload: {
+                create: function (options) {
+                    return caseProperties.casePreloadProperty.wrap(options.data, self);
+                },
+            },
+            case_properties: {
+                create: function (options) {
+                    return caseProperties.caseProperty.wrap(options.data, self);
+                },
+            },
+            auto_select: {
+                create: function (options) {
+                    if (options.data) {
+                        return autoSelect.wrap(options.data, self);
                     } else {
-                        return false;
-                    }
-                },
-                write: function (value) {
-                    self.close_condition.type(value ? 'always' : 'never');
-                    self.caseConfig.saveButton.fire('change');
-                },
-            };
-        },
-        case_tag: function (self) {
-            self.case_tag.extend({
-                withPrevious: 1,
-            });
-
-            self.case_tag.subscribe(function (tag) {
-                if (!self.auto_select && !tag) {
-                    // Don't allow user to blank out case tag
-                    self.warn_blank_case_tag(true);
-                    if (!toggles.toggleEnabled('ALLOW_BLANK_CASE_TAGS')) {
-                        self.case_tag(self.case_tag.previous());
-                    }
-                    return;
-                }
-                if (self.case_tag.previous()) {
-                    self.warn_blank_case_tag(false);
-                }
-                self.caseConfig.caseConfigViewModel.renameCaseTag(self.case_tag.previous(), tag, true);
-            });
-
-            return self.case_tag;
-        },
-        propertyCounts: function (self) {
-            return function () {
-                var count = {};
-                _(self.case_properties()).each(function (p) {
-                    var key = p.key();
-                    if (!_.has(count, key)) {
-                        count[key] = 0;
-                    }
-                    return count[key] += 1;
-                });
-                return count;
-            };
-        },
-        clean_condition: function (condition) {
-            if (condition.type() !== 'if') {
-                condition.question(null);
-                condition.answer(null);
-                condition.operator(null);
-            }
-        },
-        header: function (action) {
-            var nameSnip = "<i class=\"fa fa-tag\"></i> <%- action.case_tag() %> (<%- action.case_type() %>)";
-            var closeSnip = "<% if (action.close_case()) { %> : close<% }%>";
-            var spanSnip = '<span class="text-muted" style="font-weight: normal;">';
-            if (action.actionType === 'open') {
-                return _.template(
-                    nameSnip + spanSnip +
-                    '<% if (action.parent_tags()) { %> : ' +
-                    gettext('subcase of') + '<span style="font-weight: bold;"><%- action.parent_tags() %></span>' +
-                    '<% } %>' + closeSnip + "</span>")({
-                    action: action,
-                });
-            } else {
-                if (action.auto_select) {
-                    nameSnip = "<i class=\"fa fa-tag\"></i> <%- action.case_tag() %> (" + gettext("autoselect mode: ") + "<%- action.auto_select.mode() %>)";
-                }
-                if (action.load_case_from_fixture) {
-                    nameSnip += gettext(" (from fixture)");
-                }
-                return _.template(nameSnip + spanSnip +
-                    "<% if (action.hasPreload()) { %> : load<% } %>" +
-                    "<% if (action.hasCaseProperties()) { %> : update<% } %>" +
-                    closeSnip + "</span>")({
-                    action: action,
-                });
-            }
-        },
-        suggestedProperties: function (action, allowParent) {
-            var properties = [];
-            var propertiesMap = action.caseConfig.propertiesMap;
-            var caseType = action.case_type();
-            if (_(propertiesMap).has(caseType)) {
-                properties = _.filter(propertiesMap[caseType](), function (p) {
-                    return allowParent ? true : p.indexOf('/') === -1;
-                });
-            }
-            return properties;
-        },
-        relationshipTypes: ['child', 'extension', 'question'],
-    };
-
-    var loadUpdateAction = {
-        mapping: function (self) {
-            return {
-                include: [
-                    'case_type',
-                    'details_module',
-                    'case_tag',
-                    'close_condition',
-                    'show_product_stock',
-                    'product_program',
-                ],
-                preload: {
-                    create: function (options) {
-                        return caseProperties.casePreloadProperty.wrap(options.data, self);
-                    },
-                },
-                case_properties: {
-                    create: function (options) {
-                        return caseProperties.caseProperty.wrap(options.data, self);
-                    },
-                },
-                auto_select: {
-                    create: function (options) {
-                        if (options.data) {
-                            return autoSelect.wrap(options.data, self);
-                        } else {
-                            return null;
-                        }
-                    },
-                },
-                load_case_from_fixture: {
-                    create: function (options) {
-                        if (options.data) {
-                            return loadCaseFromFixture.wrap(options.data, self);
-                        } else {
-                            return null;
-                        }
-                    },
-                },
-                case_index: {
-                    create: function (options) {
-                        return caseIndex.wrap(options.data);
-                    },
-                },
-            };
-        },
-        wrap: function (data, caseConfig) {
-            var self = {
-                caseConfig: caseConfig,
-                actionType: 'load',
-            };
-            ko.mapping.fromJS(data, loadUpdateAction.mapping(self), self);
-            self.hasPrivilege = true;
-
-            // needed for compatibility with shared templates
-            self.searchAndFilter = false;
-            self.visible_case_properties = ko.computed(function () {
-                return self.case_properties();
-            });
-
-            // for compatibility with common templates
-            // template: case-config:condition
-            self.allow = {
-                repeats: function () {
-                    return false;
-                },
-            };
-
-            self.warn_blank_case_tag = ko.observable(false);
-
-            self.available_modules = ko.computed(function () {
-                return caseConfig.getModulesForCaseType(self.case_type(), self.show_product_stock());
-            });
-
-            if (self.auto_select) {
-                self.auto_select.mode.subscribe(function (value) {
-                    // suggestedProperties need to be those of case type "commcare-user"
-                    if (value === 'usercase') {
-                        self.case_type('commcare-user');
-                    } else {
-                        self.case_type(null);
-                    }
-
-                    _.defer(function () {
-                        $('.hq-help-template').each(function () {
-                            main.transformHelpTemplate($(this), true);
-                        });
-                    });
-                });
-            }
-
-            self.show_product_stock_var = ko.computed({
-                read: function () {
-                    return self.show_product_stock();
-                },
-                write: function (value) {
-                    self.show_product_stock(value);
-                    if (value) {
-                        var newTag = 'case_' + self.case_type();
-                        self.caseConfig.caseConfigViewModel.renameCaseTag(self.case_tag(), newTag);
-                    } else {
-                        self.product_program('');
-                    }
-                },
-            });
-
-            self.subcase = ko.computed({
-                read: function () {
-                    return self.case_index.tag();
-                },
-                write: function (value) {
-                    if (value) {
-                        var index = self.caseConfig.caseConfigViewModel.load_update_cases.indexOf(self);
-                        if (index > 0) {
-                            var parent = self.caseConfig.caseConfigViewModel.load_update_cases()[index - 1];
-                            self.case_index.tag(parent.case_tag());
-                        }
-                    } else {
-                        self.case_index.tag('');
-                    }
-                },
-            });
-
-            self.case_tag = actionBase.case_tag(self);
-
-            self.close_case = ko.computed(actionBase.close_case(self));
-
-            self.validate = ko.computed(function () {
-                if (self.auto_select) {
-                    var mode = self.auto_select.mode();
-                    var valueSource = self.auto_select.value_source();
-                    var valueKey = self.auto_select.value_key();
-                    if (!mode) {
-                        return gettext("Autoselect mode required");
-                    } else if (!valueKey && mode !== 'usercase') {
-                        return gettext('Property required');
-                    } else if (!valueSource) {
-                        if (mode === 'case') {
-                            return gettext('Case required');
-                        } else if (mode === 'fixture') {
-                            return gettext('Lookup table tag required');
-                        }
-                    }
-                    if (!self.case_type()) {
-                        return gettext('Expected case type required');
-                    }
-                    return null;
-                } else {
-                    return actionBase.validate(self, self.case_type(), self.case_tag());
-                }
-            });
-
-            // for compatibility with common templates
-            self.case_preload = ko.computed(function () {
-                return self.preload();
-            });
-
-            self.propertyCounts = ko.computed(actionBase.propertyCounts(self));
-
-            self.preloadCounts = ko.computed(function () {
-                var count = {};
-                _(self.preload()).each(function (p) {
-                    var path = p.path();
-                    if (!_.has(count, path)) {
-                        count[path] = 0;
-                    }
-                    return count[path] += 1;
-                });
-                return count;
-            });
-
-            self.suggestedProperties = ko.computed(function () {
-                return actionBase.suggestedProperties(self, !self.subcase());
-            });
-
-            self.addProperty = function () {
-                self.case_properties.push(caseProperties.caseProperty.wrap({
-                    key: '',
-                    path: '',
-                    required: false,
-                }, self));
-            };
-
-            self.removeProperty = function (property) {
-                self.case_properties.remove(property);
-                self.caseConfig.saveButton.fire('change');
-            };
-
-            self.addPreload = function () {
-                self.preload.push(caseProperties.casePreloadProperty.wrap({
-                    key: '',
-                    path: '',
-                    required: false,
-                }, self));
-            };
-
-            self.removePreload = function (property) {
-                self.preload.remove(property);
-                self.caseConfig.saveButton.fire('change');
-            };
-
-            self.hasPreload = function () {
-                return _.find(self.preload(), function (prop) {
-                    return !prop.isBlank();
-                });
-            };
-
-            self.hasCaseProperties = function () {
-                return _.find(self.case_properties(), function (prop) {
-                    return !prop.isBlank();
-                });
-            };
-
-            self.header = ko.computed(function () {
-                return actionBase.header(self);
-            });
-
-            self.relationshipTypes = actionBase.relationshipTypes;
-
-            var addCircular = function () {
-                // hacky way to prevent trying to access caseConfigViewModel before it is defined
-                self.allow_product_stock = ko.computed(function () {
-                    var supported = self.caseConfig.case_supports_products(self.case_type());
-                    var loadupdatecases = self.caseConfig.caseConfigViewModel.load_update_cases;
-                    return supported && loadupdatecases.indexOf(self) === loadupdatecases().length - 1;
-                });
-
-                self.disable_tag = ko.computed(function () {
-                    return self.show_product_stock() && self.allow_product_stock();
-                });
-
-                self.auto_select_modes = ko.computed(function () {
-                    return caseConfig.getAutoSelectModes(self);
-                });
-                self.validate_subcase = ko.computed(function () {
-                    if (!self.caseConfig.caseConfigViewModel) {
-                        return;
-                    }
-                    if (!self.case_index.tag()) {
                         return null;
                     }
-                    var parent = self.caseConfig.caseConfigViewModel.getActionFromTag(self.case_index.tag());
+                },
+            },
+            load_case_from_fixture: {
+                create: function (options) {
+                    if (options.data) {
+                        return loadCaseFromFixture.wrap(options.data, self);
+                    } else {
+                        return null;
+                    }
+                },
+            },
+            case_index: {
+                create: function (options) {
+                    return caseIndex.wrap(options.data);
+                },
+            },
+        };
+    },
+    wrap: function (data, caseConfig) {
+        var self = {
+            caseConfig: caseConfig,
+            actionType: 'load',
+        };
+        ko.mapping.fromJS(data, loadUpdateAction.mapping(self), self);
+        self.hasPrivilege = true;
+
+        // needed for compatibility with shared templates
+        self.searchAndFilter = false;
+        self.visible_case_properties = ko.computed(function () {
+            return self.case_properties();
+        });
+
+        // for compatibility with common templates
+        // template: case-config:condition
+        self.allow = {
+            repeats: function () {
+                return false;
+            },
+        };
+
+        self.warn_blank_case_tag = ko.observable(false);
+
+        self.available_modules = ko.computed(function () {
+            return caseConfig.getModulesForCaseType(self.case_type(), self.show_product_stock());
+        });
+
+        if (self.auto_select) {
+            self.auto_select.mode.subscribe(function (value) {
+                // suggestedProperties need to be those of case type "commcare-user"
+                if (value === 'usercase') {
+                    self.case_type('commcare-user');
+                } else {
+                    self.case_type(null);
+                }
+
+                _.defer(function () {
+                    $('.hq-help-template').each(function () {
+                        main.transformHelpTemplate($(this), true);
+                    });
+                });
+            });
+        }
+
+        self.show_product_stock_var = ko.computed({
+            read: function () {
+                return self.show_product_stock();
+            },
+            write: function (value) {
+                self.show_product_stock(value);
+                if (value) {
+                    var newTag = 'case_' + self.case_type();
+                    self.caseConfig.caseConfigViewModel.renameCaseTag(self.case_tag(), newTag);
+                } else {
+                    self.product_program('');
+                }
+            },
+        });
+
+        self.subcase = ko.computed({
+            read: function () {
+                return self.case_index.tag();
+            },
+            write: function (value) {
+                if (value) {
+                    var index = self.caseConfig.caseConfigViewModel.load_update_cases.indexOf(self);
+                    if (index > 0) {
+                        var parent = self.caseConfig.caseConfigViewModel.load_update_cases()[index - 1];
+                        self.case_index.tag(parent.case_tag());
+                    }
+                } else {
+                    self.case_index.tag('');
+                }
+            },
+        });
+
+        self.case_tag = actionBase.case_tag(self);
+
+        self.close_case = ko.computed(actionBase.close_case(self));
+
+        self.validate = ko.computed(function () {
+            if (self.auto_select) {
+                var mode = self.auto_select.mode();
+                var valueSource = self.auto_select.value_source();
+                var valueKey = self.auto_select.value_key();
+                if (!mode) {
+                    return gettext("Autoselect mode required");
+                } else if (!valueKey && mode !== 'usercase') {
+                    return gettext('Property required');
+                } else if (!valueSource) {
+                    if (mode === 'case') {
+                        return gettext('Case required');
+                    } else if (mode === 'fixture') {
+                        return gettext('Lookup table tag required');
+                    }
+                }
+                if (!self.case_type()) {
+                    return gettext('Expected case type required');
+                }
+                return null;
+            } else {
+                return actionBase.validate(self, self.case_type(), self.case_tag());
+            }
+        });
+
+        // for compatibility with common templates
+        self.case_preload = ko.computed(function () {
+            return self.preload();
+        });
+
+        self.propertyCounts = ko.computed(actionBase.propertyCounts(self));
+
+        self.preloadCounts = ko.computed(function () {
+            var count = {};
+            _(self.preload()).each(function (p) {
+                var path = p.path();
+                if (!_.has(count, path)) {
+                    count[path] = 0;
+                }
+                return count[path] += 1;
+            });
+            return count;
+        });
+
+        self.suggestedProperties = ko.computed(function () {
+            return actionBase.suggestedProperties(self, !self.subcase());
+        });
+
+        self.addProperty = function () {
+            self.case_properties.push(caseProperties.caseProperty.wrap({
+                key: '',
+                path: '',
+                required: false,
+            }, self));
+        };
+
+        self.removeProperty = function (property) {
+            self.case_properties.remove(property);
+            self.caseConfig.saveButton.fire('change');
+        };
+
+        self.addPreload = function () {
+            self.preload.push(caseProperties.casePreloadProperty.wrap({
+                key: '',
+                path: '',
+                required: false,
+            }, self));
+        };
+
+        self.removePreload = function (property) {
+            self.preload.remove(property);
+            self.caseConfig.saveButton.fire('change');
+        };
+
+        self.hasPreload = function () {
+            return _.find(self.preload(), function (prop) {
+                return !prop.isBlank();
+            });
+        };
+
+        self.hasCaseProperties = function () {
+            return _.find(self.case_properties(), function (prop) {
+                return !prop.isBlank();
+            });
+        };
+
+        self.header = ko.computed(function () {
+            return actionBase.header(self);
+        });
+
+        self.relationshipTypes = actionBase.relationshipTypes;
+
+        var addCircular = function () {
+            // hacky way to prevent trying to access caseConfigViewModel before it is defined
+            self.allow_product_stock = ko.computed(function () {
+                var supported = self.caseConfig.case_supports_products(self.case_type());
+                var loadupdatecases = self.caseConfig.caseConfigViewModel.load_update_cases;
+                return supported && loadupdatecases.indexOf(self) === loadupdatecases().length - 1;
+            });
+
+            self.disable_tag = ko.computed(function () {
+                return self.show_product_stock() && self.allow_product_stock();
+            });
+
+            self.auto_select_modes = ko.computed(function () {
+                return caseConfig.getAutoSelectModes(self);
+            });
+            self.validate_subcase = ko.computed(function () {
+                if (!self.caseConfig.caseConfigViewModel) {
+                    return;
+                }
+                if (!self.case_index.tag()) {
+                    return null;
+                }
+                var parent = self.caseConfig.caseConfigViewModel.getActionFromTag(self.case_index.tag());
+                if (!parent) {
+                    return gettext("Subcase parent reference is missing");
+                } else if (!self.case_index.reference_id()) {
+                    return gettext('Parent reference ID required for subcases: ') + self.case_index.tag();
+                } else if (parent.actionType === 'open') {
+                    if (!parent.repeat_context()) {
+                        return null;
+                    } else if (!self.repeat_context() ||
+                        // manual string startsWith
+                        self.repeat_context().lastIndexOf(parent.repeat_context(), 0) === 0) {
+                        return gettext('Subcase must be in same repeat context as parent "') + self.case_index.tag() + '".';
+                    }
+                }
+                return null;
+
+            });
+
+            self.moveable = ko.computed(function () {
+                // load / update case actions implicitly depend on the previously defined
+                // case when a subcase relationship is defined because of this implicit
+                // relationship, we do not support moving their position in the case management screen
+
+                if (!self.caseConfig.caseConfigViewModel) {
+                    // The view model hasn't been initialized meaning there are no case actions defined
+                    // If no case actions are defined, we can't have a parent reference
+                    return true;
+                }
+                if (self.subcase()) {
+                    // this action has the subcase of a previous case checked
+                    return false;
+                }
+
+                var loadActions = self.caseConfig.caseConfigViewModel.load_update_cases(),
+                    foundSelf = false,
+                    nextAction = _.find(loadActions, function (action) {
+                        if (foundSelf) {
+                            return true;
+                        }
+                        if (action.case_tag() === self.case_tag()) {
+                            foundSelf = true;
+                        }
+                    });
+
+                if (nextAction) {
+                    // if the action following the action defined by self is using a subcase, it cannot be moved
+                    return !nextAction.subcase();
+                }
+                return true;
+            });
+        };
+
+        if (!self.caseConfig.caseConfigViewModel) {
+            _.delay(addCircular);
+        } else {
+            addCircular();
+        }
+
+        // needed for compatibility with shared templates
+        self.searchAndFilter = false;
+        self.visible_case_properties = ko.computed(function () {
+            return self.case_properties();
+        });
+        self.saveOnlyEditedFormFieldsEnabled = toggles.toggleEnabled("SAVE_ONLY_EDITED_FORM_FIELDS");
+
+        self.hasDeprecatedProperties = ko.computed(function () {
+            if (privileges.hasPrivilege('data_dictionary')) {
+                for (const p of self.case_properties()) {
+                    if (p.isDeprecated()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        });
+
+        return self;
+    },
+    unwrap: function (self) {
+        var blank = function (prop) {
+            return prop.isBlank();
+        };
+        self.preload.remove(blank);
+        self.case_properties.remove(blank);
+        actionBase.clean_condition(self.close_condition);
+        self.show_product_stock(self.disable_tag());
+        var action = ko.mapping.toJS(self, loadUpdateAction.mapping(self));
+
+        action.preload = caseConfigUtils.preloadArrayToDict(action.preload);
+        action.case_properties = caseConfigUtils.propertyArrayToDict([], action.case_properties)[0];
+        return action;
+    },
+};
+
+var openCaseAction = {
+    mapping: function (self) {
+        return {
+            include: [
+                'case_type',
+                'name_update',
+                'case_tag',
+                'open_condition',
+                'close_condition',
+            ],
+            case_properties: {
+                create: function (options) {
+                    return caseProperties.caseProperty.wrap(options.data, self);
+                },
+            },
+            case_indices: {
+                create: function (options) {
+                    return caseIndex.wrap(options.data, self);
+                },
+            },
+        };
+    },
+    wrap: function (data, caseConfig) {
+        var self = {
+            caseConfig: caseConfig,
+            actionType: 'open',
+        };
+        ko.mapping.fromJS(data, openCaseAction.mapping(self), self);
+        self.hasPrivilege = true;
+
+        // for compatibility with common templates
+        // template: case-config:condition
+        self.allow = {
+            repeats: function () {
+                return true;
+            },
+        };
+
+        self.warn_blank_case_tag = ko.observable(false);
+
+        self.disable_tag = ko.computed(function () {
+            return false;
+        });
+
+        self.suggestedProperties = ko.computed(function () {
+            return caseConfigUtils.filteredSuggestedProperties(
+                actionBase.suggestedProperties(self, false),
+                self.case_properties(),
+            );
+        });
+
+        self.validate = ko.computed(function () {
+            return actionBase.validate(self, self.case_type(), self.case_tag());
+        });
+
+        self.parent_tags = function () {
+            var tags = [];
+            for (var i = 0; i < self.case_indices().length; i++) {
+                tags.push(self.case_indices()[i].tag());
+            }
+            return tags.join(', ');
+        };
+
+        self.subcase = ko.computed({
+            read: function () {
+                return (self.case_indices().length > 0);
+            },
+            write: function (value) {
+                if (value) {
+                    self.case_indices.push(caseIndex.wrap({
+                        tag: gettext('Select parent'),
+                        reference_id: 'parent',
+                        relationship: 'child',
+                        relationship_question: '',
+                    }));
+                } else {
+                    self.case_indices.removeAll();
+                }
+            },
+        });
+
+        self.addCaseIndex = function () {
+            /**
+             * Copy newCaseIndex form values, and push them to parents array.
+             *
+             * Reference in 'data-bind="with: newCaseIndex"' does not change, so
+             * we need to copy values to another instance, and then reset the
+             * values in the form.
+             */
+            self.case_indices.push(caseIndex.wrap({
+                tag: '',
+                reference_id: 'parent',
+                relationship: 'child',
+                relationship_question: '',
+            }));
+        };
+
+        self.removeCaseIndex = function (viewModel) {
+            self.case_indices.remove(viewModel);
+        };
+
+        self.case_tag = actionBase.case_tag(self);
+
+        self.close_case = ko.computed(actionBase.close_case(self));
+
+        self.header = ko.computed(function () {
+            return actionBase.header(self);
+        });
+
+        self.propertyCounts = ko.computed(actionBase.propertyCounts(self));
+
+        self.name_update = ko.computed(function () {
+            try {
+                return _(self.case_properties()).find(function (p) {
+                    return p.key() === 'name' && p.required();
+                }).path();
+            } catch (e) {
+                return null;
+            }
+        });
+
+        self.repeat_context = function () {
+            return self.caseConfig.get_repeat_context(self.name_update());
+        };
+
+        self.addProperty = function () {
+            self.case_properties.push(caseProperties.caseProperty.wrap({
+                key: '',
+                path: '',
+                required: false,
+            }, self));
+        };
+
+        self.removeProperty = function (property) {
+            self.case_properties.remove(property);
+            self.caseConfig.saveButton.fire('change');
+        };
+
+        self.relationshipTypes = actionBase.relationshipTypes;
+
+        self.moveable = ko.computed(function () {
+            // open case actions are always moveable as they explicitly define their case tags
+            // instead of relying on the previously defined case action
+            return true;
+        });
+
+        var addCircular = function () {
+            self.allow_subcase = ko.computed(function () {
+                return self.case_indices || self.caseConfig.caseConfigViewModel.getCaseTags('subcase', self).length > 0;
+            });
+            self.validate_subcase = ko.computed(function () {
+                if (!self.caseConfig.caseConfigViewModel) {
+                    return;
+                }
+                if (!self.case_indices) {
+                    return null;
+                }
+                for (var i = 0; i < self.case_indices.length; i++) {
+                    var caseIndex = self.case_indices[i];
+                    var parent = self.caseConfig.caseConfigViewModel.getActionFromTag(caseIndex.tag());
                     if (!parent) {
                         return gettext("Subcase parent reference is missing");
-                    } else if (!self.case_index.reference_id()) {
-                        return gettext('Parent reference ID required for subcases: ') + self.case_index.tag();
+                    } else if (!caseIndex.reference_id()) {
+                        return gettext('Parent reference ID required for subcases: ') + caseIndex.tag();
                     } else if (parent.actionType === 'open') {
                         if (!parent.repeat_context()) {
                             return null;
                         } else if (!self.repeat_context() ||
                             // manual string startsWith
                             self.repeat_context().lastIndexOf(parent.repeat_context(), 0) === 0) {
-                            return gettext('Subcase must be in same repeat context as parent "') + self.case_index.tag() + '".';
+                            return gettext('Subcase must be in same repeat context as parent "') + caseIndex.tag() + '".';
                         }
-                    }
-                    return null;
-
-                });
-
-                self.moveable = ko.computed(function () {
-                    // load / update case actions implicitly depend on the previously defined
-                    // case when a subcase relationship is defined because of this implicit
-                    // relationship, we do not support moving their position in the case management screen
-
-                    if (!self.caseConfig.caseConfigViewModel) {
-                        // The view model hasn't been initialized meaning there are no case actions defined
-                        // If no case actions are defined, we can't have a parent reference
-                        return true;
-                    }
-                    if (self.subcase()) {
-                        // this action has the subcase of a previous case checked
-                        return false;
-                    }
-
-                    var loadActions = self.caseConfig.caseConfigViewModel.load_update_cases(),
-                        foundSelf = false,
-                        nextAction = _.find(loadActions, function (action) {
-                            if (foundSelf) {
-                                return true;
-                            }
-                            if (action.case_tag() === self.case_tag()) {
-                                foundSelf = true;
-                            }
-                        });
-
-                    if (nextAction) {
-                        // if the action following the action defined by self is using a subcase, it cannot be moved
-                        return !nextAction.subcase();
-                    }
-                    return true;
-                });
-            };
-
-            if (!self.caseConfig.caseConfigViewModel) {
-                _.delay(addCircular);
-            } else {
-                addCircular();
-            }
-
-            // needed for compatibility with shared templates
-            self.searchAndFilter = false;
-            self.visible_case_properties = ko.computed(function () {
-                return self.case_properties();
-            });
-            self.saveOnlyEditedFormFieldsEnabled = toggles.toggleEnabled("SAVE_ONLY_EDITED_FORM_FIELDS");
-
-            self.hasDeprecatedProperties = ko.computed(function () {
-                if (privileges.hasPrivilege('data_dictionary')) {
-                    for (const p of self.case_properties()) {
-                        if (p.isDeprecated()) {
-                            return true;
-                        }
-                    }
-                }
-                return false;
-            });
-
-            return self;
-        },
-        unwrap: function (self) {
-            var blank = function (prop) {
-                return prop.isBlank();
-            };
-            self.preload.remove(blank);
-            self.case_properties.remove(blank);
-            actionBase.clean_condition(self.close_condition);
-            self.show_product_stock(self.disable_tag());
-            var action = ko.mapping.toJS(self, loadUpdateAction.mapping(self));
-
-            action.preload = caseConfigUtils.preloadArrayToDict(action.preload);
-            action.case_properties = caseConfigUtils.propertyArrayToDict([], action.case_properties)[0];
-            return action;
-        },
-    };
-
-    var openCaseAction = {
-        mapping: function (self) {
-            return {
-                include: [
-                    'case_type',
-                    'name_update',
-                    'case_tag',
-                    'open_condition',
-                    'close_condition',
-                ],
-                case_properties: {
-                    create: function (options) {
-                        return caseProperties.caseProperty.wrap(options.data, self);
-                    },
-                },
-                case_indices: {
-                    create: function (options) {
-                        return caseIndex.wrap(options.data, self);
-                    },
-                },
-            };
-        },
-        wrap: function (data, caseConfig) {
-            var self = {
-                caseConfig: caseConfig,
-                actionType: 'open',
-            };
-            ko.mapping.fromJS(data, openCaseAction.mapping(self), self);
-            self.hasPrivilege = true;
-
-            // for compatibility with common templates
-            // template: case-config:condition
-            self.allow = {
-                repeats: function () {
-                    return true;
-                },
-            };
-
-            self.warn_blank_case_tag = ko.observable(false);
-
-            self.disable_tag = ko.computed(function () {
-                return false;
-            });
-
-            self.suggestedProperties = ko.computed(function () {
-                return caseConfigUtils.filteredSuggestedProperties(
-                    actionBase.suggestedProperties(self, false),
-                    self.case_properties(),
-                );
-            });
-
-            self.validate = ko.computed(function () {
-                return actionBase.validate(self, self.case_type(), self.case_tag());
-            });
-
-            self.parent_tags = function () {
-                var tags = [];
-                for (var i = 0; i < self.case_indices().length; i++) {
-                    tags.push(self.case_indices()[i].tag());
-                }
-                return tags.join(', ');
-            };
-
-            self.subcase = ko.computed({
-                read: function () {
-                    return (self.case_indices().length > 0);
-                },
-                write: function (value) {
-                    if (value) {
-                        self.case_indices.push(caseIndex.wrap({
-                            tag: gettext('Select parent'),
-                            reference_id: 'parent',
-                            relationship: 'child',
-                            relationship_question: '',
-                        }));
-                    } else {
-                        self.case_indices.removeAll();
-                    }
-                },
-            });
-
-            self.addCaseIndex = function () {
-                /**
-                 * Copy newCaseIndex form values, and push them to parents array.
-                 *
-                 * Reference in 'data-bind="with: newCaseIndex"' does not change, so
-                 * we need to copy values to another instance, and then reset the
-                 * values in the form.
-                 */
-                self.case_indices.push(caseIndex.wrap({
-                    tag: '',
-                    reference_id: 'parent',
-                    relationship: 'child',
-                    relationship_question: '',
-                }));
-            };
-
-            self.removeCaseIndex = function (viewModel) {
-                self.case_indices.remove(viewModel);
-            };
-
-            self.case_tag = actionBase.case_tag(self);
-
-            self.close_case = ko.computed(actionBase.close_case(self));
-
-            self.header = ko.computed(function () {
-                return actionBase.header(self);
-            });
-
-            self.propertyCounts = ko.computed(actionBase.propertyCounts(self));
-
-            self.name_update = ko.computed(function () {
-                try {
-                    return _(self.case_properties()).find(function (p) {
-                        return p.key() === 'name' && p.required();
-                    }).path();
-                } catch (e) {
-                    return null;
-                }
-            });
-
-            self.repeat_context = function () {
-                return self.caseConfig.get_repeat_context(self.name_update());
-            };
-
-            self.addProperty = function () {
-                self.case_properties.push(caseProperties.caseProperty.wrap({
-                    key: '',
-                    path: '',
-                    required: false,
-                }, self));
-            };
-
-            self.removeProperty = function (property) {
-                self.case_properties.remove(property);
-                self.caseConfig.saveButton.fire('change');
-            };
-
-            self.relationshipTypes = actionBase.relationshipTypes;
-
-            self.moveable = ko.computed(function () {
-                // open case actions are always moveable as they explicitly define their case tags
-                // instead of relying on the previously defined case action
-                return true;
-            });
-
-            var addCircular = function () {
-                self.allow_subcase = ko.computed(function () {
-                    return self.case_indices || self.caseConfig.caseConfigViewModel.getCaseTags('subcase', self).length > 0;
-                });
-                self.validate_subcase = ko.computed(function () {
-                    if (!self.caseConfig.caseConfigViewModel) {
-                        return;
-                    }
-                    if (!self.case_indices) {
-                        return null;
-                    }
-                    for (var i = 0; i < self.case_indices.length; i++) {
-                        var caseIndex = self.case_indices[i];
-                        var parent = self.caseConfig.caseConfigViewModel.getActionFromTag(caseIndex.tag());
-                        if (!parent) {
-                            return gettext("Subcase parent reference is missing");
-                        } else if (!caseIndex.reference_id()) {
-                            return gettext('Parent reference ID required for subcases: ') + caseIndex.tag();
-                        } else if (parent.actionType === 'open') {
-                            if (!parent.repeat_context()) {
-                                return null;
-                            } else if (!self.repeat_context() ||
-                                // manual string startsWith
-                                self.repeat_context().lastIndexOf(parent.repeat_context(), 0) === 0) {
-                                return gettext('Subcase must be in same repeat context as parent "') + caseIndex.tag() + '".';
-                            }
-                        }
-                    }
-                    return null;
-                });
-            };
-            // hacky way to prevent trying to access caseConfigViewModel before it is defined
-            if (!self.caseConfig.caseConfigViewModel) {
-                _.delay(addCircular);
-            } else {
-                addCircular();
-            }
-
-            // needed for compatibility with shared templates
-            self.searchAndFilter = false;
-            self.visible_case_properties = ko.computed(function () {
-                return self.case_properties();
-            });
-            self.saveOnlyEditedFormFieldsEnabled = toggles.toggleEnabled("SAVE_ONLY_EDITED_FORM_FIELDS");
-
-            self.hasDeprecatedProperties = ko.computed(function () {
-                if (privileges.hasPrivilege('data_dictionary')) {
-                    for (const p of self.case_properties()) {
-                        if (p.isDeprecated()) {
-                            return true;
-                        }
-                    }
-                }
-                return false;
-            });
-
-            return self;
-        },
-        unwrap: function (self) {
-            self.case_properties.remove(function (prop) {
-                return prop.isBlank();
-            });
-            if (self.case_indices().length > 0 && !self.allow_subcase()) {
-                self.case_indices.removeAll();
-            }
-            actionBase.clean_condition(self.open_condition);
-            actionBase.clean_condition(self.close_condition);
-            var action = ko.mapping.toJS(self, openCaseAction.mapping(self));
-            var x = caseConfigUtils.propertyArrayToDict(['name'], action.case_properties);
-            action.case_properties = x[0];
-            action.name_update = x[1].name;
-            action.repeat_context = self.repeat_context();
-            return action;
-        },
-    };
-
-    var autoSelect = {
-        mapping: {
-            include: ['mode', 'value_source', 'value_key'],
-        },
-        wrap: function (data, action) {
-            var self = ko.mapping.fromJS(data, autoSelect.mapping);
-            self.action = action;
-            self.isBlank = ko.computed(function () {
-                return !self.value_source() && !self.value_key();
-            });
-
-            self.mode.subscribe(function () {
-                self.value_source('');
-                self.value_key('');
-            });
-            return self;
-        },
-    };
-
-    var loadCaseFromFixture = {
-        mapping: {
-            include: [
-                'fixture_nodeset',
-                'fixture_tag',
-                'fixture_variable',
-                'auto_select_fixture',
-                'case_property',
-                'auto_select',
-                'arbitrary_datum_id',
-                'arbitrary_datum_function',
-            ],
-        },
-        wrap: function (data, action) {
-            var self = _.extend({}, action, ko.mapping.fromJS(data, loadCaseFromFixture.mapping));
-            self.isBlank = ko.computed(function () {
-                return !self.fixture_nodeset() &&
-                    !self.fixture_tag() &&
-                    !self.fixture_variable() &&
-                    !self.case_property() &&
-                    !self.auto_select();
-            });
-
-            self.validate = ko.computed(function () {
-                var caseType = self.case_type,
-                    caseTag = self.case_tag;
-                if (!self.caseConfig.caseConfigViewModel) {
-                    return;
-                }
-                if (!caseType) {
-                    return gettext("Case Type required");
-                }
-                if (caseTag) {
-                    if (!/^[a-zA-Z][\w_-]*(\/[a-zA-Z][\w_-]*)*$/.test(caseTag)) {
-                        return gettext("Case Tag: only letters, numbers, '-', and '_' allowed");
-                    }
-                    var tags = self.caseConfig.caseConfigViewModel.getCaseTags('all');
-                    if (_.where(tags, { value: caseTag }).length > 1) {
-                        return gettext("Case Tag already in use");
                     }
                 }
                 return null;
             });
+        };
+        // hacky way to prevent trying to access caseConfigViewModel before it is defined
+        if (!self.caseConfig.caseConfigViewModel) {
+            _.delay(addCircular);
+        } else {
+            addCircular();
+        }
 
-            return self;
-        },
-    };
+        // needed for compatibility with shared templates
+        self.searchAndFilter = false;
+        self.visible_case_properties = ko.computed(function () {
+            return self.case_properties();
+        });
+        self.saveOnlyEditedFormFieldsEnabled = toggles.toggleEnabled("SAVE_ONLY_EDITED_FORM_FIELDS");
 
-    return {
-        loadUpdateAction: loadUpdateAction,
-        openCaseAction: openCaseAction,
-    };
-});
+        self.hasDeprecatedProperties = ko.computed(function () {
+            if (privileges.hasPrivilege('data_dictionary')) {
+                for (const p of self.case_properties()) {
+                    if (p.isDeprecated()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        });
+
+        return self;
+    },
+    unwrap: function (self) {
+        self.case_properties.remove(function (prop) {
+            return prop.isBlank();
+        });
+        if (self.case_indices().length > 0 && !self.allow_subcase()) {
+            self.case_indices.removeAll();
+        }
+        actionBase.clean_condition(self.open_condition);
+        actionBase.clean_condition(self.close_condition);
+        var action = ko.mapping.toJS(self, openCaseAction.mapping(self));
+        var x = caseConfigUtils.propertyArrayToDict(['name'], action.case_properties);
+        action.case_properties = x[0];
+        action.name_update = x[1].name;
+        action.repeat_context = self.repeat_context();
+        return action;
+    },
+};
+
+var autoSelect = {
+    mapping: {
+        include: ['mode', 'value_source', 'value_key'],
+    },
+    wrap: function (data, action) {
+        var self = ko.mapping.fromJS(data, autoSelect.mapping);
+        self.action = action;
+        self.isBlank = ko.computed(function () {
+            return !self.value_source() && !self.value_key();
+        });
+
+        self.mode.subscribe(function () {
+            self.value_source('');
+            self.value_key('');
+        });
+        return self;
+    },
+};
+
+var loadCaseFromFixture = {
+    mapping: {
+        include: [
+            'fixture_nodeset',
+            'fixture_tag',
+            'fixture_variable',
+            'auto_select_fixture',
+            'case_property',
+            'auto_select',
+            'arbitrary_datum_id',
+            'arbitrary_datum_function',
+        ],
+    },
+    wrap: function (data, action) {
+        var self = _.extend({}, action, ko.mapping.fromJS(data, loadCaseFromFixture.mapping));
+        self.isBlank = ko.computed(function () {
+            return !self.fixture_nodeset() &&
+                !self.fixture_tag() &&
+                !self.fixture_variable() &&
+                !self.case_property() &&
+                !self.auto_select();
+        });
+
+        self.validate = ko.computed(function () {
+            var caseType = self.case_type,
+                caseTag = self.case_tag;
+            if (!self.caseConfig.caseConfigViewModel) {
+                return;
+            }
+            if (!caseType) {
+                return gettext("Case Type required");
+            }
+            if (caseTag) {
+                if (!/^[a-zA-Z][\w_-]*(\/[a-zA-Z][\w_-]*)*$/.test(caseTag)) {
+                    return gettext("Case Tag: only letters, numbers, '-', and '_' allowed");
+                }
+                var tags = self.caseConfig.caseConfigViewModel.getCaseTags('all');
+                if (_.where(tags, { value: caseTag }).length > 1) {
+                    return gettext("Case Tag already in use");
+                }
+            }
+            return null;
+        });
+
+        return self;
+    },
+};
+
+export default {
+    loadUpdateAction: loadUpdateAction,
+    openCaseAction: openCaseAction,
+};

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
@@ -1,514 +1,500 @@
-hqDefine("app_manager/js/forms/advanced/case_config_ui", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "app_manager/js/case_config_utils",
-    "app_manager/js/forms/advanced/case_properties",
-    "app_manager/js/forms/advanced/actions",
-    "analytix/js/google",
-    "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/bootstrap3/main",
-    "app_manager/js/app_manager",
-    "app_manager/js/visit_scheduler",
-], function (
-    $,
-    ko,
-    _,
-    caseConfigUtils,
-    casePropertiesModels,
-    actions,
-    google,
-    initialPageData,
-    main,
-    appManager,
-    visitSchedulerModel,
-) {
-    $(function () {
-        if (initialPageData.get('module_doc_type') !== "AdvancedModule") {
-            return;
-        }
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import caseConfigUtils from "app_manager/js/case_config_utils";
+import casePropertiesModels from "app_manager/js/forms/advanced/case_properties";
+import actions from "app_manager/js/forms/advanced/actions";
+import google from "analytix/js/google";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import main from "hqwebapp/js/bootstrap3/main";
+import appManager from "app_manager/js/app_manager";
+import visitSchedulerModel from "app_manager/js/visit_scheduler";
 
-        var DEFAULT_CONDITION = function (type) {
-            return {
-                type: type,
-                question: null,
-                answer: null,
-                operator: null,
-            };
+$(function () {
+    if (initialPageData.get('module_doc_type') !== "AdvancedModule") {
+        return;
+    }
+
+    var DEFAULT_CONDITION = function (type) {
+        return {
+            type: type,
+            question: null,
+            answer: null,
+            operator: null,
+        };
+    };
+
+    var CaseConfig = function (params) {
+        var self = {};
+        self.trackGoogleEvent = function () {
+            google.track.event(...arguments);
         };
 
-        var CaseConfig = function (params) {
-            var self = {};
-            self.trackGoogleEvent = function () {
-                google.track.event(...arguments);
-            };
-
-            self.makePopover = function () {
-                $('.property-description').closest('.read-only').popover({
-                    'trigger': 'hover',
-                    'placement': 'bottom',
-                    'sanitize': false,
-                });
-            };
-
-            self.home = params.home;
-            self.questions = ko.observable(params.questions);
-            self.save_url = params.save_url;
-            self.caseType = params.caseType;
-            self.module_id = params.module_id;
-            self.reserved_words = params.reserved_words;
-            self.moduleCaseTypes = params.moduleCaseTypes;
-            // `requires` is a ko observable so it can be read by another UI
-            self.requires = params.requires;
-            self.commtrack = params.commtrack_enabled;
-            self.programs = params.commtrack_programs;
-            self.isShadowForm = params.isShadowForm;
-
-            self.setPropertiesMap = function (propertiesMap) {
-                self.propertiesMap = ko.mapping.fromJS(propertiesMap);
-            };
-            self.setPropertiesMap(params.propertiesMap);
-
-            self.descriptionDict = params.propertyDescriptions;
-            self.deprecatedPropertiesDict = params.deprecatedProperties;
-
-            self.saveButton = main.initSaveButton({
-                unsavedMessage: "You have unchanged case settings",
-                save: function () {
-                    var actions = JSON.stringify(self.caseConfigViewModel.unwrap());
-                    self.saveButton.ajax({
-                        type: 'post',
-                        url: self.save_url,
-                        data: {
-                            actions: actions,
-                            arbitrary_datums: ko.mapping.toJSON(self.caseConfigViewModel.arbitrary_datums),
-                        },
-                        dataType: 'json',
-                        success: function (data) {
-                            appManager.updateDOM(data.update);
-                            self.setPropertiesMap(data.propertiesMap);
-                            self.requires(self.caseConfigViewModel.load_update_cases().length > 0 ? 'case' : 'none');
-                        },
-                    });
-                },
+        self.makePopover = function () {
+            $('.property-description').closest('.read-only').popover({
+                'trigger': 'hover',
+                'placement': 'bottom',
+                'sanitize': false,
             });
+        };
 
-            var questionScores = {};
-            _(self.questions()).each(function (question, i) {
-                questionScores[question.value] = i;
-            });
-            self.questionScores = questionScores;
+        self.home = params.home;
+        self.questions = ko.observable(params.questions);
+        self.save_url = params.save_url;
+        self.caseType = params.caseType;
+        self.module_id = params.module_id;
+        self.reserved_words = params.reserved_words;
+        self.moduleCaseTypes = params.moduleCaseTypes;
+        // `requires` is a ko observable so it can be read by another UI
+        self.requires = params.requires;
+        self.commtrack = params.commtrack_enabled;
+        self.programs = params.commtrack_programs;
+        self.isShadowForm = params.isShadowForm;
 
-            self.caseTypes = _.unique(_(self.moduleCaseTypes).map(function (moduleCaseType) {
-                return moduleCaseType.case_type;
-            }));
+        self.setPropertiesMap = function (propertiesMap) {
+            self.propertiesMap = ko.mapping.fromJS(propertiesMap);
+        };
+        self.setPropertiesMap(params.propertiesMap);
 
-            self.getAutoSelectModes = function (action) {
-                var index = self.caseConfigViewModel.load_update_cases.indexOf(action);
-                var modes = [{
-                    label: gettext('Raw'),
-                    value: 'raw',
-                }, {
-                    label: gettext('User Data'),
-                    value: 'user',
-                }, {
-                    label: gettext('Lookup Table'),
-                    value: 'fixture',
-                }, {
-                    label: gettext('User Properties'),
-                    value: 'usercase',
-                }];
-                if (index > 0) {
-                    modes.push({
-                        label: gettext('Case Index'),
-                        value: 'case',
-                    });
-                }
-                return modes;
-            };
+        self.descriptionDict = params.propertyDescriptions;
+        self.deprecatedPropertiesDict = params.deprecatedProperties;
 
-            self.case_supports_products = function (caseType) {
-                for (var i = 0; i < self.moduleCaseTypes.length; i++) {
-                    if (self.moduleCaseTypes[i].case_type === caseType &&
-                        self.moduleCaseTypes[i].module_type === 'AdvancedModule') {
-                        return true;
-                    }
-                }
-            };
-
-            self.module = (function () {
-                var mod = _.findWhere(self.moduleCaseTypes, {
-                    id: self.module_id,
+        self.saveButton = main.initSaveButton({
+            unsavedMessage: "You have unchanged case settings",
+            save: function () {
+                var actions = JSON.stringify(self.caseConfigViewModel.unwrap());
+                self.saveButton.ajax({
+                    type: 'post',
+                    url: self.save_url,
+                    data: {
+                        actions: actions,
+                        arbitrary_datums: ko.mapping.toJSON(self.caseConfigViewModel.arbitrary_datums),
+                    },
+                    dataType: 'json',
+                    success: function (data) {
+                        appManager.updateDOM(data.update);
+                        self.setPropertiesMap(data.propertiesMap);
+                        self.requires(self.caseConfigViewModel.load_update_cases().length > 0 ? 'case' : 'none');
+                    },
                 });
-                mod.module_name = '* ' + mod.module_name;
-                return mod;
-            }());
+            },
+        });
 
-            self.getModulesForCaseType = function (caseType, supportProducts) {
-                var filter = {
-                    case_type: caseType,
-                };
-                if (supportProducts) {
-                    filter.module_type = 'AdvancedModule';
+        var questionScores = {};
+        _(self.questions()).each(function (question, i) {
+            questionScores[question.value] = i;
+        });
+        self.questionScores = questionScores;
+
+        self.caseTypes = _.unique(_(self.moduleCaseTypes).map(function (moduleCaseType) {
+            return moduleCaseType.case_type;
+        }));
+
+        self.getAutoSelectModes = function (action) {
+            var index = self.caseConfigViewModel.load_update_cases.indexOf(action);
+            var modes = [{
+                label: gettext('Raw'),
+                value: 'raw',
+            }, {
+                label: gettext('User Data'),
+                value: 'user',
+            }, {
+                label: gettext('Lookup Table'),
+                value: 'fixture',
+            }, {
+                label: gettext('User Properties'),
+                value: 'usercase',
+            }];
+            if (index > 0) {
+                modes.push({
+                    label: gettext('Case Index'),
+                    value: 'case',
+                });
+            }
+            return modes;
+        };
+
+        self.case_supports_products = function (caseType) {
+            for (var i = 0; i < self.moduleCaseTypes.length; i++) {
+                if (self.moduleCaseTypes[i].case_type === caseType &&
+                    self.moduleCaseTypes[i].module_type === 'AdvancedModule') {
+                    return true;
                 }
-                var modules = _.where(self.moduleCaseTypes, filter);
-                if (caseType === self.caseType) {
-                    modules = _.reject(modules, function (mod) {
-                        return mod.id === self.module_id;
-                    });
-                    modules.splice(0, 0, self.module);
-                }
-                return modules;
+            }
+        };
+
+        self.module = (function () {
+            var mod = _.findWhere(self.moduleCaseTypes, {
+                id: self.module_id,
+            });
+            mod.module_name = '* ' + mod.module_name;
+            return mod;
+        }());
+
+        self.getModulesForCaseType = function (caseType, supportProducts) {
+            var filter = {
+                case_type: caseType,
             };
+            if (supportProducts) {
+                filter.module_type = 'AdvancedModule';
+            }
+            var modules = _.where(self.moduleCaseTypes, filter);
+            if (caseType === self.caseType) {
+                modules = _.reject(modules, function (mod) {
+                    return mod.id === self.module_id;
+                });
+                modules.splice(0, 0, self.module);
+            }
+            return modules;
+        };
 
+        self.questionMap = {};
+        var _buildQuestionMap = function () {
             self.questionMap = {};
-            var _buildQuestionMap = function () {
-                self.questionMap = {};
-                _(self.questions()).each(function (question) {
-                    self.questionMap[question.value] = question;
-                });
-            };
-            _buildQuestionMap();
-            self.questions.subscribe(_buildQuestionMap);
+            _(self.questions()).each(function (question) {
+                self.questionMap[question.value] = question;
+            });
+        };
+        _buildQuestionMap();
+        self.questions.subscribe(_buildQuestionMap);
 
-            self.get_repeat_context = function (path) {
-                if (path && self.questionMap[path]) {
-                    return self.questionMap[path].repeat;
-                } else {
-                    return undefined;
-                }
-            };
-
-            self.getQuestions = function (filter, excludeHidden, includeRepeat) {
-                return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat);
-            };
-
-            self.getAnswers = function (condition) {
-                return caseConfigUtils.getAnswers(self.questions(), condition);
-            };
-
-            self.change = function () {
-                self.saveButton.fire('change');
-            };
-
-            self.caseConfigViewModel = caseConfigViewModel(self, params);
-
-            self.applyAccordion = function (type, index) {
-                _.each(type ? [type] : ['open', 'load'], function (t) {
-                    var selector = "#case-" + t + "-accordion";
-
-                    // Make sure all parents are set correctly so panels behave like an accordion
-                    $(selector + ' > .panel > .panel-collapse').collapse({
-                        parent: selector,
-                        toggle: false,
-                    });
-
-                    // Hide all panels, then show the requested one
-                    $(selector + ' .panel-collapse.in').collapse('hide');
-                    $(selector + ' > .panel:nth-child(' + (index + 1) + ') .panel-collapse').collapse('show');
-                });
-            };
-
-            self.initAccordion = function () {
-                // Leave all the actions, collapsed, unless there's just
-                // one in the section, and then open it
-                if ($('#case-load-accordion > .panel').length === 1) {
-                    self.applyAccordion('load', 0);
-                }
-                if ($('#case-open-accordion > .panel').length === 1) {
-                    self.applyAccordion('open', 0);
-                }
-            };
-
-            self.init = function () {
-                var $home = self.home;
-                _.delay(function () {
-                    $home.koApplyBindings(self);
-                    $home.on('textchange', 'input', self.change)
-                        // all select2's are represented by an input[type="hidden"]
-                        .on('change', 'select, input[type="hidden"]', self.change)
-                        .on('click', ':not(.hq-help) > a:not(.header)', self.change)
-                        .on('change', 'input[type="checkbox"]', self.change);
-
-                    // https://gist.github.com/mkelly12/424774/#comment-92080
-                    $home.find('input').on('textchange', self.change);
-
-                    self.initAccordion();
-                    $('#case-configuration-tab').on('click', function () {
-                        self.initAccordion();
-                    });
-
-                    $('.hq-help-template').each(function () {
-                        main.transformHelpTemplate($(this), true);
-                    });
-
-                    caseConfigUtils.initRefreshQuestions(self.questions);
-                });
-            };
-            return self;
+        self.get_repeat_context = function (path) {
+            if (path && self.questionMap[path]) {
+                return self.questionMap[path].repeat;
+            } else {
+                return undefined;
+            }
         };
 
-        var caseConfigViewModel = function (caseConfig, params) {
-            var self = {};
+        self.getQuestions = function (filter, excludeHidden, includeRepeat) {
+            return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat);
+        };
 
-            self.caseConfig = caseConfig;
-            self.hasPrivilege = true;
+        self.getAnswers = function (condition) {
+            return caseConfigUtils.getAnswers(self.questions(), condition);
+        };
 
-            self.getCaseTags = function (type, action) {
-                var tags = [],
-                    actions = [],
-                    index;
-                if (type === 'all') {
-                    actions = actions.concat(self.open_cases());
-                    actions = actions.concat(self.load_update_cases());
-                }
-                if (type === 'subcase') {
-                    actions = actions.concat(self.load_update_cases());
-                    // only allow creating subcases of actions before this one
-                    index = self.open_cases.indexOf(action);
-                    if (index > 0) {
-                        actions = actions.concat(self.open_cases.slice(0, index));
-                    }
-                }
-                if (type === 'auto-select') {
-                    // only allow auto-selecting based off loaded actions before this one
-                    index = self.load_update_cases.indexOf(action);
-                    if (index > 0) {
-                        actions = actions.concat(self.load_update_cases.slice(0, index));
-                    }
-                }
+        self.change = function () {
+            self.saveButton.fire('change');
+        };
 
-                for (var i = 0; i < actions.length; i++) {
-                    var tag = actions[i].case_tag();
-                    if (tag) {
-                        tags.push({
-                            value: tag,
-                            label: tag,
-                        });
-                    }
-                }
-                return tags;
-            };
+        self.caseConfigViewModel = caseConfigViewModel(self, params);
 
-            self.getActionFromTag = function (tag) {
-                var action = _.find(self.open_cases(), function (a) {
-                    return a.case_tag() === tag;
+        self.applyAccordion = function (type, index) {
+            _.each(type ? [type] : ['open', 'load'], function (t) {
+                var selector = "#case-" + t + "-accordion";
+
+                // Make sure all parents are set correctly so panels behave like an accordion
+                $(selector + ' > .panel > .panel-collapse').collapse({
+                    parent: selector,
+                    toggle: false,
                 });
-                if (action) {
-                    return action;
-                }
-                action = _.find(self.load_update_cases(), function (a) {
-                    return a.case_tag() === tag;
+
+                // Hide all panels, then show the requested one
+                $(selector + ' .panel-collapse.in').collapse('hide');
+                $(selector + ' > .panel:nth-child(' + (index + 1) + ') .panel-collapse').collapse('show');
+            });
+        };
+
+        self.initAccordion = function () {
+            // Leave all the actions, collapsed, unless there's just
+            // one in the section, and then open it
+            if ($('#case-load-accordion > .panel').length === 1) {
+                self.applyAccordion('load', 0);
+            }
+            if ($('#case-open-accordion > .panel').length === 1) {
+                self.applyAccordion('open', 0);
+            }
+        };
+
+        self.init = function () {
+            var $home = self.home;
+            _.delay(function () {
+                $home.koApplyBindings(self);
+                $home.on('textchange', 'input', self.change)
+                    // all select2's are represented by an input[type="hidden"]
+                    .on('change', 'select, input[type="hidden"]', self.change)
+                    .on('click', ':not(.hq-help) > a:not(.header)', self.change)
+                    .on('change', 'input[type="checkbox"]', self.change);
+
+                // https://gist.github.com/mkelly12/424774/#comment-92080
+                $home.find('input').on('textchange', self.change);
+
+                self.initAccordion();
+                $('#case-configuration-tab').on('click', function () {
+                    self.initAccordion();
                 });
+
+                $('.hq-help-template').each(function () {
+                    main.transformHelpTemplate($(this), true);
+                });
+
+                caseConfigUtils.initRefreshQuestions(self.questions);
+            });
+        };
+        return self;
+    };
+
+    var caseConfigViewModel = function (caseConfig, params) {
+        var self = {};
+
+        self.caseConfig = caseConfig;
+        self.hasPrivilege = true;
+
+        self.getCaseTags = function (type, action) {
+            var tags = [],
+                actions = [],
+                index;
+            if (type === 'all') {
+                actions = actions.concat(self.open_cases());
+                actions = actions.concat(self.load_update_cases());
+            }
+            if (type === 'subcase') {
+                actions = actions.concat(self.load_update_cases());
+                // only allow creating subcases of actions before this one
+                index = self.open_cases.indexOf(action);
+                if (index > 0) {
+                    actions = actions.concat(self.open_cases.slice(0, index));
+                }
+            }
+            if (type === 'auto-select') {
+                // only allow auto-selecting based off loaded actions before this one
+                index = self.load_update_cases.indexOf(action);
+                if (index > 0) {
+                    actions = actions.concat(self.load_update_cases.slice(0, index));
+                }
+            }
+
+            for (var i = 0; i < actions.length; i++) {
+                var tag = actions[i].case_tag();
+                if (tag) {
+                    tags.push({
+                        value: tag,
+                        label: tag,
+                    });
+                }
+            }
+            return tags;
+        };
+
+        self.getActionFromTag = function (tag) {
+            var action = _.find(self.open_cases(), function (a) {
+                return a.case_tag() === tag;
+            });
+            if (action) {
                 return action;
-            };
+            }
+            action = _.find(self.load_update_cases(), function (a) {
+                return a.case_tag() === tag;
+            });
+            return action;
+        };
 
-            self.load_update_cases = ko.observableArray(_(params.actions.load_update_cases).map(function (a) {
-                var preload = caseConfigUtils.preloadDictToArray(a.preload, caseConfig);
-                var caseProperties = caseConfigUtils.propertyDictToArray([], a.case_properties, caseConfig);
-                a.preload = [];
-                a.case_properties = [];
-                var action = actions.loadUpdateAction.wrap(a, caseConfig);
-                // add these after to avoid errors caused by 'action.suggestedProperties' being accessed
-                // before it is defined
-                _(caseProperties).each(function (p) {
-                    action.case_properties.push(casePropertiesModels.caseProperty.wrap(p, action));
-                });
-
-                _(preload).each(function (p) {
-                    action.preload.push(casePropertiesModels.casePreloadProperty.wrap(p, action));
-                });
-                return action;
-            }));
-
-
-            self.arbitrary_datums = ko.mapping.fromJS(params.arbitrary_datums);
-
-            self.arbitrary_datums.subscribe(function () {
-                self.caseConfig.saveButton.fire('change');
+        self.load_update_cases = ko.observableArray(_(params.actions.load_update_cases).map(function (a) {
+            var preload = caseConfigUtils.preloadDictToArray(a.preload, caseConfig);
+            var caseProperties = caseConfigUtils.propertyDictToArray([], a.case_properties, caseConfig);
+            a.preload = [];
+            a.case_properties = [];
+            var action = actions.loadUpdateAction.wrap(a, caseConfig);
+            // add these after to avoid errors caused by 'action.suggestedProperties' being accessed
+            // before it is defined
+            _(caseProperties).each(function (p) {
+                action.case_properties.push(casePropertiesModels.caseProperty.wrap(p, action));
             });
 
-            self.addDatum = function () {
-                self.arbitrary_datums.push(ko.mapping.fromJSON('{"datum_id": "", "datum_function": ""}'));
-            };
-
-            self.removeDatum = function (datum) {
-                self.arbitrary_datums.remove(datum);
-            };
+            _(preload).each(function (p) {
+                action.preload.push(casePropertiesModels.casePreloadProperty.wrap(p, action));
+            });
+            return action;
+        }));
 
 
-            self.open_cases = ko.observableArray(_(params.actions.open_cases).map(function (a) {
-                var requiredProperties = [{
-                    key: 'name',
-                    path: a.name_update.question_path,
-                    required: true,
-                    save_only_if_edited: a.name_update.update_mode === 'edit',
-                }];
-                var caseProperties = caseConfigUtils.propertyDictToArray(requiredProperties, a.case_properties, caseConfig);
-                a.case_properties = [];
-                var action = actions.openCaseAction.wrap(a, caseConfig);
-                // add these after to avoid errors caused by 'action.suggestedProperties' being accessed
-                // before it is defined
-                _(caseProperties).each(function (p) {
-                    action.case_properties.push(casePropertiesModels.caseProperty.wrap(p, action));
-                });
+        self.arbitrary_datums = ko.mapping.fromJS(params.arbitrary_datums);
 
-                return action;
-            }));
+        self.arbitrary_datums.subscribe(function () {
+            self.caseConfig.saveButton.fire('change');
+        });
 
-            var _actions = [{
-                display: gettext('Load / Update / Close a case'),
-                value: 'load',
-            }, {
-                display: gettext('Automatic Case Selection'),
-                value: 'auto_select',
-            }, {
-                display: gettext('Load Case From Fixture'),
-                value: 'load_case_from_fixture',
-            } ];
-            if (!self.caseConfig.isShadowForm) {
-                _actions = _actions.concat([{
-                    display: '---',
-                    value: 'separator',
-                }, {
-                    display: gettext('Open a Case'),
-                    value: 'open',
-                } ]);
-            }
-            self.actionOptions = ko.observableArray(_actions);
-
-            self.renameCaseTag = function (oldTag, newTag, parentOnly) {
-                var actions = self.load_update_cases();
-                var action;
-
-                for (var i = 0; i < actions.length; i++) {
-                    action = actions[i];
-                    if (!parentOnly && action.case_tag() === oldTag) {
-                        action.case_tag(newTag);
-                    }
-                    if (action.case_index.tag() === oldTag) {
-                        action.case_index.tag(newTag);
-                    }
-                }
-                actions = self.open_cases();
-                for (i = 0; i < actions.length; i++) {
-                    action = actions[i];
-                    if (!parentOnly && action.case_tag() === oldTag) {
-                        action.case_tag(newTag);
-                    }
-                    for (var j = 0; j < action.case_indices.length; j++) {
-                        var caseIndex = action.case_indices[j];
-                        if (caseIndex.tag() === oldTag) {
-                            caseIndex.tag(newTag);
-                        }
-                    }
-                }
-            };
-
-            self.addFormAction = function (action) {
-                var index;
-                if (action.value === 'load' || action.value === 'auto_select' || action.value === 'load_case_from_fixture') {
-                    index = self.load_update_cases().length;
-                    var tagPrefix = action.value === 'auto_select' ? 'auto' : '',
-                        actionData = {
-                            case_type: caseConfig.caseType,
-                            details_module: null,
-                            case_tag: tagPrefix + 'load_' + caseConfig.caseType + index,
-                            case_index: {
-                                tag: '',
-                                reference_id: 'parent',
-                                relationship: 'child',
-                            },
-                            preload: [],
-                            case_properties: [],
-                            close_condition: DEFAULT_CONDITION('never'),
-                            show_product_stock: false,
-                            product_program: '',
-                            auto_select: null,
-                            load_case_from_fixture: null,
-                        };
-                    if (action.value === 'auto_select') {
-                        actionData.auto_select = {
-                            mode: '',
-                            value_source: '',
-                            value_key: '',
-                        };
-                    } else if (action.value === 'load_case_from_fixture') {
-                        actionData.load_case_from_fixture = {
-                            fixture_nodeset: '',
-                            fixture_tag: '',
-                            fixture_variable: '',
-                            case_property: '',
-                            auto_select: false,
-                            auto_select_fixture: false,
-                            arbitrary_datum_id: '',
-                            arbitrary_datum_function: '',
-                        };
-                    }
-                    self.load_update_cases.push(actions.loadUpdateAction.wrap(actionData, self.caseConfig));
-                    self.caseConfig.applyAccordion('load', index);
-                } else if (action.value === 'open') {
-                    index = self.open_cases().length;
-                    self.open_cases.push(actions.openCaseAction.wrap({
-                        case_type: caseConfig.caseType,
-                        name_update: '',
-                        case_tag: 'open_' + caseConfig.caseType + '_' + index,
-                        case_properties: [{
-                            path: '',
-                            key: 'name',
-                            required: true,
-                            save_only_if_edited: false,
-                        }],
-                        repeat_context: '',
-                        case_indices: [],
-                        open_condition: DEFAULT_CONDITION('always'),
-                        close_condition: DEFAULT_CONDITION('never'),
-                    }, self.caseConfig));
-                    self.caseConfig.applyAccordion('open', index);
-                }
-            };
-
-            self.removeFormAction = function (action) {
-                if (action.actionType === 'open') {
-                    self.open_cases.remove(action);
-                } else if (action.actionType === 'load') {
-                    var index = self.caseConfig.caseConfigViewModel.load_update_cases.indexOf(action);
-                    self.load_update_cases.remove(action);
-
-                    // remove references to deleted action in subsequent load actions
-                    var loadUpdateCases = self.caseConfig.caseConfigViewModel.load_update_cases();
-                    for (var i = index; i < loadUpdateCases.length; i++) {
-                        var caseIndex = loadUpdateCases[i].case_index;
-                        if (caseIndex.tag() === action.case_tag()) {
-                            caseIndex.tag('');
-                        }
-                    }
-                }
-                self.caseConfig.saveButton.fire('change');
-            };
-
-            self.unwrap = function () {
-                return {
-                    load_update_cases: _(self.load_update_cases()).map(actions.loadUpdateAction.unwrap),
-                    open_cases: _(self.open_cases()).map(actions.openCaseAction.unwrap),
-                };
-            };
-            return self;
+        self.addDatum = function () {
+            self.arbitrary_datums.push(ko.mapping.fromJSON('{"datum_id": "", "datum_function": ""}'));
         };
 
-        if (initialPageData.get('has_form_source')) {
-            var caseConfig = CaseConfig(_.extend({}, initialPageData.get("case_config_options"), {
-                home: $('#case-config-ko'),
-                requires: ko.observable(initialPageData.get("form_requires")),
-            }));
-            caseConfig.init();
+        self.removeDatum = function (datum) {
+            self.arbitrary_datums.remove(datum);
+        };
 
-            if (initialPageData.get("schedule_options")) {
-                var visitScheduler = visitSchedulerModel.schedulerModel(_.extend({}, initialPageData.get("schedule_options"), {
-                    home: $('#visit-scheduler'),
-                }));
-                visitScheduler.init();
-            }
+
+        self.open_cases = ko.observableArray(_(params.actions.open_cases).map(function (a) {
+            var requiredProperties = [{
+                key: 'name',
+                path: a.name_update.question_path,
+                required: true,
+                save_only_if_edited: a.name_update.update_mode === 'edit',
+            }];
+            var caseProperties = caseConfigUtils.propertyDictToArray(requiredProperties, a.case_properties, caseConfig);
+            a.case_properties = [];
+            var action = actions.openCaseAction.wrap(a, caseConfig);
+            // add these after to avoid errors caused by 'action.suggestedProperties' being accessed
+            // before it is defined
+            _(caseProperties).each(function (p) {
+                action.case_properties.push(casePropertiesModels.caseProperty.wrap(p, action));
+            });
+
+            return action;
+        }));
+
+        var _actions = [{
+            display: gettext('Load / Update / Close a case'),
+            value: 'load',
+        }, {
+            display: gettext('Automatic Case Selection'),
+            value: 'auto_select',
+        }, {
+            display: gettext('Load Case From Fixture'),
+            value: 'load_case_from_fixture',
+        } ];
+        if (!self.caseConfig.isShadowForm) {
+            _actions = _actions.concat([{
+                display: '---',
+                value: 'separator',
+            }, {
+                display: gettext('Open a Case'),
+                value: 'open',
+            } ]);
         }
-    });
+        self.actionOptions = ko.observableArray(_actions);
+
+        self.renameCaseTag = function (oldTag, newTag, parentOnly) {
+            var actions = self.load_update_cases();
+            var action;
+
+            for (var i = 0; i < actions.length; i++) {
+                action = actions[i];
+                if (!parentOnly && action.case_tag() === oldTag) {
+                    action.case_tag(newTag);
+                }
+                if (action.case_index.tag() === oldTag) {
+                    action.case_index.tag(newTag);
+                }
+            }
+            actions = self.open_cases();
+            for (i = 0; i < actions.length; i++) {
+                action = actions[i];
+                if (!parentOnly && action.case_tag() === oldTag) {
+                    action.case_tag(newTag);
+                }
+                for (var j = 0; j < action.case_indices.length; j++) {
+                    var caseIndex = action.case_indices[j];
+                    if (caseIndex.tag() === oldTag) {
+                        caseIndex.tag(newTag);
+                    }
+                }
+            }
+        };
+
+        self.addFormAction = function (action) {
+            var index;
+            if (action.value === 'load' || action.value === 'auto_select' || action.value === 'load_case_from_fixture') {
+                index = self.load_update_cases().length;
+                var tagPrefix = action.value === 'auto_select' ? 'auto' : '',
+                    actionData = {
+                        case_type: caseConfig.caseType,
+                        details_module: null,
+                        case_tag: tagPrefix + 'load_' + caseConfig.caseType + index,
+                        case_index: {
+                            tag: '',
+                            reference_id: 'parent',
+                            relationship: 'child',
+                        },
+                        preload: [],
+                        case_properties: [],
+                        close_condition: DEFAULT_CONDITION('never'),
+                        show_product_stock: false,
+                        product_program: '',
+                        auto_select: null,
+                        load_case_from_fixture: null,
+                    };
+                if (action.value === 'auto_select') {
+                    actionData.auto_select = {
+                        mode: '',
+                        value_source: '',
+                        value_key: '',
+                    };
+                } else if (action.value === 'load_case_from_fixture') {
+                    actionData.load_case_from_fixture = {
+                        fixture_nodeset: '',
+                        fixture_tag: '',
+                        fixture_variable: '',
+                        case_property: '',
+                        auto_select: false,
+                        auto_select_fixture: false,
+                        arbitrary_datum_id: '',
+                        arbitrary_datum_function: '',
+                    };
+                }
+                self.load_update_cases.push(actions.loadUpdateAction.wrap(actionData, self.caseConfig));
+                self.caseConfig.applyAccordion('load', index);
+            } else if (action.value === 'open') {
+                index = self.open_cases().length;
+                self.open_cases.push(actions.openCaseAction.wrap({
+                    case_type: caseConfig.caseType,
+                    name_update: '',
+                    case_tag: 'open_' + caseConfig.caseType + '_' + index,
+                    case_properties: [{
+                        path: '',
+                        key: 'name',
+                        required: true,
+                        save_only_if_edited: false,
+                    }],
+                    repeat_context: '',
+                    case_indices: [],
+                    open_condition: DEFAULT_CONDITION('always'),
+                    close_condition: DEFAULT_CONDITION('never'),
+                }, self.caseConfig));
+                self.caseConfig.applyAccordion('open', index);
+            }
+        };
+
+        self.removeFormAction = function (action) {
+            if (action.actionType === 'open') {
+                self.open_cases.remove(action);
+            } else if (action.actionType === 'load') {
+                var index = self.caseConfig.caseConfigViewModel.load_update_cases.indexOf(action);
+                self.load_update_cases.remove(action);
+
+                // remove references to deleted action in subsequent load actions
+                var loadUpdateCases = self.caseConfig.caseConfigViewModel.load_update_cases();
+                for (var i = index; i < loadUpdateCases.length; i++) {
+                    var caseIndex = loadUpdateCases[i].case_index;
+                    if (caseIndex.tag() === action.case_tag()) {
+                        caseIndex.tag('');
+                    }
+                }
+            }
+            self.caseConfig.saveButton.fire('change');
+        };
+
+        self.unwrap = function () {
+            return {
+                load_update_cases: _(self.load_update_cases()).map(actions.loadUpdateAction.unwrap),
+                open_cases: _(self.open_cases()).map(actions.openCaseAction.unwrap),
+            };
+        };
+        return self;
+    };
+
+    if (initialPageData.get('has_form_source')) {
+        var caseConfig = CaseConfig(_.extend({}, initialPageData.get("case_config_options"), {
+            home: $('#case-config-ko'),
+            requires: ko.observable(initialPageData.get("form_requires")),
+        }));
+        caseConfig.init();
+
+        if (initialPageData.get("schedule_options")) {
+            var visitScheduler = visitSchedulerModel.schedulerModel(_.extend({}, initialPageData.get("schedule_options"), {
+                home: $('#visit-scheduler'),
+            }));
+            visitScheduler.init();
+        }
+    }
 });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
@@ -1,151 +1,145 @@
-hqDefine("app_manager/js/forms/advanced/case_properties", [
-    "knockout",
-    "underscore",
-    "app_manager/js/case_config_utils",
-], function (
-    ko,
-    _,
-    caseConfigUtils,
-) {
-    var casePropertyBase = {
-        mapping: {
-            include: ['key', 'path', 'required'],
-        },
-        wrap: function (data, action) {
-            var self = ko.mapping.fromJS(data, caseProperty.mapping);
-            self.action = action;
-            self.isBlank = ko.computed(function () {
-                return !self.key() && !self.path();
-            });
-            self.caseType = ko.computed(function () {
-                return self.action.case_type();
-            });
-            self.updatedDescription = ko.observable('');
-            self.description = ko.computed({
-                read: function () {
-                    if (self.updatedDescription()) {
-                        return self.updatedDescription();
-                    }
-                    var config = self.action.caseConfig;
-                    var type = config.descriptionDict[self.caseType()];
-                    if (type) {
-                        return type[self.key()] || '';
-                    }
-                },
-                write: function (value) {
-                    self.updatedDescription(value);
-                },
-            });
-            self.isDeprecated = ko.computed(function () {
-                const config = self.action.caseConfig;
-                const depProps = config.deprecatedPropertiesDict[self.caseType()];
-                if (depProps && self.key() !== 'name') {
-                    return depProps.includes(self.key());
+import ko from "knockout";
+import _ from "underscore";
+import caseConfigUtils from "app_manager/js/case_config_utils";
+
+var casePropertyBase = {
+    mapping: {
+        include: ['key', 'path', 'required'],
+    },
+    wrap: function (data, action) {
+        var self = ko.mapping.fromJS(data, caseProperty.mapping);
+        self.action = action;
+        self.isBlank = ko.computed(function () {
+            return !self.key() && !self.path();
+        });
+        self.caseType = ko.computed(function () {
+            return self.action.case_type();
+        });
+        self.updatedDescription = ko.observable('');
+        self.description = ko.computed({
+            read: function () {
+                if (self.updatedDescription()) {
+                    return self.updatedDescription();
                 }
-                return false;
-            });
-            return self;
-        },
-    };
+                var config = self.action.caseConfig;
+                var type = config.descriptionDict[self.caseType()];
+                if (type) {
+                    return type[self.key()] || '';
+                }
+            },
+            write: function (value) {
+                self.updatedDescription(value);
+            },
+        });
+        self.isDeprecated = ko.computed(function () {
+            const config = self.action.caseConfig;
+            const depProps = config.deprecatedPropertiesDict[self.caseType()];
+            if (depProps && self.key() !== 'name') {
+                return depProps.includes(self.key());
+            }
+            return false;
+        });
+        return self;
+    },
+};
 
-    var caseProperty = {
-        mapping: casePropertyBase.mapping,
-        wrap: function (data, action) {
-            var self = casePropertyBase.wrap(data, action);
+var caseProperty = {
+    mapping: casePropertyBase.mapping,
+    wrap: function (data, action) {
+        var self = casePropertyBase.wrap(data, action);
 
-            // for compatibility with common templates
-            self.case_transaction = {
-                // template: case-config:case-properties:question
-                allow: {
-                    repeats: function () {
-                        return action.allow.repeats();
-                    },
+        // for compatibility with common templates
+        self.case_transaction = {
+            // template: case-config:case-properties:question
+            allow: {
+                repeats: function () {
+                    return action.allow.repeats();
                 },
-                // template: case-config:case-transaction:case-properties
-                suggestedSaveProperties: ko.computed(function () {
-                    return caseConfigUtils.filteredSuggestedProperties(
-                        self.action.suggestedProperties(),
-                        self.action.case_properties(),
-                    );
-                }),
-            };
+            },
+            // template: case-config:case-transaction:case-properties
+            suggestedSaveProperties: ko.computed(function () {
+                return caseConfigUtils.filteredSuggestedProperties(
+                    self.action.suggestedProperties(),
+                    self.action.case_properties(),
+                );
+            }),
+        };
 
-            self.defaultKey = ko.computed(function () {
-                var path = self.path() || '';
-                var value = path.split('/');
-                value = value[value.length - 1];
-                return value;
-            });
-            self.repeat_context = function () {
-                return action.caseConfig.get_repeat_context(self.path());
-            };
-            self.validate = ko.computed(function () {
-                if (self.path() || self.key()) {
-                    if (action.propertyCounts()[self.key()] > 1) {
-                        return gettext("Property updated by two questions");
-                    } else if (action.caseConfig.reserved_words.indexOf(self.key()) !== -1) {
-                        return gettext("Reserved word: ") + '<strong>' + self.key() + '</strong>';
-                    } else if (self.repeat_context() && self.repeat_context() !== self.action.repeat_context()) {
-                        return gettext('Inside the wrong repeat!');
-                    } else if (action.subcase() && _(self.key()).contains('/')) {
-                        return gettext('Parent property references not allowed for subcases');
-                    }
+        self.defaultKey = ko.computed(function () {
+            var path = self.path() || '';
+            var value = path.split('/');
+            value = value[value.length - 1];
+            return value;
+        });
+        self.repeat_context = function () {
+            return action.caseConfig.get_repeat_context(self.path());
+        };
+        self.validate = ko.computed(function () {
+            if (self.path() || self.key()) {
+                if (action.propertyCounts()[self.key()] > 1) {
+                    return gettext("Property updated by two questions");
+                } else if (action.caseConfig.reserved_words.indexOf(self.key()) !== -1) {
+                    return gettext("Reserved word: ") + '<strong>' + self.key() + '</strong>';
+                } else if (self.repeat_context() && self.repeat_context() !== self.action.repeat_context()) {
+                    return gettext('Inside the wrong repeat!');
+                } else if (action.subcase() && _(self.key()).contains('/')) {
+                    return gettext('Parent property references not allowed for subcases');
                 }
-                return null;
-            });
+            }
+            return null;
+        });
 
-            return self;
-        },
-    };
+        return self;
+    },
+};
 
-    var casePreloadProperty = {
-        wrap: function (data, action) {
-            var self = casePropertyBase.wrap(data, action);
+var casePreloadProperty = {
+    wrap: function (data, action) {
+        var self = casePropertyBase.wrap(data, action);
 
-            // for compatibility with common templates
-            self.case_transaction = {
-                // template: case-config:case-properties:question
-                allow: {
-                    repeats: function () {
-                        return action.allow.repeats();
-                    },
+        // for compatibility with common templates
+        self.case_transaction = {
+            // template: case-config:case-properties:question
+            allow: {
+                repeats: function () {
+                    return action.allow.repeats();
                 },
-                // template: case-config:case-transaction:case-preload
-                suggestedPreloadProperties: ko.computed(function () {
-                    return caseConfigUtils.filteredSuggestedProperties(
-                        self.action.suggestedProperties(),
-                        self.action.preload(),
-                    );
-                }),
-            };
-            self.defaultKey = ko.computed(function () {
-                return '';
-            });
-            self.validateProperty = ko.computed(function () {
-                if (self.path() || self.key()) {
-                    if (action.caseConfig.reserved_words.indexOf(self.key()) !== -1) {
-                        return gettext("Reserved word: ") + '<strong>' + self.key() + '</strong>';
-                    } else if (action.subcase() && _(self.key()).contains('/')) {
-                        return gettext('Parent property references not allowed for subcases');
-                    }
+            },
+            // template: case-config:case-transaction:case-preload
+            suggestedPreloadProperties: ko.computed(function () {
+                return caseConfigUtils.filteredSuggestedProperties(
+                    self.action.suggestedProperties(),
+                    self.action.preload(),
+                );
+            }),
+        };
+        self.defaultKey = ko.computed(function () {
+            return '';
+        });
+        self.validateProperty = ko.computed(function () {
+            if (self.path() || self.key()) {
+                if (action.caseConfig.reserved_words.indexOf(self.key()) !== -1) {
+                    return gettext("Reserved word: ") + '<strong>' + self.key() + '</strong>';
+                } else if (action.subcase() && _(self.key()).contains('/')) {
+                    return gettext('Parent property references not allowed for subcases');
                 }
-                return null;
-            });
-            self.validateQuestion = ko.computed(function () {
-                if (self.path()) {
-                    if (action.preloadCounts()[self.path()] > 1) {
-                        return gettext("Two properties load to the same question");
-                    }
+            }
+            return null;
+        });
+        self.validateQuestion = ko.computed(function () {
+            if (self.path()) {
+                if (action.preloadCounts()[self.path()] > 1) {
+                    return gettext("Two properties load to the same question");
                 }
-                return null;
-            });
+            }
+            return null;
+        });
 
-            return self;
-        },
-    };
+        return self;
+    },
+};
 
-    return {
-        caseProperty: caseProperty,
-        casePreloadProperty: casePreloadProperty,
-    };
-});
+export default {
+    caseProperty: caseProperty,
+    casePreloadProperty: casePreloadProperty,
+};

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -1,891 +1,877 @@
-hqDefine("app_manager/js/forms/case_config_ui", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "app_manager/js/case_config_utils",
-    "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/privileges",
-    "hqwebapp/js/toggles",
-    "hqwebapp/js/bootstrap3/main",
-    "app_manager/js/app_manager",
-    "analytix/js/kissmetrix",
-    "analytix/js/google",
-], function (
-    $,
-    ko,
-    _,
-    caseConfigUtils,
-    initialPageData,
-    privileges,
-    toggles,
-    main,
-    appManager,
-    kissmetrix,
-    google,
-) {
-    $(function () {
-        if (initialPageData.get('module_doc_type') === "AdvancedModule") {
-            return;
-        }
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import caseConfigUtils from "app_manager/js/case_config_utils";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import privileges from "hqwebapp/js/privileges";
+import toggles from "hqwebapp/js/toggles";
+import main from "hqwebapp/js/bootstrap3/main";
+import appManager from "app_manager/js/app_manager";
+import kissmetrix from "analytix/js/kissmetrix";
+import google from "analytix/js/google";
 
-        const addOnsPrivileges = initialPageData.get('add_ons_privileges');
-        var actionNames = ["open_case", "update_case", "close_case", "case_preload",
-            // Usercase actions are managed in the User Properties tab.
-            "usercase_update", "usercase_preload",
-        ];
+$(function () {
+    if (initialPageData.get('module_doc_type') === "AdvancedModule") {
+        return;
+    }
 
-        var caseConfig = function (params) {
-            var self = {};
-            self.makePopover = function () {
-                $('.property-description').closest('.read-only').popover({
-                    'trigger': 'hover',
-                    'placement': 'auto right',
-                });
-            };
+    const addOnsPrivileges = initialPageData.get('add_ons_privileges');
+    var actionNames = ["open_case", "update_case", "close_case", "case_preload",
+        // Usercase actions are managed in the User Properties tab.
+        "usercase_update", "usercase_preload",
+    ];
 
-            self.home = params.home;
-            self.actions = (function (a) {
-                var actions = {};
-                _(actionNames).each(function (actionName) {
-                    actions[actionName] = a[actionName];
-                });
-                actions.subcases = a.subcases;
-                return actions;
-            }(params.actions));
-            self.questions = ko.observable(params.questions);
-            self.save_url = params.save_url;
-            // `requires` is a ko observable so it can be read by another UI
-            self.requires = params.requires;
-            self.caseType = params.caseType;
-            self.reserved_words = params.reserved_words;
-            self.valid_index_names = params.valid_index_names;
-            self.moduleCaseTypes = params.moduleCaseTypes;
-            self.allowUsercase = params.allowUsercase;
-
-            self.trackGoogleEvent = function () {
-                google.track.event(...arguments);
-            };
-
-            self.setPropertiesMap = function (propertiesMap) {
-                self.propertiesMap = ko.mapping.fromJS(propertiesMap);
-            };
-            self.setPropertiesMap(params.propertiesMap);
-
-            self.setUsercasePropertiesMap = function (propertiesMap) {
-                self.usercasePropertiesMap = ko.mapping.fromJS(propertiesMap);
-            };
-            self.setUsercasePropertiesMap(params.usercasePropertiesMap);
-
-            self.descriptionDict = params.propertyDescriptions;
-            self.deprecatedPropertiesDict = params.deprecatedProperties;
-
-            self.saveButton = main.initSaveButton({
-                unsavedMessage: gettext("You have unchanged case settings"),
-                save: function () {
-                    var requires = self.caseConfigViewModel.actionType() === 'update' ? 'case' : 'none';
-                    var subcases = _(self.caseConfigViewModel.subcases()).map(HQOpenSubCaseAction.from_case_transaction);
-                    var actions = JSON.stringify(_(self.actions).extend(
-                        HQFormActions.from_case_transaction(self.caseConfigViewModel.case_transaction), {
-                            subcases: subcases,
-                        },
-                    ));
-
-                    self.saveButton.ajax({
-                        type: 'post',
-                        url: self.save_url,
-                        data: {
-                            requires: requires,
-                            actions: actions,
-                        },
-                        dataType: 'json',
-                        success: function (data) {
-                            appManager.updateDOM(data.update);
-                            self.requires(requires);
-                            self.setPropertiesMap(data.propertiesMap);
-
-                            if (_(data.propertiesMap).has(self.caseType)) {
-                                kissmetrix.track.event("Saved question as a Case Property", {
-                                    questionsSaved: _.property(self.caseType)(data.propertiesMap).length,
-                                });
-                            }
-                        },
-                    });
-                },
+    var caseConfig = function (params) {
+        var self = {};
+        self.makePopover = function () {
+            $('.property-description').closest('.read-only').popover({
+                'trigger': 'hover',
+                'placement': 'auto right',
             });
+        };
 
-            self.saveUsercaseButton = main.initSaveButton({
-                unsavedMessage: gettext("You have unchanged user properties settings"),
-                save: function () {
-                    var actions = JSON.stringify(_(self.actions).extend(
-                        HQFormActions.from_usercase_transaction(self.caseConfigViewModel.usercase_transaction),
-                    ));
-                    self.saveUsercaseButton.ajax({
-                        type: 'post',
-                        url: self.save_url,
-                        data: {
-                            actions: actions,
-                        },
-                        dataType: 'json',
-                        success: function (data) {
-                            appManager.updateDOM(data.update);
-                            self.setUsercasePropertiesMap(data.setUsercasePropertiesMap);
-                        },
-                    });
-                },
+        self.home = params.home;
+        self.actions = (function (a) {
+            var actions = {};
+            _(actionNames).each(function (actionName) {
+                actions[actionName] = a[actionName];
             });
+            actions.subcases = a.subcases;
+            return actions;
+        }(params.actions));
+        self.questions = ko.observable(params.questions);
+        self.save_url = params.save_url;
+        // `requires` is a ko observable so it can be read by another UI
+        self.requires = params.requires;
+        self.caseType = params.caseType;
+        self.reserved_words = params.reserved_words;
+        self.valid_index_names = params.valid_index_names;
+        self.moduleCaseTypes = params.moduleCaseTypes;
+        self.allowUsercase = params.allowUsercase;
 
-            self.questionMap = {};
-            var _buildQuestionMap = function () {
-                self.questionMap = {};
-                _(self.questions()).each(function (question) {
-                    self.questionMap[question.value] = question;
-                });
-            };
-            _buildQuestionMap();
-            self.questions.subscribe(_buildQuestionMap);
+        self.trackGoogleEvent = function () {
+            google.track.event(...arguments);
+        };
 
-            self.get_repeat_context = function (path) {
-                if (path && self.questionMap[path]) {
-                    return self.questionMap[path].repeat;
-                } else {
-                    return undefined;
-                }
-            };
+        self.setPropertiesMap = function (propertiesMap) {
+            self.propertiesMap = ko.mapping.fromJS(propertiesMap);
+        };
+        self.setPropertiesMap(params.propertiesMap);
 
-            var questionScores = {};
-            _(self.questions()).each(function (question, i) {
-                questionScores[question.value] = i;
-            });
-            self.questionScores = questionScores;
-            self.caseConfigViewModel = caseConfigViewModel(self);
+        self.setUsercasePropertiesMap = function (propertiesMap) {
+            self.usercasePropertiesMap = ko.mapping.fromJS(propertiesMap);
+        };
+        self.setUsercasePropertiesMap(params.usercasePropertiesMap);
 
-            self.getQuestions = function (filter, excludeHidden, includeRepeat, excludeTrigger) {
-                return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat, excludeTrigger);
-            };
+        self.descriptionDict = params.propertyDescriptions;
+        self.deprecatedPropertiesDict = params.deprecatedProperties;
 
-            self.getAnswers = function (condition) {
-                return caseConfigUtils.getAnswers(self.questions(), condition);
-            };
+        self.saveButton = main.initSaveButton({
+            unsavedMessage: gettext("You have unchanged case settings"),
+            save: function () {
+                var requires = self.caseConfigViewModel.actionType() === 'update' ? 'case' : 'none';
+                var subcases = _(self.caseConfigViewModel.subcases()).map(HQOpenSubCaseAction.from_case_transaction);
+                var actions = JSON.stringify(_(self.actions).extend(
+                    HQFormActions.from_case_transaction(self.caseConfigViewModel.case_transaction), {
+                        subcases: subcases,
+                    },
+                ));
 
-            self.change = function () {
-                self.saveButton.fire('change');
-                self.forceRefreshTextchangeBinding(self.home);
-            };
+                self.saveButton.ajax({
+                    type: 'post',
+                    url: self.save_url,
+                    data: {
+                        requires: requires,
+                        actions: actions,
+                    },
+                    dataType: 'json',
+                    success: function (data) {
+                        appManager.updateDOM(data.update);
+                        self.requires(requires);
+                        self.setPropertiesMap(data.propertiesMap);
 
-            self.usercaseChange = function () {
-                self.saveUsercaseButton.fire('change');
-                self.forceRefreshTextchangeBinding($('#usercase-config-ko'));
-            };
-
-            self.forceRefreshTextchangeBinding = function (domNode) {
-                // This is a hack that I do not understand,
-                // and really shouldn't be necessary.
-                // For some reason, $home.on('textchange', 'input', blah)
-                // loses track of the input element __answer__ in
-                // "Only if the answer to __question__ is __answer__".
-                // Flicking that input's textchange binding seems to
-                // jigger that relationship back into place. #weird
-                // (this is potentially expensive just because it's O(N)
-                // but I'd be surprised if other things weren't too)
-                var x = function () {};
-                domNode.find('input')
-                    .off('textchange', x)
-                    .on('textchange', x);
-            };
-
-            self.init = function () {
-                var $home = self.home;
-                var $usercaseMgmt = $('#usercase-config-ko');
-                _.delay(function () {
-                    if ($home.length) {
-                        $home.koApplyBindings(self);
-                        $home.on('textchange', 'input', self.change)
-                            // all select2's are represented by an input[type="hidden"]
-                            .on('change', 'select, input[type="hidden"]', self.change)
-                            // help links should not trigger a change.
-                            // I did not see anchor tags that *should* trigger a change, but left in this trigger.
-                            // Ideally, changes should be triggered off something more specific than an anchor tag
-                            .on('click', ':not(.hq-help) > a', self.change);
-                        self.forceRefreshTextchangeBinding($home);
-                    }
-
-                    if ($usercaseMgmt.length) {
-                        $usercaseMgmt.koApplyBindings(self);
-                        if (self.allowUsercase) {
-                            $usercaseMgmt.on('textchange', 'input', self.usercaseChange)
-                                .on('change', 'select, input[type="hidden"]', self.usercaseChange)
-                                .on('click', 'a', self.usercaseChange);
-                        } else {
-                            $usercaseMgmt.find('input').prop('disabled', true);
-                            $usercaseMgmt.find('select').prop('disabled', true);
-                            $usercaseMgmt.find('a').off('click');
-                            // Remove "Load properties" / "Save properties" link
-                            _.each($usercaseMgmt.find('.add-property'), function (elem) {
-                                elem.remove();
+                        if (_(data.propertiesMap).has(self.caseType)) {
+                            kissmetrix.track.event("Saved question as a Case Property", {
+                                questionsSaved: _.property(self.caseType)(data.propertiesMap).length,
                             });
                         }
-                        self.forceRefreshTextchangeBinding($usercaseMgmt);
-                    }
-
-                    caseConfigUtils.initRefreshQuestions(self.questions);
-                });
-
-            };
-
-            return self;
-        };
-
-
-        var caseConfigViewModel = function (caseConfig) {
-            var self = {};
-
-            self.hasPrivilege = true;
-            self.caseConfig = caseConfig;
-            self.moduleCaseTypes = caseConfig.moduleCaseTypes;
-            self.caseTypes = _.unique(_(self.moduleCaseTypes).map(function (moduleCaseType) {
-                return moduleCaseType.case_type;
-            }));
-            self.getCaseTypeLabel = function (caseType) {
-                var moduleNames = [],
-                    label;
-                for (var i = 0; i < self.moduleCaseTypes.length; i++) {
-                    if (self.moduleCaseTypes[i].case_type === caseType) {
-                        moduleNames.push(self.moduleCaseTypes[i].module_name);
-                    }
-                }
-                label = moduleNames.join(', ');
-                if (caseType === self.caseConfig.caseType) {
-                    label = '*' + label;
-                }
-                return label + ' (' + caseType + ')';
-            };
-            self.case_transaction = HQFormActions.to_case_transaction(caseConfig.actions, caseConfig);
-            self.usercase_transaction = HQFormActions.to_usercase_transaction(caseConfig.actions, caseConfig);
-            self.subcases = ko.observableArray(
-                _(caseConfig.actions.subcases).map(function (subcase) {
-                    return HQOpenSubCaseAction.to_case_transaction(subcase, caseConfig);
-                }),
-            );
-            self.addSubCase = function () {
-                if (!addOnsPrivileges.subcases) {
-                    return;
-                }
-                self.subcases.push(HQOpenSubCaseAction.to_case_transaction({}, caseConfig));
-            };
-            self.removeSubCase = function (subcase) {
-                if (!addOnsPrivileges.subcases) {
-                    return;
-                }
-                self.subcases.remove(subcase);
-            };
-
-            self.actionType = ko.observable((function () {
-                var opensCase = self.case_transaction.condition.type() !== 'never';
-                var requiresCase = self.caseConfig.requires() === 'case';
-                if (requiresCase) {
-                    return 'update';
-                } else if (opensCase) {
-                    return 'open';
-                }
-                return 'update';
-            }()));
-
-            self.showLeadRegistration = ko.computed(function () {
-                return self.actionType() === 'open';
-            });
-            self.showLeadFollowup = ko.computed(function () {
-                return self.actionType() === 'update';
-            });
-
-            self.actionType.subscribe(function (value) {
-                var required;
-                if (value === 'open') {
-                    required = ['name'];
-                    if (self.case_transaction.condition.type() === 'never') {
-                        self.case_transaction.condition.type('always');
-                    }
-                } else {
-                    required = [];
-                }
-                self.case_transaction.setRequired(required);
-            });
-
-            return self;
-        };
-
-
-        var baseMapping = function (model, include) {
-            return {
-                include: include,
-                case_properties: {
-                    create: function (options) {
-                        return caseProperty.wrap(options.data, model);
                     },
-                },
-            };
-        };
-        var caseTransactionMapping = function (model) {
-            return baseMapping(model, [
-                'case_type', 'reference_id', 'condition', 'case_properties', 'case_preload', 'close_condition', 'allow',
-            ]);
-        };
-        var usercaseTransactionMapping = function (model) {
-            return baseMapping(model, ['case_properties', 'case_preload']);
-        };
-
-        var baseTransaction = function (mapping, saveButton, analyticsAction, data, caseConfig, hasPrivilege) {
-            var self = {};
-            ko.mapping.fromJS(data, mapping(self), self);
-
-            self.hasPrivilege = hasPrivilege;
-            self.caseConfig = caseConfig;
-            self.saveOnlyEditedFormFieldsEnabled = toggles.toggleEnabled("SAVE_ONLY_EDITED_FORM_FIELDS");
-
-            // link self.case_name to corresponding path observable in case_properties for convenience
-            try {
-                self.case_name = _(self.case_properties()).find(function (p) {
-                    return p.key() === 'name' && p.required();
-                }).path;
-            } catch (e) {
-                self.case_name = null;
-            }
-
-            self.sortProperties = function (p1, p2) {
-                var validPaths = _.pluck(caseConfig.questions(), 'value');
-
-                if (validPaths.includes(p1.path()) && validPaths.includes(p2.path())) {
-                    return 0;
-                } else if (!validPaths.includes(p1.path())) {
-                    return -1;
-                } else {
-                    return 1;
-                }
-            };
-
-            // Pagination and search
-            self.searchAndFilter = true;
-            self.case_property_query = ko.observable('');
-            self.filtered_case_properties = ko.computed(function () {
-                var query = self.case_property_query() || '';
-                var props = _.filter(self.case_properties(), function (item) {
-                    return (item.path() || '').indexOf(query) !== -1 || (item.key() || '').indexOf(query) !== -1;
                 });
-                props.sort(self.sortProperties);
-                return props;
-            });
-            self.visible_case_properties = ko.observableArray();
-            self.pagination_reset_flag = ko.observable(false);
-            self.goToPage = function (page) {
-                page = page || 1;
-                var props = self.filtered_case_properties();
-                var skip = self.per_page() * (page - 1);
-                props = props.slice(skip, skip + self.per_page());
-                self.visible_case_properties(props);
-            };
-            // Don't allow changing per page; "Add Property" button is where the per page changer usually is
-            self.per_page = ko.observable(10);
-            self.total_case_properties = ko.computed(function () {
-                return self.filtered_case_properties().length;
-            });
-            self.goToPage(1);
+            },
+        });
 
-            self.suggestedSaveProperties = ko.computed(function () {
-                return caseConfigUtils.filteredSuggestedProperties(self.suggestedProperties(), self.case_properties());
+        self.saveUsercaseButton = main.initSaveButton({
+            unsavedMessage: gettext("You have unchanged user properties settings"),
+            save: function () {
+                var actions = JSON.stringify(_(self.actions).extend(
+                    HQFormActions.from_usercase_transaction(self.caseConfigViewModel.usercase_transaction),
+                ));
+                self.saveUsercaseButton.ajax({
+                    type: 'post',
+                    url: self.save_url,
+                    data: {
+                        actions: actions,
+                    },
+                    dataType: 'json',
+                    success: function (data) {
+                        appManager.updateDOM(data.update);
+                        self.setUsercasePropertiesMap(data.setUsercasePropertiesMap);
+                    },
+                });
+            },
+        });
+
+        self.questionMap = {};
+        var _buildQuestionMap = function () {
+            self.questionMap = {};
+            _(self.questions()).each(function (question) {
+                self.questionMap[question.value] = question;
+            });
+        };
+        _buildQuestionMap();
+        self.questions.subscribe(_buildQuestionMap);
+
+        self.get_repeat_context = function (path) {
+            if (path && self.questionMap[path]) {
+                return self.questionMap[path].repeat;
+            } else {
+                return undefined;
+            }
+        };
+
+        var questionScores = {};
+        _(self.questions()).each(function (question, i) {
+            questionScores[question.value] = i;
+        });
+        self.questionScores = questionScores;
+        self.caseConfigViewModel = caseConfigViewModel(self);
+
+        self.getQuestions = function (filter, excludeHidden, includeRepeat, excludeTrigger) {
+            return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat, excludeTrigger);
+        };
+
+        self.getAnswers = function (condition) {
+            return caseConfigUtils.getAnswers(self.questions(), condition);
+        };
+
+        self.change = function () {
+            self.saveButton.fire('change');
+            self.forceRefreshTextchangeBinding(self.home);
+        };
+
+        self.usercaseChange = function () {
+            self.saveUsercaseButton.fire('change');
+            self.forceRefreshTextchangeBinding($('#usercase-config-ko'));
+        };
+
+        self.forceRefreshTextchangeBinding = function (domNode) {
+            // This is a hack that I do not understand,
+            // and really shouldn't be necessary.
+            // For some reason, $home.on('textchange', 'input', blah)
+            // loses track of the input element __answer__ in
+            // "Only if the answer to __question__ is __answer__".
+            // Flicking that input's textchange binding seems to
+            // jigger that relationship back into place. #weird
+            // (this is potentially expensive just because it's O(N)
+            // but I'd be surprised if other things weren't too)
+            var x = function () {};
+            domNode.find('input')
+                .off('textchange', x)
+                .on('textchange', x);
+        };
+
+        self.init = function () {
+            var $home = self.home;
+            var $usercaseMgmt = $('#usercase-config-ko');
+            _.delay(function () {
+                if ($home.length) {
+                    $home.koApplyBindings(self);
+                    $home.on('textchange', 'input', self.change)
+                        // all select2's are represented by an input[type="hidden"]
+                        .on('change', 'select, input[type="hidden"]', self.change)
+                        // help links should not trigger a change.
+                        // I did not see anchor tags that *should* trigger a change, but left in this trigger.
+                        // Ideally, changes should be triggered off something more specific than an anchor tag
+                        .on('click', ':not(.hq-help) > a', self.change);
+                    self.forceRefreshTextchangeBinding($home);
+                }
+
+                if ($usercaseMgmt.length) {
+                    $usercaseMgmt.koApplyBindings(self);
+                    if (self.allowUsercase) {
+                        $usercaseMgmt.on('textchange', 'input', self.usercaseChange)
+                            .on('change', 'select, input[type="hidden"]', self.usercaseChange)
+                            .on('click', 'a', self.usercaseChange);
+                    } else {
+                        $usercaseMgmt.find('input').prop('disabled', true);
+                        $usercaseMgmt.find('select').prop('disabled', true);
+                        $usercaseMgmt.find('a').off('click');
+                        // Remove "Load properties" / "Save properties" link
+                        _.each($usercaseMgmt.find('.add-property'), function (elem) {
+                            elem.remove();
+                        });
+                    }
+                    self.forceRefreshTextchangeBinding($usercaseMgmt);
+                }
+
+                caseConfigUtils.initRefreshQuestions(self.questions);
+            });
+
+        };
+
+        return self;
+    };
+
+
+    var caseConfigViewModel = function (caseConfig) {
+        var self = {};
+
+        self.hasPrivilege = true;
+        self.caseConfig = caseConfig;
+        self.moduleCaseTypes = caseConfig.moduleCaseTypes;
+        self.caseTypes = _.unique(_(self.moduleCaseTypes).map(function (moduleCaseType) {
+            return moduleCaseType.case_type;
+        }));
+        self.getCaseTypeLabel = function (caseType) {
+            var moduleNames = [],
+                label;
+            for (var i = 0; i < self.moduleCaseTypes.length; i++) {
+                if (self.moduleCaseTypes[i].case_type === caseType) {
+                    moduleNames.push(self.moduleCaseTypes[i].module_name);
+                }
+            }
+            label = moduleNames.join(', ');
+            if (caseType === self.caseConfig.caseType) {
+                label = '*' + label;
+            }
+            return label + ' (' + caseType + ')';
+        };
+        self.case_transaction = HQFormActions.to_case_transaction(caseConfig.actions, caseConfig);
+        self.usercase_transaction = HQFormActions.to_usercase_transaction(caseConfig.actions, caseConfig);
+        self.subcases = ko.observableArray(
+            _(caseConfig.actions.subcases).map(function (subcase) {
+                return HQOpenSubCaseAction.to_case_transaction(subcase, caseConfig);
+            }),
+        );
+        self.addSubCase = function () {
+            if (!addOnsPrivileges.subcases) {
+                return;
+            }
+            self.subcases.push(HQOpenSubCaseAction.to_case_transaction({}, caseConfig));
+        };
+        self.removeSubCase = function (subcase) {
+            if (!addOnsPrivileges.subcases) {
+                return;
+            }
+            self.subcases.remove(subcase);
+        };
+
+        self.actionType = ko.observable((function () {
+            var opensCase = self.case_transaction.condition.type() !== 'never';
+            var requiresCase = self.caseConfig.requires() === 'case';
+            if (requiresCase) {
+                return 'update';
+            } else if (opensCase) {
+                return 'open';
+            }
+            return 'update';
+        }()));
+
+        self.showLeadRegistration = ko.computed(function () {
+            return self.actionType() === 'open';
+        });
+        self.showLeadFollowup = ko.computed(function () {
+            return self.actionType() === 'update';
+        });
+
+        self.actionType.subscribe(function (value) {
+            var required;
+            if (value === 'open') {
+                required = ['name'];
+                if (self.case_transaction.condition.type() === 'never') {
+                    self.case_transaction.condition.type('always');
+                }
+            } else {
+                required = [];
+            }
+            self.case_transaction.setRequired(required);
+        });
+
+        return self;
+    };
+
+
+    var baseMapping = function (model, include) {
+        return {
+            include: include,
+            case_properties: {
+                create: function (options) {
+                    return caseProperty.wrap(options.data, model);
+                },
+            },
+        };
+    };
+    var caseTransactionMapping = function (model) {
+        return baseMapping(model, [
+            'case_type', 'reference_id', 'condition', 'case_properties', 'case_preload', 'close_condition', 'allow',
+        ]);
+    };
+    var usercaseTransactionMapping = function (model) {
+        return baseMapping(model, ['case_properties', 'case_preload']);
+    };
+
+    var baseTransaction = function (mapping, saveButton, analyticsAction, data, caseConfig, hasPrivilege) {
+        var self = {};
+        ko.mapping.fromJS(data, mapping(self), self);
+
+        self.hasPrivilege = hasPrivilege;
+        self.caseConfig = caseConfig;
+        self.saveOnlyEditedFormFieldsEnabled = toggles.toggleEnabled("SAVE_ONLY_EDITED_FORM_FIELDS");
+
+        // link self.case_name to corresponding path observable in case_properties for convenience
+        try {
+            self.case_name = _(self.case_properties()).find(function (p) {
+                return p.key() === 'name' && p.required();
+            }).path;
+        } catch (e) {
+            self.case_name = null;
+        }
+
+        self.sortProperties = function (p1, p2) {
+            var validPaths = _.pluck(caseConfig.questions(), 'value');
+
+            if (validPaths.includes(p1.path()) && validPaths.includes(p2.path())) {
+                return 0;
+            } else if (!validPaths.includes(p1.path())) {
+                return -1;
+            } else {
+                return 1;
+            }
+        };
+
+        // Pagination and search
+        self.searchAndFilter = true;
+        self.case_property_query = ko.observable('');
+        self.filtered_case_properties = ko.computed(function () {
+            var query = self.case_property_query() || '';
+            var props = _.filter(self.case_properties(), function (item) {
+                return (item.path() || '').indexOf(query) !== -1 || (item.key() || '').indexOf(query) !== -1;
+            });
+            props.sort(self.sortProperties);
+            return props;
+        });
+        self.visible_case_properties = ko.observableArray();
+        self.pagination_reset_flag = ko.observable(false);
+        self.goToPage = function (page) {
+            page = page || 1;
+            var props = self.filtered_case_properties();
+            var skip = self.per_page() * (page - 1);
+            props = props.slice(skip, skip + self.per_page());
+            self.visible_case_properties(props);
+        };
+        // Don't allow changing per page; "Add Property" button is where the per page changer usually is
+        self.per_page = ko.observable(10);
+        self.total_case_properties = ko.computed(function () {
+            return self.filtered_case_properties().length;
+        });
+        self.goToPage(1);
+
+        self.suggestedSaveProperties = ko.computed(function () {
+            return caseConfigUtils.filteredSuggestedProperties(self.suggestedProperties(), self.case_properties());
+        }, self);
+
+        self.addProperty = function () {
+            if (!self.hasPrivilege) {
+                return;
+            }
+            var property = caseProperty.wrap({
+                path: '',
+                key: '',
+                required: false,
+                save_only_if_edited: false,
             }, self);
 
-            self.addProperty = function () {
-                if (!self.hasPrivilege) {
-                    return;
-                }
-                var property = caseProperty.wrap({
-                    path: '',
-                    key: '',
-                    required: false,
-                    save_only_if_edited: false,
-                }, self);
+            self.case_properties.push(property);
+            self.visible_case_properties.push(property);
+            google.track.event('Case Management', analyticsAction, 'Save Properties');
+        };
 
-                self.case_properties.push(property);
-                self.visible_case_properties.push(property);
-                google.track.event('Case Management', analyticsAction, 'Save Properties');
-            };
+        self.removeProperty = function (property) {
+            if (!self.hasPrivilege) {
+                return;
+            }
+            google.track.event('Case Management', analyticsAction, 'Save Properties (remove)');
+            self.case_properties.remove(property);
+            self.visible_case_properties.remove(property);
+            if (!self.visible_case_properties().length) {
+                self.pagination_reset_flag(!self.pagination_reset_flag());
+            }
+            saveButton.fire('change');
+        };
 
-            self.removeProperty = function (property) {
-                if (!self.hasPrivilege) {
-                    return;
-                }
-                google.track.event('Case Management', analyticsAction, 'Save Properties (remove)');
-                self.case_properties.remove(property);
-                self.visible_case_properties.remove(property);
-                if (!self.visible_case_properties().length) {
-                    self.pagination_reset_flag(!self.pagination_reset_flag());
-                }
-                saveButton.fire('change');
-            };
+        self.switchSaveOnlyIfEdited = function (property, event) {
+            if (!self.hasPrivilege) {
+                return;
+            }
+            var checked = event.target.checked;
+            if (checked) {
+                google.track.event('Case Management', analyticsAction, 'Checked "Save only if edited"');
+            } else {
+                google.track.event('Case Management', analyticsAction, 'Unchecked "Save only if edited"');
+            }
+            var updatedCaseProp = caseProperty.wrap(_.extend(ko.mapping.toJS(property), {save_only_if_edited: checked}), self);
+            self.case_properties.replace(property, updatedCaseProp);
+            self.visible_case_properties.replace(property, updatedCaseProp);
+            saveButton.fire('change');
+        };
 
-            self.switchSaveOnlyIfEdited = function (property, event) {
-                if (!self.hasPrivilege) {
-                    return;
+        self.propertyCounts = ko.computed(function () {
+            var count = {};
+            _(self.case_properties()).each(function (p) {
+                var key = p.key();
+                if (!_.has(count, key)) {
+                    count[key] = 0;
                 }
-                var checked = event.target.checked;
-                if (checked) {
-                    google.track.event('Case Management', analyticsAction, 'Checked "Save only if edited"');
-                } else {
-                    google.track.event('Case Management', analyticsAction, 'Unchecked "Save only if edited"');
-                }
-                var updatedCaseProp = caseProperty.wrap(_.extend(ko.mapping.toJS(property), {save_only_if_edited: checked}), self);
-                self.case_properties.replace(property, updatedCaseProp);
-                self.visible_case_properties.replace(property, updatedCaseProp);
-                saveButton.fire('change');
-            };
-
-            self.propertyCounts = ko.computed(function () {
-                var count = {};
-                _(self.case_properties()).each(function (p) {
-                    var key = p.key();
-                    if (!_.has(count, key)) {
-                        count[key] = 0;
-                    }
-                    return count[key] += 1;
-                });
-                return count;
+                return count[key] += 1;
             });
+            return count;
+        });
 
-            self.hasDeprecatedProperties = ko.computed(function () {
-                if (privileges.hasPrivilege('data_dictionary')) {
-                    for (const p of self.case_properties()) {
-                        if (p.isDeprecated()) {
-                            return true;
+        self.hasDeprecatedProperties = ko.computed(function () {
+            if (privileges.hasPrivilege('data_dictionary')) {
+                for (const p of self.case_properties()) {
+                    if (p.isDeprecated()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        });
+
+        self.repeat_context = function () {
+            if (self.case_name) {
+                return caseConfig.get_repeat_context(self.case_name());
+            } else {
+                return null;
+            }
+        };
+
+        self.setRequired = function (required) {
+            var deleteMe = [];
+            _(self.case_properties()).each(function (caseProperty) {
+                var key = caseProperty.key();
+                if (_(required).contains(key)) {
+                    caseProperty.required(true);
+                    required.splice(required.indexOf(key), 1);
+                } else {
+                    if (caseProperty.required()) {
+                        caseProperty.required(false);
+                        if (!caseProperty.path()) {
+                            deleteMe.push(caseProperty);
                         }
+                    }
+
+                }
+            });
+            _(deleteMe).each(function (caseProperty) {
+                self.case_properties.remove(caseProperty);
+            });
+            _(required).each(function (key) {
+                self.case_properties.splice(0, 0, caseProperty.wrap({
+                    path: '',
+                    key: key,
+                    required: true,
+                }, self));
+            });
+            self.pagination_reset_flag(!self.pagination_reset_flag());
+        };
+
+        self.unwrap = function () {
+            ko.mapping.toJS(self, mapping(self));
+        };
+
+        return self;
+    };
+
+    var caseTransaction = function (data, caseConfig, hasPrivilege) {
+        data.type = 'case-property';
+        var self = baseTransaction(caseTransactionMapping, caseConfig.saveButton, 'Form Level', data, caseConfig, hasPrivilege);
+
+        self.case_type(self.case_type() || caseConfig.caseType);
+
+        self.close_case = ko.computed({
+            read: function () {
+                if (self.close_condition) {
+                    return self.close_condition.type() !== 'never';
+                } else {
+                    return false;
+                }
+
+            },
+            write: function (value) {
+                self.close_condition.type(value ? 'always' : 'never');
+                self.caseConfig.saveButton.fire('change');
+            },
+        });
+
+        return self;
+    };
+
+
+    var usercaseTransaction = function (data, caseConfig) {
+        data.type = 'user-property';
+        var self = baseTransaction(usercaseTransactionMapping, caseConfig.saveUsercaseButton, 'User Case Management', data, caseConfig, true);
+
+        self.case_type = function () {
+            return 'commcare-user';
+        };
+
+        return self;
+    };
+
+
+    var casePropertyBase = {
+        mapping: {
+            include: ['key', 'path', 'required', 'save_only_if_edited'],
+        },
+        wrap: function (data, caseTransaction) {
+            var self = ko.mapping.fromJS(data, caseProperty.mapping);
+            self.case_transaction = caseTransaction;
+            self.caseType = ko.computed(function () {
+                return self.case_transaction.case_type();
+            });
+            self.updatedDescription = ko.observable();
+            self.isDeprecated = ko.computed(function () {
+                if (privileges.hasPrivilege('data_dictionary')) {
+                    const config = self.case_transaction.caseConfig;
+                    const depProps = config.deprecatedPropertiesDict[self.caseType()];
+                    if (depProps && self.key() !== 'name') {
+                        return depProps.includes(self.key());
                     }
                 }
                 return false;
             });
-
-            self.repeat_context = function () {
-                if (self.case_name) {
-                    return caseConfig.get_repeat_context(self.case_name());
-                } else {
-                    return null;
-                }
-            };
-
-            self.setRequired = function (required) {
-                var deleteMe = [];
-                _(self.case_properties()).each(function (caseProperty) {
-                    var key = caseProperty.key();
-                    if (_(required).contains(key)) {
-                        caseProperty.required(true);
-                        required.splice(required.indexOf(key), 1);
-                    } else {
-                        if (caseProperty.required()) {
-                            caseProperty.required(false);
-                            if (!caseProperty.path()) {
-                                deleteMe.push(caseProperty);
-                            }
-                        }
-
-                    }
-                });
-                _(deleteMe).each(function (caseProperty) {
-                    self.case_properties.remove(caseProperty);
-                });
-                _(required).each(function (key) {
-                    self.case_properties.splice(0, 0, caseProperty.wrap({
-                        path: '',
-                        key: key,
-                        required: true,
-                    }, self));
-                });
-                self.pagination_reset_flag(!self.pagination_reset_flag());
-            };
-
-            self.unwrap = function () {
-                ko.mapping.toJS(self, mapping(self));
-            };
-
-            return self;
-        };
-
-        var caseTransaction = function (data, caseConfig, hasPrivilege) {
-            data.type = 'case-property';
-            var self = baseTransaction(caseTransactionMapping, caseConfig.saveButton, 'Form Level', data, caseConfig, hasPrivilege);
-
-            self.case_type(self.case_type() || caseConfig.caseType);
-
-            self.close_case = ko.computed({
+            self.description = ko.computed({
                 read: function () {
-                    if (self.close_condition) {
-                        return self.close_condition.type() !== 'never';
-                    } else {
-                        return false;
+                    if (self.updatedDescription() !== undefined) {
+                        return self.updatedDescription();
                     }
-
+                    var config = self.case_transaction.caseConfig;
+                    var type = config.descriptionDict[self.caseType()];
+                    if (type) {
+                        return type[self.key()] || '';
+                    }
                 },
                 write: function (value) {
-                    self.close_condition.type(value ? 'always' : 'never');
-                    self.caseConfig.saveButton.fire('change');
+                    self.updatedDescription(value);
                 },
             });
-
             return self;
-        };
+        },
+    };
 
-
-        var usercaseTransaction = function (data, caseConfig) {
-            data.type = 'user-property';
-            var self = baseTransaction(usercaseTransactionMapping, caseConfig.saveUsercaseButton, 'User Case Management', data, caseConfig, true);
-
-            self.case_type = function () {
-                return 'commcare-user';
+    var caseProperty = {
+        mapping: casePropertyBase.mapping,
+        wrap: function (data, caseTransaction) {
+            var self = casePropertyBase.wrap(data, caseTransaction);
+            self.defaultKey = ko.computed(function () {
+                var path = self.path() || '';
+                var value = path.split('/');
+                value = value[value.length - 1];
+                return value;
+            });
+            self.repeat_context = function () {
+                return caseTransaction.caseConfig.get_repeat_context(self.path());
             };
-
-            return self;
-        };
-
-
-        var casePropertyBase = {
-            mapping: {
-                include: ['key', 'path', 'required', 'save_only_if_edited'],
-            },
-            wrap: function (data, caseTransaction) {
-                var self = ko.mapping.fromJS(data, caseProperty.mapping);
-                self.case_transaction = caseTransaction;
-                self.caseType = ko.computed(function () {
-                    return self.case_transaction.case_type();
-                });
-                self.updatedDescription = ko.observable();
-                self.isDeprecated = ko.computed(function () {
-                    if (privileges.hasPrivilege('data_dictionary')) {
-                        const config = self.case_transaction.caseConfig;
-                        const depProps = config.deprecatedPropertiesDict[self.caseType()];
-                        if (depProps && self.key() !== 'name') {
-                            return depProps.includes(self.key());
-                        }
+            self.validate = ko.computed(function () {
+                if (self.path() || self.key()) {
+                    if (caseTransaction.propertyCounts()[self.key()] > 1) {
+                        return gettext("Property updated by two questions");
+                    } else if (caseTransaction.caseConfig.reserved_words.indexOf(self.key()) !== -1) {
+                        return '<strong>' + self.key() + '</strong> is a reserved word';
+                    } else if (self.repeat_context() && self.repeat_context() !== caseTransaction.repeat_context()) {
+                        return gettext('Inside the wrong repeat!');
+                    } else if (_.difference(
+                        _.initial(self.key().split(/\//)),
+                        caseTransaction.caseConfig.valid_index_names,
+                    ).length) {
+                        return gettext('Property uses unrecognized prefix <strong>' +
+                            self.key().replace(/\/[^/]*$/, '') + '</strong>');
                     }
-                    return false;
-                });
-                self.description = ko.computed({
-                    read: function () {
-                        if (self.updatedDescription() !== undefined) {
-                            return self.updatedDescription();
-                        }
-                        var config = self.case_transaction.caseConfig;
-                        var type = config.descriptionDict[self.caseType()];
-                        if (type) {
-                            return type[self.key()] || '';
-                        }
-                    },
-                    write: function (value) {
-                        self.updatedDescription(value);
-                    },
-                });
-                return self;
-            },
-        };
-
-        var caseProperty = {
-            mapping: casePropertyBase.mapping,
-            wrap: function (data, caseTransaction) {
-                var self = casePropertyBase.wrap(data, caseTransaction);
-                self.defaultKey = ko.computed(function () {
-                    var path = self.path() || '';
-                    var value = path.split('/');
-                    value = value[value.length - 1];
-                    return value;
-                });
-                self.repeat_context = function () {
-                    return caseTransaction.caseConfig.get_repeat_context(self.path());
-                };
-                self.validate = ko.computed(function () {
-                    if (self.path() || self.key()) {
-                        if (caseTransaction.propertyCounts()[self.key()] > 1) {
-                            return gettext("Property updated by two questions");
-                        } else if (caseTransaction.caseConfig.reserved_words.indexOf(self.key()) !== -1) {
-                            return '<strong>' + self.key() + '</strong> is a reserved word';
-                        } else if (self.repeat_context() && self.repeat_context() !== caseTransaction.repeat_context()) {
-                            return gettext('Inside the wrong repeat!');
-                        } else if (_.difference(
-                            _.initial(self.key().split(/\//)),
-                            caseTransaction.caseConfig.valid_index_names,
-                        ).length) {
-                            return gettext('Property uses unrecognized prefix <strong>' +
-                                self.key().replace(/\/[^/]*$/, '') + '</strong>');
-                        }
-                    }
-                    return null;
-                });
-                return self;
-            },
-        };
-
-        var DEFAULT_CONDITION_ALWAYS = {
-            type: 'always',
-            question: null,
-            answer: null,
-            operator: null,
-        };
-
-        var DEFAULT_CONDITION_NEVER = {
-            type: 'never',
-            question: null,
-            answer: null,
-            operator: null,
-        };
-
-        // Default UpdateCaseAction json
-        var DEFAULT_UPDATE_ALWAYS = {
-            question_path: '',
-            update_mode: 'always',
-        };
-
-        var cleanCondition = function (condition) {
-            if (condition.type !== 'if') {
-                condition.question = null;
-                condition.answer = null;
-                condition.operator = null;
-            }
-            return condition;
-        };
-
-        var HQFormActions = {
-            normalize: function (o) {
-                var self = {};
-                self.open_case = {
-                    condition: (o.open_case || {}).condition || DEFAULT_CONDITION_ALWAYS,
-                    name_update: (o.open_case || {}).name_update || DEFAULT_UPDATE_ALWAYS,
-                };
-                self.update_case = {
-                    update: (o.update_case || {}).update || {},
-                };
-                self.case_preload = {
-                    preload: (o.case_preload || {}).preload || {},
-                };
-                self.close_case = {
-                    condition: (o.close_case || {}).condition || DEFAULT_CONDITION_ALWAYS,
-                };
-                self.usercase_update = {
-                    update: (o.usercase_update || {}).update || {},
-                };
-                self.usercase_preload = {
-                    preload: (o.usercase_preload || {}).preload || {},
-                };
-                return self;
-            },
-            to_case_transaction: function (o, caseConfig) {
-                var self = HQFormActions.normalize(o);
-                var requiredProperties = (caseConfig.requires() === 'none' &&
-                    caseConfig.actions.open_case.condition.type !== "never" &&
-                    !o.update_case.update.name) ? [{
-                        key: 'name',
-                        path: self.open_case.name_update.question_path,
-                        required: true,
-                        save_only_if_edited: self.open_case.name_update.update_mode === 'edit',
-                    }] : [];
-                var caseProperties = caseConfigUtils.propertyDictToArray(
-                    requiredProperties,
-                    self.update_case.update,
-                    caseConfig,
-                );
-                var casePreload = caseConfigUtils.preloadDictToArray(
-                    self.case_preload.preload,
-                    caseConfig,
-                );
-                var x = caseTransaction({
-                    case_type: null, // will get overridden by the default
-                    reference_id: null, // not used in normal case config
-                    case_properties: caseProperties,
-                    case_preload: casePreload,
-                    condition: self.open_case.condition,
-                    close_condition: self.close_case.condition,
-                    suggestedProperties: function () {
-                        if (_(caseConfig.propertiesMap).has(this.case_type())) {
-                            return caseConfig.propertiesMap[this.case_type()]();
-                        } else {
-                            return [];
-                        }
-                    },
-                }, caseConfig, true);
-                _.delay(function () {
-                    x.allow = {
-                        condition: ko.computed(function () {
-                            return caseConfig.caseConfigViewModel.actionType() === 'open';
-                        }),
-                        repeats: function () {
-                            return false;
-                        },
-                    };
-                });
-                return x;
-            },
-            from_case_transaction: function (caseTransaction) {
-                var o = ko.mapping.toJS(caseTransaction, caseTransactionMapping(caseTransaction));
-                var x = caseConfigUtils.propertyArrayToDict(['name'], o.case_properties);
-                var caseProperties = x[0],
-                    openNameUpdate = x[1].name;
-                var casePreload = caseConfigUtils.preloadArrayToDict(o.case_preload);
-                var openCondition = o.condition;
-                var closeCondition = o.close_condition;
-                var updateCondition = DEFAULT_CONDITION_ALWAYS;
-                var actionType = caseTransaction.caseConfig.caseConfigViewModel.actionType();
-
-                if (actionType === 'open') {
-                    if (openCondition.type === 'never') {
-                        openCondition.type = 'always';
-                    }
-                } else {
-                    openCondition.type = 'never';
-
                 }
+                return null;
+            });
+            return self;
+        },
+    };
 
-                updateCondition.type = 'always';
+    var DEFAULT_CONDITION_ALWAYS = {
+        type: 'always',
+        question: null,
+        answer: null,
+        operator: null,
+    };
 
-                return {
-                    open_case: {
-                        condition: cleanCondition(openCondition),
-                        name_update: openNameUpdate,
-                    },
-                    update_case: {
-                        update: caseProperties,
-                        condition: cleanCondition(updateCondition),
-                    },
-                    case_preload: {
-                        preload: casePreload,
-                        condition: cleanCondition(updateCondition),
-                    },
-                    close_case: {
-                        condition: cleanCondition(closeCondition),
-                    },
-                };
-            },
-            to_usercase_transaction: function (o, caseConfig) {
-                var self = HQFormActions.normalize(o);
-                var caseProperties = caseConfigUtils.propertyDictToArray(
-                    [], // usercase has no required properties; it has already been created with everything it needs
-                    self.usercase_update.update,
-                    caseConfig,
-                );
-                var casePreload = caseConfigUtils.preloadDictToArray(
-                    self.usercase_preload.preload,
-                    caseConfig,
-                );
-                return usercaseTransaction({
-                    case_properties: caseProperties,
-                    case_preload: casePreload,
-                    case_type: 'commcare-user', // will get overridden by the default. Set here to check deprecated status for saved properties on initial page load
-                    allow: {
-                        repeats: function () {
-                            // This placeholder function allows us to reuse the "case-config:case-properties:question"
-                            // template in case_config_ko_templates.html
-                            return true;
-                        },
-                    },
+    var DEFAULT_CONDITION_NEVER = {
+        type: 'never',
+        question: null,
+        answer: null,
+        operator: null,
+    };
 
-                    suggestedProperties: function () {
-                        if (_(caseConfig.usercasePropertiesMap).has('commcare-user')) {
-                            return caseConfig.usercasePropertiesMap['commcare-user']();
-                        } else {
-                            return [];
-                        }
-                    },
-                }, caseConfig);
-            },
-            from_usercase_transaction: function (usercaseTransaction) {
-                var o = ko.mapping.toJS(usercaseTransaction, usercaseTransactionMapping(usercaseTransaction));
-                var x = caseConfigUtils.propertyArrayToDict([], o.case_properties);
-                var caseProperties = x[0];
-                var casePreload = caseConfigUtils.preloadArrayToDict(o.case_preload);
-                return {
-                    usercase_update: {
-                        update: caseProperties,
-                        condition: cleanCondition(DEFAULT_CONDITION_ALWAYS), // usercase_update action is always active
-                    },
-                    usercase_preload: {
-                        preload: casePreload,
-                    },
-                };
-            },
-        };
+    // Default UpdateCaseAction json
+    var DEFAULT_UPDATE_ALWAYS = {
+        question_path: '',
+        update_mode: 'always',
+    };
 
-        var HQOpenSubCaseAction = {
-            normalize: function (o) {
-                var self = {};
-                self.case_type = o.case_type || null;
-                self.name_update = o.name_update || {};
-                self.reference_id = o.reference_id || null;
-                self.case_properties = o.case_properties || {};
-                self.condition = o.condition || DEFAULT_CONDITION_ALWAYS;
-                self.close_condition = o.close_condition || DEFAULT_CONDITION_NEVER;
-                self.repeat_context = o.repeat_context;
-                self.relationship = o.relationship || null;
-                return self;
-            },
-            to_case_transaction: function (o, caseConfig) {
-                var self = HQOpenSubCaseAction.normalize(o);
-                var caseProperties = caseConfigUtils.propertyDictToArray([{
-                    path: self.name_update.question_path,
-                    key: 'name',
-                    required: true,
-                    save_only_if_edited: o.name_update ?
-                        o.name_update.update_mode === 'edit' : false,
-                }], self.case_properties, caseConfig);
-
-                return caseTransaction({
-                    case_type: self.case_type,
-                    reference_id: self.reference_id,
-                    case_properties: caseProperties,
-                    condition: self.condition,
-                    close_condition: self.close_condition,
-                    relationship: self.relationship,
-                    suggestedProperties: function () {
-                        if (this.case_type() && _(caseConfig.propertiesMap).has(this.case_type())) {
-                            var all = caseConfig.propertiesMap[this.case_type()]();
-                            return _(all).filter(function (property) {
-                                return !_(property).contains('/');
-                            });
-                        } else {
-                            return [];
-                        }
-                    },
-                    allow: {
-                        condition: function () {
-                            return true;
-                        },
-                        case_preload: function () {
-                            return false;
-                        },
-                        repeats: function () {
-                            return true;
-                        },
-                        parentProperties: function () {
-                            return false;
-                        },
-                    },
-                }, caseConfig, addOnsPrivileges.subcases);
-            },
-            from_case_transaction: function (caseTransaction) {
-                var o = ko.mapping.toJS(caseTransaction, caseTransactionMapping(caseTransaction));
-                var x = caseConfigUtils.propertyArrayToDict(['name'], o.case_properties);
-                var caseProperties = x[0],
-                    openSubcaseUpdateName = x[1].name;
-
-                return {
-                    name_update: openSubcaseUpdateName,
-                    case_type: o.case_type,
-                    case_properties: caseProperties,
-                    reference_id: o.reference_id,
-                    condition: cleanCondition(o.condition),
-                    close_condition: cleanCondition(o.close_condition),
-                    repeat_context: caseTransaction.repeat_context(),
-                };
-            },
-        };
-
-        if (initialPageData.get('has_form_source')) {
-            var caseConfigObj = caseConfig(_.extend({}, initialPageData.get("case_config_options"), {
-                home: $('#case-config-ko'),
-                requires: ko.observable(initialPageData.get("form_requires")),
-            }));
-            caseConfigObj.init();
+    var cleanCondition = function (condition) {
+        if (condition.type !== 'if') {
+            condition.question = null;
+            condition.answer = null;
+            condition.operator = null;
         }
-    });
+        return condition;
+    };
+
+    var HQFormActions = {
+        normalize: function (o) {
+            var self = {};
+            self.open_case = {
+                condition: (o.open_case || {}).condition || DEFAULT_CONDITION_ALWAYS,
+                name_update: (o.open_case || {}).name_update || DEFAULT_UPDATE_ALWAYS,
+            };
+            self.update_case = {
+                update: (o.update_case || {}).update || {},
+            };
+            self.case_preload = {
+                preload: (o.case_preload || {}).preload || {},
+            };
+            self.close_case = {
+                condition: (o.close_case || {}).condition || DEFAULT_CONDITION_ALWAYS,
+            };
+            self.usercase_update = {
+                update: (o.usercase_update || {}).update || {},
+            };
+            self.usercase_preload = {
+                preload: (o.usercase_preload || {}).preload || {},
+            };
+            return self;
+        },
+        to_case_transaction: function (o, caseConfig) {
+            var self = HQFormActions.normalize(o);
+            var requiredProperties = (caseConfig.requires() === 'none' &&
+                caseConfig.actions.open_case.condition.type !== "never" &&
+                !o.update_case.update.name) ? [{
+                    key: 'name',
+                    path: self.open_case.name_update.question_path,
+                    required: true,
+                    save_only_if_edited: self.open_case.name_update.update_mode === 'edit',
+                }] : [];
+            var caseProperties = caseConfigUtils.propertyDictToArray(
+                requiredProperties,
+                self.update_case.update,
+                caseConfig,
+            );
+            var casePreload = caseConfigUtils.preloadDictToArray(
+                self.case_preload.preload,
+                caseConfig,
+            );
+            var x = caseTransaction({
+                case_type: null, // will get overridden by the default
+                reference_id: null, // not used in normal case config
+                case_properties: caseProperties,
+                case_preload: casePreload,
+                condition: self.open_case.condition,
+                close_condition: self.close_case.condition,
+                suggestedProperties: function () {
+                    if (_(caseConfig.propertiesMap).has(this.case_type())) {
+                        return caseConfig.propertiesMap[this.case_type()]();
+                    } else {
+                        return [];
+                    }
+                },
+            }, caseConfig, true);
+            _.delay(function () {
+                x.allow = {
+                    condition: ko.computed(function () {
+                        return caseConfig.caseConfigViewModel.actionType() === 'open';
+                    }),
+                    repeats: function () {
+                        return false;
+                    },
+                };
+            });
+            return x;
+        },
+        from_case_transaction: function (caseTransaction) {
+            var o = ko.mapping.toJS(caseTransaction, caseTransactionMapping(caseTransaction));
+            var x = caseConfigUtils.propertyArrayToDict(['name'], o.case_properties);
+            var caseProperties = x[0],
+                openNameUpdate = x[1].name;
+            var casePreload = caseConfigUtils.preloadArrayToDict(o.case_preload);
+            var openCondition = o.condition;
+            var closeCondition = o.close_condition;
+            var updateCondition = DEFAULT_CONDITION_ALWAYS;
+            var actionType = caseTransaction.caseConfig.caseConfigViewModel.actionType();
+
+            if (actionType === 'open') {
+                if (openCondition.type === 'never') {
+                    openCondition.type = 'always';
+                }
+            } else {
+                openCondition.type = 'never';
+
+            }
+
+            updateCondition.type = 'always';
+
+            return {
+                open_case: {
+                    condition: cleanCondition(openCondition),
+                    name_update: openNameUpdate,
+                },
+                update_case: {
+                    update: caseProperties,
+                    condition: cleanCondition(updateCondition),
+                },
+                case_preload: {
+                    preload: casePreload,
+                    condition: cleanCondition(updateCondition),
+                },
+                close_case: {
+                    condition: cleanCondition(closeCondition),
+                },
+            };
+        },
+        to_usercase_transaction: function (o, caseConfig) {
+            var self = HQFormActions.normalize(o);
+            var caseProperties = caseConfigUtils.propertyDictToArray(
+                [], // usercase has no required properties; it has already been created with everything it needs
+                self.usercase_update.update,
+                caseConfig,
+            );
+            var casePreload = caseConfigUtils.preloadDictToArray(
+                self.usercase_preload.preload,
+                caseConfig,
+            );
+            return usercaseTransaction({
+                case_properties: caseProperties,
+                case_preload: casePreload,
+                case_type: 'commcare-user', // will get overridden by the default. Set here to check deprecated status for saved properties on initial page load
+                allow: {
+                    repeats: function () {
+                        // This placeholder function allows us to reuse the "case-config:case-properties:question"
+                        // template in case_config_ko_templates.html
+                        return true;
+                    },
+                },
+
+                suggestedProperties: function () {
+                    if (_(caseConfig.usercasePropertiesMap).has('commcare-user')) {
+                        return caseConfig.usercasePropertiesMap['commcare-user']();
+                    } else {
+                        return [];
+                    }
+                },
+            }, caseConfig);
+        },
+        from_usercase_transaction: function (usercaseTransaction) {
+            var o = ko.mapping.toJS(usercaseTransaction, usercaseTransactionMapping(usercaseTransaction));
+            var x = caseConfigUtils.propertyArrayToDict([], o.case_properties);
+            var caseProperties = x[0];
+            var casePreload = caseConfigUtils.preloadArrayToDict(o.case_preload);
+            return {
+                usercase_update: {
+                    update: caseProperties,
+                    condition: cleanCondition(DEFAULT_CONDITION_ALWAYS), // usercase_update action is always active
+                },
+                usercase_preload: {
+                    preload: casePreload,
+                },
+            };
+        },
+    };
+
+    var HQOpenSubCaseAction = {
+        normalize: function (o) {
+            var self = {};
+            self.case_type = o.case_type || null;
+            self.name_update = o.name_update || {};
+            self.reference_id = o.reference_id || null;
+            self.case_properties = o.case_properties || {};
+            self.condition = o.condition || DEFAULT_CONDITION_ALWAYS;
+            self.close_condition = o.close_condition || DEFAULT_CONDITION_NEVER;
+            self.repeat_context = o.repeat_context;
+            self.relationship = o.relationship || null;
+            return self;
+        },
+        to_case_transaction: function (o, caseConfig) {
+            var self = HQOpenSubCaseAction.normalize(o);
+            var caseProperties = caseConfigUtils.propertyDictToArray([{
+                path: self.name_update.question_path,
+                key: 'name',
+                required: true,
+                save_only_if_edited: o.name_update ?
+                    o.name_update.update_mode === 'edit' : false,
+            }], self.case_properties, caseConfig);
+
+            return caseTransaction({
+                case_type: self.case_type,
+                reference_id: self.reference_id,
+                case_properties: caseProperties,
+                condition: self.condition,
+                close_condition: self.close_condition,
+                relationship: self.relationship,
+                suggestedProperties: function () {
+                    if (this.case_type() && _(caseConfig.propertiesMap).has(this.case_type())) {
+                        var all = caseConfig.propertiesMap[this.case_type()]();
+                        return _(all).filter(function (property) {
+                            return !_(property).contains('/');
+                        });
+                    } else {
+                        return [];
+                    }
+                },
+                allow: {
+                    condition: function () {
+                        return true;
+                    },
+                    case_preload: function () {
+                        return false;
+                    },
+                    repeats: function () {
+                        return true;
+                    },
+                    parentProperties: function () {
+                        return false;
+                    },
+                },
+            }, caseConfig, addOnsPrivileges.subcases);
+        },
+        from_case_transaction: function (caseTransaction) {
+            var o = ko.mapping.toJS(caseTransaction, caseTransactionMapping(caseTransaction));
+            var x = caseConfigUtils.propertyArrayToDict(['name'], o.case_properties);
+            var caseProperties = x[0],
+                openSubcaseUpdateName = x[1].name;
+
+            return {
+                name_update: openSubcaseUpdateName,
+                case_type: o.case_type,
+                case_properties: caseProperties,
+                reference_id: o.reference_id,
+                condition: cleanCondition(o.condition),
+                close_condition: cleanCondition(o.close_condition),
+                repeat_context: caseTransaction.repeat_context(),
+            };
+        },
+    };
+
+    if (initialPageData.get('has_form_source')) {
+        var caseConfigObj = caseConfig(_.extend({}, initialPageData.get("case_config_options"), {
+            home: $('#case-config-ko'),
+            requires: ko.observable(initialPageData.get("form_requires")),
+        }));
+        caseConfigObj.init();
+    }
 });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/copy_form_to_app.js
@@ -1,75 +1,67 @@
-hqDefine("app_manager/js/forms/copy_form_to_app", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/toggles",
-], function (
-    $,
-    ko,
-    _,
-    initialPageData,
-    toggles,
-) {
-    var module = function (moduleId, moduleName, isCurrentModule) {
-        var self = {};
-        self.id = moduleId;
-        self.name = moduleName;
-        self.isCurrent = isCurrentModule;
-        return self;
-    };
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import toggles from "hqwebapp/js/toggles";
 
-    var application = function (appId, appName, isCurrentApp, modules) {
-        var self = {};
-        self.id = appId;
-        self.name = appName;
-        self.isCurrent = isCurrentApp;
-        self.modules = ko.observableArray(
-            _.map(modules, function (mod) {
-                return module(mod["module_id"], mod["name"], mod["is_current"]);
-            }),
-        );
-        var currentModule = _.find(self.modules(), function (mod) {
-            return mod.isCurrent;
-        });
-        self.selectedModuleId = ko.observable(currentModule ? currentModule.id : undefined);
-        return self;
-    };
+var module = function (moduleId, moduleName, isCurrentModule) {
+    var self = {};
+    self.id = moduleId;
+    self.name = moduleName;
+    self.isCurrent = isCurrentModule;
+    return self;
+};
 
-    var appsModulesModel = function (appsModules) {
-        var self = {};
-        self.apps = ko.observableArray(
-            _.map(appsModules, function (app) {
-                return application(app["app_id"], app["name"], app["is_current"], app["modules"]);
-            }),
-        );
-        var currentApp = _.find(self.apps(), function (app) {
-            return app.isCurrent;
-        });
-        self.selectedAppId = ko.observable(currentApp ? currentApp.id : undefined);
-        self.selectedApp = ko.computed(function () {
-            return _.find(self.apps(), function (app) {
-                return app.id === self.selectedAppId();
-            });
-        });
-        return self;
-    };
-
-    $(function () {
-        if (!toggles.toggleEnabled('COPY_FORM_TO_APP')) {
-            return;
-        }
-
-        if (!initialPageData.get("allow_form_copy")) {
-            return;
-        }
-
-        var $appModuleSelection = $("#app-module-selection");
-        var viewModel = appsModulesModel(
-            initialPageData.get("apps_modules"),
-        );
-        if ($appModuleSelection.length) {
-            $appModuleSelection.koApplyBindings(viewModel);
-        }
+var application = function (appId, appName, isCurrentApp, modules) {
+    var self = {};
+    self.id = appId;
+    self.name = appName;
+    self.isCurrent = isCurrentApp;
+    self.modules = ko.observableArray(
+        _.map(modules, function (mod) {
+            return module(mod["module_id"], mod["name"], mod["is_current"]);
+        }),
+    );
+    var currentModule = _.find(self.modules(), function (mod) {
+        return mod.isCurrent;
     });
+    self.selectedModuleId = ko.observable(currentModule ? currentModule.id : undefined);
+    return self;
+};
+
+var appsModulesModel = function (appsModules) {
+    var self = {};
+    self.apps = ko.observableArray(
+        _.map(appsModules, function (app) {
+            return application(app["app_id"], app["name"], app["is_current"], app["modules"]);
+        }),
+    );
+    var currentApp = _.find(self.apps(), function (app) {
+        return app.isCurrent;
+    });
+    self.selectedAppId = ko.observable(currentApp ? currentApp.id : undefined);
+    self.selectedApp = ko.computed(function () {
+        return _.find(self.apps(), function (app) {
+            return app.id === self.selectedAppId();
+        });
+    });
+    return self;
+};
+
+$(function () {
+    if (!toggles.toggleEnabled('COPY_FORM_TO_APP')) {
+        return;
+    }
+
+    if (!initialPageData.get("allow_form_copy")) {
+        return;
+    }
+
+    var $appModuleSelection = $("#app-module-selection");
+    var viewModel = appsModulesModel(
+        initialPageData.get("apps_modules"),
+    );
+    if ($appModuleSelection.length) {
+        $appModuleSelection.koApplyBindings(viewModel);
+    }
 });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -1,193 +1,181 @@
-hqDefine("app_manager/js/forms/form_view", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "hqwebapp/js/initial_page_data",
-    "app_manager/js/app_manager",
-    "analytix/js/kissmetrix",
-    "app_manager/js/forms/form_workflow",
-    "hqwebapp/js/toggles",
-    "app_manager/js/forms/custom_instances",
-    "app_manager/js/nav_menu_media",
-    "app_manager/js/forms/copy_form_to_app",
-    "app_manager/js/forms/case_knockout_bindings",  // casePropertyAutocomplete and questionsSelect
-    "app_manager/js/forms/case_config_ui",          // non-advanced modules only
-    "app_manager/js/forms/advanced/case_config_ui", // advanced modules only
-    "app_manager/js/xpathValidator",
-    "app_manager/js/custom_assertions",
-    "hqwebapp/js/components/pagination",
-    "hqwebapp/js/components/search_box",
-    "hqwebapp/js/bootstrap3/knockout_bindings.ko",  // sortable binding
-    "commcarehq",
-], function (
-    $,
-    ko,
-    _,
-    initialPageData,
-    appManagerUtils,
-    kissmetrix,
-    formWorkflow,
-    toggles,
-    customInstancesModule,
-) {
-    appManagerUtils.setPrependedPageTitle("\u2699 ", true);
-    appManagerUtils.setAppendedPageTitle(gettext("Form Settings"));
-    appManagerUtils.updatePageTitle(initialPageData.get("form_name"));
+import "commcarehq";
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import appManagerUtils from "app_manager/js/app_manager";
+import kissmetrix from "analytix/js/kissmetrix";
+import formWorkflow from "app_manager/js/forms/form_workflow";
+import toggles from "hqwebapp/js/toggles";
+import customInstancesModule from "app_manager/js/forms/custom_instances";
+import "app_manager/js/nav_menu_media";
+import "app_manager/js/forms/copy_form_to_app";
+import "app_manager/js/forms/case_knockout_bindings";  // casePropertyAutocomplete and questionsSelect
+import "app_manager/js/forms/case_config_ui";  // non-advanced modules only
+import "app_manager/js/forms/advanced/case_config_ui";  // advanced modules only
+import "app_manager/js/xpathValidator";
+import "app_manager/js/custom_assertions";
+import "hqwebapp/js/components/pagination";
+import "hqwebapp/js/components/search_box";
+import "hqwebapp/js/bootstrap3/knockout_bindings.ko";  // sortable binding
 
-    function formFilterMatches(filter, substringMatches) {
-        if (typeof(filter) !== 'string') {
-            return false;
-        }
+appManagerUtils.setPrependedPageTitle("\u2699 ", true);
+appManagerUtils.setAppendedPageTitle(gettext("Form Settings"));
+appManagerUtils.updatePageTitle(initialPageData.get("form_name"));
 
-        var result = false;
-        $.each(substringMatches, function (index, sub) {
-            result = result || filter.indexOf(sub) !== -1;
-        });
-
-        return result;
+function formFilterMatches(filter, substringMatches) {
+    if (typeof(filter) !== 'string') {
+        return false;
     }
 
-    function formFilterModel() {
-        var self = {};
-        var patterns = initialPageData.get('form_filter_patterns');
-
-        self.formFilter = ko.observable(initialPageData.get('form_filter'));
-
-        self.caseReferenceNotAllowed = ko.computed(function () {
-            var moduleUsesCase = initialPageData.get('all_other_forms_require_a_case') && initialPageData.get('form_requires') === 'case';
-            if (!moduleUsesCase || (initialPageData.get('put_in_root') && !initialPageData.get('root_requires_same_case'))) {
-                // We want to determine here if the filter expression references
-                // any case but the user case.
-                var filter = self.formFilter();
-                if (typeof(filter) !== 'string') {
-                    return true;
-                }
-
-                $.each(patterns.usercase_substring, function (index, sub) {
-                    filter = filter.replace(sub, '');
-                });
-
-                if (formFilterMatches(filter, patterns.case_substring)) {
-                    return true;
-                }
-            }
-            return false;
-        });
-
-        self.isUsercaseInUse = ko.observable(initialPageData.get('is_usercase_in_use'));
-        self.usercaseReferenceNotAllowed = ko.computed(function () {
-            return !self.isUsercaseInUse() && formFilterMatches(
-                self.formFilter(), patterns.usercase_substring,
-            );
-        });
-
-        self.enableUsercaseInProgress = ko.observable(false);
-        self.enableUsercaseError = ko.observable();
-        self.enableUsercase = function () {
-            self.enableUsercaseInProgress(true);
-            const url = initialPageData.reverse("enable_usercase");
-            $.ajax(url, {
-                method: "POST",
-                success: function () {
-                    self.isUsercaseInUse(true);
-                },
-                error: function () {
-                    self.enableUsercaseInProgress(false);
-                    self.enableUsercaseError(gettext("Could not enable user properties, please try again later."));
-                },
-            });
-        };
-
-        self.allowed = ko.computed(function () {
-            return !self.formFilter() || !self.caseReferenceNotAllowed() && !self.usercaseReferenceNotAllowed();
-        });
-
-        return self;
-    }
-
-    $(function () {
-        // Form name
-        $(document).on("inline-edit-save", function (e, data) {
-            if (_.has(data.update, '.variable-form_name')) {
-                appManagerUtils.updatePageTitle(data.update['.variable-form_name']);
-                appManagerUtils.updateDOM(data.update);
-            }
-        });
-
-        // Validation for build
-        var setupValidation = appManagerUtils.setupValidation;
-        setupValidation(initialPageData.reverse("validate_form_for_build"));
-
-        // Analytics for renaming form
-        $(".appmanager-edit-title").on('click', '.btn-primary', function () {
-            kissmetrix.track.event("Renamed form from form settings page");
-        });
-
-        // Settings > Logic
-        var $formFilter = $('#form-filter');
-        if ($formFilter.length && initialPageData.get('allow_form_filtering')) {
-            $('#form-filter').koApplyBindings(formFilterModel());
-        }
-
-        const labels = initialPageData.get('form_workflows');
-        var options = {
-            labels: labels,
-            workflow: initialPageData.get('post_form_workflow'),
-            workflow_fallback: initialPageData.get('post_form_workflow_fallback'),
-        };
-
-        if (_.has(labels, formWorkflow.FormWorkflow.Values.FORM)) {
-            options.forms = initialPageData.get('linkable_forms');
-            options.formLinks = initialPageData.get('form_links');
-            options.formDatumsUrl = initialPageData.reverse('get_form_datums');
-        }
-
-        $('#form-workflow').koApplyBindings(new formWorkflow.FormWorkflow(options));
-
-        // Settings > Advanced
-        $('#auto-gps-capture').koApplyBindings({
-            auto_gps_capture: ko.observable(initialPageData.get('auto_gps_capture')),
-        });
-
-        if (initialPageData.get('is_training_module')) {
-            $('#release-notes-setting').koApplyBindings({
-                is_release_notes_form: ko.observable(initialPageData.get('is_release_notes_form')),
-                enable_release_notes: ko.observable(initialPageData.get('enable_release_notes')),
-                is_allowed_to_be_release_notes_form: ko.observable(initialPageData.get('is_allowed_to_be_release_notes_form')),
-                toggle_enable: function () {
-                    var allowed = this.is_release_notes_form();
-                    if (!allowed) {
-                        this.enable_release_notes(false);
-                    }
-                    return true;
-                },
-            });
-        }
-
-        var $shadowParent = $('#shadow-parent');
-        if ($shadowParent.length) {
-            $shadowParent.koApplyBindings({
-                shadow_parent: ko.observable(initialPageData.get('shadow_parent_form_id')),
-            });
-        }
-
-        if (toggles.toggleEnabled('CUSTOM_INSTANCES')) {
-            var customInstances = customInstancesModule.wrap({
-                customInstances: initialPageData.get('custom_instances'),
-            });
-            $('#custom-instances').koApplyBindings(customInstances);
-        }
-
-        // Case Management > Data dictionary descriptions for case properties
-        $('.property-description').popover();
-
-        // Advanced > XForm > Upload
-        $("#xform_file_input").change(function () {
-            if ($(this).val()) {
-                $("#xform_file_submit").show();
-            } else {
-                $("#xform_file_submit").hide();
-            }
-        }).trigger('change');
+    var result = false;
+    $.each(substringMatches, function (index, sub) {
+        result = result || filter.indexOf(sub) !== -1;
     });
+
+    return result;
+}
+
+function formFilterModel() {
+    var self = {};
+    var patterns = initialPageData.get('form_filter_patterns');
+
+    self.formFilter = ko.observable(initialPageData.get('form_filter'));
+
+    self.caseReferenceNotAllowed = ko.computed(function () {
+        var moduleUsesCase = initialPageData.get('all_other_forms_require_a_case') && initialPageData.get('form_requires') === 'case';
+        if (!moduleUsesCase || (initialPageData.get('put_in_root') && !initialPageData.get('root_requires_same_case'))) {
+            // We want to determine here if the filter expression references
+            // any case but the user case.
+            var filter = self.formFilter();
+            if (typeof(filter) !== 'string') {
+                return true;
+            }
+
+            $.each(patterns.usercase_substring, function (index, sub) {
+                filter = filter.replace(sub, '');
+            });
+
+            if (formFilterMatches(filter, patterns.case_substring)) {
+                return true;
+            }
+        }
+        return false;
+    });
+
+    self.isUsercaseInUse = ko.observable(initialPageData.get('is_usercase_in_use'));
+    self.usercaseReferenceNotAllowed = ko.computed(function () {
+        return !self.isUsercaseInUse() && formFilterMatches(
+            self.formFilter(), patterns.usercase_substring,
+        );
+    });
+
+    self.enableUsercaseInProgress = ko.observable(false);
+    self.enableUsercaseError = ko.observable();
+    self.enableUsercase = function () {
+        self.enableUsercaseInProgress(true);
+        const url = initialPageData.reverse("enable_usercase");
+        $.ajax(url, {
+            method: "POST",
+            success: function () {
+                self.isUsercaseInUse(true);
+            },
+            error: function () {
+                self.enableUsercaseInProgress(false);
+                self.enableUsercaseError(gettext("Could not enable user properties, please try again later."));
+            },
+        });
+    };
+
+    self.allowed = ko.computed(function () {
+        return !self.formFilter() || !self.caseReferenceNotAllowed() && !self.usercaseReferenceNotAllowed();
+    });
+
+    return self;
+}
+
+$(function () {
+    // Form name
+    $(document).on("inline-edit-save", function (e, data) {
+        if (_.has(data.update, '.variable-form_name')) {
+            appManagerUtils.updatePageTitle(data.update['.variable-form_name']);
+            appManagerUtils.updateDOM(data.update);
+        }
+    });
+
+    // Validation for build
+    var setupValidation = appManagerUtils.setupValidation;
+    setupValidation(initialPageData.reverse("validate_form_for_build"));
+
+    // Analytics for renaming form
+    $(".appmanager-edit-title").on('click', '.btn-primary', function () {
+        kissmetrix.track.event("Renamed form from form settings page");
+    });
+
+    // Settings > Logic
+    var $formFilter = $('#form-filter');
+    if ($formFilter.length && initialPageData.get('allow_form_filtering')) {
+        $('#form-filter').koApplyBindings(formFilterModel());
+    }
+
+    const labels = initialPageData.get('form_workflows');
+    var options = {
+        labels: labels,
+        workflow: initialPageData.get('post_form_workflow'),
+        workflow_fallback: initialPageData.get('post_form_workflow_fallback'),
+    };
+
+    if (_.has(labels, formWorkflow.FormWorkflow.Values.FORM)) {
+        options.forms = initialPageData.get('linkable_forms');
+        options.formLinks = initialPageData.get('form_links');
+        options.formDatumsUrl = initialPageData.reverse('get_form_datums');
+    }
+
+    $('#form-workflow').koApplyBindings(new formWorkflow.FormWorkflow(options));
+
+    // Settings > Advanced
+    $('#auto-gps-capture').koApplyBindings({
+        auto_gps_capture: ko.observable(initialPageData.get('auto_gps_capture')),
+    });
+
+    if (initialPageData.get('is_training_module')) {
+        $('#release-notes-setting').koApplyBindings({
+            is_release_notes_form: ko.observable(initialPageData.get('is_release_notes_form')),
+            enable_release_notes: ko.observable(initialPageData.get('enable_release_notes')),
+            is_allowed_to_be_release_notes_form: ko.observable(initialPageData.get('is_allowed_to_be_release_notes_form')),
+            toggle_enable: function () {
+                var allowed = this.is_release_notes_form();
+                if (!allowed) {
+                    this.enable_release_notes(false);
+                }
+                return true;
+            },
+        });
+    }
+
+    var $shadowParent = $('#shadow-parent');
+    if ($shadowParent.length) {
+        $shadowParent.koApplyBindings({
+            shadow_parent: ko.observable(initialPageData.get('shadow_parent_form_id')),
+        });
+    }
+
+    if (toggles.toggleEnabled('CUSTOM_INSTANCES')) {
+        var customInstances = customInstancesModule.wrap({
+            customInstances: initialPageData.get('custom_instances'),
+        });
+        $('#custom-instances').koApplyBindings(customInstances);
+    }
+
+    // Case Management > Data dictionary descriptions for case properties
+    $('.property-description').popover();
+
+    // Advanced > XForm > Upload
+    $("#xform_file_input").change(function () {
+        if ($(this).val()) {
+            $("#xform_file_submit").show();
+        } else {
+            $("#xform_file_submit").hide();
+        }
+    }).trigger('change');
 });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
@@ -1,267 +1,258 @@
-hqDefine("app_manager/js/forms/form_workflow", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list",
-    "hqwebapp/js/initial_page_data",
-    "hqwebapp/js/toggles",
-], function (
-    $,
-    ko,
-    _,
-    uiElementKeyValueList,
-    initialPageData,
-    toggles,
-) {
-    var FormWorkflow = function (options) {
-        var self = this;
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import uiElementKeyValueList from "hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import toggles from "hqwebapp/js/toggles";
 
-        self.formDatumsUrl = options.formDatumsUrl;
+var FormWorkflow = function (options) {
+    var self = this;
 
-        // Human readable labels for the workflow types
-        self.labels = options.labels;
+    self.formDatumsUrl = options.formDatumsUrl;
 
-        // Workflow type. See FormWorkflow.Values for available types
-        self.workflow = ko.observable(options.workflow);
+    // Human readable labels for the workflow types
+    self.labels = options.labels;
 
-        self.workflowfallback = ko.observable(options.workflow_fallback);
-        self.hasError = ko.observable(self.workflow() === FormWorkflow.Values.ERROR);
-        self.hasWarning = ko.computed(function () {
-            return !self.hasError()
-                && initialPageData.get("is_case_list_form")
-                && self.workflow() !== FormWorkflow.Values.DEFAULT;
+    // Workflow type. See FormWorkflow.Values for available types
+    self.workflow = ko.observable(options.workflow);
+
+    self.workflowfallback = ko.observable(options.workflow_fallback);
+    self.hasError = ko.observable(self.workflow() === FormWorkflow.Values.ERROR);
+    self.hasWarning = ko.computed(function () {
+        return !self.hasError()
+            && initialPageData.get("is_case_list_form")
+            && self.workflow() !== FormWorkflow.Values.DEFAULT;
+    });
+
+    self.workflow.subscribe(function (value) {
+        self.showFormLinkUI(value === FormWorkflow.Values.FORM);
+        self.hasError(value === FormWorkflow.Values.ERROR);
+    });
+
+    // Element used to trigger a change when form link is removed
+    self.$changeEl = options.$changeEl || $('#form-workflow .workflow-change-trigger');
+
+    /* Form linking */
+    self.showFormLinkUI = ko.observable(self.workflow() === FormWorkflow.Values.FORM);
+    self.forms = _.map(options.forms, function (f) {
+        return new FormWorkflow.Form(f);
+    });
+
+    // If original value isn't recognized, display an error
+    if (!self.labels[self.workflow()]) {
+        self.workflow(FormWorkflow.Values.ERROR);
+    }
+
+    var uniqueIds = _.pluck(self.forms,  'uniqueId');
+    self.formLinks = ko.observableArray(_.map(_.filter(options.formLinks, function (link) {
+        return uniqueIds.indexOf(link.uniqueId) >= 0;
+    }), function (link) {
+        return new FormWorkflow.FormLink(
+            link.xpath,
+            link.uniqueId,
+            self,
+            link.datums,
+        );
+    }));
+};
+
+FormWorkflow.Values = {
+    DEFAULT: 'default',
+    ROOT: 'root',
+    FORM: 'form',
+    ERROR: 'error',
+};
+
+FormWorkflow.Errors = {
+    FORM_NOT_FOUND: gettext('This form either no longer exists or has a different case type'),
+};
+
+
+FormWorkflow.prototype.workflowOptions = function () {
+    var options = _.map(this.labels, function (label, value) {
+        return {
+            value: value,
+            label: (value === FormWorkflow.Values.DEFAULT ? '* ' + label : label),
+        };
+    });
+    if (this.hasError()) {
+        options = options.concat({
+            value: FormWorkflow.Values.ERROR,
+            label: gettext("Unrecognized value"),
         });
+    }
+    return options;
+};
 
-        self.workflow.subscribe(function (value) {
-            self.showFormLinkUI(value === FormWorkflow.Values.FORM);
-            self.hasError(value === FormWorkflow.Values.ERROR);
+FormWorkflow.prototype.workflowFallbackOptions = function () {
+    // allow all options as fallback except the one for form linking
+    var fallbackOptions = _.omit(this.labels, function (key, value) { return value === FormWorkflow.Values.FORM; });
+    var options = _.map(fallbackOptions, function (label, value) {
+        return {
+            value: value,
+            label: (value === FormWorkflow.Values.DEFAULT ? '* ' + label : label),
+        };
+    });
+    if (this.hasError()) {
+        options = options.concat({
+            value: FormWorkflow.Values.ERROR,
+            label: gettext("Unrecognized value"),
         });
+    }
+    return options;
+};
 
-        // Element used to trigger a change when form link is removed
-        self.$changeEl = options.$changeEl || $('#form-workflow .workflow-change-trigger');
+FormWorkflow.prototype.onAddFormLink = function (workflow) {
+    // Default to linking to first form that can be auto linked
+    var defaultChoice = _.find(workflow.forms, function (form) { return form.autoLink; }),
+        formId = defaultChoice ? defaultChoice.uniqueId : null;
+    this.formLinks.push(new FormWorkflow.FormLink('', formId, workflow));
+};
 
-        /* Form linking */
-        self.showFormLinkUI = ko.observable(self.workflow() === FormWorkflow.Values.FORM);
-        self.forms = _.map(options.forms, function (f) {
-            return new FormWorkflow.Form(f);
-        });
+FormWorkflow.prototype.onDestroyFormLink = function (formLink) {
+    var workflow = this;
 
-        // If original value isn't recognized, display an error
-        if (!self.labels[self.workflow()]) {
-            self.workflow(FormWorkflow.Values.ERROR);
-        }
+    workflow.formLinks.remove(formLink);
+    workflow.$changeEl.trigger('change'); // Manually trigger change so Save button activates
+};
 
-        var uniqueIds = _.pluck(self.forms,  'uniqueId');
-        self.formLinks = ko.observableArray(_.map(_.filter(options.formLinks, function (link) {
-            return uniqueIds.indexOf(link.uniqueId) >= 0;
-        }), function (link) {
-            return new FormWorkflow.FormLink(
-                link.xpath,
-                link.uniqueId,
-                self,
-                link.datums,
-            );
+FormWorkflow.prototype.displayUnknownForm = function (formLink) {
+    if (_.contains(formLink.errors(), FormWorkflow.Errors.FORM_NOT_FOUND)) {
+        return "Unknown form";
+    }
+};
+
+FormWorkflow.Form = function (form) {
+    this.name = (form.auto_link ? "* " : "") + form.name;
+    this.uniqueId = form.unique_id;
+    this.autoLink = form.auto_link;
+    this.allowManualLinking = form.allow_manual_linking;
+};
+
+FormWorkflow.FormDatum = function (formLink, datum) {
+    var self = this;
+    self.formLink = formLink;
+    self.name = datum.name;
+    self.caseType = datum.case_type || 'unknown';
+    self.xpath = ko.observable(datum.xpath || '');
+    self.xpath.extend({ rateLimit: 200 });  // 1 update per 200 milliseconds
+    self.xpath.subscribe(function () {
+        self.formLink.serializeDatums();
+    });
+};
+
+FormWorkflow.FormLink = function (xpath, formId, workflow, datums) {
+    var self = this;
+    self.xpath = ko.observable(xpath);
+    self.formId = ko.observable(formId);
+    self.autoLink = ko.observable();
+    self.allowManualLinking = ko.observable();
+    self.advancedMode = toggles.toggleEnabled('FORM_LINK_ADVANCED_MODE');
+    self.forms = workflow.forms || [];
+    self.datums = ko.observableArray();
+    self.manualDatums = ko.observable(false);
+    self.datumsFetched = ko.observable(false);
+    self.datumsError = ko.observable(false);
+    self.serializedDatums = ko.observable('');
+
+    self.get_form_by_id = function (formId) {
+        return _.find(self.forms, function (form) { return form.uniqueId === formId; });
+    };
+
+    self.serializeDatums = function () {
+        var jsonDatums = JSON.stringify(_.map(self.datums(), function (datum) {
+            return {'name': datum.name, 'xpath': datum.xpath()};
         }));
+        self.serializedDatums(jsonDatums);
     };
 
-    FormWorkflow.Values = {
-        DEFAULT: 'default',
-        ROOT: 'root',
-        FORM: 'form',
-        ERROR: 'error',
-    };
+    self.datums.subscribe(function () {
+        self.serializeDatums();
+    });
 
-    FormWorkflow.Errors = {
-        FORM_NOT_FOUND: gettext('This form either no longer exists or has a different case type'),
-    };
-
-
-    FormWorkflow.prototype.workflowOptions = function () {
-        var options = _.map(this.labels, function (label, value) {
-            return {
-                value: value,
-                label: (value === FormWorkflow.Values.DEFAULT ? '* ' + label : label),
-            };
-        });
-        if (this.hasError()) {
-            options = options.concat({
-                value: FormWorkflow.Values.ERROR,
-                label: gettext("Unrecognized value"),
-            });
-        }
-        return options;
-    };
-
-    FormWorkflow.prototype.workflowFallbackOptions = function () {
-        // allow all options as fallback except the one for form linking
-        var fallbackOptions = _.omit(this.labels, function (key, value) { return value === FormWorkflow.Values.FORM; });
-        var options = _.map(fallbackOptions, function (label, value) {
-            return {
-                value: value,
-                label: (value === FormWorkflow.Values.DEFAULT ? '* ' + label : label),
-            };
-        });
-        if (this.hasError()) {
-            options = options.concat({
-                value: FormWorkflow.Values.ERROR,
-                label: gettext("Unrecognized value"),
-            });
-        }
-        return options;
-    };
-
-    FormWorkflow.prototype.onAddFormLink = function (workflow) {
-        // Default to linking to first form that can be auto linked
-        var defaultChoice = _.find(workflow.forms, function (form) { return form.autoLink; }),
-            formId = defaultChoice ? defaultChoice.uniqueId : null;
-        this.formLinks.push(new FormWorkflow.FormLink('', formId, workflow));
-    };
-
-    FormWorkflow.prototype.onDestroyFormLink = function (formLink) {
-        var workflow = this;
-
-        workflow.formLinks.remove(formLink);
-        workflow.$changeEl.trigger('change'); // Manually trigger change so Save button activates
-    };
-
-    FormWorkflow.prototype.displayUnknownForm = function (formLink) {
-        if (_.contains(formLink.errors(), FormWorkflow.Errors.FORM_NOT_FOUND)) {
-            return "Unknown form";
-        }
-    };
-
-    FormWorkflow.Form = function (form) {
-        this.name = (form.auto_link ? "* " : "") + form.name;
-        this.uniqueId = form.unique_id;
-        this.autoLink = form.auto_link;
-        this.allowManualLinking = form.allow_manual_linking;
-    };
-
-    FormWorkflow.FormDatum = function (formLink, datum) {
-        var self = this;
-        self.formLink = formLink;
-        self.name = datum.name;
-        self.caseType = datum.case_type || 'unknown';
-        self.xpath = ko.observable(datum.xpath || '');
-        self.xpath.extend({ rateLimit: 200 });  // 1 update per 200 milliseconds
-        self.xpath.subscribe(function () {
-            self.formLink.serializeDatums();
+    self.wrap_datums = function (data) {
+        self.datumsFetched(true);
+        return _.map(data, function (datum) {
+            return new FormWorkflow.FormDatum(self, datum);
         });
     };
 
-    FormWorkflow.FormLink = function (xpath, formId, workflow, datums) {
-        var self = this;
-        self.xpath = ko.observable(xpath);
-        self.formId = ko.observable(formId);
-        self.autoLink = ko.observable();
-        self.allowManualLinking = ko.observable();
-        self.advancedMode = toggles.toggleEnabled('FORM_LINK_ADVANCED_MODE');
-        self.forms = workflow.forms || [];
-        self.datums = ko.observableArray();
-        self.manualDatums = ko.observable(false);
-        self.datumsFetched = ko.observable(false);
-        self.datumsError = ko.observable(false);
-        self.serializedDatums = ko.observable('');
+    self.enableManualDatums = function () {
+        self.manualDatums(true);
+    };
 
-        self.get_form_by_id = function (formId) {
-            return _.find(self.forms, function (form) { return form.uniqueId === formId; });
-        };
+    self.disableManualDatums = function () {
+        self.manualDatums(false);
+        $('#form-workflow .workflow-change-trigger').trigger('change');
+        self.datums.removeAll();
+    };
 
-        self.serializeDatums = function () {
-            var jsonDatums = JSON.stringify(_.map(self.datums(), function (datum) {
-                return {'name': datum.name, 'xpath': datum.xpath()};
-            }));
-            self.serializedDatums(jsonDatums);
-        };
+    // initialize
+    let form = self.get_form_by_id(self.formId());
+    self.autoLink(form ? form.autoLink : false);
+    self.allowManualLinking(form ? form.allowManualLinking : false);
+    self.datums(self.wrap_datums(datums));
+    self.manualDatums(self.datums().length && self.autoLink());
+    self.showLinkDatums = ko.computed(function () {
+        return (!self.autoLink() || self.manualDatums());
+    });
 
-        self.datums.subscribe(function () {
-            self.serializeDatums();
+    if (self.advancedMode) {
+        self.advancedModeDatumsElement = uiElementKeyValueList.new(
+            String(Math.random()).slice(2),  // random id
+            gettext("Manual Linking Datums"),
+            gettext("Set datums required to navigate to the selected form or menu"),
+            {key: gettext("Datum ID"), value: gettext("XPath Expression")},  // placeholders
+        );
+        const datumsDict = {};
+        _.each(datums, function (datum) {
+            datumsDict[datum.name] = datum.xpath;
         });
+        self.advancedModeDatumsElement.val(datumsDict);
+        self.advancedModeDatumsElement.on("change", function () {
+            self.serializedDatums(JSON.stringify(_.map(this.val(), function (xpath, name) {
+                return {name: name, xpath: xpath};
+            })));
+            workflow.$changeEl.trigger('change'); // Manually trigger change so Save button activates
+        });
+    }
 
-        self.wrap_datums = function (data) {
-            self.datumsFetched(true);
-            return _.map(data, function (datum) {
-                return new FormWorkflow.FormDatum(self, datum);
-            });
-        };
-
-        self.enableManualDatums = function () {
-            self.manualDatums(true);
-        };
-
-        self.disableManualDatums = function () {
-            self.manualDatums(false);
-            $('#form-workflow .workflow-change-trigger').trigger('change');
-            self.datums.removeAll();
-        };
-
-        // initialize
-        let form = self.get_form_by_id(self.formId());
+    self.formId.subscribe(function (formId) {
+        let form = self.get_form_by_id(formId);
         self.autoLink(form ? form.autoLink : false);
         self.allowManualLinking(form ? form.allowManualLinking : false);
-        self.datums(self.wrap_datums(datums));
-        self.manualDatums(self.datums().length && self.autoLink());
-        self.showLinkDatums = ko.computed(function () {
-            return (!self.autoLink() || self.manualDatums());
-        });
+        self.datumsFetched(false);
+        self.datums([]);
+        self.serializedDatums('');
+    });
 
-        if (self.advancedMode) {
-            self.advancedModeDatumsElement = uiElementKeyValueList.new(
-                String(Math.random()).slice(2),  // random id
-                gettext("Manual Linking Datums"),
-                gettext("Set datums required to navigate to the selected form or menu"),
-                {key: gettext("Datum ID"), value: gettext("XPath Expression")},  // placeholders
-            );
-            const datumsDict = {};
-            _.each(datums, function (datum) {
-                datumsDict[datum.name] = datum.xpath;
-            });
-            self.advancedModeDatumsElement.val(datumsDict);
-            self.advancedModeDatumsElement.on("change", function () {
-                self.serializedDatums(JSON.stringify(_.map(this.val(), function (xpath, name) {
-                    return {name: name, xpath: xpath};
-                })));
-                workflow.$changeEl.trigger('change'); // Manually trigger change so Save button activates
-            });
-        }
-
-        self.formId.subscribe(function (formId) {
-            let form = self.get_form_by_id(formId);
-            self.autoLink(form ? form.autoLink : false);
-            self.allowManualLinking(form ? form.allowManualLinking : false);
+    self.fetchDatums = function () {
+        $.get(
+            workflow.formDatumsUrl,
+            {form_id: self.formId()},
+            function (data) {
+                self.datums(self.wrap_datums(data));
+            },
+            "json",
+        ).fail(function () {
             self.datumsFetched(false);
-            self.datums([]);
-            self.serializedDatums('');
-        });
-
-        self.fetchDatums = function () {
-            $.get(
-                workflow.formDatumsUrl,
-                {form_id: self.formId()},
-                function (data) {
-                    self.datums(self.wrap_datums(data));
-                },
-                "json",
-            ).fail(function () {
-                self.datumsFetched(false);
-                self.datumsError(true);
-            });
-        };
-
-        self.errors = ko.computed(function () {
-            var found,
-                errors = [];
-
-            found = _.find(self.forms, function (f) {
-                return self.formId() === f.uniqueId;
-            });
-
-            if (!found) {
-                errors.push(FormWorkflow.Errors.FORM_NOT_FOUND);
-            }
-
-            return errors;
+            self.datumsError(true);
         });
     };
-    return {FormWorkflow: FormWorkflow};
-});
+
+    self.errors = ko.computed(function () {
+        var found,
+            errors = [];
+
+        found = _.find(self.forms, function (f) {
+            return self.formId() === f.uniqueId;
+        });
+
+        if (!found) {
+            errors.push(FormWorkflow.Errors.FORM_NOT_FOUND);
+        }
+
+        return errors;
+    });
+};
+export default {FormWorkflow: FormWorkflow};

--- a/corehq/apps/app_manager/static/app_manager/js/modules/case_list_setting.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/case_list_setting.js
@@ -1,49 +1,44 @@
-hqDefine("app_manager/js/modules/case_list_setting", [
-    'jquery',
-    'underscore',
-], function (
-    $,
-    _,
-) {
-    function getLabel(slug) { return $('.case-list-setting-label[data-slug="' + slug + '"]'); }
-    function getShow(slug) { return $('.case-list-setting-show[data-slug="' + slug + '"]'); }
-    function getMedia(slug) { return $('.case-list-setting-media[data-slug="' + slug + '"]'); }
+import $ from "jquery";
+import _ from "underscore";
 
-    function updateCaseListLabelError(slug) {
-        var labelText = getLabel(slug).find('input').val();
-        var show = getShow(slug).val() === 'true';
-        if (!labelText.length && show) {
-            getLabel(slug).closest('.form-group').addClass('has-error');
-            $('#case_list_label_error').removeClass("hide");
-        } else {
-            getLabel(slug).closest('.form-group').removeClass('has-error');
-            $('#case_list_label_error').addClass("hide");
-        }
+function getLabel(slug) { return $('.case-list-setting-label[data-slug="' + slug + '"]'); }
+function getShow(slug) { return $('.case-list-setting-show[data-slug="' + slug + '"]'); }
+function getMedia(slug) { return $('.case-list-setting-media[data-slug="' + slug + '"]'); }
+
+function updateCaseListLabelError(slug) {
+    var labelText = getLabel(slug).find('input').val();
+    var show = getShow(slug).val() === 'true';
+    if (!labelText.length && show) {
+        getLabel(slug).closest('.form-group').addClass('has-error');
+        $('#case_list_label_error').removeClass("hide");
+    } else {
+        getLabel(slug).closest('.form-group').removeClass('has-error');
+        $('#case_list_label_error').addClass("hide");
     }
+}
 
-    function updateCaseListLabel(slug, show) {
-        getLabel(slug)[show ? 'show' : 'hide']();
-        getMedia(slug)[show ? 'show' : 'hide']();
-        updateCaseListLabelError(slug);
-    }
+function updateCaseListLabel(slug, show) {
+    getLabel(slug)[show ? 'show' : 'hide']();
+    getMedia(slug)[show ? 'show' : 'hide']();
+    updateCaseListLabelError(slug);
+}
 
-    $(function () {
-        _.each($(".case-list-setting-label"), function (el) {
-            var $el = $(el),
-                slug = $el.data("slug");
-            $el.find("input").attr("name", slug + "-label");
-            $el.find("input").on('textchange', function () {
-                updateCaseListLabelError(slug);
-            });
+$(function () {
+    _.each($(".case-list-setting-label"), function (el) {
+        var $el = $(el),
+            slug = $el.data("slug");
+        $el.find("input").attr("name", slug + "-label");
+        $el.find("input").on('textchange', function () {
+            updateCaseListLabelError(slug);
         });
+    });
 
-        _.each($(".case-list-setting-show"), function (el) {
-            var $el = $(el),
-                slug = $el.data("slug");
+    _.each($(".case-list-setting-show"), function (el) {
+        var $el = $(el),
+            slug = $el.data("slug");
+        updateCaseListLabel(slug, $el.val() === 'true');
+        $el.change(function () {
             updateCaseListLabel(slug, $el.val() === 'true');
-            $el.change(function () {
-                updateCaseListLabel(slug, $el.val() === 'true');
-            });
         });
     });
 });

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -1,335 +1,322 @@
-hqDefine("app_manager/js/modules/module_view", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "analytix/js/kissmetrix",
-    "hqwebapp/js/initial_page_data",
-    "app_manager/js/app_manager",
-    "app_manager/js/details/screen_config",
-    "app_manager/js/modules/shadow_module_settings",
-    "hqwebapp/js/toggles",
-    "app_manager/js/visit_scheduler",   // advanced modules only
-    "app_manager/js/custom_assertions",
-    "select2/dist/js/select2.full.min",
-    "app_manager/js/nav_menu_media",
-    "app_manager/js/modules/case_list_setting",
-    "hqwebapp/js/components/select_toggle",
-    "hqwebapp/js/key-value-mapping",
-    "app_manager/js/xpathValidator",
-    "commcarehq",
-], function (
-    $,
-    ko,
-    _,
-    kissmetrix,
-    initialPageData,
-    appManager,
-    screenConfig,
-    shadowModuleSettings,
-    toggles,
-    VisitScheduler,
-) {
-    $(function () {
-        // Module name
-        $(document).on("inline-edit-save", function (e, data) {
-            if (_.has(data.update, '.variable-module_name')) {
-                appManager.updatePageTitle(data.update['.variable-module_name']);
-                appManager.updateDOM(data.update);
-            }
-        });
+import "commcarehq";
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import kissmetrix from "analytix/js/kissmetrix";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import appManager from "app_manager/js/app_manager";
+import screenConfig from "app_manager/js/details/screen_config";
+import shadowModuleSettings from "app_manager/js/modules/shadow_module_settings";
+import toggles from "hqwebapp/js/toggles";
+import VisitScheduler from "app_manager/js/visit_scheduler";  // advanced modules only
+import "app_manager/js/custom_assertions";
+import "select2/dist/js/select2.full.min";
+import "app_manager/js/nav_menu_media";
+import "app_manager/js/modules/case_list_setting";
+import "hqwebapp/js/components/select_toggle";
+import "hqwebapp/js/key-value-mapping";
+import "app_manager/js/xpathValidator";
 
-        $('.case-type-dropdown').select2();
-        $('.overwrite-danger').on("click", function () {
-            kissmetrix.track.event("Overwrite Case Lists/Case Details");
-        });
-        var moduleBrief = initialPageData.get('module_brief'),
-            moduleType = moduleBrief.module_type,
-            options = initialPageData.get('js_options') || {};
+$(function () {
+    // Module name
+    $(document).on("inline-edit-save", function (e, data) {
+        if (_.has(data.update, '.variable-module_name')) {
+            appManager.updatePageTitle(data.update['.variable-module_name']);
+            appManager.updateDOM(data.update);
+        }
+    });
 
-        appManager.setAppendedPageTitle(gettext("Menu Settings"));
-        // Set up details
-        if (moduleBrief.case_type) {
-            var details = initialPageData.get('details');
-            for (var i = 0; i < details.length; i++) {
-                var detail = details[i];
-                var detailScreenConfigOptions = {
-                    module_id: moduleBrief.id,
-                    moduleUniqueId: moduleBrief.unique_id,
-                    state: {
-                        type: detail.type,
-                        short: detail.short,
-                        long: detail.long,
-                    },
-                    sortRows: detail.sort_elements,
-                    model: detail.model,
-                    properties: detail.properties,
-                    lang: moduleBrief.lang,
-                    langs: moduleBrief.langs,
-                    saveUrl: initialPageData.reverse('edit_module_detail_screens'),
-                    parentModules: initialPageData.get('parent_case_modules'),
-                    allCaseModules: initialPageData.get('all_case_modules'),
-                    caseTileTemplateOptions: options.case_tile_template_options,
-                    caseTileTemplateConfigs: options.case_tile_template_configs,
-                    childCaseTypes: detail.subcase_types,
-                    fixture_columns_by_type: options.fixture_columns_by_type || {},
-                    parentSelect: detail.parent_select,
-                    fixtureSelect: detail.fixture_select,
-                    multimedia: initialPageData.get('multimedia_object_map'),
-                };
-                _.extend(detailScreenConfigOptions, options.search_config);
-                var detailScreenConfig = screenConfig(detailScreenConfigOptions);
+    $('.case-type-dropdown').select2();
+    $('.overwrite-danger').on("click", function () {
+        kissmetrix.track.event("Overwrite Case Lists/Case Details");
+    });
+    var moduleBrief = initialPageData.get('module_brief'),
+        moduleType = moduleBrief.module_type,
+        options = initialPageData.get('js_options') || {};
 
-                var $listHome = $("#" + detail.type + "-detail-screen-config-tab");
-                $listHome.koApplyBindings(detailScreenConfig);
+    appManager.setAppendedPageTitle(gettext("Menu Settings"));
+    // Set up details
+    if (moduleBrief.case_type) {
+        var details = initialPageData.get('details');
+        for (var i = 0; i < details.length; i++) {
+            var detail = details[i];
+            var detailScreenConfigOptions = {
+                module_id: moduleBrief.id,
+                moduleUniqueId: moduleBrief.unique_id,
+                state: {
+                    type: detail.type,
+                    short: detail.short,
+                    long: detail.long,
+                },
+                sortRows: detail.sort_elements,
+                model: detail.model,
+                properties: detail.properties,
+                lang: moduleBrief.lang,
+                langs: moduleBrief.langs,
+                saveUrl: initialPageData.reverse('edit_module_detail_screens'),
+                parentModules: initialPageData.get('parent_case_modules'),
+                allCaseModules: initialPageData.get('all_case_modules'),
+                caseTileTemplateOptions: options.case_tile_template_options,
+                caseTileTemplateConfigs: options.case_tile_template_configs,
+                childCaseTypes: detail.subcase_types,
+                fixture_columns_by_type: options.fixture_columns_by_type || {},
+                parentSelect: detail.parent_select,
+                fixtureSelect: detail.fixture_select,
+                multimedia: initialPageData.get('multimedia_object_map'),
+            };
+            _.extend(detailScreenConfigOptions, options.search_config);
+            var detailScreenConfig = screenConfig(detailScreenConfigOptions);
 
-                if (detail.long !== undefined) {
-                    var $detailHome = $("#" + detail.type + "-detail-screen-detail-config-tab");
-                    $detailHome.koApplyBindings(detailScreenConfig);
-                }
+            var $listHome = $("#" + detail.type + "-detail-screen-config-tab");
+            $listHome.koApplyBindings(detailScreenConfig);
+
+            if (detail.long !== undefined) {
+                var $detailHome = $("#" + detail.type + "-detail-screen-detail-config-tab");
+                $detailHome.koApplyBindings(detailScreenConfig);
             }
         }
+    }
 
-        var originalCaseType = initialPageData.get('case_type');
-        var casesExist = false;
-        var deprecatedCaseTypes = [];
-        // If this async request is slow or fails, we will default to hiding the case type changed and
-        // deprecated case type warnings.
-        $.ajax({
-            method: 'GET',
-            url: initialPageData.reverse('existing_case_types'),
-            success: function (data) {
-                casesExist = data.existing_case_types.includes(originalCaseType);
-                deprecatedCaseTypes = data.deprecated_case_types;
-                if (deprecatedCaseTypes.includes(originalCaseType)) {
-                    showCaseTypeDeprecatedWarning();
-                }
-            },
-        });
-
-        // Validation for case type
-        var showCaseTypeError = function (message) {
-            var $caseTypeError = $('#case_type_error');
-            $caseTypeError.css('display', 'block').removeClass('hide');
-            $caseTypeError.text(message);
-        };
-        var hideCaseTypeError = function () {
-            $('#case_type_error').addClass('hide');
-        };
-
-        var showCaseTypeChangedWarning = function () {
-            if (casesExist) {
-                $('#case_type_changed_warning').css('display', 'block').removeClass('hide');
-                $('#case_type_form_group').addClass('has-error');
+    var originalCaseType = initialPageData.get('case_type');
+    var casesExist = false;
+    var deprecatedCaseTypes = [];
+    // If this async request is slow or fails, we will default to hiding the case type changed and
+    // deprecated case type warnings.
+    $.ajax({
+        method: 'GET',
+        url: initialPageData.reverse('existing_case_types'),
+        success: function (data) {
+            casesExist = data.existing_case_types.includes(originalCaseType);
+            deprecatedCaseTypes = data.deprecated_case_types;
+            if (deprecatedCaseTypes.includes(originalCaseType)) {
+                showCaseTypeDeprecatedWarning();
             }
-        };
-        var hideCaseTypeChangedWarning = function () {
-            $('#case_type_changed_warning').addClass('hide');
-            $('#case_type_form_group').removeClass('has-error');
-        };
+        },
+    });
 
-        var showCaseTypeDeprecatedWarning = function () {
-            $('#case_type_deprecated_warning').css('display', 'block').removeClass('hide');
-            $('#case_type_form_group').addClass('has-warning');
-        };
-        var hideCaseTypeDeprecatedWarning = function () {
-            $('#case_type_deprecated_warning').addClass('hide');
-            $('#case_type_form_group').removeClass('has-warning');
-        };
+    // Validation for case type
+    var showCaseTypeError = function (message) {
+        var $caseTypeError = $('#case_type_error');
+        $caseTypeError.css('display', 'block').removeClass('hide');
+        $caseTypeError.text(message);
+    };
+    var hideCaseTypeError = function () {
+        $('#case_type_error').addClass('hide');
+    };
 
-        $('#case_type').on('textchange', function () {
-            var $el = $(this),
-                value = $el.val(),
-                valueNoSpaces = value.replace(/ /g, '_');
-            if (value !== valueNoSpaces) {
-                var pos = $el.caret('pos');
-                $el.val(valueNoSpaces);
-                $el.caret('pos', pos);
-            }
-            if (!valueNoSpaces) {
-                $el.closest('.form-group').addClass('has-error');
-                showCaseTypeError(
-                    gettext("Case type is required."),
-                );
-                return;
+    var showCaseTypeChangedWarning = function () {
+        if (casesExist) {
+            $('#case_type_changed_warning').css('display', 'block').removeClass('hide');
+            $('#case_type_form_group').addClass('has-error');
+        }
+    };
+    var hideCaseTypeChangedWarning = function () {
+        $('#case_type_changed_warning').addClass('hide');
+        $('#case_type_form_group').removeClass('has-error');
+    };
+
+    var showCaseTypeDeprecatedWarning = function () {
+        $('#case_type_deprecated_warning').css('display', 'block').removeClass('hide');
+        $('#case_type_form_group').addClass('has-warning');
+    };
+    var hideCaseTypeDeprecatedWarning = function () {
+        $('#case_type_deprecated_warning').addClass('hide');
+        $('#case_type_form_group').removeClass('has-warning');
+    };
+
+    $('#case_type').on('textchange', function () {
+        var $el = $(this),
+            value = $el.val(),
+            valueNoSpaces = value.replace(/ /g, '_');
+        if (value !== valueNoSpaces) {
+            var pos = $el.caret('pos');
+            $el.val(valueNoSpaces);
+            $el.caret('pos', pos);
+        }
+        if (!valueNoSpaces) {
+            $el.closest('.form-group').addClass('has-error');
+            showCaseTypeError(
+                gettext("Case type is required."),
+            );
+            return;
+        }
+        if (deprecatedCaseTypes.includes(value)) {
+            showCaseTypeDeprecatedWarning();
+        } else {
+            hideCaseTypeDeprecatedWarning();
+        }
+        if (appManager.valueIncludeInvalidCharacters(valueNoSpaces)) {
+            $el.closest('.form-group').addClass('has-error');
+            showCaseTypeError(
+                appManager.invalidCharErrorMsg,
+            );
+        } else if (appManager.valueIsReservedWord(valueNoSpaces) && moduleType !== 'advanced') {
+            $el.closest('.form-group').addClass('has-error');
+            showCaseTypeError(
+                appManager.reservedWordErrorMsg,
+            );
+
+        } else {
+            $el.closest('.form-group').removeClass('has-error');
+            hideCaseTypeError();
+
+            if (value !== originalCaseType) {
+                showCaseTypeChangedWarning();
+            } else {
+                hideCaseTypeChangedWarning();
             }
             if (deprecatedCaseTypes.includes(value)) {
                 showCaseTypeDeprecatedWarning();
             } else {
                 hideCaseTypeDeprecatedWarning();
             }
-            if (appManager.valueIncludeInvalidCharacters(valueNoSpaces)) {
-                $el.closest('.form-group').addClass('has-error');
-                showCaseTypeError(
-                    appManager.invalidCharErrorMsg,
-                );
-            } else if (appManager.valueIsReservedWord(valueNoSpaces) && moduleType !== 'advanced') {
-                $el.closest('.form-group').addClass('has-error');
-                showCaseTypeError(
-                    appManager.reservedWordErrorMsg,
-                );
-
-            } else {
-                $el.closest('.form-group').removeClass('has-error');
-                hideCaseTypeError();
-
-                if (value !== originalCaseType) {
-                    showCaseTypeChangedWarning();
-                } else {
-                    hideCaseTypeChangedWarning();
-                }
-                if (deprecatedCaseTypes.includes(value)) {
-                    showCaseTypeDeprecatedWarning();
-                } else {
-                    hideCaseTypeDeprecatedWarning();
-                }
-            }
-        });
-
-        $('#module-settings-form').on('saved-app-manager-form', function () {
-            hideCaseTypeChangedWarning();
-        });
-
-        // Module filter
-        var $moduleFilter = $('#module-filter');
-        if ($moduleFilter.length) {
-            $moduleFilter.koApplyBindings({xpath: initialPageData.get("module_filter") || ''});
         }
-
-        // UCR last updated tile
-        var $reportContextTile = $('#report-context-tile');
-        if ($reportContextTile.length) {
-            $reportContextTile.koApplyBindings({
-                report_context_tile: ko.observable(moduleBrief.report_context_tile),
-            });
-        }
-
-        var lazyloadCaseListFields = $('#lazy-load-case-list-fields');
-        if (lazyloadCaseListFields.length > 0) {
-            lazyloadCaseListFields.koApplyBindings({
-                lazy_load_case_list_fields: ko.observable(initialPageData.get('lazy_load_case_list_fields')),
-            });
-        }
-
-        var $showCaseListOptimizationsElement = $('#show_case_list_optimization_options');
-        if ($showCaseListOptimizationsElement.length) {
-            $showCaseListOptimizationsElement.koApplyBindings({
-                show_case_list_optimization_options: ko.observable(
-                    initialPageData.get('show_case_list_optimization_options'),
-                ),
-            });
-        }
-
-
-        // Registration in case list
-        if ($('#case-list-form').length) {
-            var caseListFormModel = function (originalFormId, formOptions, postFormWorkflow) {
-                var self = {};
-
-                self.caseListForm = ko.observable(originalFormId);
-                self.caseListFormSettingsUrl = ko.computed(function () {
-                    return initialPageData.reverse("view_form", self.caseListForm());
-                });
-                self.postFormWorkflow = ko.observable(postFormWorkflow);
-                self.endOfRegistrationOptions = ko.computed(function () {
-                    if (!self.caseListForm() || formOptions[self.caseListForm()].is_registration_form) {
-                        return [
-                            {id: 'case_list', text: gettext('Go back to case list')},
-                            {id: 'default', text: gettext('Proceed with registered case')},
-                        ];
-                    } else {
-                        return [{id: 'case_list', text: gettext('Go back to case list')}];
-                    }
-                });
-
-                self.formMissing = ko.computed(function () {
-                    return self.caseListForm() && !formOptions[self.caseListForm()];
-                });
-                self.caseListForm.subscribe(function () {
-                    if (self.caseListForm() && !formOptions[self.caseListForm()].is_registration_form) {
-                        self.postFormWorkflow('case_list');
-                    }
-                });
-                self.formHasEOFNav = ko.computed(function () {
-                    if (!self.caseListForm()) {
-                        return false;
-                    }
-                    var formData = formOptions[self.caseListForm()];
-                    if (formData) {
-                        return formData.post_form_workflow !== 'default';
-                    }
-                    return false;
-                });
-
-                var showMedia = function (formId) {
-                    if (formId) {
-                        $("#case_list_media").show();
-                    } else {
-                        $("#case_list_media").hide();
-                    }
-                };
-
-                // Show or hide associated multimedia. Not done in knockout because
-                // the multimedia section has its own separate set of knockout bindings
-                showMedia(originalFormId);
-                self.caseListForm.subscribe(showMedia);
-
-                return self;
-            };
-            var caseListFormOptions = initialPageData.get('case_list_form_options');
-            var caseListForm = caseListFormModel(
-                caseListFormOptions ? caseListFormOptions.form.form_id : null,
-                caseListFormOptions ? caseListFormOptions.options : [],
-                caseListFormOptions ? caseListFormOptions.form.post_form_workflow : 'default',
-            );
-            $('#case-list-form').koApplyBindings(caseListForm);
-
-            // Reset save button after bindings
-            // see http://manage.dimagi.com/default.asp?145851
-            var $form = $('#case-list-form').closest('form'),
-                $button = $form.find('.save-button-holder').data('button');
-            $button.setStateWhenReady('saved');
-        }
-
-        if (moduleType === 'shadow') {
-            // Shadow module checkboxes for including/excluding forms
-            const shadowOptions = initialPageData.get('shadow_module_options');
-            $('#sourceModuleForms').koApplyBindings(new shadowModuleSettings.ShadowModule(
-                shadowOptions.modules,
-                shadowOptions.source_module_id,
-                shadowOptions.excluded_form_ids,
-                shadowOptions.form_session_endpoints,
-                shadowOptions.shadow_module_version,
-            ));
-        } else if (moduleType === 'advanced') {
-            if (moduleBrief.has_schedule || toggles.toggleEnabled('VISIT_SCHEDULER')) {
-                var visitScheduler = VisitScheduler.moduleScheduler({
-                    home: $('#module-scheduler'),
-                    saveUrl: initialPageData.reverse('edit_schedule_phases'),
-                    hasSchedule: moduleBrief.has_schedule,
-                    schedulePhases: initialPageData.get('schedule_phases'),
-                    caseProperties: initialPageData.get('details')[0].properties,
-                });
-                visitScheduler.init();
-            }
-
-            $('#auto-select-case').koApplyBindings({
-                auto_select_case: ko.observable(moduleBrief.auto_select_case),
-            });
-        }
-
-        appManager.setupValidation(initialPageData.reverse('validate_module_for_build'));
-
-        // show display style options only when module configured to show module and then forms
-        var $menuMode = $('#put_in_root');
-        var $displayStyleContainer = $('#display_style_container');
-        var updateDisplayView = function () {
-            if ($menuMode.val() === 'false') {
-                $displayStyleContainer.show();
-            } else {
-                $displayStyleContainer.hide();
-            }
-        };
-        updateDisplayView();
-        $menuMode.on('change', updateDisplayView);
     });
+
+    $('#module-settings-form').on('saved-app-manager-form', function () {
+        hideCaseTypeChangedWarning();
+    });
+
+    // Module filter
+    var $moduleFilter = $('#module-filter');
+    if ($moduleFilter.length) {
+        $moduleFilter.koApplyBindings({xpath: initialPageData.get("module_filter") || ''});
+    }
+
+    // UCR last updated tile
+    var $reportContextTile = $('#report-context-tile');
+    if ($reportContextTile.length) {
+        $reportContextTile.koApplyBindings({
+            report_context_tile: ko.observable(moduleBrief.report_context_tile),
+        });
+    }
+
+    var lazyloadCaseListFields = $('#lazy-load-case-list-fields');
+    if (lazyloadCaseListFields.length > 0) {
+        lazyloadCaseListFields.koApplyBindings({
+            lazy_load_case_list_fields: ko.observable(initialPageData.get('lazy_load_case_list_fields')),
+        });
+    }
+
+    var $showCaseListOptimizationsElement = $('#show_case_list_optimization_options');
+    if ($showCaseListOptimizationsElement.length) {
+        $showCaseListOptimizationsElement.koApplyBindings({
+            show_case_list_optimization_options: ko.observable(
+                initialPageData.get('show_case_list_optimization_options'),
+            ),
+        });
+    }
+
+
+    // Registration in case list
+    if ($('#case-list-form').length) {
+        var caseListFormModel = function (originalFormId, formOptions, postFormWorkflow) {
+            var self = {};
+
+            self.caseListForm = ko.observable(originalFormId);
+            self.caseListFormSettingsUrl = ko.computed(function () {
+                return initialPageData.reverse("view_form", self.caseListForm());
+            });
+            self.postFormWorkflow = ko.observable(postFormWorkflow);
+            self.endOfRegistrationOptions = ko.computed(function () {
+                if (!self.caseListForm() || formOptions[self.caseListForm()].is_registration_form) {
+                    return [
+                        {id: 'case_list', text: gettext('Go back to case list')},
+                        {id: 'default', text: gettext('Proceed with registered case')},
+                    ];
+                } else {
+                    return [{id: 'case_list', text: gettext('Go back to case list')}];
+                }
+            });
+
+            self.formMissing = ko.computed(function () {
+                return self.caseListForm() && !formOptions[self.caseListForm()];
+            });
+            self.caseListForm.subscribe(function () {
+                if (self.caseListForm() && !formOptions[self.caseListForm()].is_registration_form) {
+                    self.postFormWorkflow('case_list');
+                }
+            });
+            self.formHasEOFNav = ko.computed(function () {
+                if (!self.caseListForm()) {
+                    return false;
+                }
+                var formData = formOptions[self.caseListForm()];
+                if (formData) {
+                    return formData.post_form_workflow !== 'default';
+                }
+                return false;
+            });
+
+            var showMedia = function (formId) {
+                if (formId) {
+                    $("#case_list_media").show();
+                } else {
+                    $("#case_list_media").hide();
+                }
+            };
+
+            // Show or hide associated multimedia. Not done in knockout because
+            // the multimedia section has its own separate set of knockout bindings
+            showMedia(originalFormId);
+            self.caseListForm.subscribe(showMedia);
+
+            return self;
+        };
+        var caseListFormOptions = initialPageData.get('case_list_form_options');
+        var caseListForm = caseListFormModel(
+            caseListFormOptions ? caseListFormOptions.form.form_id : null,
+            caseListFormOptions ? caseListFormOptions.options : [],
+            caseListFormOptions ? caseListFormOptions.form.post_form_workflow : 'default',
+        );
+        $('#case-list-form').koApplyBindings(caseListForm);
+
+        // Reset save button after bindings
+        // see http://manage.dimagi.com/default.asp?145851
+        var $form = $('#case-list-form').closest('form'),
+            $button = $form.find('.save-button-holder').data('button');
+        $button.setStateWhenReady('saved');
+    }
+
+    if (moduleType === 'shadow') {
+        // Shadow module checkboxes for including/excluding forms
+        const shadowOptions = initialPageData.get('shadow_module_options');
+        $('#sourceModuleForms').koApplyBindings(new shadowModuleSettings.ShadowModule(
+            shadowOptions.modules,
+            shadowOptions.source_module_id,
+            shadowOptions.excluded_form_ids,
+            shadowOptions.form_session_endpoints,
+            shadowOptions.shadow_module_version,
+        ));
+    } else if (moduleType === 'advanced') {
+        if (moduleBrief.has_schedule || toggles.toggleEnabled('VISIT_SCHEDULER')) {
+            var visitScheduler = VisitScheduler.moduleScheduler({
+                home: $('#module-scheduler'),
+                saveUrl: initialPageData.reverse('edit_schedule_phases'),
+                hasSchedule: moduleBrief.has_schedule,
+                schedulePhases: initialPageData.get('schedule_phases'),
+                caseProperties: initialPageData.get('details')[0].properties,
+            });
+            visitScheduler.init();
+        }
+
+        $('#auto-select-case').koApplyBindings({
+            auto_select_case: ko.observable(moduleBrief.auto_select_case),
+        });
+    }
+
+    appManager.setupValidation(initialPageData.reverse('validate_module_for_build'));
+
+    // show display style options only when module configured to show module and then forms
+    var $menuMode = $('#put_in_root');
+    var $displayStyleContainer = $('#display_style_container');
+    var updateDisplayView = function () {
+        if ($menuMode.val() === 'false') {
+            $displayStyleContainer.show();
+        } else {
+            $displayStyleContainer.hide();
+        }
+    };
+    updateDisplayView();
+    $menuMode.on('change', updateDisplayView);
 });

--- a/corehq/apps/app_manager/static/app_manager/js/modules/shadow_module_settings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/shadow_module_settings.js
@@ -1,96 +1,91 @@
-hqDefine('app_manager/js/modules/shadow_module_settings', [
-    'knockout',
-    'underscore',
-], function (
-    ko,
-    _,
-) {
-    const module = {
+import ko from "knockout";
+import _ from "underscore";
 
-        /**
-         * Returns a Knockout view model based on the modules and forms given in modules
-         */
-        ShadowModule: function (modules, selectedModuleId, excludedFormIds, formSessionEndpointMappings, shadowModuleVersion) {
-            const self = this;
-            self.modules = ko.observableArray();
-            self.shadowModuleVersion = shadowModuleVersion;
-            self.selectedModuleId = ko.observable(selectedModuleId);
-            self.selectedModule = ko.pureComputed(function () {
-                return _.findWhere(self.modules(), {uniqueId: self.selectedModuleId()});
-            });
-            // Find all forms that could potentially be included in the current module:
-            self.sourceForms = ko.pureComputed(function () {
-                if (self.shadowModuleVersion === 1) {
-                    // Forms belonging to the source module and to the source module's children
-                    return self.selectedModule().forms().concat(_.flatten(_.map(_.filter(self.modules(), function (m) {
-                        return m.rootId === self.selectedModuleId();
-                    }), function (m) {
-                        return m.forms();
-                    })));
-                } else {
-                    // Forms belonging only to the source module
-                    return self.selectedModule().forms();
-                }
+const module = {
 
-            });
-            self.includedFormIds = ko.observableArray();
-            self.excludedFormIds = ko.pureComputed(function () {
-                const exclForms = _.filter(self.sourceForms(), function (form) {
-                    return self.includedFormIds().indexOf(form.uniqueId) === -1;
-                });
-                return _.map(exclForms, function (form) { return form.uniqueId; });
-            });
-
-            self.formSessionEndpointIds = ko.pureComputed(function () {
-                return _.map(self.sourceForms(), function (form) {
-                    return ko.pureComputed(function () {
-                        return JSON.stringify({form_id: form.uniqueId, session_endpoint_id: form.sessionEndpointId()});
-                    });
-                });
-            });
-
-            const sourceModuleModel = function (uniqueId, name, rootId) {
-                const self = {};
-
-                self.uniqueId = uniqueId;
-                self.name = name;
-                self.rootId = rootId;
-                self.forms = ko.observableArray();
-
-                return self;
-            };
-
-            const sourceModuleFormModel = function (uniqueId, name, sessionEndpointId) {
-                return {
-                    uniqueId: uniqueId,
-                    name: name,
-                    sessionEndpointId: ko.observable(sessionEndpointId),
-                };
-            };
-
-            let sourceModule = sourceModuleModel('', 'None');
-            self.modules.push(sourceModule);
-            modules = _.sortBy(modules, function (m) { return m.name; });
-            for (let i = 0; i < modules.length; i++) {
-                const mod = modules[i];
-                sourceModule = sourceModuleModel(mod.unique_id, mod.name, mod.root_module_id);
-                for (let j = 0; j < mod.forms.length; j++) {
-                    const form = mod.forms[j];
-                    let formSessionEndpointId = "";
-                    const mapping = _.find(formSessionEndpointMappings, m => m.form_id === form.unique_id);
-                    if (mapping) {
-                        formSessionEndpointId = mapping.session_endpoint_id;
-                    }
-                    const sourceModuleForm =
-                        sourceModuleFormModel(form.unique_id, form.name, formSessionEndpointId);
-                    sourceModule.forms.push(sourceModuleForm);
-                    if (excludedFormIds.indexOf(form.unique_id) === -1) {
-                        self.includedFormIds.push(form.unique_id);
-                    }
-                }
-                self.modules.push(sourceModule);
+    /**
+     * Returns a Knockout view model based on the modules and forms given in modules
+     */
+    ShadowModule: function (modules, selectedModuleId, excludedFormIds, formSessionEndpointMappings, shadowModuleVersion) {
+        const self = this;
+        self.modules = ko.observableArray();
+        self.shadowModuleVersion = shadowModuleVersion;
+        self.selectedModuleId = ko.observable(selectedModuleId);
+        self.selectedModule = ko.pureComputed(function () {
+            return _.findWhere(self.modules(), {uniqueId: self.selectedModuleId()});
+        });
+        // Find all forms that could potentially be included in the current module:
+        self.sourceForms = ko.pureComputed(function () {
+            if (self.shadowModuleVersion === 1) {
+                // Forms belonging to the source module and to the source module's children
+                return self.selectedModule().forms().concat(_.flatten(_.map(_.filter(self.modules(), function (m) {
+                    return m.rootId === self.selectedModuleId();
+                }), function (m) {
+                    return m.forms();
+                })));
+            } else {
+                // Forms belonging only to the source module
+                return self.selectedModule().forms();
             }
-        },
-    };
-    return module;
-});
+
+        });
+        self.includedFormIds = ko.observableArray();
+        self.excludedFormIds = ko.pureComputed(function () {
+            const exclForms = _.filter(self.sourceForms(), function (form) {
+                return self.includedFormIds().indexOf(form.uniqueId) === -1;
+            });
+            return _.map(exclForms, function (form) { return form.uniqueId; });
+        });
+
+        self.formSessionEndpointIds = ko.pureComputed(function () {
+            return _.map(self.sourceForms(), function (form) {
+                return ko.pureComputed(function () {
+                    return JSON.stringify({form_id: form.uniqueId, session_endpoint_id: form.sessionEndpointId()});
+                });
+            });
+        });
+
+        const sourceModuleModel = function (uniqueId, name, rootId) {
+            const self = {};
+
+            self.uniqueId = uniqueId;
+            self.name = name;
+            self.rootId = rootId;
+            self.forms = ko.observableArray();
+
+            return self;
+        };
+
+        const sourceModuleFormModel = function (uniqueId, name, sessionEndpointId) {
+            return {
+                uniqueId: uniqueId,
+                name: name,
+                sessionEndpointId: ko.observable(sessionEndpointId),
+            };
+        };
+
+        let sourceModule = sourceModuleModel('', 'None');
+        self.modules.push(sourceModule);
+        modules = _.sortBy(modules, function (m) { return m.name; });
+        for (let i = 0; i < modules.length; i++) {
+            const mod = modules[i];
+            sourceModule = sourceModuleModel(mod.unique_id, mod.name, mod.root_module_id);
+            for (let j = 0; j < mod.forms.length; j++) {
+                const form = mod.forms[j];
+                let formSessionEndpointId = "";
+                const mapping = _.find(formSessionEndpointMappings, m => m.form_id === form.unique_id);
+                if (mapping) {
+                    formSessionEndpointId = mapping.session_endpoint_id;
+                }
+                const sourceModuleForm =
+                    sourceModuleFormModel(form.unique_id, form.name, formSessionEndpointId);
+                sourceModule.forms.push(sourceModuleForm);
+                if (excludedFormIds.indexOf(form.unique_id) === -1) {
+                    self.includedFormIds.push(form.unique_id);
+                }
+            }
+            self.modules.push(sourceModule);
+        }
+    },
+};
+export default module;

--- a/corehq/apps/app_manager/static/app_manager/js/visit_scheduler.js
+++ b/corehq/apps/app_manager/static/app_manager/js/visit_scheduler.js
@@ -1,431 +1,420 @@
-hqDefine("app_manager/js/visit_scheduler", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "app_manager/js/app_manager",
-    "app_manager/js/case_config_utils",
-    "hqwebapp/js/bootstrap3/main",
-    "hqwebapp/js/ui_elements/bootstrap3/ui-element-select",
-    "app_manager/js/details/utils",
-    "app_manager/js/forms/case_knockout_bindings",  // numericValue
-    "commcarehq",
-], function (
-    $,
-    ko,
-    _,
-    appManager,
-    caseConfigUtils,
-    main,
-    uiElementSelect,
-    utils,
-) {
-    var moduleScheduler = function (params) {
-        // Edits the schedule phases on the module setting page
-        var self = {};
-        self.$ = $;     // make $ available to data bindings, where it's used in sorting elements
-        self.home = params.home;
+import "commcarehq";
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import appManager from "app_manager/js/app_manager";
+import caseConfigUtils from "app_manager/js/case_config_utils";
+import main from "hqwebapp/js/bootstrap3/main";
+import uiElementSelect from "hqwebapp/js/ui_elements/bootstrap3/ui-element-select";
+import utils from "app_manager/js/details/utils";
+import "app_manager/js/forms/case_knockout_bindings";  // numericValue
 
-        self.init = function () {
-            _.defer(function () {
-                if (self.home.length) {
-                    self.home.koApplyBindings(self);
-                    self.home.on('textchange', 'input', self.change)
-                        .on('change', 'select', self.change)
-                        .on('click', 'a:not(.header)', self.change)
-                        .on('change', 'input[type="checkbox"]', self.change);
+var moduleScheduler = function (params) {
+    // Edits the schedule phases on the module setting page
+    var self = {};
+    self.$ = $;     // make $ available to data bindings, where it's used in sorting elements
+    self.home = params.home;
 
-                    // https://gist.github.com/mkelly12/424774/#comment-92080
-                    // textchange doesn't work with live event binding
-                    $('#module-scheduler input').on('textchange', self.change);
-                }
-            });
-        };
-
-        self.change = function () {
-            self.saveButton.fire('change');
-        };
-
-        self.saveButton = main.initSaveButton({
-            unsavedMessage: "You have unchanged schedule settings",
-            save: function () {
-                self.saveButton.ajax({
-                    type: 'post',
-                    url: params.saveUrl,
-                    data: {
-                        phases: JSON.stringify(self.serializePhases()),
-                        has_schedule: self.hasSchedule(),
-                    },
-                    dataType: 'json',
-                    success: function (data) {
-                        appManager.updateDOM(data.update);
-                    },
-                });
-            },
-        });
-
-        var phaseModel = function (id, anchor, forms) {
-            var self = {};
-            self.id = id;
-            self.anchor = uiElementSelect.new(params.caseProperties).val(anchor);
-            self.anchor.observableVal = ko.observable(self.anchor.val());
-            self.anchor.on("change", function () {
-                self.anchor.observableVal(self.anchor.val());
-            });
-            utils.setUpAutocomplete(self.anchor, params.caseProperties);
-            self.forms = ko.observable(forms);
-            self.form_abbreviations = ko.computed(function () {
-                return _.map(self.forms(), function (form) {
-                    return form === '' ? '(no abbreviation)' : form;
-                }).join(', ');
-            });
-            return self;
-        };
-
-        self.hasSchedule = ko.observable(params.hasSchedule);
-
-        self.phases = ko.observableArray(
-            _.map(params.schedulePhases, function (phase) {
-                return phaseModel(phase.id, phase.anchor, phase.forms);
-            }),
-        );
-        self.phases.subscribe(function () {
-            self.change();
-        });
-
-        self.selectedPhase = ko.observable();
-        self.selectPhase = function (phase) {
-            self.selectedPhase(phase);
-        };
-
-        self.addPhase = function () {
-            var NEW_PHASE_ID = -1;
-            self.phases.push(phaseModel(NEW_PHASE_ID, "", []));
-        };
-
-        self.removePhase = function (phase) {
-            self.phases.remove(phase);
-        };
-
-        self.serializePhases = function () {
-            return _.map(self.phases(), function (phase) {
-                return {
-                    id: phase.id,
-                    anchor: phase.anchor.val(),
-                };
-            });
-        };
-
-        return self;
-    };
-
-    var schedulerModel = function (params) {
-        var self = {};
-
-        self.home = params.home;
-        self.questions = params.questions;
-        self.save_url = params.save_url;
-
-        self.saveButton = main.initSaveButton({
-            unsavedMessage: "You have unsaved schedule settings",
-            save: function () {
-                var isValid = self.validate();
-                if (isValid) {
-                    var schedule = JSON.stringify(formSchedule.unwrap(self.formSchedule));
-                    self.saveButton.ajax({
-                        type: 'post',
-                        url: self.save_url,
-                        data: {
-                            schedule: schedule,
-                        },
-                        dataType: 'json',
-                        success: function (data) {
-                            appManager.updateDOM(data.update);
-                        },
-                    });
-                }
-            },
-        });
-
-        self.getQuestions = function (filter, excludeHidden, includeRepeat) {
-            return caseConfigUtils.getQuestions(self.questions, filter, excludeHidden, includeRepeat);
-        };
-        self.getAnswers = function (condition) {
-            return caseConfigUtils.getAnswers(self.questions, condition);
-        };
-
-        self.change = function () {
-            self.saveButton.fire('change');
-        };
-
-        self.validate = function () {
-            var errors = 0;
-            var $addVisitButton = self.home.find("#add-visit");
-
-            if (self.formSchedule.visits().length === 0) {
-                $addVisitButton.closest(".form-group").addClass("has-error");
-                $addVisitButton.siblings(".error-text").show();
-                errors += 1;
-            } else {
-                $addVisitButton.closest(".form-group").removeClass("has-error");
-                $addVisitButton.siblings(".error-text").hide();
-            }
-
-            var required = self.home.find(":required").not(":disabled");
-            required.each(function (i, req) {
-                var $req = $(req);
-                if ($req.val().trim().length === 0) {
-                    $req.closest(".form-group").addClass("has-error");
-                    $req.siblings(".error-text").show();
-                    errors += 1;
-                } else {
-                    $req.closest(".form-group").removeClass("has-error");
-                    $req.siblings(".error-text").hide();
-                }
-            });
-
-            if (!self.formSchedule.scheduleEnabled() || !errors) {
-                self.home.find("#form-errors").hide();
-                return true;
-            } else {
-                self.home.find("#form-errors").show();
-                return false;
-            }
-        };
-
-        self.schedulePhase = schedulePhase.wrap(params.phase, self);
-        self.formSchedule = formSchedule.wrap(params, self, self.schedulePhase);
-
-        self.init = function () {
-            _.defer(function () {
+    self.init = function () {
+        _.defer(function () {
+            if (self.home.length) {
                 self.home.koApplyBindings(self);
                 self.home.on('textchange', 'input', self.change)
                     .on('change', 'select', self.change)
                     .on('click', 'a:not(.header)', self.change)
                     .on('change', 'input[type="checkbox"]', self.change);
 
-                self.applyGlobalEventHandlers();
+                // https://gist.github.com/mkelly12/424774/#comment-92080
+                // textchange doesn't work with live event binding
+                $('#module-scheduler input').on('textchange', self.change);
+            }
+        });
+    };
+
+    self.change = function () {
+        self.saveButton.fire('change');
+    };
+
+    self.saveButton = main.initSaveButton({
+        unsavedMessage: "You have unchanged schedule settings",
+        save: function () {
+            self.saveButton.ajax({
+                type: 'post',
+                url: params.saveUrl,
+                data: {
+                    phases: JSON.stringify(self.serializePhases()),
+                    has_schedule: self.hasSchedule(),
+                },
+                dataType: 'json',
+                success: function (data) {
+                    appManager.updateDOM(data.update);
+                },
             });
-        };
+        },
+    });
 
-        self.applyGlobalEventHandlers = function () {
-            // https://gist.github.com/mkelly12/424774/#comment-92080
-            // textchange doesn't work with live event binding
-            $('#visit-scheduler input').on('textchange', self.change);
-        };
-
+    var phaseModel = function (id, anchor, forms) {
+        var self = {};
+        self.id = id;
+        self.anchor = uiElementSelect.new(params.caseProperties).val(anchor);
+        self.anchor.observableVal = ko.observable(self.anchor.val());
+        self.anchor.on("change", function () {
+            self.anchor.observableVal(self.anchor.val());
+        });
+        utils.setUpAutocomplete(self.anchor, params.caseProperties);
+        self.forms = ko.observable(forms);
+        self.form_abbreviations = ko.computed(function () {
+            return _.map(self.forms(), function (form) {
+                return form === '' ? '(no abbreviation)' : form;
+            }).join(', ');
+        });
         return self;
     };
 
-    var scheduleRelevancy = {
-        mapping: function () {
-            return {
-                include: [
-                    'starts',
-                    'expires',
-                ],
-            };
-        },
-        wrap: function (data) {
-            var self = {};
-            ko.mapping.fromJS(data, scheduleRelevancy.mapping(self), self);
-            self.starts_type = ko.observable(self.starts() < 0 ? 'before' : 'after');
-            self.expires_type = ko.observable(self.expires() < 0 ? 'before' : 'after');
-            self.enableFormExpiry = ko.observable(self.expires() !== null);
-            self.starts = ko.observable(Math.abs(self.starts()));
-            self.expires = ko.observable(Math.abs(self.expires()));
-            return self;
-        },
-        unwrap: function (self) {
-            return ko.mapping.toJS(self, scheduleRelevancy.mapping(self));
-        },
+    self.hasSchedule = ko.observable(params.hasSchedule);
+
+    self.phases = ko.observableArray(
+        _.map(params.schedulePhases, function (phase) {
+            return phaseModel(phase.id, phase.anchor, phase.forms);
+        }),
+    );
+    self.phases.subscribe(function () {
+        self.change();
+    });
+
+    self.selectedPhase = ko.observable();
+    self.selectPhase = function (phase) {
+        self.selectedPhase(phase);
     };
 
-    var scheduleVisit = {
-        mapping: function () {
-            return {
-                include: [
-                    'due',
-                    'type',
-                    'starts',
-                    'expires',
-                    'repeats',
-                    'increment',
-                ],
-            };
-        },
-        wrap: function (data, config) {
-            var self = {
-                config: config,
-            };
-            ko.mapping.fromJS(data, scheduleVisit.mapping(self), self);
-            if (self.repeats()) {
-                self.due(self.increment());
-                self.type('repeats');
-            }
-            self.starts(self.starts() * -1);
-            return self;
-        },
-
-        unwrap: function (self) {
-            return ko.mapping.toJS(self, scheduleVisit.mapping(self));
-        },
+    self.addPhase = function () {
+        var NEW_PHASE_ID = -1;
+        self.phases.push(phaseModel(NEW_PHASE_ID, "", []));
     };
 
-    var schedulePhase = {
-        mapping: function () {
-            return {
-                include: [
-                    'anchor',
-                ],
-            };
-        },
-        wrap: function (data) {
-            var self = {};
-            ko.mapping.fromJS(data, schedulePhase.mapping(self), self);
-            return self;
-        },
+    self.removePhase = function (phase) {
+        self.phases.remove(phase);
     };
 
-    var formSchedule = {
-        mapping: function (self) {
+    self.serializePhases = function () {
+        return _.map(self.phases(), function (phase) {
             return {
-                include: [
-                    'expires',
-                    'allow_unscheduled',
-                    'transition_condition',
-                    'termination_condition',
-                    'schedule_form_id',
-                ],
-                visits: {
-                    create: function (options) {
-                        options.data.type = options.data.due < 0 ? 'before' : 'after';
-                        options.data.due = Math.abs(options.data.due);
-                        return scheduleVisit.wrap(options.data, self);
+                id: phase.id,
+                anchor: phase.anchor.val(),
+            };
+        });
+    };
+
+    return self;
+};
+
+var schedulerModel = function (params) {
+    var self = {};
+
+    self.home = params.home;
+    self.questions = params.questions;
+    self.save_url = params.save_url;
+
+    self.saveButton = main.initSaveButton({
+        unsavedMessage: "You have unsaved schedule settings",
+        save: function () {
+            var isValid = self.validate();
+            if (isValid) {
+                var schedule = JSON.stringify(formSchedule.unwrap(self.formSchedule));
+                self.saveButton.ajax({
+                    type: 'post',
+                    url: self.save_url,
+                    data: {
+                        schedule: schedule,
                     },
-                },
-            };
-        },
-        wrap: function (data, config, phase) {
-            var self = {
-                config: config,
-                all_schedule_phase_anchors: data.all_schedule_phase_anchors,
-                phase: phase,
-            };
-            ko.mapping.fromJS(data.schedule, formSchedule.mapping(self), self);
-
-            // for compatibility with common template: case-config:condition
-            self.allow = {
-                repeats: function () {
-                    return false;
-                },
-            };
-
-            self.scheduleEnabled = ko.observable(data.schedule.enabled);
-            self.transition = ko.computed(formSchedule.conditionComputed(self.config, self.transition_condition));
-            self.terminate = ko.computed(formSchedule.conditionComputed(self.config, self.termination_condition));
-
-            self.allowExpiry = ko.computed(function () {
-                return self.transition_condition.type() === 'never' &&
-                    self.termination_condition.type() === 'never';
-            });
-
-            self.hasExpiry = ko.observable();
-
-            self.hasRepeatVisit = ko.computed(function () {
-                return self.visits().length > 0 && self.visits()[self.visits().length - 1].type() === 'repeats';
-            });
-
-            self.relevancy = scheduleRelevancy.wrap(data.schedule);
-            var xmlRe = /\s+|<+|>+|&+|"+|'+/g;
-            self.schedule_form_id = ko.observable(data.schedule_form_id || '').snakeCase(xmlRe);
-
-            self.addVisit = function () {
-                self.visits.push(scheduleVisit.wrap({
-                    due: null,
-                    type: 'after',
-                    starts: null,
-                    expires: null,
-                    increment: null,
-                    repeats: false,
-                }));
-            };
-
-            self.removeVisit = function (visit) {
-                self.visits.remove(visit);
-            };
-
-            return self;
-        },
-
-        conditionComputed: function (config, condition) {
-            return {
-                read: function () {
-                    if (condition) {
-                        return condition.type() !== 'never';
-                    } else {
-                        return false;
-                    }
-
-                },
-                write: function (value) {
-                    condition.type(value ? 'always' : 'never');
-                    config.saveButton.fire('change');
-                },
-            };
-        },
-
-        cleanCondition: function (condition) {
-            if (condition.type() !== 'if') {
-                condition.question(null);
-                condition.answer(null);
-                condition.operator(null);
-            }
-        },
-
-        unwrap: function (self) {
-            formSchedule.cleanCondition(self.transition_condition);
-            formSchedule.cleanCondition(self.termination_condition);
-            var schedule = ko.mapping.toJS(self, formSchedule.mapping(self));
-            schedule.enabled = self.scheduleEnabled();
-            schedule.starts = self.relevancy.starts() * (self.relevancy.starts_type() === 'before' ? -1 : 1);
-            if (self.relevancy.enableFormExpiry() && self.allowExpiry()) {
-                schedule.expires = self.relevancy.expires() * (self.relevancy.expires_type() === 'before' ? -1 : 1);
-            } else {
-                schedule.expires = null;
-            }
-
-            schedule.anchor = self.phase.anchor() || '';
-            schedule.schedule_form_id = self.schedule_form_id();
-            schedule.visits = _.map(schedule.visits, function (visit) {
-                var due = visit.due * (visit.type === 'before' ? -1 : 1);
-                var repeats = visit.type === 'repeats';
-                return {
-                    due: repeats ? null : due,
-                    starts: visit.starts * -1,
-                    expires: visit.expires,
-                    repeats: repeats,
-                    increment: repeats ? visit.due : null,
-                };
-            });
-            return schedule;
-        },
-    };
-
-    // Verbatim from http://www.knockmeout.net/2011/05/dragging-dropping-and-sorting-with.html
-    //control visibility, give element focus, and select the contents (in order)
-    ko.bindingHandlers.visibleAndSelect = {
-        update: function (element, valueAccessor) {
-            ko.bindingHandlers.visible.update(element, valueAccessor);
-            if (valueAccessor()) {
-                _.defer(function () {
-                    $(element).focus().select();
+                    dataType: 'json',
+                    success: function (data) {
+                        appManager.updateDOM(data.update);
+                    },
                 });
             }
         },
+    });
+
+    self.getQuestions = function (filter, excludeHidden, includeRepeat) {
+        return caseConfigUtils.getQuestions(self.questions, filter, excludeHidden, includeRepeat);
+    };
+    self.getAnswers = function (condition) {
+        return caseConfigUtils.getAnswers(self.questions, condition);
     };
 
-    return {
-        schedulerModel: schedulerModel,
-        moduleScheduler: moduleScheduler,
+    self.change = function () {
+        self.saveButton.fire('change');
     };
-});
+
+    self.validate = function () {
+        var errors = 0;
+        var $addVisitButton = self.home.find("#add-visit");
+
+        if (self.formSchedule.visits().length === 0) {
+            $addVisitButton.closest(".form-group").addClass("has-error");
+            $addVisitButton.siblings(".error-text").show();
+            errors += 1;
+        } else {
+            $addVisitButton.closest(".form-group").removeClass("has-error");
+            $addVisitButton.siblings(".error-text").hide();
+        }
+
+        var required = self.home.find(":required").not(":disabled");
+        required.each(function (i, req) {
+            var $req = $(req);
+            if ($req.val().trim().length === 0) {
+                $req.closest(".form-group").addClass("has-error");
+                $req.siblings(".error-text").show();
+                errors += 1;
+            } else {
+                $req.closest(".form-group").removeClass("has-error");
+                $req.siblings(".error-text").hide();
+            }
+        });
+
+        if (!self.formSchedule.scheduleEnabled() || !errors) {
+            self.home.find("#form-errors").hide();
+            return true;
+        } else {
+            self.home.find("#form-errors").show();
+            return false;
+        }
+    };
+
+    self.schedulePhase = schedulePhase.wrap(params.phase, self);
+    self.formSchedule = formSchedule.wrap(params, self, self.schedulePhase);
+
+    self.init = function () {
+        _.defer(function () {
+            self.home.koApplyBindings(self);
+            self.home.on('textchange', 'input', self.change)
+                .on('change', 'select', self.change)
+                .on('click', 'a:not(.header)', self.change)
+                .on('change', 'input[type="checkbox"]', self.change);
+
+            self.applyGlobalEventHandlers();
+        });
+    };
+
+    self.applyGlobalEventHandlers = function () {
+        // https://gist.github.com/mkelly12/424774/#comment-92080
+        // textchange doesn't work with live event binding
+        $('#visit-scheduler input').on('textchange', self.change);
+    };
+
+    return self;
+};
+
+var scheduleRelevancy = {
+    mapping: function () {
+        return {
+            include: [
+                'starts',
+                'expires',
+            ],
+        };
+    },
+    wrap: function (data) {
+        var self = {};
+        ko.mapping.fromJS(data, scheduleRelevancy.mapping(self), self);
+        self.starts_type = ko.observable(self.starts() < 0 ? 'before' : 'after');
+        self.expires_type = ko.observable(self.expires() < 0 ? 'before' : 'after');
+        self.enableFormExpiry = ko.observable(self.expires() !== null);
+        self.starts = ko.observable(Math.abs(self.starts()));
+        self.expires = ko.observable(Math.abs(self.expires()));
+        return self;
+    },
+    unwrap: function (self) {
+        return ko.mapping.toJS(self, scheduleRelevancy.mapping(self));
+    },
+};
+
+var scheduleVisit = {
+    mapping: function () {
+        return {
+            include: [
+                'due',
+                'type',
+                'starts',
+                'expires',
+                'repeats',
+                'increment',
+            ],
+        };
+    },
+    wrap: function (data, config) {
+        var self = {
+            config: config,
+        };
+        ko.mapping.fromJS(data, scheduleVisit.mapping(self), self);
+        if (self.repeats()) {
+            self.due(self.increment());
+            self.type('repeats');
+        }
+        self.starts(self.starts() * -1);
+        return self;
+    },
+
+    unwrap: function (self) {
+        return ko.mapping.toJS(self, scheduleVisit.mapping(self));
+    },
+};
+
+var schedulePhase = {
+    mapping: function () {
+        return {
+            include: [
+                'anchor',
+            ],
+        };
+    },
+    wrap: function (data) {
+        var self = {};
+        ko.mapping.fromJS(data, schedulePhase.mapping(self), self);
+        return self;
+    },
+};
+
+var formSchedule = {
+    mapping: function (self) {
+        return {
+            include: [
+                'expires',
+                'allow_unscheduled',
+                'transition_condition',
+                'termination_condition',
+                'schedule_form_id',
+            ],
+            visits: {
+                create: function (options) {
+                    options.data.type = options.data.due < 0 ? 'before' : 'after';
+                    options.data.due = Math.abs(options.data.due);
+                    return scheduleVisit.wrap(options.data, self);
+                },
+            },
+        };
+    },
+    wrap: function (data, config, phase) {
+        var self = {
+            config: config,
+            all_schedule_phase_anchors: data.all_schedule_phase_anchors,
+            phase: phase,
+        };
+        ko.mapping.fromJS(data.schedule, formSchedule.mapping(self), self);
+
+        // for compatibility with common template: case-config:condition
+        self.allow = {
+            repeats: function () {
+                return false;
+            },
+        };
+
+        self.scheduleEnabled = ko.observable(data.schedule.enabled);
+        self.transition = ko.computed(formSchedule.conditionComputed(self.config, self.transition_condition));
+        self.terminate = ko.computed(formSchedule.conditionComputed(self.config, self.termination_condition));
+
+        self.allowExpiry = ko.computed(function () {
+            return self.transition_condition.type() === 'never' &&
+                self.termination_condition.type() === 'never';
+        });
+
+        self.hasExpiry = ko.observable();
+
+        self.hasRepeatVisit = ko.computed(function () {
+            return self.visits().length > 0 && self.visits()[self.visits().length - 1].type() === 'repeats';
+        });
+
+        self.relevancy = scheduleRelevancy.wrap(data.schedule);
+        var xmlRe = /\s+|<+|>+|&+|"+|'+/g;
+        self.schedule_form_id = ko.observable(data.schedule_form_id || '').snakeCase(xmlRe);
+
+        self.addVisit = function () {
+            self.visits.push(scheduleVisit.wrap({
+                due: null,
+                type: 'after',
+                starts: null,
+                expires: null,
+                increment: null,
+                repeats: false,
+            }));
+        };
+
+        self.removeVisit = function (visit) {
+            self.visits.remove(visit);
+        };
+
+        return self;
+    },
+
+    conditionComputed: function (config, condition) {
+        return {
+            read: function () {
+                if (condition) {
+                    return condition.type() !== 'never';
+                } else {
+                    return false;
+                }
+
+            },
+            write: function (value) {
+                condition.type(value ? 'always' : 'never');
+                config.saveButton.fire('change');
+            },
+        };
+    },
+
+    cleanCondition: function (condition) {
+        if (condition.type() !== 'if') {
+            condition.question(null);
+            condition.answer(null);
+            condition.operator(null);
+        }
+    },
+
+    unwrap: function (self) {
+        formSchedule.cleanCondition(self.transition_condition);
+        formSchedule.cleanCondition(self.termination_condition);
+        var schedule = ko.mapping.toJS(self, formSchedule.mapping(self));
+        schedule.enabled = self.scheduleEnabled();
+        schedule.starts = self.relevancy.starts() * (self.relevancy.starts_type() === 'before' ? -1 : 1);
+        if (self.relevancy.enableFormExpiry() && self.allowExpiry()) {
+            schedule.expires = self.relevancy.expires() * (self.relevancy.expires_type() === 'before' ? -1 : 1);
+        } else {
+            schedule.expires = null;
+        }
+
+        schedule.anchor = self.phase.anchor() || '';
+        schedule.schedule_form_id = self.schedule_form_id();
+        schedule.visits = _.map(schedule.visits, function (visit) {
+            var due = visit.due * (visit.type === 'before' ? -1 : 1);
+            var repeats = visit.type === 'repeats';
+            return {
+                due: repeats ? null : due,
+                starts: visit.starts * -1,
+                expires: visit.expires,
+                repeats: repeats,
+                increment: repeats ? visit.due : null,
+            };
+        });
+        return schedule;
+    },
+};
+
+// Verbatim from http://www.knockmeout.net/2011/05/dragging-dropping-and-sorting-with.html
+//control visibility, give element focus, and select the contents (in order)
+ko.bindingHandlers.visibleAndSelect = {
+    update: function (element, valueAccessor) {
+        ko.bindingHandlers.visible.update(element, valueAccessor);
+        if (valueAccessor()) {
+            _.defer(function () {
+                $(element).focus().select();
+            });
+        }
+    },
+};
+
+export default {
+    schedulerModel: schedulerModel,
+    moduleScheduler: moduleScheduler,
+};


### PR DESCRIPTION
## Technical Summary
Migrates the entry points for form and module view, plus other modules that are only imported by those two modules, which means a bunch of app manager.

## Safety Assurance

### Safety story
I smoke tested locally (normal, shadow, and advanced modules; normal and advanced forms. I did this PR by starting with the two entry points (`app_manager/js/modules/module_view` and `app_manager/js/forms/form_view`) and then working "outwards" from there: checking each dependency, migrating it if possible, and then checking *that* dependency, and so on.

### Automated test coverage

not really

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
