### PR TITLE
Swap billing statements with current subscription link on prepayment invoices

### DIFF
--- a/corehq/apps/accounting/invoice_pdf.py
+++ b/corehq/apps/accounting/invoice_pdf.py
@@ -549,11 +549,13 @@ class InvoiceTemplate(object):
     def _add_credit_card_footer_item(self, items, text_style):
         from corehq.apps.domain.views.accounting import (
             DomainBillingStatementsView,
+            DomainSubscriptionView,
         )
+        billing_view = DomainSubscriptionView if self.is_prepayment else DomainBillingStatementsView
         credit_card = """<strong>Credit or debit card payments (USD)</strong> can be made online here:<br />
                             <link href='{payment_page}' color='blue'>{payment_page}</link><br />""".format(
             payment_page=absolute_reverse(
-                DomainBillingStatementsView.urlname, args=[self.project_name])
+                billing_view.urlname, args=[self.project_name])
         )
         credit_card_text = Paragraph(credit_card, text_style)
         items.append(credit_card_text)

--- a/corehq/apps/accounting/tests/data/invoice_000.pdf
+++ b/corehq/apps/accounting/tests/data/invoice_000.pdf
@@ -33,8 +33,8 @@ endobj
 6 0 obj
 <<
 /A <<
-/S /URI /Type /Action /URI (http://server.local/a/group-therapy/settings/project/billing/statements/)
->> /Border [ 0 0 0 ] /Rect [ 36 177.6 338.35 189.6 ] /Subtype /Link /Type /Annot
+/S /URI /Type /Action /URI (http://server.local/a/group-therapy/settings/project/subscription/)
+>> /Border [ 0 0 0 ] /Rect [ 36 177.6 314.45 189.6 ] /Subtype /Link /Type /Annot
 >>
 endobj
 7 0 obj
@@ -67,10 +67,10 @@ endobj
 endobj
 11 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2086
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2084
 >>
 stream
-Gau1/gN):5&;KY!MS@/L0iLA?nc>/YX^*'k$sO#`_/+:pEat&!8?g&MP72BEP'i&pG49$X.L33M]@HkZ>F(46'0fUtpO%M*"76I)R"2LCC`ihM9/q,6BtLh*Ni39KhsHcMpP*B1>N/#ZTOV0BC863n6iULW6ShZ1=h6O>7'ha</uV4?)5F(k=uLHb(s[Bd7ZN1DDE3/h.8:]t=gG0on6ktsS0r8>6PIAHJ4D;MZ5+g0"-9!>Y7J4AA^.oMDhC&<NstH$\=0<9EJtXm@]JMoNl8__Yog-`?8:M\5A)2'W+?Q,8OOYVQBp>m"AD,^@u;[f$mlEo6i7le.$:A06k1I<qk"grC)">fI<mk%<=VZa*)cXf+'r9*1G2.#3h&VJ[UQ3iq)8h/Nr:rq:VVe#Y*$TJ:L`N4oEB07d>Ya_RR_^\51Xg>8fn^WOh?mk_-fAG3Br:h>(o4g1]G8LGNc@R&*Dt^l8DNTG)3>I*O<)bo2uVj`'PO]+nq\>%RJ"15W"$:ip'_!ibMLK6q\eGb7lSVA/#m`.9RVtQ."nBPqj?X1EI%OCLG4q>@=i)AA%kDd`).J"qWS[,M>[8K>$tpmc(g@]bm65*n9PsN>QjL)l;!LUhOjsk)BkF_CaM31nM+]So\50f@\Ra,rDMonA&^rb&9!CA:d)YM=o0imFA#T\-Sm?jhtf\F#\:(=:XU!ffF4/_A6-`A7i2*;\W3M^m9sr,CbJ7b*=<96EDCf&aE@C%9klU;oVR7745A\-'ZORerXaF2'4KJ/Y[Z$Ymg\WLq$1Pq8l'7C8DPs&F6G_^*r\R/_@0Y$N7O^Qfb).^*rUmHIaU]k5()cUh-O%-sc_RDoZM>JPuT\@j=nt9e*lFp.!?Sq,XXF]$.98e'l^kJ\cS/@9ftiPeP6ee%RV]HC#@]8s#>p5.Ea?)`e_UDHI++$[aEVZ!3[[hm8hMaKZU9T&0oKrS'B5N9:T]Br60rfJDI@BK*m^$PneL/[[4E_c8ZF13$'5Jhb\'8jX=3d&AUo-8LCF;n#LYA6,W<$h'SA'?:VS=Ts7P<[:8W4eNuCj+BV=EM1I#%A9,l%a]O]'POAH"#OZ%%&dU7!`qY;pCa.9')<YHrA[Vb]`uhW<sND%E=+O$f)_<r>mAfA]G$t'HO3OFdJPh]j.s)gPLe()3mn]fXe1sP]r\Reirl+Q/g2!RK*Kk'N3W.K22"-_Gdh35@mb.-oWk$0jpdI(M4$IG[^1c[m]'LMH7[X2D34Vsm[KMmo%X,@GOLX*dJ0[8Nbr"H3H?<%:fX_5A`CZ86"\)2-PiS3T+L$JH#-P"HZ,bfml\1t1[OlP(-I9;Af3_HJG]>]'nF'UTV$Q(l'?X[e+Y?.81T8R$K8SjmHT)[_"cV$N^o<$?:bi$:g4\m6GY?VQ<P9U0F$\t1#9PdM8uSW@WNNF@nY`L9-1Sn8<,HpGgNo*RrIIQZ`G+3J]&8>ML4>8D]=E^n94<,FC?L67cIsi=g0UQ?'A#?"]R-co48&r)pVm#':`,Sr[KouO38!6QGIVYe4jp.d_j*R>&V">p?N&;<kHspW6V1*5Nchr/S!-,34o$Mh50,2!f#7!W<u`bVEsRXLg\M?B`K$2qrW!@G5pe,Rcal/A)Ot?#!<IE0mI4PMs85dnkk8e2_9>b+];S"DYl^>jju)(Oq6CA:38rLieL6T*V(T?7IAcK-&b$p2j#%6j\!-3#2MiE&B1L!H65Lmn5V6R>Ga^IUE(sdmJ+4c;&PM.knM]!k&+9Pg2'2`M;p>^h<!oR<Dk(t]$8&QLc8sS_aW:h&\Kkfg34e11![u/8C#b$&<D_PocfO,07<#hXH8q'YrBkA>A`Q)$c?'H,E>OX3i3=L[4C.?\3W%50GhB5&P1s)H^%6=)/_Oj@,u"%_at<oad<=Cn!iX)M&I%q$!\_baO8-lPUfj>KrM!!8\1"ai;9[Y[M+apd$r?K[b5c]g3$c4E,Y[6\nd[$:jgFh<H"4mCO'E=\tJ5366!aSld&\c'liMXbI96^P;\gF]md-mL2"=o0RX%E5Z"BI'>2LSfgkh\=NH1t=%hEMK$p>N9O='DW47cr\4kFRX0k_3)ZKhCrAY#~>endstream
+Gau1/>BALX'Z],,'^$XO6T[S9ncbGLSR"S1QCS/A?oHc-]GMk+;J]4b,j!da,[Y#5*Sg"'EWJg_+.`#P3O30(ReX_a^ZP]h3RI_X!>BF<J.6%>EsWXX.r3c1g(?1cqn)g^qVEt:AP7F7(A(9n=D`1Fn^.<&cdCOtk*GEe#gmI_]1ZlNCX/lX\X(Lq"bq*T\rgL]Jm48-?V6Ld7[@k+4$;/D!9XZYO3ko92;g2_j1N>;h8!Nu0K9/?e+2WeaLAtei^X2s4BsPFN[2W5EA>uN"34m/^Xs(KhlI^d\6gpeE7D1LTHp6B6qbSg+T`u6J2'J,63bmSZ6B#Q+-];p![<C3rF[3VRVEPM.=HM%.<Q+nOW79qHT&IJ"D:VmZuS'c)!iMG@Ie=Xn,iJY^n6&jHX.kmTqB9M8*C?;=JIm'7C7mE&:L;;]pCo0a<F&##K,M22KjNZ3OMJ1%d*\W_=)?_G!&l+LT0$!<S/J/p3"G7m`oH2$o&-<=GGUd_'T9oT*!CCNgQk_>t_=t`=O&Pa;n3h7+5"D%&@?P-rimCQWD7Br6Jn1]P)g=T5B/,ZIA@;B1Wp2UDlJBI#__fPmmB?o=7NZ9(l_1ML&+*T/:$44)C-RZ^7N1nX2=^L^LV-)pr3Ic3MW`F^AQV6^5rL2T5dY$*(_Y0TZSF5pXi>(UmJp3o_EGSlH>ocS"/&R:A7U'4gFU_['IGR?<obd7dD62$7&@ZAmia#,tXl6jg2ZbZ(OmR5AaE6p[5#@?mD)F-KKN$Wod)Q.:8fP]hlVNl<mVg`tf:e`WhHWN!9t'LJnQroBg/:UNO(\g[7;Q<]m-roBg'Ds2JMr*&;GSrf87QD/3_^V68/c\>1(kamc-OYiL$Ai:Jf,NijMRclN9?;8bc,6rseBoR,CDH$B]T?b`PM)2ZC;,`(RK(7ge`VITS8Tr!,OBg^"EJ<5k4TD#9N'`QLAF]S(>3]JH;.[CJLe'>h43"u8/rXsPhQgPZW7NfjdQ:]hP9LYVF=.nMXem@cOTE/8@VR*>Qj%Wq6pkRGg9C(\krj%WJ<X'lVe&<FFPHsJ+u8!]PT0q.X>^-Jl^@fj-I./(l6\b(VQ54cVCHNg<.1qM.P-^+!nE>6<Rr)hc#la22A9^gF*/.h"k-I:/]g'XWkMO7V=2Z)j#Bff-p)/7gh\1Z5gne?8`.Z_>;AqsWp^R0BfB^%*@2QGO&SL!'9@?1VD:'j(.tda8a"qABq:XU_dPWfH0h^226J<94l$=Q5N'7m#q3REIsCPp\Jn8'MJq.Uon"D9@KTU84&r.aS.K5^luWkK2Y[S5%[>"WQ&56IQLN1p)gm8YhnkP3Y`2]"!t;a/%p]52b74<IB:j(@7lc!u&r`n)BV?!?#@FYe`XY\FS^Ct1mI-<.Gm(Nd;'V;6@qE3G+Uqq#?;f8.:F,TmF%:&,"*&,`gj$d?G7Ee6-;"JjNN`jnmPgGU_^^b86<J;)guWCjO9OJNSl[Pg-,WiT9VWmA1Z((S6sDqL6FL"8i47eJju^D)^#gu2F8WP*@(co]og.Du6m=dAN8mX^mri'hBY!!5X?q%NmJaY(;7oL`s5X%BF+0I5Wt#tILSd+?opCJjh]dXURqDc_3:>P-l1t:5")+8F^mouE/f=(C7*"5JKe/peE%+7*JrEh,bX/,8G2;S=36H/#iZoVWS"8c%7Do^6G8'Npk/H.i4-.$n[?1m/%0>Z^[X0DUb1>;I#/`)LqR]biIPK-q;H8]`a:X[FKpthGZY"*n&lH"N'dX@0b]d.Sf-JIGbZF+QFR]"_eJX1Q8/O:?(T&&HDX9M5)4;Sd\U";9EKQ\r//%ZEY<8,;E;M]dAefRVm=P">PR([@d4&<JHssU+jnfcOaQFHWDCk6S`g-9HT?Je?G.t@4crS2M#/&D>%rgF82^&jb-#sX.8/I@VOaAM.Y,qUX:M8-m$!4s8\['LU5^pRXYm=JHp#4VIT=JoZo'Eq,R)VsO^BA]JQ.d1&@r](fi-@X._g(Ln=kFO1l>XqU14.J.R2:L^5p$NaHBVb1mcAtl:>[CC=+IT;n<^DA9<PE5]Di&27r=X-XHmjO!?H3KWgumtT,=s7!u,9'e,~>endstream
 endobj
 xref
 0 12
@@ -81,11 +81,11 @@ xref
 0000000717 00000 n 
 0000000829 00000 n 
 0000001010 00000 n 
-0000001220 00000 n 
-0000001512 00000 n 
-0000001581 00000 n 
-0000001831 00000 n 
-0000001891 00000 n 
+0000001214 00000 n 
+0000001506 00000 n 
+0000001575 00000 n 
+0000001825 00000 n 
+0000001885 00000 n 
 trailer
 <<
 /ID 
@@ -94,5 +94,5 @@ trailer
 /Size 12
 >>
 startxref
-4069
+4061
 %%EOF

--- a/corehq/apps/accounting/tests/data/invoice_002.pdf
+++ b/corehq/apps/accounting/tests/data/invoice_002.pdf
@@ -33,8 +33,8 @@ endobj
 6 0 obj
 <<
 /A <<
-/S /URI /Type /Action /URI (http://server.local/a/group-therapy/settings/project/billing/statements/)
->> /Border [ 0 0 0 ] /Rect [ 36 177.6 338.35 189.6 ] /Subtype /Link /Type /Annot
+/S /URI /Type /Action /URI (http://server.local/a/group-therapy/settings/project/subscription/)
+>> /Border [ 0 0 0 ] /Rect [ 36 177.6 314.45 189.6 ] /Subtype /Link /Type /Annot
 >>
 endobj
 7 0 obj
@@ -67,10 +67,10 @@ endobj
 endobj
 11 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2075
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2072
 >>
 stream
-Gau1/>BALX'Z],,'^$W$6T[S9nkE_.B9s1`dRbPfc=T/%(Loj"MCiR:dX:qWj9mlu_9G_&(U3Q+d5aF^,>6%LM'&huqZ4L#$f+Sq0EH@ufK]YN(GKr8=hD,oNi39;hp(?8O-XK.>N/#Z^c!cQ[FP5oUYoKC6ShZ1=h6gF7!"1P/Z;+>)5F(k=Ut&c(s[Em>)n:EDRi&^.8:]t=gG0so'l;S\52%3KJnR'+cg%Mk:LT4Kg%SPrYapgQ8eO_^('6:5;Kb/d;#7q,Vdl/MlB_o3#2Vrc$juTHGtulK7\r3UR"=O,nYPR=uq\'#ag8F`Y;:+(ee/TJ`Jb9:a/U?L`AnVT7(NiW_rDco]b>1e2]'KE_,H`g$%DsgdsNSb1SmdY`hV3afdhf"nn.A5Q*5.\jf:Z5Dc(pckj@"7W\9\BG'VTqF"i.QTiu_Xcn@#=#Z>H_h%]#aJi/HoKgi-G6G"g>JF3/WB3WcfHIs%<Q*JFCV[e(@MT-OLj/puFT`UH"el;A0iuu<Q<^2B+Z^g.4/VM'VPD3D8B':Z.MUW4$Y;0oB/1A6)c4U'Ri#Nnl$3)h,R>(>!+P(h,[76YYh,IB>uF_/(LpC.K:;_6&S(^B;(>:%bECm!DqKjQ[i>Y#ACAd#m]\aSZ)Jm=BL/-IJaikChdRGD"G7h[khY4Bjg<=C#fO.Yiq(nJ*'/-l"a,D:*Gg\=7?naY)'-s9oi*`OjWMSlhI2L\V+IIZ</R(NofA:k,Fp52'.9le'7#TN8nIs9aK`%6:KGmRdGD.ZL4F+bDGtsLHBFY"WC.oJg@Zg0jaO3EqUJ$6?ao+=SG"<HV1(eXHf`jGhslB,/7an!dP'1Fo@s4d-jOTNa:q40M6Cjp@s@!_X&]m>k17iMm<I^/?o"i=/sgEIGOk"cR6,Ec(H#r"OB+&!\/Cm!gmVb4/-F#e4VLoLXj$AYH-Ri!fM!(,+/P6O[uMru"[b\HC#:Z=*H5Golgg&>M^Q3(=dS"(3h-nP\=bq"(hkiRTo0>`)iL\P$t:"%SJ)I#2/:%Gqkj,+an&A16'.BI8^hYiW//N>-W"h'W3Y7[BWc+P[$`lUR]DnX/XW[BC7)$:'i=S:!iW=kh?d.G%THSL!&W:b!SU5;!R9.hJ/1g[!OX3A'WCk7!L1;W5E4\_Bqt$jc#^4J1]p==k9YO,.il_kKrD^YLo&q#6$8E"/3d#A@8B#B/Xac6OBX-HC*T9r6_nj6V@SIL/EX4HlIED9M"Pj/jSac/[O%UEEW>"B461993@V[NgX-ChS;7VR*UHanH>u95=gQRKK\>92`&LR7gJoTWRp!V?O'_T%?MP?P4G)s4)*Yid#Jn1hJA5?a?[DG1Q?neE[jo58.Y/?BiMuqFE]A5NEoi<.j(WG8,g%@1/W1O@A/Hi?*=Z^"KDUh#mX?@Za-f"uEu^'I9Ba>f*dT>-O#!28cs;<A\FdMA]Gm01`"^%Fqr05X)au=M?f?:p_+ZVC`PHZ&?r?'u-CnfXW.)\Ib8>U[R`"JlE*f[AMrYjB/iU"<L>R?NDFu+8*^7U6HIM2'?WLjFH@8pcl8[MrCX+j.1@b:go?5JU>q3!<?s"G<l@@Dp)C0ci#j,rh"d%cSDr4=9mlqdWo=Y]I$j(@mJ;5=0#3)#l'"SC9@[&(X%?$f\KG<%@f.EOf7;".qIb8bo&V"8=gmp#u_WX@2'72H4Y&kUld#DiP;-o]n[k[L[?R199AJRZgg<i7;:/K"GPnA_>:1:hFhM*>NbuW>Z3$,EA>HW.KOs,t8D%9l<m$rV9(MVpKnA5n(^l/03,VSa63EL,bHnH&]O%%bdo;0e(6>g-VhCM$D[@OWFN"Q/M3BDkpKJH6QSp\Z>L&$\F>k"%J+H7o?;*LgV\=J#";4t$$-Ok<u@ijRBDm(B4C.r.bE02t"9-a1-Y$bBIAtIjSZ\;WfJ*+jf3s#-`rV8QbRnXEr4R\[GpEn4X[t\T*jd/Y;pN!7HQ8]SW$i7RjZn[NK_2LfG&Z6*tHn07tD3K7m5O8'Z0Wd8?AoD&e#jV&!Jp.AHqZqZj$b>clC<??[:i,F4oOYRhbKK+"b>dkN3r?jgocI(p34/~>endstream
+Gau1/>BALX'Z],,'^$W$6T[S9ncbGLSR"Qq9.,9931K;/?AoJQ;dZJ?P31N&,[[dl%W6GN\U^NkO3[Rc**G$$L&YQVhsg`m/EhT#J-f=n^`(Y:\q#XfakN)oG!pJos)(#EIWT[+g>X3S!<_09<]g7U@H@G-0%!QuQA4\+#Z49ig1tF7A'([PfS7N7'o)=aF"PDK-+>G?\.g8IN""+b[DLkp"'A?,I=s5-DaBc++t6]sa:925$DTCR'r>Rb7H$.,61W+T/r[GChN>h10J94pC#FXTr&=Leq\tS>-hL%Y8raeoiKSTZ!H74j"%5C%">H^/6H!9Z5piDBd=W,^;F&/S]`7>.8!/eD2ks.Z-`+pn+VI-LJ'Xu.(LYLgOk.h?&VIbrb"[<oK<W:C*e[>(MnQ-Pb0Wq3kTf^[Dlh<;]d-cNH\al9%,OW!X(\/hP*8s+o<4@_okVXJ;$llGe(XFRXN982ejl^.8/Bi$^$\n=2YO2tJcl]%q65lG+%D_*'RU6UiA?]o?E6\ENG=43nN?7(g`r8I,!mD0CI=pp#(s!RVR(d7e+'4;Kjq?E#)8P*[m*HS0Ms\MH8.j_PmR_BmD[SOAL2XWep09sa\Nj1*ZR'FV*;u,jS6Z/"%9\(VMStIC$-^V;P2NB<tH[bUs8DECl[e!d57YO7M&/af&Yt6d:AaP1,)>[o@jQk3cchU<J!mZ"rLd$8i%YIHA^#6WF92P7&F#!6R27rSHpCB'Km,09dV_r3)NSN:)HtYMB!q,MY^>7C#gS4Y,"4T]OS&Q!"T@M:%nD97:s]+M*d$'lVB16rDY6=bDT!-C5A-8lVB/`rL-p^MQ`kjisBE:a<8*kT<CWF\,5Jf!IA,tSL7,a^:kW4XJtlp?;4C]><C<CZ`+,gq4b^8=LK[7aVVF!f%_0L1oMih9$-l'Ao^)C)NnA^1aLZH>[1dJ2U?je3?sYr4^C1"<*&kO3\$,U$kZpFHcOc_^noG]X#h*@TCb`n?$M-oE)NLlP3rH_Ubn<hatmGP>"j(7&\Y".SL@$I:hp9l2n^S6T9#]Rr2ctjQB$;WGsp@JJWf%YV=bTh$XF^EmDM$36JViZa`JP"9pZ#9J]dF=5e/33:8$llT[J,oTS9NXd!"CgBVB;GZt-`XW$-Cu5iq_YT_,qnW?'#N>@f1!T:9\n3Cqjf0Bl\DBaVit7/:+RXR$-KWhL2;ooZ7oHi3DOLfDB_fKuQ[)sP3Y,-2G@HT5i.8XS/eYeg!3XCg30q^:0C%1_K\q[[W%+a0XF8b!8EVHS$$KQ!NP?t[X+M\C^7L7M'hbQg?Ug4AhIXtoZVcP,/]["Ii:)K&t(7^.m.huUikmuM;qprbPkV.ZE8a@A7=WtMeP&nn6UY"%;$-Sl.m=4VIW>7C6uU,mn]ZH*V-L9\,@;ilSc=>-*,r[3kSS@cZt`rSE5"ErdZJaGaHP_mjTG7f#Wdf.OLDK#]/.0;/Epg)0'MHJfL_R"$q;D:f>_),K)./.!Z:38Kq-XnSb!QU4$Y^GQ&4YM0pS<HH%#1!am%mf':7NssB9Ti+4m.XjL[.[g5gdiJVqgY_MS@GQ]J"C"r0(+mB2$(Vcd*r3"):LS<Rn'\lb<1:Va*m]*EIRrH!1IC&Y[l\H.gBFtULV*#R4P2(E[aN#K8`t*bT\=Cp?d=jCs"gQ*q;VQhaHE:F-;!b?,fY#D?PT@9)tuXmiJKeZLKi'dJ/WUrm&dE0?6(YbGt)*3?iO<FOM[T4D)Vb'uaB`;>ahGI,"=;8Wptn\t0][]R8?l"*)Bq`_PHG8]JK830.cC(5MEV^Ai.=SsiEk'D=G.*EJDDpF>jU%30;u@RHN[!gn]*'Wt?JYh7Ufonjb(Et'W]&U-h,dX+qeAfYcqfNOMQb@=*OhV"8$\F7&!M"0ci3=-j)(D'#4GUV.G]`)qID\r3^/qZBp7@g!"pk7%0'sT_>_Net&LYTT=ZYaVgO[/U4&i@:&l>FP"jlqAZj)Ai:Z`UuQd?)DJ_G.NTfpfC+]GR3!L7meNRfr>,0*_V[qDQ1%&sRft^Q!qLE`K[&r@]Q$C;SuL>pn/+F<$0;mIbf&`1Z]D"m%Xo~>endstream
 endobj
 xref
 0 12
@@ -81,11 +81,11 @@ xref
 0000000717 00000 n 
 0000000829 00000 n 
 0000001010 00000 n 
-0000001220 00000 n 
-0000001512 00000 n 
-0000001581 00000 n 
-0000001831 00000 n 
-0000001891 00000 n 
+0000001214 00000 n 
+0000001506 00000 n 
+0000001575 00000 n 
+0000001825 00000 n 
+0000001885 00000 n 
 trailer
 <<
 /ID 
@@ -94,5 +94,5 @@ trailer
 /Size 12
 >>
 startxref
-4058
+4049
 %%EOF

--- a/corehq/apps/accounting/tests/data/invoice_004.pdf
+++ b/corehq/apps/accounting/tests/data/invoice_004.pdf
@@ -26,8 +26,8 @@ endobj
 5 0 obj
 <<
 /A <<
-/S /URI /Type /Action /URI (http://server.local/a/group-therapy/settings/project/billing/statements/)
->> /Border [ 0 0 0 ] /Rect [ 36 43.2 338.35 55.2 ] /Subtype /Link /Type /Annot
+/S /URI /Type /Action /URI (http://server.local/a/group-therapy/settings/project/subscription/)
+>> /Border [ 0 0 0 ] /Rect [ 36 43.2 314.45 55.2 ] /Subtype /Link /Type /Annot
 >>
 endobj
 6 0 obj
@@ -63,7 +63,7 @@ endobj
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1547
 >>
 stream
-Gau0CgN)%,&:N/3m"=%i1(cp)!!rG#]"(h]O_fqjl5@?5&q#U.au#ZGs1SJX0e&5#j-bp;LVOt&>o`2`5R`tT_<12I!#U%/5Jr!XGdi2PU>VT[`9ZLUf%rM%%.`;V5<DX]7Lb^\cfX.>Y#mdaZR?=_NE0`3X;/4r)aZ*Bf`&#2KWh1ZQHrk$D_R-FcDC5g94<*31";F%,Hg4@?51,&!q-`6cd9XM*C^>dP%)FhrGX@'^gIGVAJN[H3-kliOPEM((<,$&DFiC3i"ld%j>^"ss,]JD@(2D7*<daH;P9NnV35#1W+L@YK*X.t!+UQ_`"Eh+j?i\r^,$nT!/Pfnm).-ib=jC$VS5%FPbrsg8A!CA%]ALQi6A;QXkh5HKY8)".0#=EW20ASN#r!Pm;7b\>X'^i8(:Ud@nRNi)b%ru*_N&6S<'\2$0%a#jBsg505'.F8M57!Tn?A;6c/:GPcmroWF)Oi,#_p*noZTp\as/1)((Hd3.TaC$=L)r_89Q0=A"T!11T'2a/I!H:F1%BWK9O17B_9l1l"]"3)3L'e(HtWl"JL3L17WWN82\UmI-4?p;a$q=KtAB<bMs9k)6oGlUkA9AuZorm\c6c4,9"<adbIfNpf)QOAKAr/e[EON<e=95-H]IO<C9Nc/aH/*7_ej.:POK+t;B<>^]m7OfO0q]EB9/-ZBpHYoL+WEc#bL_H[orSJaSKWIel(b[';Xnf*hC,8nloCa55Hm3YHjl6&^?1^ICsU<$1UKJ$X?\NI(k[$C?@omp]o!d9BGc.IVaOATjhU(G3!m-10X(KSXq"r4bpF_f:hl(DL`G%&p^-/7sCjP7,:]_>c<c,\"if-%H\,,UMM#@B(g1N2Paf;"2)F6eg33Lb=KRP,T#Fl*to%DGpS]t$']Da4\^X:k?mC,2B,%EV@*7Cp=ui#:J+4F\i$`^l+mg,tuWXo>G`)Y+LQd59Zt;LSjUnoe0LZ=%h)><0<U%QDKY&AogL$-(&$-ja*hJC>Df(nu\Kd(L)#Ym*&HGb99mS0!d'$A,@\8=#9_JuTR5%gkph$Yn<u#[60?#hfcY$X04X#[3t*'9k7Ni'pQ7>U-1V+s.NK4t`dBD]reFCEmLSE%YgTDBihO\kZ))p!*[tcS^<3O6.fQ/uNBJSYCOM[XmR-MY;<EhTJMmCRg5pT!aB>gE74h8nG(FWDrDej.5L8``-<=m(/[.&Im.SKOoqVb:8>]Is]l\H4%*eCQSQ0DRs)0o%VEeGMgcVdI^B-*H'I]"`g=i:ebD3a=N2^Jloob-O&YX:C'*K*kPFLdBbso]mE!A%^47fgdX$24?nLC0T(Hij=>f]\jX;Tp??KokP`+]o0O"b3k-#3J"=eGQsY*eq.t&^<tQ/PeBT(6Gd/Deq>+_LM_^>ZSbfVH4=$TN\</<7YkI)dA7%(;C<r6)n]`HApMGmqKaM67+n.E'U2]u@9":4m9EWcVVXCjEq]sjcpA</krZPdYNRn*;n+Z;#GNl9.5"fC8pSs0DU',r5n)EP.Y*8kM@B2rfqTk"j8/"VQ:`",<<.N8DbUC>G~>endstream
+Gau0CgN):5&:N^lqB<Ji9F\k%-!AOB![50lAKV:kB2b'3"3PJb9oLkcq>6H<95Lhb-WOB=A1[EDl./^U9?(A=+)LqZ!e?sLrGrC7J9M6c+q!01N4htMDsbdo_'&ckrj24O@FT7qs(i/Tj,17n5EFg^he7k4bZ]%6[3ih4M='1,:A@]oB)15IrYi[We@F#AE%*=k.#+1R@`7qEf8IMt:Z+BepDLOZDSdfQGuDk2Yog.0(DmRs[]Eqa&4\D4)Nk=3hkGA%c40"V)uO/RPoM0onK7>"+)EkKXeMIV;$rP/U/Y$k&(OA"FV"RC#[f3FJ69\$K3UtI`V0RI)$&'%P^W>;A!oo"c.!PbS'i"T#&0DbhVmPT!k_ZYV7!p\KWpe0($4=M(mVJ#L!eBLV7g`.MX)YOqM=u?Det7sH_Y7Wg-b+'N:Tp>0gV=oK,fh>Zc1Gk29?$*/9J+TIRs5SL@R2/fCd=o?">GO:ql@//@YUo+N"<p)$b*s7fa%,0j+2Y&51--6tU7>knqs\kc$u<0bokm]]_57Rc[GG'Z\<FAMX3s2AqKYaAD63P**AE^\qHDec+28#V5U>cO-ejhL)SPBjGF'`_=p8g&6"*A*7f/,FOanamkq"%MC6Bf0pn>[BkECY0Un-/0p$"@5E1:3^`SD:l6)dJk1dn`n+S\:#p%4%PNCZ(1T<4k#`,I"M$EM(h#$*NR!KS`Df,\39Di6C&&31lB.$=+LVm*J9DSPF`e6AA/YTS##XG0&OI;<Kj:5$I+h2>`;2a*%08OY]k2(H2TVgT-;b'-Dt\9L[0s$G2hR"Dk.3E_p2j-9;nK:!a-,h76?6sI;;V1'Y@hL+Ok1__j!(@`-3mm0##fI"h:/3VX`NffH81t80Ug6*aE?AUiXJ(Y%)&&f\7e,8JufU\k^%V7nJ[R]Ef+skcbVKO[<_aVjG]3@Za>!A='GQ,+#W+*,,/e_hk^/[\E*%WH=aqXW4-ej*?B$\;]pff\.ag`ePHmeaoJ=s=>3,L/"q;;(1I_db4.[g*]Q;*FVP$^=ck6UpB4JHU)t)6*#I,/[h,p^[1Tbd3#Aqe[h5u8>ph%3VSJ1ak.*rX`C)m<W-qoI_qm`,!nTogG2QWP!o6>m&p9b<>jIpeC7]2D'd([rH<a4m.Q^)rgh[);KbWqG;S8?]Y1>QGd6)1V/%7eoCm<(E4]89=;o^uOWJmgj6J6K?koq%?fa5h3LR2Qb-3!&6+nQIbB@e:+-ermU''6UW:[c#kDklQpi]Gqu>mfX\?(dY)cB)0C-Np]/Rna=7SY$I>J38"U9VZ6G_KufBp`3\9(V#B4GhG67pFqJV@,rhhs11P3FS=s;;s4+n6M!MTV)l++gjC,<4d]N$PM(&,\lTIY#Lq$><-YYk:AObL,`=F=6(RkW>X'R.f!q#=os"#I2.U&K41470q:Y-_j7dDM?%iVo.3\34&u'@:(eT%7YtP8L&Z5!(K81`*T(`%C)?5dQg-dH@e+`b6lFV/m;kKnk^O9,%,Z+X3qV*uUP,kCnHWfc;n`)NQN5E:P/KugL+$0E&.CHrQ~>endstream
 endobj
 xref
 0 11
@@ -73,11 +73,11 @@ xref
 0000000221 00000 n 
 0000000717 00000 n 
 0000000829 00000 n 
-0000001037 00000 n 
-0000001322 00000 n 
-0000001390 00000 n 
-0000001640 00000 n 
-0000001699 00000 n 
+0000001031 00000 n 
+0000001316 00000 n 
+0000001384 00000 n 
+0000001634 00000 n 
+0000001693 00000 n 
 trailer
 <<
 /ID 
@@ -86,5 +86,5 @@ trailer
 /Size 11
 >>
 startxref
-3338
+3332
 %%EOF

--- a/corehq/apps/accounting/tests/data/invoice_006.pdf
+++ b/corehq/apps/accounting/tests/data/invoice_006.pdf
@@ -26,8 +26,8 @@ endobj
 5 0 obj
 <<
 /A <<
-/S /URI /Type /Action /URI (http://server.local/a/group-therapy/settings/project/billing/statements/)
->> /Border [ 0 0 0 ] /Rect [ 36 43.2 338.35 55.2 ] /Subtype /Link /Type /Annot
+/S /URI /Type /Action /URI (http://server.local/a/group-therapy/settings/project/subscription/)
+>> /Border [ 0 0 0 ] /Rect [ 36 43.2 314.45 55.2 ] /Subtype /Link /Type /Annot
 >>
 endobj
 6 0 obj
@@ -60,10 +60,10 @@ endobj
 endobj
 10 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1537
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1535
 >>
 stream
-Gau0C?$"^Z'Rf.GgkY5)knG;_Ot>d1$.)s=.3u`G2`#_6i-Z9o`,Ri_^L'S3^]lm1RFt/q>.Vc;?6.jK,nn)ZLR>iW!8uXdrYGWhJpR`U+U7?<N875mO8%e!jH0CJs4)D_E+ZW0J!L)($cUiaIu31Che7k4*&!#R>#U;!C3b#$:pKX=a.@6tDbXURFfr));@:SVMP6nX":76CFeeHn'\k'T5=(XO9c,01:Pp#Kp;3*p)$]83@9cJ:ioi7)6h90QpF+n"F$mOY#/<RcP2eqjrmUo/"l##t<`)\f-j;('<@XuuLME^LfSBU,'F9gl6L;V&K,dG^`V0Ri%=i1Pb's>hK?^3tB'RRW9kar:K="8ln+l&(!o-q$V7!p\KWpe0($4$qN(VgM_W^7adb_jJiqc6W5,,d>Rp]B4D\OcrHRO<"Ys56PZ&ihM;NR6sZ`iD_qg4K!;-E+r;JY#c@`@3tXaZP$K1ph:Wn4qCrN5f0pgF5\*sZa$7fa%,0jsPi-rt(.OVq@_*MXMh4dF&NXs0$s(VKrTdi0cj@bY%Z9W%j6-Gsg2'oL85%"si?gYX9Q0XV`o?>PaqQ!/gRq-r[<ZI2c?\1.`iq<9.Jp>Mf:E]_U1iu?<\,ZRs,K4MQ-UObM0:M[g%P#RaOR630oU&%h-6Q?q31r[)elYlAAEjZH_Pea'5(_20YQ@]l@NWh=,6qB\?1S]`9Wi$'A_EeY^^VOSHP#DfhQ,5>MeO7M!*CL4%"sL!4'KJd^eFe`^,P%!n4)'c8&+nQeLeZE8`YN*;N+ui8Ki51^Vh;!Tif`++.X"JKcCES:6,h-N_Q"\N[c7ZC";5h.qGeUU/b]'<+ggVZY*(+:?S)I\GN.K/UT()2CIc(*:0\X]jpgC_D+hElcPPd4bT0qFTI!%:6pA7)O!\a3Z89=YmdE0GL:9(eT8T3oOqXEFcf[ouht9i6?6Z,4VYf3DIfLpC];j^iLcXd?cE<oe9l`kE8I9T-#f7#s@As[>>D"4lN:IUmGCgEF5Vk_"WV=3mq5C>:aNBBPl*r+>=qUY)T_,aeL:r;6"g3iXmD-9*"hK\d-0dNW))h_:"?"L_Jgr,D5s_X5Jf==uJekjSK!kdEJemQ.JsNA$";P,/9Mk=c,H1NRI^8!Sb#[1EgZN/fBJ-)sT9o,^XE:hhR>C!.McdM!123F]`p/]/'V@GCKhc3roG,NK]1<ac:sDa\Fu[,eP:5rZB+:Q4?n8hnH,&:G/!MH3gn)7WL;&YE?]+;k4'!el'6Sk@&j&Hm;4LJ$)f@\c0R%t4f`CZrXYPm-k6^T@Gi90XMdG?pMW+6i0t`9M'Egd!$2jN4qQ7)"J"#*[pD&u1Jh5Hgjl#:UGj<04d[eUZo<Z,fW&S0cm\%Ei$usGAs$F%?o,,uV+8bBE"On@Ar_bn\]Qan==3QTVo>Q*!HYWKHf%=!$&=,K_hV*`5gcU<TW,F"I%8]Q^]%7E5P%8pjn%\Yf:Hq=<B]X+-?GH')V2S!?"FfTRj64Tl-2lrc7ZlR%?P5$^9dkEW?,U#H!BU5]9Us!?~>endstream
+Gau0C?$"^Z'Rf.GgkY5)knG;_Ot>d1$)+tQ;FlDmDJ&HK_"fIgM/bT$^L'S3^]lm1RFt/q>.Vc;?6.jK,nn)ZLR>j"!8uXdrYGWhJpS#]+U7?\N8./lO8%e!jH0Dur7-)WE+ZW0J!L)($cUiaIu31Che7QV*%uuQ>Z$A!C3fPO:pKL9a.@6tDaiS.l<J+3U_K+6'LPU:#SMHdlUKjf.Cd^^IY'2'gFu6-Q4u,mm"J+41CVRF_RPsS`6iA1K&k=7mnp`(jb@l:%=X/P--(j_r29S<$T;cB/Yet,;$p8.W`2ls&(OA"Yn7.7.1d\cK\2&_#<@nFM]W?5)Z\E+Pl:MY#Fe:rc.&)8S'i"T#&0DbhXg:!-+MFh8o&YB#[oB?.a"ql(mVJ#L=,VmV7hRs`V$QXI7/L[2o2fHhC)Qnp/(T"@t.I+@NjL#V')sZVI)h\p\,r"U9`,NV:MNA`/;7Q>Q$$'#FPWT<3LW`q]"uUnA>AA57ZU8NWL&6@_h%\:or/;+u?ZH3^ttZH7Fu&>X]no07!r3VDhH]`O<*>),L7"NeaAF.MS@H)$hV]\%bL,@;7Ni]\"Dk/%#S.o>T:WAYlM^E)dB[o@$8tm))DSjE@+@a#BUC8?/m6#K_):/dCaB5-5.385`U-B(E`JMX"PW$uoYhd1l&0DSFAaaONUn;$(+K7rT<hYnXPnE\+F$,!m1dSJaT7<BW3!((P@eq$fgZOdp0ZWYD$*XX6[&kTEL=1^HqfU<$1]V640a*0HS8g.?W*J"YDJ5]!H,1U\DFA5m?..$TU[4WRMh&sqrs:pF4kGNR,@%OuX6'it98Z5l_3+crA/f!"qs`I,E2'ggXbi[SY_nF_/_EQ@Ka4doP8[s$9mak2=+FOi^[gU<>.phYEI:>N`t"'STU9B=![dDaaT89Q<sdeu<6fC7ARq+Hi+7WQApk4qp>oXd;%a@ep#dr`A%rXU+tDqEMY$W/97cIm>^Ue+=<3%<f]#XPto,V52]G&+>CLf%JFpJ*F%%;7*054osV4Wee]"BemT/04Hf<@_N#'U0XTe?HCn[(s']ZlM+BZp;)4Zp\1I.-%2?NM,FE7Sq&l5:EIQ>Yr>p6I5ec7aQ>:>gNQ.7aMcjSY/=8SI'&&CBTnEbtiLf:>%*YAc(8!"3lOamIO5iQ^*T^3"s\%CCr)+5pe1Jb#gf)RGq/c]?mNNR(bmiFVj9d)QMI>cOP`^71pp'qQ(k4'Pq@4+R^-%FbLIiO1WkbhpAj[oLn]pDT=41EhY0_9k%bV/;b*uGf*6'"m4*+-p'[8]2b`Uo/u!f7kac@Dp^)j7kqYoT>CgM7R8a#Pe_cUUYe-0oV\\eIU?N/+imP%>RbScN@$8OYMAYi1-=6kLl):HjUNcQ`"8hor@^!c164_lqQ[e]8jKLujY,-$dYh1gIDp$QT$M$cGGiILDN.qU$=Vm\i2qB__Y$jkKDK3Ndf=NDWI+$j0hF99rVkB/J,1m'7n[dVp\L-c/S.Tg-1J@XM5+^5RImtlMsW9Kg*BHkfJfTp`23,ok<GgJ_!(~>endstream
 endobj
 xref
 0 11
@@ -73,11 +73,11 @@ xref
 0000000221 00000 n 
 0000000717 00000 n 
 0000000829 00000 n 
-0000001037 00000 n 
-0000001322 00000 n 
-0000001390 00000 n 
-0000001640 00000 n 
-0000001699 00000 n 
+0000001031 00000 n 
+0000001316 00000 n 
+0000001384 00000 n 
+0000001634 00000 n 
+0000001693 00000 n 
 trailer
 <<
 /ID 
@@ -86,5 +86,5 @@ trailer
 /Size 11
 >>
 startxref
-3328
+3320
 %%EOF


### PR DESCRIPTION
## Product Description
Changes a link on prepayment invoices:
<img width="410" alt="image" src="https://github.com/user-attachments/assets/9b987afd-ae55-4dd6-be50-33aa11f62d99" />

to:
<img width="396" alt="image" src="https://github.com/user-attachments/assets/299be298-a899-4006-b62e-ccbed0996bb0" />

Which is where prepayments by card are actually made.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17580
Really basic change that just conditionally swaps one link for another.

## Safety Assurance

### Safety story
Confirmed locally this does switch the link as expected and the link works.

### Automated test coverage
There are some invoice PDF tests but they are mostly to check against changes in the PDF library.

### QA Plan
Nope


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
