### PR TITLE
[Data Cleaning] make All Data the default Case Owner(s) filter option

### DIFF
--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -78,6 +78,7 @@ class CaseOwnersPinnedFilter(SessionPinnedFilterMixin, CaseListFilter):
     template = "data_cleaning/filters/pinned/multi_option.html"
     placeholder = gettext_lazy("Please add case owners to filter the list of cases.")
     filter_type = PinnedFilterType.CASE_OWNERS
+    default_selections = [('all_data', gettext_lazy("[All Data]"))]
 
     @property
     def filter_context(self):

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -35,7 +35,6 @@ from corehq.apps.es.users import user_adapter
 from corehq.apps.hqwebapp.tests.tables.generator import get_case_blocks
 from corehq.apps.reports.models import HQUserType
 from corehq.apps.reports.standard.cases.utils import (
-    all_project_data_filter,
     deactivated_case_owners,
     get_case_owners,
     query_location_restricted_cases,
@@ -630,7 +629,7 @@ class TestReportFilterSubclasses(TestCase):
                     ],
                     'default_text': 'Filter by...',
                     'selected': [
-                        {'id': 'project_data', 'text': '[Project Data]'},
+                        {'id': 'all_data', 'text': '[All Data]'},
                     ],
                     'placeholder': 'Please add case owners to filter the list of cases.',
                 },
@@ -664,7 +663,7 @@ class TestReportFilterSubclasses(TestCase):
                     ],
                     'default_text': 'Filter by...',
                     'selected': [
-                        {'id': 'project_data', 'text': '[Project Data]'},
+                        {'id': 'all_data', 'text': '[All Data]'},
                     ],
                     'placeholder': 'Please add case owners to filter the list of cases.',
                 },
@@ -817,8 +816,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         )
         self.assertIsNone(pinned_filter.value)
         filtered_query = pinned_filter.filter_query(query)
-        expected_query = query.OR(all_project_data_filter(self.domain, ['project_data']))
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        self.assertDictEqual(filtered_query.es_query, query.es_query)
 
     def test_default_location_restricted(self):
         query = CaseSearchES().domain(self.domain)

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -23,7 +23,6 @@ from corehq.apps.es.tests.utils import (
     es_test,
 )
 from corehq.apps.hqwebapp.tests.tables.generator import get_case_blocks
-from corehq.apps.reports.standard.cases.utils import all_project_data_filter
 from corehq.apps.users.models import WebUser
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
@@ -257,7 +256,6 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
                 self.domain_name,
                 "phonetic-match(name, 'lowkey') and num_leaves > 2 and height_cm <= 11.1"
             )
-            .OR(all_project_data_filter(self.domain_name, ['project_data']))  # default Case Owners pinned filter
         )
         self.assertEqual(query.es_query, expected_query.es_query)
 
@@ -270,7 +268,6 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             .domain(self.domain_name)
             .case_type(self.case_type)
             .NOT(case_property_missing('watered_on'))
-            .OR(all_project_data_filter(self.domain_name, ['project_data']))  # default Case Owners pinned filter
         )
         self.assertEqual(query.es_query, expected_query.es_query)
 
@@ -286,7 +283,6 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
                 self.domain_name,
                 "num_leaves > 2"
             )
-            .OR(all_project_data_filter(self.domain_name, ['project_data']))  # default Case Owners pinned filter
         )
         self.assertEqual(query.es_query, expected_query.es_query)
 


### PR DESCRIPTION
## Product Description
Does what the title says, makes "All Data" the default option for the `Case Owner(s)` filter in the bulk data editing tool. Does not affect report filters.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
small change affecting feature flagged, unreleased code

### Automated test coverage
yes

### QA Plan
not blocking PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
