### PR TITLE
[Data Cleaning] fix issue where changes bar doesn't show if first edit is inline

### DIFF
--- a/corehq/apps/data_cleaning/static/data_cleaning/js/bulk_edit_session.js
+++ b/corehq/apps/data_cleaning/static/data_cleaning/js/bulk_edit_session.js
@@ -14,6 +14,12 @@ Alpine.data('wiggleButtonModel', wiggleButton);
 
 Alpine.store('isCleaningAllowed', false);
 Alpine.store('showWhitespaces', false);
+Alpine.store('changes', {
+    'hasChanges': false,
+    update: function (hasChanges) {
+        this.hasChanges = hasChanges;
+    },
+});
 
 import Alpine from 'alpinejs';
 Alpine.start();
@@ -21,4 +27,8 @@ Alpine.start();
 document.body.addEventListener("showDataCleaningModal", function (event) {
     const modal = new Modal(event.detail.elt);
     modal.show();
+});
+
+document.body.addEventListener("updateChanges", function (event) {
+    Alpine.store('changes').update(event.detail.hasChanges);
 });

--- a/corehq/apps/data_cleaning/templates/data_cleaning/tables/bulk_edit_session.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/tables/bulk_edit_session.html
@@ -16,6 +16,7 @@
   x-init="
     updateCleaningStatus(numRecordsSelected);
     $watch('numRecordsSelected', updateCleaningStatus);
+    $store.changes.update({{ table.has_changes|yesno:"true,false" }});
   "
 {% endblock %}
 
@@ -36,48 +37,49 @@
 {% block before_table %}
   <div class="d-flex align-items-center pb-2">
 
-    {% if table.has_changes %}
-      <div class="pe-2">
-        <div class="input-group">
-          <div class="input-group-text">
-            <i class="fa-solid fa-pencil me-2"></i>
-            {% trans "Edits" %}
-          </div>
-          <button
-            class="btn btn-outline-danger"
-            type="button"
-            data-bs-toggle="modal"
-            data-bs-target="#confirm-clear-modal"
-            @click="$dispatch('updateClearSummaryMessage');"
-          >
-            <i class="fa-solid fa-close"></i>
-            {% trans "Clear" %}
-          </button>
-
-          <button
-            class="btn btn-outline-secondary"
-            type="button"
-            data-bs-toggle="modal"
-            data-bs-target="#confirm-undo-modal"
-            @click="$dispatch('updateUndoSummaryMessage');"
-          >
-            <i class="fa-solid fa-undo"></i>
-            {% trans "Undo" %}
-          </button>
-
-          <button
-            class="btn btn-success"
-            type="button"
-            data-bs-toggle="modal"
-            data-bs-target="#confirm-apply-modal"
-            @click="$dispatch('updateApplySummaryMessage');"
-          >
-            <i class="fa-solid fa-check-double"></i>
-            {% trans "Apply" %}
-          </button>
+    <div
+      class="pe-2"
+      x-show="$store.changes.hasChanges"
+    >
+      <div class="input-group">
+        <div class="input-group-text">
+          <i class="fa-solid fa-pencil me-2"></i>
+          {% trans "Edits" %}
         </div>
+        <button
+          class="btn btn-outline-danger"
+          type="button"
+          data-bs-toggle="modal"
+          data-bs-target="#confirm-clear-modal"
+          @click="$dispatch('updateClearSummaryMessage');"
+        >
+          <i class="fa-solid fa-close"></i>
+          {% trans "Clear" %}
+        </button>
+
+        <button
+          class="btn btn-outline-secondary"
+          type="button"
+          data-bs-toggle="modal"
+          data-bs-target="#confirm-undo-modal"
+          @click="$dispatch('updateUndoSummaryMessage');"
+        >
+          <i class="fa-solid fa-undo"></i>
+          {% trans "Undo" %}
+        </button>
+
+        <button
+          class="btn btn-success"
+          type="button"
+          data-bs-toggle="modal"
+          data-bs-target="#confirm-apply-modal"
+          @click="$dispatch('updateApplySummaryMessage');"
+        >
+          <i class="fa-solid fa-check-double"></i>
+          {% trans "Apply" %}
+        </button>
       </div>
-    {% endif %}
+    </div>
 
     {% if table.has_any_filtering %}
       <div class="pe-2">

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -181,9 +181,15 @@ class EditCasesTableView(BulkEditSessionViewMixin,
             record,
             table,
         )
-        return self.render_htmx_partial_response(
+        response = self.render_htmx_partial_response(
             request, EditableHtmxColumn.template_name, context
         )
+        response['HX-Trigger'] = json.dumps({
+            "updateChanges": {
+                "hasChanges": self.session.has_changes(),
+            },
+        })
+        return response
 
     def _get_cell_request_details(self, request):
         """


### PR DESCRIPTION
## Product Description
<img width="475" alt="Screenshot 2025-05-26 at 12 46 48 PM" src="https://github.com/user-attachments/assets/0d507191-363d-4557-a09d-83db11086ab7" />


## Technical Summary
We are back to storing the "has changes" status on the client side again. This allows us to update that value from table cell request without doing a full refresh of the table.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change made to feature flagged code currently under testing on staging

### Automated test coverage
n/a javascript

### QA Plan
not blocking PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
