### PR TITLE
Cleaned up DOMPurify imports

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/utils.js
@@ -5,7 +5,7 @@
  * Depends on `add_ons` being available in initial page data
  */
 import _ from "underscore";
-import DOMPurify from "DOMPurify";
+import DOMPurify from "dompurify";
 import toggles from "hqwebapp/js/toggles";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import "select2/dist/js/select2.full.min";

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
@@ -2,7 +2,7 @@ hqDefine("app_manager/js/forms/case_knockout_bindings", [
     'jquery',
     'knockout',
     'underscore',
-    'DOMPurify',
+    'dompurify',
     'hqwebapp/js/atwho',    // autocompleteAtwho
     'select2/dist/js/select2.full.min',
 ], function (

--- a/corehq/apps/app_manager/static/app_manager/js/summary/models.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/models.js
@@ -11,7 +11,7 @@ import assertProperties from "hqwebapp/js/assert_properties";
 import hqLayout from "hqwebapp/js/layout";
 import widgets from "app_manager/js/widgets";  // version dropdown
 import kissmetricsAnalytics from "analytix/js/kissmetrix";
-import DOMPurify from "DOMPurify";
+import DOMPurify from "dompurify";
 
 var menuItemModel = function (options) {
     assertProperties.assert(options, ['unique_id', 'name', 'icon'], ['subitems', 'has_errors', 'has_changes']);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -2,7 +2,7 @@ hqDefine("cloudcare/js/form_entry/entries", [
     'jquery',
     'knockout',
     'underscore',
-    'DOMPurify',
+    'dompurify',
     'moment',
     'fast-levenshtein/levenshtein',
     'hqwebapp/js/initial_page_data',

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -2,7 +2,7 @@ hqDefine("cloudcare/js/form_entry/form_ui", [
     'jquery',
     'knockout',
     'underscore',
-    'DOMPurify',
+    'dompurify',
     'hqwebapp/js/toggles',
     'bootstrap5',
     'cloudcare/js/markdown',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -2,7 +2,7 @@ hqDefine("cloudcare/js/formplayer/menus/controller", [
     'jquery',
     'underscore',
     'backbone',
-    'DOMPurify',
+    'dompurify',
     'bootstrap5',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -3,7 +3,7 @@ hqDefine("cloudcare/js/formplayer/menus/views", [
     'underscore',
     'backbone',
     'backbone.marionette',
-    'DOMPurify',
+    'dompurify',
     'bootstrap5',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views/query.js
@@ -2,7 +2,7 @@ hqDefine("cloudcare/js/formplayer/menus/views/query", [
     'jquery',
     'underscore',
     'backbone',
-    'DOMPurify',
+    'dompurify',
     'backbone.marionette',
     'moment',
     'hqwebapp/js/initial_page_data',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -2,7 +2,7 @@ hqDefine("cloudcare/js/formplayer/utils/utils", [
     'jquery',
     'underscore',
     'backbone',
-    'DOMPurify',
+    'dompurify',
     'bootstrap5',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',

--- a/corehq/apps/cloudcare/static/cloudcare/js/markdown.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/markdown.js
@@ -1,6 +1,6 @@
 hqDefine('cloudcare/js/markdown', [
     'jquery',
-    'DOMPurify',
+    'dompurify',
     'markdown-it/dist/markdown-it',
     'hqwebapp/js/initial_page_data',
     'integration/js/hmac_callout',

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -6,7 +6,7 @@ import initialPageData from "hqwebapp/js/initial_page_data";
 import hqMain from "hqwebapp/js/bootstrap3/main";
 import googleAnalytics from "analytix/js/google";
 import uiElementKeyValueList from "hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-list";
-import DOMPurify from "DOMPurify";
+import DOMPurify from "dompurify";
 import toggles from "hqwebapp/js/toggles";
 import "hqwebapp/js/bootstrap3/knockout_bindings.ko";
 import "data_interfaces/js/make_read_only";

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/inline_edit.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/inline_edit.js
@@ -25,7 +25,7 @@ hqDefine('hqwebapp/js/components/inline_edit', [
     'jquery',
     'knockout',
     'underscore',
-    'DOMPurify',
+    'dompurify',
     'hqwebapp/js/components.ko',
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -53,7 +53,7 @@ function hqDefine(path, dependencies, moduleAccessor) {
             'd3/d3.min': 'd3',
             'ace-builds/src-min-noconflict/ace': 'ace',
             'chai/chai': 'chai',
-            'DOMPurify': 'DOMPurify',
+            'dompurify': 'DOMPurify',
             'mocha/mocha': 'mocha',
             'moment/moment': 'moment',
             'crypto-js/crypto-js': 'CryptoJS',

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -54,7 +54,6 @@ function hqDefine(path, dependencies, moduleAccessor) {
             'ace-builds/src-min-noconflict/ace': 'ace',
             'chai/chai': 'chai',
             'DOMPurify': 'DOMPurify',
-            'DOMPurify/dist/purify.min': 'DOMPurify',
             'mocha/mocha': 'mocha',
             'moment/moment': 'moment',
             'crypto-js/crypto-js': 'CryptoJS',

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select2_knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select2_knockout_bindings.ko.js
@@ -3,7 +3,7 @@ hqDefine("hqwebapp/js/select2_knockout_bindings.ko", [
     'jquery',
     'underscore',
     'knockout',
-    'DOMPurify',
+    'dompurify',
     'select2/dist/js/select2.full.min',
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap3/ui-element-input-map.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap3/ui-element-input-map.js
@@ -3,7 +3,7 @@ hqDefine('hqwebapp/js/ui_elements/bootstrap3/ui-element-input-map', [
     'jquery',
     'underscore',
     'hqwebapp/js/bootstrap3/main',
-    'DOMPurify',
+    'dompurify',
 ], function (
     $,
     _,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap5/ui-element-input-map.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap5/ui-element-input-map.js
@@ -3,7 +3,7 @@ hqDefine('hqwebapp/js/ui_elements/bootstrap5/ui-element-input-map', [
     'jquery',
     'underscore',
     'hqwebapp/js/bootstrap5/main',
-    'DOMPurify',
+    'dompurify',
 ], function (
     $,
     _,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/ui_elements/ui-element-input-map.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/ui_elements/ui-element-input-map.js.diff.txt
@@ -8,7 +8,7 @@
      'underscore',
 -    'hqwebapp/js/bootstrap3/main',
 +    'hqwebapp/js/bootstrap5/main',
-     'DOMPurify',
+     'dompurify',
  ], function (
      $,
 @@ -20,7 +20,7 @@

--- a/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
@@ -1,7 +1,7 @@
 import "commcarehq";
 import $ from "jquery";
 import _ from "underscore";
-import DOMPurify from "DOMPurify";
+import DOMPurify from "dompurify";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import "select2/dist/js/select2.full.min";
 

--- a/docs/js-guide/external-packages.rst
+++ b/docs/js-guide/external-packages.rst
@@ -100,14 +100,14 @@ In ESM modules:
 
 ::
 
-    import DOMPurify from "DOMPurify";
+    import DOMPurify from "dompurify";
 
 In modules using ``hqDefine``:
 
 ::
 
     hqDefine("my_app/js/my_module", [
-        "DOMPurify",
+        "dompurify",
     ], function (
         DOMPurify,
     ) {


### PR DESCRIPTION
## Technical Summary
With some of the recent requireJS migrations, I've started seeing yarn issue the following warning:
![image](https://github.com/user-attachments/assets/9d4bd3e8-23c4-47e2-b03e-c4743096535a)

In the conflict above, we have our custom module importing from `DOMPurify`, while a 3rd party library imports from `dompurify`. DOMPurify's [official docs](https://github.com/cure53/DOMPurify#how-do-i-use-it) show the `dompurify` syntax. Even though it appears that webpack is case-insensitive with module imports,  it seems best to standardize around `dompurify`.

This PR removes an old dependency mapping (likely missing from https://github.com/dimagi/commcare-hq/pull/36107), and changes all imports to use `dompurify`, whether they're old-style require imports or new ES6 imports.

## Feature Flag
None

## Safety Assurance

### Safety story
Verified locally that webpack modules were still able to access the `DOMPurify` from the changed import name. Rolled back to a previous version of the form builder, still using RequireJS, in order to test that RequireJS would also work with the import change.

### Automated test coverage
No tests

### QA Plan

No QA


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
