### PR TITLE
Improve logging, fix browser caching for hq-hx-action requests

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_action.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_action.js
@@ -17,7 +17,21 @@
 document.body.addEventListener('htmx:configRequest', (evt) => {
     // Require that the hq-hx-action attribute is present
     if (evt.detail.elt.hasAttribute('hq-hx-action')) {
+        const action = evt.detail.elt.getAttribute('hq-hx-action');
         // insert HQ-HX-Action in the header to be processed by the `HqHtmxActionMixin`
-        evt.detail.headers['HQ-HX-Action'] = evt.detail.elt.getAttribute('hq-hx-action');
+        evt.detail.headers['HQ-HX-Action'] = action;
+
+        /*
+            Below we namespace the URL with a flag in the querystring so that
+            the browser keys the cache for each partial separately.
+
+            It also creates distinct log paths for each hq-hx-action--helpful for troubleshooting.
+
+            This querystring flag will be removed by `HqHtmxActionMiddleware` so that it
+            doesn't accidentally get passed around to other requests.
+        */
+        const url = new URL(evt.detail.path, window.location.origin);
+        url.searchParams.set('_hq-hx-action', action);
+        evt.detail.path = url.pathname + url.search;
     }
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_action.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_action.js
@@ -1,17 +1,18 @@
-/*
-    To use:
-
-    1) In your page's entry point, import HTMX and this module, eg:
-    import 'htmx.org';
-    import 'hqwebapp/js/htmx_utils/hq_hx_action';
-
-    2) Then, make sure your class-based view extends the `HqHtmxActionMixin`.
-
-    3) Apply the `@hq_hx_action()` decorator to methods you want to make available to
-       `hq-hx-action` attributes
-
-    4) Reference that method in the `hq-hx-action` attribute alongside `hx-get`,
-       `hx-post`, or equivalent
+/**
+ *  To use:
+ *
+ *     1) In your page's entry point, import HTMX and this module, eg:
+ *
+ *     import 'htmx.org';
+ *     import 'hqwebapp/js/htmx_utils/hq_hx_action';
+ *
+ *     2) Then, make sure your class-based view extends the `HqHtmxActionMixin`.
+ *
+ *     3) Apply the `@hq_hx_action()` decorator to methods you want to make available to
+ *        `hq-hx-action` attributes
+ *
+ *     4) Reference that method in the `hq-hx-action` attribute alongside `hx-get`,
+ *        `hx-post`, or equivalent
  */
 document.body.addEventListener('htmx:configRequest', (evt) => {
     // Require that the hq-hx-action attribute is present

--- a/settings.py
+++ b/settings.py
@@ -157,6 +157,7 @@ MIDDLEWARE = [
     'django.middleware.common.BrokenLinkEmailsMiddleware',
     'django_otp.middleware.OTPMiddleware',
     'django_user_agents.middleware.UserAgentMiddleware',
+    'corehq.middleware.HqHtmxActionMiddleware',
     'corehq.middleware.OpenRosaMiddleware',
     'corehq.util.global_request.middleware.GlobalRequestMiddleware',
     'corehq.apps.users.middleware.UsersMiddleware',


### PR DESCRIPTION
## Technical Summary
This fixes two issues:

1) logs didn't have insight into which htmx partial is being served as only the top-level url is shown. Now, each request has a unique URL due to the `_hq-hx-action` flag added to the querystring.
![Screenshot 2025-05-22 at 9 58 40 PM](https://github.com/user-attachments/assets/970ac170-81ee-4b34-b3a6-a53ac341ef89)

2) When relying on browser caching, we can often run into issues when using back/forward buttons to navigate. This is because the browser will cache the last-received partial / HTMX fragment received from a URL as the top-level URL. There was no way to provide a fragment-specific cache depending on which `hq-hx-action` the response was for. By adding the `_hq-hx-action` to the URL of each request, it creates a unique key for the browser to store the result in its cache. Now the cache behaves as expected.

We use the `HqHtmxActionMiddleware` to strip the `_hq-hx-action` flag from the request URL so that this flag isn't passed to the view logic. Without this, a view might accidentally pass this flag it into the visible URL in the browser, causing a confusing mess in the logs (and possibly confusing the cache keys).

## Feature Flag
no feature flag on this

## Safety Assurance

### Safety story
safe change. tested on staging and locally with the data cleaning tool

### Automated test coverage
n/a

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
