### PR TITLE
Do not consider invalid users for kyc verification

### DIFF
--- a/corehq/apps/integration/kyc/views.py
+++ b/corehq/apps/integration/kyc/views.py
@@ -150,14 +150,11 @@ class KycVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableView):
         return self.render_htmx_partial_response(request, 'kyc/partials/kyc_verify_alert.html', context)
 
     def _filter_valid_users(self, kyc_users):
-        valid_users = []
+        def is_user_valid(kyc_user):
+            return all(kyc_user.get(field) for field in kyc_user_api_fields)
+
         kyc_user_api_fields = self.kyc_config.get_api_field_to_user_data_map_values().values()
-        for kyc_user in kyc_users:
-            is_user_invalid = any(not kyc_user.get(field) for field in kyc_user_api_fields)
-            if is_user_invalid:
-                continue
-            valid_users.append(kyc_user)
-        return valid_users
+        return [kyc_user for kyc_user in kyc_users if is_user_valid(kyc_user)]
 
     def _report_success_on_reverification_metric(self, existing_failed_user_ids, results):
         successful_user_ids = [user_id for user_id, status in results.items() if status is True]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

When a user clicks on "Verify All"on KYC Verifiation page,  all records are currently considered for KYC verification including invalid ones. Here, invalid refers to any row (user) with missing data. In the UI, these invalid records have the Verify button disabled and cannot be selected individually.

The same logic should apply when "Verify All" is clicked, only valid rows should be considered.

This PR updates the backend view to include the same validation check, ensuring that only valid users are processed for verification.

Before the change:
![image](https://github.com/user-attachments/assets/d2c27fec-61c0-491f-9a4b-a211cafb785d)


After the change:
![image](https://github.com/user-attachments/assets/20535801-b883-489a-9746-82f4d949a115)


Side Note: Although users were considered for verification, the verification returned an error `USER_INFORMATION_INCOMPLETE`. However this is sill confusing for end user, as record should not be considered even for verification.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
KYC_INTEGRATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Local testing done.
To be tested on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
