### PR TITLE
[Data Cleaning] Improve table performance (especially with lots of rows shown)

### DIFF
--- a/corehq/apps/data_cleaning/columns.py
+++ b/corehq/apps/data_cleaning/columns.py
@@ -101,7 +101,7 @@ class DataCleaningHtmxSelectionColumn(CheckBoxColumn):
                 self.template_column,
                 {
                     'hq_hx_action': self.select_record_action,
-                    'is_checked': self.is_checked(value, record),
+                    'is_checked': self.is_checked(record),
                     'value': value,
                     'css_id': self.get_selected_record_checkbox_id(value),
                     'record': record,
@@ -112,5 +112,5 @@ class DataCleaningHtmxSelectionColumn(CheckBoxColumn):
             )
         )
 
-    def is_checked(self, value, record):
-        return self.session.is_record_selected(value)
+    def is_checked(self, record):
+        return record.is_selected

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -390,9 +390,6 @@ class BulkEditSession(models.Model):
         self.changes.all().delete()
         self.purge_records()
 
-    def is_record_selected(self, doc_id):
-        return BulkEditRecord.is_record_selected(self, doc_id)
-
     def select_record(self, doc_id):
         return BulkEditRecord.select_record(self, doc_id)
 
@@ -993,13 +990,6 @@ class BulkEditRecord(models.Model):
             defaults={'is_selected': False}
         )
         return record
-
-    @classmethod
-    def is_record_selected(self, session, doc_id):
-        return session.records.filter(
-            doc_id=doc_id,
-            is_selected=True,
-        ).exists()
 
     @classmethod
     def get_unrecorded_doc_ids(cls, session, doc_ids):

--- a/corehq/apps/data_cleaning/records.py
+++ b/corehq/apps/data_cleaning/records.py
@@ -18,6 +18,12 @@ class EditableCaseSearchElasticRecord(CaseSearchElasticRecord):
             return None
 
     @property
+    def is_selected(self):
+        if self.edited_record:
+            return self.edited_record.is_selected
+        return False
+
+    @property
     @memoized
     def edited_properties(self):
         if self.edited_record:

--- a/corehq/apps/data_cleaning/tests/test_records.py
+++ b/corehq/apps/data_cleaning/tests/test_records.py
@@ -39,13 +39,6 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
         self.assertIsNone(record)
         self.assertFalse(self.session.records.filter(doc_id=case_id).exists())
 
-    def test_is_record_selected(self):
-        case_id = self._get_case_id()
-        self.session.select_record(case_id)
-        self.assertTrue(self.session.is_record_selected(case_id))
-        self.session.deselect_record(case_id)
-        self.assertFalse(self.session.is_record_selected(case_id))
-
     def test_select_record_with_changes(self):
         case_id = self._get_case_id()
         record = BulkEditRecord.objects.create(
@@ -54,7 +47,6 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
             is_selected=False,
         )
         change = self._add_change_to_record(record)
-        self.assertFalse(self.session.is_record_selected(case_id))
 
         record = self.session.select_record(case_id)
         self.assertEqual(record.session, self.session)
@@ -63,7 +55,6 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
         self.assertEqual(record.changes.count(), 1)
         self.assertEqual(record.changes.first(), change)
 
-        self.assertTrue(self.session.is_record_selected(case_id))
         self.assertTrue(self.session.records.filter(doc_id=case_id).exists())
 
     def test_deselect_record_with_changes(self):
@@ -74,7 +65,6 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
             is_selected=True,
         )
         change = self._add_change_to_record(record)
-        self.assertTrue(self.session.is_record_selected(case_id))
 
         record = self.session.deselect_record(case_id)
         self.assertIsNotNone(record)
@@ -84,7 +74,6 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
         self.assertEqual(record.changes.first(), change)
         self.assertFalse(record.is_selected)
 
-        self.assertFalse(self.session.is_record_selected(case_id))
         self.assertTrue(self.session.records.filter(doc_id=case_id).exists())
 
     def test_select_multiple_records(self):


### PR DESCRIPTION
## Technical Summary
This PR reduces the query count per row in the table from 2 to 1. This matters quite a bit when showing 100 rows on a page. Review commit-by-commit and the commit messages have additional context. 

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change made to a feature flagged area of codebase currently under QA

### Automated test coverage
most important bits are tested

### QA Plan
not blocking pr

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
