### PR TITLE
Added bindings import to graphing

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/graph_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/graph_config.js
@@ -19,6 +19,7 @@ import _ from "underscore";
 import main from "hqwebapp/js/bootstrap3/main";
 import ClipboardJS from "clipboard/dist/clipboard";
 import "hqwebapp/js/components/select_toggle";
+import "hqwebapp/js/select2_knockout_bindings.ko";      // autocompleteSelect2
 
 var graphConfigurationUiElement = function (moduleOptions, serverRepresentationOfGraph) {
     var self = {};


### PR DESCRIPTION
## Product Description
Reported on the forum. Fixes this graphing dropdown, which is currently blank:

<img width="1346" alt="Screenshot 2025-05-12 at 12 03 06 PM" src="https://github.com/user-attachments/assets/327a3ee9-3818-41cc-bbdf-1b3045d534af" />

## Technical Summary
Guessing I missed this when migrating app manager to webpack.

## Feature Flag
graphing

## Safety Assurance

### Safety story
Adding an import is typically very safe.

### Automated test coverage
no

### QA Plan
no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
