### PR TITLE
Simplify elasticsearch queries in data dictionary

### DIFF
--- a/corehq/apps/data_dictionary/tests/test_views.py
+++ b/corehq/apps/data_dictionary/tests/test_views.py
@@ -15,6 +15,8 @@ from corehq.apps.data_dictionary.models import (
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.geospatial.const import GPS_POINT_CASE_PROPERTY
+from corehq.apps.es import case_search_adapter
+from corehq.apps.es.tests.utils import es_test
 from corehq.apps.users.models import HqPermissions, WebUser
 from corehq.apps.users.models_role import UserRole
 from corehq.util.test_utils import flag_enabled, privilege_enabled
@@ -367,6 +369,7 @@ class TestDeprecateOrRestoreCaseTypeView(DataDictionaryViewTestBase):
         self.assertEqual(case_prop_group_count, 0)
 
 
+@es_test(requires=[case_search_adapter], setup_class=True)
 @patch('corehq.apps.data_dictionary.views.get_case_type_app_module_count', return_value={})
 @flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
 @privilege_enabled(privileges.DATA_DICTIONARY)

--- a/corehq/apps/data_dictionary/tests/test_views.py
+++ b/corehq/apps/data_dictionary/tests/test_views.py
@@ -368,7 +368,6 @@ class TestDeprecateOrRestoreCaseTypeView(DataDictionaryViewTestBase):
 
 
 @patch('corehq.apps.data_dictionary.views.get_case_type_app_module_count', return_value={})
-@patch('corehq.apps.data_dictionary.views.get_used_props_by_case_type', return_value={})
 @flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION')
 @privilege_enabled(privileges.DATA_DICTIONARY)
 class DataDictionaryJsonTest(DataDictionaryViewTestBase):

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -18,10 +18,7 @@ from corehq.apps.data_dictionary.models import (
     CasePropertyGroup,
     CaseType,
 )
-from corehq.apps.es.aggregations import NestedAggregation, TermsAggregation
 from corehq.apps.es.case_search import (
-    CASE_PROPERTIES_PATH,
-    PROPERTY_KEY,
     CaseSearchES,
     case_property_missing,
 )
@@ -408,32 +405,6 @@ def is_case_type_unused(domain, case_type):
 def is_case_property_unused(domain, case_type, case_property):
     query = CaseSearchES().domain(domain).case_type(case_type)
     return query.NOT(case_property_missing(case_property)).count() == 0
-
-
-@quickcache(vary_on=['domain', 'case_type'], timeout=60 * 10)
-def get_used_props_by_case_type(domain, case_type=None):
-    agg = TermsAggregation('case_types', 'type.exact').aggregation(
-        NestedAggregation('case_props', CASE_PROPERTIES_PATH).aggregation(
-            TermsAggregation('props', PROPERTY_KEY)
-        )
-    )
-    query = (
-        CaseSearchES()
-        .domain(domain)
-        .size(0)
-        .aggregation(agg)
-    )
-    if case_type:
-        query = query.case_type(case_type)
-    case_type_buckets = query.run().aggregations.case_types.buckets_list
-    props_by_case_type = {}
-    for case_type_bucket in case_type_buckets:
-        prop_buckets = case_type_bucket.case_props.props.buckets_list
-        for prop_bucket in prop_buckets:
-            if case_type_bucket.key not in props_by_case_type:
-                props_by_case_type[case_type_bucket.key] = []
-            props_by_case_type[case_type_bucket.key].append(prop_bucket.key)
-    return props_by_case_type
 
 
 def get_case_property_group_name_for_properties(domain, case_type_name):

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -33,7 +33,8 @@ from corehq.apps.data_dictionary.models import (
 from corehq.apps.data_dictionary.util import (
     delete_case_property,
     get_data_dict_props_by_case_type,
-    get_used_props_by_case_type,
+    is_case_type_unused,
+    is_case_property_unused,
     save_case_property,
     save_case_property_group,
     update_url_query_params,
@@ -71,19 +72,17 @@ def data_dictionary_json_case_types(request, domain):
         queryset = queryset.filter(is_deprecated=False)
 
     case_type_app_module_count = get_case_type_app_module_count(domain)
-    used_props_by_case_type = get_used_props_by_case_type(domain)
     geo_case_prop = get_geo_case_property(domain)
     case_types_data = []
     for case_type in queryset:
         module_count = case_type_app_module_count.get(case_type.name, 0)
-        used_props = used_props_by_case_type.get(case_type.name, [])
         case_types_data.append({
             "name": case_type.name,
             "fhir_resource_type": fhir_resource_type_name_by_case_type.get(case_type),
             "is_deprecated": case_type.is_deprecated,
             "module_count": module_count,
             "properties_count": case_type.properties_count,
-            "is_safe_to_delete": len(used_props) == 0,
+            "is_safe_to_delete": is_case_type_unused(domain, case_type.name)
         })
     return JsonResponse({
         'case_types': case_types_data,
@@ -132,15 +131,13 @@ def data_dictionary_json_case_properties(request, domain, case_type_name):
     )
 
     data_validation_enabled = toggles.CASE_IMPORT_DATA_DICTIONARY_VALIDATION.enabled(domain)
-    used_props_by_case_type = get_used_props_by_case_type(domain, case_type_name)
     geo_case_prop = get_geo_case_property(domain)
-
-    used_props = used_props_by_case_type.get(case_type.name, [])
 
     for group_id, props in itertools.groupby(properties_queryset, key=attrgetter("group_id")):
         props = list(props)
         grouped_properties = []
         for prop in props:
+            is_geo_prop = prop.name == geo_case_prop
             prop_data = {
                 'id': prop.id,
                 'description': prop.description,
@@ -148,7 +145,8 @@ def data_dictionary_json_case_properties(request, domain, case_type_name):
                 'fhir_resource_prop_path': fhir_resource_prop_by_case_prop.get(prop),
                 'name': prop.name,
                 'deprecated': prop.deprecated,
-                'is_safe_to_delete': prop.name not in used_props and prop.name != geo_case_prop,
+                'is_safe_to_delete': not is_geo_prop
+                and is_case_property_unused(domain, case_type.name, prop.name),
                 'index': prop.index,
             }
             if data_validation_enabled:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-17516

There have been various discussions about optimizing this page load in other PRs (https://github.com/dimagi/commcare-hq/pull/36287 and https://github.com/dimagi/commcare-hq/pull/36297) and [slack threads](https://dimagi.slack.com/archives/C0BGN9LDU/p1746125669229339). I believe this is the simplest approach to preserve existing behavior while avoiding any expensive elasticsearch queries.

Currently, when a user navigate to the data dictionary, an elasticsearch query that aggregates usage for all of a project's case types and properties of those case types. This effectively requires doing a full scan of the table/index, which for larger domains can be especially time consuming. So we've been seeing slower page load times and increased load on elasticsearch because of this.

Rather than fire off one very large query, it would actually be better to trigger simple queries that basically result in direct lookups to see if a case type or case property is being used (are there any docs with this case type? are there any docs with this case property set to a non-null value?).

So now when a user loads this page, there is still an initial query that will iterate over all case types for this domain and check the doc count for each, but that should take at most a couple of seconds on very large domains, if not less based on testing in a shell. While we could wait to fetch data for case types that are not the active selection being displayed, this way resulted in the most minimal changeset.

When the user selects another case type, this triggers [an ajax request](https://github.com/dimagi/commcare-hq/blob/4c285d33efc21a7c194759e7aa09737694625139/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js#L522) that eventually determines if any of the case properties for this case type are in use. So we similarly fire off an ES query for each case property, which should still be pretty performant for large domains.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
My local env isn't cooperating at the moment, so I plan to test this on staging. The blast radius is definitely scoped to the data dictionary page only, and in the worst case we allow a user to delete a case type or property that is in use, which would mean the user might have to manually re-create the type or property in data dictionary again.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I added some simple tests for the new helpers to check if case types and properties are unused.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Don't think this is necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
