### PR TITLE
Fix name of general_credit input

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/credits.js
+++ b/corehq/apps/accounting/static/accounting/js/credits.js
@@ -57,7 +57,7 @@ hqDefine('accounting/js/credits', [
     var cardPaymentCreditItem = function (paymentHandler) {
         var self = {};
         self.name = ko.observable("Credits");
-        self.creditType = ko.observable("card_general_credit");
+        self.creditType = ko.observable("general_credit");
         self.addAmount = ko.observable(0);
         self.isAddAmountValid = ko.computed(function () {
             return  parseFloat(self.addAmount()) === 0 || (parseFloat(self.addAmount()) >= 0.5);


### PR DESCRIPTION
## Technical Summary
Fixes [a bug](https://dimagi.atlassian.net/browse/SAAS-17523) that was introduced with #36064
Because the name of the `general_credit` input was changed and therefore was not in POST data, `self.general_credits` on the `CreditStripePaymentHandler` was not being set here:
https://github.com/dimagi/commcare-hq/blob/ed2de690e2b2335ea46cffbcc70a6f7b440db7b3/corehq/apps/accounting/payment_handlers.py#L324-L328

Meaning that the check for `self.general_credits` here would always fail, and the credit adjustment would not be created:
https://github.com/dimagi/commcare-hq/blob/ed2de690e2b2335ea46cffbcc70a6f7b440db7b3/corehq/apps/accounting/payment_handlers.py#L358-L361

The overall effect (which we are seeing) is that Stripe payments for these credits would have been processed correctly but not applied to the project space/billing account.


## Safety Assurance

### Safety story
Small bugfix, just changing the name of the input back to what it was previously. Checked for sanity on staging as well.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
