### PR TITLE
Add notice and confirmation when signing up for a Pay Annually plan

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -23,6 +23,8 @@ var confirmPlanModel = function (isMonthlyUpgrade, isSameEdition, isPaused, isAn
     self.isPaused = isPaused;
     self.currentPlan = currentPlan;
 
+    // If the user is upgrading or subscribing to Pay Annually,
+    // don't let them continue until they agree to the minimum subscription terms
     self.oUserAgreementSigned = ko.observable(!(isMonthlyUpgrade || isAnnualPlan));
 
     self.downgradeReasonList = [

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -14,13 +14,10 @@ var LIMITED_FEATURES = gettext("I need more limited features");
 var MORE_FEATURES = gettext("I need additional/custom features");
 var OTHER = gettext("Other");
 
-var confirmPlanModel = function (isMonthlyUpgrade, isSameEdition, isPaused, isAnnualPlan, isDowngrade, currentPlan) {
+var confirmPlanModel = function (isMonthlyUpgrade, isPaused, isAnnualPlan, isDowngrade, currentPlan) {
     var self = {};
 
-    self.isUpgrade = isMonthlyUpgrade;
-    self.isSameEdition = isSameEdition;
     self.isDowngrade = isDowngrade;
-    self.isPaused = isPaused;
     self.currentPlan = currentPlan;
 
     // If the user is upgrading or subscribing to Pay Annually,
@@ -33,7 +30,7 @@ var confirmPlanModel = function (isMonthlyUpgrade, isSameEdition, isPaused, isAn
         SWITCH_TOOLS,
     ];
 
-    if (!self.isPaused) {
+    if (!isPaused) {
         self.downgradeReasonList.push(CONTINUE_COMMCARE);
     }
 
@@ -108,7 +105,6 @@ var confirmPlanModel = function (isMonthlyUpgrade, isSameEdition, isPaused, isAn
 $(function () {
     var confirmPlan = confirmPlanModel(
         initialPageData.get('is_monthly_upgrade'),
-        initialPageData.get('is_same_edition'),
         initialPageData.get('is_paused'),
         initialPageData.get('is_annual_plan'),
         initialPageData.get('is_downgrade'),

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -14,7 +14,7 @@ var LIMITED_FEATURES = gettext("I need more limited features");
 var MORE_FEATURES = gettext("I need additional/custom features");
 var OTHER = gettext("Other");
 
-var confirmPlanModel = function (isUpgrade, isSameEdition, isPaused, currentPlan) {
+var confirmPlanModel = function (isUpgrade, isSameEdition, isPaused, isAnnualPlan, currentPlan) {
     var self = {};
 
     self.isUpgrade = isUpgrade;
@@ -23,7 +23,7 @@ var confirmPlanModel = function (isUpgrade, isSameEdition, isPaused, currentPlan
     self.currentPlan = currentPlan;
 
     // If the user is upgrading, don't let them continue until they agree to the minimum subscription terms
-    self.oUserAgreementSigned = ko.observable(!isUpgrade || isSameEdition);
+    self.oUserAgreementSigned = ko.observable(!(isUpgrade || isAnnualPlan));
 
     self.downgradeReasonList = [
         PROJECT_ENDED,
@@ -108,6 +108,7 @@ $(function () {
         initialPageData.get('is_upgrade'),
         initialPageData.get('is_same_edition'),
         initialPageData.get('is_paused'),
+        initialPageData.get('is_annual_plan'),
         initialPageData.get('current_plan'),
     );
 

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -14,16 +14,16 @@ var LIMITED_FEATURES = gettext("I need more limited features");
 var MORE_FEATURES = gettext("I need additional/custom features");
 var OTHER = gettext("Other");
 
-var confirmPlanModel = function (isUpgrade, isSameEdition, isPaused, isAnnualPlan, currentPlan) {
+var confirmPlanModel = function (isMonthlyUpgrade, isSameEdition, isPaused, isAnnualPlan, isDowngrade, currentPlan) {
     var self = {};
 
-    self.isUpgrade = isUpgrade;
+    self.isUpgrade = isMonthlyUpgrade;
     self.isSameEdition = isSameEdition;
+    self.isDowngrade = isDowngrade;
     self.isPaused = isPaused;
     self.currentPlan = currentPlan;
 
-    // If the user is upgrading, don't let them continue until they agree to the minimum subscription terms
-    self.oUserAgreementSigned = ko.observable(!(isUpgrade || isAnnualPlan));
+    self.oUserAgreementSigned = ko.observable(!(isMonthlyUpgrade || isAnnualPlan));
 
     self.downgradeReasonList = [
         PROJECT_ENDED,
@@ -73,11 +73,11 @@ var confirmPlanModel = function (isUpgrade, isSameEdition, isPaused, isAnnualPla
     self.form = undefined;
     self.openDowngradeModal = function (confirmPlanModel, e) {
         self.form = $(e.currentTarget).closest("form");
-        if (confirmPlanModel.isUpgrade || confirmPlanModel.isSameEdition) {
-            self.form.submit();
-        } else {
+        if (confirmPlanModel.isDowngrade) {
             var $modal = $("#modal-downgrade");
             $modal.modal('show');
+        } else {
+            self.form.submit();
         }
     };
     self.submitDowngrade = function (pricingTable, e) {
@@ -105,10 +105,11 @@ var confirmPlanModel = function (isUpgrade, isSameEdition, isPaused, isAnnualPla
 
 $(function () {
     var confirmPlan = confirmPlanModel(
-        initialPageData.get('is_upgrade'),
+        initialPageData.get('is_monthly_upgrade'),
         initialPageData.get('is_same_edition'),
         initialPageData.get('is_paused'),
         initialPageData.get('is_annual_plan'),
+        initialPageData.get('is_downgrade'),
         initialPageData.get('current_plan'),
     );
 

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -50,7 +50,7 @@
   </h4>
 
   {% if is_annual_plan %}
-    <p class="text-free">
+    <p class="alert-subscription-text">
       {% blocktrans %}
         By continuing you are subscribing to a Pay Annually plan and will
         receive an invoice via email for plan fees due. In case you incur any
@@ -64,7 +64,7 @@
       {% endblocktrans %}
     </p>
   {% elif is_upgrade %}
-    <p class="text-free">
+    <p class="alert-subscription-text">
       {% blocktrans with next_invoice_date as invoice_date %}
         CommCare is billed on a monthly basis, and all subscriptions require a
         30 day minimum commitment. You should expect your first invoice on
@@ -76,7 +76,7 @@
         >.
       {% endblocktrans %}
     </p>
-    <p class="text-free">
+    <p class="alert-subscription-text">
       {% blocktrans %}
         Once you subscribe to a paid plan, you will be able to pause your
         subscription after 30 days, but you will no longer be able to downgrade

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -107,7 +107,7 @@
     </p>
   {% endif %}
 
-  {% if is_upgrade %}
+  {% if is_upgrade or is_annual_plan %}
     <p>
       <strong>
         {% blocktrans %}

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -63,7 +63,7 @@
         for more information about payment, cancellation, and refunds.
       {% endblocktrans %}
     </p>
-  {% elif is_upgrade %}
+  {% elif is_monthly_upgrade %}
     <p class="alert-subscription-text">
       {% blocktrans with next_invoice_date as invoice_date %}
         CommCare is billed on a monthly basis, and all subscriptions require a
@@ -92,6 +92,7 @@
       {% endblocktrans %}
     </p>
   {% endif %}
+
   {% if is_downgrade_before_minimum %}
     <p>
       {% blocktrans with current_plan as p %}
@@ -102,7 +103,7 @@
         will be downgraded to the {{ new_plan_edition }} Edition Software Plan.
       {% endblocktrans %}
     </p>
-  {% elif not is_upgrade and not is_same_edition %}
+  {% elif is_downgrade %}
     <p>
       {% blocktrans with current_plan as p %}
         We're sorry to see you downgrade! You are currently subscribed to the
@@ -111,7 +112,7 @@
     </p>
   {% endif %}
 
-  {% if is_upgrade or is_annual_plan %}
+  {% if is_monthly_upgrade or is_annual_plan %}
     <p>
       <strong>
         {% blocktrans %}

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -1,28 +1,20 @@
 {% load i18n %}
 
 {% if not is_renewal_page %}
-<p class="lead text-center">
-  {% blocktrans with plan.name as p %}
-    You have selected the <strong>{{ p }} Edition</strong> subscription.
-  {% endblocktrans %}
-</p>
+  <p class="lead text-center">
+    {% blocktrans with plan.name as p %}
+      You have selected the <strong>{{ p }} Edition</strong> subscription.
+    {% endblocktrans %}
+  </p>
 {% endif %}
 <div class="confirm-plan-summary">
   <div class="tile {{ tile_css }}">
-    <h3>
-      {{ plan.name }}
-    </h3>
-    <p class="plan-price">
-      {{ plan.monthly_fee }}
-    </p>
+    <h3>{{ plan.name }}</h3>
+    <p class="plan-price">{{ plan.monthly_fee }}</p>
     <p class="plan-monthly-label">
-      <strong>
-        {% trans "Monthly Fee" %}
-      </strong>
+      <strong> {% trans "Monthly Fee" %} </strong>
     </p>
-    <h4>
-      {% trans 'Included each month' %}
-    </h4>
+    <h4>{% trans 'Included each month' %}</h4>
     <div class="plan-included well well-sm">
       <dl class="dl-horizontal">
         {% for rate in plan.rates %}
@@ -33,13 +25,13 @@
         {% endfor %}
       </dl>
     </div>
-    <p class="plan-desc">
-      {{ plan.description }}
-    </p>
+    <p class="plan-desc">{{ plan.description }}</p>
   </div>
 </div>
 
-<div class="alert {% if is_same_edition %}alert-info{% else %}alert-warning{% endif %} alert-subscription">
+<div
+  class="alert {% if is_same_edition %}alert-info{% else %}alert-warning{% endif %} alert-subscription"
+>
   {% if is_same_edition %}
     <h4>
       {% blocktrans %}
@@ -47,9 +39,7 @@
       {% endblocktrans %}
     </h4>
   {% elif is_downgrade_before_minimum %}
-    <h4>
-      {% trans "We're sorry to see you downgrade!" %}
-    </h4>
+    <h4>{% trans "We're sorry to see you downgrade!" %}</h4>
   {% else %}
     <h4>
       <i class="fa fa-warning"></i>
@@ -60,32 +50,43 @@
   {% if is_annual_plan %}
     <p class="text-free">
       {% blocktrans %}
-        By continuing you are subscribing to a Pay Annually plan and will receive an invoice via email for plan fees due.
-        In case you incur any on-demand fees for excess users or SMS, you will receive invoices for these charges on a monthly basis.
-        See <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Pay-Annually-Subscription">here</a>
+        By continuing you are subscribing to a Pay Annually plan and will
+        receive an invoice via email for plan fees due. In case you incur any
+        on-demand fees for excess users or SMS, you will receive invoices for
+        these charges on a monthly basis. See
+        <a
+          href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Pay-Annually-Subscription"
+          >here</a
+        >
         for more information about payment, cancellation, and refunds.
       {% endblocktrans %}
     </p>
   {% elif is_upgrade %}
     <p class="text-free">
       {% blocktrans with next_invoice_date as invoice_date %}
-        CommCare is billed on a monthly basis, and all subscriptions require a 30 day minimum commitment.
-        You should expect your first invoice on {{ invoice_date }}, or you can prepay for your
-        subscription by following the instructions
-        <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods">here</a>.
+        CommCare is billed on a monthly basis, and all subscriptions require a
+        30 day minimum commitment. You should expect your first invoice on
+        {{ invoice_date }}, or you can prepay for your subscription by following
+        the instructions
+        <a
+          href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods"
+          >here</a
+        >.
       {% endblocktrans %}
     </p>
     <p class="text-free">
       {% blocktrans %}
-        Once you subscribe to a paid plan, you will be able to pause your subscription after 30 days,
-        but you will no longer be able to downgrade to the CommCare Free edition.
+        Once you subscribe to a paid plan, you will be able to pause your
+        subscription after 30 days, but you will no longer be able to downgrade
+        to the CommCare Free edition.
       {% endblocktrans %}
     </p>
   {% elif is_same_edition %}
     <p>
       {% blocktrans with current_plan as p %}
-        Continuing will keep you on <strong>{{ p }} Edition Software Plan</strong> and any
-        pending subscriptions will be cancelled.
+        Continuing will keep you on
+        <strong>{{ p }} Edition Software Plan</strong> and any pending
+        subscriptions will be cancelled.
       {% endblocktrans %}
     </p>
   {% endif %}
@@ -93,9 +94,10 @@
     <p>
       {% blocktrans with current_plan as p %}
         You’ll have access to the features on your
-        <strong>{{ p }} Edition Software Plan </strong> through {{ current_subscription_end_date }}.<br />
-        On {{ start_date_after_minimum_subscription }} your current subscription will be downgraded
-        to the {{ new_plan_edition }} Edition Software Plan.
+        <strong>{{ p }} Edition Software Plan </strong> through
+        {{ current_subscription_end_date }}.<br />
+        On {{ start_date_after_minimum_subscription }} your current subscription
+        will be downgraded to the {{ new_plan_edition }} Edition Software Plan.
       {% endblocktrans %}
     </p>
   {% elif not is_upgrade and not is_same_edition %}
@@ -111,7 +113,8 @@
     <p>
       <strong>
         {% blocktrans %}
-          <input type="checkbox" data-bind="checked: oUserAgreementSigned"> I understand and wish to continue.
+          <input type="checkbox" data-bind="checked: oUserAgreementSigned" /> I
+          understand and wish to continue.
         {% endblocktrans %}
       </strong>
     </p>

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -57,7 +57,16 @@
     </h4>
   {% endif %}
 
-  {% if is_upgrade %}
+  {% if is_annual_plan %}
+    <p class="text-free">
+      {% blocktrans %}
+        By continuing you are subscribing to a Pay Annually plan and will receive an invoice via email for plan fees due.
+        In case you incur any on-demand fees for excess users or SMS, you will receive invoices for these charges on a monthly basis.
+        See <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Pay-Annually-Subscription">here</a>
+        for more information about payment, cancellation, and refunds.
+      {% endblocktrans %}
+    </p>
+  {% elif is_upgrade %}
     <p class="text-free">
       {% blocktrans with next_invoice_date as invoice_date %}
         CommCare is billed on a monthly basis, and all subscriptions require a 30 day minimum commitment.
@@ -79,7 +88,8 @@
         pending subscriptions will be cancelled.
       {% endblocktrans %}
     </p>
-  {% elif is_downgrade_before_minimum %}
+  {% endif %}
+  {% if is_downgrade_before_minimum %}
     <p>
       {% blocktrans with current_plan as p %}
         You’ll have access to the features on your
@@ -88,7 +98,7 @@
         to the {{ new_plan_edition }} Edition Software Plan.
       {% endblocktrans %}
     </p>
-  {% else %}
+  {% elif not is_upgrade and not is_same_edition %}
     <p>
       {% blocktrans with current_plan as p %}
         We're sorry to see you downgrade! You are currently subscribed to the

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -38,72 +38,71 @@
     </p>
   </div>
 </div>
-{% if current_plan %}
-  <div class="alert {% if is_same_edition %}alert-info{% else %}alert-warning{% endif %} alert-subscription">
-    {% if is_upgrade %}
-      <h4>
-        <i class="fa fa-warning"></i>
-        {% trans "Note: Continuing will change your current subscription." %}
-      </h4>
-      <p class="text-free">
-        {% blocktrans with next_invoice_date as invoice_date %}
-          CommCare is billed on a monthly basis, and all subscriptions require a 30 day minimum commitment.
-          You should expect your first invoice on {{ invoice_date }}, or you can prepay for your
-          subscription by following the instructions
-          <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods">here</a>.
-        {% endblocktrans %}
-      </p>
-      <p class="text-free">
+
+<div class="alert {% if is_same_edition %}alert-info{% else %}alert-warning{% endif %} alert-subscription">
+  {% if is_upgrade %}
+    <h4>
+      <i class="fa fa-warning"></i>
+      {% trans "Note: Continuing will change your current subscription." %}
+    </h4>
+    <p class="text-free">
+      {% blocktrans with next_invoice_date as invoice_date %}
+        CommCare is billed on a monthly basis, and all subscriptions require a 30 day minimum commitment.
+        You should expect your first invoice on {{ invoice_date }}, or you can prepay for your
+        subscription by following the instructions
+        <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Payment-Methods">here</a>.
+      {% endblocktrans %}
+    </p>
+    <p class="text-free">
+      {% blocktrans %}
+        Once you subscribe to a paid plan, you will be able to pause your subscription after 30 days,
+        but you will no longer be able to downgrade to the CommCare Free edition.
+      {% endblocktrans %}
+    </p>
+    <p>
+      <strong>
         {% blocktrans %}
-          Once you subscribe to a paid plan, you will be able to pause your subscription after 30 days,
-          but you will no longer be able to downgrade to the CommCare Free edition.
+          <input type="checkbox" data-bind="checked: oUserAgreementSigned"> I understand and wish to continue.
         {% endblocktrans %}
-      </p>
-      <p>
-        <strong>
-          {% blocktrans %}
-            <input type="checkbox" data-bind="checked: oUserAgreementSigned"> I understand and wish to continue.
-          {% endblocktrans %}
-        </strong>
-      </p>
-    {% elif is_same_edition %}
-      <h4>
-        {% blocktrans %}
-          Thank you for staying with your current subscription.
-        {% endblocktrans %}
-      </h4>
-      <p>
-        {% blocktrans with current_plan as p %}
-          Continuing will keep you on <strong>{{ p }} Edition Software Plan</strong> and any
-          pending subscriptions will be cancelled.
-        {% endblocktrans %}
-      </p>
-    {% elif is_downgrade_before_minimum %}
-      <h4>
-        {% trans "We're sorry to see you downgrade!" %}
-      </h4>
-      <p>
-        {% blocktrans with current_plan as p %}
-          You’ll have access to the features on your
-          <strong>{{ p }} Edition Software Plan </strong> through {{ current_subscription_end_date }}.<br />
-          On {{ start_date_after_minimum_subscription }} your current subscription will be downgraded
-          to the {{ new_plan_edition }} Edition Software Plan.
-        {% endblocktrans %}
-      </p>
-    {% else %}
-      <h4>
-        <i class="fa fa-warning"></i>
-        {% trans "Note: Continuing will change your current subscription." %}
-      </h4>
-      <p>
-        {% blocktrans with current_plan as p %}
-          We're sorry to see you downgrade! You are currently subscribed to the
-          <strong>{{ p }} Software Plan.</strong>
-        {% endblocktrans %}
-      </p>
-    {% endif %}
-  </div>
-{% endif %}
+      </strong>
+    </p>
+  {% elif is_same_edition %}
+    <h4>
+      {% blocktrans %}
+        Thank you for staying with your current subscription.
+      {% endblocktrans %}
+    </h4>
+    <p>
+      {% blocktrans with current_plan as p %}
+        Continuing will keep you on <strong>{{ p }} Edition Software Plan</strong> and any
+        pending subscriptions will be cancelled.
+      {% endblocktrans %}
+    </p>
+  {% elif is_downgrade_before_minimum %}
+    <h4>
+      {% trans "We're sorry to see you downgrade!" %}
+    </h4>
+    <p>
+      {% blocktrans with current_plan as p %}
+        You’ll have access to the features on your
+        <strong>{{ p }} Edition Software Plan </strong> through {{ current_subscription_end_date }}.<br />
+        On {{ start_date_after_minimum_subscription }} your current subscription will be downgraded
+        to the {{ new_plan_edition }} Edition Software Plan.
+      {% endblocktrans %}
+    </p>
+  {% else %}
+    <h4>
+      <i class="fa fa-warning"></i>
+      {% trans "Note: Continuing will change your current subscription." %}
+    </h4>
+    <p>
+      {% blocktrans with current_plan as p %}
+        We're sorry to see you downgrade! You are currently subscribed to the
+        <strong>{{ p }} Software Plan.</strong>
+      {% endblocktrans %}
+    </p>
+  {% endif %}
+</div>
 
 {% if downgrade_messages and not is_same_edition %}
   {% include 'accounting/partials/downgrade_messages.html' with messages=downgrade_messages only %}

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -40,12 +40,7 @@
 </div>
 
 <div class="alert {% if is_same_edition %}alert-info{% else %}alert-warning{% endif %} alert-subscription">
-  {% if is_upgrade %}
-    <h4>
-      <i class="fa fa-warning"></i>
-      {% trans "Note: Continuing will change your current subscription." %}
-    </h4>
-  {% elif is_same_edition %}
+  {% if is_same_edition %}
     <h4>
       {% blocktrans %}
         Thank you for staying with your current subscription.

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -32,20 +32,22 @@
 <div
   class="alert {% if is_same_edition %}alert-info{% else %}alert-warning{% endif %} alert-subscription"
 >
-  {% if is_same_edition %}
-    <h4>
+  <h4>
+    {% if is_same_edition %}
       {% blocktrans %}
         Thank you for staying with your current subscription.
       {% endblocktrans %}
-    </h4>
-  {% elif is_downgrade_before_minimum %}
-    <h4>{% trans "We're sorry to see you downgrade!" %}</h4>
-  {% else %}
-    <h4>
+    {% elif is_downgrade_before_minimum %}
+      {% blocktrans %}
+        We're sorry to see you downgrade!
+      {% endblocktrans %}
+    {% else %}
       <i class="fa fa-warning"></i>
-      {% trans "Note: Continuing will change your current subscription." %}
-    </h4>
-  {% endif %}
+      {% blocktrans %}
+        Note: Continuing will change your current subscription.
+      {% endblocktrans %}
+    {% endif %}
+  </h4>
 
   {% if is_annual_plan %}
     <p class="text-free">

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -45,6 +45,24 @@
       <i class="fa fa-warning"></i>
       {% trans "Note: Continuing will change your current subscription." %}
     </h4>
+  {% elif is_same_edition %}
+    <h4>
+      {% blocktrans %}
+        Thank you for staying with your current subscription.
+      {% endblocktrans %}
+    </h4>
+  {% elif is_downgrade_before_minimum %}
+    <h4>
+      {% trans "We're sorry to see you downgrade!" %}
+    </h4>
+  {% else %}
+    <h4>
+      <i class="fa fa-warning"></i>
+      {% trans "Note: Continuing will change your current subscription." %}
+    </h4>
+  {% endif %}
+
+  {% if is_upgrade %}
     <p class="text-free">
       {% blocktrans with next_invoice_date as invoice_date %}
         CommCare is billed on a monthly basis, and all subscriptions require a 30 day minimum commitment.
@@ -59,19 +77,7 @@
         but you will no longer be able to downgrade to the CommCare Free edition.
       {% endblocktrans %}
     </p>
-    <p>
-      <strong>
-        {% blocktrans %}
-          <input type="checkbox" data-bind="checked: oUserAgreementSigned"> I understand and wish to continue.
-        {% endblocktrans %}
-      </strong>
-    </p>
   {% elif is_same_edition %}
-    <h4>
-      {% blocktrans %}
-        Thank you for staying with your current subscription.
-      {% endblocktrans %}
-    </h4>
     <p>
       {% blocktrans with current_plan as p %}
         Continuing will keep you on <strong>{{ p }} Edition Software Plan</strong> and any
@@ -79,9 +85,6 @@
       {% endblocktrans %}
     </p>
   {% elif is_downgrade_before_minimum %}
-    <h4>
-      {% trans "We're sorry to see you downgrade!" %}
-    </h4>
     <p>
       {% blocktrans with current_plan as p %}
         You’ll have access to the features on your
@@ -91,15 +94,21 @@
       {% endblocktrans %}
     </p>
   {% else %}
-    <h4>
-      <i class="fa fa-warning"></i>
-      {% trans "Note: Continuing will change your current subscription." %}
-    </h4>
     <p>
       {% blocktrans with current_plan as p %}
         We're sorry to see you downgrade! You are currently subscribed to the
         <strong>{{ p }} Software Plan.</strong>
       {% endblocktrans %}
+    </p>
+  {% endif %}
+
+  {% if is_upgrade %}
+    <p>
+      <strong>
+        {% blocktrans %}
+          <input type="checkbox" data-bind="checked: oUserAgreementSigned"> I understand and wish to continue.
+        {% endblocktrans %}
+      </strong>
     </p>
   {% endif %}
 </div>

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -30,7 +30,14 @@
 </div>
 
 <div
-  class="alert {% if is_same_edition %}alert-info{% else %}alert-warning{% endif %} alert-subscription"
+  class="
+    alert alert-subscription
+    {% if is_same_edition %}
+      alert-info
+    {% else %}
+      alert-warning
+    {% endif %}
+  "
 >
   <h4>
     {% if is_same_edition %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/confirm_plan.html
@@ -4,8 +4,9 @@
 {% js_entry_b3 'accounting/js/confirm_plan' %}
 
 {% block form_content %}
-  {% initial_page_data 'is_upgrade' is_upgrade %}
+  {% initial_page_data 'is_monthly_upgrade' is_monthly_upgrade %}
   {% initial_page_data 'is_same_edition' is_same_edition %}
+  {% initial_page_data 'is_downgrade' is_downgrade %}
   {% initial_page_data 'is_paused' is_paused %}
   {% initial_page_data 'is_annual_plan' is_annual_plan %}
   {% initial_page_data 'next_invoice_date' next_invoice_date %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/confirm_plan.html
@@ -4,16 +4,11 @@
 {% js_entry_b3 'accounting/js/confirm_plan' %}
 
 {% block form_content %}
+  {% initial_page_data 'is_annual_plan' is_annual_plan %}
   {% initial_page_data 'is_monthly_upgrade' is_monthly_upgrade %}
-  {% initial_page_data 'is_same_edition' is_same_edition %}
   {% initial_page_data 'is_downgrade' is_downgrade %}
   {% initial_page_data 'is_paused' is_paused %}
-  {% initial_page_data 'is_annual_plan' is_annual_plan %}
-  {% initial_page_data 'next_invoice_date' next_invoice_date %}
   {% initial_page_data 'current_plan' current_plan %}
-  {% initial_page_data 'new_plan_edition' new_plan_edition %}
-  {% initial_page_data 'is_downgrade_before_minimum' is_downgrade_before_minimum %}
-  {% initial_page_data 'current_subscription_end_date' current_subscription_end_date %}
   {% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}
   {% registerurl 'confirm_billing_account_info' domain %}
 

--- a/corehq/apps/domain/templates/domain/bootstrap3/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/confirm_plan.html
@@ -1,7 +1,6 @@
 {% extends "domain/bootstrap3/base_change_plan.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
-
 {% js_entry_b3 'accounting/js/confirm_plan' %}
 
 {% block form_content %}
@@ -24,34 +23,57 @@
       {% include 'accounting/partials/confirm_plan_summary.html' %}
     {% endif %}
 
-    <form action="{% if is_paused %}{% url 'pause_subscription' domain %}{% else %}{% url 'confirm_billing_account_info' domain %}{% endif %}"
-          method="post"
-          class="form">
+    <form
+      action="{% if is_paused %}{% url 'pause_subscription' domain %}{% else %}{% url 'confirm_billing_account_info' domain %}{% endif %}"
+      method="post"
+      class="form"
+    >
       {% csrf_token %}
       <input type="hidden" value="{{ plan.edition }}" name="plan_edition" />
-      <input type="hidden" value="" name="downgrade_reason" id="downgrade-reason"/>
-      <input type="hidden" value="" name="will_project_restart" id="will-project-restart"/>
-      <input type="hidden" value="" name="new_tool" id="new-tool"/>
-      <input type="hidden" value="" name="new_tool_reason" id="new-tool-reason"/>
-      <input type="hidden" value="" name="feedback" id="feedback"/>
+      <input
+        type="hidden"
+        value=""
+        name="downgrade_reason"
+        id="downgrade-reason"
+      />
+      <input
+        type="hidden"
+        value=""
+        name="will_project_restart"
+        id="will-project-restart"
+      />
+      <input type="hidden" value="" name="new_tool" id="new-tool" />
+      <input
+        type="hidden"
+        value=""
+        name="new_tool_reason"
+        id="new-tool-reason"
+      />
+      <input type="hidden" value="" name="feedback" id="feedback" />
       {% if not is_paused %}
         <hr />
         <p class="text-center">
           {% blocktrans %}
-            Clicking the 'Confirm Plan' button below will bring you to a page where you can confirm your billing information.
+            Clicking the 'Confirm Plan' button below will bring you to a page
+            where you can confirm your billing information.
           {% endblocktrans %}
         </p>
       {% endif %}
       <div class="text-center plan-next">
-        <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default btn-lg">
+        <a
+          href="{% url 'domain_select_plan' domain %}"
+          class="btn btn-default btn-lg"
+        >
           {% if is_paused %}
             {% trans 'Select different option' %}
           {% else %}
             {% trans 'Select different plan' %}
           {% endif %}
         </a>
-        <button class="btn btn-primary btn-lg"
-                data-bind="enable: oUserAgreementSigned, click: openDowngradeModal">
+        <button
+          class="btn btn-primary btn-lg"
+          data-bind="enable: oUserAgreementSigned, click: openDowngradeModal"
+        >
           {% if is_paused %}
             {% trans 'Confirm Pause' %}
           {% else %}
@@ -60,11 +82,11 @@
         </button>
       </div>
     </form>
-
   </div>
 {% endblock %}
 
-{% block modals %}{{ block.super }}
+{% block modals %}
+  {{ block.super }}
   <div class="modal fade" id="modal-downgrade">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -84,8 +106,8 @@
         <div class="modal-body">
           <p class="lead">
             {% blocktrans %}
-              We'd love to make CommCare work better for you.
-              Please help us by answering these simple questions.
+              We'd love to make CommCare work better for you. Please help us by
+              answering these simple questions.
             {% endblocktrans %}
           </p>
 
@@ -99,82 +121,85 @@
                 Why are you downgrading your subscription today?
               {% endblocktrans %}
             {% endif %}
-            <select multiple="multiple"
-                    class="form-control"
-                    data-bind="selectedOptions: oDowngradeReason,
-                               options: downgradeReasonList"></select>
+            <select
+              multiple="multiple"
+              class="form-control"
+              data-bind="selectedOptions: oDowngradeReason,
+                         options: downgradeReasonList"
+            ></select>
           </p>
 
           <!-- ko if: oProjectEnded -->
-            <p>
-              {% blocktrans %}
-                Do you think your project may start again?
-              {% endblocktrans %}
-              <select class="form-control"
-                      data-bind="value: oWillProjectRestart">
-                <option value="yes">
-                  {% trans "Yes" %}
-                </option>
-                <option value="no"
-                        selected="selected">
-                  {% trans "No" %}
-                </option>
-              </select>
-            </p>
+          <p>
+            {% blocktrans %}
+              Do you think your project may start again?
+            {% endblocktrans %}
+            <select class="form-control" data-bind="value: oWillProjectRestart">
+              <option value="yes">{% trans "Yes" %}</option>
+              <option value="no" selected="selected">{% trans "No" %}</option>
+            </select>
+          </p>
           <!-- /ko -->
 
           <!-- ko if: oNewToolNeeded -->
-            <p>
-              {% blocktrans %}
-                Could you indicate which new tool you’re using?
-              {% endblocktrans %}
-              <textarea class="form-control vertical-resize"
-                        data-bind="textInput: oNewTool"></textarea>
-            </p>
-            <p>
-              {% blocktrans %}
-                Why are you switching to a new tool?
-              {% endblocktrans %}
-              <select multiple="multiple"
-                      class="form-control"
-                      data-bind="selectedOptions: oNewToolReason,
-                                 options: newToolReasonList"></select>
-            </p>
+          <p>
+            {% blocktrans %}
+              Could you indicate which new tool you’re using?
+            {% endblocktrans %}
+            <textarea
+              class="form-control vertical-resize"
+              data-bind="textInput: oNewTool"
+            ></textarea>
+          </p>
+          <p>
+            {% blocktrans %}
+              Why are you switching to a new tool?
+            {% endblocktrans %}
+            <select
+              multiple="multiple"
+              class="form-control"
+              data-bind="selectedOptions: oNewToolReason,
+                         options: newToolReasonList"
+            ></select>
+          </p>
           <!-- /ko -->
 
           <!-- ko if: oOtherSelected -->
-            <p>
-              {% blocktrans %}
-                Please specify
-              {% endblocktrans %}
-              <textarea class="form-control vertical-resize"
-                        data-bind="textInput: oOtherNewToolReason"></textarea>
-            </p>
+          <p>
+            {% blocktrans %}
+              Please specify
+            {% endblocktrans %}
+            <textarea
+              class="form-control vertical-resize"
+              data-bind="textInput: oOtherNewToolReason"
+            ></textarea>
+          </p>
           <!-- /ko -->
 
           <p>
             {% blocktrans %}
               Please let us know any other feedback you have
             {% endblocktrans %}
-            <textarea class="form-control vertical-resize"
-                      data-bind="textInput: oFeedback"></textarea>
+            <textarea
+              class="form-control vertical-resize"
+              data-bind="textInput: oFeedback"
+            ></textarea>
           </p>
-
         </div>
         <div class="modal-footer">
           <!-- ko if: oRequiredQuestionsAnswered -->
-            <button type="button"
-                    class="btn btn-primary"
-                    data-bind="click: submitDowngrade">
-              {% trans "Continue" %}
-            </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-bind="click: submitDowngrade"
+          >
+            {% trans "Continue" %}
+          </button>
           <!-- /ko -->
           <!-- ko ifnot: oRequiredQuestionsAnswered -->
-            <button type="button"
-                    disabled="disabled"
-                    class="btn btn-default">
-              {% trans "Continue" %}
-            </button>
+          <button type="button" disabled="disabled" class="btn btn-default">
+            {% trans "Continue" %}
+          </button>
           <!-- /ko -->
         </div>
       </div>

--- a/corehq/apps/domain/templates/domain/bootstrap3/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/confirm_plan.html
@@ -8,6 +8,7 @@
   {% initial_page_data 'is_upgrade' is_upgrade %}
   {% initial_page_data 'is_same_edition' is_same_edition %}
   {% initial_page_data 'is_paused' is_paused %}
+  {% initial_page_data 'is_annual_plan' is_annual_plan %}
   {% initial_page_data 'next_invoice_date' next_invoice_date %}
   {% initial_page_data 'current_plan' current_plan %}
   {% initial_page_data 'new_plan_edition' new_plan_edition %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/confirm_plan.html
@@ -1,7 +1,6 @@
 {% extends "domain/bootstrap5/base_change_plan.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
-
 {% js_entry 'accounting/js/confirm_plan' %}
 
 {% block form_content %}
@@ -24,34 +23,57 @@
       {% include 'accounting/partials/confirm_plan_summary.html' %}
     {% endif %}
 
-    <form action="{% if is_paused %}{% url 'pause_subscription' domain %}{% else %}{% url 'confirm_billing_account_info' domain %}{% endif %}"
-          method="post"
-          class="form">
+    <form
+      action="{% if is_paused %}{% url 'pause_subscription' domain %}{% else %}{% url 'confirm_billing_account_info' domain %}{% endif %}"
+      method="post"
+      class="form"
+    >
       {% csrf_token %}
       <input type="hidden" value="{{ plan.edition }}" name="plan_edition" />
-      <input type="hidden" value="" name="downgrade_reason" id="downgrade-reason"/>
-      <input type="hidden" value="" name="will_project_restart" id="will-project-restart"/>
-      <input type="hidden" value="" name="new_tool" id="new-tool"/>
-      <input type="hidden" value="" name="new_tool_reason" id="new-tool-reason"/>
-      <input type="hidden" value="" name="feedback" id="feedback"/>
+      <input
+        type="hidden"
+        value=""
+        name="downgrade_reason"
+        id="downgrade-reason"
+      />
+      <input
+        type="hidden"
+        value=""
+        name="will_project_restart"
+        id="will-project-restart"
+      />
+      <input type="hidden" value="" name="new_tool" id="new-tool" />
+      <input
+        type="hidden"
+        value=""
+        name="new_tool_reason"
+        id="new-tool-reason"
+      />
+      <input type="hidden" value="" name="feedback" id="feedback" />
       {% if not is_paused %}
         <hr />
         <p class="text-center">
           {% blocktrans %}
-            Clicking the 'Confirm Plan' button below will bring you to a page where you can confirm your billing information.
+            Clicking the 'Confirm Plan' button below will bring you to a page
+            where you can confirm your billing information.
           {% endblocktrans %}
         </p>
       {% endif %}
       <div class="text-center plan-next">
-        <a href="{% url 'domain_select_plan' domain %}" class="btn btn-outline-primary btn-lg">
+        <a
+          href="{% url 'domain_select_plan' domain %}"
+          class="btn btn-outline-primary btn-lg"
+        >
           {% if is_paused %}
             {% trans 'Select different option' %}
           {% else %}
             {% trans 'Select different plan' %}
           {% endif %}
         </a>
-        <button class="btn btn-primary btn-lg"
-                data-bind="enable: oUserAgreementSigned, click: openDowngradeModal">
+        <button
+          class="btn btn-primary btn-lg"
+          data-bind="enable: oUserAgreementSigned, click: openDowngradeModal"
+        >
           {% if is_paused %}
             {% trans 'Confirm Pause' %}
           {% else %}
@@ -60,16 +82,17 @@
         </button>
       </div>
     </form>
-
   </div>
 {% endblock %}
 
-{% block modals %}{{ block.super }}
+{% block modals %}
+  {{ block.super }}
   <div class="modal fade" id="modal-downgrade">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="btn-close" data-bs-dismiss="modal">  {# todo B5: css-close #}
+          <button type="button" class="btn-close" data-bs-dismiss="modal">
+            {# todo B5: css-close #}
             <span aria-hidden="true">&times;</span>
             <span class="sr-only">{% trans "Close" %}</span>
           </button>
@@ -84,8 +107,8 @@
         <div class="modal-body">
           <p class="lead">
             {% blocktrans %}
-              We'd love to make CommCare work better for you.
-              Please help us by answering these simple questions.
+              We'd love to make CommCare work better for you. Please help us by
+              answering these simple questions.
             {% endblocktrans %}
           </p>
 
@@ -99,82 +122,91 @@
                 Why are you downgrading your subscription today?
               {% endblocktrans %}
             {% endif %}
-            <select multiple="multiple"  {# todo B5: css-select-form-control #}
-                    class="form-control"
-                    data-bind="selectedOptions: oDowngradeReason,
-                               options: downgradeReasonList"></select>
+            <select
+              multiple="multiple"
+              {# todo B5: css-select-form-control #}
+              class="form-control"
+              data-bind="selectedOptions: oDowngradeReason,
+                         options: downgradeReasonList"
+            ></select>
           </p>
 
           <!-- ko if: oProjectEnded -->
-            <p>
-              {% blocktrans %}
-                Do you think your project may start again?
-              {% endblocktrans %}
-              <select class="form-select"
-                      data-bind="value: oWillProjectRestart">
-                <option value="yes">
-                  {% trans "Yes" %}
-                </option>
-                <option value="no"
-                        selected="selected">
-                  {% trans "No" %}
-                </option>
-              </select>
-            </p>
+          <p>
+            {% blocktrans %}
+              Do you think your project may start again?
+            {% endblocktrans %}
+            <select class="form-select" data-bind="value: oWillProjectRestart">
+              <option value="yes">{% trans "Yes" %}</option>
+              <option value="no" selected="selected">{% trans "No" %}</option>
+            </select>
+          </p>
           <!-- /ko -->
 
           <!-- ko if: oNewToolNeeded -->
-            <p>
-              {% blocktrans %}
-                Could you indicate which new tool you’re using?
-              {% endblocktrans %}
-              <textarea class="form-control vertical-resize"
-                        data-bind="textInput: oNewTool"></textarea>
-            </p>
-            <p>
-              {% blocktrans %}
-                Why are you switching to a new tool?
-              {% endblocktrans %}
-              <select multiple="multiple"  {# todo B5: css-select-form-control #}
-                      class="form-control"
-                      data-bind="selectedOptions: oNewToolReason,
-                                 options: newToolReasonList"></select>
-            </p>
+          <p>
+            {% blocktrans %}
+              Could you indicate which new tool you’re using?
+            {% endblocktrans %}
+            <textarea
+              class="form-control vertical-resize"
+              data-bind="textInput: oNewTool"
+            ></textarea>
+          </p>
+          <p>
+            {% blocktrans %}
+              Why are you switching to a new tool?
+            {% endblocktrans %}
+            <select
+              multiple="multiple"
+              {# todo B5: css-select-form-control #}
+              class="form-control"
+              data-bind="selectedOptions: oNewToolReason,
+                         options: newToolReasonList"
+            ></select>
+          </p>
           <!-- /ko -->
 
           <!-- ko if: oOtherSelected -->
-            <p>
-              {% blocktrans %}
-                Please specify
-              {% endblocktrans %}
-              <textarea class="form-control vertical-resize"
-                        data-bind="textInput: oOtherNewToolReason"></textarea>
-            </p>
+          <p>
+            {% blocktrans %}
+              Please specify
+            {% endblocktrans %}
+            <textarea
+              class="form-control vertical-resize"
+              data-bind="textInput: oOtherNewToolReason"
+            ></textarea>
+          </p>
           <!-- /ko -->
 
           <p>
             {% blocktrans %}
               Please let us know any other feedback you have
             {% endblocktrans %}
-            <textarea class="form-control vertical-resize"
-                      data-bind="textInput: oFeedback"></textarea>
+            <textarea
+              class="form-control vertical-resize"
+              data-bind="textInput: oFeedback"
+            ></textarea>
           </p>
-
         </div>
         <div class="modal-footer">
           <!-- ko if: oRequiredQuestionsAnswered -->
-            <button type="button"
-                    class="btn btn-primary"
-                    data-bind="click: submitDowngrade">
-              {% trans "Continue" %}
-            </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-bind="click: submitDowngrade"
+          >
+            {% trans "Continue" %}
+          </button>
           <!-- /ko -->
           <!-- ko ifnot: oRequiredQuestionsAnswered -->
-            <button type="button"
-                    disabled="disabled"
-                    class="btn btn-outline-primary">
-              {% trans "Continue" %}
-            </button>
+          <button
+            type="button"
+            disabled="disabled"
+            class="btn btn-outline-primary"
+          >
+            {% trans "Continue" %}
+          </button>
           <!-- /ko -->
         </div>
       </div>

--- a/corehq/apps/domain/templates/domain/bootstrap5/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/confirm_plan.html
@@ -4,16 +4,11 @@
 {% js_entry 'accounting/js/confirm_plan' %}
 
 {% block form_content %}
+  {% initial_page_data 'is_annual_plan' is_annual_plan %}
   {% initial_page_data 'is_monthly_upgrade' is_monthly_upgrade %}
-  {% initial_page_data 'is_same_edition' is_same_edition %}
   {% initial_page_data 'is_downgrade' is_downgrade %}
   {% initial_page_data 'is_paused' is_paused %}
-  {% initial_page_data 'is_annual_plan' is_annual_plan %}
-  {% initial_page_data 'next_invoice_date' next_invoice_date %}
   {% initial_page_data 'current_plan' current_plan %}
-  {% initial_page_data 'new_plan_edition' new_plan_edition %}
-  {% initial_page_data 'is_downgrade_before_minimum' is_downgrade_before_minimum %}
-  {% initial_page_data 'current_subscription_end_date' current_subscription_end_date %}
   {% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}
   {% registerurl 'confirm_billing_account_info' domain %}
 

--- a/corehq/apps/domain/templates/domain/bootstrap5/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/confirm_plan.html
@@ -8,6 +8,7 @@
   {% initial_page_data 'is_upgrade' is_upgrade %}
   {% initial_page_data 'is_same_edition' is_same_edition %}
   {% initial_page_data 'is_paused' is_paused %}
+  {% initial_page_data 'is_annual_plan' is_annual_plan %}
   {% initial_page_data 'next_invoice_date' next_invoice_date %}
   {% initial_page_data 'current_plan' current_plan %}
   {% initial_page_data 'new_plan_edition' new_plan_edition %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/confirm_plan.html
@@ -4,8 +4,9 @@
 {% js_entry 'accounting/js/confirm_plan' %}
 
 {% block form_content %}
-  {% initial_page_data 'is_upgrade' is_upgrade %}
+  {% initial_page_data 'is_monthly_upgrade' is_monthly_upgrade %}
   {% initial_page_data 'is_same_edition' is_same_edition %}
+  {% initial_page_data 'is_downgrade' is_downgrade %}
   {% initial_page_data 'is_paused' is_paused %}
   {% initial_page_data 'is_annual_plan' is_annual_plan %}
   {% initial_page_data 'next_invoice_date' next_invoice_date %}

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1387,14 +1387,9 @@ class ConfirmSelectedPlanView(PlanViewBase):
 
     @property
     def is_downgrade_before_minimum(self):
-        if self.is_upgrade:
-            return False
-        elif self.current_subscription is None or self.current_subscription.is_trial:
-            return False
-        elif self.current_subscription.is_below_minimum_subscription:
-            return True
-        else:
-            return False
+        return (not self.is_monthly_upgrade
+                and self.is_downgrade
+                and self.current_subscription.is_below_minimum_subscription)
 
     @property
     def current_subscription_end_date(self):

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1419,6 +1419,7 @@ class ConfirmSelectedPlanView(PlanViewBase):
             'start_date_after_minimum_subscription': self.start_date_after_minimum_subscription,
             'new_plan_edition': self.edition,
             'is_paused': self.is_paused,
+            'is_annual_plan': self.is_annual_plan,
             'tile_css': 'tile-{}'.format(self.edition.lower()),
         }
 

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1408,18 +1408,18 @@ class ConfirmSelectedPlanView(PlanViewBase):
     def page_context(self):
         return {
             'downgrade_messages': self.downgrade_messages(),
-            'is_monthly_upgrade': self.is_monthly_upgrade,
-            'is_same_edition': self.is_same_edition,
             'next_invoice_date': self.next_invoice_date.strftime(USER_DATE_FORMAT),
             'current_plan': (self.current_subscription.plan_version.plan.edition
                              if self.current_subscription is not None else None),
-            'is_downgrade_before_minimum': self.is_downgrade_before_minimum,
             'current_subscription_end_date': self.current_subscription_end_date.strftime(USER_DATE_FORMAT),
             'start_date_after_minimum_subscription': self.start_date_after_minimum_subscription,
             'new_plan_edition': self.edition,
-            'is_paused': self.is_paused,
             'is_annual_plan': self.is_annual_plan,
+            'is_monthly_upgrade': self.is_monthly_upgrade,
+            'is_same_edition': self.is_same_edition,
             'is_downgrade': self.is_downgrade,
+            'is_downgrade_before_minimum': self.is_downgrade_before_minimum,
+            'is_paused': self.is_paused,
             'tile_css': 'tile-{}'.format(self.edition.lower()),
         }
 

--- a/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
+++ b/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
@@ -354,7 +354,7 @@ input:checked + .slider:before {
   margin: 10px auto;
 }
 
-.text-free {
+.alert-subscription-text {
   text-align: left;
   max-width: 600px;
   margin: 0 auto;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_plan.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_plan.html.diff.txt
@@ -9,8 +9,8 @@
 +{% js_entry 'accounting/js/confirm_plan' %}
  
  {% block form_content %}
-   {% initial_page_data 'is_upgrade' is_upgrade %}
-@@ -62,7 +62,7 @@
+   {% initial_page_data 'is_annual_plan' is_annual_plan %}
+@@ -58,7 +58,7 @@
        <div class="text-center plan-next">
          <a
            href="{% url 'domain_select_plan' domain %}"
@@ -19,7 +19,7 @@
          >
            {% if is_paused %}
              {% trans 'Select different option' %}
-@@ -91,7 +91,8 @@
+@@ -87,7 +87,8 @@
      <div class="modal-dialog">
        <div class="modal-content">
          <div class="modal-header">
@@ -29,7 +29,7 @@
              <span aria-hidden="true">&times;</span>
              <span class="sr-only">{% trans "Close" %}</span>
            </button>
-@@ -123,6 +124,7 @@
+@@ -119,6 +120,7 @@
              {% endif %}
              <select
                multiple="multiple"
@@ -37,7 +37,7 @@
                class="form-control"
                data-bind="selectedOptions: oDowngradeReason,
                           options: downgradeReasonList"
-@@ -134,7 +136,7 @@
+@@ -130,7 +132,7 @@
              {% blocktrans %}
                Do you think your project may start again?
              {% endblocktrans %}
@@ -46,7 +46,7 @@
                <option value="yes">{% trans "Yes" %}</option>
                <option value="no" selected="selected">{% trans "No" %}</option>
              </select>
-@@ -157,6 +159,7 @@
+@@ -153,6 +155,7 @@
              {% endblocktrans %}
              <select
                multiple="multiple"
@@ -54,7 +54,7 @@
                class="form-control"
                data-bind="selectedOptions: oNewToolReason,
                           options: newToolReasonList"
-@@ -197,7 +200,11 @@
+@@ -193,7 +196,11 @@
            </button>
            <!-- /ko -->
            <!-- ko ifnot: oRequiredQuestionsAnswered -->

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_plan.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_plan.html.diff.txt
@@ -1,67 +1,69 @@
 --- 
 +++ 
-@@ -1,8 +1,8 @@
+@@ -1,7 +1,7 @@
 -{% extends "domain/bootstrap3/base_change_plan.html" %}
 +{% extends "domain/bootstrap5/base_change_plan.html" %}
  {% load i18n %}
  {% load hq_shared_tags %}
- 
 -{% js_entry_b3 'accounting/js/confirm_plan' %}
 +{% js_entry 'accounting/js/confirm_plan' %}
  
  {% block form_content %}
    {% initial_page_data 'is_upgrade' is_upgrade %}
-@@ -42,7 +42,7 @@
-         </p>
-       {% endif %}
+@@ -62,7 +62,7 @@
        <div class="text-center plan-next">
--        <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default btn-lg">
-+        <a href="{% url 'domain_select_plan' domain %}" class="btn btn-outline-primary btn-lg">
+         <a
+           href="{% url 'domain_select_plan' domain %}"
+-          class="btn btn-default btn-lg"
++          class="btn btn-outline-primary btn-lg"
+         >
            {% if is_paused %}
              {% trans 'Select different option' %}
-           {% else %}
-@@ -68,7 +68,7 @@
+@@ -91,7 +91,8 @@
      <div class="modal-dialog">
        <div class="modal-content">
          <div class="modal-header">
 -          <button type="button" class="close" data-dismiss="modal">
-+          <button type="button" class="btn-close" data-bs-dismiss="modal">  {# todo B5: css-close #}
++          <button type="button" class="btn-close" data-bs-dismiss="modal">
++            {# todo B5: css-close #}
              <span aria-hidden="true">&times;</span>
              <span class="sr-only">{% trans "Close" %}</span>
            </button>
-@@ -98,7 +98,7 @@
-                 Why are you downgrading your subscription today?
-               {% endblocktrans %}
+@@ -123,6 +124,7 @@
              {% endif %}
--            <select multiple="multiple"
-+            <select multiple="multiple"  {# todo B5: css-select-form-control #}
-                     class="form-control"
-                     data-bind="selectedOptions: oDowngradeReason,
-                                options: downgradeReasonList"></select>
-@@ -109,7 +109,7 @@
-               {% blocktrans %}
-                 Do you think your project may start again?
-               {% endblocktrans %}
--              <select class="form-control"
-+              <select class="form-select"
-                       data-bind="value: oWillProjectRestart">
-                 <option value="yes">
-                   {% trans "Yes" %}
-@@ -134,7 +134,7 @@
-               {% blocktrans %}
-                 Why are you switching to a new tool?
-               {% endblocktrans %}
--              <select multiple="multiple"
-+              <select multiple="multiple"  {# todo B5: css-select-form-control #}
-                       class="form-control"
-                       data-bind="selectedOptions: oNewToolReason,
-                                  options: newToolReasonList"></select>
-@@ -171,7 +171,7 @@
+             <select
+               multiple="multiple"
++              {# todo B5: css-select-form-control #}
+               class="form-control"
+               data-bind="selectedOptions: oDowngradeReason,
+                          options: downgradeReasonList"
+@@ -134,7 +136,7 @@
+             {% blocktrans %}
+               Do you think your project may start again?
+             {% endblocktrans %}
+-            <select class="form-control" data-bind="value: oWillProjectRestart">
++            <select class="form-select" data-bind="value: oWillProjectRestart">
+               <option value="yes">{% trans "Yes" %}</option>
+               <option value="no" selected="selected">{% trans "No" %}</option>
+             </select>
+@@ -157,6 +159,7 @@
+             {% endblocktrans %}
+             <select
+               multiple="multiple"
++              {# todo B5: css-select-form-control #}
+               class="form-control"
+               data-bind="selectedOptions: oNewToolReason,
+                          options: newToolReasonList"
+@@ -197,7 +200,11 @@
+           </button>
+           <!-- /ko -->
            <!-- ko ifnot: oRequiredQuestionsAnswered -->
-             <button type="button"
-                     disabled="disabled"
--                    class="btn btn-default">
-+                    class="btn btn-outline-primary">
-               {% trans "Continue" %}
-             </button>
+-          <button type="button" disabled="disabled" class="btn btn-default">
++          <button
++            type="button"
++            disabled="disabled"
++            class="btn btn-outline-primary"
++          >
+             {% trans "Continue" %}
+           </button>
            <!-- /ko -->


### PR DESCRIPTION
## Product Description
Adds a new disclaimer blurb and requires confirmation when a user selects to sign up for a Pay Annually plan. This is not possible through the UI as of yet, but will be soon.
<img width="628" alt="image" src="https://github.com/user-attachments/assets/870f5aad-b526-4f92-b1bc-866e301d6dc8" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17494
Reorders some of the conditionals in `confirm_plan_summary.html` to determine which notices are shown after a user has selected a plan, before they continue on to the billing information screen. Adds a new blurb and requires confirmation for Pay Annually plans here, which is shown whether the user is upgrading, downgrading, or moving to the same edition. Adds an `is_annual_plan` check to the context of `ConfirmSelectedPlanView` -- noting that the `confirm_plan_summary.html` template is included in two views, and the `SubscriptionRenewalView` already includes `is_annual_plan` in its context.


## Safety Assurance

### Safety story
Most of these changes are to simple text blocks within a django html template, pretty low risk in general. Tested locally to see that the subscription confirmation page loads as expected.

### Automated test coverage
Unlikely here.

### QA Plan
The "Pay Annually" component of this will get QA as part of allowing users to sign up independently for a Pay Annually plan.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
