### PR TITLE
Removed underscore from HTML bindings in case detail screen

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/graph_configuration_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/graph_configuration_modal.html
@@ -279,6 +279,6 @@
         data-bind="
             text: getBackup().lang,
             {# language badge is only visible if the field is empty and a backup was found #}
-            visible: !_([$parent.lang, null]).contains(getBackup().lang) && values[$parent.lang]() === null
+            visible: ![$parent.lang, null].includes(getBackup().lang) && values[$parent.lang]() === null
     "></span>
 </script>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/style_configuration_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/style_configuration_modal.html
@@ -69,6 +69,6 @@
         data-bind="
             text: getBackup().lang,
             {# language badge is only visible if the field is empty and a backup was found #}
-            visible: !_([$parent.lang, null]).contains(getBackup().lang) && values[$parent.lang]() === null
+            visible: ![$parent.lang, null].includes(getBackup().lang) && values[$parent.lang]() === null
     "></span>
 </script>


### PR DESCRIPTION
## Product Description
Fixes a javascript error that causes the graphing modal, and presumably the style configuration modal, not to pop up.

https://dimagi.atlassian.net/browse/SAAS-17520

## Technical Summary
As of the webpack switchover, underscore is no longer globally available. In this case, the simplest thing to do is replace `_.contains` with `Array.includes`.

## Feature Flag
graphing, case tiles

## Safety Assurance

### Safety story
Relatively minor change in flagged features that are already unusable due to js error.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
