### PR TITLE
[Data Cleaning] quick fix: get_active_session was removed

### DIFF
--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -113,9 +113,8 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
 
     @hq_hx_action('post')
     def resume_session(self, request, *args, **kwargs):
-        active_session = self.get_active_session()
-        if active_session:
-            active_session.delete()
+        if self.active_session is not None:
+            self.active_session.delete()
         new_session = self.session.get_resumed_session()
 
         from corehq.apps.data_cleaning.views.main import BulkEditCasesSessionView


### PR DESCRIPTION
## Technical Summary
Realized I missed a spot after merging: https://github.com/dimagi/commcare-hq/pull/36496
- replace `get_active_session` with memoized `self.active_session`

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe change only affecting feature flagged workflow

### Automated test coverage
most important functionality of this feature is tested
ensuring this works will be part of the next round of test writing

### QA Plan
not blocking PR


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
