### PR TITLE
Limit UCR exports to 1M rows

### DIFF
--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -384,12 +384,16 @@ def is_query_too_big(domain, mobile_user_and_group_slugs, request_user):
     return user_es_query.count() > USER_QUERY_LIMIT
 
 
-def send_report_download_email(title, recipient, link, subject=None, domain=None):
+def send_report_download_email(title, recipient, link, subject=None, domain=None, limit=None):
     if subject is None:
         subject = _("%s: Requested export excel data") % title
     body = "The export you requested for the '%s' report is ready.<br>" \
            "You can download the data at the following link: %s<br><br>" \
            "Please remember that this link will only be active for 24 hours."
+
+    if limit:
+        body += f"<br><br>This download is limited to {limit:,d} rows. " \
+                "If you need to export more than this, please use filters to create multiple exports."
 
     send_HTML_email(
         subject,

--- a/corehq/apps/userreports/reports/util.py
+++ b/corehq/apps/userreports/reports/util.py
@@ -1,9 +1,7 @@
 from memoized import memoized
 
 from couchexport.export import export_from_tables
-from couchexport.models import Format
 
-from corehq.apps.export.const import MAX_NORMAL_EXPORT_SIZE
 from corehq.apps.userreports.columns import get_expanded_column_config
 from corehq.apps.userreports.models import get_report_config
 
@@ -56,12 +54,13 @@ class ReportExport(object):
         data_source.set_order_by([(o['field'], o['order']) for o in self.report_config.sort_expression])
         return data_source
 
-    def create_export(self, file_path, format_):
+    def create_export(self, file_path, format_, limit=None):
         """Save this report to a file
         :param file_path: The path to the file the report should be saved
         :param format_: The format of the resulting export
+        :param limit: Maximum rows in the export
         """
-        return export_from_tables(self.get_table(format_), file_path, format_)
+        return export_from_tables(self.get_table(limit=limit), file_path, format_)
 
     @property
     def header_rows(self):
@@ -71,11 +70,7 @@ class ReportExport(object):
         ]]
 
     @memoized
-    def get_data(self):
-        limit = None
-        if format in [Format.XLS, Format.XLS_2007]:
-            # Excel files max out at 1,048,576 rows, so we can reasonably limit excel exports to 1M rows
-            limit = MAX_NORMAL_EXPORT_SIZE
+    def get_data(self, limit=None):
         return list(self.data_source.get_data(limit=limit))
 
     @property
@@ -84,7 +79,7 @@ class ReportExport(object):
         return [self.data_source.get_total_row()] if self.data_source.has_total_row else []
 
     @memoized
-    def data_rows(self, format):
+    def data_rows(self, limit=None):
         column_id_to_expanded_column_ids = get_expanded_columns(
             self.data_source.top_level_columns,
             self.data_source.config
@@ -94,19 +89,19 @@ class ReportExport(object):
             if column.visible:
                 column_ids.extend(column_id_to_expanded_column_ids.get(column.column_id, [column.column_id]))
 
-        return [[raw_row[column_id] for column_id in column_ids] for raw_row in self.get_data(format)]
+        return [[raw_row[column_id] for column_id in column_ids] for raw_row in self.get_data(limit)]
 
-    def get_table_data(self, format):
-        return self.header_rows + self.data_rows(format) + self.total_rows
+    def get_table_data(self, limit=None):
+        return self.header_rows + self.data_rows(limit) + self.total_rows
 
     @memoized
-    def get_table(self, format):
+    def get_table(self, limit=None):
         """Generate a table of all rows of this report
         """
         export_table = [
             [
                 self.title,
-                self.get_table_data(format)
+                self.get_table_data(limit)
             ]
         ]
 

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -26,6 +26,7 @@ from corehq.apps.celery import periodic_task, task
 from corehq.apps.change_feed.data_sources import (
     get_document_store_for_doc_type,
 )
+from corehq.apps.export.const import MAX_DAILY_EXPORT_SIZE
 from corehq.apps.reports.util import send_report_download_email
 from corehq.elastic import ESError
 from corehq.util.context_managers import notify_someone
@@ -613,8 +614,12 @@ def export_ucr_async(report_export, download_id, user):
     filename = '{}.xlsx'.format(ascii_title.replace('/', '?'))
     file_path = get_download_file_path(use_transfer, filename)
 
-    report_export.create_export(file_path, Format.XLS_2007)
+    # Excel files max out at 1,048,576 rows, so we can reasonably limit excel exports to 1M rows
+    limit = MAX_DAILY_EXPORT_SIZE
+
+    report_export.create_export(file_path, Format.XLS_2007, limit=limit)
     expose_download(use_transfer, file_path, filename, download_id, 'xlsx', owner_ids=[user.get_id])
     link = reverse("retrieve_download", args=[download_id], params={"get_file": '1'}, absolute=True)
 
-    send_report_download_email(report_export.title, user.get_email(), link, domain=report_export.domain)
+    send_report_download_email(report_export.title, user.get_email(), link,
+                               domain=report_export.domain, limit=limit)

--- a/corehq/apps/userreports/tests/test_report_rendering.py
+++ b/corehq/apps/userreports/tests/test_report_rendering.py
@@ -8,7 +8,7 @@ class VeryFakeReportExport(ReportExport):
     def __init__(self, data):
         self._data = data
 
-    def get_table(self):
+    def get_table(self, limit=None):
         return self._data
 
 


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SAAS-17562

## Technical Summary
Cuts off emailed UCR exports at 1,000,000 rows. Adds a note to the email that data may be cut off.

## Feature Flag
UCRs

## Safety Assurance

### Safety story
Major risk is of missing calling code, which is why new `limit` parameter is optional. Tested end to end workflow locally.

### Automated test coverage

There's coverage of the limiting behavior in [test_report_data](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/tests/test_report_data.py). There's a UI test in [test_report_rendering](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/tests/test_report_data.py) but it uses mocks that mean it doesn't hit this code path. I looked at extending the rendering tests to add coverage for this code and decided that having the limit behavior tested in test_report_rendering is sufficient.

### QA Plan

Not requesting QA.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
