### PR TITLE
ESM for some hqwebapp and miscellaneous modules

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/500.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/500.js
@@ -1,15 +1,13 @@
-hqDefine("hqwebapp/js/500",[
-    'jquery',
-    'bootstrap5',
-    'commcarehq',
-], function ($, bootstrap) {
-    $(function () {
-        new bootstrap.Popover('#sad-danny', {
-            title: gettext("This is Danny, one of our best developers."),
-            content: gettext("Danny is pretty sad that you had to encounter this issue. He's making sure it gets fixed as soon as possible."),
-        });
-        $('#refresh').click(function () {
-            window.location.reload(true);
-        });
+import "commcarehq";
+import $ from "jquery";
+import bootstrap from "bootstrap5";
+
+$(function () {
+    new bootstrap.Popover('#sad-danny', {
+        title: gettext("This is Danny, one of our best developers."),
+        content: gettext("Danny is pretty sad that you had to encounter this issue. He's making sure it gets fixed as soon as possible."),
+    });
+    $('#refresh').click(function () {
+        window.location.reload(true);
     });
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bulk_upload_file.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bulk_upload_file.js
@@ -1,19 +1,14 @@
-hqDefine("hqwebapp/js/bulk_upload_file", [
-    "jquery",
-    "knockout",
-    "commcarehq",
-], function (
-    $,
-    ko,
-) {
-    $(function () {
-        var $form = $("#bulk_upload_form");
-        if ($form.length) {
-            $form.koApplyBindings({
-                file: ko.observable(),
-            });
-        }
-    });
+import "commcarehq";
+import $ from "jquery";
+import ko from "knockout";
 
-    return 1;
+$(function () {
+    var $form = $("#bulk_upload_form");
+    if ($form.length) {
+        $form.koApplyBindings({
+            file: ko.observable(),
+        });
+    }
 });
+
+export default 1;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/maintenance_alerts.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/maintenance_alerts.js
@@ -1,26 +1,23 @@
+import "commcarehq";
+import $ from "jquery";
+import ko from "knockout";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import "hqwebapp/js/bootstrap5/widgets";
 
-hqDefine("hqwebapp/js/maintenance_alerts",[
-    'jquery',
-    'knockout',
-    'hqwebapp/js/initial_page_data',
-    'hqwebapp/js/bootstrap5/widgets',
-    'commcarehq',
-], function ($, ko, initialPageData) {
-    $(function () {
-        var alertFormModel = {
-            text: ko.observable(),
-            domains: ko.observable(),
-            startTime: ko.observable(),
-            endTime: ko.observable(),
-            timezone: ko.observable(),
-        };
+$(function () {
+    var alertFormModel = {
+        text: ko.observable(),
+        domains: ko.observable(),
+        startTime: ko.observable(),
+        endTime: ko.observable(),
+        timezone: ko.observable(),
+    };
 
-        var alertViewModel = {
-            alerts: initialPageData.get('alerts'),
-        };
+    var alertViewModel = {
+        alerts: initialPageData.get('alerts'),
+    };
 
-        $('#timezone').select2({ placeholder: 'UTC (default)' });
-        $('#ko-alert-form').koApplyBindings(alertFormModel);
-        $('#ko-alert-container').koApplyBindings(alertViewModel);
-    });
+    $('#timezone').select2({ placeholder: 'UTC (default)' });
+    $('#ko-alert-form').koApplyBindings(alertFormModel);
+    $('#ko-alert-container').koApplyBindings(alertViewModel);
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/multiselect_utils.js
@@ -1,225 +1,218 @@
-hqDefine('hqwebapp/js/multiselect_utils', [
-    "jquery",
-    "knockout",
-    "underscore",
-    "hqwebapp/js/assert_properties",
-    "multiselect/js/jquery.multi-select",
-    "multiselect/css/multi-select.css",
-    "hqwebapp/less/components/multiselect/multiselect.less",
-], function (
-    $,
-    ko,
-    _,
-    assertProperties,
-) {
-    var self = {};
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import assertProperties from "hqwebapp/js/assert_properties";
+import "multiselect/js/jquery.multi-select";
+import "multiselect/css/multi-select.css";
+import "hqwebapp/less/components/multiselect/multiselect.less";
 
-    var _renderHeader = function (title, action, search) {
-        // Since action and search are created from _renderAction() and _renderSearch()
-        // and the variables the functions are esacaped so it would be safe to use them with <%=
-        var header = _.template('<div class="ms-header"><%- headerTitle %><%= actionButton %></div><%= searchInput %>');
-        return header({
-            headerTitle: title,
-            actionButton: action || '',
-            searchInput: search || '',
-        });
-    };
+var self = {};
 
-    var _renderAction = function (buttonId, buttonClass, buttonIcon, text, disabled = false) {
-        var action = _.template(
-            '<button class="btn <%-actionButtonClass %> btn-xs <%- floatClass %>" id="<%- actionButtonId %>" <% if (actionDisabled) { %> disabled <% } %>>' +
-                '<i class="<%- actionButtonIcon %>"></i> <%- actionButtonText %>' +
-            '</button>',
+var _renderHeader = function (title, action, search) {
+    // Since action and search are created from _renderAction() and _renderSearch()
+    // and the variables the functions are esacaped so it would be safe to use them with <%=
+    var header = _.template('<div class="ms-header"><%- headerTitle %><%= actionButton %></div><%= searchInput %>');
+    return header({
+        headerTitle: title,
+        actionButton: action || '',
+        searchInput: search || '',
+    });
+};
+
+var _renderAction = function (buttonId, buttonClass, buttonIcon, text, disabled = false) {
+    var action = _.template(
+        '<button class="btn <%-actionButtonClass %> btn-xs <%- floatClass %>" id="<%- actionButtonId %>" <% if (actionDisabled) { %> disabled <% } %>>' +
+            '<i class="<%- actionButtonIcon %>"></i> <%- actionButtonText %>' +
+        '</button>',
+    );
+    return action({
+        actionButtonId: buttonId,
+        actionButtonClass: buttonClass,
+        actionButtonIcon: buttonIcon,
+        actionButtonText: text,
+        actionDisabled: disabled,
+        floatClass: window.USE_BOOTSTRAP5 ? "float-end" : "pull-right",
+    });
+};
+
+var _renderSearch = function (inputId, placeholder) {
+    var inputGroupTextClass = (window.USE_BOOTSTRAP5) ? "input-group-text" : "input-group-addon",
+        input = _.template(
+            '<div class="input-group ms-input-group">' +
+                '<span class="' + inputGroupTextClass + '">' +
+                    '<i class="fa fa-search"></i>' +
+                '</span>' +
+                '<input type="search" class="form-control search-input" id="<%- searchInputId %>" autocomplete="off" placeholder="<%- searchInputPlaceholder %>" />' +
+            '</div>',
         );
-        return action({
-            actionButtonId: buttonId,
-            actionButtonClass: buttonClass,
-            actionButtonIcon: buttonIcon,
-            actionButtonText: text,
-            actionDisabled: disabled,
-            floatClass: window.USE_BOOTSTRAP5 ? "float-end" : "pull-right",
-        });
-    };
+    return input({
+        searchInputId: inputId,
+        searchInputPlaceholder: placeholder,
+    });
+};
 
-    var _renderSearch = function (inputId, placeholder) {
-        var inputGroupTextClass = (window.USE_BOOTSTRAP5) ? "input-group-text" : "input-group-addon",
-            input = _.template(
-                '<div class="input-group ms-input-group">' +
-                    '<span class="' + inputGroupTextClass + '">' +
-                        '<i class="fa fa-search"></i>' +
-                    '</span>' +
-                    '<input type="search" class="form-control search-input" id="<%- searchInputId %>" autocomplete="off" placeholder="<%- searchInputPlaceholder %>" />' +
-                '</div>',
-            );
-        return input({
-            searchInputId: inputId,
-            searchInputPlaceholder: placeholder,
-        });
-    };
+/**
+ * Given an element, configures multiselect functionality based on the multiselect.js library
+ * @param {object} properties - a key-value object that expects the following optional keys:
+ * selectableHeaderTitle -  String title for items yet to be selected. Defaults to "Items".
+ * selectedHeaderTitle - String for selected items title. Defaults to "Selected items".
+ * searchItemTitle - String for search bar placeholder title. Defaults to "Search items".
+ * willSelectAllListener - Function to call before the multiselect processes the Add All action.
+ * disableModifyAllActions - Boolean value to enable/disable Add All and Remove All buttons. Defaults to false.
+ */
+self.createFullMultiselectWidget = function (elementOrId, properties) {
+    assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle', 'willSelectAllListener', 'disableModifyAllActions']);
+    var selectableHeaderTitle = properties.selectableHeaderTitle || gettext("Items");
+    var selectedHeaderTitle = properties.selectedHeaderTitle || gettext("Selected items");
+    var searchItemTitle = properties.searchItemTitle || gettext("Search items");
+    var willSelectAllListener = properties.willSelectAllListener;
+    var disableModifyAllActions = properties['disableModifyAllActions'] || false;
 
-    /**
-     * Given an element, configures multiselect functionality based on the multiselect.js library
-     * @param {object} properties - a key-value object that expects the following optional keys:
-     * selectableHeaderTitle -  String title for items yet to be selected. Defaults to "Items".
-     * selectedHeaderTitle - String for selected items title. Defaults to "Selected items".
-     * searchItemTitle - String for search bar placeholder title. Defaults to "Search items".
-     * willSelectAllListener - Function to call before the multiselect processes the Add All action.
-     * disableModifyAllActions - Boolean value to enable/disable Add All and Remove All buttons. Defaults to false.
-     */
-    self.createFullMultiselectWidget = function (elementOrId, properties) {
-        assertProperties.assert(properties, [], ['selectableHeaderTitle', 'selectedHeaderTitle', 'searchItemTitle', 'willSelectAllListener', 'disableModifyAllActions']);
-        var selectableHeaderTitle = properties.selectableHeaderTitle || gettext("Items");
-        var selectedHeaderTitle = properties.selectedHeaderTitle || gettext("Selected items");
-        var searchItemTitle = properties.searchItemTitle || gettext("Search items");
-        var willSelectAllListener = properties.willSelectAllListener;
-        var disableModifyAllActions = properties['disableModifyAllActions'] || false;
+    var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId),
+        baseId = _.isString(elementOrId) ? elementOrId : "multiselect-" + String(Math.random()).substring(2),
+        selectAllId = baseId + '-select-all',
+        removeAllId = baseId + '-remove-all',
+        searchSelectableId = baseId + '-search-selectable',
+        searchSelectedId = baseId + '-search-selected',
+        defaultBtnClass = (window.USE_BOOTSTRAP5) ? 'btn-outline-primary btn-sm' : 'btn-default';
 
-        var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId),
-            baseId = _.isString(elementOrId) ? elementOrId : "multiselect-" + String(Math.random()).substring(2),
-            selectAllId = baseId + '-select-all',
-            removeAllId = baseId + '-remove-all',
-            searchSelectableId = baseId + '-search-selectable',
-            searchSelectedId = baseId + '-search-selected',
-            defaultBtnClass = (window.USE_BOOTSTRAP5) ? 'btn-outline-primary btn-sm' : 'btn-default';
+    $element.multiSelect({
+        selectableHeader: _renderHeader(
+            selectableHeaderTitle,
+            _renderAction(selectAllId, defaultBtnClass, 'fa fa-plus', gettext("Add All"), disableModifyAllActions),
+            _renderSearch(searchSelectableId, searchItemTitle),
+        ),
+        selectionHeader: _renderHeader(
+            selectedHeaderTitle,
+            _renderAction(removeAllId, defaultBtnClass, 'fa fa-remove', gettext("Remove All"), disableModifyAllActions),
+            _renderSearch(searchSelectedId, searchItemTitle),
+        ),
+        afterInit: function () {
+            var that = this,
+                $selectableSearch = $('#' + searchSelectableId),
+                $selectionSearch = $('#' + searchSelectedId),
+                selectableSearchString = '#' + that.$container.attr('id') + ' .ms-elem-selectable:not(.ms-selected)',
+                selectionSearchString = '#' + that.$container.attr('id') + ' .ms-elem-selection.ms-selected';
 
-        $element.multiSelect({
-            selectableHeader: _renderHeader(
-                selectableHeaderTitle,
-                _renderAction(selectAllId, defaultBtnClass, 'fa fa-plus', gettext("Add All"), disableModifyAllActions),
-                _renderSearch(searchSelectableId, searchItemTitle),
-            ),
-            selectionHeader: _renderHeader(
-                selectedHeaderTitle,
-                _renderAction(removeAllId, defaultBtnClass, 'fa fa-remove', gettext("Remove All"), disableModifyAllActions),
-                _renderSearch(searchSelectedId, searchItemTitle),
-            ),
-            afterInit: function () {
-                var that = this,
-                    $selectableSearch = $('#' + searchSelectableId),
-                    $selectionSearch = $('#' + searchSelectedId),
-                    selectableSearchString = '#' + that.$container.attr('id') + ' .ms-elem-selectable:not(.ms-selected)',
-                    selectionSearchString = '#' + that.$container.attr('id') + ' .ms-elem-selection.ms-selected';
-
-                const _search = function (query, itemSelector) {
-                    const queries = (query || '').toLowerCase().split(/\s+/);
-                    $(itemSelector).each(function (index, item) {
-                        const $item = $(item),
-                            itemText = $item.text().toLowerCase();
-                        let found = _.every(queries, function (q) {
-                            return !q || itemText.indexOf(q) !== -1;
-                        });
-
-                        if (found) {
-                            $item.removeClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
-                        } else {
-                            $item.addClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
-                        }
-                    });
-                };
-
-                that.search_left = $selectableSearch
-                    .on('keydown', function (e) {
-                        if (e.which === 40) {  // down arrow, was recommended by loudev docs
-                            that.$selectableUl.focus();
-                            return false;
-                        }
-                    })
-                    .on('keyup change search input', function () {
-                        _search($selectableSearch.val(), selectableSearchString);
-
-                        // disable add all functionality so that user is not confused
-                        if (that.search_left.val().length > 0) {
-                            $('#' + selectAllId).addClass('disabled').prop('disabled', true);
-                        } else {
-                            if (!disableModifyAllActions) {
-                                $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
-                            }
-                        }
+            const _search = function (query, itemSelector) {
+                const queries = (query || '').toLowerCase().split(/\s+/);
+                $(itemSelector).each(function (index, item) {
+                    const $item = $(item),
+                        itemText = $item.text().toLowerCase();
+                    let found = _.every(queries, function (q) {
+                        return !q || itemText.indexOf(q) !== -1;
                     });
 
-                that.search_right = $selectionSearch
-                    .on('keydown', function (e) {
-                        if (e.which === 40) {  // down arrow, was recommended by loudev docs
-                            that.$selectionUl.focus();
-                            return false;
+                    if (found) {
+                        $item.removeClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
+                    } else {
+                        $item.addClass(window.USE_BOOTSTRAP5 ? "d-none" : "hide");
+                    }
+                });
+            };
+
+            that.search_left = $selectableSearch
+                .on('keydown', function (e) {
+                    if (e.which === 40) {  // down arrow, was recommended by loudev docs
+                        that.$selectableUl.focus();
+                        return false;
+                    }
+                })
+                .on('keyup change search input', function () {
+                    _search($selectableSearch.val(), selectableSearchString);
+
+                    // disable add all functionality so that user is not confused
+                    if (that.search_left.val().length > 0) {
+                        $('#' + selectAllId).addClass('disabled').prop('disabled', true);
+                    } else {
+                        if (!disableModifyAllActions) {
+                            $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
                         }
-                    })
-                    .on('keyup change search input', function () {
-                        _search($selectionSearch.val(), selectionSearchString);
+                    }
+                });
 
-                        // disable remove all functionality so that user is not confused
-                        if (that.search_right.val().length > 0) {
-                            $('#' + removeAllId).addClass('disabled').prop('disabled', true);
-                        } else if (!disableModifyAllActions) {
-                            $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
-                        }
-                    });
-            },
-            afterSelect: function () {
-                if (!disableModifyAllActions) {
-                    $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
-                }
-            },
-            afterDeselect: function () {
-                if (!disableModifyAllActions) {
-                    $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
-                }
-            },
-        });
+            that.search_right = $selectionSearch
+                .on('keydown', function (e) {
+                    if (e.which === 40) {  // down arrow, was recommended by loudev docs
+                        that.$selectionUl.focus();
+                        return false;
+                    }
+                })
+                .on('keyup change search input', function () {
+                    _search($selectionSearch.val(), selectionSearchString);
 
-        $('#' + selectAllId).click(function () {
-            if (willSelectAllListener) {
-                willSelectAllListener();
-            }
-            $element.multiSelect('select_all');
-            return false;
-        });
-        $('#' + removeAllId).click(function () {
-            $element.multiSelect('deselect_all');
-            return false;
-        });
-    };
-
-    self.rebuildMultiselect = function (elementOrId, multiselectProperties) {
-        var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId);
-        // multiSelect('refresh') breaks existing click handlers, so the alternative is to destroy and rebuild
-        $element.multiSelect('destroy');
-        self.createFullMultiselectWidget(elementOrId, multiselectProperties);
-    };
-
-    /*
-     * A custom binding for setting multiselect properties and additional knockout bindings
-     * The only dynamic part of this binding are the options
-     * For a list of configurable multiselect properties, see http://loudev.com/ under Options
-     * properties - a dictionary of properties used by the multiselect element (see createFullMultiselectWidget above)
-     * options - an observable array of option elements (only supports array of strings)
-     * didUpdateListener - method to invoke when the multiselect updates
-     */
-    ko.bindingHandlers.multiselect = {
-        init: function (element, valueAccessor) {
-            var model = valueAccessor();
-            assertProperties.assert(model, [], ['properties', 'options', 'didUpdateListener']);
-            self.createFullMultiselectWidget(element, model.properties);
-
-            if (model.options) {
-                // apply bindings after the multiselect has been setup
-                ko.applyBindingsToNode(element, {options: model.options});
+                    // disable remove all functionality so that user is not confused
+                    if (that.search_right.val().length > 0) {
+                        $('#' + removeAllId).addClass('disabled').prop('disabled', true);
+                    } else if (!disableModifyAllActions) {
+                        $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
+                    }
+                });
+        },
+        afterSelect: function () {
+            if (!disableModifyAllActions) {
+                $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
             }
         },
-        update: function (element, valueAccessor) {
-            var model = valueAccessor();
-            assertProperties.assert(model, [], ['properties', 'options', 'didUpdateListener']);
-            if (model.options) {
-                // have to access the observable to get the `update` method to fire on changes to options
-                ko.unwrap(model.options());
-            }
-
-            self.rebuildMultiselect(element, model.properties);
-            if (model.didUpdateListener) {
-                model.didUpdateListener();
+        afterDeselect: function () {
+            if (!disableModifyAllActions) {
+                $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
             }
         },
-    };
+    });
 
-    return self;
-});
+    $('#' + selectAllId).click(function () {
+        if (willSelectAllListener) {
+            willSelectAllListener();
+        }
+        $element.multiSelect('select_all');
+        return false;
+    });
+    $('#' + removeAllId).click(function () {
+        $element.multiSelect('deselect_all');
+        return false;
+    });
+};
+
+self.rebuildMultiselect = function (elementOrId, multiselectProperties) {
+    var $element = _.isString(elementOrId) ? $('#' + elementOrId) : $(elementOrId);
+    // multiSelect('refresh') breaks existing click handlers, so the alternative is to destroy and rebuild
+    $element.multiSelect('destroy');
+    self.createFullMultiselectWidget(elementOrId, multiselectProperties);
+};
+
+/*
+ * A custom binding for setting multiselect properties and additional knockout bindings
+ * The only dynamic part of this binding are the options
+ * For a list of configurable multiselect properties, see http://loudev.com/ under Options
+ * properties - a dictionary of properties used by the multiselect element (see createFullMultiselectWidget above)
+ * options - an observable array of option elements (only supports array of strings)
+ * didUpdateListener - method to invoke when the multiselect updates
+ */
+ko.bindingHandlers.multiselect = {
+    init: function (element, valueAccessor) {
+        var model = valueAccessor();
+        assertProperties.assert(model, [], ['properties', 'options', 'didUpdateListener']);
+        self.createFullMultiselectWidget(element, model.properties);
+
+        if (model.options) {
+            // apply bindings after the multiselect has been setup
+            ko.applyBindingsToNode(element, {options: model.options});
+        }
+    },
+    update: function (element, valueAccessor) {
+        var model = valueAccessor();
+        assertProperties.assert(model, [], ['properties', 'options', 'didUpdateListener']);
+        if (model.options) {
+            // have to access the observable to get the `update` method to fire on changes to options
+            ko.unwrap(model.options());
+        }
+
+        self.rebuildMultiselect(element, model.properties);
+        if (model.didUpdateListener) {
+            model.didUpdateListener();
+        }
+    },
+};
+
+export default self;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select2_handler.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select2_handler.js
@@ -1,136 +1,130 @@
-hqDefine("hqwebapp/js/select2_handler", [
-    "jquery",
-    "knockout",
-    "underscore",
-    "select2/dist/js/select2.full.min",
-], function (
-    $,
-    ko,
-    _,
-) {
-    var baseSelect2Handler = function (options) {
-        // For use with BaseAsyncHandler
-        // todo: documentation (biyeun)
-        var self = {};
-        self.fieldName = options.fieldName;
-        self.placeholder = options.placeholder;
-        self.multiple = options.multiple || false;
-        self.value = ko.observable();
-        self.createTags = options.createTags || false;
-        self.clear = function () {
-            var fieldInput = self.utils.getField();
-            fieldInput.val("").trigger("change");
-        };
+import $ from "jquery";
+import ko from "knockout";
+import _ from "underscore";
+import "select2/dist/js/select2.full.min";
 
-        self.getHandlerSlug = function () {
-            // This is the slug for the AsyncHandler you'll be using on the server side
-            throw new Error('getHandlerSlug must be implemented');
-        };
+var baseSelect2Handler = function (options) {
+    // For use with BaseAsyncHandler
+    // todo: documentation (biyeun)
+    var self = {};
+    self.fieldName = options.fieldName;
+    self.placeholder = options.placeholder;
+    self.multiple = options.multiple || false;
+    self.value = ko.observable();
+    self.createTags = options.createTags || false;
+    self.clear = function () {
+        var fieldInput = self.utils.getField();
+        fieldInput.val("").trigger("change");
+    };
 
-        self.getExtraData = function () {
-            return {};
-        };
+    self.getHandlerSlug = function () {
+        // This is the slug for the AsyncHandler you'll be using on the server side
+        throw new Error('getHandlerSlug must be implemented');
+    };
 
-        self.processResults = function (response, params) {
-            // override this if you want to do something special with the response.
-            return response;
-        };
+    self.getExtraData = function () {
+        return {};
+    };
 
-        self.createNewChoice = function (term, selectedData) {
-            // override this if you want the search to return the option of creating whatever
-            // the user entered.
-        };
+    self.processResults = function (response, params) {
+        // override this if you want to do something special with the response.
+        return response;
+    };
 
-        self.templateResult = function (result) {
+    self.createNewChoice = function (term, selectedData) {
+        // override this if you want the search to return the option of creating whatever
+        // the user entered.
+    };
 
-            return result.text;
-        };
+    self.templateResult = function (result) {
 
-        self.templateSelection = function (result) {
-            return result.text;
-        };
+        return result.text;
+    };
 
-        self.getInitialData = function (element) {
-            // override this if you want to format the value that is initially stored in the field for this widget.
-        };
+    self.templateSelection = function (result) {
+        return result.text;
+    };
 
-        self.utils = {
-            getField: function () {
-                return $('[name="' + self.fieldName + '"]');
-            },
-        };
+    self.getInitialData = function (element) {
+        // override this if you want to format the value that is initially stored in the field for this widget.
+    };
 
-        self.init = function () {
-            var fieldInput = self.utils.getField();
+    self.utils = {
+        getField: function () {
+            return $('[name="' + self.fieldName + '"]');
+        },
+    };
 
-            fieldInput.select2(_.extend({
-                multiple: true,
-                tags: fieldInput.data("choices"),
-            }, {}));
+    self.init = function () {
+        var fieldInput = self.utils.getField();
 
-            fieldInput.select2({
-                minimumInputLength: 0,
-                allowClear: true,
-                multiple: self.multiple,
-                placeholder: self.placeholder || ' ',   // some placeholder required for allowClear
-                width: '100%',
-                ajax: {
-                    delay: 150,
-                    url: '',
-                    dataType: 'json',
-                    type: 'post',
-                    data: function (params) {
-                        $('.select2-results__options').find('li:not(.loading-results)').remove();
-                        var data = self.getExtraData(params.term);
-                        data['handler'] = self.getHandlerSlug();
-                        data['action'] = self.fieldName;
-                        data['searchString'] = params.term || '';
-                        return data;
-                    },
-                    processResults: self.processResults,
-                    error: function () {
-                        var select2options = $('.select2-results__options');
+        fieldInput.select2(_.extend({
+            multiple: true,
+            tags: fieldInput.data("choices"),
+        }, {}));
 
-                        select2options.empty();
-                        var errorMessage = $('<li role="treeitem" ' +
-                            'class="select2-results__option " ' +
-                            'aria-disabled="true">' +
-                            gettext("There was an issue communicating with the server. Please try back later.") +
-                            '</li>');
-
-                        select2options.append(errorMessage);
-                    },
-
+        fieldInput.select2({
+            minimumInputLength: 0,
+            allowClear: true,
+            multiple: self.multiple,
+            placeholder: self.placeholder || ' ',   // some placeholder required for allowClear
+            width: '100%',
+            ajax: {
+                delay: 150,
+                url: '',
+                dataType: 'json',
+                type: 'post',
+                data: function (params) {
+                    $('.select2-results__options').find('li:not(.loading-results)').remove();
+                    var data = self.getExtraData(params.term);
+                    data['handler'] = self.getHandlerSlug();
+                    data['action'] = self.fieldName;
+                    data['searchString'] = params.term || '';
+                    return data;
                 },
-                tags: self.createTags,
-                createTag: self.createNewChoice,
-                templateResult: self.templateResult,
-                templateSelection: self.templateSelection,
-                escapeMarkup: function (m) { return m; },
+                processResults: self.processResults,
+                error: function () {
+                    var select2options = $('.select2-results__options');
+
+                    select2options.empty();
+                    var errorMessage = $('<li role="treeitem" ' +
+                        'class="select2-results__option " ' +
+                        'aria-disabled="true">' +
+                        gettext("There was an issue communicating with the server. Please try back later.") +
+                        '</li>');
+
+                    select2options.append(errorMessage);
+                },
+
+            },
+            tags: self.createTags,
+            createTag: self.createNewChoice,
+            templateResult: self.templateResult,
+            templateSelection: self.templateSelection,
+            escapeMarkup: function (m) { return m; },
+        });
+
+        var initial = self.getInitialData(fieldInput);
+        if (initial) {
+            if (!_.isArray(initial)) {
+                initial = [initial];
+            }
+            _.each(initial, function (result) {
+                fieldInput.append(new Option(result.text, result.id));
             });
+            fieldInput.val(_.pluck(initial, 'id')).trigger('change');
+        }
 
-            var initial = self.getInitialData(fieldInput);
-            if (initial) {
-                if (!_.isArray(initial)) {
-                    initial = [initial];
-                }
-                _.each(initial, function (result) {
-                    fieldInput.append(new Option(result.text, result.id));
-                });
-                fieldInput.val(_.pluck(initial, 'id')).trigger('change');
-            }
-
-            if (self.onSelect2Change) {
-                fieldInput.on("change", self.onSelect2Change);
-            }
+        if (self.onSelect2Change) {
+            fieldInput.on("change", self.onSelect2Change);
+        }
 
 
-        };
-
-        return self;
     };
 
-    return {
-        baseSelect2Handler: baseSelect2Handler,
-    };
-});
+    return self;
+};
+
+export default {
+    baseSelect2Handler: baseSelect2Handler,
+};

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/soil.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/soil.js
@@ -1,35 +1,30 @@
 
-hqDefine("hqwebapp/js/soil", [
-    "jquery",
-    "hqwebapp/js/initial_page_data",
-    "commcarehq",
-], function (
-    $,
-    initialPageData,
-) {
-    $(function () {
-        var downloadId = initialPageData.get("download_id"),
-            autoRefresh = '',
-            pollDownloader = function () {
-                if (!$('#ready_' + downloadId).length) {
-                    $.ajax(initialPageData.get("poll_url"), {
-                        success: function (data) {
-                            $("#display_" + downloadId).html(data);
-                        },
-                        error: function (data) {
-                            var message = initialPageData.get("error_text");
-                            if (data.responseText !== undefined && data.responseText !== '') {
-                                message = data.responseText;
-                            }
-                            $("#display_" + downloadId).html('<p class="alert alert-danger">' + message + '</p>');
-                            clearInterval(autoRefresh);
-                        },
-                    });
-                } else {
-                    clearInterval(autoRefresh);
-                }
-            };
-        pollDownloader();
-        autoRefresh = setInterval(pollDownloader, 2000);
-    });
+import "commcarehq";
+import $ from "jquery";
+import initialPageData from "hqwebapp/js/initial_page_data";
+
+$(function () {
+    var downloadId = initialPageData.get("download_id"),
+        autoRefresh = '',
+        pollDownloader = function () {
+            if (!$('#ready_' + downloadId).length) {
+                $.ajax(initialPageData.get("poll_url"), {
+                    success: function (data) {
+                        $("#display_" + downloadId).html(data);
+                    },
+                    error: function (data) {
+                        var message = initialPageData.get("error_text");
+                        if (data.responseText !== undefined && data.responseText !== '') {
+                            message = data.responseText;
+                        }
+                        $("#display_" + downloadId).html('<p class="alert alert-danger">' + message + '</p>');
+                        clearInterval(autoRefresh);
+                    },
+                });
+            } else {
+                clearInterval(autoRefresh);
+            }
+        };
+    pollDownloader();
+    autoRefresh = setInterval(pollDownloader, 2000);
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/sso_inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/sso_inactivity.js
@@ -1,10 +1,9 @@
-
 /*
  * Handles communication about the status of SSO login after the inactivity
  * timer has requested a re-login
  */
-hqDefine('hqwebapp/js/sso_inactivity', ['commcarehq'], function () {
-    localStorage.setItem('ssoInactivityMessage', JSON.stringify({
-        isLoggedIn: true,
-    }));
-});
+import "commcarehq";
+
+localStorage.setItem('ssoInactivityMessage', JSON.stringify({
+    isLoggedIn: true,
+}));

--- a/corehq/apps/translations/static/translations/js/translations.js
+++ b/corehq/apps/translations/static/translations/js/translations.js
@@ -1,292 +1,284 @@
-hqDefine("translations/js/translations", [
-    'jquery',
-    'underscore',
-    'hqwebapp/js/bootstrap3/main',
-    'hqwebapp/js/ui_elements/bootstrap3/ui-element-input',
-    'hqwebapp/js/ui_elements/bootstrap3/ui-element-select',
-], function (
-    $,
-    _,
-    hqMain,
-    UIInput,
-    UISelect,
-) {
-    var mk_translation_ui = function (spec) {
-        var translation_ui = {
-                translations: {},
-                $home: spec.$home,
-                url: spec.url,
-                lang: spec.lang,
-                doc_id: spec.doc_id,
-                edit: spec.edit,
-                allow_autofill: spec.allow_autofill,
-            },
-            suggestionURL = spec.suggestion_url,
-            suggestionCache = {},
-            key,
-            Translation = (function () {
-                var Translation = function (key, value) {
-                    var self = this;
-                    self.key = UIInput.new().val(key).setEdit(false);
-                    var options = value ? [{label: value, value: value}] : [];
-                    self.value = UISelect.new(options);
-                    if (value) {
-                        self.value.val(value);
+import $ from "jquery";
+import _ from "underscore";
+import hqMain from "hqwebapp/js/bootstrap3/main";
+import UIInput from "hqwebapp/js/ui_elements/bootstrap3/ui-element-input";
+import UISelect from "hqwebapp/js/ui_elements/bootstrap3/ui-element-select";
+
+var mk_translation_ui = function (spec) {
+    var translation_ui = {
+            translations: {},
+            $home: spec.$home,
+            url: spec.url,
+            lang: spec.lang,
+            doc_id: spec.doc_id,
+            edit: spec.edit,
+            allow_autofill: spec.allow_autofill,
+        },
+        suggestionURL = spec.suggestion_url,
+        suggestionCache = {},
+        key,
+        Translation = (function () {
+            var Translation = function (key, value) {
+                var self = this;
+                self.key = UIInput.new().val(key).setEdit(false);
+                var options = value ? [{label: value, value: value}] : [];
+                self.value = UISelect.new(options);
+                if (value) {
+                    self.value.val(value);
+                }
+                self.solid = true;
+
+                self.$delete = $('<button class="btn btn-danger"><i class="fa fa-remove"></i></button>').click(function () {
+                    $(this).remove();
+                    translation_ui.deleteTranslation(self.key.val());
+                }).css({
+                    cursor: 'pointer',
+                }).attr('title', gettext("Delete Translation"));
+
+                self.$add = $('<button class="btn btn-default"><i class="fa fa-plus"></i></button>').click(function () {
+                    // remove any trailing whitespace from the input box
+                    self.key.val($.trim(self.key.val()));
+                    if (self.key.val() && !translation_ui.translations[self.key.val()]) {
+                        var hasError = translation_ui.addTranslation(self);
+                        if (!hasError) {
+                            translation_ui.appendAdder();
+                        }
+                    } else {
+                        self.key.$edit_view.focus();
                     }
-                    self.solid = true;
+                }).css({
+                    cursor: 'pointer',
+                }).attr('title', gettext("Add Translation")).hide();
+                self.$error = $('<span></span>').addClass('label label-danger');
+                self.ui = $('<div/>').addClass("row").addClass("form-group");
+                $('<div/>').addClass("col-sm-3").append(self.key.ui).appendTo(self.ui);
+                $('<div/>').addClass("col-sm-3").append(self.value.ui).appendTo(self.ui);
+                $('<div/>').addClass("col-sm-1").append(self.$delete).append(self.$add).appendTo(self.ui);
+                $('<div/>').addClass("col-sm-5").append(self.$error).appendTo(self.ui);
+                self.ui = $('<div/>').append(self.ui);
+                self.$error.hide();
 
-                    self.$delete = $('<button class="btn btn-danger"><i class="fa fa-remove"></i></button>').click(function () {
-                        $(this).remove();
-                        translation_ui.deleteTranslation(self.key.val());
-                    }).css({
-                        cursor: 'pointer',
-                    }).attr('title', gettext("Delete Translation"));
+                var helperFunction = function () {
+                    if (self.solid) {
+                        translation_ui.saveButton.fire('change');
+                    }
+                };
 
-                    self.$add = $('<button class="btn btn-default"><i class="fa fa-plus"></i></button>').click(function () {
-                        // remove any trailing whitespace from the input box
-                        self.key.val($.trim(self.key.val()));
-                        if (self.key.val() && !translation_ui.translations[self.key.val()]) {
-                            var hasError = translation_ui.addTranslation(self);
-                            if (!hasError) {
-                                translation_ui.appendAdder();
-                            }
-                        } else {
-                            self.key.$edit_view.focus();
-                        }
-                    }).css({
-                        cursor: 'pointer',
-                    }).attr('title', gettext("Add Translation")).hide();
-                    self.$error = $('<span></span>').addClass('label label-danger');
-                    self.ui = $('<div/>').addClass("row").addClass("form-group");
-                    $('<div/>').addClass("col-sm-3").append(self.key.ui).appendTo(self.ui);
-                    $('<div/>').addClass("col-sm-3").append(self.value.ui).appendTo(self.ui);
-                    $('<div/>').addClass("col-sm-1").append(self.$delete).append(self.$add).appendTo(self.ui);
-                    $('<div/>').addClass("col-sm-5").append(self.$error).appendTo(self.ui);
-                    self.ui = $('<div/>').append(self.ui);
-                    self.$error.hide();
+                self.value.on('change', helperFunction);
 
-                    var helperFunction = function () {
-                        if (self.solid) {
-                            translation_ui.saveButton.fire('change');
-                        }
-                    };
-
-                    self.value.on('change', helperFunction);
-
-                    self.value.ui.find('select').select2({
-                        minimumInputLength: 0,
-                        allowClear: 1,
-                        placeholder: ' ', // allowClear requires a placeholder
-                        tags: true,
-                        width: '100%',
-                        ajax: {
-                            delay: 100,
-                            url: suggestionURL,
-                            data: function () {
-                                return {
-                                    lang: translation_ui.lang,
-                                    key: self.key.val(),
-                                };
-                            },
-                            processResults: function (data) {
-                                return {
-                                    results: _.map(_.compact(data), function (item) {
-                                        return {
-                                            id: item,
-                                            text: item,
-                                        };
-                                    }),
-                                };
-                            },
+                self.value.ui.find('select').select2({
+                    minimumInputLength: 0,
+                    allowClear: 1,
+                    placeholder: ' ', // allowClear requires a placeholder
+                    tags: true,
+                    width: '100%',
+                    ajax: {
+                        delay: 100,
+                        url: suggestionURL,
+                        data: function () {
+                            return {
+                                lang: translation_ui.lang,
+                                key: self.key.val(),
+                            };
                         },
-                    });
-                };
-                Translation.init = function (key, value) {
-                    return new Translation(key, value);
-                };
-                Translation.prototype = {
-                    setSolid: function (solid) {
-                        var self = this;
-                        self.solid = solid;
-                        if (solid) {
-                            self.ui.find("legend").closest(".row").remove();
-                            self.key.setEdit(false);
-                            self.$delete.show();
-                            self.$add.hide();
-                        } else {
-                            self.ui.prepend("<div class='row'><div class='col-sm-12'><legend>" +
-                                gettext("Add Translation") + "</legend></div></div>");
-                            self.key.setEdit(true);
-                            self.$delete.hide();
-                            self.$add.show();
-                        }
+                        processResults: function (data) {
+                            return {
+                                results: _.map(_.compact(data), function (item) {
+                                    return {
+                                        id: item,
+                                        text: item,
+                                    };
+                                }),
+                            };
+                        },
                     },
-                };
-                return Translation;
-            }()),
-            $home = $('<div/>'),
-            $list = $('<div/>').appendTo($home),
-            $adder = $('<div/>').appendTo($home),
-            $autoFill = $('<a/>').attr('href', '').attr('class', 'btn btn-primary').text(gettext('Auto fill translations'));
-        $autoFill.click(function (e) {
-            e.preventDefault();
-            $.ajax({
-                type: "get",
-                url: suggestionURL,
-                dataType: "json",
-                data: {
-                    lang: translation_ui.lang,
-                    one: true,
-                },
-                success: function (data) {
-                    var key;
-                    for (key in data) {
-                        if (data.hasOwnProperty(key) && !translation_ui.translations[key]) {
-                            translation_ui.addTranslation(Translation.init(key, data[key]));
-                        }
+                });
+            };
+            Translation.init = function (key, value) {
+                return new Translation(key, value);
+            };
+            Translation.prototype = {
+                setSolid: function (solid) {
+                    var self = this;
+                    self.solid = solid;
+                    if (solid) {
+                        self.ui.find("legend").closest(".row").remove();
+                        self.key.setEdit(false);
+                        self.$delete.show();
+                        self.$add.hide();
+                    } else {
+                        self.ui.prepend("<div class='row'><div class='col-sm-12'><legend>" +
+                            gettext("Add Translation") + "</legend></div></div>");
+                        self.key.setEdit(true);
+                        self.$delete.hide();
+                        self.$add.show();
                     }
+                },
+            };
+            return Translation;
+        }()),
+        $home = $('<div/>'),
+        $list = $('<div/>').appendTo($home),
+        $adder = $('<div/>').appendTo($home),
+        $autoFill = $('<a/>').attr('href', '').attr('class', 'btn btn-primary').text(gettext('Auto fill translations'));
+    $autoFill.click(function (e) {
+        e.preventDefault();
+        $.ajax({
+            type: "get",
+            url: suggestionURL,
+            dataType: "json",
+            data: {
+                lang: translation_ui.lang,
+                one: true,
+            },
+            success: function (data) {
+                var key;
+                for (key in data) {
+                    if (data.hasOwnProperty(key) && !translation_ui.translations[key]) {
+                        translation_ui.addTranslation(Translation.init(key, data[key]));
+                    }
+                }
+            },
+        });
+    });
+    var $autoFillHelp = "<span class='auto-fill-help hq-help-template' data-placement='right' " +
+        "data-title='" + gettext("Auto Fill translations") + "' " + "data-content='" +
+        gettext("This will pick the most common translations for your selected language. " +
+            "You can then edit them as needed.") +
+        "'></span>";
+
+    for (key in spec.translations) {
+        if (spec.translations.hasOwnProperty(key)) {
+            translation_ui.translations[key] = Translation.init(key, spec.translations[key]);
+        }
+    }
+
+    translation_ui.saveButton = hqMain.initSaveButton({
+        unsavedMessage: gettext("You have unsaved user interface translations."),
+        save: function () {
+            translation_ui.save();
+        },
+    });
+    translation_ui.$home.prepend(translation_ui.saveButton.ui);
+    translation_ui.$home.append($home);
+
+    translation_ui.translate = function (key) {
+        return translation_ui.translations[key].value.val();
+    };
+
+    translation_ui.save = function () {
+        var key,
+            data = {};
+        var error = false;
+        for (key in translation_ui.translations) {
+            if (translation_ui.translations.hasOwnProperty(key)) {
+                if (translation_ui.validate_translation(translation_ui.translations[key])) {
+                    translation_ui.translations[key].$error.text(gettext('Parameters formatting problem!'));
+                    translation_ui.translations[key].$error.show();
+                    error = true;
+                } else {
+                    translation_ui.translations[key].$error.hide();
+                    data[translation_ui.translations[key].key.val()] = translation_ui.translations[key].value.val();
+                }
+            }
+        }
+        if (!error) {
+            this.saveButton.ajax({
+                type: "POST",
+                dataType: "json",
+                url: translation_ui.url,
+                data: {
+                    doc_id: JSON.stringify(translation_ui.doc_id),
+                    lang: JSON.stringify(translation_ui.lang),
+                    translations: JSON.stringify(data),
+                },
+                context: this,
+                success: function (data) {
+                    hqMain.updateDOM(data.update);
                 },
             });
-        });
-        var $autoFillHelp = "<span class='auto-fill-help hq-help-template' data-placement='right' " +
-            "data-title='" + gettext("Auto Fill translations") + "' " + "data-content='" +
-            gettext("This will pick the most common translations for your selected language. " +
-                "You can then edit them as needed.") +
-            "'></span>";
+        }
+    };
 
-        for (key in spec.translations) {
-            if (spec.translations.hasOwnProperty(key)) {
-                translation_ui.translations[key] = Translation.init(key, spec.translations[key]);
+    translation_ui.deleteTranslation = function (key) {
+        translation_ui.saveButton.fire('change');
+        this.translations[key].ui.fadeOut(function () {
+            $(this).remove();
+        });
+        delete this.translations[key];
+    };
+
+    translation_ui.addTranslation = function (translation) {
+        var error = translation_ui.validate_translation(translation);
+        if (!error) {
+            translation.$error.hide();
+            translation_ui.saveButton.fire('change');
+            translation_ui.translations[translation.key.val()] = translation;
+            translation.ui.detach();
+            translation.setSolid(true);
+            $list.append(translation.ui.hide());
+            translation.ui.fadeIn();
+        } else {
+            translation.$error.text('Parameters formatting problem!');
+            translation.$error.show();
+        }
+
+        return error;
+    };
+
+    translation_ui.appendAdder = function () {
+        var adder = Translation.init("", "");
+        adder.setSolid(false);
+        $adder.append(adder.ui);
+    };
+    translation_ui.render = function () {
+        var key,
+            keys = [],
+            translation,
+            i;
+        for (key in translation_ui.translations) {
+            if (translation_ui.translations.hasOwnProperty(key)) {
+                keys.push(key);
+            }
+        }
+        keys.sort();
+        if (keys.length) {
+            for (i = 0; i < keys.length; i += 1) {
+                key = keys[i];
+                translation = translation_ui.translations[key];
+                translation.ui.appendTo($list);
             }
         }
 
-        translation_ui.saveButton = hqMain.initSaveButton({
-            unsavedMessage: gettext("You have unsaved user interface translations."),
-            save: function () {
-                translation_ui.save();
-            },
-        });
-        translation_ui.$home.prepend(translation_ui.saveButton.ui);
-        translation_ui.$home.append($home);
+        $home.append($autoFill);
+        $home.append($autoFillHelp);
 
-        translation_ui.translate = function (key) {
-            return translation_ui.translations[key].value.val();
-        };
-
-        translation_ui.save = function () {
-            var key,
-                data = {};
-            var error = false;
-            for (key in translation_ui.translations) {
-                if (translation_ui.translations.hasOwnProperty(key)) {
-                    if (translation_ui.validate_translation(translation_ui.translations[key])) {
-                        translation_ui.translations[key].$error.text(gettext('Parameters formatting problem!'));
-                        translation_ui.translations[key].$error.show();
-                        error = true;
-                    } else {
-                        translation_ui.translations[key].$error.hide();
-                        data[translation_ui.translations[key].key.val()] = translation_ui.translations[key].value.val();
-                    }
-                }
-            }
-            if (!error) {
-                this.saveButton.ajax({
-                    type: "POST",
-                    dataType: "json",
-                    url: translation_ui.url,
-                    data: {
-                        doc_id: JSON.stringify(translation_ui.doc_id),
-                        lang: JSON.stringify(translation_ui.lang),
-                        translations: JSON.stringify(data),
-                    },
-                    context: this,
-                    success: function (data) {
-                        hqMain.updateDOM(data.update);
-                    },
-                });
-            }
-        };
-
-        translation_ui.deleteTranslation = function (key) {
-            translation_ui.saveButton.fire('change');
-            this.translations[key].ui.fadeOut(function () {
-                $(this).remove();
-            });
-            delete this.translations[key];
-        };
-
-        translation_ui.addTranslation = function (translation) {
-            var error = translation_ui.validate_translation(translation);
-            if (!error) {
-                translation.$error.hide();
-                translation_ui.saveButton.fire('change');
-                translation_ui.translations[translation.key.val()] = translation;
-                translation.ui.detach();
-                translation.setSolid(true);
-                $list.append(translation.ui.hide());
-                translation.ui.fadeIn();
-            } else {
-                translation.$error.text('Parameters formatting problem!');
-                translation.$error.show();
-            }
-
-            return error;
-        };
-
-        translation_ui.appendAdder = function () {
-            var adder = Translation.init("", "");
-            adder.setSolid(false);
-            $adder.append(adder.ui);
-        };
-        translation_ui.render = function () {
-            var key,
-                keys = [],
-                translation,
-                i;
-            for (key in translation_ui.translations) {
-                if (translation_ui.translations.hasOwnProperty(key)) {
-                    keys.push(key);
-                }
-            }
-            keys.sort();
-            if (keys.length) {
-                for (i = 0; i < keys.length; i += 1) {
-                    key = keys[i];
-                    translation = translation_ui.translations[key];
-                    translation.ui.appendTo($list);
-                }
-            }
-
-            $home.append($autoFill);
-            $home.append($autoFillHelp);
-
-            if (!translation_ui.allow_autofill) {
-                $autoFill.attr('class', 'disabled btn btn-primary');
-                $('.auto-fill-help').attr('data-content', gettext("Autofill is not available in English (en). " +
-                    "Please change your language using the dropdown in the top left."));
-            }
-            hqMain.transformHelpTemplate($('.auto-fill-help'), true);
-            translation_ui.appendAdder();
-            $home.append($home);
-        };
-        translation_ui.validate_translation = function (translation) {
-            var patt = /\$.*?}/g;
-            var parameters = translation.value.val().match(patt);
-            var error = false;
-            if (parameters !== null && parameters.length !== 0) {
-                var patt2 = /\$\{[0-9]+}/;
-                for (var idx in parameters) {
-                    if (!parameters[idx].match(patt2)) {
-                        error = true;
-                    }
-                }
-            }
-            return error;
-        };
-        translation_ui.render();
+        if (!translation_ui.allow_autofill) {
+            $autoFill.attr('class', 'disabled btn btn-primary');
+            $('.auto-fill-help').attr('data-content', gettext("Autofill is not available in English (en). " +
+                "Please change your language using the dropdown in the top left."));
+        }
+        hqMain.transformHelpTemplate($('.auto-fill-help'), true);
+        translation_ui.appendAdder();
+        $home.append($home);
     };
-
-    return {
-        makeTranslationUI: mk_translation_ui,
+    translation_ui.validate_translation = function (translation) {
+        var patt = /\$.*?}/g;
+        var parameters = translation.value.val().match(patt);
+        var error = false;
+        if (parameters !== null && parameters.length !== 0) {
+            var patt2 = /\$\{[0-9]+}/;
+            for (var idx in parameters) {
+                if (!parameters[idx].match(patt2)) {
+                    error = true;
+                }
+            }
+        }
+        return error;
     };
-});
+    translation_ui.render();
+};
+
+export default {
+    makeTranslationUI: mk_translation_ui,
+};

--- a/corehq/messaging/smsbackends/telerivet/static/telerivet/js/telerivet_setup.js
+++ b/corehq/messaging/smsbackends/telerivet/static/telerivet/js/telerivet_setup.js
@@ -1,175 +1,170 @@
-hqDefine("telerivet/js/telerivet_setup", [
-    'knockout',
-    'hqwebapp/js/initial_page_data',
-    'commcarehq',
-], function (
-    ko,
-    initialPageData,
-) {
-    var telerivetSetupModel = function () {
-        var self = {};
+import "commcarehq";
+import ko from "knockout";
+import initialPageData from "hqwebapp/js/initial_page_data";
 
-        // Step handling
-        self.step = ko.observable(0);
-        self.start = ko.computed(function () { return self.step() === 0; });
-        self.step1 = ko.computed(function () { return self.step() === 1; });
-        self.step2 = ko.computed(function () { return self.step() === 2; });
-        self.step3 = ko.computed(function () { return self.step() === 3; });
-        self.finish = ko.computed(function () { return self.step() === 4; });
-        self.nextStep = function () {
-            self.step(self.step() + 1);
-        };
+var telerivetSetupModel = function () {
+    var self = {};
 
-        // Step 2: UI control
-        self.showApiKeyGeneration = ko.observable(false);
-        self.showApiInfoLocation = ko.observable(false);
-        self.testSMSSent = ko.observable(false);
-        self.showOutboundTroubleshoot = ko.observable(false);
-
-        // Step 2: Outgoing SMS Form
-        self.apiKey = ko.observable('');
-        self.apiKeyError = ko.observable('');
-        self.projectId = ko.observable('');
-        self.projectIdError = ko.observable('');
-        self.phoneId = ko.observable('');
-        self.phoneIdError = ko.observable('');
-
-        // Step 2: Phone Number Form
-        self.testPhoneNumber = ko.observable('');
-        self.testPhoneNumberError = ko.observable('');
-        self.sendSmsButtonError = ko.observable(false);
-        self.sendSmsButtonText = ko.computed(function () {
-            return self.sendSmsButtonError() ? gettext('Server error. Try again...') : gettext('Send');
-        });
-
-        self.sendTestSMS = function () {
-            $.ajax({
-                method: 'POST',
-                url: initialPageData.reverse('send_sample_sms'),
-                data: {
-                    api_key: self.apiKey(),
-                    project_id: self.projectId(),
-                    phone_id: self.phoneId(),
-                    test_phone_number: self.testPhoneNumber(),
-                    request_token: initialPageData.get('request_token'),
-                },
-                success: function (data) {
-                    self.sendSmsButtonError(false);
-                    self.apiKeyError(data.api_key_error);
-                    self.projectIdError(data.project_id_error);
-                    self.phoneIdError(data.phone_id_error);
-                    self.testPhoneNumberError(data.unexpected_error || data.test_phone_number_error);
-                    self.testSMSSent(data.success);
-                },
-                error: function () {
-                    self.sendSmsButtonError(true);
-                },
-            });
-        };
-
-        // Step 3
-        self.showAddWebhookNavigation = ko.observable(false);
-        self.showWebhookDetails = ko.observable(false);
-        self.pollForInboundSMS = ko.observable(false);
-        self.inboundSMSReceived = ko.observable(false);
-        self.inboundWaitTimedOut = ko.observable(false);
-        self.pollingErrorOccurred = ko.observable(false);
-        self.showInboundTroubleshoot = ko.observable(false);
-        self.waiting = ko.computed(function () {
-            return !self.inboundSMSReceived() && !self.inboundWaitTimedOut() && !self.pollingErrorOccurred();
-        });
-        self.messageReceived = ko.computed(function () {
-            return self.inboundSMSReceived() && !self.pollingErrorOccurred();
-        });
-        self.messageNotReceived = ko.computed(function () {
-            return self.inboundWaitTimedOut() && !self.inboundSMSReceived() && !self.pollingErrorOccurred();
-        });
-
-        self.startInboundPolling = function () {
-            self.pollForInboundSMS(true);
-            self.inboundWaitTimedOut(false);
-            setTimeout(function () {
-                self.inboundWaitTimedOut(true);
-            }, 30000);
-            self.getLastInboundSMS();
-        };
-
-        self.getLastInboundSMS = function () {
-            $.ajax({
-                method: 'GET',
-                url: initialPageData.reverse('get_last_inbound_sms'),
-                data: {
-                    request_token: initialPageData.get('request_token'),
-                },
-                success: function (data) {
-                    if (data.success) {
-                        if (data.found) {
-                            self.inboundSMSReceived(true);
-                        } else {
-                            setTimeout(self.getLastInboundSMS, 10000);
-                        }
-                    } else {
-                        self.pollingErrorOccurred(true);
-                    }
-                },
-                error: function () {
-                    // This is just an http error, for example, rather than
-                    // something like a missing request token, so just retry it.
-                    setTimeout(self.getLastInboundSMS, 10000);
-                },
-            });
-        };
-
-        // Finish
-        self.setupComplete = ko.observable(false);
-        self.creatingBackend = ko.observable(false);
-        self.backendButtonError = ko.observable(false);
-        self.backendButtonText = ko.computed(function () {
-            return self.backendButtonError() ? gettext("Server error. Try again...") : gettext("Complete");
-        });
-        self.name = ko.observable(initialPageData.get('form_name'));
-        self.nameError = ko.observable('');
-        self.setAsDefault = ko.observable(initialPageData.get('form_set_as_default'));
-        self.setAsDefaultError = ko.observable('');
-
-        self.createBackend = function () {
-            self.creatingBackend(true);
-            $.ajax({
-                method: 'POST',
-                url: initialPageData.reverse('create_backend'),
-                data: {
-                    name: self.name(),
-                    api_key: self.apiKey(),
-                    project_id: self.projectId(),
-                    phone_id: self.phoneId(),
-                    request_token: initialPageData.get('request_token'),
-                    set_as_default: self.setAsDefault(),
-                },
-                success: function (data) {
-                    if (data.success) {
-                        self.setupComplete(true);
-                        setTimeout(function () {
-                            window.location.href = initialPageData.get('gateway_list_url');
-                        }, 2000);
-                    } else {
-                        self.nameError(data.unexpected_error || data.name_error);
-                        if (data.name_error) {
-                            self.creatingBackend(false);
-                            self.backendButtonError(false);
-                        }
-                    }
-                },
-                error: function () {
-                    self.creatingBackend(false);
-                    self.backendButtonError(true);
-                },
-            });
-        };
-
-        return self;
+    // Step handling
+    self.step = ko.observable(0);
+    self.start = ko.computed(function () { return self.step() === 0; });
+    self.step1 = ko.computed(function () { return self.step() === 1; });
+    self.step2 = ko.computed(function () { return self.step() === 2; });
+    self.step3 = ko.computed(function () { return self.step() === 3; });
+    self.finish = ko.computed(function () { return self.step() === 4; });
+    self.nextStep = function () {
+        self.step(self.step() + 1);
     };
 
-    $(function () {
-        $("#telerivet-setup").koApplyBindings(telerivetSetupModel());
+    // Step 2: UI control
+    self.showApiKeyGeneration = ko.observable(false);
+    self.showApiInfoLocation = ko.observable(false);
+    self.testSMSSent = ko.observable(false);
+    self.showOutboundTroubleshoot = ko.observable(false);
+
+    // Step 2: Outgoing SMS Form
+    self.apiKey = ko.observable('');
+    self.apiKeyError = ko.observable('');
+    self.projectId = ko.observable('');
+    self.projectIdError = ko.observable('');
+    self.phoneId = ko.observable('');
+    self.phoneIdError = ko.observable('');
+
+    // Step 2: Phone Number Form
+    self.testPhoneNumber = ko.observable('');
+    self.testPhoneNumberError = ko.observable('');
+    self.sendSmsButtonError = ko.observable(false);
+    self.sendSmsButtonText = ko.computed(function () {
+        return self.sendSmsButtonError() ? gettext('Server error. Try again...') : gettext('Send');
     });
+
+    self.sendTestSMS = function () {
+        $.ajax({
+            method: 'POST',
+            url: initialPageData.reverse('send_sample_sms'),
+            data: {
+                api_key: self.apiKey(),
+                project_id: self.projectId(),
+                phone_id: self.phoneId(),
+                test_phone_number: self.testPhoneNumber(),
+                request_token: initialPageData.get('request_token'),
+            },
+            success: function (data) {
+                self.sendSmsButtonError(false);
+                self.apiKeyError(data.api_key_error);
+                self.projectIdError(data.project_id_error);
+                self.phoneIdError(data.phone_id_error);
+                self.testPhoneNumberError(data.unexpected_error || data.test_phone_number_error);
+                self.testSMSSent(data.success);
+            },
+            error: function () {
+                self.sendSmsButtonError(true);
+            },
+        });
+    };
+
+    // Step 3
+    self.showAddWebhookNavigation = ko.observable(false);
+    self.showWebhookDetails = ko.observable(false);
+    self.pollForInboundSMS = ko.observable(false);
+    self.inboundSMSReceived = ko.observable(false);
+    self.inboundWaitTimedOut = ko.observable(false);
+    self.pollingErrorOccurred = ko.observable(false);
+    self.showInboundTroubleshoot = ko.observable(false);
+    self.waiting = ko.computed(function () {
+        return !self.inboundSMSReceived() && !self.inboundWaitTimedOut() && !self.pollingErrorOccurred();
+    });
+    self.messageReceived = ko.computed(function () {
+        return self.inboundSMSReceived() && !self.pollingErrorOccurred();
+    });
+    self.messageNotReceived = ko.computed(function () {
+        return self.inboundWaitTimedOut() && !self.inboundSMSReceived() && !self.pollingErrorOccurred();
+    });
+
+    self.startInboundPolling = function () {
+        self.pollForInboundSMS(true);
+        self.inboundWaitTimedOut(false);
+        setTimeout(function () {
+            self.inboundWaitTimedOut(true);
+        }, 30000);
+        self.getLastInboundSMS();
+    };
+
+    self.getLastInboundSMS = function () {
+        $.ajax({
+            method: 'GET',
+            url: initialPageData.reverse('get_last_inbound_sms'),
+            data: {
+                request_token: initialPageData.get('request_token'),
+            },
+            success: function (data) {
+                if (data.success) {
+                    if (data.found) {
+                        self.inboundSMSReceived(true);
+                    } else {
+                        setTimeout(self.getLastInboundSMS, 10000);
+                    }
+                } else {
+                    self.pollingErrorOccurred(true);
+                }
+            },
+            error: function () {
+                // This is just an http error, for example, rather than
+                // something like a missing request token, so just retry it.
+                setTimeout(self.getLastInboundSMS, 10000);
+            },
+        });
+    };
+
+    // Finish
+    self.setupComplete = ko.observable(false);
+    self.creatingBackend = ko.observable(false);
+    self.backendButtonError = ko.observable(false);
+    self.backendButtonText = ko.computed(function () {
+        return self.backendButtonError() ? gettext("Server error. Try again...") : gettext("Complete");
+    });
+    self.name = ko.observable(initialPageData.get('form_name'));
+    self.nameError = ko.observable('');
+    self.setAsDefault = ko.observable(initialPageData.get('form_set_as_default'));
+    self.setAsDefaultError = ko.observable('');
+
+    self.createBackend = function () {
+        self.creatingBackend(true);
+        $.ajax({
+            method: 'POST',
+            url: initialPageData.reverse('create_backend'),
+            data: {
+                name: self.name(),
+                api_key: self.apiKey(),
+                project_id: self.projectId(),
+                phone_id: self.phoneId(),
+                request_token: initialPageData.get('request_token'),
+                set_as_default: self.setAsDefault(),
+            },
+            success: function (data) {
+                if (data.success) {
+                    self.setupComplete(true);
+                    setTimeout(function () {
+                        window.location.href = initialPageData.get('gateway_list_url');
+                    }, 2000);
+                } else {
+                    self.nameError(data.unexpected_error || data.name_error);
+                    if (data.name_error) {
+                        self.creatingBackend(false);
+                        self.backendButtonError(false);
+                    }
+                }
+            },
+            error: function () {
+                self.creatingBackend(false);
+                self.backendButtonError(true);
+            },
+        });
+    };
+
+    return self;
+};
+
+$(function () {
+    $("#telerivet-setup").koApplyBindings(telerivetSetupModel());
 });


### PR DESCRIPTION
## Technical Summary
This is a couple of random pages that are no longer imported by AMD modules.

Combined with the other PRs I've opened tonight, this will get HQ to 80% of js files on ESM. What's remaining is form designer (which is blocked by its webpack migration), cloudcare (which is the most intricate app to migrate), and the js libraries that are used by pretty much all pages and therefore have to be done last (analytics, inactivity popup, knockout components, etc.).

## Safety Assurance

### Safety story
I'll smoke test lightly on staging. Marking "don't merge" in the meantime.

### Automated test coverage

doubt it

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
