### PR TITLE
Don't translate dayViewHeaderFormat options

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
@@ -7,7 +7,6 @@ import _ from 'underscore';
 const defaultTranslations = {
     clear: gettext('Clear selection'),
     close: gettext('Close the picker'),
-    dayViewHeaderFormat: { month: gettext('long'), year: gettext('2-digit') },
     decrementHour: gettext('Decrement Hour'),
     decrementMinute: gettext('Decrement Minute'),
     decrementSecond: gettext('Decrement Second'),
@@ -58,6 +57,7 @@ Alpine.directive('datepicker', (el, { expression }, { cleanup }) => {
         clock: false,
     };
     let localization = {
+        dayViewHeaderFormat: { month: 'long', year: '2-digit' },
         format: 'yyyy-MM-dd',
     };
 
@@ -66,6 +66,7 @@ Alpine.directive('datepicker', (el, { expression }, { cleanup }) => {
             seconds: true,
         };
         localization = {
+            dayViewHeaderFormat: { month: 'long', year: '2-digit' },
             hourCycle: 'h23',
             format: 'yyyy-MM-dd H:mm:ss',
         };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/tempus_dominus.js
@@ -26,6 +26,7 @@ hqDefine("hqwebapp/js/tempus_dominus", [
                 },
             },
             localization: _.extend(defaultTranslations, {
+                dayViewHeaderFormat: { month: 'long', year: '2-digit' },
                 format: 'yyyy-MM-dd',
             }),
         }));
@@ -71,6 +72,7 @@ hqDefine("hqwebapp/js/tempus_dominus", [
                     },
                 },
                 localization: _.extend(defaultTranslations, {
+                    dayViewHeaderFormat: { month: 'long', year: '2-digit' },
                     format: 'yyyy-MM-dd',
                 }),
             },
@@ -108,6 +110,7 @@ hqDefine("hqwebapp/js/tempus_dominus", [
                 },
             },
             localization: _.extend(defaultTranslations, {
+                dayViewHeaderFormat: { month: 'long', year: '2-digit' },
                 hourCycle: 'h23',
                 format: 'H:mm',
             }),
@@ -155,7 +158,6 @@ hqDefine("hqwebapp/js/tempus_dominus", [
     const defaultTranslations = {
         clear: gettext('Clear selection'),
         close: gettext('Close the picker'),
-        dayViewHeaderFormat: { month: gettext('long'), year: gettext('2-digit') },
         decrementHour: gettext('Decrement Hour'),
         decrementMinute: gettext('Decrement Minute'),
         decrementSecond: gettext('Decrement Second'),


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-17634

There is a bug with the date picker when the browser or commcare is set to a different language. This is because we translate the `dayViewHeaderFormat` option for the date picker even though it should not be translated. This change ensures the option is always recognized by the date picker.

To preserve behavior I just added dayViewHeaderFormat to all of the places where we extend the localization option with defaultTranslations and removed it from defaultTranslations. This didn't feel like the _cleanest_ solution but I believe does the trick.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Attempted to preserve existing behavior by including this option everywhere that we set the `localization` paramter on the date picker.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
