### PR TITLE
[Data Cleaning] ensure that committed or completed sessions can't be viewed again

### DIFF
--- a/corehq/apps/data_cleaning/exceptions.py
+++ b/corehq/apps/data_cleaning/exceptions.py
@@ -8,3 +8,11 @@ class UnsupportedFilterValueException(Exception):
     its FilterMatchType and DataType combination. This is rare,
     as the filter creation form should catch most of the issues.
     """
+
+
+class SessionAccessClosedException(Exception):
+    """
+    Raised when a session has been closed for editing. This is
+    raised in the view, so that we can redirect to the main page
+    with a message.
+    """

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -81,7 +81,6 @@ def _claim_bulk_edit_session_for_task(task, bulk_edit_session_id):
         | Q(task_id=task.request.id)  # or already claimed by *this* worker
     ).update(
         task_id=task.request.id,
-        committed_on=timezone.now(),
     )
     if not updated:
         logger.info("commit_data_cleaning: dropped task to avoid duplication", extra={

--- a/corehq/apps/data_cleaning/views/mixins.py
+++ b/corehq/apps/data_cleaning/views/mixins.py
@@ -20,6 +20,7 @@ class BulkEditSessionViewMixin:
                 user=self.request.user,
                 domain=self.domain,
                 session_id=self.session_id,
+                committed_on__isnull=True,
             )
         except BulkEditSession.DoesNotExist:
             raise Http404(self.session_not_found_message)

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -2,6 +2,7 @@ import json
 
 from django.contrib import messages
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 
@@ -132,6 +133,8 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
 
     @hq_hx_action("post")
     def apply_all_changes(self, request, *args, **kwargs):
+        self.session.committed_on = timezone.now()
+        self.session.save()
         commit_data_cleaning.delay(self.session.session_id)
         messages.success(
             request,


### PR DESCRIPTION
## Product Description
This change will ensure that a user cannot manually visit an old URL of a previously committed or completed session. If they do, they are re-directed to the main clean cases view and are presented with a "warning" message via the django messages framework:
<img width="1018" alt="Screenshot 2025-05-07 at 10 05 05 AM" src="https://github.com/user-attachments/assets/d39d3a65-07f2-4da1-ab70-75b5adc61432" />


## Technical Summary
Another change not visible in the UI is setting the `session.committed_on` prior to passing the session to the task, so that there is no delay in setting this date which will effectively "lock" the user out from visiting a URL directly that would allow them to continue editing that session. The a celery worker still "claims" the task through setting the `task_id`, ensuring that multiple workers don't pick up this task at the same time.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
only affects feature flagged workflow that will be undergoing QA (release PR will be a different one)

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
not blocking this PR


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
