### PR TITLE
Form and view changes to allow self-signup for Pay Annually plans

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1928,13 +1928,10 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
 
                 cancel_future_subscriptions(self.domain, datetime.date.today(), self.creating_user)
                 if self.current_subscription is not None:
-                    if self.is_same_edition():
-                        self.current_subscription.update_subscription(
-                            date_start=self.current_subscription.date_start,
-                            date_end=None
-                        )
-                    elif self.is_downgrade_from_paid_plan() and \
-                            self.current_subscription.is_below_minimum_subscription:
+                    if (
+                        self.is_downgrade_from_paid_plan()
+                        and self.current_subscription.is_below_minimum_subscription
+                    ):
                         self.current_subscription.update_subscription(
                             date_start=self.current_subscription.date_start,
                             date_end=self.current_subscription.date_start + datetime.timedelta(days=30)

--- a/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/select_plan.html
@@ -255,6 +255,11 @@
           name="plan_edition"
           data-bind="value: oSelectedPlan"
         />
+        <input
+          type="hidden"
+          name="is_annual_plan"
+          data-bind="value: oShowAnnualPricing"
+        />
         <div class="text-center plan-next">
           <button
             type="submit"

--- a/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/select_plan.html
@@ -255,6 +255,11 @@
           name="plan_edition"
           data-bind="value: oSelectedPlan"
         />
+        <input
+          type="hidden"
+          name="is_annual_plan"
+          data-bind="value: oShowAnnualPricing"
+        />
         <div class="text-center plan-next">
           <button
             type="submit"

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -240,9 +240,6 @@ class BaseTestSubscriptionForm(TestCase):
         self.domain = generator.arbitrary_domain()
         self.user = generator.arbitrary_user(self.domain.name, is_webuser=True, is_admin=True)
         self.account = generator.billing_account(self.user, self.user.name)
-        self.subscription = generator.generate_domain_subscription(
-            self.account, self.domain, datetime.today(), datetime.today() + timedelta(days=7), is_active=True
-        )
 
     def tearDown(self):
         self.user.delete(self.domain.name, deleted_by=None)
@@ -264,12 +261,25 @@ class BaseTestSubscriptionForm(TestCase):
 
 
 class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
+    def setUp(self):
+        super().setUp()
+        self.subscription = generator.generate_domain_subscription(
+            self.account, self.domain, date.today(), None,
+            plan_version=DefaultProductPlan.get_default_plan_version(), is_active=True,
+        )
+
     def create_form(self, new_plan_version, **kwargs):
         args = (self.account, self.domain.name, self.user, new_plan_version, self.subscription)
         return ConfirmNewSubscriptionForm(*args, **kwargs)
 
 
 class TestConfirmSubscriptionRenewalForm(BaseTestSubscriptionForm):
+    def setUp(self):
+        super().setUp()
+        self.subscription = generator.generate_domain_subscription(
+            self.account, self.domain, datetime.today(), datetime.today() + timedelta(days=7), is_active=True
+        )
+
     def create_form(self, new_plan_version, **kwargs):
         args = (self.account, self.domain, self.user, self.subscription, new_plan_version)
         return ConfirmSubscriptionRenewalForm(*args, **kwargs)

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1338,6 +1338,10 @@ class ConfirmSelectedPlanView(PlanViewBase):
         return self.edition == SoftwarePlanEdition.PAUSED
 
     @property
+    def is_annual_plan(self):
+        return self.request.POST.get('is_annual_plan') == 'true'
+
+    @property
     @memoized
     def edition(self):
         edition = self.request.POST.get('plan_edition').title()
@@ -1348,7 +1352,7 @@ class ConfirmSelectedPlanView(PlanViewBase):
     @property
     @memoized
     def selected_plan_version(self):
-        return DefaultProductPlan.get_default_plan_version(self.edition)
+        return DefaultProductPlan.get_default_plan_version(self.edition, is_annual_plan=self.is_annual_plan)
 
     def downgrade_messages(self):
         subscription = Subscription.get_active_subscription_by_domain(self.domain)

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/select_plan.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/select_plan.html.diff.txt
@@ -47,7 +47,7 @@
        action="{% url 'confirm_selected_plan' domain %}"
      >
        {% csrf_token %}
-@@ -307,9 +307,9 @@
+@@ -312,9 +312,9 @@
          <div class="modal-header">
            <button
              type="button"
@@ -60,7 +60,7 @@
              <span aria-hidden="true">&times;</span>
              <span class="sr-only">{% trans "Close" %}</span>
            </button>
-@@ -320,13 +320,13 @@
+@@ -325,13 +325,13 @@
            <button
              type="button"
              class="btn btn-primary"


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17493,
https://dimagi.atlassian.net/browse/SAAS-17496
Adds a hidden input `is_annual_plan` on the Select Plan page, based on whether annual pricing is currently selected. (Note: Currently, a user cannot continue with selecting their plan when annual pricing is shown -- the button is replaced with a "Talk to Sales" option. That will be changed in a future PR.) Passes the `is_annual_plan` selection to the `ConfirmSelectedPlanView` to determine whether to use a Pay Monthly or Pay Annually version of the selected software edition. Adds logic to the `ConfirmNewSubscriptionForm` to set a 12-month subscription length for subscriptions to Pay Annually software plans.

Also adds tests for the `ConfirmNewSubscriptionForm` and removes a couple of unusable/unreachable code paths from that form's `save()` method.

Review by commit recommended.

## Safety Assurance

### Safety story
This change is not accessible to customers yet, which helps minimize risk until after future development and QA. Automated testing is added for the confirm subscription form. The biggest piece of logic here is setting an end date for Pay Annually subscriptions; the core functions of the `ConfirmNewSubscriptionForm` are untouched. 

### Automated test coverage
`TestConfirmNewSubscriptionForm` added

### QA Plan
This will get QA when additional changes to implement this feature (auto-generating a prepayment invoice, UI updates, some user-facing disclaimers about how Pay Annually plans work) are written and deployed to staging. For now, these changes are invisible and not accessible from the UI.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
