### PR TITLE
Reverted app_manager_media, nav_menu_media_common, and uploaders back…

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
@@ -1,228 +1,236 @@
-import $ from "jquery";
-import ko from "knockout";
-import initialPageData from "hqwebapp/js/initial_page_data";
-import google from "analytix/js/google";
-import uploaders from "app_manager/js/nav_menu_media_common";
-
-var appMenuMediaManager = function (o) {
-    /* This interfaces the media reference for a form or module menu
-    (as an icon or image) with the upload manager.*/
-    let self = {
-        isDefaultLanguage: initialPageData.get('current_language') === initialPageData.get('default_language'),
-    };
-
-    self.trackGoogleEvent = function () {
-        google.track.event(...arguments);
-    };
-
-    self.enabled = ko.observable(
-        o.ref.use_default_media ? self.isDefaultLanguage : true,
-    );
-    self.ref = ko.observable(new MenuMediaReference(o.ref));
-    self.refHasPath = ko.computed(function () {
-        return self.ref().path.length > 0;
-    });
-    self.objectMap = ko.observable(o.objectMap);
-    self.defaultPath = o.defaultPath;
-    self.inputElement = o.inputElement;
-
-    self.uploadController = o.uploadController;
-
-    self.customPath = ko.observable(o.ref.path || '');
-    self.useCustomPath = ko.observable(self.customPath() !== self.defaultPath && self.refHasPath());
-
-    self.showCustomPath = ko.computed(function () {
-        return self.useCustomPath();
-    });
-
-    self.showDefaultPath = ko.computed(function () {
-        return !self.showCustomPath();
-    });
-
-    self.savedPath = ko.computed(function () {
-        if (self.useCustomPath()) {
-            return self.customPath();
-        }
-        return self.ref().path;
-    });
-
-    self.currentPath = ko.computed(function () {
-        if (self.savedPath().length === 0) {
-            return self.defaultPath;
-        }
-        return self.savedPath();
-    });
-
-    self.altText = ko.observable(o.ref.alt_text);
-
-    self.multimediaObject = ko.computed(function () {
-        return self.objectMap()[self.currentPath()];
-    });
-
-    self.isMediaMatched = ko.computed(function () {
-        return !!self.multimediaObject() && self.refHasPath();
-    });
-
-    self.isMediaUnmatched = ko.computed(function () {
-        return !self.isMediaMatched();
-    });
-
-    self.url = ko.computed(function () {
-        if (self.multimediaObject()) {
-            return self.multimediaObject().url;
-        }
-    });
-
-    self.thumbnailUrl = ko.computed(function () {
-        if (self.multimediaObject()) {
-            return self.url() + "?thumb=50";
-        }
-        return '#';
-    });
-
-    self.objectId = ko.computed(function () {
-        if (self.multimediaObject()) {
-            return self.multimediaObject().m_id;
-        }
-    });
-
-    self.languagesLinked = ko.observable(o.ref.use_default_media);
-
-    self.setCustomPath = function () {
-        self.useCustomPath(true);
-        if (self.customPath().length === 0) {
-            self.customPath(self.defaultPath);
-        }
-        self.updateResource();
-    };
-
-    self.setDefaultPath = function () {
-        self.useCustomPath(false);
-        var newRef = self.ref();
-        newRef.path = self.defaultPath;
-        self.ref(newRef);
-        self.updateResource();
-    };
-
-    self.removeMedia = function () {
-        self.ref(new MenuMediaReference({}));
-        self.useCustomPath(false);
-        self.customPath('');
-        self.updateResource();
-    };
-
-    self.getUploadParams = function () {
-        return {
-            path: interpolatePath(self.currentPath()),
-            media_type: self.ref().mediaType,
-            replace_attachment: true,
+hqDefine("app_manager/js/app_manager_media", [
+    "jquery",
+    "knockout",
+    "hqwebapp/js/initial_page_data",
+    "analytix/js/google",
+    "app_manager/js/nav_menu_media_common",
+], function (
+    $,
+    ko,
+    initialPageData,
+    google,
+    uploaders,
+) {
+    var appMenuMediaManager = function (o) {
+        /* This interfaces the media reference for a form or module menu
+        (as an icon or image) with the upload manager.*/
+        let self = {
+            isDefaultLanguage: initialPageData.get('current_language') === initialPageData.get('default_language'),
         };
-    };
 
-    self.getControllerRef = function () {
-        return {
-            path: self.currentPath(),
-            isMediaMatched: self.isMediaMatched,
-            getUrl: self.url,
-            m_id: self.objectId,
+        self.trackGoogleEvent = function () {
+            google.track.event(...arguments);
         };
-    };
 
-    self.passToUploadController = function () {
-        self.uploadController.currentReference = self.getControllerRef();
-        self.uploadController.uploadParams = self.getUploadParams();
-        self.uploadController.updateUploadFormUI();
-    };
+        self.enabled = ko.observable(
+            o.ref.use_default_media ? self.isDefaultLanguage : true,
+        );
+        self.ref = ko.observable(new MenuMediaReference(o.ref));
+        self.refHasPath = ko.computed(function () {
+            return self.ref().path.length > 0;
+        });
+        self.objectMap = ko.observable(o.objectMap);
+        self.defaultPath = o.defaultPath;
+        self.inputElement = o.inputElement;
 
-    self.uploadComplete = function (trigger, event, data) {
-        if (data.ref) {
-            var ref = data.ref,
-                objMap = self.objectMap();
-            objMap[ref.path] = ref;
-            self.ref(new MenuMediaReference(ref));
-            self.objectMap(objMap);
-            self.updateResource();
-            if (self.currentPath() !== data.ref.path) {
-                //CurrentPath has a different filetype to the
-                //uploaded file
-                self.customPath(data.ref.path);
+        self.uploadController = o.uploadController;
+
+        self.customPath = ko.observable(o.ref.path || '');
+        self.useCustomPath = ko.observable(self.customPath() !== self.defaultPath && self.refHasPath());
+
+        self.showCustomPath = ko.computed(function () {
+            return self.useCustomPath();
+        });
+
+        self.showDefaultPath = ko.computed(function () {
+            return !self.showCustomPath();
+        });
+
+        self.savedPath = ko.computed(function () {
+            if (self.useCustomPath()) {
+                return self.customPath();
             }
+            return self.ref().path;
+        });
+
+        self.currentPath = ko.computed(function () {
+            if (self.savedPath().length === 0) {
+                return self.defaultPath;
+            }
+            return self.savedPath();
+        });
+
+        self.altText = ko.observable(o.ref.alt_text);
+
+        self.multimediaObject = ko.computed(function () {
+            return self.objectMap()[self.currentPath()];
+        });
+
+        self.isMediaMatched = ko.computed(function () {
+            return !!self.multimediaObject() && self.refHasPath();
+        });
+
+        self.isMediaUnmatched = ko.computed(function () {
+            return !self.isMediaMatched();
+        });
+
+        self.url = ko.computed(function () {
+            if (self.multimediaObject()) {
+                return self.multimediaObject().url;
+            }
+        });
+
+        self.thumbnailUrl = ko.computed(function () {
+            if (self.multimediaObject()) {
+                return self.url() + "?thumb=50";
+            }
+            return '#';
+        });
+
+        self.objectId = ko.computed(function () {
+            if (self.multimediaObject()) {
+                return self.multimediaObject().m_id;
+            }
+        });
+
+        self.languagesLinked = ko.observable(o.ref.use_default_media);
+
+        self.setCustomPath = function () {
+            self.useCustomPath(true);
+            if (self.customPath().length === 0) {
+                self.customPath(self.defaultPath);
+            }
+            self.updateResource();
+        };
+
+        self.setDefaultPath = function () {
+            self.useCustomPath(false);
+            var newRef = self.ref();
+            newRef.path = self.defaultPath;
+            self.ref(newRef);
+            self.updateResource();
+        };
+
+        self.removeMedia = function () {
+            self.ref(new MenuMediaReference({}));
+            self.useCustomPath(false);
+            self.customPath('');
+            self.updateResource();
+        };
+
+        self.getUploadParams = function () {
+            return {
+                path: interpolatePath(self.currentPath()),
+                media_type: self.ref().mediaType,
+                replace_attachment: true,
+            };
+        };
+
+        self.getControllerRef = function () {
+            return {
+                path: self.currentPath(),
+                isMediaMatched: self.isMediaMatched,
+                getUrl: self.url,
+                m_id: self.objectId,
+            };
+        };
+
+        self.passToUploadController = function () {
+            self.uploadController.currentReference = self.getControllerRef();
+            self.uploadController.uploadParams = self.getUploadParams();
+            self.uploadController.updateUploadFormUI();
+        };
+
+        self.uploadComplete = function (trigger, event, data) {
+            if (data.ref) {
+                var ref = data.ref,
+                    objMap = self.objectMap();
+                objMap[ref.path] = ref;
+                self.ref(new MenuMediaReference(ref));
+                self.objectMap(objMap);
+                self.updateResource();
+                if (self.currentPath() !== data.ref.path) {
+                    //CurrentPath has a different filetype to the
+                    //uploaded file
+                    self.customPath(data.ref.path);
+                }
+            }
+        };
+
+        self.updateResource = function () {
+            self.inputElement.trigger('change');
+        };
+
+        return self;
+    };
+
+    var MenuMediaReference = function (ref) {
+        var self = {};
+        self.path = ref.path || '';
+        self.iconType = ref.icon_class || '';
+        self.mediaType = ref.media_class || '';
+        self.module = ref.module;
+        self.form = ref.form;
+        self.altText = ref.alt_text || '';
+
+        return self;
+    };
+
+    function initNavMenuMedia(qualifier, imageRef, audioRef, objectMap, defaultFileName) {
+        var $mediaImage = $('#' + qualifier + 'media_image'),
+            $mediaAudio = $('#' + qualifier + 'media_audio');
+
+        var menuImage = appMenuMediaManager({
+            ref: imageRef,
+            objectMap: objectMap,
+            uploadController: uploaders.iconUploader,
+            defaultPath: 'jr://file/commcare/image/' + defaultFileName + '.png',
+            inputElement: $mediaImage,
+        });
+
+        var menuAudio = appMenuMediaManager({
+            ref: audioRef,
+            objectMap: objectMap,
+            uploadController: uploaders.audioUploader,
+            defaultPath: 'jr://file/commcare/audio/' + defaultFileName + '.mp3',
+            inputElement: $mediaAudio,
+        });
+
+        if ($mediaImage.length) {
+            $mediaImage.koApplyBindings(menuImage);
         }
-    };
-
-    self.updateResource = function () {
-        self.inputElement.trigger('change');
-    };
-
-    return self;
-};
-
-var MenuMediaReference = function (ref) {
-    var self = {};
-    self.path = ref.path || '';
-    self.iconType = ref.icon_class || '';
-    self.mediaType = ref.media_class || '';
-    self.module = ref.module;
-    self.form = ref.form;
-    self.altText = ref.alt_text || '';
-
-    return self;
-};
-
-function initNavMenuMedia(qualifier, imageRef, audioRef, objectMap, defaultFileName) {
-    var $mediaImage = $('#' + qualifier + 'media_image'),
-        $mediaAudio = $('#' + qualifier + 'media_audio');
-
-    var menuImage = appMenuMediaManager({
-        ref: imageRef,
-        objectMap: objectMap,
-        uploadController: uploaders.iconUploader,
-        defaultPath: 'jr://file/commcare/image/' + defaultFileName + '.png',
-        inputElement: $mediaImage,
-    });
-
-    var menuAudio = appMenuMediaManager({
-        ref: audioRef,
-        objectMap: objectMap,
-        uploadController: uploaders.audioUploader,
-        defaultPath: 'jr://file/commcare/audio/' + defaultFileName + '.mp3',
-        inputElement: $mediaAudio,
-    });
-
-    if ($mediaImage.length) {
-        $mediaImage.koApplyBindings(menuImage);
+        if ($mediaAudio.length) {
+            $mediaAudio.koApplyBindings(menuAudio);
+        }
+        return {
+            menuImage: menuImage,
+            menuAudio: menuAudio,
+        };
     }
-    if ($mediaAudio.length) {
-        $mediaAudio.koApplyBindings(menuAudio);
-    }
+
     return {
-        menuImage: menuImage,
-        menuAudio: menuAudio,
+        initNavMenuMedia: initNavMenuMedia,
+        appMenuMediaManager: appMenuMediaManager,
     };
-}
 
-export default {
-    initNavMenuMedia: initNavMenuMedia,
-    appMenuMediaManager: appMenuMediaManager,
-};
+    function interpolatePath(path) {
+        // app media attributes are interpolated on server side, media uploads should also be interpolated
+        // See corehq.apps.app_manager.views.media_utils.process_media_attribute
+        if (!path) {
+            return path;
+        }
 
-function interpolatePath(path) {
-    // app media attributes are interpolated on server side, media uploads should also be interpolated
-    // See corehq.apps.app_manager.views.media_utils.process_media_attribute
-    if (!path) {
+        if (path.startsWith('jr://')) {
+            return path;
+        } else if (path.startsWith('/file/')) {
+            path = 'jr:/' + path;
+        } else if (path.startsWith('file/')) {
+            path = 'jr://' + path;
+        } else if (path.startsWith('/')) {
+            path = 'jr://file' + path;
+        } else {
+            path = 'jr://file/' + path;
+        }
         return path;
     }
-
-    if (path.startsWith('jr://')) {
-        return path;
-    } else if (path.startsWith('/file/')) {
-        path = 'jr:/' + path;
-    } else if (path.startsWith('file/')) {
-        path = 'jr://' + path;
-    } else if (path.startsWith('/')) {
-        path = 'jr://file' + path;
-    } else {
-        path = 'jr://file/' + path;
-    }
-    return path;
-}
+});

--- a/corehq/apps/app_manager/static/app_manager/js/nav_menu_media_common.js
+++ b/corehq/apps/app_manager/static/app_manager/js/nav_menu_media_common.js
@@ -1,17 +1,23 @@
-import _ from "underscore";
-import initialPageData from "hqwebapp/js/initial_page_data";
-import uploadersModule from "hqmedia/js/uploaders";
+hqDefine("app_manager/js/nav_menu_media_common", [
+    "underscore",
+    "hqwebapp/js/initial_page_data",
+    "hqmedia/js/uploaders",
+], function (
+    _,
+    initialPageData,
+    uploadersModule,
+) {
+    let uploaders = {};
 
-let uploaders = {};
+    _.each(initialPageData.get("multimedia_upload_managers"), function (uploader, type) {
+        uploaders[type] = uploadersModule.uploader(
+            uploader.slug,
+            uploader.options,
+        );
+    });
 
-_.each(initialPageData.get("multimedia_upload_managers"), function (uploader, type) {
-    uploaders[type] = uploadersModule.uploader(
-        uploader.slug,
-        uploader.options,
-    );
+    return {
+        audioUploader: uploaders.audio,
+        iconUploader: uploaders.icon,
+    };
 });
-
-export default {
-    audioUploader: uploaders.audio,
-    iconUploader: uploaders.icon,
-};

--- a/corehq/apps/hqmedia/static/hqmedia/js/uploaders.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/uploaders.js
@@ -1,152 +1,159 @@
-import $ from "jquery";
-import _ from "underscore";
-import assertProperties from "hqwebapp/js/assert_properties";
-import initialPageData from "hqwebapp/js/initial_page_data";
+hqDefine("hqmedia/js/uploaders", [
+    "jquery",
+    "underscore",
+    "hqwebapp/js/assert_properties",
+    "hqwebapp/js/initial_page_data",
+], function (
+    $,
+    _,
+    assertProperties,
+    initialPageData,
+) {
+    const uploader = function (slug, options) {
+        assertProperties.assertRequired(options, [
+            'uploadURL', 'uploadParams',
+            'queueTemplate', 'errorsTemplate', 'existingFileTemplate',
+        ]);
 
-const uploader = function (slug, options) {
-    assertProperties.assertRequired(options, [
-        'uploadURL', 'uploadParams',
-        'queueTemplate', 'errorsTemplate', 'existingFileTemplate',
-    ]);
+        let self = {};
+        self.uploadParams = options.uploadParams;
 
-    let self = {};
-    self.uploadParams = options.uploadParams;
+        self.$container = $("#" + slug);
+        self.$fileInputTrigger = self.$container.find(".hqm-select-files-container .btn-primary");
+        self.$fileInput = self.$container.find(".hqm-select-files-container input[type='file']");
+        self.$uploadStatusContainer = self.$container.find(".hqm-upload-status");
+        self.$uploadButton = self.$container.find(".hqm-upload-confirm");
+        self.uploadCompleteLabelSelector = ".hqm-upload-completed";
+        self.$existingFile = self.$container.find(".hqm-existing");
 
-    self.$container = $("#" + slug);
-    self.$fileInputTrigger = self.$container.find(".hqm-select-files-container .btn-primary");
-    self.$fileInput = self.$container.find(".hqm-select-files-container input[type='file']");
-    self.$uploadStatusContainer = self.$container.find(".hqm-upload-status");
-    self.$uploadButton = self.$container.find(".hqm-upload-confirm");
-    self.uploadCompleteLabelSelector = ".hqm-upload-completed";
-    self.$existingFile = self.$container.find(".hqm-existing");
+        self.allowClose = true;
 
-    self.allowClose = true;
+        self.updateUploadButton = function (enable, spin) {
+            if (enable) {
+                self.$uploadButton.removeClass('disabled');
+            } else {
+                self.$uploadButton.addClass('disabled');
+            }
+            if (spin) {
+                self.$uploadButton.find(".fa-spin").removeClass("hide");
+                self.$uploadButton.find(".fa-cloud-arrow-up").addClass("hide");
+            } else {
+                self.$uploadButton.find(".fa-spin").addClass("hide");
+                self.$uploadButton.find(".fa-cloud-arrow-up").removeClass("hide");
+            }
+        };
 
-    self.updateUploadButton = function (enable, spin) {
-        if (enable) {
-            self.$uploadButton.removeClass('disabled');
-        } else {
-            self.$uploadButton.addClass('disabled');
-        }
-        if (spin) {
-            self.$uploadButton.find(".fa-spin").removeClass("hide");
-            self.$uploadButton.find(".fa-cloud-arrow-up").addClass("hide");
-        } else {
-            self.$uploadButton.find(".fa-spin").addClass("hide");
-            self.$uploadButton.find(".fa-cloud-arrow-up").removeClass("hide");
-        }
-    };
+        self.updateUploadFormUI = function () {
+            self.$container.find(self.uploadCompleteLabelSelector).addClass('hide');
 
-    self.updateUploadFormUI = function () {
-        self.$container.find(self.uploadCompleteLabelSelector).addClass('hide');
+            if (self.currentReference && self.currentReference.getUrl() && self.currentReference.isMediaMatched()) {
+                self.$existingFile.removeClass('hide');
+                self.$existingFile.find('.hqm-existing-controls').html(_.template(options.existingFileTemplate)({
+                    url: self.currentReference.getUrl(),
+                }));
+            } else {
+                self.$existingFile.addClass('hide');
+                self.$existingFile.find('.hqm-existing-controls').empty();
+            }
+            $('.existing-media').tooltip({
+                placement: 'bottom',
+            });
+        };
 
-        if (self.currentReference && self.currentReference.getUrl() && self.currentReference.isMediaMatched()) {
-            self.$existingFile.removeClass('hide');
-            self.$existingFile.find('.hqm-existing-controls').html(_.template(options.existingFileTemplate)({
-                url: self.currentReference.getUrl(),
-            }));
-        } else {
-            self.$existingFile.addClass('hide');
-            self.$existingFile.find('.hqm-existing-controls').empty();
-        }
-        $('.existing-media').tooltip({
-            placement: 'bottom',
-        });
-    };
-
-    self.$container.on('show.bs.modal', function () {
-        self.updateUploadFormUI();
-    });
-
-    // Don't allow user to close modal while server is processing upload
-    self.$container.on('hide.bs.modal', function (event) {
-        if (!self.allowClose) {
-            event.preventDefault();
-        }
-    });
-
-    self.$fileInputTrigger.click(function () {
-        self.$fileInput.click();
-    });
-
-    self.$fileInput.change(function () {
-        const MEGABYTE = 1048576;
-
-        if (self.$fileInput.get(0).files.length) {
-            const file = self.$fileInput.get(0).files[0];
-            self.$uploadStatusContainer.html(_.template(options.queueTemplate)({
-                file_size: (file.size / MEGABYTE).toFixed(3),
-                file_name: file.name,
-            }));
-            self.updateUploadButton(true, false);
-        } else {
-            self.$uploadStatusContainer.empty();
-            self.updateUploadButton(false, false);
-        }
-    });
-
-    self.$uploadButton.click(function () {
-        event.preventDefault();
-
-        self.updateUploadButton(false, true);
-        self.allowClose = false;
-
-        const file = self.$fileInput.get(0).files[0],
-            data = new FormData();
-        data.append("Filedata", file);
-
-        if (self.uploadParams.path) {
-            const newExtension = '.' + file.name.split('.').pop().toLowerCase();
-            self.uploadParams.path = self.uploadParams.path.replace(/(\.[^/.]+)?$/, newExtension);
-        }
-        _.each(self.uploadParams, function (value, key) {
-            data.append(key, value);
+        self.$container.on('show.bs.modal', function () {
+            self.updateUploadFormUI();
         });
 
-        $.ajax({
-            url: options.uploadURL,
-            type: 'POST',
-            data: data,
-            contentType: false,
-            processData: false,
-            enctype: 'multipart/form-data',
-            success: function (response) {
-                response = JSON.parse(response);
-                $('[data-hqmediapath^="' + self.currentReference.path.replace(/\.\w+$/, ".") + '"]').trigger('mediaUploadComplete', response);
+        // Don't allow user to close modal while server is processing upload
+        self.$container.on('hide.bs.modal', function (event) {
+            if (!self.allowClose) {
+                event.preventDefault();
+            }
+        });
+
+        self.$fileInputTrigger.click(function () {
+            self.$fileInput.click();
+        });
+
+        self.$fileInput.change(function () {
+            const MEGABYTE = 1048576;
+
+            if (self.$fileInput.get(0).files.length) {
+                const file = self.$fileInput.get(0).files[0];
+                self.$uploadStatusContainer.html(_.template(options.queueTemplate)({
+                    file_size: (file.size / MEGABYTE).toFixed(3),
+                    file_name: file.name,
+                }));
+                self.updateUploadButton(true, false);
+            } else {
                 self.$uploadStatusContainer.empty();
                 self.updateUploadButton(false, false);
-                self.updateUploadFormUI();
-                self.$container.find(self.uploadCompleteLabelSelector).removeClass('hide');
-                self.allowClose = true;
-            },
-            error: function (response) {
-                response = JSON.parse(response.responseText);
-                self.$container.find(".hqm-error").removeClass('hide');
-                self.$container.find(".hqm-errors").html(_.template(options.errorsTemplate)({
-                    errors: response.errors,
-                }));
-                self.$container.find(".hqm-begin").hide();
-                self.updateUploadButton(false, false);
-                self.allowClose = true;
-            },
+            }
         });
-    });
 
-    return self;
-};
+        self.$uploadButton.click(function () {
+            event.preventDefault();
 
-let allUploaders = {};
-const uploaderPreset = function (slug) {
-    if (!allUploaders[slug]) {
-        const options = _.find(initialPageData.get("uploaders"), function (data) { return data.slug === slug; });
-        if (options) {
-            allUploaders[slug] = uploader(options.slug, options.options);
+            self.updateUploadButton(false, true);
+            self.allowClose = false;
+
+            const file = self.$fileInput.get(0).files[0],
+                data = new FormData();
+            data.append("Filedata", file);
+
+            if (self.uploadParams.path) {
+                const newExtension = '.' + file.name.split('.').pop().toLowerCase();
+                self.uploadParams.path = self.uploadParams.path.replace(/(\.[^/.]+)?$/, newExtension);
+            }
+            _.each(self.uploadParams, function (value, key) {
+                data.append(key, value);
+            });
+
+            $.ajax({
+                url: options.uploadURL,
+                type: 'POST',
+                data: data,
+                contentType: false,
+                processData: false,
+                enctype: 'multipart/form-data',
+                success: function (response) {
+                    response = JSON.parse(response);
+                    $('[data-hqmediapath^="' + self.currentReference.path.replace(/\.\w+$/, ".") + '"]').trigger('mediaUploadComplete', response);
+                    self.$uploadStatusContainer.empty();
+                    self.updateUploadButton(false, false);
+                    self.updateUploadFormUI();
+                    self.$container.find(self.uploadCompleteLabelSelector).removeClass('hide');
+                    self.allowClose = true;
+                },
+                error: function (response) {
+                    response = JSON.parse(response.responseText);
+                    self.$container.find(".hqm-error").removeClass('hide');
+                    self.$container.find(".hqm-errors").html(_.template(options.errorsTemplate)({
+                        errors: response.errors,
+                    }));
+                    self.$container.find(".hqm-begin").hide();
+                    self.updateUploadButton(false, false);
+                    self.allowClose = true;
+                },
+            });
+        });
+
+        return self;
+    };
+
+    let allUploaders = {};
+    const uploaderPreset = function (slug) {
+        if (!allUploaders[slug]) {
+            const options = _.find(initialPageData.get("uploaders"), function (data) { return data.slug === slug; });
+            if (options) {
+                allUploaders[slug] = uploader(options.slug, options.options);
+            }
         }
-    }
-    return allUploaders[slug];
-};
+        return allUploaders[slug];
+    };
 
-export default {
-    uploader: uploader,
-    uploaderPreset: uploaderPreset,
-};
+    return {
+        uploader: uploader,
+        uploaderPreset: uploaderPreset,
+    };
+});


### PR DESCRIPTION
## Product Description
This fixes an issue with not being able to upload multimedia for icon previews in app manager.

https://dimagi.atlassian.net/browse/SAAS-17563

## Technical Summary
This reverts a couple of app manager files back to use hqDefine. The specific problem is that `app_manager_media` and `nav_menu_media_common` are imported [here](https://github.com/dimagi/commcare-hq/blob/75f915e7f80dc833fa5efcaac8bf9bdc394135b7/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-mapping.js#L91-L93) in an hqDefine file. `uploaders` then also needed to be reverted because it's a dependency of `nav_menu_media_common`.

The other option is to switch `ui-element-key-val-mapping` to ESM, but I'd prefer not to do that because I'd like to do all of the ui element files together, but `ui-element-langcode-button` of them is a dependency of form builder, which isn't yet on webpack so it can't be converted.

## Feature Flag
GA, but specific to one case detail column format.

## Safety Assurance

### Safety story
This PR doesn't feel great. I'm making a lot of js changes to push the codebase to ESM and I'm only doing smoke testing. On the other hand, I really don't want to regression test the entire HQ UI, and the error percentage so far is pretty low (this is the first user-identified error, and I've migrated ~300 files).

I think I missed this change in my own testing & code verification because the relevant imports are async, which meant:
1) For smoke testing, I'm just checking for errors on page load, but this error doesn't happen until you open an icon preview popup.
2) Async imports in AMD modules visually look very similar to ESM imports, both using the `import` keyword. I can be more aware of that as I continue to work through this migration.

Async imports are pretty rare in HQ. I don't currently plan to change my smoke testing approach, but I can keep an eye out for areas that have async imports (primarily web apps and reports).

### Automated test coverage

No. I'm exploring writing a script/test to scan all of HQ for AMD files attempting to import ESM files but haven't finished it.

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
