### PR TITLE
Fix ES6 issue with "docker run" and "docker ps"

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -424,7 +424,7 @@ needs of most developers.
     ```sh
     ./scripts/docker up -d
     # Optionally, start only specific containers.
-    ./scripts/docker up -d postgres couch redis elasticsearch5 zookeeper kafka minio formplayer
+    ./scripts/docker up -d postgres couch redis elasticsearch6 zookeeper kafka minio formplayer
     ```
 
    **Mac OS:** Note that you will encounter many issues at this stage.

--- a/docker/README.rst
+++ b/docker/README.rst
@@ -38,7 +38,7 @@ etc.), you should stop them now.
 
 Run ::
 
-    $ scripts/docker up -d postgres couch redis elasticsearch5 zookeeper kafka minio
+    $ scripts/docker up -d postgres couch redis elasticsearch6 zookeeper kafka minio
 
 to build and start those Docker services in the background. (Omit ``-d``
 to run them in the foreground.)

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -14,7 +14,7 @@ x-commcarehq_base: &commcarehq_base
       condition: service_healthy
     redis:
       condition: service_healthy
-    elasticsearch5:
+    elasticsearch6:
       condition: service_healthy
     kafka:
       condition: service_healthy
@@ -79,10 +79,10 @@ services:
       file: hq-compose-services.yml
       service: redis
 
-  elasticsearch5:
+  elasticsearch6:
     extends:
       file: hq-compose-services.yml
-      service: elasticsearch5
+      service: elasticsearch6
 
   zookeeper:
     extends:

--- a/scripts/docker
+++ b/scripts/docker
@@ -356,6 +356,7 @@ else
             ${VOLUME_PREFIX}couchdb \
             ${VOLUME_PREFIX}elasticsearch2 \
             ${VOLUME_PREFIX}elasticsearch5 \
+            ${VOLUME_PREFIX}elasticsearch6 \
             ${VOLUME_PREFIX}kafka \
             ${VOLUME_PREFIX}lib \
             ${VOLUME_PREFIX}postgresql \


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
While our documentation suggests to run services via `docker up`, the `docker` script supports other commands: `start` (to immediately start the services in the background) and `ps` (to display a nicely-formatted list of running services). These were broken when the configuration removed `elasticsearch5`, so this PR migrates these to `elasticsearch6`.

I also updated some documentation references and docker cleanup code to handle `elasticsearch6`

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Verified that `docker start` and `docker ps` work correctly. I did notice some other `elasticsearch5` references in the code that deal with the docker configuration, which I did not change. If the `runserver` changes are used by something that still relies upon elasticsearch5, it is possible this may cause an issue.

### Automated test coverage
No tests

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
