### PR TITLE
Simplified dompurify's package import

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@turf/turf": "6.5.0",
         "At.js": "millerdev/At.js#master",
         "Caret.js": "INTELOGIE/Caret.js#0.3.1",
-        "DOMPurify": "npm:dompurify#3.1.7",
+        "dompurify": "3.1.7",
         "ace-builds": "1.5.0",
         "alpinejs": "3.14.1",
         "babel-loader": "9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,11 +2127,6 @@ Caret.js@INTELOGIE/Caret.js#0.3.1:
   dependencies:
     grunt "~0.4.1"
 
-"DOMPurify@npm:dompurify#3.1.7":
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.7.tgz#711a8c96479fb6ced93453732c160c3c72418a6a"
-  integrity sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==
-
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -3289,6 +3284,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dompurify@3.1.7:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.7.tgz#711a8c96479fb6ced93453732c160c3c72418a6a"
+  integrity sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==
 
 dompurify@^3.2.4:
   version "3.2.4"
@@ -8174,6 +8174,7 @@ workerpool@^6.5.1:
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Technical Summary
The previous PR (https://github.com/dimagi/commcare-hq/pull/36481#pullrequestreview-2862463302) was an incomplete fix, where I didn't understand how the package.json file worked.

My current understanding is that the line:
`"DOMPurify": "npm:dompurify#3.1.7"`
was the reason that something like:
`import DOMPurify from "DOMPurify"` worked, because the actual package name is `dompurify`. The previous fix was incomplete, in that it still allowed code to use the above syntax. Modifying the dependency definition should now generate an error when attempting to do so on case-sensitive systems (i.e. linux). At least in my testing, the capitalized import still worked on OS X, but it doesn't seem there's much to be done there. This should still be a slight improvement.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Verified locally that I can still access `DOMPurify`, even if the capitalized version still worked.

### Automated test coverage

No tests

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
