### PR TITLE
[Data Cleaning] template cleanup: use assigned count

### DIFF
--- a/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/status/complete.html
@@ -12,7 +12,7 @@
   {% blocktrans count count=num_records_changed %}
     Finished processing changes, updated 1 case.
   {% plural %}
-    Finished processing changes, updated {{ num_records_changed }} cases.
+    Finished processing changes, updated {{ count }} cases.
   {% endblocktrans %}
   {# prettier-ignore-end #}
 {% endblock task-status-text %}

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/apply_changes.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/apply_changes.html
@@ -6,7 +6,7 @@
     {% blocktrans count count=num_changes %}
       One edit will be applied.
     {% plural %}
-      A total of {{ num_changes }} edits will be applied.
+      A total of {{ count }} edits will be applied.
     {% endblocktrans %}
     {# prettier-ignore-end #}
   </p>

--- a/corehq/apps/data_cleaning/templates/data_cleaning/summary/clear_changes.html
+++ b/corehq/apps/data_cleaning/templates/data_cleaning/summary/clear_changes.html
@@ -6,7 +6,7 @@
     {% blocktrans count count=num_changes %}
       One edit will be cleared.
     {% plural %}
-      A total of {{ num_changes }} edits will be cleared.
+      A total of {{ count }} edits will be cleared.
     {% endblocktrans %}
     {# prettier-ignore-end #}
   </p>


### PR DESCRIPTION
## Technical Summary
I'm not sure why I thought I couldn't reference `count` in `blocktrans`. I tested this out locally, and turns out I can!

Just a tiny quick cleanup to update this.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
safe template text change in a feature flagged area

### Automated test coverage
n/a

### QA Plan
not blocking PR

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
