### PR TITLE
Unset awaiting flag

### DIFF
--- a/corehq/apps/userreports/management/commands/async_rebuild_table.py
+++ b/corehq/apps/userreports/management/commands/async_rebuild_table.py
@@ -71,8 +71,7 @@ class Command(BaseCommand):
 
         for config in configs:
             if not config.is_static:
-                config.meta.build.rebuilt_asynchronously = True
-                config.save()
+                config.save_rebuilt_async()
 
     @property
     def fake_change_doc(self):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -805,6 +805,10 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
         self.meta.build.rebuilt_asynchronously = False
         self.save()
 
+    def save_build_resumed(self):
+        self.meta.build.awaiting = False
+        self.save()
+
     def save_build_finished(self, *, in_place=False):
         if in_place:
             self.meta.build.finished_in_place = True
@@ -829,6 +833,11 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
                 ):
                     current_config.meta.build.finished = True
             current_config.save()
+
+    def save_rebuilt_async(self):
+        self.meta.build.awaiting = False
+        self.meta.build.rebuilt_asynchronously = True
+        self.save()
 
 
 class RegistryDataSourceConfiguration(DataSourceConfiguration):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -810,6 +810,7 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
         self.save()
 
     def save_build_finished(self, *, in_place=False):
+        self.meta.build.awaiting = False
         if in_place:
             self.meta.build.finished_in_place = True
         else:

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -205,8 +205,7 @@ def resume_building_indicators(indicator_config_id, initiated_by=None):
     failure = _('There was an error rebuilding Your UCR table {} in {}.').format(config.table_id, config.domain)
     with notify_someone(initiated_by, success_message=success, error_message=failure, send=True):
         if not id_is_static(indicator_config_id):
-            config.meta.build.awaiting = False
-            config.save()
+            config.save_build_resumed()
         resume_helper = DataSourceResumeHelper(config)
         adapter = get_indicator_adapter(config)
         adapter.log_table_build(


### PR DESCRIPTION
## Technical Summary

`DataSourceConfiguration.meta.build.awaiting` is not always set back to False, and so this banner can appear on a data source that has been rebuilt:
![image](https://github.com/user-attachments/assets/e910421e-a196-45fa-bb75-343774fc2bb9)

This change resets the `awaiting` flag after rebuilds, and when rebuilds are triggered from the command line.

:blowfish: 

## Safety Assurance

### Safety story

* Small change.

### Automated test coverage

This change is not covered by tests

### QA Plan

QA not planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
