### PR TITLE
Updated hqDefine script classification

### DIFF
--- a/scripts/codechecks/hqDefine.sh
+++ b/scripts/codechecks/hqDefine.sh
@@ -9,11 +9,11 @@ function list-js() {
 }
 
 function list-no-esm-js() {
-  list-js | xargs grep -L '^import.*;'
+  list-js | xargs grep -l '^hqDefine.*'
 }
 
 function list-esm-js() {
-  list-js | xargs grep -l '^import.*;'
+  list-js | xargs grep -L '^hqDefine.*'
 }
 
 ## Calculate migrated percentage for given statistic


### PR DESCRIPTION
## Technical Summary
Updates how this script determines whether a file is AMD or ESM. Checking for `import` misses files like [this](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/static/userreports/js/utils.js) that are ESM but don't have any dependencies. Instead, just look for `hqDefine`, which is what's being eradicated.

## Safety Assurance

### Safety story
Minor change to an internal engineering metrics tool.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
