### PR TITLE
[Data Cleaning] Resume the Bulk Edit session after applying changes

### DIFF
--- a/corehq/apps/data_cleaning/exceptions.py
+++ b/corehq/apps/data_cleaning/exceptions.py
@@ -8,11 +8,3 @@ class UnsupportedFilterValueException(Exception):
     its FilterMatchType and DataType combination. This is rare,
     as the filter creation form should catch most of the issues.
     """
-
-
-class SessionAccessClosedException(Exception):
-    """
-    Raised when a session has been closed for editing. This is
-    raised in the view, so that we can redirect to the main page
-    with a message.
-    """

--- a/corehq/apps/data_cleaning/models/column.py
+++ b/corehq/apps/data_cleaning/models/column.py
@@ -37,6 +37,17 @@ class BulkEditColumnManager(models.Manager):
                 is_system=self.model.is_system_property(prop_id),
             )
 
+    def copy_to_session(self, source_session, dest_session):
+        for column in self.filter(session=source_session):
+            self.model.objects.create(
+                session=dest_session,
+                index=column.index,
+                prop_id=column.prop_id,
+                label=column.label,
+                data_type=column.data_type,
+                is_system=column.is_system,
+            )
+
     def create_for_session(self, session, prop_id, label, data_type=None):
         is_system_property = self.model.is_system_property(prop_id)
         from corehq.apps.data_cleaning.utils.cases import get_system_property_data_type

--- a/corehq/apps/data_cleaning/models/filters.py
+++ b/corehq/apps/data_cleaning/models/filters.py
@@ -45,6 +45,17 @@ class BulkEditFilterManager(models.Manager):
             query = query.xpath_query(session.domain, " and ".join(xpath_expressions))
         return query
 
+    def copy_to_session(self, source_session, dest_session):
+        for custom_filter in self.filter(session=source_session):
+            self.model.objects.create(
+                session=dest_session,
+                index=custom_filter.index,
+                prop_id=custom_filter.prop_id,
+                data_type=custom_filter.data_type,
+                match_type=custom_filter.match_type,
+                value=custom_filter.value,
+            )
+
 
 class BulkEditFilter(models.Model):
     session = models.ForeignKey("data_cleaning.BulkEditSession", related_name="filters", on_delete=models.CASCADE)
@@ -198,6 +209,15 @@ class BulkEditPinnedFilterManager(models.Manager):
         for pinned_filter in session.pinned_filters.all():
             query = pinned_filter.filter_query(query)
         return query
+
+    def copy_to_session(self, source_session, dest_session):
+        for pinned_filter in self.filter(session=source_session):
+            self.model.objects.create(
+                session=dest_session,
+                index=pinned_filter.index,
+                filter_type=pinned_filter.filter_type,
+                value=pinned_filter.value,
+            )
 
 
 class BulkEditPinnedFilter(models.Model):

--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -14,6 +14,7 @@ from corehq.apps.es import CaseSearchES
 BULK_OPERATION_CHUNK_SIZE = 1000
 MAX_RECORDED_LIMIT = 100000
 MAX_SESSION_CHANGES = 200
+APPLY_CHANGES_WAIT_TIME = 15  # seconds
 
 
 class BulkEditSession(models.Model):

--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -58,15 +58,16 @@ class BulkEditSession(models.Model):
             return None
 
     @classmethod
-    def new_case_session(cls, user, domain_name, case_type):
+    def new_case_session(cls, user, domain_name, case_type, is_default=True):
         case_session = cls.objects.create(
             user=user,
             domain=domain_name,
             identifier=case_type,
             session_type=BulkEditSessionType.CASE,
         )
-        case_session.pinned_filters.create_session_defaults(case_session)
-        case_session.columns.create_session_defaults(case_session)
+        if is_default:
+            case_session.pinned_filters.create_session_defaults(case_session)
+            case_session.columns.create_session_defaults(case_session)
         return case_session
 
     @classmethod
@@ -86,6 +87,18 @@ class BulkEditSession(models.Model):
     @classmethod
     def get_committed_sessions(cls, user, domain_name):
         return cls.objects.filter(user=user, domain=domain_name, committed_on__isnull=False)
+
+    def get_resumed_session(self):
+        new_session = self.new_case_session(
+            self.user,
+            self.domain,
+            self.identifier,
+            is_default=False,
+        )
+        self.pinned_filters.copy_to_session(self, new_session)
+        self.filters.copy_to_session(self, new_session)
+        self.columns.copy_to_session(self, new_session)
+        return new_session
 
     @property
     def is_read_only(self):

--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -88,6 +88,10 @@ class BulkEditSession(models.Model):
         return cls.objects.filter(user=user, domain=domain_name, committed_on__isnull=False)
 
     @property
+    def is_read_only(self):
+        return self.committed_on is not None
+
+    @property
     def form_ids(self):
         if self.result is None or 'form_ids' not in self.result:
             return []

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -131,3 +131,7 @@ class RecentCaseSessionsTable(BaseHtmxTable, tables.Table):
         template_name="data_cleaning/columns/task_form_ids.html",
         verbose_name=gettext_lazy("Form IDs"),
     )
+    session_url = columns.TemplateColumn(
+        template_name="data_cleaning/columns/task_session_url.html",
+        verbose_name=gettext_lazy("Open Session"),
+    )

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -71,6 +71,10 @@ class EditCasesTable(BaseHtmxTable, ElasticTable):
         return visible_columns
 
     @property
+    def is_read_only(self):
+        return self.session.is_read_only
+
+    @property
     @memoized
     def has_any_filtering(self):
         """

--- a/corehq/apps/data_cleaning/templates/data_cleaning/bulk_edit_session.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/bulk_edit_session.html
@@ -41,9 +41,11 @@
     </div>
   </div>
   <div
+    id="primary-view-container"
     class="mx-3"
     hx-get="{{ htmx_primary_view_url }}{% querystring %}"
-    hx-trigger="load"
+    hx-trigger="load, statusRefresh"
+    hx-swap="innerHTML"
   >
     <div class="htmx-indicator">
       <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading..." %}
@@ -54,5 +56,6 @@
 
 {% block modals %}
   {% include "hqwebapp/htmx/error_modal.html" %}
+  {% include "data_cleaning/status/modal.html" %}
   {{ block.super }}
 {% endblock modals %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection_read_only.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/selection_read_only.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+
+<div
+  data-bs-header
+  x-tooltip=""
+  data-bs-custom-class="fs-6"
+  data-bs-title="{% trans "This session is read-only." %}"
+>
+  <input type="checkbox" disabled="disabled" />
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_session_url.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_session_url.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+
+<a href="{{ record.session_url }}">
+  <i class="fa-solid fa-arrow-up-right-from-square"></i>
+</a>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
@@ -1,0 +1,63 @@
+{% load i18n %}
+
+<div class="modal-header">
+  <h5 class="modal-title">
+    {% trans "Changes Applied" %}
+  </h5>
+</div>
+<div class="modal-body">
+  <div class="alert alert-success">
+    <div class="progress mb-2" role="progressbar" aria-label="Basic example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
+      <div class="progress-bar bg-success" style="width: 100%"></div>
+    </div>
+    <i class="fa-solid fa-check-double me-1"></i>
+    {# prettier-ignore-start #}
+    {% blocktrans count count=num_records_changed %}
+      Finished processing changes, updated 1 case.
+    {% plural %}
+      Finished processing changes, updated {{ num_records_changed }} cases.
+    {% endblocktrans %}
+    {# prettier-ignore-end #}
+  </div>
+  {% if active_session %}
+    <p class="lead">
+      {% blocktrans %}
+        Resume this session with the same columns and filters?
+      {% endblocktrans %}
+    </p>
+    <div class="alert alert-warning">
+      <strong>{% trans "Important" %}:</strong>
+      {% blocktrans %}
+        This will replace your existing active session with a new one. Any edits you made will be lost.
+      {% endblocktrans %}
+    </div>
+  {% else %}
+    <p class="lead">
+      {% blocktrans %}
+        Continue editing <strong class="fw-bold">{{ case_type }}</strong> cases with the same columns and filters?
+      {% endblocktrans %}
+    </p>
+  {% endif %}
+</div>
+<div class="modal-footer">
+  <a
+    class="btn btn-outline-primary"
+    href="{{ exit_url }}"
+  >
+    {% trans "Exit session" %}
+  </a>
+  <button
+    type="button"
+    class="btn btn-primary"
+    hx-post="{{ request.path_info }}"
+    hq-hx-action="resume_session"
+    hx-swap="none"
+    hx-disabled-elt="this"
+  >
+    {% if active_session %}
+      {% trans "Resume this session" %}
+    {% else %}
+      {% trans "Continue editing" %}
+    {% endif %}
+  </button>
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
@@ -1,0 +1,52 @@
+{% load i18n %}
+
+<div
+  hx-get="{{ request.path_info }}"
+  hx-trigger="every 5s from:load"
+  hq-hx-action="poll_session_status"
+  hx-swap="outerHTML"
+>
+  <div class="modal-header">
+    <h5 class="modal-title">
+      {% trans "Applying Changes..." %}
+    </h5>
+  </div>
+  <div class="modal-body">
+    <div class="alert alert-success">
+      <div class="progress mb-2" role="progressbar" aria-label="Basic example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
+        <div class="progress-bar bg-success" style="width: {{ session.percent_complete }}%"></div>
+      </div>
+      <div class="d-flex justify-content-between">
+        <div>
+          <i class="fa-solid fa-check-double me-1"></i>
+          {% blocktrans %}
+            Applying changes, please wait...
+          {% endblocktrans %}
+        </div>
+        {% if is_task_complete %}
+          <div>
+            <i class="fa-solid fa-spinner fa-spin"></i>
+            {% blocktrans %}
+              Database is refreshing...almost there!
+            {% endblocktrans %}
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <a
+      class="btn btn-outline-primary"
+      href="{{ exit_url }}"
+    >
+      {% trans "Exit session" %}
+    </a>
+    <button
+      type="button"
+      class="btn btn-primary"
+      disabled="disabled"
+    >
+      {% trans "Continue editing" %}
+    </button>
+  </div>
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/modal.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/modal.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+
+<div
+  id="session-status-modal"
+  class="modal fade"
+  tabindex="-1"
+  aria-labelledby="staticBackdropLabel"
+  aria-hidden="true"
+  data-bs-backdrop="static"
+  data-bs-keyboard="false"
+>
+  <div class="modal-dialog modal-dialog-centered">
+    <div
+      class="modal-content"
+      id="session-status-modal-body"
+      hx-get="{{ htmx_session_status_view_url }}"
+      hx-trigger="{% if session.is_read_only %}load, {% endif %}dcRefreshStatusModal"
+      hx-swap="innerHTML"
+    ></div>
+  </div>
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/table_with_controls.html
@@ -111,23 +111,28 @@
           class="input-group-text"
           :class="(numRecordsSelected > 0) || 'rounded-end'"
         >
-          <i class="fa-solid fa-circle-check me-2"></i>
-          <span
-            class="me-1"
-            x-text="numRecordsSelected"
-          ></span>
-          {% blocktrans %}
-            Cases Selected
-          {% endblocktrans %}
-          {% if table.num_visible_selected_records != table.num_selected_records %}
-            <div
-              class="ms-2 ps-2 border-start inline-block text-warning"
-              data-bs-custom-class="fs-6"
-              data-bs-title="{% trans 'You have selected cases which have been filtered out. New previewed edits will only apply to selected cases in the current filters, unless you remove filters.' %}"
-              x-tooltip=""
-            >
-              <i class="fa-solid fa-triangle-exclamation"></i>
-            </div>
+          {% if table.is_read_only %}
+            <i class="fa-solid fa-circle-info me-2"></i>
+            {% trans "This session is read-only." %}
+          {% else %}
+            <i class="fa-solid fa-circle-check me-2"></i>
+            <span
+              class="me-1"
+              x-text="numRecordsSelected"
+            ></span>
+            {% blocktrans %}
+              Cases Selected
+            {% endblocktrans %}
+            {% if table.num_visible_selected_records != table.num_selected_records %}
+              <div
+                class="ms-2 ps-2 border-start inline-block text-warning"
+                data-bs-custom-class="fs-6"
+                data-bs-title="{% trans 'You have selected cases which have been filtered out. New previewed edits will only apply to selected cases in the current filters, unless you remove filters.' %}"
+                x-tooltip=""
+              >
+                <i class="fa-solid fa-triangle-exclamation"></i>
+              </div>
+            {% endif %}
           {% endif %}
         </div>
         <button

--- a/corehq/apps/data_cleaning/tests/test_views.py
+++ b/corehq/apps/data_cleaning/tests/test_views.py
@@ -21,6 +21,9 @@ from corehq.apps.data_cleaning.views.main import (
     BulkEditCasesMainView,
     BulkEditCasesSessionView,
 )
+from corehq.apps.data_cleaning.views.status import (
+    BulkEditSessionStatusView,
+)
 from corehq.apps.data_cleaning.views.tables import (
     EditCasesTableView,
     RecentCaseSessionsTableView,
@@ -113,6 +116,8 @@ class CleanCasesViewAccessTest(TestCase):
             (ManageFiltersView, (cls.domain_name, cls.fake_session_id,)),
             (EditSelectedRecordsFormView, (cls.domain_name, cls.real_session_id,)),
             (EditSelectedRecordsFormView, (cls.domain_name, cls.fake_session_id,)),
+            (BulkEditSessionStatusView, (cls.domain_name, cls.real_session_id,)),
+            (BulkEditSessionStatusView, (cls.domain_name, cls.fake_session_id,)),
         ]
         cls.views_not_found_with_invalid_session = [
             EditCasesTableView,
@@ -120,6 +125,7 @@ class CleanCasesViewAccessTest(TestCase):
             ManageFiltersView,
             ManageColumnsFormView,
             EditSelectedRecordsFormView,
+            BulkEditSessionStatusView,
         ]
 
         clear_caches_case_data_cleaning(cls.domain_name)

--- a/corehq/apps/data_cleaning/urls.py
+++ b/corehq/apps/data_cleaning/urls.py
@@ -24,6 +24,9 @@ from corehq.apps.data_cleaning.views.tables import (
 from corehq.apps.data_cleaning.views.start import (
     StartCaseSessionView,
 )
+from corehq.apps.data_cleaning.views.status import (
+    BulkEditSessionStatusView,
+)
 
 urlpatterns = [
     url(r'^cases/$', BulkEditCasesMainView.as_view(), name=BulkEditCasesMainView.urlname),
@@ -35,6 +38,8 @@ urlpatterns = [
         name=EditCasesTableView.urlname),
     url(r'^cases/(?P<session_id>[\w\-]+)/summary/$', ChangesSummaryView.as_view(),
         name=ChangesSummaryView.urlname),
+    url(r'^session/(?P<session_id>[\w\-]+)/status/$', BulkEditSessionStatusView.as_view(),
+        name=BulkEditSessionStatusView.urlname),
     url(r'^session/(?P<session_id>[\w\-]+)/filters/$', ManageFiltersView.as_view(),
         name=ManageFiltersView.urlname),
     url(r'^session/(?P<session_id>[\w\-]+)/filters/pinned/$', ManagePinnedFiltersView.as_view(),

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -59,7 +59,7 @@ class BulkEditCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
     page_title = gettext_lazy("Bulk Edit Case Type")
     urlname = "bulk_edit_cases_session"
     template_name = "data_cleaning/bulk_edit_session.html"
-    redirect_on_session_exceptions = True
+    redirect_on_missing_session = True
 
     def get_redirect_url(self):
         return reverse(BulkEditCasesMainView.urlname, args=(self.domain, ))

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -16,6 +16,7 @@ from corehq.apps.data_cleaning.views.columns import ManageColumnsFormView
 from corehq.apps.data_cleaning.views.filters import ManageFiltersView, ManagePinnedFiltersView
 from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
 from corehq.apps.data_cleaning.views.start import StartCaseSessionView
+from corehq.apps.data_cleaning.views.status import BulkEditSessionStatusView
 from corehq.apps.data_cleaning.views.tables import RecentCaseSessionsTableView
 from corehq.apps.data_cleaning.views.tables import EditCasesTableView
 from corehq.apps.domain.decorators import login_and_domain_required
@@ -106,6 +107,10 @@ class BulkEditCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
             ),
             "htmx_edit_selected_records_view_url": reverse(
                 EditSelectedRecordsFormView.urlname,
+                args=(self.domain, self.session_id),
+            ),
+            "htmx_session_status_view_url": reverse(
+                BulkEditSessionStatusView.urlname,
                 args=(self.domain, self.session_id),
             ),
         }

--- a/corehq/apps/data_cleaning/views/mixins.py
+++ b/corehq/apps/data_cleaning/views/mixins.py
@@ -42,7 +42,7 @@ class BulkEditSessionViewMixin:
         })
         return context
 
-    def dispatch(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):
         try:
             # force evaluation of self.session
             _ = self.session
@@ -51,4 +51,4 @@ class BulkEditSessionViewMixin:
                 messages.error(request, self.session_not_found_message)
                 return redirect(self.get_redirect_url())
             raise Http404(self.session_not_found_message)
-        return super().dispatch(request, *args, **kwargs)
+        return super().get(request, *args, **kwargs)

--- a/corehq/apps/data_cleaning/views/mixins.py
+++ b/corehq/apps/data_cleaning/views/mixins.py
@@ -3,45 +3,36 @@ from memoized import memoized
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.http import Http404
-from django.utils.translation import gettext_lazy, gettext as _
-
-from corehq.apps.data_cleaning.exceptions import SessionAccessClosedException
+from django.utils.translation import gettext_lazy
 from corehq.apps.data_cleaning.models import BulkEditSession
 
 
 class BulkEditSessionViewMixin:
     session_not_found_message = gettext_lazy("That session does not exist. Please start a new session.")
-    redirect_on_session_exceptions = False
+    redirect_on_missing_session = False
 
     @property
     def session_id(self):
         return self.kwargs['session_id']
 
     def get_redirect_url(self):
+        """
+        Return the URL to redirect to if the session is missing.
+        Only used when `redirect_on_missing_session` is True.
+        """
         raise NotImplementedError(
             "get_redirect_url must be implemented in the subclass of BulkEditSessionViewMixin "
-            "in order to use redirect_on_session_exceptions"
+            "in order to use redirect_on_missing_session"
         )
 
     @property
     @memoized
     def session(self):
-        session = BulkEditSession.objects.get(
+        return BulkEditSession.objects.get(
             user=self.request.user,
             domain=self.domain,
             session_id=self.session_id,
         )
-        if session.completed_on:
-            raise SessionAccessClosedException(_(
-                "You tried to access a session for \"{}\" that was already completed. "
-                "Please start a new session."
-            ).format(session.identifier))
-        elif session.committed_on:
-            raise SessionAccessClosedException(_(
-                "You tried to access a session for \"{}\" that is currently applying changes. "
-                "Please wait for that task to complete, then start a new session."
-            ).format(session.identifier))
-        return session
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -51,22 +42,13 @@ class BulkEditSessionViewMixin:
         })
         return context
 
-    def get(self, request, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):
         try:
-            return super().get(request, *args, **kwargs)
-
+            # force evaluation of self.session
+            _ = self.session
         except BulkEditSession.DoesNotExist:
-
-            if self.redirect_on_session_exceptions:
+            if self.redirect_on_missing_session:
                 messages.error(request, self.session_not_found_message)
                 return redirect(self.get_redirect_url())
-
             raise Http404(self.session_not_found_message)
-
-        except SessionAccessClosedException as error:
-
-            if self.redirect_on_session_exceptions:
-                messages.warning(request, str(error))
-                return redirect(self.get_redirect_url())
-
-            return Http404(error.msg)
+        return super().dispatch(request, *args, **kwargs)

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -1,0 +1,74 @@
+import json
+
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+from django.utils.translation import gettext as _
+
+from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
+from corehq.apps.data_cleaning.models.session import BulkEditSession
+from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
+from corehq.apps.domain.decorators import LoginAndDomainMixin
+from corehq.apps.domain.views import DomainViewMixin
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
+
+
+@method_decorator([
+    use_bootstrap5,
+    require_bulk_data_cleaning_cases,
+], name='dispatch')
+class BaseStatusView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
+    pass
+
+
+class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
+    urlname = "bulk_edit_session_status"
+    template_name = "data_cleaning/status/complete.html"
+
+    def get_active_session(self):
+        if self.session.completed_on is None:
+            return None
+        return BulkEditSession.get_active_case_session(
+            self.request.user, self.domain, self.session.identifier
+        )
+
+    @property
+    def exit_url(self):
+        from corehq.apps.data_cleaning.views.main import BulkEditCasesMainView
+        return reverse(
+            BulkEditCasesMainView.urlname,
+            args=(self.domain,),
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update({
+            "active_session": self.get_active_session(),
+            "num_records_changed": self.session.num_changed_records,
+            "case_type": self.session.identifier,
+            "exit_url": self.exit_url,
+        })
+        return context
+
+    def get(self, request, *args, **kwargs):
+        response = super().get(request, *args, **kwargs)
+        if self.session.is_read_only:
+            response['HX-Trigger'] = json.dumps({
+                'showDataCleaningModal': {
+                    'target': '#session-status-modal',
+                },
+            })
+        return response
+
+    @hq_hx_action('post')
+    def resume_session(self, request, *args, **kwargs):
+
+        from corehq.apps.data_cleaning.views.main import BulkEditCasesSessionView
+        return self.render_htmx_redirect(
+            reverse(
+                BulkEditCasesSessionView.urlname,
+                args=(self.domain, self.session_id),
+            ),
+            response_message=_("Resuming Bulk Edit Session..."),
+        )

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -63,7 +63,11 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
         context = super().get_context_data(**kwargs)
         context.update({
             "active_session": self.get_active_session(),
-            "num_records_changed": self.session.num_changed_records,
+            "num_records_changed": (
+                self.session.num_changed_records
+                if self.session.committed_on is not None
+                else 0
+            ),
             "case_type": self.session.identifier,
             "exit_url": self.exit_url,
             "is_task_complete": self.session.percent_complete == 100,

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -95,12 +95,16 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
 
     @hq_hx_action('post')
     def resume_session(self, request, *args, **kwargs):
+        active_session = self.get_active_session()
+        if active_session:
+            active_session.delete()
+        new_session = self.session.get_resumed_session()
 
         from corehq.apps.data_cleaning.views.main import BulkEditCasesSessionView
         return self.render_htmx_redirect(
             reverse(
                 BulkEditCasesSessionView.urlname,
-                args=(self.domain, self.session_id),
+                args=(self.domain, new_session.session_id),
             ),
             response_message=_("Resuming Bulk Edit Session..."),
         )

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -230,6 +230,7 @@ class RecentCaseSessionsTableView(BaseDataCleaningTableView):
         ]
 
     def _get_record(self, session):
+        from corehq.apps.data_cleaning.views.main import BulkEditCasesSessionView
         return {
             "committed_on": session.committed_on,
             "completed_on": session.completed_on,
@@ -238,4 +239,5 @@ class RecentCaseSessionsTableView(BaseDataCleaningTableView):
             "percent": session.percent_complete,
             "form_ids_url": reverse('download_form_ids', args=(session.domain, session.session_id)),
             "has_form_ids": bool(len(session.form_ids)),
+            "session_url": reverse(BulkEditCasesSessionView.urlname, args=(session.domain, session.session_id)),
         }

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -1,10 +1,8 @@
 import json
 
-from django.contrib import messages
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
-from django.utils.translation import gettext as _
 
 from corehq.apps.data_cleaning.columns import EditableHtmxColumn
 from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
@@ -132,17 +130,21 @@ class EditCasesTableView(BulkEditSessionViewMixin,
 
     @hq_hx_action("post")
     def apply_all_changes(self, request, *args, **kwargs):
-        self.session.committed_on = timezone.now()
-        self.session.save()
-        commit_data_cleaning.delay(self.session.session_id)
-        messages.success(
-            request,
-            _("Changes applied. Check the Recent Tasks table for progress.")
-        )
-        from corehq.apps.data_cleaning.views.main import BulkEditCasesMainView
-        return self.render_htmx_redirect(
-            reverse(BulkEditCasesMainView.urlname, args=(self.domain,)),
-        )
+        # even if a user hacks their way to more edits in this session, they can never apply those edits
+        if not self.session.is_read_only:
+            self.session.committed_on = timezone.now()
+            self.session.save()
+            commit_data_cleaning.delay(self.session.session_id)
+        response = self.get(request, *args, **kwargs)
+        response['HX-Trigger'] = json.dumps({
+            'showDataCleaningModal': {
+                'target': '#session-status-modal',
+            },
+            'dcRefreshStatusModal': {
+                'target': '#session-status-modal-body',
+            },
+        })
+        return response
 
     @hq_hx_action("post")
     def undo_last_change(self, request, *args, **kwargs):


### PR DESCRIPTION
## Product Description
This allows the user to resume bulk edit session after applying changes. It also allows the user to go to a previous session from the tasks lists, preview the columns, and start a new session with that configuration.


## Technical Summary
"resume" is used from a UX perspective. What actually happens when a session is "resumed" is that a new session is created with the resuming session's filters and columns.
<img width="597" alt="Screenshot 2025-05-20 at 3 10 38 PM" src="https://github.com/user-attachments/assets/e5cd6806-b077-4b10-ba49-f0ef91511cca" />
<img width="582" alt="Screenshot 2025-05-20 at 3 10 56 PM" src="https://github.com/user-attachments/assets/99ca3db2-8450-4d26-940e-5485c1938539" />

when resuming a session if there is already an active session
<img width="545" alt="Screenshot 2025-05-20 at 3 09 59 PM" src="https://github.com/user-attachments/assets/4d426b56-6726-4861-a3ce-3f54c445d4cc" />

new open session column on Recent Tasks
<img width="1391" alt="Screenshot 2025-05-20 at 3 11 59 PM" src="https://github.com/user-attachments/assets/23c45cd3-07f5-48a4-9513-032df58f9170" />



## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe changes only made to a feature-flagged workflow that is currently undergoing testing on staging

### Automated test coverage
most important bits are already tested, but I will be adding tests for this functionality once the timeline pressures are eased

### QA Plan
not blocking PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
