### PR TITLE
Fixed an issue causing threads to sometimes use the incorrect bootstr…

### DIFF
--- a/corehq/apps/hqwebapp/tests/utils/test_thread_var.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_thread_var.py
@@ -1,0 +1,45 @@
+from django.test import SimpleTestCase
+from threading import Thread
+from corehq.apps.hqwebapp.utils.bootstrap import (
+    get_bootstrap_version,
+    set_bootstrap_version3,
+    set_bootstrap_version5,
+    clear_bootstrap_version,
+    BOOTSTRAP_3,
+    BOOTSTRAP_5,
+)
+
+
+class BootstrapThreadTests(SimpleTestCase):
+    def setUp(self):
+        self.addCleanup(clear_bootstrap_version)
+
+    def test_no_explicit_version_defaults_to_bootstrap3(self):
+        self.assertEqual(get_bootstrap_version(), BOOTSTRAP_3)
+
+    def test_can_set_bootstrap3(self):
+        set_bootstrap_version3()
+        self.assertEqual(get_bootstrap_version(), BOOTSTRAP_3)
+
+    def test_can_set_bootstrap5(self):
+        set_bootstrap_version5()
+        self.assertEqual(get_bootstrap_version(), BOOTSTRAP_5)
+
+    def test_clear_bootstrap_version_removes_previous_setting(self):
+        set_bootstrap_version5()
+        clear_bootstrap_version()
+        # Should default to bootstrap 3 when no explicit setting is found
+        self.assertEqual(get_bootstrap_version(), BOOTSTRAP_3)
+
+    def test_setting_is_local_to_thread(self):
+        results = {}
+
+        def get_version(results):
+            results['thread'] = get_bootstrap_version()
+
+        set_bootstrap_version5()
+        thread = Thread(target=get_version, args=(results,))
+        thread.start()
+        thread.join()
+
+        self.assertEqual(results['thread'], BOOTSTRAP_3)

--- a/corehq/apps/hqwebapp/utils/bootstrap/__init__.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/__init__.py
@@ -20,3 +20,8 @@ def set_bootstrap_version3():
 
 def set_bootstrap_version5():
     _thread_local.BOOTSTRAP_VERSION = BOOTSTRAP_5
+
+
+def clear_bootstrap_version():
+    if hasattr(_thread_local, 'BOOTSTRAP_VERSION'):
+        del _thread_local.BOOTSTRAP_VERSION

--- a/corehq/apps/hqwebapp/utils/bootstrap/middleware.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/middleware.py
@@ -1,0 +1,17 @@
+from corehq.apps.hqwebapp.utils.bootstrap import clear_bootstrap_version
+
+
+class ThreadLocalCleanupMiddleware:
+    '''
+    Middleware to ensure that any bootstrap variables added to the thread via functions
+    within corehq.apps.hqwebapp.utils.bootstrap are cleared before the thread is re-used
+    '''
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        try:
+            response = self.get_response(request)
+            return response
+        finally:
+            clear_bootstrap_version()

--- a/settings.py
+++ b/settings.py
@@ -172,6 +172,7 @@ MIDDLEWARE = [
     'corehq.apps.domain.middleware.DomainHistoryMiddleware',
     'corehq.apps.domain.project_access.middleware.ProjectAccessMiddleware',
     'casexml.apps.phone.middleware.SyncTokenMiddleware',
+    'corehq.apps.hqwebapp.utils.bootstrap.middleware.ThreadLocalCleanupMiddleware',
     'corehq.apps.auditcare.middleware.AuditMiddleware',
     'no_exceptions.middleware.NoExceptionsMiddleware',
     'corehq.apps.locations.middleware.LocationAccessMiddleware',


### PR DESCRIPTION
…ap version

## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-17553

We use thread-local variables to help frameworks like Crispyforms detect the correct bootstrap templates to use. Unfortunately, these variables were not being cleaned up after the request was finished processing, and so when the thread was later re-used for an unrelated task, that unrelated task sometimes intended to use different bootstrap templates. Specifically, if a thread was earlier used to use bootstrap 5 templates, a later request for a bootstrap 3 page would generate an error if it used the old thread.

This PR fixes the issue by introducing new middleware to clean up the thread variable after the request has finished processing.

Long-term, we may still want to revisit this solution to see if we can avoid using thread variables entirely.

## Safety Assurance

### Safety story
Verified the changes locally, in terms of creating logging statements that confirmed the above theory. When the middleware was applied, the local environment no longer generated template errors. I clicked around the application to verify that the middle didn't break various bootstrap3 or bootstrap5 pages.

### Automated test coverage

Added a new test suite to cover the existing functionality for the bootstrap accessors. Also created a new test to verify that clearing those variables works correctly.

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
