### PR TITLE
Increase Scope of Primed Users

### DIFF
--- a/custom/bha/tasks.py
+++ b/custom/bha/tasks.py
@@ -12,8 +12,8 @@ from corehq.apps.formplayer_api.tasks import (
 )
 
 
-# Include users that have synced in the last week
-SYNC_WINDOW_HOURS = 24 * 7
+# Include users that have synced in the last 2 weeks
+SYNC_WINDOW_HOURS = 24 * 14
 
 # 10th percentile of first form submission occurs by 7AM GMT-7. The task should be completed by then to be useful.
 # Don't allow tasks to run beyond then (2PM UTC).


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Larger scope of the users on domains with "PRIME_FORMPLAYER_DBS_BHA" enabled will be included in the prime sync. This was reduce the chance of a user having a slow/cold start. 

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/USH-5936
 From users who have submitted in the last month ~35% of those users have  greater than 7 days between form submissions. ~4.8% have greater than 14 days. Given that, the priming task window should be expanded to 14 days.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
PRIME_FORMPLAYER_DBS_BHA

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change is limited to that one feature flag and only expands number of people who syncs.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests exists that checks the expected users are fetched for priming.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
