### PR TITLE
In vellum webpack utils, replace loader paths to point to HQ

### DIFF
--- a/webpack/vellumUtils.js
+++ b/webpack/vellumUtils.js
@@ -63,12 +63,20 @@ const getDebugRule = function () {
     if (!config) {
         return {};
     }
+    const debugDir = getDebugDir(),
+        hqDir = path.resolve(__dirname, '..');
+    const rules = config.module.rules.map(function (rule) {
+        if (rule.loader) {
+            rule.loader = rule.loader.replace(hqDir, debugDir);
+        }
+        return rule;
+    });
     return {
         test: getDebugDir(),    // if config exists, this dir exists
         resolve: {
             alias: config.resolve.alias,
         },
-        rules: config.module.rules,
+        rules: rules,
     };
 };
 

--- a/webpack/vellumUtils.js
+++ b/webpack/vellumUtils.js
@@ -66,7 +66,7 @@ const getDebugRule = function () {
     const debugDir = getDebugDir(),
         hqDir = path.resolve(__dirname, '..');
     const rules = config.module.rules.map(function (rule) {
-        if (rule.loader) {
+        if (rule.loader && rule.loader.startsWith(hqDir)) {
             rule.loader = rule.loader.replace(hqDir, debugDir);
         }
         return rule;


### PR DESCRIPTION
## Technical Summary
This is pretty heinous but nonetheless the best idea I've come up with. Someone with a better knowledge of webpack resolutions might have a more elegant solution.

Vellum uses a [custom template loader](https://github.com/dimagi/Vellum/blob/3017ef5e29835a8ad50933ad423a81cbfb38d09b/webpack/webpack.common.js#L27) to load underscore templates as functions instead of plain text. Unfortunately, there doesn't seem to be a way to alias the path to the loader.

This presents a problem for HQ environments with VELLUM_DEBUG set to True (which doesn't happen in production, only local environments). In this situation, webpack builds vellum by incorporating vellum's webpack config into HQ's webpack config (see the usage of `vellum Utils` in [webpack.common.js](https://github.com/dimagi/commcare-hq/blob/master/webpack/webpack.common.js)).

This fails because when webpack is run from within HQ, `path.resolve('src/template-loader.js')` ends up rooted in the HQ directory, so the path is something like `/Users/jenny/Documents/commcare-hq/src/template-loader.js` which doesn't exist.

This PR replaces that HQ-based root with the directory where vellum is stored within HQ, which is ultimately based on `submodules/formdesigner` (see [here](https://github.com/dimagi/commcare-hq/blob/2d3b9a123e0a53edd2dbfa92b2852100f63b4e38/webpack/vellumUtils.js#L29-L41)).

An alternative would be to use [underscore-template-loader](https://www.npmjs.com/package/underscore-template-loader) rather than a custom loader. However, then `underscore-template-loader` needs to be added to HQ's `package.json` for webpack to run in this situation (HQ repo, VELLUM_DEBUG=True), which isn't ideal, either. Conveniently, all of the other loaders used by Vellum are also needed by HQ.

This whole setup increases my belief that Vellum might be better suited to become part of HQ instead of a separate repository, but that's a question for another day.

## Safety Assurance

### Safety story
This is a change to the dev and build processes, not a user-facing change.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
