### PR TITLE
Add `eu` in list of SaaS environments

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1261,7 +1261,7 @@ for database in DATABASES.values():
 
 _location = lambda x: os.path.join(FILEPATH, x)
 
-IS_SAAS_ENVIRONMENT = SERVER_ENVIRONMENT in ('production', 'staging')
+IS_SAAS_ENVIRONMENT = SERVER_ENVIRONMENT in ('eu', 'production', 'staging')
 
 if 'KAFKA_URL' in globals():
     import warnings


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Came up in [QA-7750](https://dimagi.atlassian.net/browse/QA-7750) where schedule a demo was not working in EU env. There were two reasons for the same, one is it is not marked as SaaS env and another one is it does not have Hubspot credentials configured.
This PR adds eu env to SaaS envs.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
na
## Safety Assurance
very safe, just updates a setting
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

na

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[QA-7750]: https://dimagi.atlassian.net/browse/QA-7750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ