### PR TITLE
add case type created by SaveToCase feature in refresh_data_dictionar…

### DIFF
--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -18,7 +18,7 @@ from corehq.apps.app_manager.exceptions import (
 )
 from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.apps.app_manager.const import USERCASE_TYPE
-from corehq.toggles import USH_USERCASES_FOR_WEB_USERS
+from corehq.toggles import USH_USERCASES_FOR_WEB_USERS, VELLUM_SAVE_TO_CASE
 from corehq.util.decorators import serial_task
 from corehq.util.metrics import metrics_counter
 
@@ -95,7 +95,11 @@ def refresh_data_dictionary_from_app(domain, app_id):
 
     from corehq.apps.app_manager.util import actions_use_usercase
     from corehq.apps.data_dictionary.util import create_properties_for_case_types
+
     case_type_to_prop = defaultdict(set)
+    if VELLUM_SAVE_TO_CASE.enabled(domain):
+        for form in app.get_forms():
+            case_type_to_prop.update(form.get_save_to_case_updates())
     for module in app.get_modules():
         if not module.is_surveys:
             for form in module.get_forms():


### PR DESCRIPTION
…y_from_app

## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

If user add a SaveToCase question, then the case type and its property created by this question should also be added to Data Dictionary.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17441

The implementation iterates all the forms in an app twice, first time to get savetocase updates, second time to get case type and property names created in the regular way. I thought about combining two iteration, so we only iterate once. But the second iteration need to skip Survey module, it means code will have a if else block in the iteration, handling two scenarios, and repeat some code. I think this introduce more complex conditional logic, and makes the code hard to maintain.

```
    for module in app.get_modules():
        if module.is_surveys:
            for form in module.get_forms():
                if toggle enabled:
                    get SaveToCase case types
        else:
            for form in module.get_forms():
                if toggle enabled:
                    get SaveToCase case types
                get regular case types

```
So I go with the two iterations.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
VELLUM_SAVE_TO_CASE

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I think it is safe, just adding more case properties to data dictionary. The function I used here is also an existing function.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

test_refresh_data_dictionary_from_app

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Planning on QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
