### PR TITLE
[Data Cleaning] Text updates - consistency, clarity

### DIFF
--- a/corehq/apps/data_cleaning/forms/cleaning.py
+++ b/corehq/apps/data_cleaning/forms/cleaning.py
@@ -25,7 +25,7 @@ class CleanSelectedRecordsForm(forms.Form):
     applied to only ONE field.
     """
     clean_prop_id = forms.ChoiceField(
-        label=gettext_lazy("Select a property to clean"),
+        label=gettext_lazy("Select a property to edit"),
         required=False,
         help_text=gettext_lazy(
             "Choices are editable case properties that are "
@@ -33,7 +33,7 @@ class CleanSelectedRecordsForm(forms.Form):
         ),
     )
     clean_action = forms.ChoiceField(
-        label=gettext_lazy("Data cleaning action"),
+        label=gettext_lazy("Edit action"),
         widget=AlpineSelect,
         choices=EditActionType.CHOICES,
         required=False
@@ -155,7 +155,7 @@ class CleanSelectedRecordsForm(forms.Form):
                         css_class="card mb-3",
                     ),
                     twbscrispy.StrictButton(
-                        _("Preview Changes"),
+                        _("Preview Edits"),
                         type="submit",
                         css_class="btn-primary",
                     ),

--- a/corehq/apps/data_cleaning/forms/cleaning.py
+++ b/corehq/apps/data_cleaning/forms/cleaning.py
@@ -28,8 +28,8 @@ class CleanSelectedRecordsForm(forms.Form):
         label=gettext_lazy("Select a property to edit"),
         required=False,
         help_text=gettext_lazy(
-            "Choices are editable case properties that are "
-            "currently visible in the table."
+            "You can only select editable case properties that are currently visible in "
+            "the table as a column. System properties cannot be edited."
         ),
     )
     clean_action = forms.ChoiceField(

--- a/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_main.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/clean_cases_main.html
@@ -9,7 +9,7 @@
   <div class="card">
     <div class="card-body">
       <h3 class="card-title">
-        {% trans "Start a Cleaning Session" %}
+        {% trans "Start a Bulk Edit Session" %}
       </h3>
       <div
         class="mt-3"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/column_editable.html
@@ -57,7 +57,7 @@
             hx-disabled-elt="this"
           >
             <i class="fa fa-close"></i>
-            <span class="visually-hidden">{% trans "Reset Changes" %}</span>
+            <span class="visually-hidden">{% trans "Reset Edits" %}</span>
           </button>
         </div>
       </div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/clean_selected_records_form.html
@@ -13,7 +13,7 @@
     >
       {# todo: make this more descriptive #}
       {% blocktrans with change.records.count as num_records %}
-        {{ num_records }} records have been cleaned.
+        Priviewed edits on {{ num_records }} cases.
       {% endblocktrans %}
       <button
         type="button" class="btn-close" aria-label="{% trans "Close" %}"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/forms/partials/active_session_exists.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/forms/partials/active_session_exists.html
@@ -2,7 +2,7 @@
 
 <div class="alert alert-info">
   {% blocktrans %}
-    An active data cleaning session already exists for this case type.
+    An active bulk edit session already exists for this case type.
     Please decide how you would like to proceed.
   {% endblocktrans %}
 </div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_apply.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_apply.html
@@ -21,6 +21,18 @@
 {% endblock %}
 
 {% block modal_body %}
+  {% if table.num_visible_selected_records != table.num_selected_records %}
+    <div class="alert alert-info">
+      <h5>
+        {% blocktrans %}You have selected cases which have been filtered out.{% endblocktrans %}
+      </h5>
+      <p class="mb-0">
+        {% blocktrans %}
+          "Apply" will apply all previewed edits in the session, regardless of filters.
+        {% endblocktrans %}
+      </p>
+    </div>
+  {% endif %}
   <div
     hx-trigger="updateApplySummaryMessage from:window"
     hx-swap="innerHTML"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_clear.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_clear.html
@@ -17,7 +17,7 @@
 
 {% block modal_continue_text %}
   <i class="fa-solid fa-close"></i>
-  {% trans "Clear" %}
+  {% trans "Clear All Edits" %}
 {% endblock %}
 
 {% block modal_body %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/button_bar.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/button_bar.html
@@ -35,5 +35,5 @@
   }"
   :disabled="!$store.isCleaningAllowed"
 >
-  <i class="fa-solid fa-shower"></i> {% trans "Clean Selected Cases" %}
+  <i class="fa-solid fa-shower"></i> {% trans "Edit Selected Cases" %}
 </button>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/partials/offcanvas.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/partials/offcanvas.html
@@ -67,7 +67,7 @@
 >
   <div class="offcanvas-header">
     <h5 class="offcanvas-title">
-      <i class="fa-solid fa-shower"></i> {% trans "Clean Selected Cases" %}
+      <i class="fa-solid fa-shower"></i> {% trans "Edit Selected Cases" %}
     </h5>
     <button
       class="btn-close" type="button" aria-label="{% trans "Close" %}"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -85,7 +85,7 @@
           <div class="input-group-text">
             <i class="fa-solid fa-filter me-2"></i>
             {% blocktrans with table.page.paginator.count as num_records %}
-              Filters Applied: {{ num_records }} Matching Records
+              Filters Applied: {{ num_records }} Matching Cases
             {% endblocktrans %}
           </div>
           <button
@@ -117,13 +117,13 @@
             x-text="numRecordsSelected"
           ></span>
           {% blocktrans %}
-            Records Selected
+            Cases Selected
           {% endblocktrans %}
           {% if table.num_visible_selected_records != table.num_selected_records %}
             <div
               class="ms-2 ps-2 border-start inline-block text-warning"
               data-bs-custom-class="fs-6"
-              data-bs-title="{% trans 'Some records are selected in the session but not currently visible. They will not be part of cleaning actions until all filters are removed.' %}"
+              data-bs-title="{% trans 'You have selected cases which have been filtered out. New previewed edits will only apply to selected cases in the current filters, unless you remove filters.' %}"
               x-tooltip=""
             >
               <i class="fa-solid fa-triangle-exclamation"></i>

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -24,7 +24,7 @@ from corehq.util.view_utils import set_file_download
     require_bulk_data_cleaning_cases,
 ], name='dispatch')
 class CleanCasesMainView(BaseProjectDataView):
-    page_title = gettext_lazy("Clean Case Data")
+    page_title = gettext_lazy("Bulk Edit Case Data")
     urlname = "data_cleaning_cases"
     template_name = "data_cleaning/clean_cases_main.html"
 
@@ -43,7 +43,7 @@ class CleanCasesMainView(BaseProjectDataView):
     require_bulk_data_cleaning_cases,
 ], name='dispatch')
 class CleanCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
-    page_title = gettext_lazy("Clean Case Type")
+    page_title = gettext_lazy("Bulk Edit Case Type")
     urlname = "data_cleaning_cases_session"
     template_name = "data_cleaning/clean_cases_session.html"
 


### PR DESCRIPTION
## Product Description
This PR:
- makes sure we use "edit" and "bulk edit" consistently. "change", "clean", etc. have been swapped out
- makes sure we use "cases" instead of "records"
- updates the text seen in the screenshots below:

<img width="753" alt="Screenshot 2025-05-12 at 2 44 14 PM" src="https://github.com/user-attachments/assets/71864c56-1201-45e9-99db-ea20283bfbbd" />
<img width="246" alt="Screenshot 2025-05-12 at 2 44 08 PM" src="https://github.com/user-attachments/assets/308544ae-03ad-4c9b-a427-8b7d94183eaa" />
<img width="535" alt="Screenshot 2025-05-12 at 2 42 25 PM" src="https://github.com/user-attachments/assets/d5a817cb-ada3-4d86-b9ea-86094f029eb4" />
<img width="657" alt="Screenshot 2025-05-12 at 2 32 05 PM" src="https://github.com/user-attachments/assets/41033b04-d24e-46d5-a2b8-28dd209037b6" />
<img width="1107" alt="Screenshot 2025-05-12 at 2 31 59 PM" src="https://github.com/user-attachments/assets/0e0ed1df-b77a-4b1c-9336-4e6e8d9609b9" />
<img width="398" alt="Screenshot 2025-05-12 at 2 30 14 PM" src="https://github.com/user-attachments/assets/66f33649-05e2-4582-9a01-5eaa136854cd" />
<img width="414" alt="Screenshot 2025-05-12 at 2 30 07 PM" src="https://github.com/user-attachments/assets/4f102818-1341-43bb-a5cd-23082c12d51f" />


## Technical Summary
review commit-by-commit for extra details in the messages

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
only affects text

### Automated test coverage
n/a

### QA Plan
not blocking PR


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
