### PR TITLE
Add experiment for exports between couch and ES

### DIFF
--- a/corehq/apps/experiments/__init__.py
+++ b/corehq/apps/experiments/__init__.py
@@ -1,4 +1,5 @@
 from .experiment import Experiment  # noqa: F401
 
 # campaigns
+ES_FOR_EXPORTS = 'es-for-exports'
 RM_HQCASES = 'rm-hqcases'

--- a/corehq/ex-submodules/couchforms/analytics.py
+++ b/corehq/ex-submodules/couchforms/analytics.py
@@ -12,7 +12,8 @@ from corehq.util.dates import iso_string_to_datetime
 experiment = Experiment(
     campaign=ES_FOR_EXPORTS,
     old_args={},
-    new_args={'use_es': True}
+    new_args={'use_es': True},
+    is_equal=lambda a, b: True,
 )
 
 

--- a/corehq/ex-submodules/couchforms/analytics.py
+++ b/corehq/ex-submodules/couchforms/analytics.py
@@ -2,11 +2,18 @@ import datetime
 
 from corehq.apps.es import AppES, FormES
 from corehq.apps.es.aggregations import TermsAggregation
+from corehq.apps.experiments import Experiment, ES_FOR_EXPORTS
 from corehq.const import MISSING_APP_ID
 from corehq.util.quickcache import quickcache
 
 from corehq.util.couch import stale_ok
 from corehq.util.dates import iso_string_to_datetime
+
+experiment = Experiment(
+    campaign=ES_FOR_EXPORTS,
+    old_args={},
+    new_args={'use_es': True}
+)
 
 
 def domain_has_submission_in_last_30_days(domain):
@@ -133,17 +140,12 @@ def get_form_analytics_metadata(domain, app_id, xmlns):
 
 
 def get_exports_by_form(domain, use_es=False):
-    from corehq.apps.app_manager.models import Application
     if use_es:
+        # if use_es is True here, the "export_apps_use_elasticsearch" ff is enabled for
+        # this domain so just return es results without the experiment
         rows = _get_export_forms_by_app_es(domain)
     else:
-        rows = Application.get_db().view(
-            'exports_forms_by_app/view',
-            startkey=[domain],
-            endkey=[domain, {}],
-            group=True,
-            stale=stale_ok()
-        ).all()
+        rows = _experiment_get_export_forms(domain)
     form_count_breakdown = get_form_count_breakdown_for_domain(domain)
 
     for row in rows:
@@ -155,6 +157,22 @@ def get_exports_by_form(domain, use_es=False):
         rows.append({'key': list(key), 'value': {'xmlns': key[2], 'submissions': value}})
 
     rows.sort(key=lambda row: row['key'])
+    return rows
+
+
+@experiment
+def _experiment_get_export_forms(domain, use_es=False):
+    from corehq.apps.app_manager.models import Application
+    if use_es:
+        rows = _get_export_forms_by_app_es(domain)
+    else:
+        rows = Application.get_db().view(
+            'exports_forms_by_app/view',
+            startkey=[domain],
+            endkey=[domain, {}],
+            group=True,
+            stale=stale_ok()
+        ).all()
     return rows
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://github.com/dimagi/commcare-hq/pull/34266 was added to speed up fetching apps/forms for exports. This behavior is behind a feature flag, and we are curious if this change is generally good across all of HQ so we want to run an experiment on it.

Running an experiment involves running both the old and new code paths, which could have negative performance impacts. In the case of this feature flag, there is only one domain under it and I have structured the code in a way that we will not run the experiment on any domain with this flag enabled. This ensures that performance doesn't backslide for this domain.

This experiment doesn't need to be run for more than a week, so this code is very temporary.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
EXPORTS_APPS_USE_ELASTICSEARCH

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

It is still true that domains might experience negative performance so we will need to monitor datadog closely to ensure this isn't adding too much time to exports. Given the evidence is that ES has been much faster in certain use cases, it seems unlikely that adding an ES query is going to cause a significant change in overall timing but still good to keep in mind.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
