### PR TITLE
Silence analysis-phonetic progress in test logs

### DIFF
--- a/docker/files/Dockerfile.es.6
+++ b/docker/files/Dockerfile.es.6
@@ -1,3 +1,3 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.23
 
-RUN bin/elasticsearch-plugin install analysis-phonetic
+RUN bin/elasticsearch-plugin install --silent analysis-phonetic


### PR DESCRIPTION
Tiny change to prevent progress output in test logs:

```
#13 [elasticsearch6 2/2] RUN bin/elasticsearch-plugin install analysis-phonetic
#13 1.565 -> Downloading analysis-phonetic from elastic
#13 1.574 
[                                                 ] 1%?? 
[>                                                ] 2%?? 
[>                                                ] 3%?? 
[=>                                               ] 4%?? 
[=>                                               ] 5%?? 
...
[==============================================>  ] 95%?? 
[===============================================> ] 96%?? 
[===============================================> ] 97%?? 
[================================================>] 98%?? 
[================================================>] 99%?? 
[=================================================] 100%?? 
#13 2.452 -> Installed analysis-phonetic
```

## Safety Assurance

### Safety story

Does not affect production code. The ES container file is mainly used for local development and testing.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations