### PR TITLE
[Data Cleaning] Improve status modal when clicking on a previously opened session when an active session exists.

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/base_modal_body.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/base_modal_body.html
@@ -7,10 +7,12 @@
     </h5>
   </div>
   <div class="modal-body">
-    <div class="alert alert-success">
-      {% include "data_cleaning/status/partial/task_progress_bar.html" %}
-      {% block task-status-text %}{% endblock task-status-text %}
-    </div>
+    {% block task-status-progress %}
+      <div class="alert alert-success">
+        {% include "data_cleaning/status/partial/task_progress_bar.html" %}
+        {% block task-status-text %}{% endblock task-status-text %}
+      </div>
+    {% endblock task-status-progress %}
     {% block modal-body %}{% endblock modal-body %}
   </div>
   <div class="modal-footer">

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
@@ -18,25 +18,11 @@
 {% endblock task-status-text %}
 
 {% block modal-body %}
-  {% if active_session %}
-    <p class="lead">
-      {% blocktrans %}
-        Resume this session with the same columns and filters?
-      {% endblocktrans %}
-    </p>
-    <div class="alert alert-warning">
-      <strong>{% trans "Important" %}:</strong>
-      {% blocktrans %}
-        This will replace your existing active session with a new one. Any edits you made will be lost.
-      {% endblocktrans %}
-    </div>
-  {% else %}
-    <p class="lead">
-      {% blocktrans %}
-        Continue editing <strong class="fw-bold">{{ case_type }}</strong> cases with the same columns and filters?
-      {% endblocktrans %}
-    </p>
-  {% endif %}
+  <p class="lead">
+    {% blocktrans %}
+      Continue editing <strong class="fw-bold">{{ case_type }}</strong> cases with the same columns and filters?
+    {% endblocktrans %}
+  </p>
 {% endblock modal-body %}
 
 {% block continue-button %}
@@ -48,10 +34,6 @@
     hx-swap="none"
     hx-disabled-elt="this"
   >
-    {% if active_session %}
-      {% trans "Resume this session" %}
-    {% else %}
-      {% trans "Continue editing" %}
-    {% endif %}
+    {% trans "Continue editing" %}
   </button>
 {% endblock continue-button %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/previous_session.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/previous_session.html
@@ -1,0 +1,40 @@
+{% extends "data_cleaning/status/base_modal_body.html" %}
+{% load i18n %}
+{% load django_tables2 %}
+
+{% block modal-header %}
+  {% trans "This is a completed session" %}
+{% endblock modal-header %}
+
+{% block task-status-progress %}{% endblock task-status-progress %}
+
+{% block modal-body %}
+  <p class="lead">
+    {% blocktrans %}
+      Restart this session with the same columns and filters?
+    {% endblocktrans %}
+  </p>
+  <div class="alert alert-warning">
+    <strong>{% trans "Important" %}:</strong>
+    {% blocktrans %}
+      This will replace your existing active session with a new one.
+    {% endblocktrans %}
+    <br />
+    {% blocktrans %}
+      Any edits you made will be lost.
+    {% endblocktrans %}
+  </div>
+{% endblock modal-body %}
+
+{% block continue-button %}
+  <button
+    type="button"
+    class="btn btn-primary"
+    hx-post="{{ request.path_info }}{% querystring %}"
+    hq-hx-action="resume_session"
+    hx-swap="none"
+    hx-disabled-elt="this"
+  >
+    {% trans "Restart this session" %}
+  </button>
+{% endblock continue-button %}

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -78,7 +78,6 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update({
-            "active_session": self.get_active_session(),
             "num_records_changed": (
                 self.session.num_changed_records
                 if self.session.committed_on is not None


### PR DESCRIPTION
## Product Description

Here's what the modal looks like now:
<img width="528" alt="Screenshot 2025-05-26 at 2 29 52 PM" src="https://github.com/user-attachments/assets/9d693c3b-db04-43e3-a83c-1c50913e37bc" />


Here's what the modal looked like before:
<img width="594" alt="Screenshot 2025-05-26 at 2 19 13 PM" src="https://github.com/user-attachments/assets/b8678614-0b99-470f-a02c-21dea3b1246a" />


## Technical Summary
mostly template updates. I have some additional cleanup with `BulkEditSession`, but I'm going to introduce that in a separate PR.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe UI change to feature flagged workflow currently undergoing testing on staging

### Automated test coverage
most important bits are updated

### QA Plan
not blocking PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
