### PR TITLE
Include enterprise subscriptions as possible downgrade candidates

### DIFF
--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1175,6 +1175,7 @@ class PlanViewBase(DomainAccountingSettings):
                     SoftwarePlanEdition.STANDARD,
                     SoftwarePlanEdition.PRO,
                     SoftwarePlanEdition.ADVANCED,
+                    SoftwarePlanEdition.ENTERPRISE,
                 ]
             ],
             'plan_options': [p._asdict() for p in self.plan_options],

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1168,17 +1168,6 @@ class PlanViewBase(DomainAccountingSettings):
             current_price = 0
             default_price = 0
         return {
-            'editions': [
-                edition.lower()
-                for edition in [
-                    SoftwarePlanEdition.FREE,
-                    SoftwarePlanEdition.STANDARD,
-                    SoftwarePlanEdition.PRO,
-                    SoftwarePlanEdition.ADVANCED,
-                    SoftwarePlanEdition.ENTERPRISE,
-                ]
-            ],
-            'plan_options': [p._asdict() for p in self.plan_options],
             'current_edition': (self.current_subscription.plan_version.plan.edition.lower()
                                 if self.current_subscription is not None
                                 and not self.current_subscription.is_trial
@@ -1189,7 +1178,6 @@ class PlanViewBase(DomainAccountingSettings):
             'subscription_below_minimum': (self.current_subscription.is_below_minimum_subscription
                                            if self.current_subscription is not None else False),
             'next_subscription_edition': self.next_subscription_edition,
-            'can_domain_unpause': self.can_domain_unpause,
         }
 
 
@@ -1208,6 +1196,24 @@ class SelectPlanView(PlanViewBase):
         subscription = self.current_subscription
         is_annual_plan = subscription.plan_version.plan.is_annual_plan
         return not is_annual_plan
+
+    @property
+    def page_context(self):
+        context = super().page_context
+        context.update({
+            'editions': [
+                edition.lower() for edition in [
+                    SoftwarePlanEdition.FREE,
+                    SoftwarePlanEdition.STANDARD,
+                    SoftwarePlanEdition.PRO,
+                    SoftwarePlanEdition.ADVANCED,
+                    SoftwarePlanEdition.ENTERPRISE,
+                ]
+            ],
+            'plan_options': [p._asdict() for p in self.plan_options],
+            'can_domain_unpause': self.can_domain_unpause,
+        })
+        return context
 
 
 class ContactFormViewBase(PlanViewBase):


### PR DESCRIPTION
## Product Description
When on the Change Subscription screen, Enterprise subscriptions were not displaying the downgrade workflow that Advanced, Pro, and Standard were. This PR adds Enterprise into the list of downgradable subscriptions, so that an Enterprise Subscription moving to a lower tier sees the following modal:
<img width="635" alt="image" src="https://github.com/user-attachments/assets/5840c6e2-1b23-41c8-9822-3d228f29b79e" />

It also includes small refactoring changes to move `SelectPlanView`-specific context variables into `SelectPlanView`

## Feature Flag
No Feature Flag

## Safety Assurance

### Safety story
Verified this behavior locally for `SelectPlanView`. I did not verify the other screens, however, I did code searches to confirm that the other children of `PlanViewBase` did not use any of the 3 refactored variables (and so would not be affected by modifying `editions`

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
No new tests. The change to editions is only relevant to JS code, and the refactored context variables would require tests that just verify their absence, which didn't seem like good tests

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
