### PR TITLE
Removed old es references in teardown process

### DIFF
--- a/scripts/docker
+++ b/scripts/docker
@@ -354,8 +354,6 @@ else
         fi
         docker volume rm \
             ${VOLUME_PREFIX}couchdb \
-            ${VOLUME_PREFIX}elasticsearch2 \
-            ${VOLUME_PREFIX}elasticsearch5 \
             ${VOLUME_PREFIX}elasticsearch6 \
             ${VOLUME_PREFIX}kafka \
             ${VOLUME_PREFIX}lib \


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
Forked off https://github.com/dimagi/commcare-hq/pull/36398, this just handles some cleanup there where I wasn't comfortable rolling it into the initial PR. Now, if people still need the es5 deletion code, for whatever reason, we don't have to roll back the `start` and `ps` changes.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Small change and we believe es2/es5 are no longer in use and can be safely removed. If not, this change can be easily reverted.

### Automated test coverage

No tests

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
