### PR TITLE
[Data Cleaning] Keep UI data when committing a session

### DIFF
--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -32,7 +32,7 @@ def commit_data_cleaning(self, bulk_edit_session_id):
         'domain': session.domain,
     })
 
-    _purge_ui_data_from_session(session)
+    _purge_unedited_records(session)
 
     form_ids = []
     session.update_result(0)
@@ -91,11 +91,8 @@ def _claim_bulk_edit_session_for_task(task, bulk_edit_session_id):
 
 
 @transaction.atomic
-def _purge_ui_data_from_session(session):
+def _purge_unedited_records(session):
     session.deselect_all_records_in_queryset()
-    session.filters.all().delete()
-    session.pinned_filters.all().delete()
-    session.columns.all().delete()
     session.purge_records()
 
 

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -4,15 +4,10 @@ from django.test import TestCase
 from casexml.apps.case.mock import CaseFactory
 from corehq.apps.data_cleaning.models import (
     BulkEditChange,
-    BulkEditColumn,
-    BulkEditFilter,
-    BulkEditPinnedFilter,
     BulkEditRecord,
     BulkEditSessionType,
     BulkEditSession,
-    DataType,
     EditActionType,
-    FilterMatchType,
 )
 from corehq.apps.data_cleaning.tasks import commit_data_cleaning
 from corehq.apps.domain.shortcuts import create_domain
@@ -177,32 +172,3 @@ class CommitCasesTest(TestCase):
 
         case = CommCareCase.objects.get_case(self.case.case_id, self.domain.name)
         self.assertEqual(case.get_case_property('speed'), 'slow!')
-
-    def test_delete_ui_models(self):
-        record = BulkEditRecord(
-            session=self.session,
-            doc_id=self.case.case_id,
-        )
-        record.save()
-
-        change = BulkEditChange(
-            session=self.session,
-            prop_id='speed',
-            action_type=EditActionType.UPPER_CASE,
-        )
-        change.save()
-
-        self.session.pinned_filters.create_session_defaults(self.session)
-        self.session.columns.create_session_defaults(self.session)
-        self.session.add_filter('play_count', DataType.INTEGER, FilterMatchType.GREATER_THAN, 1)
-        self.session.save()
-
-        self.assertTrue(BulkEditFilter.objects.filter(session=self.session).count() > 0)
-        self.assertTrue(BulkEditPinnedFilter.objects.filter(session=self.session).count() > 0)
-        self.assertTrue(BulkEditColumn.objects.filter(session=self.session).count() > 0)
-
-        commit_data_cleaning(self.session.session_id)
-
-        self.assertEqual(BulkEditFilter.objects.filter(session=self.session).count(), 0)
-        self.assertEqual(BulkEditPinnedFilter.objects.filter(session=self.session).count(), 0)
-        self.assertEqual(BulkEditColumn.objects.filter(session=self.session).count(), 0)


### PR DESCRIPTION

## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
Getting this quick PR up to make sure we avoid creating more committed sessions on staging with UI data purged from them. After some discussion we are going to allow "resuming" committed sessions, and I will PR that code later.

For now, let's merge in this change, I will delete and previous committed sessions on staging, and then we can start fresh.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change, only affects feature flagged workflow

### Automated test coverage
most important bits are tested

### QA Plan
not blocking PR


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
