### PR TITLE
Rename User(s) filter to Submitted by in Submission History

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -474,6 +474,10 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         }
 
 
+class SubmittedByExpandedMobileWorkerFilter(ExpandedMobileWorkerFilter):
+    label = gettext_lazy("Submitted By")
+
+
 class EnterpriseUsersUtils(EmwfUtils):
 
     def user_tuple(self, user):

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -11,7 +11,7 @@ from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.display import FormDisplay
 from corehq.apps.reports.filters.forms import FormsByApplicationFilter
 from corehq.apps.reports.filters.users import \
-    ExpandedMobileWorkerFilter as EMWF
+    SubmittedByExpandedMobileWorkerFilter as EMWF
 from corehq.apps.reports.generic import ElasticProjectInspectionReport
 from corehq.apps.reports.models import HQUserType
 from corehq.apps.reports.standard import (
@@ -36,7 +36,7 @@ class SubmitHistoryMixin(ElasticProjectInspectionReport,
     name = gettext_noop('Submission History')
     slug = 'submit_history'
     fields = [
-        'corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',
+        'corehq.apps.reports.filters.users.SubmittedByExpandedMobileWorkerFilter',
         'corehq.apps.reports.filters.forms.FormsByApplicationFilter',
         'corehq.apps.reports.filters.forms.CompletionOrSubmissionTimeFilter',
         'corehq.apps.reports.filters.dates.DatespanFilter',


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Before:
![image](https://github.com/user-attachments/assets/69699077-133d-40b6-b1c3-993d6b0c24fb)

After:
<img width="1190" alt="image" src="https://github.com/user-attachments/assets/19bc359d-4835-4c46-ab4b-718b7f51f530" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17570

`ExpandedMobileWorkerFilter` is used in many report, in many cases, "User(s)" make sense while "Submitted by" doesn't. So to limit the change to Submission History report only, I create a new Class inherit from `ExpandedMobileWorkerFilter` then override the `label` field.



## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Only rename label

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
