### PR TITLE
Fix query for missing or empty user data property for UserES

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -182,6 +182,7 @@ class ESQuery(object):
             filters.doc_id,
             filters.nested,
             filters.regexp,
+            filters.wildcard,
         ]
 
     def __getattr__(self, attr):

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -30,6 +30,10 @@ def prefix(field, value):
     return {"prefix": {field: value}}
 
 
+def wildcard(field, value):
+    return {"wildcard": {field: value}}
+
+
 def term(field, value):
     """
     Filter docs by a field

--- a/corehq/apps/es/tests/test_users_es.py
+++ b/corehq/apps/es/tests/test_users_es.py
@@ -4,9 +4,9 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.es.users import (
     UserES,
-    empty_user_data_property,
+    _empty_user_data_property,
     missing_or_empty_user_data_property,
-    missing_user_data_property,
+    _missing_user_data_property,
     user_adapter,
 )
 from corehq.apps.users.models import CommCareUser
@@ -80,7 +80,7 @@ class TestUserDataFilters(TestCase):
     def test_missing_user_data_property(self):
         results = (UserES()
                    .domain(self.domain)
-                   .filter(missing_user_data_property('location'))
+                   .filter(_missing_user_data_property('location'))
                    .get_ids())
 
         expected_ids = [self.user_no_data.user_id, self.user_other_data.user_id]
@@ -89,7 +89,7 @@ class TestUserDataFilters(TestCase):
     def test_empty_user_data_property(self):
         results = (UserES()
                    .domain(self.domain)
-                   .filter(empty_user_data_property('location'))
+                   .filter(_empty_user_data_property('location'))
                    .get_ids())
 
         expected_ids = [self.user_empty_data.user_id]

--- a/corehq/apps/es/tests/test_users_es.py
+++ b/corehq/apps/es/tests/test_users_es.py
@@ -1,0 +1,72 @@
+from django.test import TestCase
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.es.tests.utils import es_test
+from corehq.apps.es.users import UserES, user_adapter, missing_or_empty_user_data_property
+from corehq.apps.users.models import CommCareUser
+
+
+@es_test(requires=[user_adapter], setup_class=True)
+class TestUserDataFilters(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'user-data-es-test'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+
+        cls.user_with_data = CommCareUser.create(
+            username="user1",
+            domain=cls.domain,
+            password="***********",
+            created_by=None,
+            created_via=None,
+            user_data={'location': 'Boston'}
+        )
+        cls.user_empty_data = CommCareUser.create(
+            username="user2",
+            domain=cls.domain,
+            password="***********",
+            created_by=None,
+            created_via=None,
+            user_data={'location': ''}
+        )
+        cls.user_no_data = CommCareUser.create(
+            username="user3",
+            domain=cls.domain,
+            password="***********",
+            created_by=None,
+            created_via=None
+        )
+        cls.user_other_data = CommCareUser.create(
+            username="user4",
+            domain=cls.domain,
+            password="***********",
+            created_by=None,
+            created_via=None,
+            user_data={'other_prop': 'value'}
+        )
+
+        for user in [cls.user_with_data, cls.user_empty_data, cls.user_no_data, cls.user_other_data]:
+            user_adapter.index(user, refresh=True)
+            cls.addClassCleanup(user.delete, None, None)
+
+    def test_missing_or_empty_user_data_property(self):
+        results = (UserES()
+                   .domain(self.domain)
+                   .filter(missing_or_empty_user_data_property('location'))
+                   .get_ids())
+
+        expected_ids = [self.user_no_data.user_id, self.user_empty_data.user_id, self.user_other_data.user_id]
+        self.assertCountEqual(results, expected_ids)
+
+    def test_missing_or_empty_user_data_multiple_properties(self):
+        results = (UserES()
+                   .domain(self.domain)
+                   .filter(missing_or_empty_user_data_property('location'))
+                   .filter(missing_or_empty_user_data_property('other_prop'))
+                   .get_ids())
+
+        expected_ids = [self.user_no_data.user_id, self.user_empty_data.user_id]
+        self.assertCountEqual(results, expected_ids)

--- a/corehq/apps/es/tests/test_users_es.py
+++ b/corehq/apps/es/tests/test_users_es.py
@@ -2,7 +2,13 @@ from django.test import TestCase
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es.tests.utils import es_test
-from corehq.apps.es.users import UserES, user_adapter, missing_or_empty_user_data_property
+from corehq.apps.es.users import (
+    UserES,
+    empty_user_data_property,
+    missing_or_empty_user_data_property,
+    missing_user_data_property,
+    user_adapter,
+)
 from corehq.apps.users.models import CommCareUser
 
 
@@ -69,4 +75,22 @@ class TestUserDataFilters(TestCase):
                    .get_ids())
 
         expected_ids = [self.user_no_data.user_id, self.user_empty_data.user_id]
+        self.assertCountEqual(results, expected_ids)
+
+    def test_missing_user_data_property(self):
+        results = (UserES()
+                   .domain(self.domain)
+                   .filter(missing_user_data_property('location'))
+                   .get_ids())
+
+        expected_ids = [self.user_no_data.user_id, self.user_other_data.user_id]
+        self.assertCountEqual(results, expected_ids)
+
+    def test_empty_user_data_property(self):
+        results = (UserES()
+                   .domain(self.domain)
+                   .filter(empty_user_data_property('location'))
+                   .get_ids())
+
+        expected_ids = [self.user_empty_data.user_id]
         self.assertCountEqual(results, expected_ids)

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -246,7 +246,7 @@ def login_as_user(value):
     return _user_data('login_as_user', filters.term('user_data_es.value', value))
 
 
-def missing_user_data_property(property_name):
+def _missing_user_data_property(property_name):
     """
     A user_data property doesn't exist.
     """
@@ -256,7 +256,7 @@ def missing_user_data_property(property_name):
     ))
 
 
-def empty_user_data_property(property_name):
+def _empty_user_data_property(property_name):
     """
     A user_data property exists but has an empty string value.
     """
@@ -273,6 +273,6 @@ def missing_or_empty_user_data_property(property_name):
     A user_data property doesn't exist, or does exist but has an empty string value.
     """
     return filters.OR(
-        missing_user_data_property(property_name),
-        empty_user_data_property(property_name),
+        _missing_user_data_property(property_name),
+        _empty_user_data_property(property_name),
     )

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -254,5 +254,10 @@ def missing_or_empty_user_data_property(property_name):
         'user_data_es',
         filters.term(field='user_data_es.key', value=property_name),
     ))
-    empty_value = _user_data(property_name, filters.term('user_data_es.value', ''))
+    empty_value = _user_data(
+        property_name,
+        filters.NOT(
+            filters.wildcard(field='user_data_es.value', value='*')
+        )
+    )
     return filters.OR(missing_property, empty_value)

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -246,18 +246,33 @@ def login_as_user(value):
     return _user_data('login_as_user', filters.term('user_data_es.value', value))
 
 
-def missing_or_empty_user_data_property(property_name):
+def missing_user_data_property(property_name):
     """
-    A user_data property doesn't exist, or does exist but has an empty string value.
+    A user_data property doesn't exist.
     """
-    missing_property = filters.NOT(queries.nested(
+    return filters.NOT(queries.nested(
         'user_data_es',
         filters.term(field='user_data_es.key', value=property_name),
     ))
-    empty_value = _user_data(
+
+
+def empty_user_data_property(property_name):
+    """
+    A user_data property exists but has an empty string value.
+    """
+    return _user_data(
         property_name,
         filters.NOT(
             filters.wildcard(field='user_data_es.value', value='*')
         )
     )
-    return filters.OR(missing_property, empty_value)
+
+
+def missing_or_empty_user_data_property(property_name):
+    """
+    A user_data property doesn't exist, or does exist but has an empty string value.
+    """
+    return filters.OR(
+        missing_user_data_property(property_name),
+        empty_user_data_property(property_name),
+    )


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The query for [missing_or_empty_user_data_property](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/es/users.py#L249) is currently not working as expected, specifically when trying to match an empty user data property value.

This happens because the property is mapped as a [text](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/text#text-field-type) type in Elasticsearch. ES doesn’t support direct checks for an empty string ('') on text fields. Internally, ES breaks down text fields into tokens for partial matching, and since an empty string doesn’t produce any tokens, it ends up not matching anything.

To fix this, I’ve reverted the query to the earlier approach, which uses a wildcard together with a not condition. This seems to handle the case correctly.

I also considered changing the mapping to use the keyword type, which allows exact matches including empty strings. But since this field is user-defined and can include things like descriptions or addresses, sticking with the text type still makes sense.Also, since this function is only used in one place, it might not be worth doing a reindex just for this. Not a strong preference and we could consider this if other folks are in favour of this.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/QA-7733)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Microplanning

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local and staging.
QA to be done as well

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Test cases added.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[Ticket](https://dimagi.atlassian.net/browse/QA-7733)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
