### PR TITLE
Allow Stripe pages to load even if key is not present

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/stripe.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe.js
@@ -4,11 +4,11 @@ self.stripePromise = undefined;
 self.cardElement = undefined;
 
 function getCardElementPromise(key) {
-    if (!key) {
-        throw new Error("Cannot load Stripe, key not provided");
-    }
-
     let promise = new Promise((resolve) => {
+        if (!key) {
+            console.warn("Cannot load Stripe, key not provided");
+            return;
+        }
         self.stripePromise = loadStripe(key);
         self.stripePromise.then(function (stripe) {
             self.cardElement = stripe.elements().create('card', {


### PR DESCRIPTION
## Technical Summary
This PR aims to reduce the noise on https://dimagi.atlassian.net/browse/SAAS-17553

As of https://github.com/dimagi/commcare-hq/pull/36073, environments that don't have a stripe key throw a js error, which stops them from completing loading. While working on this I was only thinking of production environments, which ought to always have a key provided, but not local environments.

This PR changes the error to a warning and allows the page to finish loading, although the credit card UI will never load. One could update the UI to show a warning or something, but given that this change is targeted at local environments, I think this is a reasonable quick change to make development easier on Stripe pages (for development that doesn't require the credit card UI). Open to objections.

## Safety Assurance

### Safety story
This ought to only affect local environments. Third party environments that don't use stripe are also affected by this, but they're probably not using these pages at all.

I tested this locally. This is a moderately risky area, since it's payments-related, but it's also a rather straightforward change.

### Automated test coverage

Not at the UI level.

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
