### PR TITLE
Added select2 import to app_manager.js

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -14,6 +14,7 @@ hqDefine('app_manager/js/app_manager', [
     'app_manager/js/preview_app',
     'app_manager/js/section_changer',
     "hqwebapp/js/components/inline_edit",   // app, menu, and form names and comments all use these
+    "select2/dist/js/select2.full.min",
     'commcarehq',
 ], function (
     $,


### PR DESCRIPTION
## Technical Summary
This module should import select2 because it directly calls select2 [here](https://github.com/dimagi/commcare-hq/blob/9325b7ef0c9ca69d754bca533320a3a5be8a1d6f/corehq/apps/app_manager/static/app_manager/js/app_manager.js#L560). This doesn't error for me locally, surprisingly, but I saw a QA ticket with a screenshot of a related js error.

## Safety Assurance

### Safety story
Adding a js import is very safe, and this is an import used all over HQ.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
