### PR TITLE
Add web user to default filter

### DIFF
--- a/corehq/apps/reports/filters/case_list.py
+++ b/corehq/apps/reports/filters/case_list.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext as _
 from memoized import memoized
 
 from corehq.apps.locations.permissions import location_safe
+from corehq.apps.reports.models import HQUserType
 
 from .users import EmwfUtils, ExpandedMobileWorkerFilter
 
@@ -36,7 +37,6 @@ class CaseListFilter(ExpandedMobileWorkerFilter):
     label = _("Case Owner(s)")
     slug = 'case_list_filter'
     options_url = 'case_list_options'
-    default_selections = [('project_data', _("[Project Data]"))]
     placeholder = _("Add case owners to filter this report.")
 
     @property
@@ -83,6 +83,6 @@ class CaseListFilter(ExpandedMobileWorkerFilter):
 
     def get_default_selections(self):
         if self.request.can_access_all_locations:
-            return self.default_selections
+            return [('project_data', _("[Project Data]")), self.utils.user_type_tuple(HQUserType.WEB)]
         else:
             return self._get_assigned_locations_default()

--- a/corehq/apps/reports/filters/case_list.py
+++ b/corehq/apps/reports/filters/case_list.py
@@ -37,6 +37,7 @@ class CaseListFilter(ExpandedMobileWorkerFilter):
     label = _("Case Owner(s)")
     slug = 'case_list_filter'
     options_url = 'case_list_options'
+    default_selections = None   # Can be overridden by subclasses
     placeholder = _("Add case owners to filter this report.")
 
     @property
@@ -83,6 +84,8 @@ class CaseListFilter(ExpandedMobileWorkerFilter):
 
     def get_default_selections(self):
         if self.request.can_access_all_locations:
+            if self.default_selections:
+                return self.default_selections
             return [('project_data', _("[Project Data]")), self.utils.user_type_tuple(HQUserType.WEB)]
         else:
             return self._get_assigned_locations_default()

--- a/corehq/apps/reports/filters/case_list.py
+++ b/corehq/apps/reports/filters/case_list.py
@@ -63,8 +63,8 @@ class CaseListFilter(ExpandedMobileWorkerFilter):
 
     @classmethod
     def selected_group_ids(cls, mobile_user_and_group_slugs):
-        return (super(CaseListFilter, cls).selected_group_ids(mobile_user_and_group_slugs) +
-                cls.selected_sharing_group_ids(mobile_user_and_group_slugs))
+        return (super(CaseListFilter, cls).selected_group_ids(mobile_user_and_group_slugs)
+                + cls.selected_sharing_group_ids(mobile_user_and_group_slugs))
 
     def _selected_group_entries(self, mobile_user_and_group_slugs):
         query_results = self._selected_groups_query(mobile_user_and_group_slugs)

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -275,9 +275,8 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         defaults = [
             self.utils.user_type_tuple(HQUserType.ACTIVE),
             self.utils.user_type_tuple(HQUserType.DEACTIVATED),
+            self.utils.user_type_tuple(HQUserType.WEB),
         ]
-        if toggles.WEB_USERS_IN_REPORTS.enabled(self.domain):
-            defaults.append(self.utils.user_type_tuple(HQUserType.WEB))
         if self.request.project.commtrack_enabled:
             defaults.append(self.utils.user_type_tuple(HQUserType.COMMTRACK))
         return defaults

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -1,4 +1,3 @@
-from corehq import toggles
 from corehq.apps.es import cases as case_es
 from corehq.apps.es import filters
 from corehq.apps.es import users as user_es
@@ -47,7 +46,7 @@ def all_project_data_filter(domain, mobile_user_and_group_slugs):
         domain=domain,
         admin=HQUserType.ADMIN not in user_types,
         unknown=HQUserType.UNKNOWN not in user_types,
-        web=not toggles.WEB_USERS_IN_REPORTS.enabled(domain),  # don't exclude if flag enabled
+        web=HQUserType.WEB not in user_types,
         demo=HQUserType.DEMO_USER not in user_types,
         commtrack=False,
     )

--- a/corehq/apps/reports/tests/test_case_list_report.py
+++ b/corehq/apps/reports/tests/test_case_list_report.py
@@ -14,7 +14,6 @@ from corehq.apps.users.models import (
     WebUser,
 )
 from corehq.form_processor.models import CommCareCase
-from corehq.util.test_utils import flag_enabled
 
 
 @es_test(requires=[case_adapter, group_adapter, user_adapter], setup_class=True)
@@ -80,10 +79,6 @@ class TestCaseListReport(TestCase):
 
     def test_with_project_data_slug(self):
         self.assert_filters_yield_cases(['project_data'], ['id-1', 'id-2', 'id-3', 'id-5'])
-
-    @flag_enabled('WEB_USERS_IN_REPORTS')
-    def test_with_project_data_slug_web_users_enabled(self):
-        self.assert_filters_yield_cases(['project_data'], ['id-1', 'id-2', 'id-3', 'id-4', 'id-5'])
 
     def test_with_deactivated_slug(self):
         self.assert_filters_yield_cases(['t__5'], ['id-1'])

--- a/corehq/apps/reports/tests/test_filters.py
+++ b/corehq/apps/reports/tests/test_filters.py
@@ -243,8 +243,7 @@ class TestCaseListFilter(TestCase):
         self.request.can_access_all_locations = True
         self.request.project = self.domain
         emwf = self.subject(self.request)
-        default_selections = emwf.get_default_selections()
-        self.assertEqual(default_selections, emwf.default_selections)
+        emwf.get_default_selections()
         assert not assigned_locations_patch.called
 
     @patch('corehq.apps.users.models.WebUser.get_sql_locations')

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2660,11 +2660,10 @@ LOCATION_RESTRICTED_SCHEDULED_REPORTS = StaticToggle(
 
 WEB_USERS_IN_REPORTS = StaticToggle(
     'web_users_in_reports',
-    'Adds web users to standard reports by default',
+    'Adds web users to to the body of the Worker Activity and Project Health reports',
     TAG_RELEASE,
     namespaces=[NAMESPACE_DOMAIN],
-    description='Adds web users to default filter selections, the [Project Data] filter for the '
-                'case list reports, and to the body of the Worker Activity and Project Health reports'
+    description='Adds web users to the body of the Worker Activity and Project Health reports'
 )
 
 CUSTOM_EMAIL_GATEWAY = StaticToggle(


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This PR partially GAed feature flag `WEB_USERS_IN_REPORTS`.

- Adds web users to the default User(s) Filter selections for standard reports.
<img width="685" alt="image" src="https://github.com/user-attachments/assets/69a27969-5509-4aa1-92d3-d3dd6fee29bf" />


- The Feature Flag intends to change the definition of "Project Data" to include both mobile workers and web users in Case Owner(s) filter. This PR reverts the definition of “Project Data“ back and add “Web Users“ to default selection.
<img width="523" alt="image" src="https://github.com/user-attachments/assets/a44eb2b5-4ba2-4ade-86e7-727a10f6507d" />

Hopefully with the changes, it is easier for our user to find data submitted by Web Users.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17587

This PR is partially GAing [this PR](https://github.com/dimagi/commcare-hq/pull/33478), we remain the Worker Activity and Project Performance report untouched because we think it should means for mobile worker for now.

User(s) Filter is `ExpandedMobileWorkerFilter` under the hood, and Case Owner(s) Filter is `CaseListFilter`.

Adding Web User as default selection is pretty straightforward.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe as just adding Web User to default selection. Not changing any existing export or report.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
