### PR TITLE
Fix setting rebuild flags on data source

### DIFF
--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -443,14 +443,14 @@ class DataSourceConfigurationRebuildTests(TestCase):
         self.config.meta.build.finished = True
         assert self.config.rebuild_awaiting_or_in_progress is None
 
-    def test_build_missing_table(self):
+    def test_rebuild_flag_for_missing_table(self):
         assert self.config.meta.build.awaiting is False
         self.config.set_rebuild_flags()
         assert self.config.meta.build.awaiting is True
 
     @patch('sqlalchemy.Table.exists', return_value=True)
     @patch('corehq.apps.userreports.rebuild.get_table_diffs')
-    def test_not_set_rebuild_flags_queued(self, mock_get_table_diffs, mock_table_exists):
+    def test_rebuild_flag_for_migratable_table(self, mock_get_table_diffs, mock_table_exists):
         table_name = get_table_name(self.config.domain, self.config.table_id)
         diff = MagicMock(table_name=table_name, type=DiffTypes.ADD_NULLABLE_COLUMN)
         mock_get_table_diffs.return_value = [diff]
@@ -459,7 +459,7 @@ class DataSourceConfigurationRebuildTests(TestCase):
 
     @patch('sqlalchemy.Table.exists', return_value=True)
     @patch('corehq.apps.userreports.rebuild.get_table_diffs')
-    def test_set_rebuild_flags_queued(self, mock_get_table_diffs, mock_table_exists):
+    def test_rebuild_flag_for_rebuildable_table(self, mock_get_table_diffs, mock_table_exists):
         table_name = get_table_name(self.config.domain, self.config.table_id)
         diff = MagicMock(table_name=table_name, type=DiffTypes.MODIFY_TYPE)
         mock_get_table_diffs.return_value = [diff]
@@ -468,14 +468,14 @@ class DataSourceConfigurationRebuildTests(TestCase):
 
     @patch('sqlalchemy.Table.exists', return_value=True)
     @patch('corehq.apps.userreports.rebuild.get_table_diffs')
-    def test_set_rebuild_flags_not_required(self, mock_get_table_diffs, mock_table_exists):
+    def test_rebuild_flag_for_no_change(self, mock_get_table_diffs, mock_table_exists):
         mock_get_table_diffs.return_value = []
         self.config.set_rebuild_flags()
         assert self.config.meta.build.awaiting is False
 
     @patch('sqlalchemy.Table.exists', return_value=True)
     @patch('corehq.apps.userreports.rebuild.get_table_diffs')
-    def test_set_rebuild_flags_not_required_awaiting(self, mock_get_table_diffs, mock_table_exists):
+    def test_rebuild_flag_for_already_queued_table(self, mock_get_table_diffs, mock_table_exists):
         # If a rebuild is already awaiting, it is not unset.
         mock_get_table_diffs.return_value = []
         self.config.meta.build.awaiting = True
@@ -484,8 +484,7 @@ class DataSourceConfigurationRebuildTests(TestCase):
 
     @patch('sqlalchemy.Table.exists', return_value=True)
     @patch('corehq.apps.userreports.rebuild.get_table_diffs')
-    def test_set_rebuild_flags_in_progress(self, mock_get_table_diffs, mock_table_exists):
-        # If a rebuild is in progress, it is set to awaiting.
+    def test_rebuild_flag_for_rebuilding_table(self, mock_get_table_diffs, mock_table_exists):
         table_name = get_table_name(self.config.domain, self.config.table_id)
         diff = MagicMock(table_name=table_name, type=DiffTypes.MODIFY_TYPE)
         mock_get_table_diffs.return_value = [diff]

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -443,30 +443,34 @@ class DataSourceConfigurationRebuildTests(TestCase):
         self.config.meta.build.finished = True
         assert self.config.rebuild_awaiting_or_in_progress is None
 
+    @patch('sqlalchemy.Table.exists', return_value=True)
     @patch('corehq.apps.userreports.rebuild.get_table_diffs')
-    def test_set_rebuild_flags_queued(self, mock_get_table_diffs):
+    def test_set_rebuild_flags_queued(self, mock_get_table_diffs, mock_table_exists):
         table_name = get_table_name(self.config.domain, self.config.table_id)
         diff = MagicMock(table_name=table_name, type=DiffTypes.MODIFY_TYPE)
         mock_get_table_diffs.return_value = [diff]
         self.config.set_rebuild_flags()
         assert self.config.meta.build.awaiting is True
 
+    @patch('sqlalchemy.Table.exists', return_value=True)
     @patch('corehq.apps.userreports.rebuild.get_table_diffs')
-    def test_set_rebuild_flags_not_required(self, mock_get_table_diffs):
+    def test_set_rebuild_flags_not_required(self, mock_get_table_diffs, mock_table_exists):
         mock_get_table_diffs.return_value = []
         self.config.set_rebuild_flags()
         assert self.config.meta.build.awaiting is False
 
+    @patch('sqlalchemy.Table.exists', return_value=True)
     @patch('corehq.apps.userreports.rebuild.get_table_diffs')
-    def test_set_rebuild_flags_not_required_awaiting(self, mock_get_table_diffs):
+    def test_set_rebuild_flags_not_required_awaiting(self, mock_get_table_diffs, mock_table_exists):
         # If a rebuild is already awaiting, it is not unset.
         mock_get_table_diffs.return_value = []
         self.config.meta.build.awaiting = True
         self.config.set_rebuild_flags()
         assert self.config.meta.build.awaiting is True
 
+    @patch('sqlalchemy.Table.exists', return_value=True)
     @patch('corehq.apps.userreports.rebuild.get_table_diffs')
-    def test_set_rebuild_flags_in_progress(self, mock_get_table_diffs):
+    def test_set_rebuild_flags_in_progress(self, mock_get_table_diffs, mock_table_exists):
         # If a rebuild is in progress, it is set to awaiting.
         table_name = get_table_name(self.config.domain, self.config.table_id)
         diff = MagicMock(table_name=table_name, type=DiffTypes.MODIFY_TYPE)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Bugfix. This fixes the behavior which sets a flag on data source when they are created/edited to mark them awaiting for rebuild.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SC-4464
The issue was mainly around using cached metadata about tables, which resulted in faulty settings.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
USER_CONFIGURABLE_REPORTS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and on staging, added/updated tests.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
