### PR TITLE
Split fixtures into one per indicator (Module Badges)

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -336,7 +336,6 @@ INSTANCE_KWARGS_BY_ID = {
     'casedb': {'id': 'casedb', 'src': 'jr://instance/casedb'},
     'commcaresession': {'id': 'commcaresession', 'src': 'jr://instance/session'},
     'registry': {'id': 'registry', 'src': 'jr://instance/remote/registry'},
-    'case-search-fixture': {'id': 'case-search-fixture', 'src': 'jr://fixture/case-search-fixture'},
 }
 
 
@@ -409,6 +408,11 @@ def location_fixture_instances(app, instance_name):
             and not LocationFixtureConfiguration.for_domain(app.domain).sync_flat_fixture):
         return Instance(id=instance_name, src='jr://fixture/commtrack:{}'.format(instance_name))
     return Instance(id=instance_name, src='jr://fixture/{}'.format(instance_name))
+
+
+@register_factory('case-search-fixture')
+def case_search_fixture_instances(app, instance_name):
+    return Instance(id=instance_name, src=f'jr://fixture/{instance_name}')
 
 
 def get_all_instances_referenced_in_xpaths(app, xpaths):

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -15,8 +15,10 @@ from corehq.apps.app_manager.models import (
     ShadowModule,
 )
 from corehq.apps.app_manager.suite_xml.post_process.instances import (
+    get_all_instances_referenced_in_xpaths,
     get_instance_names,
 )
+from corehq.apps.app_manager.suite_xml.xml_models import Instance
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
@@ -298,3 +300,14 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
 ], SuiteInstanceTests)
 def test_get_instance_names(self, xpath, expected_names):
     self.assertEqual(get_instance_names(xpath), expected_names)
+
+
+@generate_cases([
+    ("instance('case-search-fixture:myindicator')/value",
+     Instance(id="case-search-fixture:myindicator", src="jr://fixture/case-search-fixture:myindicator")),
+], SuiteInstanceTests)
+def test_instance_factories(self, xpath, expected_instance):
+    instances, _ = get_all_instances_referenced_in_xpaths(self.factory.app, [xpath])
+    instance, = instances
+    self.assertEqual(instance.id, expected_instance.id)
+    self.assertEqual(instance.src, expected_instance.src)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user facing effects.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-5940](https://dimagi.atlassian.net/browse/USH-5940)
Originally, all indicators (CSQL Fixture Expression) were defined under one fixture. This change splits it so a fixture defines one indicator. This is in preparation for caching.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
tested locally and will test on staging. This only affects apps that use CSQL fixtures. This is currently limited to co-carecoordination domain.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests were updated that verifies:
- the expected xml fixtures are generated in the restore
- high level `generate_fixtures` produces  correct values for the fixtures in the restore
- the suite generates the instance xml for the CSQL fixture

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
This PR changes the xpath expression that needs to be configured on the app. If this PR is reverted, the applications using CSQL will need to be updated.
old: instance('case-search-fixture')/values/value[@name=”{CSQL_fixture_name}”]
new: instance('case-search-fixture:{CSQL_fixture_name'})/value

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-5940]: https://dimagi.atlassian.net/browse/USH-5940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ