### PR TITLE
Add column headers to feature flags page

### DIFF
--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -151,14 +151,21 @@
       </div>
     {% endif %}
     {% if allows_items %}
-      <h4>
-        {% trans "Enabled toggle items" %}
-        {% if is_random %}
-        <span data-bind="makeHqHelp: {
-            description: '{% trans "Items added here will be enabled regardless of the randomness (or disabled if preceded by `!`)" %}'}"></span>
-        {% endif %}
-      </h4>
       <table class="table table-condensed"><!-- B5: add table-borderless and remove `border: none` inline styles on table cells -->
+        <thead>
+          <tr>
+            <th>
+              {% trans "Enabled toggle items" %}
+              {% if is_random %}
+              <span data-bind="makeHqHelp: {
+                description: '{% trans "Items added here will be enabled regardless of the randomness (or disabled if preceded by `!`)" %}'}"></span>
+              {% endif %}
+            </th>
+            <th>Namespace</th>
+            <th>Latest Form Submission</th>
+            <th>Subscription Plan</th>
+          </tr>
+        </thead>
         <tbody data-bind="foreach: items">
           <tr>
             <td class="col-sm-4" style="border: 0">

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -176,12 +176,9 @@
                   </button>
                 </span>
                 <input class="form-control" type="text" data-bind="value: value">
-                <!-- ko if: value() && value()[0] == '!' -->
-                <span class="input-group-addon"><i class="fa fa-circle-xmark"></i></span>
-                <!-- /ko -->
-                <!-- ko ifnot: value() && value()[0] == '!' -->
-                <span class="input-group-addon"><i class="fa fa-check"></i></span>
-                <!-- /ko -->
+                <span class="input-group-addon">
+                  <i data-bind="class: (value() && value()[0] == '!') ? 'fa fa-circle-xmark' : 'fa fa-check'"></i>
+                </span>
               </div>
             </td>
             <!-- B5: replace inline styles with vertical alignment class: https://getbootstrap.com/docs/5.3/utilities/vertical-align/#css -->


### PR DESCRIPTION
## Product Description

I did this primarily for "latest form submission", which is otherwise just a naked date - had to go source diving to figure out what it actually represents

Before:
![image](https://github.com/user-attachments/assets/17a199af-23d2-4a64-beef-d951b62a04ad)

After:
![image](https://github.com/user-attachments/assets/94e43e9b-a962-401b-916b-b1d275ea23c2)

The columns are just blank if you don't click "show usage", which in my opinion is fine:
![image](https://github.com/user-attachments/assets/6a68889f-5854-40bc-8ffb-7822a7b5c5e9)


## Technical Summary


## Feature Flag


## Safety Assurance


### Safety story
admin-only page, local testing seems fine

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
