### PR TITLE
Close S3BlobDB the file after reading it on write

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -178,9 +178,9 @@ class ItemListsProvider(FixtureProvider):
                 if data is None:
                     record_datadog_metric('generate', key)
                     items = self._get_global_items(global_type, domain)
-                    io_data = write_fixture_items_to_io(items)
-                    data = io_data.getvalue()
-                    cache_fixture_items_data(io_data, domain, '', key)
+                    with write_fixture_items_to_io(items) as io_data:
+                        data = io_data.getvalue()
+                        cache_fixture_items_data(io_data, domain, '', key)
 
         global_id = GLOBAL_USER_ID.encode('utf-8')
         b_user_id = user_id.encode('utf-8')

--- a/corehq/blobs/fsdb.py
+++ b/corehq/blobs/fsdb.py
@@ -47,22 +47,16 @@ class FilesystemBlobDB(AbstractBlobDB):
             content = GzipStream(content)
         chunk_sizes = []
         digest = md5()
-        try:
-            with open(path, "wb") as fh:
-                while True:
-                    chunk = content.read(CHUNK_SIZE)
-                    if not chunk:
-                        break
-                    fh.write(chunk)
-                    chunk_sizes.append(len(chunk))
-                    digest.update(chunk)
-        finally:
-            # align with S3DB behavior
-            if not isinstance(content, BlobStream):
-                content.close()
+        with open(path, "wb") as fh:
+            while True:
+                chunk = content.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                fh.write(chunk)
+                chunk_sizes.append(len(chunk))
+                digest.update(chunk)
 
-        meta.content_length, meta.compressed_length = get_content_size(
-            content, chunk_sizes)
+        meta.content_length, meta.compressed_length = get_content_size(content, chunk_sizes)
         self.metadb.put(meta)
         return meta
 

--- a/corehq/blobs/management/commands/emergency_restore_blobs_for_domain.py
+++ b/corehq/blobs/management/commands/emergency_restore_blobs_for_domain.py
@@ -44,8 +44,8 @@ def get_blob_metas_for_domain(domain):
 
 def restore_blobs(db, blob_metas):
     for meta in blob_metas:
-        stream = _get_stream_of_latest_version_before_deletion_for_object(meta)
-        db.put(stream, meta=meta)
+        with _get_stream_of_latest_version_before_deletion_for_object(meta) as stream:
+            db.put(stream, meta=meta)
 
 
 def _get_blob_metas(parent_id):

--- a/corehq/blobs/tests/test_fsdb.py
+++ b/corehq/blobs/tests/test_fsdb.py
@@ -157,12 +157,14 @@ class _BlobDBTests(object):
         with self.assertRaises(mod.NotFound):
             self.db.get(key="abc", type_code=CODES.tempfile)
 
-    def test_raw_io_content_stream_should_be_closed_after_put(self):
+    def test_raw_io_content_stream_should_be_open_after_put(self):
         content = BytesIO(b"regular content")
         self.db.put(content, meta=self.new_meta())
-        self.assertTrue(content.closed, "Regular content stream should be closed after put")
-        with self.assertRaises(ValueError):
+        self.assertFalse(content.closed, "Regular content stream should remain open after put")
+        try:
             content.read()
+        except Exception as e:
+            self.fail(f"Reading from BlobStream failed with exception: {e}")
 
     def test_blob_stream_should_remain_open_after_put(self):
         source_meta = self.db.put(BytesIO(b"blob stream content"), meta=self.new_meta())

--- a/corehq/blobs/tests/test_fsdb.py
+++ b/corehq/blobs/tests/test_fsdb.py
@@ -13,6 +13,7 @@ import corehq.blobs.fsdb as mod
 from corehq.blobs import CODES
 from corehq.blobs.metadata import MetaDB
 from corehq.blobs.tasks import delete_expired_blobs
+from corehq.blobs.util import BlobStream
 from corehq.blobs.tests.util import new_meta, temporary_blob_db
 from corehq.util.metrics.tests.utils import capture_metrics
 from corehq.util.test_utils import generate_cases
@@ -155,6 +156,28 @@ class _BlobDBTests(object):
         self.db.expire("test", "abc")  # should not raise error
         with self.assertRaises(mod.NotFound):
             self.db.get(key="abc", type_code=CODES.tempfile)
+
+    def test_raw_io_content_stream_should_be_closed_after_put(self):
+        content = BytesIO(b"regular content")
+        self.db.put(content, meta=self.new_meta())
+        self.assertTrue(content.closed, "Regular content stream should be closed after put")
+        with self.assertRaises(ValueError):
+            content.read()
+
+    def test_blob_stream_should_remain_open_after_put(self):
+        source_meta = self.db.put(BytesIO(b"blob stream content"), meta=self.new_meta())
+        with self.db.get(meta=source_meta) as blob_stream:
+            self.assertIsInstance(blob_stream, BlobStream)
+            self.assertFalse(blob_stream.closed)
+
+            self.db.put(blob_stream, meta=self.new_meta())
+
+            self.assertFalse(blob_stream.closed, "BlobStream should remain open after put")
+
+            try:
+                blob_stream.read()
+            except Exception as e:
+                self.fail(f"Reading from BlobStream failed with exception: {e}")
 
 
 def _is_overridden(method):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -83,7 +83,7 @@ class BaseCaseMultimediaTest(TestCase, TestFileMixin):
     def _attachmentFileStream(self, key):
         attachment_path = MEDIA_FILES[key]
         attachment = open(attachment_path, 'rb')
-        return NoClose(UploadedFile(attachment, key))
+        return UploadedFile(attachment, key)
 
     def _calc_file_hash(self, key):
         with open(MEDIA_FILES[key], 'rb') as attach:
@@ -291,24 +291,3 @@ class CaseMultimediaS3DBTest(BaseCaseMultimediaTest):
             self._calc_file_hash(single_attach),
             hashlib.md5(case.get_attachment(single_attach)).hexdigest()
         )
-
-
-class NoClose(object):
-    """HACK file object with no-op `close()` to avoid close by S3Transfer
-
-    https://github.com/boto/s3transfer/issues/80
-    """
-
-    def __init__(self, fileobj):
-        self.fileobj = fileobj
-
-    def __getattr__(self, name):
-        return getattr(self.fileobj, name)
-
-    def open(self, *args, **kw):
-        # compatible with django.core.files.base.File.open()
-        obj = self.fileobj.open(*args, **kw)
-        return self if obj is self.fileobj else obj
-
-    def close(self):
-        pass

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -243,7 +243,7 @@ class CachedResponse(object):
         """
         name = 'restore-{}.xml'.format(uuid4().hex)
         get_blob_db().put(
-            NoClose(fileobj),
+            fileobj,
             domain=domain,
             parent_id=restore_user_id,
             type_code=CODES.restore,
@@ -864,19 +864,3 @@ RESTORE_SEGMENTS = {
     "FixtureElementProvider": "fixtures",
     "CasePayloadProvider": "cases",
 }
-
-
-class NoClose(object):
-    """HACK file object with no-op `close()` to avoid close by S3Transfer
-
-    https://github.com/boto/s3transfer/issues/80
-    """
-
-    def __init__(self, fileobj):
-        self.fileobj = fileobj
-
-    def __getattr__(self, name):
-        return getattr(self.fileobj, name)
-
-    def close(self):
-        pass


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user facing effects

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-5943](https://dimagi.atlassian.net/browse/USH-5943)
This resulted from a retro item that came out related to this PR https://github.com/dimagi/commcare-hq/pull/36242

S3 closes the file after reading it while FileSystemBlobDb does not. FilesystemBlobDb is used by default used locally while S3 is used on staging and production. This results in a discrepancy when testing things locally vs its behavior on staging/production. This PR closes that gap by making S3 keep the file open upon `put`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change has a large blast radius in the sense that it affects all uses of `put`.  I went through callers of `get_blob_db` `put` and verified that the content passed to `put` is either explicitly closed, is a`BytesIO` that does not need to be explicitly closed, or comes from `request.FILE` which is `InMemoryUploadedFile` and also does not need to be explicitly closed. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I added a test that checks if the file is readable after it is `put` in the db.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-5943]: https://dimagi.atlassian.net/browse/USH-5943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ