### PR TITLE
Also create newer indices in ES 6 in the migrations

### DIFF
--- a/corehq/apps/es/migrations/0011_add_indices_for_es5_reindex.py
+++ b/corehq/apps/es/migrations/0011_add_indices_for_es5_reindex.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
                 'analyzer': {'default': {'filter': ['lowercase'], 'tokenizer': 'whitespace', 'type': 'custom'}},
             },
             settings_key='hqapps',
-            es_versions=[5],
+            es_versions=[5, 6],
         ),
         corehq.apps.es.migration_operations.CreateIndex(
             name=index_runtime_name('case-search-2024-05-09'),
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
                 'analyzer': {'default': {'filter': ['lowercase'], 'tokenizer': 'whitespace', 'type': 'custom'}, 'phonetic': {'filter': ['standard', 'lowercase', 'soundex'], 'tokenizer': 'standard'}},
             },
             settings_key='case_search',
-            es_versions=[5],
+            es_versions=[5, 6],
         ),
         corehq.apps.es.migration_operations.CreateIndex(
             name=index_runtime_name('cases-2024-05-09'),
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
                 'analyzer': {'default': {'filter': ['lowercase'], 'tokenizer': 'whitespace', 'type': 'custom'}},
             },
             settings_key='hqcases',
-            es_versions=[5],
+            es_versions=[5, 6],
         ),
         corehq.apps.es.migration_operations.CreateIndex(
             name=index_runtime_name('domains-2024-05-09'),
@@ -76,7 +76,7 @@ class Migration(migrations.Migration):
                 'analyzer': {'comma': {'pattern': '\\s*,\\s*', 'type': 'pattern'}, 'default': {'filter': ['lowercase'], 'tokenizer': 'whitespace', 'type': 'custom'}},
             },
             settings_key='hqdomains',
-            es_versions=[5],
+            es_versions=[5, 6],
         ),
         corehq.apps.es.migration_operations.CreateIndex(
             name=index_runtime_name('forms-2024-05-09'),
@@ -91,7 +91,7 @@ class Migration(migrations.Migration):
                 'analyzer': {'default': {'filter': ['lowercase'], 'tokenizer': 'whitespace', 'type': 'custom'}},
             },
             settings_key='xforms',
-            es_versions=[5],
+            es_versions=[5, 6],
         ),
         corehq.apps.es.migration_operations.CreateIndex(
             name=index_runtime_name('groups-2024-05-09'),
@@ -106,7 +106,7 @@ class Migration(migrations.Migration):
                 'analyzer': {'default': {'filter': ['lowercase'], 'tokenizer': 'whitespace', 'type': 'custom'}},
             },
             settings_key='hqgroups',
-            es_versions=[5],
+            es_versions=[5, 6],
         ),
         corehq.apps.es.migration_operations.CreateIndex(
             name=index_runtime_name('sms-2024-05-09'),
@@ -122,7 +122,7 @@ class Migration(migrations.Migration):
                 'analyzer': {'default': {'filter': ['lowercase'], 'tokenizer': 'whitespace', 'type': 'custom'}},
             },
             settings_key='smslogs',
-            es_versions=[5],
+            es_versions=[5, 6],
         ),
         corehq.apps.es.migration_operations.CreateIndex(
             name=index_runtime_name('users-2024-05-09'),
@@ -138,6 +138,6 @@ class Migration(migrations.Migration):
                 'analyzer': {'default': {'filter': ['lowercase'], 'tokenizer': 'whitespace', 'type': 'custom'}},
             },
             settings_key='hqusers',
-            es_versions=[5],
+            es_versions=[5, 6],
         ),
     ]

--- a/corehq/apps/es/migrations/0012_add_new_index_for_bha.py
+++ b/corehq/apps/es/migrations/0012_add_new_index_for_bha.py
@@ -22,7 +22,7 @@ def _create_bha_index_on_saas_envs(apps, schema_editor):
                 'analyzer': {'default': {'filter': ['lowercase'], 'tokenizer': 'whitespace', 'type': 'custom'}, 'phonetic': {'filter': ['standard', 'lowercase', 'soundex'], 'tokenizer': 'standard'}},
             },
             settings_key='case_search_bha',
-            es_versions=[5],
+            es_versions=[5, 6],
         ).run()
 
 

--- a/corehq/apps/es/migrations/0013_add_last_modifed.py
+++ b/corehq/apps/es/migrations/0013_add_last_modifed.py
@@ -1,7 +1,8 @@
 
+from django.db import migrations
+
 import corehq.apps.es.migration_operations
 from corehq.apps.es.utils import index_runtime_name
-from django.db import migrations
 
 
 class Migration(migrations.Migration):
@@ -20,6 +21,6 @@ class Migration(migrations.Migration):
                     'format': "yyyy-MM-dd||yyyy-MM-dd'T'HH:mm:ssZZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSS||yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'||yyyy-MM-dd'T'HH:mm:ss'Z'||yyyy-MM-dd'T'HH:mm:ssZ||yyyy-MM-dd'T'HH:mm:ssZZ'Z'||yyyy-MM-dd'T'HH:mm:ss.SSSZZ||yyyy-MM-dd'T'HH:mm:ss||yyyy-MM-dd' 'HH:mm:ss||yyyy-MM-dd' 'HH:mm:ss.SSSSSS||mm/dd/yy' 'HH:mm:ss"
                 },
             },
-            es_versions=[5],
+            es_versions=[5, 6],
         ),
     ]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Now we have moved to ES 6, if anyone will start with ES 6 on a fresh env, we want their indices to automatically setup. So the changes in migrations ensure that the newer indices are created when elaticsearch's version is 6.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan
NA
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
