### PR TITLE
[Data Cleaning] refactor - move away from kwargs.pop in get_context_data

### DIFF
--- a/corehq/apps/data_cleaning/views/cleaning.py
+++ b/corehq/apps/data_cleaning/views/cleaning.py
@@ -21,13 +21,13 @@ class CleanSelectedRecordsFormView(BulkEditSessionViewMixin,
     template_name = "data_cleaning/forms/clean_selected_records_form.html"
     session_not_found_message = gettext_lazy("Cannot load clean selected records form, session was not found.")
 
-    def get_context_data(self, **kwargs):
+    def get_context_data(self, cleaning_form=None, change=None, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update({
             'container_id': 'clean-selected-records',
-            'cleaning_form': kwargs.pop('cleaning_form', None) or CleanSelectedRecordsForm(self.session),
+            'cleaning_form': cleaning_form or CleanSelectedRecordsForm(self.session),
             'are_bulk_edits_allowed': self.session.are_bulk_edits_allowed(),
-            'change': kwargs.pop('change', None),
+            'change': change,
         })
         return context
 

--- a/corehq/apps/data_cleaning/views/columns.py
+++ b/corehq/apps/data_cleaning/views/columns.py
@@ -22,12 +22,12 @@ class ManageColumnsFormView(BulkEditSessionViewMixin,
     template_name = "data_cleaning/forms/manage_columns_form.html"
     session_not_found_message = gettext_lazy("Cannot retrieve columns, session was not found.")
 
-    def get_context_data(self, **kwargs):
+    def get_context_data(self, column_form=None, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update({
             'container_id': 'manage-columns',
             'active_columns': self.session.columns.all(),
-            'add_column_form': kwargs.pop('column_form', None) or AddColumnForm(self.session),
+            'add_column_form': column_form or AddColumnForm(self.session),
         })
         return context
 

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -66,12 +66,12 @@ class ManageFiltersFormView(BulkEditSessionViewMixin, BaseFilterFormView):
     template_name = "data_cleaning/forms/manage_filters_form.html"
     session_not_found_message = gettext_lazy("Cannot retrieve filters, session was not found.")
 
-    def get_context_data(self, **kwargs):
+    def get_context_data(self, filter_form=None, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update({
             'container_id': 'manage-filters',
             'active_filters': self.session.filters.all(),
-            'add_filter_form': kwargs.pop('filter_form', None) or AddFilterForm(self.session),
+            'add_filter_form': filter_form or AddFilterForm(self.session),
         })
         return context
 

--- a/corehq/apps/data_cleaning/views/setup.py
+++ b/corehq/apps/data_cleaning/views/setup.py
@@ -24,12 +24,12 @@ class SetupCaseSessionFormView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActio
     template_name = "data_cleaning/forms/next_action_form.html"
     container_id = "setup-case-session"
 
-    def get_context_data(self, **kwargs):
+    def get_context_data(self, form=None, next_action=None, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update({
-            "form": kwargs.pop('form', None) or SelectCaseTypeForm(self.domain),
+            "form": form or SelectCaseTypeForm(self.domain),
             "container_id": self.container_id,
-            "next_action": kwargs.pop('next_action', 'validate_session'),
+            "next_action": next_action or 'validate_session',
         })
         return context
 


### PR DESCRIPTION
## Technical Summary
Does what the title says. A quick cleanup that's been lingering from a previous PR comment. I wanted to address every issue within `data_cleaning` so that it was consistent throughout.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
changes only affect feature flagged area of the codebase that is undergoing QA on staging

### Automated test coverage
not this part, but yes

### QA Plan
not blocking PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
