### PR TITLE
[Data Cleaning] Updates to the "Recent Tasks" table

### DIFF
--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -89,6 +89,10 @@ class BulkEditSession(models.Model):
     def get_committed_sessions(cls, user, domain_name):
         return cls.objects.filter(user=user, domain=domain_name, committed_on__isnull=False)
 
+    @classmethod
+    def get_all_sessions(cls, user, domain_name):
+        return cls.objects.filter(user=user, domain=domain_name).order_by('-created_on')
+
     def get_resumed_session(self):
         new_session = self.new_case_session(
             self.user,

--- a/corehq/apps/data_cleaning/static/data_cleaning/js/bulk_edit_main.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/bulk_edit_main.js
@@ -1,6 +1,7 @@
 import 'commcarehq';
 import 'hqwebapp/js/htmx_base';
 import 'hqwebapp/js/alpinejs/directives/select2';
+import 'hqwebapp/js/alpinejs/directives/tooltip';
 
 import Alpine from 'alpinejs';
 Alpine.start();

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -109,7 +109,10 @@ class EditCasesTable(BaseHtmxTable, ElasticTable):
 class RecentCaseSessionsTable(BaseHtmxTable, tables.Table):
 
     class Meta(BaseHtmxTable.Meta):
-        pass
+        template_name = "data_cleaning/tables/recent_sessions.html"
+        attrs = {
+            "class": "table table-striped align-middle",
+        }
 
     status = columns.TemplateColumn(
         template_name="data_cleaning/columns/task_status.html",

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -134,7 +134,3 @@ class RecentCaseSessionsTable(BaseHtmxTable, tables.Table):
         template_name="data_cleaning/columns/task_form_ids.html",
         verbose_name=gettext_lazy("Form IDs"),
     )
-    session_url = columns.TemplateColumn(
-        template_name="data_cleaning/columns/task_session_url.html",
-        verbose_name=gettext_lazy("Open Session"),
-    )

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -115,14 +115,14 @@ class RecentCaseSessionsTable(BaseHtmxTable, tables.Table):
         template_name="data_cleaning/columns/task_status.html",
         verbose_name=gettext_lazy("Status"),
     )
+    case_type = columns.Column(
+        verbose_name=gettext_lazy("Case Type"),
+    )
     committed_on = columns.Column(
         verbose_name=gettext_lazy("Committed On"),
     )
     completed_on = columns.Column(
         verbose_name=gettext_lazy("Completed On"),
-    )
-    case_type = columns.Column(
-        verbose_name=gettext_lazy("Case Type"),
     )
     case_count = columns.Column(
         verbose_name=gettext_lazy("# Cases Edited"),

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -125,7 +125,7 @@ class RecentCaseSessionsTable(BaseHtmxTable, tables.Table):
         verbose_name=gettext_lazy("Case Type"),
     )
     case_count = columns.Column(
-        verbose_name=gettext_lazy("# Cases Cleaned"),
+        verbose_name=gettext_lazy("# Cases Edited"),
     )
     form_ids = columns.TemplateColumn(
         template_name="data_cleaning/columns/task_form_ids.html",

--- a/corehq/apps/data_cleaning/templates/data_cleaning/bulk_edit_main.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/bulk_edit_main.html
@@ -24,7 +24,7 @@
   <div class="card mt-4">
     <div class="card-body">
       <h5 class="card-title">
-        {% trans "Recent Tasks" %}
+        {% trans "Recent Bulk Edit Sessions" %}
       </h5>
       <div
         class="mt-3"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_session_url.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_session_url.html
@@ -1,5 +1,0 @@
-{% load i18n %}
-
-<a href="{{ record.session_url }}">
-  <i class="fa-solid fa-arrow-up-right-from-square"></i>
-</a>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
@@ -21,4 +21,12 @@
   </div>
 {% elif record.committed_on %}
   <span class="badge text-bg-secondary"> {% trans "Pending" %} </span>
+{% else %}
+  <span
+    class="badge text-bg-primary"
+    x-tooltip=""
+    data-bs-title="{% trans "Only one active session per case type allowed." %}"
+  >
+    {% trans "Active" %}
+  </span>
 {% endif %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% if record.completed_on %}
-  <span class="badge text-bg-success"> {% trans "Success" %} </span>
+  <span class="badge text-bg-success"> {% trans "Completed" %} </span>
 {% elif record.percent and record.percent < 100 %}
   <div
     class="progress"

--- a/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/columns/task_status.html
@@ -1,6 +1,14 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
+<a
+  class="py-2 pe-2"
+  href="{{ record.session_url }}"
+  x-tooltip=""
+  data-bs-title="{% trans "Open Session" %}"
+>
+  <i class="fa-solid fa-arrow-up-right-from-square"></i>
+</a>
 {% if record.completed_on %}
   <span class="badge text-bg-success"> {% trans "Completed" %} </span>
 {% elif record.percent and record.percent < 100 %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/recent_sessions.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/recent_sessions.html
@@ -1,0 +1,16 @@
+{% extends "hqwebapp/tables/bootstrap5_htmx.html" %}
+{% load i18n %}
+{% load django_tables2 %}
+
+{% block no_results_table %}
+  <div class="alert alert-primary">
+    <strong>
+      {% blocktrans %}
+        No sessions exist.
+      {% endblocktrans %}
+    </strong>
+    {% blocktrans %}
+      Please start a new bulk edit session above.
+    {% endblocktrans %}
+  </div>
+{% endblock %}

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -251,11 +251,7 @@ class RecentCaseSessionsTableView(BaseDataCleaningTableView):
     def _get_active_record(self, session):
         return {
             "is_active": True,
-            "committed_on": "--",
-            "completed_on": "--",
             "case_type": session.identifier,
-            "case_count": "--",
             "percent": 0,
-            "has_form_ids": False,
             "session_url": self._get_session_url(session),
         }

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -231,8 +231,11 @@ class RecentCaseSessionsTableView(BaseDataCleaningTableView):
             for session in BulkEditSession.get_all_sessions(self.request.user, self.domain)
         ]
 
-    def _get_record(self, session):
+    def _get_session_url(self, session):
         from corehq.apps.data_cleaning.views.main import BulkEditCasesSessionView
+        return reverse(BulkEditCasesSessionView.urlname, args=(session.domain, session.session_id))
+
+    def _get_record(self, session):
         return {
             "is_active": False,
             "committed_on": session.committed_on,
@@ -242,11 +245,10 @@ class RecentCaseSessionsTableView(BaseDataCleaningTableView):
             "percent": session.percent_complete,
             "form_ids_url": reverse('download_form_ids', args=(session.domain, session.session_id)),
             "has_form_ids": bool(len(session.form_ids)),
-            "session_url": reverse(BulkEditCasesSessionView.urlname, args=(session.domain, session.session_id)),
+            "session_url": self._get_session_url(session),
         }
 
     def _get_active_record(self, session):
-        from corehq.apps.data_cleaning.views.main import BulkEditCasesSessionView
         return {
             "is_active": True,
             "committed_on": "--",
@@ -255,5 +257,5 @@ class RecentCaseSessionsTableView(BaseDataCleaningTableView):
             "case_count": "--",
             "percent": 0,
             "has_form_ids": False,
-            "session_url": reverse(BulkEditCasesSessionView.urlname, args=(session.domain, session.session_id)),
+            "session_url": self._get_session_url(session),
         }


### PR DESCRIPTION
## Product Description
Show active sessions in "Recent Tasks" table, and make some text adjustments, outlined below.
![Screenshot 2025-05-21 at 7 22 13 PM](https://github.com/user-attachments/assets/33f459d1-ae49-4a15-8fbf-cb427f338dfa)

link moved next to status
![Screenshot 2025-05-21 at 7 20 45 PM](https://github.com/user-attachments/assets/d8557348-9c4a-4444-b970-5d15b3d2f0a3)

tooltip over active label
![Screenshot 2025-05-21 at 7 20 51 PM](https://github.com/user-attachments/assets/fd363898-c560-4899-90e7-b0f7c0a86db6)

better text for empty table
![Screenshot 2025-05-21 at 7 19 07 PM](https://github.com/user-attachments/assets/6de94b3a-c998-4376-8342-35b97406c12d)

## Technical Summary
Commits are very small
Review commit-by-commit

- Rename “Recent Tasks” to “Recent Bulk Edit Sessions”
- Show all sessions in the recent-sessions list and move “case type” into the second column
- Add an active-session status indicator and make the status column link to open the session; remove the old Session URL column
- Update the “no results” text for empty recent-sessions tables
- Rename status labels (“success” → “completed”, “Cleaned” → “Edited”)
- Remove irrelevant fields from get_active_record now that Django Tables handles None values
- DRY up record context logic in the recent-sessions table
- Add tooltip support in bulk_edit_main.js

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe changed only made to feature flagged area of codebase

### Automated test coverage
most important bits already tested

### QA Plan
testing underway, not blocking PR merge

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
