### PR TITLE
Speed up cache check for locations fixture

### DIFF
--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -295,18 +295,14 @@ class LookupTableRowOwner(models.Model):
         ]
 
 
-class UserLookupTableType:
-    LOCATION = 1
-    CHOICES = (
-        (LOCATION, "Location"),
-    )
-
-
 class UserLookupTableStatus(models.Model):
     """Keeps track of when a user needs to re-sync a fixture"""
+    class Fixture(models.IntegerChoices):
+        LOCATION = (1, "Location")
+
     id = models.AutoField(primary_key=True, verbose_name="ID", auto_created=True)
     user_id = models.CharField(max_length=100, db_index=True)
-    fixture_type = models.PositiveSmallIntegerField(choices=UserLookupTableType.CHOICES)
+    fixture_type = models.PositiveSmallIntegerField(choices=Fixture.choices)
     last_modified = models.DateTimeField()
 
     DEFAULT_LAST_MODIFIED = datetime.min
@@ -315,3 +311,7 @@ class UserLookupTableStatus(models.Model):
         app_label = 'fixtures'
         db_table = 'fixtures_userfixturestatus'
         unique_together = ("user_id", "fixture_type")
+
+
+# TODO update these references
+UserLookupTableType = UserLookupTableStatus.Fixture

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -317,6 +317,14 @@ class UserLookupTableStatus(models.Model):
         unique_together = ("user_id", "fixture_type")
 
     @classmethod
+    def update(cls, user_id, fixture_type):
+        cls.objects.update_or_create(
+            user_id=user_id,
+            fixture_type=fixture_type,
+            defaults={'last_modified': datetime.utcnow()},
+        )
+
+    @classmethod
     def bulk_update(cls, user_ids, fixture_type):
         now = datetime.utcnow()
         for ids in chunked(user_ids, 50):
@@ -331,7 +339,3 @@ class UserLookupTableStatus(models.Model):
             return cls.objects.get(user_id=user_id, fixture_type=fixture_type).last_modified
         except cls.DoesNotExist:
             return cls.DEFAULT_LAST_MODIFIED
-
-
-# TODO update these references
-UserLookupTableType = UserLookupTableStatus.Fixture

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -17,6 +17,7 @@ from corehq.apps.app_manager.const import (
     SYNC_HIERARCHICAL_FIXTURE,
 )
 from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
+from corehq.apps.fixtures.models import UserLookupTableStatus
 from corehq.apps.fixtures.utils import get_index_schema_node
 from corehq.apps.locations.models import (
     LocationFixtureConfiguration,
@@ -73,8 +74,11 @@ def _app_has_changed(last_sync, app_id):
 
 
 def _fixture_has_changed(last_sync, restore_user):
-    return (not last_sync or not last_sync.date or
-            restore_user.get_fixture_last_modified() >= last_sync.date)
+    if not last_sync or not last_sync.date:
+        return True
+    last_modified = UserLookupTableStatus.get_last_modified(
+        restore_user.user_id, UserLookupTableStatus.Fixture.LOCATION)
+    return last_modified >= last_sync.date
 
 
 def _locations_have_changed(last_sync, locations_queryset, restore_user):

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -22,7 +22,6 @@ from corehq.apps.locations.models import (
     LocationFixtureConfiguration,
     LocationType,
     SQLLocation,
-    get_domain_locations,
 )
 
 
@@ -245,9 +244,6 @@ int_array = ArrayField(int_field)
 
 
 def get_location_fixture_queryset(user):
-    if toggles.SYNC_ALL_LOCATIONS.enabled(user.domain):
-        return get_domain_locations(user.domain).prefetch_related('location_type')
-
     user_locations = user.get_sql_locations(user.domain)
     user_location_pks = list(user_locations.order_by().values_list("pk", flat=True))
 

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -1,9 +1,9 @@
 from collections import defaultdict
 from itertools import groupby
-from xml.etree.cElementTree import Element, SubElement
+from xml.etree.cElementTree import Element
 
 from django.contrib.postgres.fields.array import ArrayField
-from django.db.models import IntegerField, Q
+from django.db.models import IntegerField
 from django.utils.functional import cached_property
 
 from django_cte import With
@@ -295,7 +295,8 @@ def _append_children(node, location_db, locations, data_fields):
 
 
 def _group_by_type(locations):
-    key = lambda loc: (loc.location_type.code, loc.location_type)
+    def key(loc):
+        return (loc.location_type.code, loc.location_type)
     for (code, type), locs in groupby(sorted(locations, key=key), key=key):
         yield type, list(locs)
 

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -31,11 +31,11 @@ from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.util.test_utils import flag_enabled, generate_cases
 
 from ..fixtures import (
+    LocationsAccessor,
     LocationSet,
     _location_to_fixture,
     get_location_data_fields,
     flat_location_fixture_generator,
-    get_location_fixture_queryset,
     location_fixture_generator,
     should_sync_flat_fixture,
     should_sync_hierarchical_fixture,
@@ -113,7 +113,7 @@ class FixtureHasLocationsMixin(TestXmlMixin):
         self.assertXmlEqual(desired_fixture, fixture)
 
     def assert_fixture_queryset_equals_locations(self, desired_locations):
-        actual = get_location_fixture_queryset(self.user).values_list('name', flat=True)
+        actual = LocationsAccessor(self.user).queryset.values_list('name', flat=True)
         self.assertItemsEqual(actual, desired_locations)
 
 
@@ -631,6 +631,10 @@ class ShouldSyncLocationFixturesTest(TestCase):
         cls.domain_obj.delete()
         super(ShouldSyncLocationFixturesTest, cls).tearDownClass()
 
+    def _should_sync_location(self, last_sync_date, location, restore_state):
+        accessor = mock.Mock(queryset=SQLLocation.objects.filter(pk=location.pk))
+        return should_sync_locations(SimplifiedSyncLog(date=last_sync_date), accessor, restore_state)
+
     def test_should_sync_locations_change_location_type(self):
         """
         When location_type gets changed, we should resync locations
@@ -651,22 +655,14 @@ class ShouldSyncLocationFixturesTest(TestCase):
 
         SQLLocation.objects.filter(pk=location.pk).update(last_modified=day_before_yesterday)
         location = SQLLocation.objects.last()
-        locations_queryset = SQLLocation.objects.filter(pk=location.pk)
-
         restore_state = MockRestoreState(self.user.to_ota_restore_user(self.domain), RestoreParams())
-        self.assertFalse(
-            should_sync_locations(SimplifiedSyncLog(date=yesterday), locations_queryset, restore_state)
-        )
+        self.assertFalse(self._should_sync_location(yesterday, location, restore_state))
 
         self.location_type.shares_cases = True
         self.location_type.save()
 
         location = SQLLocation.objects.last()
-        locations_queryset = SQLLocation.objects.filter(pk=location.pk)
-
-        self.assertTrue(
-            should_sync_locations(SimplifiedSyncLog(date=yesterday), locations_queryset, restore_state)
-        )
+        self.assertTrue(self._should_sync_location(yesterday, location, restore_state))
 
     def test_archiving_location_should_resync(self):
         """
@@ -680,40 +676,33 @@ class ShouldSyncLocationFixturesTest(TestCase):
         location.save()
         after_save = datetime.utcnow()
         self.assertEqual('winterfell', location.name)
-        locations_queryset = SQLLocation.objects.filter(pk=location.pk)
         restore_state = MockRestoreState(self.user.to_ota_restore_user(self.domain), RestoreParams())
         # Should not resync if last sync was after location save
-        self.assertFalse(
-            should_sync_locations(SimplifiedSyncLog(date=after_save), locations_queryset, restore_state)
-        )
+        self.assertFalse(self._should_sync_location(after_save, location, restore_state))
 
         # archive the location
         location.archive()
         after_archive = datetime.utcnow()
 
         location = SQLLocation.objects.last()
-        locations_queryset = SQLLocation.objects.filter(pk=location.pk)
         # Should resync if last sync was after location was saved but before location was archived
-        self.assertTrue(
-            should_sync_locations(SimplifiedSyncLog(date=after_save), locations_queryset, restore_state)
-        )
+        self.assertTrue(self._should_sync_location(after_save, location, restore_state))
         # Should not resync if last sync was after location was deleted
-        self.assertFalse(
-            should_sync_locations(SimplifiedSyncLog(date=after_archive), locations_queryset, restore_state)
-        )
+        self.assertFalse(self._should_sync_location(after_archive, location, restore_state))
 
     def test_changed_build_id(self):
         app = MockApp('project_default', 'build_1')
         restore_state = MockRestoreState(self.user.to_ota_restore_user(self.domain), RestoreParams(app=app))
         sync_log_from_old_app = SimplifiedSyncLog(date=datetime.utcnow(), build_id=app.get_id)
+        accessor = mock.Mock(queryset=SQLLocation.objects.all())
         self.assertFalse(
-            should_sync_locations(sync_log_from_old_app, SQLLocation.objects.all(), restore_state)
+            should_sync_locations(sync_log_from_old_app, accessor, restore_state)
         )
 
         new_build = MockApp('project_default', 'build_2')
         restore_state = MockRestoreState(self.user.to_ota_restore_user(self.domain), RestoreParams(app=new_build))
         self.assertTrue(
-            should_sync_locations(sync_log_from_old_app, SQLLocation.objects.all(), restore_state)
+            should_sync_locations(sync_log_from_old_app, accessor, restore_state)
         )
 
     def test_changing_user_assigned_locations_should_sync(self):
@@ -724,27 +713,18 @@ class ShouldSyncLocationFixturesTest(TestCase):
         )
         location.save()
         after_save = datetime.utcnow()
-        locations_queryset = SQLLocation.objects.filter(pk=location.pk)
 
         cc_user_restore_state = MockRestoreState(self.user.to_ota_restore_user(self.domain), RestoreParams())
         web_user_restore_state = MockRestoreState(self.web_user.to_ota_restore_user(self.domain), RestoreParams())
 
-        self.assertFalse(
-            should_sync_locations(SimplifiedSyncLog(date=after_save), locations_queryset, cc_user_restore_state)
-        )
-        self.assertFalse(
-            should_sync_locations(SimplifiedSyncLog(date=after_save), locations_queryset, web_user_restore_state)
-        )
+        self.assertFalse(self._should_sync_location(after_save, location, cc_user_restore_state))
+        self.assertFalse(self._should_sync_location(after_save, location, web_user_restore_state))
 
         self.user.set_location(location)
         self.web_user.set_location(self.domain, location)
 
-        self.assertTrue(
-            should_sync_locations(SimplifiedSyncLog(date=after_save), locations_queryset, cc_user_restore_state)
-        )
-        self.assertTrue(
-            should_sync_locations(SimplifiedSyncLog(date=after_save), locations_queryset, web_user_restore_state)
-        )
+        self.assertTrue(self._should_sync_location(after_save, location, cc_user_restore_state))
+        self.assertTrue(self._should_sync_location(after_save, location, web_user_restore_state))
 
 
 MockApp = namedtuple("MockApp", ["location_fixture_restore", "get_id"])

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -189,14 +189,6 @@ class LocationFixturesTest(LocationHierarchyTestCase, FixtureHasLocationsMixin):
              'New York City', 'Manhattan', 'Queens', 'Brooklyn']
         )
 
-    def test_all_locations_flag_returns_all_locations(self):
-        with flag_enabled('SYNC_ALL_LOCATIONS'):
-            self._assert_fixture_matches_file(
-                'expand_from_root',
-                ['Massachusetts', 'Suffolk', 'Middlesex', 'Boston', 'Revere', 'Cambridge',
-                 'Somerville', 'New York', 'New York City', 'Manhattan', 'Queens', 'Brooklyn']
-            )
-
     def test_expand_to_county(self):
         """
         expand to "county"
@@ -258,15 +250,6 @@ class LocationFixturesTest(LocationHierarchyTestCase, FixtureHasLocationsMixin):
             'expand_from_root_to_county',
             ['Massachusetts', 'Suffolk', 'Middlesex', 'New York', 'New York City']
         )
-
-    def test_flat_sync_format(self):
-        with flag_enabled('SYNC_ALL_LOCATIONS'):
-            self._assert_fixture_matches_file(
-                'expand_from_root_flat',
-                ['Massachusetts', 'Suffolk', 'Middlesex', 'Boston', 'Revere', 'Cambridge',
-                    'Somerville', 'New York', 'New York City', 'Manhattan', 'Queens', 'Brooklyn'],
-                flat=True,
-            )
 
     def test_include_without_expanding(self):
         self.user._couch_user.set_location(self.locations['Boston'])

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -707,7 +707,7 @@ class ShouldSyncLocationFixturesTest(TestCase):
             location_type=self.location_type.name,
         )
         location.save()
-        after_save = mock.Mock(date=datetime.utcnow())
+        after_save = datetime.utcnow()
 
         self.assertFalse(_fixture_has_changed(after_save, self.user))
         self.user.set_location(location)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1767,7 +1767,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 def get_fixture_statuses(user_id):
     from corehq.apps.fixtures.models import UserLookupTableType, UserLookupTableStatus
     last_modifieds = {choice[0]: UserLookupTableStatus.DEFAULT_LAST_MODIFIED
-                    for choice in UserLookupTableType.CHOICES}
+                      for choice in UserLookupTableType.choices}
     for fixture_status in UserLookupTableStatus.objects.filter(user_id=user_id):
         last_modifieds[fixture_status.fixture_type] = fixture_status.last_modified
     return last_modifieds

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1737,19 +1737,6 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         # short-circuit after only a few domains
         return any(domain.granted_messaging_access for domain in domains)
 
-    @property
-    def fixture_statuses(self):
-        """Returns all of the last modified times for each fixture type"""
-        from corehq.apps.fixtures.models import UserLookupTableStatus
-        return UserLookupTableStatus.get_all(self._id)
-
-    def fixture_status(self, fixture_type):
-        try:
-            return self.fixture_statuses[fixture_type]
-        except KeyError:
-            from corehq.apps.fixtures.models import UserLookupTableStatus
-            return UserLookupTableStatus.DEFAULT_LAST_MODIFIED
-
     def update_fixture_status(self, fixture_type):
         from corehq.apps.fixtures.models import UserLookupTableStatus
         now = datetime.utcnow()
@@ -1761,7 +1748,6 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         if not new:
             user_fixture_sync.last_modified = now
             user_fixture_sync.save()
-        UserLookupTableStatus.get_all.clear(UserLookupTableStatus, self._id)
 
 
 class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1773,20 +1773,6 @@ def get_fixture_statuses(user_id):
     return last_modifieds
 
 
-def update_fixture_status_for_users(user_ids, fixture_type):
-    from corehq.apps.fixtures.models import UserLookupTableStatus
-    from dimagi.utils.chunked import chunked
-
-    now = datetime.utcnow()
-    for ids in chunked(user_ids, 50):
-        (UserLookupTableStatus.objects
-        .filter(user_id__in=ids,
-                fixture_type=fixture_type)
-        .update(last_modified=now))
-    for user_id in user_ids:
-        get_fixture_statuses.clear(user_id)
-
-
 class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin):
     domain = StringProperty()
     registering_device_id = StringProperty()

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1739,15 +1739,11 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
     def update_fixture_status(self, fixture_type):
         from corehq.apps.fixtures.models import UserLookupTableStatus
-        now = datetime.utcnow()
-        user_fixture_sync, new = UserLookupTableStatus.objects.get_or_create(
+        UserLookupTableStatus.objects.update_or_create(
             user_id=self._id,
             fixture_type=fixture_type,
-            defaults={'last_modified': now},
+            defaults={'last_modified': datetime.utcnow()},
         )
-        if not new:
-            user_fixture_sync.last_modified = now
-            user_fixture_sync.save()
 
 
 class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin):

--- a/corehq/apps/users/tests/fixture_status.py
+++ b/corehq/apps/users/tests/fixture_status.py
@@ -32,40 +32,23 @@ class TestFixtureStatus(TestCase):
         UserLookupTableStatus.objects.all().delete()
         clear_domain_names('my-domain')
 
-    def test_get_statuses(self):
-        no_status = {UserLookupTableStatus.Fixture.choices[0][0]: UserLookupTableStatus.DEFAULT_LAST_MODIFIED}
-        self.assertEqual(UserLookupTableStatus.get_all(self.couch_user._id), no_status)
-
-        now = datetime.utcnow()
-        UserLookupTableStatus(
-            user_id=self.couch_user._id,
-            fixture_type=UserLookupTableStatus.Fixture.choices[0][0],
-            last_modified=now,
-        ).save()
-        expected_status = {UserLookupTableStatus.Fixture.choices[0][0]: now}
-        self.assertEqual(UserLookupTableStatus.get_all(self.couch_user._id), expected_status)
-
-    def test_get_status(self):
-        now = datetime.utcnow()
-        couch_user = CommCareUser.get_by_username(self.username)
-        UserLookupTableStatus(
-            user_id=self.couch_user._id,
-            fixture_type=UserLookupTableStatus.Fixture.choices[0][0],
-            last_modified=now,
-        ).save()
-
+    def test_get_last_modified(self):
+        my_fixture = UserLookupTableStatus.Fixture.choices[0][0]
         self.assertEqual(
-            self.couch_user.fixture_status("fake_status"),
+            UserLookupTableStatus.get_last_modified(self.couch_user._id, my_fixture),
             UserLookupTableStatus.DEFAULT_LAST_MODIFIED,
         )
-        self.assertEqual(couch_user.fixture_status(UserLookupTableStatus.Fixture.choices[0][0]), now)
 
+        now = datetime.utcnow()
         UserLookupTableStatus(
-            user_id=self.web_user._id,
-            fixture_type=UserLookupTableStatus.Fixture.choices[0][0],
+            user_id=self.couch_user._id,
+            fixture_type=my_fixture,
             last_modified=now,
         ).save()
-        self.assertEqual(self.web_user.fixture_status(UserLookupTableStatus.Fixture.choices[0][0]), now)
+        self.assertEqual(
+            UserLookupTableStatus.get_last_modified(self.couch_user._id, my_fixture),
+            now,
+        )
 
     def test_update_status_set_location(self):
         fake_location = MagicMock()

--- a/corehq/apps/users/tests/fixture_status.py
+++ b/corehq/apps/users/tests/fixture_status.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import clear_domain_names
-from corehq.apps.fixtures.models import UserLookupTableStatus, UserLookupTableType
+from corehq.apps.fixtures.models import UserLookupTableStatus
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.apps.users.models import CommCareUser, WebUser, get_fixture_statuses
 
@@ -33,16 +33,16 @@ class TestFixtureStatus(TestCase):
         clear_domain_names('my-domain')
 
     def test_get_statuses(self):
-        no_status = {UserLookupTableType.CHOICES[0][0]: UserLookupTableStatus.DEFAULT_LAST_MODIFIED}
+        no_status = {UserLookupTableStatus.Fixture.choices[0][0]: UserLookupTableStatus.DEFAULT_LAST_MODIFIED}
         self.assertEqual(get_fixture_statuses(self.couch_user._id), no_status)
 
         now = datetime.utcnow()
         UserLookupTableStatus(
             user_id=self.couch_user._id,
-            fixture_type=UserLookupTableType.CHOICES[0][0],
+            fixture_type=UserLookupTableStatus.Fixture.choices[0][0],
             last_modified=now,
         ).save()
-        expected_status = {UserLookupTableType.CHOICES[0][0]: now}
+        expected_status = {UserLookupTableStatus.Fixture.choices[0][0]: now}
         self.assertEqual(get_fixture_statuses(self.couch_user._id), expected_status)
 
     def test_get_status(self):
@@ -50,7 +50,7 @@ class TestFixtureStatus(TestCase):
         couch_user = CommCareUser.get_by_username(self.username)
         UserLookupTableStatus(
             user_id=self.couch_user._id,
-            fixture_type=UserLookupTableType.CHOICES[0][0],
+            fixture_type=UserLookupTableStatus.Fixture.choices[0][0],
             last_modified=now,
         ).save()
 
@@ -58,14 +58,14 @@ class TestFixtureStatus(TestCase):
             self.couch_user.fixture_status("fake_status"),
             UserLookupTableStatus.DEFAULT_LAST_MODIFIED,
         )
-        self.assertEqual(couch_user.fixture_status(UserLookupTableType.CHOICES[0][0]), now)
+        self.assertEqual(couch_user.fixture_status(UserLookupTableStatus.Fixture.choices[0][0]), now)
 
         UserLookupTableStatus(
             user_id=self.web_user._id,
-            fixture_type=UserLookupTableType.CHOICES[0][0],
+            fixture_type=UserLookupTableStatus.Fixture.choices[0][0],
             last_modified=now,
         ).save()
-        self.assertEqual(self.web_user.fixture_status(UserLookupTableType.CHOICES[0][0]), now)
+        self.assertEqual(self.web_user.fixture_status(UserLookupTableStatus.Fixture.choices[0][0]), now)
 
     def test_update_status_set_location(self):
         fake_location = MagicMock()
@@ -79,11 +79,11 @@ class TestFixtureStatus(TestCase):
 
         user_fixture_status = UserLookupTableStatus.objects.get(user_id=self.couch_user._id)
         self.assertEqual(user_fixture_status.user_id, self.couch_user._id)
-        self.assertEqual(user_fixture_status.fixture_type, UserLookupTableType.LOCATION)
+        self.assertEqual(user_fixture_status.fixture_type, UserLookupTableStatus.Fixture.LOCATION)
 
         user_fixture_status = UserLookupTableStatus.objects.get(user_id=self.web_user._id)
         self.assertEqual(user_fixture_status.user_id, self.web_user._id)
-        self.assertEqual(user_fixture_status.fixture_type, UserLookupTableType.LOCATION)
+        self.assertEqual(user_fixture_status.fixture_type, UserLookupTableStatus.Fixture.LOCATION)
 
     def test_update_status_unset_location(self):
         fake_location = MagicMock()

--- a/corehq/apps/users/tests/fixture_status.py
+++ b/corehq/apps/users/tests/fixture_status.py
@@ -8,7 +8,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import clear_domain_names
 from corehq.apps.fixtures.models import UserLookupTableStatus
 from corehq.apps.users.dbaccessors import delete_all_users
-from corehq.apps.users.models import CommCareUser, WebUser, get_fixture_statuses
+from corehq.apps.users.models import CommCareUser, WebUser
 
 
 class TestFixtureStatus(TestCase):
@@ -34,7 +34,7 @@ class TestFixtureStatus(TestCase):
 
     def test_get_statuses(self):
         no_status = {UserLookupTableStatus.Fixture.choices[0][0]: UserLookupTableStatus.DEFAULT_LAST_MODIFIED}
-        self.assertEqual(get_fixture_statuses(self.couch_user._id), no_status)
+        self.assertEqual(UserLookupTableStatus.get_all(self.couch_user._id), no_status)
 
         now = datetime.utcnow()
         UserLookupTableStatus(
@@ -43,7 +43,7 @@ class TestFixtureStatus(TestCase):
             last_modified=now,
         ).save()
         expected_status = {UserLookupTableStatus.Fixture.choices[0][0]: now}
-        self.assertEqual(get_fixture_statuses(self.couch_user._id), expected_status)
+        self.assertEqual(UserLookupTableStatus.get_all(self.couch_user._id), expected_status)
 
     def test_get_status(self):
         now = datetime.utcnow()

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -141,11 +141,6 @@ class OTARestoreUser(object):
     def get_case_sharing_groups(self):
         return self._couch_user.get_case_sharing_groups(domain=self.domain)
 
-    def get_fixture_last_modified(self):
-        from corehq.apps.fixtures.models import UserLookupTableType
-
-        return self._couch_user.fixture_status(UserLookupTableType.LOCATION)
-
     def get_ucr_filter_value(self, ucr_filter, ui_filter):
         return ucr_filter.get_filter_value(self._couch_user, ui_filter)
 

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -113,10 +113,6 @@ class OTARestoreUser(object):
         return self.request_user.user_id if self.request_user else None
 
     @property
-    def locations(self):
-        raise NotImplementedError()
-
-    @property
     def sql_location(self):
         "User's primary SQLLocation"
         return self._couch_user.get_sql_location(self.domain)
@@ -160,10 +156,6 @@ class OTARestoreWebUser(OTARestoreUser):
         assert isinstance(couch_user, WebUser)
         super(OTARestoreWebUser, self).__init__(domain, couch_user, **kwargs)
 
-    @property
-    def locations(self):
-        return []
-
     def get_fixture_data_items(self):
         return []
 
@@ -189,10 +181,6 @@ class OTARestoreCommCareUser(OTARestoreUser):
 
         assert isinstance(couch_user, CommCareUser)
         super(OTARestoreCommCareUser, self).__init__(domain, couch_user, **kwargs)
-
-    @property
-    def locations(self):
-        return self._couch_user.locations
 
     def get_fixture_data_items(self):
         from corehq.apps.fixtures.models import LookupTableRow

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -142,7 +142,9 @@ class OTARestoreUser(object):
         return self._couch_user.get_case_sharing_groups(domain=self.domain)
 
     def get_fixture_last_modified(self):
-        raise NotImplementedError()
+        from corehq.apps.fixtures.models import UserLookupTableType
+
+        return self._couch_user.fixture_status(UserLookupTableType.LOCATION)
 
     def get_ucr_filter_value(self, ucr_filter, ui_filter):
         return ucr_filter.get_filter_value(self._couch_user, ui_filter)
@@ -164,11 +166,6 @@ class OTARestoreWebUser(OTARestoreUser):
 
     def get_call_center_indicators(self, config):
         return None
-
-    def get_fixture_last_modified(self):
-        from corehq.apps.fixtures.models import UserLookupTableType
-
-        return self._couch_user.fixture_status(UserLookupTableType.LOCATION)
 
     def get_usercase_id(self):
         return self._couch_user.get_usercase_id(self.domain)
@@ -202,11 +199,6 @@ class OTARestoreCommCareUser(OTARestoreUser):
             self._couch_user,
             indicator_config=config
         )
-
-    def get_fixture_last_modified(self):
-        from corehq.apps.fixtures.models import UserLookupTableType
-
-        return self._couch_user.fixture_status(UserLookupTableType.LOCATION)
 
     def get_usercase_id(self):
         return self._couch_user.get_usercase_id()

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -940,16 +940,6 @@ REPORT_BUILDER_BETA_GROUP = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-SYNC_ALL_LOCATIONS = StaticToggle(
-    'sync_all_locations',
-    '(Deprecated) Sync the full location hierarchy when syncing location fixtures',
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN],
-    description="Do not turn this feature flag. It is only used for providing compatability for old projects. "
-                "We are actively trying to remove projects from this list. This functionality is now possible by using the "  # noqa: E501
-                "Advanced Settings on the Organization Levels page and setting the Level to Expand From option.",
-)
-
 HIERARCHICAL_LOCATION_FIXTURE = StaticToggle(
     'hierarchical_location_fixture',
     'Display Settings To Get Hierarchical Location Fixture',


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.atlassian.net/browse/USH-5935
This includes a lot of clean up - definitely read by commit, should make sense that way.
Highlights:

* Remove `SYNC_ALL_LOCATIONS` feature flag
* Simplify/clarify (in my opinion) the fixture status stuff
* Add some deferred evaluation to speed up the cache check

## Feature Flag


## Safety Assurance


### Safety story
lots of automated tests

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
