### PR TITLE
[Data Cleaning] add model managers

### DIFF
--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -646,6 +646,10 @@ class FilterMatchType:
     )
 
 
+class BulkEditFilterManager(models.Manager):
+    use_for_related_fields = True
+
+
 class BulkEditFilter(models.Model):
     session = models.ForeignKey(BulkEditSession, related_name="filters", on_delete=models.CASCADE)
     filter_id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True, db_index=True)
@@ -662,6 +666,8 @@ class BulkEditFilter(models.Model):
         choices=FilterMatchType.ALL_CHOICES,
     )
     value = models.TextField(null=True, blank=True)
+
+    objects = BulkEditFilterManager()
 
     class Meta:
         ordering = ["index"]

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -1153,6 +1153,10 @@ class EditActionType:
     )
 
 
+class BulkEditChangeManager(models.Manager):
+    use_for_related_fields = True
+
+
 class BulkEditChange(models.Model):
     session = models.ForeignKey(BulkEditSession, related_name="changes", on_delete=models.CASCADE)
     change_id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
@@ -1167,6 +1171,8 @@ class BulkEditChange(models.Model):
     replace_string = models.TextField(null=True, blank=True)
     use_regex = models.BooleanField(default=False)
     copy_from_prop_id = models.CharField(max_length=255)
+
+    objects = BulkEditChangeManager()
 
     class Meta:
         ordering = ["created_on"]

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -306,7 +306,7 @@ class BulkEditSession(models.Model):
         # M2M relationships don't support bulk_create, so we need to access the through model
         # to properly batch this action
         if selected_records:
-            through = BulkEditChange.records.through
+            through = change.records.through
             rows = [
                 through(bulkeditchange_id=change.pk, bulkeditrecord_id=record.pk)
                 for record in selected_records

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -943,12 +943,18 @@ class BulkEditColumn(models.Model):
         return self.label if self.label == self.prop_id else f"{self.label} ({self.prop_id})"
 
 
+class BulkEditRecordManager(models.Manager):
+    use_for_related_fields = True
+
+
 class BulkEditRecord(models.Model):
     session = models.ForeignKey(BulkEditSession, related_name="records", on_delete=models.CASCADE)
     doc_id = models.CharField(max_length=126, db_index=True)  # case_id or form_id
     is_selected = models.BooleanField(default=True)
     calculated_change_id = models.UUIDField(null=True, blank=True)
     calculated_properties = models.JSONField(null=True, blank=True)
+
+    objects = BulkEditRecordManager()
 
     class Meta:
         constraints = [

--- a/corehq/apps/data_cleaning/models.py
+++ b/corehq/apps/data_cleaning/models.py
@@ -874,6 +874,10 @@ class BulkEditPinnedFilter(models.Model):
         return self.get_report_filter_class().filter_query(query, self)
 
 
+class BulkEditColumnManager(models.Manager):
+    use_for_related_fields = True
+
+
 class BulkEditColumn(models.Model):
     session = models.ForeignKey(BulkEditSession, related_name="columns", on_delete=models.CASCADE)
     column_id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True, db_index=True)
@@ -886,6 +890,8 @@ class BulkEditColumn(models.Model):
         choices=DataType.CHOICES,
     )
     is_system = models.BooleanField(default=False)
+
+    objects = BulkEditColumnManager()
 
     class Meta:
         ordering = ["index"]

--- a/corehq/apps/data_cleaning/tests/test_records.py
+++ b/corehq/apps/data_cleaning/tests/test_records.py
@@ -134,11 +134,11 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
         self.session.select_multiple_records(case_ids)
         unrecorded_case_ids = [self._get_case_id() for _ in range(5)]
         self.assertListEqual(
-            BulkEditRecord.get_unrecorded_doc_ids(self.session, case_ids),
+            self.session.records.get_unrecorded_doc_ids(self.session, case_ids),
             []
         )
         all_case_ids = case_ids + unrecorded_case_ids
         self.assertEqual(
-            set(BulkEditRecord.get_unrecorded_doc_ids(self.session, all_case_ids)),
+            set(self.session.records.get_unrecorded_doc_ids(self.session, all_case_ids)),
             set(unrecorded_case_ids)
         )

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -192,8 +192,8 @@ class CommitCasesTest(TestCase):
         )
         change.save()
 
-        BulkEditPinnedFilter.create_default_filters(self.session)
-        BulkEditColumn.create_default_columns(self.session)
+        self.session.pinned_filters.create_session_defaults(self.session)
+        self.session.columns.create_session_defaults(self.session)
         self.session.add_filter('play_count', DataType.INTEGER, FilterMatchType.GREATER_THAN, 1)
         self.session.save()
 


### PR DESCRIPTION
## Technical Summary
Adds custom model Managers to relevant data cleaning models to both improve readability, separate concerns a little better, and prevent circular dependencies.

The goal is to follow up this PR with a PR that splits the gigantic `models.py` into a module.

Please review commit-by-commit

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change that affects only a feature flagged workflow that is undergoing QA and testing right now

### Automated test coverage
yes

### QA Plan
not blocking PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change