### PR TITLE
Ensure cursor parameter is not url encoded

### DIFF
--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -1,4 +1,5 @@
 from base64 import b64decode, b64encode
+from urllib.parse import unquote
 
 from django.http import QueryDict
 
@@ -95,7 +96,8 @@ COMPOUND_FILTERS = {
 
 def get_list(domain, couch_user, params):
     if 'cursor' in params:
-        params_string = b64decode(params['cursor']).decode('utf-8')
+        url_decoded_cursor = unquote(params['cursor'])
+        params_string = b64decode(url_decoded_cursor).decode('utf-8')
         params = QueryDict(params_string, mutable=True)
         # QueryDict.pop() returns a list
         last_date = params.pop(INDEXED_AFTER, [None])[0]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-17644

When preparing the [next parameter](https://github.com/dimagi/commcare-hq/blob/22eeec5dd32896dc619de6e3c8eac899ebee80ee/corehq/apps/hqcase/views.py#L168) in the response for the case API, the `params` option is [urlencoded](https://github.com/dimagi/commcare-hq/blob/92ce981f6e175c5bc1ef390cb791e2b3a13702bc/corehq/util/view_utils.py#L127-L128) in our definition of [reverse](https://github.com/dimagi/commcare-hq/blob/92ce981f6e175c5bc1ef390cb791e2b3a13702bc/corehq/util/view_utils.py#L119-L129). This results in the `cursor` parameter being url encoded, which can cause issues when attempting to decode the `cursor` parameter on the next request.

It seemed easiest to just ensure that we url decode the cursor option before b64 decoding it. This worked when testing in a shell as well.

I'm also wondering if we need to url decode the cursor option after b64 decoding it, since it looks like [we urlencode it prior to b64 encoding it](https://github.com/dimagi/commcare-hq/blob/92ce981f6e175c5bc1ef390cb791e2b3a13702bc/corehq/apps/hqcase/api/get_list.py#L126-L127)? Though reading the docstring for `unquote`, it does mention that
>     By default, percent-encoded sequences are decoded with UTF-8, and invalid sequences are replaced by a placeholder character.

And we do [utf-8 decode](https://github.com/dimagi/commcare-hq/blob/92ce981f6e175c5bc1ef390cb791e2b3a13702bc/corehq/apps/hqcase/api/get_list.py#L100-L100) the cursor string after b64 decoding it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
My understanding is that unquote only searches for %xx characters and replaces those. Given we urlencode the the b64 encoded string, this should make it safe to attempt to unquote this string first.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
