### PR TITLE
Update wording for user limit email

### DIFF
--- a/corehq/apps/users/templates/users/email/user_limit_notice.html
+++ b/corehq/apps/users/templates/users/email/user_limit_notice.html
@@ -6,13 +6,15 @@
     {% endblocktrans %}
   {% else %}
     {% blocktrans %}
-      Please note that you have utilised 90% of the user limit included in your plan.
+      Please note that you have utilised 90% of the user limit included in your
+      plan.
     {% endblocktrans %}
   {% endif %}
   {% blocktrans %}
-    Your project currently has {{ user_count }} mobile users out of {{ plan_limit }} included in your plan.
-    Your user limit represents all mobile users that are not currently deactivated
-    (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
-    included in your plan, you will be charged as per the terms of plan.
+    Your project currently has {{ user_count }} mobile users out of
+    {{ plan_limit }} included in your plan. Your user limit represents all
+    mobile users that are not currently deactivated (see
+    <a href="{{ url }}">here</a> for more). If you exceed the number of mobile
+    users included in your plan, you will be charged as per the terms of plan.
   {% endblocktrans %}
 </p>

--- a/corehq/apps/users/templates/users/email/user_limit_notice.html
+++ b/corehq/apps/users/templates/users/email/user_limit_notice.html
@@ -1,22 +1,18 @@
 {% load i18n %}
-{% if at_capacity %}
-  <p>
+<p>
+  {% if at_capacity %}
     {% blocktrans %}
       Please note that you have reached the user limit included in your plan.
-      Your project currently has {{ user_count }} mobile users out of {{ plan_limit }} included in your plan.
-      Your user limit represents all mobile users that are not currently deactivated
-      (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
-      included in your plan, you will be charged as per the terms of plan.
     {% endblocktrans %}
-  </p>
-{% else %}
-  <p>
+  {% else %}
     {% blocktrans %}
       Please note that you have utilised 90% of the user limit included in your plan.
-      Your project currently has {{ user_count }} mobile users out of {{ plan_limit }} included in your plan.
-      Your user limit represents all mobile users that are not currently deactivated
-      (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
-      included in your plan, you will be charged as per the terms of plan.
     {% endblocktrans %}
-  </p>
-{% endif %}
+  {% endif %}
+  {% blocktrans %}
+    Your project currently has {{ user_count }} mobile users out of {{ plan_limit }} included in your plan.
+    Your user limit represents all mobile users that are not currently deactivated
+    (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
+    included in your plan, you will be charged as per the terms of plan.
+  {% endblocktrans %}
+</p>

--- a/corehq/apps/users/templates/users/email/user_limit_notice.html
+++ b/corehq/apps/users/templates/users/email/user_limit_notice.html
@@ -2,7 +2,8 @@
 {% if at_capacity %}
   <p>
     {% blocktrans %}
-      Please note that you have reached {{ user_count }} mobile users, the maximum user limit included in your plan.
+      Please note that you have reached the user limit included in your plan.
+      Your project currently has {{ user_count }} mobile users out of {{ plan_limit }} included in your plan.
       Your user limit represents all mobile users that are not currently deactivated
       (see <a href="{{ url }}">here</a> for more). If you exceed the number of mobile users
       included in your plan, you will be charged as per the terms of plan.


### PR DESCRIPTION
## Product Description
Changes wording from
> Please note that you have reached 65 mobile users, the maximum user limit included in your plan.

to

> Please note that you have reached the user limit included in your plan. Your project currently has 65 mobile users out of
    50 included in your plan.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17429
Updates wording for 100%+ and 90% of user limit reached emails to be more similar and share most of their text.

## Safety Assurance

### Safety story
This is a straightforward text change, nothing risky here.

### Automated test coverage
Unlikely for an HTML email template.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
