### PR TITLE
[Data Cleaning] move table loading indicator to top of table

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_tables.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_tables.scss
@@ -160,7 +160,7 @@
       height: $table-loading-spinner-size;
       $_offset: $table-loading-spinner-size / 2;
       left: calc(50% - $_offset);
-      top: calc(50% - $_offset);
+      top: 10%;
     }
 
     .table-loading-progress {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/tables._tables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/tables._tables.style.diff.txt
@@ -106,7 +106,7 @@
 +      height: $table-loading-spinner-size;
 +      $_offset: $table-loading-spinner-size / 2;
 +      left: calc(50% - $_offset);
-+      top: calc(50% - $_offset);
++      top: 10%;
 +    }
 +
 +    .table-loading-progress {


### PR DESCRIPTION
## Product Description
Previously the loading indicator would show up in the middle of the table. This means that the user will not see the loading indicator if the table is very long. Users are always usually at the top of the table when making table-wide edits, so the better place for the loading indicator is at the top.

The change, visualized:
![May-26-2025 12-54-12](https://github.com/user-attachments/assets/07dd4d61-fcb3-4cd8-a45c-27d1986416dd)


## Technical Summary
- this ensures that if someone is looking at the top of a long table, they see the loading indicator

## Safety Assurance

### Safety story
stylesheet change only

### Automated test coverage
n/a

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
