### PR TITLE
Added update_multi field for FormActions

### DIFF
--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -1,0 +1,93 @@
+from django.test import SimpleTestCase
+from corehq.apps.app_manager.models import UpdateCaseAction
+
+
+class UpdateCaseActionTests(SimpleTestCase):
+    def test_construction(self):
+        action = UpdateCaseAction({
+            'update': {'one': {'question_path': '/root/'}},
+            'update_multi': {
+                'two': [
+                    {'question_path': '/one/'},
+                    {'question_path': '/two/'},
+                ]
+            }
+        })
+
+        self.assertEqual(action.update['one'].question_path, '/root/')
+        multi_paths = {k: [action.question_path for action in v] for (k, v) in action.update_multi.items()}
+        self.assertEqual(multi_paths, {'two': ['/one/', '/two/']})
+
+    def test_make_multi_when_no_updates_does_nothing(self):
+        action = UpdateCaseAction({
+            'update_multi': {
+                'two': [
+                    {'question_path': '/one/'},
+                    {'question_path': '/two/'},
+                ]
+            }
+        })
+
+        action.make_multi()
+
+        multi_paths = {k: [action.question_path for action in v] for (k, v) in action.update_multi.items()}
+        self.assertEqual(multi_paths, {'two': ['/one/', '/two/']})
+
+    def test_make_multi_when_updates_are_none_does_nothing(self):
+        action = UpdateCaseAction({
+            'update': None,
+            'update_multi': {
+                'two': [
+                    {'question_path': '/one/'},
+                    {'question_path': '/two/'},
+                ]
+            }
+        })
+
+        action.make_multi()
+
+        multi_paths = {k: [action.question_path for action in v] for (k, v) in action.update_multi.items()}
+        self.assertEqual(multi_paths, {'two': ['/one/', '/two/']})
+
+    def test_make_multi_populates_multi(self):
+        action = UpdateCaseAction({
+            'update': {
+                'one': {'question_path': '/one/'},
+                'two': {'question_path': '/two/'},
+            }
+        })
+
+        action.make_multi()
+
+        multi_paths = {k: [action.question_path for action in v] for (k, v) in action.update_multi.items()}
+        self.assertEqual(multi_paths, {'one': ['/one/'], 'two': ['/two/']})
+        self.assertEqual(action.update, {})
+
+    def test_normalize_update_when_case_property_has_multiple_questions_does_nothing(self):
+        action = UpdateCaseAction({
+            'update_multi': {
+                'one': [
+                    {'question_path': '/one/'},
+                    {'question_path': '/two/'}
+                ]
+            }
+        })
+
+        action.normalize_update()
+
+        self.assertEqual(action.update, {})
+
+    def test_normalize_update_moves_update_multi_to_update(self):
+        action = UpdateCaseAction({
+            'update_multi': {
+                'one': [{'question_path': '/one/'}],
+                'two': [{'question_path': '/two/'}]
+            }
+        })
+
+        action.normalize_update()
+
+        update_paths = {k: v.question_path for (k, v) in action.update.items()}
+
+        self.assertEqual(update_paths, {'one': '/one/', 'two': '/two/'})
+        self.assertIsNone(action.update_multi)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-17568.
This just creates the field to make saving multiple questions to a single case property possible. It also introduces utility functions to eventually allow us to use `update_multi` as a substitute for `update`, even for actions that don't save multiple questions to a single case property. However, it does not introduce any logic allowing for this yet. Anything that would break current behavior will be introduced behind a feature flag.

## Feature Flag
No current feature flag, but the follow-up work will be feature-flagged.

## Safety Assurance

### Safety story
The new field is unused by current code, so it shouldn't pose a safety risk

### Automated test coverage

New test suite for the utility functions

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
