### PR TITLE
[Data Cleaning] rename privilege to BULK_DATA_EDITING, assign to Advanced

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -159,11 +159,11 @@ advanced_v0 = pro_v1 + [
     privileges.CASE_COPY,
     privileges.CUSTOM_DOMAIN_ALERTS,
     privileges.APP_DEPENDENCIES,
+    privileges.BULK_DATA_EDITING,
 ]
 
 enterprise_v0 = advanced_v0 + [
     privileges.GEOCODER,
     privileges.DEFAULT_EXPORT_SETTINGS,
     privileges.RELEASE_MANAGEMENT,
-    privileges.BULK_DATA_CLEANING,
 ]

--- a/corehq/apps/accounting/migrations/0099_data_cleaning_priv.py
+++ b/corehq/apps/accounting/migrations/0099_data_cleaning_priv.py
@@ -1,7 +1,6 @@
 from django.core.management import call_command
 from django.db import migrations
 
-from corehq.privileges import BULK_DATA_CLEANING
 from corehq.util.django_migrations import skip_on_fresh_install
 
 
@@ -11,7 +10,7 @@ def _add_data_cleaning_to_enterprise(apps, schema_editor):
     call_command('cchq_prbac_bootstrap')
     call_command(
         'cchq_prbac_grandfather_privs',
-        BULK_DATA_CLEANING,
+        "bulk_data_cleaning",
         skip_edition='Paused,Community,Standard,Pro,Advanced',
         noinput=True,
     )
@@ -20,7 +19,7 @@ def _add_data_cleaning_to_enterprise(apps, schema_editor):
 def _reverse(apps, schema_editor):
     call_command(
         'cchq_prbac_revoke_privs',
-        BULK_DATA_CLEANING,
+        "bulk_data_cleaning",
         skip_edition='Paused,Community,Standard,Pro,Advanced',
         delete_privs=False,
         check_privs_exist=True,
@@ -28,7 +27,7 @@ def _reverse(apps, schema_editor):
     )
 
     from corehq.apps.hqadmin.management.commands.cchq_prbac_bootstrap import Command
-    Command.OLD_PRIVILEGES.append(BULK_DATA_CLEANING)
+    Command.OLD_PRIVILEGES.append("bulk_data_cleaning")
     call_command('cchq_prbac_bootstrap')
 
 

--- a/corehq/apps/accounting/migrations/0103_bulk_data_cleaning_priv.py
+++ b/corehq/apps/accounting/migrations/0103_bulk_data_cleaning_priv.py
@@ -1,0 +1,59 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.privileges import BULK_DATA_EDITING
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _add_data_editing_to_advanced_and_clean_old_privilege(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+
+    # first remove the old privilege ("bulk_data_cleaning") if it exists
+    call_command(
+        'cchq_prbac_revoke_privs',
+        "bulk_data_cleaning",
+        delete_privs=True,
+        check_privs_exist=False,
+        noinput=True,
+    )
+
+    # then grandfather new privilege (Advanced + Enterprise)
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        BULK_DATA_EDITING,
+        skip_edition='Paused,Community,Standard,Pro',
+        noinput=True,
+    )
+
+
+def _reverse(apps, schema_editor):
+    # grandfather the old privilege ("bulk_data_cleaning") to Advanced and Enterprise plans again
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        "bulk_data_cleaning",
+        skip_edition='Paused,Community,Standard,Pro,Advanced',
+        noinput=True,
+    )
+    # undo assigning the new privilege to Advanced and Enterprise plans
+    call_command(
+        'cchq_prbac_revoke_privs',
+        BULK_DATA_EDITING,
+        delete_privs=True,
+        check_privs_exist=True,
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0102_alter_defaultproductplan_edition_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _add_data_editing_to_advanced_and_clean_old_privilege,
+            reverse_code=_reverse,
+        ),
+    ]

--- a/corehq/apps/data_cleaning/decorators.py
+++ b/corehq/apps/data_cleaning/decorators.py
@@ -4,7 +4,7 @@ from no_exceptions.exceptions import Http403
 from django.http.response import Http404
 
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.privileges import BULK_DATA_CLEANING
+from corehq.privileges import BULK_DATA_EDITING
 from corehq.toggles import DATA_CLEANING_CASES
 
 
@@ -23,7 +23,7 @@ def require_bulk_data_cleaning_cases(view_func):
 
 
 def bulk_data_cleaning_enabled_for_request(request):
-    if domain_has_privilege(request.domain, BULK_DATA_CLEANING):
+    if domain_has_privilege(request.domain, BULK_DATA_EDITING):
         if hasattr(request, "couch_user"):
             if request.couch_user.can_edit_data(request.domain):
                 return True

--- a/corehq/apps/data_cleaning/tests/test_views.py
+++ b/corehq/apps/data_cleaning/tests/test_views.py
@@ -37,7 +37,7 @@ from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.es.users import user_adapter
 from corehq.apps.users.models import HqPermissions, UserRole, WebUser
-from corehq.privileges import BULK_DATA_CLEANING
+from corehq.privileges import BULK_DATA_EDITING
 from corehq.util.test_utils import flag_enabled, privilege_enabled
 
 
@@ -139,7 +139,7 @@ class CleanCasesViewAccessTest(TestCase):
         cls.other_domain_obj.delete()
         super().tearDownClass()
 
-    @privilege_enabled(BULK_DATA_CLEANING)
+    @privilege_enabled(BULK_DATA_EDITING)
     def test_has_no_access_without_login(self):
         for view_class, args in self.all_views:
             url = reverse(view_class.urlname, args=args)
@@ -150,7 +150,7 @@ class CleanCasesViewAccessTest(TestCase):
                 msg=f"{view_class.__name__} should NOT be accessible"
             )
 
-    @privilege_enabled(BULK_DATA_CLEANING)
+    @privilege_enabled(BULK_DATA_EDITING)
     def test_has_no_access_without_flag(self):
         self.client.login(username=self.user_in_domain.username, password=self.password)
         for view_class, args in self.all_views:
@@ -173,7 +173,7 @@ class CleanCasesViewAccessTest(TestCase):
                 msg=f"{view_class.__name__} should NOT be accessible"
             )
 
-    @privilege_enabled(BULK_DATA_CLEANING)
+    @privilege_enabled(BULK_DATA_EDITING)
     def test_has_no_access_without_permission(self):
         self.client.login(username=self.user_without_role.username, password=self.password)
         for view_class, args in self.all_views:
@@ -185,7 +185,7 @@ class CleanCasesViewAccessTest(TestCase):
                 msg=f"{view_class.__name__} should NOT be accessible"
             )
 
-    @privilege_enabled(BULK_DATA_CLEANING)
+    @privilege_enabled(BULK_DATA_EDITING)
     @flag_enabled('DATA_CLEANING_CASES')
     def test_has_access_with_prereqs(self):
         self.client.login(username=self.user_in_domain.username, password=self.password)
@@ -201,7 +201,7 @@ class CleanCasesViewAccessTest(TestCase):
                 msg=f"{view_class.__name__} should be accessible"
             )
 
-    @privilege_enabled(BULK_DATA_CLEANING)
+    @privilege_enabled(BULK_DATA_EDITING)
     @flag_enabled('DATA_CLEANING_CASES')
     def test_has_no_access_to_wrong_session(self):
         self.client.login(
@@ -220,7 +220,7 @@ class CleanCasesViewAccessTest(TestCase):
                 msg=f"{view_class.__name__} should NOT be accessible"
             )
 
-    @privilege_enabled(BULK_DATA_CLEANING)
+    @privilege_enabled(BULK_DATA_EDITING)
     @flag_enabled('DATA_CLEANING_CASES')
     def test_redirects_session_with_no_existing_session(self):
         self.client.login(username=self.user_in_domain.username, password=self.password)
@@ -228,7 +228,7 @@ class CleanCasesViewAccessTest(TestCase):
         response = self.client.get(session_url)
         self.assertEqual(response.status_code, 302)
 
-    @privilege_enabled(BULK_DATA_CLEANING)
+    @privilege_enabled(BULK_DATA_EDITING)
     @flag_enabled('DATA_CLEANING_CASES')
     def test_views_not_found_with_invalid_session(self):
         self.client.login(username=self.user_in_domain.username, password=self.password)
@@ -246,7 +246,7 @@ class CleanCasesViewAccessTest(TestCase):
                 msg=f"{view_class.__name__} should NOT be accessible"
             )
 
-    @privilege_enabled(BULK_DATA_CLEANING)
+    @privilege_enabled(BULK_DATA_EDITING)
     @flag_enabled('DATA_CLEANING_CASES')
     def test_has_no_access_with_other_domain(self):
         self.client.login(username=self.user_outside_of_domain.username, password=self.password)

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -238,7 +238,7 @@ class Command(BaseCommand):
         Role(slug=privileges.APP_DEPENDENCIES,
              name='App Dependencies',
              description='Set Android app dependencies that must be installed before using a CommCare app'),
-        Role(slug=privileges.BULK_DATA_CLEANING, name='Bulk Data Cleaning', description=''),
+        Role(slug=privileges.BULK_DATA_EDITING, name='Bulk Data Editing', description=''),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -38,7 +38,7 @@ INBOUND_SMS = 'inbound_sms'
 
 BULK_CASE_MANAGEMENT = 'bulk_case_management'
 BULK_USER_MANAGEMENT = 'bulk_user_management'
-BULK_DATA_CLEANING = 'bulk_data_cleaning'
+BULK_DATA_EDITING = 'bulk_data_editing'
 
 DEIDENTIFIED_DATA = 'deidentified_data'
 
@@ -188,7 +188,7 @@ MAX_PRIVILEGES = [
     CASE_DEDUPE,
     CUSTOM_DOMAIN_ALERTS,
     APP_DEPENDENCIES,
-    BULK_DATA_CLEANING,
+    BULK_DATA_EDITING,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -220,7 +220,7 @@ class Titles(object):
             CUSTOM_SMS_GATEWAY: _("Custom Android Gateway"),
             BULK_CASE_MANAGEMENT: _("Bulk Case Management"),
             BULK_USER_MANAGEMENT: _("Bulk User Management"),
-            BULK_DATA_CLEANING: _("Bulk Data Cleaning"),
+            BULK_DATA_EDITING: _("Bulk Data Editing"),
             ALLOW_EXCESS_USERS: _("Add Mobile Workers Above Limit"),
             DEIDENTIFIED_DATA: _("De-Identified Data"),
             HIPAA_COMPLIANCE_ASSURANCE: _("HIPAA Compliance Assurance"),

--- a/migrations.lock
+++ b/migrations.lock
@@ -122,6 +122,7 @@ accounting
  0100_alter_customerinvoicecommunicationhistory_communication_type_and_more
  0101_update_standard_plan_pricing_users_and_privs
  0102_alter_defaultproductplan_edition_and_more
+ 0103_bulk_data_cleaning_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Technical Summary
- this renames the `BULK_DATA_CLEANING` privilege to `BULK_DATA_EDITING`
- assigns `BULK_DATA_EDITING` privilege to Advanced plans and above (before it was enterprise only
- includes migration + update to old migration with reference to the `BULK_DATA_CLEANING` constant

## Feature Flag
technically the code that also checks this privilege is still guarded by the `DATA_CLEANING_CASES` feature flag. That will be removed as the final step to release.

## Safety Assurance

### Safety story
safe change. tested locally to ensure reverse is also working as expected.

### Automated test coverage
yes, tests that check access were updated and are passing

### QA Plan
not blocking this PR


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
leaving unchecked due to migrations
- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
