### PR TITLE
[Data Cleaning] Updates to session status view

### DIFF
--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -14,7 +14,7 @@ from corehq.apps.es import CaseSearchES
 BULK_OPERATION_CHUNK_SIZE = 1000
 MAX_RECORDED_LIMIT = 100000
 MAX_SESSION_CHANGES = 200
-APPLY_CHANGES_WAIT_TIME = 15  # seconds
+APPLY_CHANGES_WAIT_TIME = 3  # seconds
 
 
 class BulkEditSession(models.Model):

--- a/corehq/apps/data_cleaning/templates/data_cleaning/bulk_edit_session.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/bulk_edit_session.html
@@ -41,10 +41,9 @@
     </div>
   </div>
   <div
-    id="primary-view-container"
     class="mx-3"
     hx-get="{{ htmx_primary_view_url }}{% querystring %}"
-    hx-trigger="load, statusRefresh"
+    hx-trigger="load"
     hx-swap="innerHTML"
   >
     <div class="htmx-indicator">

--- a/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_apply.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/modals/confirm_apply.html
@@ -10,7 +10,7 @@
   hx-post="{{ request.path_info }}{% querystring %}"
   hq-hx-action="apply_all_changes"
   hx-target="{% if table.container_id %}#{{ table.container_id }}{% else %}.table-container{% endif %}"
-  hx-swap="outerHTML"
+  hx-swap="none"
   hq-hx-loading="{{ table.loading_indicator_id }}"
   hx-disable-elt="this"
 {% endblock %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/base_modal_body.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/base_modal_body.html
@@ -1,0 +1,33 @@
+{% load i18n %}
+
+<div {% block htmx-attrs %}{% endblock htmx-attrs %}>
+  <div class="modal-header">
+    <h5 class="modal-title">
+      {% block modal-header %}{% endblock modal-header %}
+    </h5>
+  </div>
+  <div class="modal-body">
+    <div class="alert alert-success">
+      {% include "data_cleaning/status/partial/task_progress_bar.html" %}
+      {% block task-status-text %}{% endblock task-status-text %}
+    </div>
+    {% block modal-body %}{% endblock modal-body %}
+  </div>
+  <div class="modal-footer">
+    <a
+      class="btn btn-outline-primary"
+      href="{{ exit_url }}"
+    >
+      {% trans "Exit session" %}
+    </a>
+    {% block continue-button %}
+      <button
+        type="button"
+        class="btn btn-primary"
+        disabled="disabled"
+      >
+        {% trans "Continue editing" %}
+      </button>
+    {% endblock continue-button %}
+  </div>
+</div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
@@ -1,22 +1,22 @@
+{% extends "data_cleaning/status/base_modal_body.html" %}
 {% load i18n %}
 
-<div class="modal-header">
-  <h5 class="modal-title">
-    {% trans "Changes Applied" %}
-  </h5>
-</div>
-<div class="modal-body">
-  <div class="alert alert-success">
-    {% include "data_cleaning/status/partial/task_progress_bar.html" %}
-    <i class="fa-solid fa-check-double me-1"></i>
-    {# prettier-ignore-start #}
-    {% blocktrans count count=num_records_changed %}
-      Finished processing changes, updated 1 case.
-    {% plural %}
-      Finished processing changes, updated {{ num_records_changed }} cases.
-    {% endblocktrans %}
-    {# prettier-ignore-end #}
-  </div>
+{% block modal-header %}
+  {% trans "Changes Applied" %}
+{% endblock modal-header %}
+
+{% block task-status-text %}
+  <i class="fa-solid fa-check-double me-1"></i>
+  {# prettier-ignore-start #}
+  {% blocktrans count count=num_records_changed %}
+    Finished processing changes, updated 1 case.
+  {% plural %}
+    Finished processing changes, updated {{ num_records_changed }} cases.
+  {% endblocktrans %}
+  {# prettier-ignore-end #}
+{% endblock task-status-text %}
+
+{% block modal-body %}
   {% if active_session %}
     <p class="lead">
       {% blocktrans %}
@@ -36,14 +36,9 @@
       {% endblocktrans %}
     </p>
   {% endif %}
-</div>
-<div class="modal-footer">
-  <a
-    class="btn btn-outline-primary"
-    href="{{ exit_url }}"
-  >
-    {% trans "Exit session" %}
-  </a>
+{% endblock modal-body %}
+
+{% block continue-button %}
   <button
     type="button"
     class="btn btn-primary"
@@ -58,4 +53,4 @@
       {% trans "Continue editing" %}
     {% endif %}
   </button>
-</div>
+{% endblock continue-button %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
@@ -7,9 +7,7 @@
 </div>
 <div class="modal-body">
   <div class="alert alert-success">
-    <div class="progress mb-2" role="progressbar" aria-label="Basic example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
-      <div class="progress-bar bg-success" style="width: 100%"></div>
-    </div>
+    {% include "data_cleaning/status/partial/task_progress_bar.html" %}
     <i class="fa-solid fa-check-double me-1"></i>
     {# prettier-ignore-start #}
     {% blocktrans count count=num_records_changed %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
@@ -1,5 +1,6 @@
 {% extends "data_cleaning/status/base_modal_body.html" %}
 {% load i18n %}
+{% load django_tables2 %}
 
 {% block modal-header %}
   {% trans "Changes Applied" %}
@@ -42,7 +43,7 @@
   <button
     type="button"
     class="btn btn-primary"
-    hx-post="{{ request.path_info }}"
+    hx-post="{{ request.path_info }}{% querystring %}"
     hq-hx-action="resume_session"
     hx-swap="none"
     hx-disabled-elt="this"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
@@ -2,7 +2,7 @@
 
 <div
   hx-get="{{ request.path_info }}"
-  hx-trigger="every 5s from:load"
+  hx-trigger="every 1s from:load"
   hq-hx-action="poll_session_status"
   hx-swap="outerHTML"
 >

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
@@ -13,9 +13,8 @@
   </div>
   <div class="modal-body">
     <div class="alert alert-success">
-      <div class="progress mb-2" role="progressbar" aria-label="Basic example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
-        <div class="progress-bar bg-success" style="width: {{ session.percent_complete }}%"></div>
-      </div>
+      {% include "data_cleaning/status/partial/task_progress_bar.html" %}
+
       <div class="d-flex justify-content-between">
         <div>
           <i class="fa-solid fa-check-double me-1"></i>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
@@ -1,8 +1,9 @@
 {% extends "data_cleaning/status/base_modal_body.html" %}
 {% load i18n %}
+{% load django_tables2 %}
 
 {% block htmx-attrs %}
-  hx-get="{{ request.path_info }}"
+  hx-get="{{ request.path_info }}{% querystring %}"
   hx-swap="outerHTML"
   hx-trigger="every 0.5s from:load"
   hq-hx-action="poll_session_status"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
@@ -12,6 +12,7 @@
     </h5>
   </div>
   <div class="modal-body">
+
     <div class="alert alert-success">
       {% include "data_cleaning/status/partial/task_progress_bar.html" %}
 
@@ -22,6 +23,8 @@
             Applying changes, please wait...
           {% endblocktrans %}
         </div>
+
+        {# artificial buffer to let change feed catch up #}
         {% if is_task_complete %}
           <div>
             <i class="fa-solid fa-spinner fa-spin"></i>
@@ -32,6 +35,7 @@
         {% endif %}
       </div>
     </div>
+
   </div>
   <div class="modal-footer">
     <a

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
@@ -1,55 +1,34 @@
+{% extends "data_cleaning/status/base_modal_body.html" %}
 {% load i18n %}
 
-<div
+{% block htmx-attrs %}
   hx-get="{{ request.path_info }}"
+  hx-swap="outerHTML"
   hx-trigger="every 1s from:load"
   hq-hx-action="poll_session_status"
-  hx-swap="outerHTML"
->
-  <div class="modal-header">
-    <h5 class="modal-title">
-      {% trans "Applying Changes..." %}
-    </h5>
-  </div>
-  <div class="modal-body">
+{% endblock htmx-attrs %}
 
-    <div class="alert alert-success">
-      {% include "data_cleaning/status/partial/task_progress_bar.html" %}
+{% block modal-header %}
+  {% trans "Applying Changes..." %}
+{% endblock modal-header %}
 
-      <div class="d-flex justify-content-between">
-        <div>
-          <i class="fa-solid fa-check-double me-1"></i>
-          {% blocktrans %}
-            Applying changes, please wait...
-          {% endblocktrans %}
-        </div>
-
-        {# artificial buffer to let change feed catch up #}
-        {% if is_task_complete %}
-          <div>
-            <i class="fa-solid fa-spinner fa-spin"></i>
-            {% blocktrans %}
-              Database is refreshing...almost there!
-            {% endblocktrans %}
-          </div>
-        {% endif %}
-      </div>
+{% block task-status-text %}
+  <div class="d-flex justify-content-between">
+    <div>
+      <i class="fa-solid fa-check-double me-1"></i>
+      {% blocktrans %}
+        Applying changes, please wait...
+      {% endblocktrans %}
     </div>
 
+    {# artificial buffer to let change feed catch up #}
+    {% if is_task_complete %}
+      <div>
+        <i class="fa-solid fa-spinner fa-spin"></i>
+        {% blocktrans %}
+          Database is refreshing...almost there!
+        {% endblocktrans %}
+      </div>
+    {% endif %}
   </div>
-  <div class="modal-footer">
-    <a
-      class="btn btn-outline-primary"
-      href="{{ exit_url }}"
-    >
-      {% trans "Exit session" %}
-    </a>
-    <button
-      type="button"
-      class="btn btn-primary"
-      disabled="disabled"
-    >
-      {% trans "Continue editing" %}
-    </button>
-  </div>
-</div>
+{% endblock task-status-text %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/in_progress.html
@@ -4,7 +4,7 @@
 {% block htmx-attrs %}
   hx-get="{{ request.path_info }}"
   hx-swap="outerHTML"
-  hx-trigger="every 1s from:load"
+  hx-trigger="every 0.5s from:load"
   hq-hx-action="poll_session_status"
 {% endblock htmx-attrs %}
 

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/modal.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/modal.html
@@ -14,7 +14,7 @@
       The HTMX request below will trigger a `showDataCleaningModal` event
       for the `#session-status-modal` above after the HTMX swap.
 
-      This request will not be triggered unless the sesison is read-only (triggers on `load`)
+      This request will not be triggered unless the session is read-only (triggers on `load`)
       OR the `dcRefreshStatusModal` event is sent to `#session-status-modal-body`.
     {% endcomment %}
     <div

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/modal.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/modal.html
@@ -5,7 +5,6 @@
   id="session-status-modal"
   class="modal fade"
   tabindex="-1"
-  aria-labelledby="staticBackdropLabel"
   aria-hidden="true"
   data-bs-backdrop="static"
   data-bs-keyboard="false"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/modal.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/modal.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load django_tables2 %}
 
 <div
   id="session-status-modal"
@@ -13,8 +14,11 @@
     <div
       class="modal-content"
       id="session-status-modal-body"
-      hx-get="{{ htmx_session_status_view_url }}"
-      hx-trigger="{% if session.is_read_only %}load, {% endif %}dcRefreshStatusModal"
+      hx-get="{{ htmx_session_status_view_url }}{% querystring %}"
+      hx-trigger="
+        {% if session.is_read_only %}load,{% endif %}
+        dcRefreshStatusModal
+      "
       hx-swap="innerHTML"
     ></div>
   </div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/modal.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/modal.html
@@ -11,6 +11,13 @@
   data-bs-keyboard="false"
 >
   <div class="modal-dialog modal-dialog-centered">
+    {% comment %}
+      The HTMX request below will trigger a `showDataCleaningModal` event
+      for the `#session-status-modal` above after the HTMX swap.
+
+      This request will not be triggered unless the sesison is read-only (triggers on `load`)
+      OR the `dcRefreshStatusModal` event is sent to `#session-status-modal-body`.
+    {% endcomment %}
     <div
       class="modal-content"
       id="session-status-modal-body"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/partial/task_progress_bar.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/partial/task_progress_bar.html
@@ -4,12 +4,12 @@
   class="progress mb-2"
   role="progressbar"
   aria-label="{% trans "Task progress" %}"
-  aria-valuenow="{{ session.percent_complete }}"
+  aria-valuenow="{{ weighted_percent_complete }}"
   aria-valuemin="0"
   aria-valuemax="100"
 >
   <div
     class="progress-bar bg-success"
-    style="width: {{ session.percent_complete }}%"
+    style="width: {{ weighted_percent_complete }}%"
   ></div>
 </div>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/partial/task_progress_bar.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/partial/task_progress_bar.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+
+<div
+  class="progress mb-2"
+  role="progressbar"
+  aria-label="{% trans "Task progress" %}"
+  aria-valuenow="{{ session.percent_complete }}"
+  aria-valuemin="0"
+  aria-valuemax="100"
+>
+  <div
+    class="progress-bar bg-success"
+    style="width: {{ session.percent_complete }}%"
+  ></div>
+</div>

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -86,16 +86,8 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
 
     @hq_hx_action('get')
     def poll_session_status(self, request, *args, **kwargs):
-        # we call super() to avoid the default behavior of this view
-        # which is to trigger the session status modal
-        response = super().get(request, *args, **kwargs)
-        if self.session.completed_on is not None:
-            response['HX-Trigger'] = json.dumps({
-                'statusRefresh': {
-                    'target': '#primary-view-container',
-                },
-            })
-        return response
+        # we call super() to avoid triggering "showDataCleaningModal" again
+        return super().get(request, *args, **kwargs)
 
     @hq_hx_action('post')
     def resume_session(self, request, *args, **kwargs):

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -37,7 +37,7 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
 
     @property
     def is_session_in_progress(self):
-        return self.seconds_since_complete < APPLY_CHANGES_WAIT_TIME
+        return self.session.committed_on is not None and self.seconds_since_complete < APPLY_CHANGES_WAIT_TIME
 
     def get_template_names(self):
         if self.is_session_in_progress:

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -114,10 +114,12 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
         new_session = self.session.get_resumed_session()
 
         from corehq.apps.data_cleaning.views.main import BulkEditCasesSessionView
+        new_session_url = reverse(
+            BulkEditCasesSessionView.urlname,
+            args=(self.domain, new_session.session_id),
+        )
+        query_string = request.META.get('QUERY_STRING', '')
         return self.render_htmx_redirect(
-            reverse(
-                BulkEditCasesSessionView.urlname,
-                args=(self.domain, new_session.session_id),
-            ),
+            f"{new_session_url}?{query_string}",
             response_message=_("Resuming Bulk Edit Session..."),
         )

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -137,9 +137,6 @@ class EditCasesTableView(BulkEditSessionViewMixin,
             commit_data_cleaning.delay(self.session.session_id)
         response = self.render_htmx_no_response(request, *args, **kwargs)
         response['HX-Trigger'] = json.dumps({
-            'showDataCleaningModal': {
-                'target': '#session-status-modal',
-            },
             'dcRefreshStatusModal': {
                 'target': '#session-status-modal-body',
             },

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -135,7 +135,7 @@ class EditCasesTableView(BulkEditSessionViewMixin,
             self.session.committed_on = timezone.now()
             self.session.save()
             commit_data_cleaning.delay(self.session.session_id)
-        response = self.get(request, *args, **kwargs)
+        response = self.render_htmx_no_response(request, *args, **kwargs)
         response['HX-Trigger'] = json.dumps({
             'showDataCleaningModal': {
                 'target': '#session-status-modal',


### PR DESCRIPTION
## Technical Summary
- dry up the code surrounding the status modal, improving readability
- make the progress bar feel more responsive by decreasing the polling time and simulating progress during the "buffering period"
- decrease the buffering period to 3 seconds, with a note that we should update this value in the future based on real time change feed delays
- remove unnecessary refreshes to table view after hitting apply changes

Note: I plan to address issues with the text content of the status modal in an upcoming PR. so that bit isn't a part of this PR

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
changes made to a feature flagged workflow that is undergoing user testing on staging

### Automated test coverage
most important bits are tested, but more tests are coming

### QA Plan
not blocking PR, as this still is feature flagged


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
