### PR TITLE
Fix syntax error in downgrade error message

### DIFF
--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1575,7 +1575,7 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
             messages.error(
                 request, _(
                     "You have already scheduled a downgrade to the %(software_plan_name)s Software Plan on "
-                    "%(downgrade_date)s. If this is a mistake, please reach out to %(contact_email)."
+                    "%(downgrade_date)s. If this is a mistake, please reach out to %(contact_email)s."
                 ) % {
                     'software_plan_name': software_plan_name,
                     'downgrade_date': downgrade_date,


### PR DESCRIPTION
## Product Description
In the rare circumstance someone manages to schedule a downgrade of their subscription when one is already scheduled (normally future subscriptions are cancelled first), this message would have given an "incomplete format" error and likely shown a 500.

## Technical Summary
Adds an `s`

## Safety Assurance

### Safety story
Very small fix to a previously-broken, seldom-seen piece of string formatting.

### Automated test coverage
Nope

### QA Plan
Nada


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
