### PR TITLE
[Data Cleaning] Improve table performance and remove "num records with an edit history" indicator

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -22,7 +22,6 @@ from corehq.apps.es import CaseSearchES
 
 BULK_OPERATION_CHUNK_SIZE = 1000
 MAX_RECORDED_LIMIT = 100000
-MAX_RECORD_CHANGES = 20
 MAX_SESSION_CHANGES = 200
 
 
@@ -339,27 +338,6 @@ class BulkEditSession(models.Model):
                 "Session not committed yet. Please commit the session first or use get_change_counts()"
             )
         return self.result['record_count'] if self.completed_on else self.records.count()
-
-    def get_change_counts(self):
-        """
-        Get the details of the number of records with changes, and the number
-        of records that have more than `MAX_RECORD_CHANGES` changes associated with it.
-
-        This is an aggregated query to reduce the number of db hits, since
-        both num_records_edited and num_records_at_max_changes are always used
-        together and are related in structure.
-
-        :return: dict {
-            'num_records_edited': int - number of records with changes
-            'num_records_at_max_changes': int - number of records at or above `MAX_RECORD_CHANGES`
-        }
-        """
-        return self.records.annotate(num_changes=models.Count("changes")).aggregate(
-            num_records_edited=models.Count("pk", filter=models.Q(num_changes__gt=0)),
-            num_records_at_max_changes=models.Count(
-                "pk", filter=models.Q(num_changes__gte=MAX_RECORD_CHANGES)
-            ),
-        )
 
     def get_num_changes(self):
         return self.changes.count()

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -345,14 +345,6 @@ class BulkEditSession(models.Model):
     def are_bulk_edits_allowed(self):
         return self.changes.count() < MAX_SESSION_CHANGES
 
-    def is_undo_multiple(self):
-        """
-        Check if the last change in the session affects multiple records.
-        :return: bool - True if the last change affects multiple records
-        """
-        last_change = self.changes.last()
-        return last_change and last_change.records.count() > 1
-
     def purge_records(self):
         """
         Delete all records that do not have changes or are not selected.

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -339,11 +339,11 @@ class BulkEditSession(models.Model):
             )
         return self.result['record_count'] if self.completed_on else self.records.count()
 
-    def get_num_changes(self):
-        return self.changes.count()
+    def has_changes(self):
+        return self.changes.exists()
 
     def are_bulk_edits_allowed(self):
-        return self.get_num_changes() < MAX_SESSION_CHANGES
+        return self.changes.count() < MAX_SESSION_CHANGES
 
     def is_undo_multiple(self):
         """

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -342,6 +342,9 @@ class BulkEditSession(models.Model):
     def get_num_changes(self):
         return self.changes.count()
 
+    def are_bulk_edits_allowed(self):
+        return self.get_num_changes() < MAX_SESSION_CHANGES
+
     def is_undo_multiple(self):
         """
         Check if the last change in the session affects multiple records.

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -15,10 +15,8 @@ Alpine.data('wiggleButtonModel', wiggleButton);
 Alpine.store('isCleaningAllowed', false);
 Alpine.store('showWhitespaces', false);
 Alpine.store('editDetails', {
-    isSessionAtChangeLimit: false,
     isUndoMultiple: false,
     update(details) {
-        this.isSessionAtChangeLimit = details.isSessionAtChangeLimit;
         this.isUndoMultiple = details.isUndoMultiple;
     },
 });

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -14,12 +14,6 @@ Alpine.data('wiggleButtonModel', wiggleButton);
 
 Alpine.store('isCleaningAllowed', false);
 Alpine.store('showWhitespaces', false);
-Alpine.store('editDetails', {
-    isUndoMultiple: false,
-    update(details) {
-        this.isUndoMultiple = details.isUndoMultiple;
-    },
-});
 
 import Alpine from 'alpinejs';
 Alpine.start();
@@ -27,8 +21,4 @@ Alpine.start();
 document.body.addEventListener("showDataCleaningModal", function (event) {
     const modal = new Modal(event.detail.elt);
     modal.show();
-});
-
-document.body.addEventListener("updateEditDetails", function (event) {
-    Alpine.store('editDetails').update(event.detail.editDetails);
 });

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -15,13 +15,11 @@ Alpine.data('wiggleButtonModel', wiggleButton);
 Alpine.store('isCleaningAllowed', false);
 Alpine.store('showWhitespaces', false);
 Alpine.store('editDetails', {
-    numRecordsEdited: 0,
-    showApplyWarning: false,
+    numChanges: 0,
     isSessionAtChangeLimit: false,
     isUndoMultiple: false,
     update(details) {
-        this.numRecordsEdited = details.numRecordsEdited;
-        this.showApplyWarning = details.numRecordsOverLimit > 0;
+        this.numChanges = details.numChanges;
         this.isSessionAtChangeLimit = details.isSessionAtChangeLimit;
         this.isUndoMultiple = details.isUndoMultiple;
     },

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/clean_cases_session.js
@@ -15,11 +15,9 @@ Alpine.data('wiggleButtonModel', wiggleButton);
 Alpine.store('isCleaningAllowed', false);
 Alpine.store('showWhitespaces', false);
 Alpine.store('editDetails', {
-    numChanges: 0,
     isSessionAtChangeLimit: false,
     isUndoMultiple: false,
     update(details) {
-        this.numChanges = details.numChanges;
         this.isSessionAtChangeLimit = details.isSessionAtChangeLimit;
         this.isUndoMultiple = details.isUndoMultiple;
     },

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -99,47 +99,21 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         return self.num_selected_records
 
     @property
-    def num_edited_records(self):
-        """
-        Return the number of edited records in the session.
-        """
-        return self.change_counts["num_records_edited"]
-
-    @property
     @memoized
-    def change_counts(self):
-        """
-        A dictionary of "change_counts" for the session.
-        This includes the number of records edited and the number of records
-        that have reached the maximum number of changes.
-        The keys are:
-            - num_records_edited: the number of records edited
-            - num_records_at_max_changes: the number of records that have reached the maximum number of changes
-        """
-        return self.session.get_change_counts()
+    def num_changes(self):
+        return self.session.get_num_changes()
 
     @staticmethod
-    def get_edit_details(session, change_counts=None):
+    def get_edit_details(session, num_changes=None):
         """
         Return a dictionary of edit details for the Alpine.store.
-        This includes the number of records edited and the number of records
-        that have reached the maximum number of changes.
-
-        This is a staticmethod so that the TableHostView can also call this.
-
-        `change_counts` is optional and will be fetched from the session if not provided,
-        it allows us to memoize the change_counts for additional references in the table's template.
-
-        The keys are:
-            - numRecordsEdited: the number of records edited
-            - numRecordsOverLimit: the number of records that have reached the maximum number of changes
-            - isSessionAtChangeLimit: whether the session has reached the maximum number of changes
+        NOTE: The Table's Host View also calls this.
         """
-        change_counts = change_counts or session.get_change_counts()
+        if num_changes is None:
+            num_changes = session.get_num_changes()
         return {
-            "numRecordsEdited": change_counts["num_records_edited"],
-            "numRecordsOverLimit": change_counts["num_records_at_max_changes"],
-            "isSessionAtChangeLimit": session.get_num_changes() >= MAX_SESSION_CHANGES,
+            "numChanges": num_changes,
+            "isSessionAtChangeLimit": num_changes >= MAX_SESSION_CHANGES,
             "isUndoMultiple": session.is_undo_multiple(),
         }
 
@@ -149,9 +123,8 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         """
         Return a JSON dump of the result of get_edit_details.
         This is used to pass the edit details to the Alpine store.
-        This is a property so that it can be memoized and used in the template.
         """
-        return json.dumps(self.get_edit_details(self.session, self.change_counts))
+        return json.dumps(self.get_edit_details(self.session, self.num_changes))
 
 
 class CaseCleaningTasksTable(BaseHtmxTable, tables.Table):

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -99,8 +99,8 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
 
     @property
     @memoized
-    def num_changes(self):
-        return self.session.get_num_changes()
+    def has_changes(self):
+        return self.session.has_changes()
 
     @staticmethod
     def get_edit_details(session):

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -112,7 +112,6 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         if num_changes is None:
             num_changes = session.get_num_changes()
         return {
-            "numChanges": num_changes,
             "isSessionAtChangeLimit": num_changes >= MAX_SESSION_CHANGES,
             "isUndoMultiple": session.is_undo_multiple(),
         }

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -1,4 +1,3 @@
-import json
 from memoized import memoized
 
 from django.utils.translation import gettext_lazy
@@ -101,25 +100,6 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
     @memoized
     def has_changes(self):
         return self.session.has_changes()
-
-    @staticmethod
-    def get_edit_details(session):
-        """
-        Return a dictionary of edit details for the Alpine.store.
-        NOTE: The Table's Host View also calls this.
-        """
-        return {
-            "isUndoMultiple": session.is_undo_multiple(),
-        }
-
-    @property
-    @memoized
-    def edit_details(self):
-        """
-        Return a JSON dump of the result of get_edit_details.
-        This is used to pass the edit details to the Alpine store.
-        """
-        return json.dumps(self.get_edit_details(self.session))
 
 
 class CaseCleaningTasksTable(BaseHtmxTable, tables.Table):

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -11,7 +11,6 @@ from corehq.apps.data_cleaning.columns import (
 from corehq.apps.data_cleaning.models import (
     BULK_OPERATION_CHUNK_SIZE,
     MAX_RECORDED_LIMIT,
-    MAX_SESSION_CHANGES,
 )
 from corehq.apps.data_cleaning.records import EditableCaseSearchElasticRecord
 from corehq.apps.hqwebapp.tables.elasticsearch.tables import ElasticTable
@@ -104,15 +103,12 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         return self.session.get_num_changes()
 
     @staticmethod
-    def get_edit_details(session, num_changes=None):
+    def get_edit_details(session):
         """
         Return a dictionary of edit details for the Alpine.store.
         NOTE: The Table's Host View also calls this.
         """
-        if num_changes is None:
-            num_changes = session.get_num_changes()
         return {
-            "isSessionAtChangeLimit": num_changes >= MAX_SESSION_CHANGES,
             "isUndoMultiple": session.is_undo_multiple(),
         }
 
@@ -123,7 +119,7 @@ class CleanCaseTable(BaseHtmxTable, ElasticTable):
         Return a JSON dump of the result of get_edit_details.
         This is used to pass the edit details to the Alpine store.
         """
-        return json.dumps(self.get_edit_details(self.session, self.num_changes))
+        return json.dumps(self.get_edit_details(self.session))
 
 
 class CaseCleaningTasksTable(BaseHtmxTable, tables.Table):

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -22,29 +22,30 @@
     </div>
   {% endif %}
   {% if cleaning_form.is_form_visible %}
-    <form
-      hx-post="{{ request.path_info }}"
-      hx-target="#{{ container_id }}"
-      hx-disabled-elt="find button"
-      hq-hx-action="create_bulk_edit_change"
-      x-show="!$store.editDetails.isSessionAtChangeLimit"
-    >
-      {% crispy cleaning_form %}
-    </form>
-    <div
-      class="alert alert-warning"
-      x-show="$store.editDetails.isSessionAtChangeLimit"
-    >
-      <h5>
-        {% trans "Edit history is too large..." %}
-      </h5>
-      <p>
-        {% blocktrans %}
-          The edit history for this session is too large to support new bulk edits.
-          You can either apply the current edits, undo edits, or clear the edit history to start over.
-        {% endblocktrans%}
-      </p>
-    </div>
+
+    {% if are_bulk_edits_allowed %}
+      <form
+        hx-post="{{ request.path_info }}"
+        hx-target="#{{ container_id }}"
+        hx-disabled-elt="find button"
+        hq-hx-action="create_bulk_edit_change"
+      >
+        {% crispy cleaning_form %}
+      </form>
+    {% else %}
+      <div class="alert alert-warning">
+        <h5>
+          {% trans "Edit history is too large..." %}
+        </h5>
+        <p>
+          {% blocktrans %}
+            The edit history for this session is too large to support new bulk edits.
+            You can either apply the current edits, undo edits, or clear the edit history to start over.
+          {% endblocktrans%}
+        </p>
+      </div>
+    {% endif %}
+
   {% else %}
     <div class="alert alert-primary">
       <h5>{% trans "No editible case properties are visible" %}</h5>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -41,7 +41,7 @@
           {% blocktrans %}
             The edit history for this session is too large to support new bulk edits.
             You can either apply the current edits, undo edits, or clear the edit history to start over.
-          {% endblocktrans%}
+          {% endblocktrans %}
         </p>
       </div>
     {% endif %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -22,21 +22,6 @@
     </div>
   {% endif %}
   {% if cleaning_form.is_form_visible %}
-    <div
-      class="alert alert-warning"
-      role="alert"
-      x-show="$store.editDetails.showApplyWarning && !$store.editDetails.isSessionAtChangeLimit"
-    >
-      <h5>
-        {% trans "Performance might be impacted..." %}
-      </h5>
-      <p>
-        {% blocktrans %}
-          Some cases have a large number of edits. You can continue to preview new bulk edits,
-          but some pages may take longer to load.
-        {% endblocktrans %}
-      </p>
-    </div>
     <form
       hx-post="{{ request.path_info }}"
       hx-target="#{{ container_id }}"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/modals/select_all_not_possible.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/modals/select_all_not_possible.html
@@ -13,7 +13,7 @@
 {% block modal_continue_button %}{% endblock %}
 
 {% block modal_body %}
-  {% if table.num_edited_records > 0 %}
+  {% if table.num_changes > 0 %}
     <p class="lead fw-bold">
       <i class="fa-solid fa-triangle-exclamation"></i>
       {% blocktrans with table.max_recorded_limit as max_recorded_limit %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/modals/select_all_not_possible.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/modals/select_all_not_possible.html
@@ -13,7 +13,7 @@
 {% block modal_continue_button %}{% endblock %}
 
 {% block modal_body %}
-  {% if table.num_changes > 0 %}
+  {% if table.has_changes %}
     <p class="lead fw-bold">
       <i class="fa-solid fa-triangle-exclamation"></i>
       {% blocktrans with table.max_recorded_limit as max_recorded_limit %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -14,7 +14,6 @@
     },
   }"
   x-init="
-    $store.editDetails.update({{ table.edit_details }});
     updateCleaningStatus(numRecordsSelected);
     $watch('numRecordsSelected', updateCleaningStatus);
   "
@@ -60,25 +59,10 @@
             type="button"
             data-bs-toggle="modal"
             data-bs-target="#confirm-undo-modal"
-            x-show="$store.editDetails.isUndoMultiple"
             @click="$dispatch('updateUndoSummaryMessage');"
           >
             <i class="fa-solid fa-undo"></i>
-            {% trans "Undo" %} {# note: undo for multiple records #}
-          </button>
-          <button
-            class="btn btn-outline-secondary"
-            type="button"
-            hx-post="{{ request.path_info }}{% querystring %}"
-            hq-hx-action="undo_last_change"
-            hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}.table-container{% endif %}"
-            hx-swap="outerHTML"
-            hq-hx-loading="{{ table.loading_indicator_id }}"
-            hx-disable-elt="this"
-            x-show="!$store.editDetails.isUndoMultiple"
-          >
-            <i class="fa-solid fa-undo"></i>
-            {% trans "Undo" %} {# note: undo for a single record #}
+            {% trans "Undo" %}
           </button>
 
           <button

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -37,64 +37,63 @@
 {% block before_table %}
   <div class="d-flex align-items-center pb-2">
 
-    <div
-      class="pe-2"
-      x-show="$store.editDetails.numChanges > 0"
-    >
-      <div class="input-group">
-        <div class="input-group-text">
-          <i class="fa-solid fa-pencil me-2"></i>
-          {% trans "Edits" %}
+    {% if table.num_changes > 0 %}
+      <div class="pe-2">
+        <div class="input-group">
+          <div class="input-group-text">
+            <i class="fa-solid fa-pencil me-2"></i>
+            {% trans "Edits" %}
+          </div>
+          <button
+            class="btn btn-outline-danger"
+            type="button"
+            data-bs-toggle="modal"
+            data-bs-target="#confirm-clear-modal"
+            @click="$dispatch('updateClearSummaryMessage');"
+          >
+            <i class="fa-solid fa-close"></i>
+            {% trans "Clear" %}
+          </button>
+
+          <button
+            class="btn btn-outline-secondary"
+            type="button"
+            data-bs-toggle="modal"
+            data-bs-target="#confirm-undo-modal"
+            x-show="$store.editDetails.isUndoMultiple"
+            @click="$dispatch('updateUndoSummaryMessage');"
+          >
+            <i class="fa-solid fa-undo"></i>
+            {% trans "Undo" %} {# note: undo for multiple records #}
+          </button>
+          <button
+            class="btn btn-outline-secondary"
+            type="button"
+            hx-post="{{ request.path_info }}{% querystring %}"
+            hq-hx-action="undo_last_change"
+            hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}.table-container{% endif %}"
+            hx-swap="outerHTML"
+            hq-hx-loading="{{ table.loading_indicator_id }}"
+            hx-disable-elt="this"
+            x-show="!$store.editDetails.isUndoMultiple"
+          >
+            <i class="fa-solid fa-undo"></i>
+            {% trans "Undo" %} {# note: undo for a single record #}
+          </button>
+
+          <button
+            class="btn btn-success"
+            type="button"
+            data-bs-toggle="modal"
+            data-bs-target="#confirm-apply-modal"
+            @click="$dispatch('updateApplySummaryMessage');"
+          >
+            <i class="fa-solid fa-check-double"></i>
+            {% trans "Apply" %}
+          </button>
         </div>
-        <button
-          class="btn btn-outline-danger"
-          type="button"
-          data-bs-toggle="modal"
-          data-bs-target="#confirm-clear-modal"
-          @click="$dispatch('updateClearSummaryMessage');"
-        >
-          <i class="fa-solid fa-close"></i>
-          {% trans "Clear" %}
-        </button>
-
-        <button
-          class="btn btn-outline-secondary"
-          type="button"
-          data-bs-toggle="modal"
-          data-bs-target="#confirm-undo-modal"
-          x-show="$store.editDetails.isUndoMultiple"
-          @click="$dispatch('updateUndoSummaryMessage');"
-        >
-          <i class="fa-solid fa-undo"></i>
-          {% trans "Undo" %} {# note: undo for multiple records #}
-        </button>
-        <button
-          class="btn btn-outline-secondary"
-          type="button"
-          hx-post="{{ request.path_info }}{% querystring %}"
-          hq-hx-action="undo_last_change"
-          hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}.table-container{% endif %}"
-          hx-swap="outerHTML"
-          hq-hx-loading="{{ table.loading_indicator_id }}"
-          hx-disable-elt="this"
-          x-show="!$store.editDetails.isUndoMultiple"
-        >
-          <i class="fa-solid fa-undo"></i>
-          {% trans "Undo" %} {# note: undo for a single record #}
-        </button>
-
-        <button
-          class="btn btn-success"
-          type="button"
-          data-bs-toggle="modal"
-          data-bs-target="#confirm-apply-modal"
-          @click="$dispatch('updateApplySummaryMessage');"
-        >
-          <i class="fa-solid fa-check-double"></i>
-          {% trans "Apply" %}
-        </button>
       </div>
-    </div>
+    {% endif %}
 
     {% if table.has_any_filtering %}
       <div class="pe-2">

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -39,7 +39,7 @@
 
     <div
       class="pe-2"
-      x-show="$store.editDetails.numRecordsEdited > 0"
+      x-show="$store.editDetails.numChanges > 0"
     >
       <div class="input-group">
         <div class="input-group-text">

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -45,12 +45,6 @@
         <div class="input-group-text">
           <i class="fa-solid fa-pencil me-2"></i>
           {% trans "Edits" %}
-          <span
-            class="ms-2 badge text-bg-secondary"
-            data-bs-title="{% trans "number of cases with an edit history" %}"
-            x-tooltip=""
-            x-text="$store.editDetails.numRecordsEdited"
-          ></span>
         </div>
         <button
           class="btn btn-outline-danger"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -37,7 +37,7 @@
 {% block before_table %}
   <div class="d-flex align-items-center pb-2">
 
-    {% if table.num_changes > 0 %}
+    {% if table.has_changes %}
       <div class="pe-2">
         <div class="input-group">
           <div class="input-group-text">

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -5,14 +5,11 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 
 from corehq.apps.data_cleaning.models import (
-    BulkEditChange,
     BulkEditRecord,
     BulkEditSession,
     BulkEditSessionType,
     DataType,
-    EditActionType,
     FilterMatchType,
-    MAX_RECORD_CHANGES,
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es import CaseSearchES, user_adapter, group_adapter
@@ -399,43 +396,3 @@ class BulkEditSessionChangesTests(BaseBulkEditSessionTest):
 
     def _get_list_of_doc_ids(self, num):
         return [str(uuid.uuid4()) for _ in range(num)]
-
-    def test_get_change_counts(self):
-        doc_ids = self._get_list_of_doc_ids(MAX_RECORD_CHANGES)
-        selected_edited_doc_ids = self._get_list_of_doc_ids(MAX_RECORD_CHANGES)
-        records = []
-        changes = []
-        for doc_id in doc_ids + selected_edited_doc_ids:
-            record = BulkEditRecord.objects.create(
-                session=self.session,
-                doc_id=doc_id,
-                is_selected=doc_id in selected_edited_doc_ids,
-            )
-            records.append(record)
-            change = BulkEditChange.objects.create(
-                session=self.session,
-                prop_id='name',
-                action_type=EditActionType.STRIP,
-            )
-            change.records.add(record)
-            changes.append(change)
-
-        # ensure that if a record has multiple changes, those changes aren't counted
-        changes[1].records.add(records[0], records[5])
-        changes[4].records.add(records[2])
-
-        # ensure that one record is over the limit
-        for change in changes[1:MAX_RECORD_CHANGES]:
-            change.records.add(records[MAX_RECORD_CHANGES])
-
-        selected_doc_ids = self._get_list_of_doc_ids(40)
-        self.session.select_multiple_records(selected_doc_ids)
-        change_counts = self.session.get_change_counts()
-        self.assertEqual(
-            change_counts["num_records_edited"],
-            len(doc_ids) + len(selected_edited_doc_ids),
-        )
-        self.assertEqual(
-            records[MAX_RECORD_CHANGES].changes.count(), MAX_RECORD_CHANGES
-        )
-        self.assertEqual(change_counts["num_records_at_max_changes"], 1)

--- a/corehq/apps/data_cleaning/views/cleaning.py
+++ b/corehq/apps/data_cleaning/views/cleaning.py
@@ -26,6 +26,7 @@ class CleanSelectedRecordsFormView(BulkEditSessionViewMixin,
         context.update({
             'container_id': 'clean-selected-records',
             'cleaning_form': kwargs.pop('cleaning_form', None) or CleanSelectedRecordsForm(self.session),
+            'are_bulk_edits_allowed': self.session.are_bulk_edits_allowed(),
             'change': kwargs.pop('change', None),
         })
         return context

--- a/corehq/apps/data_cleaning/views/summary.py
+++ b/corehq/apps/data_cleaning/views/summary.py
@@ -41,7 +41,7 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
             "data_cleaning/summary/clear_changes.html",
             {
                 "changes": self.session.changes.all(),
-                "num_changes": self.session.get_num_changes(),
+                "num_changes": self.session.changes.count(),
             },
         )
 
@@ -52,6 +52,6 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
             "data_cleaning/summary/apply_changes.html",
             {
                 "changes": self.session.changes.all(),
-                "num_changes": self.session.get_num_changes(),
+                "num_changes": self.session.changes.count(),
             },
         )

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -147,18 +147,18 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
     @hq_hx_action("post")
     def undo_last_change(self, request, *args, **kwargs):
         self.session.undo_last_change()
-        return self._trigger_clean_form_referesh(
+        return self._trigger_clean_form_refresh(
             self.get(request, *args, **kwargs)
         )
 
     @hq_hx_action("post")
     def clear_all_changes(self, request, *args, **kwargs):
         self.session.clear_all_changes()
-        return self._trigger_clean_form_referesh(
+        return self._trigger_clean_form_refresh(
             self.get(request, *args, **kwargs)
         )
 
-    def _trigger_clean_form_referesh(self, response):
+    def _trigger_clean_form_refresh(self, response):
         response['HX-Trigger'] = json.dumps({
             'dcCleanFormRefresh': {
                 'target': '#hq-hx-clean-selected-records-form',

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -147,12 +147,24 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
     @hq_hx_action("post")
     def undo_last_change(self, request, *args, **kwargs):
         self.session.undo_last_change()
-        return self.get(request, *args, **kwargs)
+        return self._trigger_clean_form_referesh(
+            self.get(request, *args, **kwargs)
+        )
 
     @hq_hx_action("post")
     def clear_all_changes(self, request, *args, **kwargs):
         self.session.clear_all_changes()
-        return self.get(request, *args, **kwargs)
+        return self._trigger_clean_form_referesh(
+            self.get(request, *args, **kwargs)
+        )
+
+    def _trigger_clean_form_referesh(self, response):
+        response['HX-Trigger'] = json.dumps({
+            'dcCleanFormRefresh': {
+                'target': '#hq-hx-clean-selected-records-form',
+            },
+        })
+        return response
 
     def _render_table_cell_response(self, doc_id, column, request, *args, **kwargs):
         """

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -170,18 +170,9 @@ class CleanCasesTableView(BulkEditSessionViewMixin,
             record,
             table,
         )
-        response = self.render_htmx_partial_response(
+        return self.render_htmx_partial_response(
             request, DataCleaningHtmxColumn.template_name, context
         )
-        response["HX-Trigger"] = json.dumps(
-            {
-                "updateEditDetails": {
-                    "target": "body",
-                    "editDetails": self.table_class.get_edit_details(self.session),
-                },
-            }
-        )
-        return response
 
     def _get_cell_request_details(self, request):
         """


### PR DESCRIPTION
## Product Description
This removes the more confusing than helpful "num records with an edit history" number next to "edits" in the edit bar
<img width="303" alt="Screenshot 2025-05-08 at 10 47 31 AM" src="https://github.com/user-attachments/assets/caf546b5-219b-423d-9e02-040666a1286f" />


## Technical Summary
After deciding we wanted to remove this number, I took a deep dive into what is impacting performance in the table loading, and realized that the `get_change_counts` query was doing more harm than good.

I decided to remove the `get_change_counts` query, and in the process peeled away all the statistics we were keeping track of in the `Alpine.store` `editDetails`. Instead of over-eagerly checking for indicators that would alert the user of performance issues on every table or cell refresh, we apply performance checks at specific moments. The former approach caused a greater performance reduction than benefit.

After removing everything in `editDetails`, we eventually only ended up checking whether the previous change in the edit history affected 1 record, allowing the user to either undo with one click or confirm in the modal (if there were multiple records affected). I decided this check wasn't worth keeping around. Now the user just has to confirm the undo action each time regardless of the number of records affected. This keeps UX consistent, cleaner code that's easier to understand, and removes yet another query to the db when refreshing the table or cell...improving table performance just a little bit more.

Please please please review commit-by-commit on this one. I provide additional context in the commit messages.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change that only affects a feature flagged workflow that is entering QA next week

### Automated test coverage
yes

### QA Plan
not blocking PR


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
