### PR TITLE
Don't override local translations

### DIFF
--- a/corehq/ex-submodules/couchforms/openrosa_response.py
+++ b/corehq/ex-submodules/couchforms/openrosa_response.py
@@ -64,7 +64,7 @@ class OpenRosaResponse(object):
 
 def get_openarosa_success_response(message=None):
     if not message:
-        message = _('   √   ')
+        message = '   √   '
     return get_openrosa_reponse(message, ResponseNature.SUBMIT_SUCCESS, 201)
 
 SUBMISSION_IGNORED_RESPONSE = get_openrosa_reponse(

--- a/corehq/ex-submodules/couchforms/openrosa_response.py
+++ b/corehq/ex-submodules/couchforms/openrosa_response.py
@@ -1,7 +1,8 @@
-from lxml import etree as ElementTree, etree
 from django.http import HttpResponse
-from django.utils.translation import gettext_lazy as _
+
 import six
+from lxml import etree
+from lxml import etree as ElementTree
 
 RESPONSE_XMLNS = 'http://openrosa.org/http/response'
 
@@ -67,9 +68,11 @@ def get_openarosa_success_response(message=None):
         message = '   √   '
     return get_openrosa_reponse(message, ResponseNature.SUBMIT_SUCCESS, 201)
 
+
 SUBMISSION_IGNORED_RESPONSE = get_openrosa_reponse(
     '√ (this submission was ignored)', ResponseNature.SUBMIT_SUCCESS, 201
 )
+
 BLACKLISTED_RESPONSE = get_openrosa_reponse(
     message=(
         "This submission was blocked because of an unusual volume "

--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -65,7 +65,7 @@ then
 fi
 
 echo "Pulling translations from transifex"
-tx pull -f
+tx pull
 
 ./scripts/make-translations.sh "$@"
 


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

All the AI generated translations were overridden by the `tx pull -f` during last deploy. We don't want that to happen. 
I tested that if I add a new translation in transifix and then do `tx pull` then also the entries were getting updated and we don't need to overwrite entire file.


## Safety Assurance
Pretty safe used in Github Actions.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

NA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
