### PR TITLE
[Data Cleaning] hide data type field in AddColumnForm

### DIFF
--- a/corehq/apps/data_cleaning/forms/columns.py
+++ b/corehq/apps/data_cleaning/forms/columns.py
@@ -70,6 +70,9 @@ class AddColumnForm(forms.Form):
             'label': initial_label,
             "casePropertyDetails": property_details,
             "isEditable": is_initial_editable,
+            # todo: for now, don't show data type to user since we don't use it in the table UI (yet)
+            # we will implement this in the future, so we want to store it in the db
+            "isDataTypeVisible": False,
         }
 
         self.helper = FormHelper()
@@ -99,7 +102,7 @@ class AddColumnForm(forms.Form):
                             'column_data_type',
                             x_model="dataType",
                         ),
-                        x_show="isEditable",
+                        x_show="isEditable && isDataTypeVisible",
                     ),
                     twbscrispy.StrictButton(
                         _("Add Column"),


### PR DESCRIPTION
## Product Description
This hides the "data type" field in AddColumnForm since we don't actually use this information in the table (yet). Keeping it visible creates more confusion rather than help (at this time)

## Technical Summary
I'm hiding instead of removing because:
- system columns are typed properly
- data dictionary typed properties are typed properly
...and we want this information to be stored in the db.

We will release an update to bulk data cleaning that will change the widget depending on data type when the user is expected to enter a value (inline editing and bulk edit form).

We also definitely need this field when we add bulk edit functionality for forms.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change scoped to the UI of a feature flagged workflow that is still in QA

### Automated test coverage
n/a

### QA Plan
not blocking PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
