### PR TITLE
Disable enabling feature flags while copying app and makes it view only.

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -51,12 +51,9 @@ class CopyApplicationForm(forms.Form):
         widget=forms.Select(choices=[], attrs={"class": "app-manager-version-dropdown",
                                                "placeholder": _("Current")}))
 
-    # Toggles to enable when copying the app
-    toggles = forms.CharField(required=False, widget=forms.HiddenInput, max_length=5000)
-
     def __init__(self, from_domain, app, *args, **kwargs):
         super(CopyApplicationForm, self).__init__(*args, **kwargs)
-        fields = ['domain', 'name', 'toggles', 'build_id']
+        fields = ['domain', 'name', 'build_id']
         self.from_domain = from_domain
         if app:
             self.fields['name'].initial = app.name

--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -84,7 +84,10 @@ $(function () {
                 success: function (toggles) {
                     if (toggles.length) {
                         var template = _.template($modal.find("script").html()),
-                            $ul = $modal.find("ul").html("");
+                            $ul = $modal.find("ul").html(""),
+                            flagsUrl = initialPageData.reverse("feature_flags_and_privileges", domain);
+
+                        $modal.find("#feature-flags-link").attr("href", flagsUrl);
 
                         _.each(toggles, function (toggle) {
                             $ul.append(template(toggle));

--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -84,22 +84,13 @@ $(function () {
                 success: function (toggles) {
                     if (toggles.length) {
                         var template = _.template($modal.find("script").html()),
-                            $ul = $modal.find("ul").html(""),
-                            allSelected = false;
-                        $modal.find(".select-all").click(function (e) {
-                            allSelected = !allSelected;
-                            $(e.currentTarget).text(allSelected ? gettext("Select None") : gettext("Select All"));
-                            $ul.find("input:checkbox").prop('checked', allSelected);
-                        });
+                            $ul = $modal.find("ul").html("");
+
                         _.each(toggles, function (toggle) {
                             $ul.append(template(toggle));
                         });
                         $modal.modal().one("click", ".btn-primary", function () {
                             $(this).disableButton();
-                            var slugs = _.map($modal.find(":checked"), function (c) {
-                                return $(c).data("slug");
-                            });
-                            $form.find("input[name='toggles']").val(slugs.join(","));
                             $form.submit();
                         }).one("hide.bs.modal", function () {
                             $submit.enableButton();

--- a/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
@@ -17,9 +17,6 @@
           {% endblocktrans %}
         </p>
         <div>
-          <button class="btn btn-default btn-xs select-all">
-            {% trans "Select All" %}
-          </button>
         </div>
         <ul class="list-unstyled"></ul>
       </div>
@@ -32,7 +29,6 @@
   <script type="text/html">
     <li class="checkbox">
       <label>
-        <input type="checkbox" data-slug="<%- slug %>" />
         <span class='label label-<%- tag_css_class %>'><%- tag_name %></span>
         <%- label %>
       </label>

--- a/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
-{% registerurl "feature_flags_and_privileges" "---"%}
+{% registerurl "feature_flags_and_privileges" "---" %}
 
 <div class="modal fade" id="copy-toggles">
   <div class="modal-dialog">
@@ -14,25 +14,27 @@
       <div class="modal-body form-horizontal">
         <p>
           {% blocktrans %}
-            The following features are not turned on in the domain to which you're copying.
-            Please enable the necessary feature flags required for the app to function
-            from <a id="feature-flags-link" href="" target="_blank">here</a>.
+            The following features are not turned on in the domain to which
+            you're copying. Please enable the necessary feature flags required
+            for the app to function from
+            <a id="feature-flags-link" href="" target="_blank">here</a>.
           {% endblocktrans %}
         </p>
-        <div>
-        </div>
+        <div></div>
         <ul class="list-unstyled"></ul>
       </div>
       <div class="modal-footer">
-        <button class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
+        <button class="btn btn-default" data-dismiss="modal">
+          {% trans "Cancel" %}
+        </button>
         <button class="btn btn-primary">{% trans "Copy" %}</button>
       </div>
     </div>
   </div>
   <script type="text/html">
     <li class="mb-3">
-        <span class='label label-<%- tag_css_class %>'><%- tag_name %></span>
-        <%- label %>
+      <span class="label label-<%- tag_css_class %>"><%- tag_name %></span>
+      <%- label %>
     </li>
   </script>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
@@ -1,4 +1,6 @@
 {% load i18n %}
+{% load hq_shared_tags %}
+{% registerurl "feature_flags_and_privileges" "---"%}
 
 <div class="modal fade" id="copy-toggles">
   <div class="modal-dialog">
@@ -13,7 +15,8 @@
         <p>
           {% blocktrans %}
             The following features are not turned on in the domain to which you're copying.
-            Select any that you wish to copy along with this application.
+            Please enable the necessary feature flags required for the app to function
+            from <a id="feature-flags-link" href="" target="_blank">here</a>.
           {% endblocktrans %}
         </p>
         <div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
@@ -30,11 +30,9 @@
     </div>
   </div>
   <script type="text/html">
-    <li class="checkbox">
-      <label>
+    <li class="mb-3">
         <span class='label label-<%- tag_css_class %>'><%- tag_name %></span>
         <%- label %>
-      </label>
     </li>
   </script>
 </div>

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -3,7 +3,6 @@ import doctest
 import json
 import re
 from contextlib import contextmanager
-from unittest import mock
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -559,11 +559,9 @@ class TestViews(ViewsBase):
             'name': 'Copy App',
             'toggles': 'test_toggle',
         }
-        with patch('corehq.toggles.all_toggles_by_name', return_value={'test_toggle': TEST_TOGGLE}), \
-             mock.patch('corehq.apps.toggle_ui.views.clear_toggle_cache_by_namespace') as mock_clear_cache:
+        with patch('corehq.toggles.all_toggles_by_name', return_value={'test_toggle': TEST_TOGGLE}):
             self.client.post(reverse('copy_app', args=[self.domain]), copy_data)
-            mock_clear_cache.assert_called_once_with(NAMESPACE_DOMAIN, other_domain.name)
-        self.assertTrue(TEST_TOGGLE.enabled(other_domain.name))
+        self.assertFalse(TEST_TOGGLE.enabled(other_domain.name))
 
 
 @contextmanager

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -104,7 +104,6 @@ from corehq.apps.users.dbaccessors import (
 )
 from corehq.elastic import ESError
 from corehq.tabs.tabclasses import ApplicationsTab
-from corehq.toggles.shortcuts import set_toggles
 from corehq.util.dates import iso_string_to_datetime
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import reverse as reverse_util
@@ -450,10 +449,6 @@ def copy_app(request, domain):
 
     def _inner(request, to_domain, data, from_domain=domain):
         clear_app_cache(request, to_domain)
-
-        if data['toggles']:
-            toggle_slugs = data['toggles'].split(",")
-            set_toggles(toggle_slugs, to_domain, True, namespace=toggles.NAMESPACE_DOMAIN)
 
         linked = data.get('linked')
         if linked:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
A small change that disables enabling feature flags during copying app from the modal. The modal just shows the list of feature flags with a link to project's feature flags settings page. The intention here is to create a barrier for the end user to enable feature flags to avoid enabling unnecessary flags.  For more context, please refer the comments in [this PR](https://github.com/dimagi/commcare-hq/pull/36266).

Before :

![image](https://github.com/user-attachments/assets/3fb740be-4e5e-464b-b587-15e372f4f22c)

After:

![image](https://github.com/user-attachments/assets/76f86b0b-25cf-4ce3-8d80-7ae9c844af34)

The link for enabling the features flags opens a page in a new tab.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-4447)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local. Small change and only impacts the copy app operation.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Updated to reflect changed behaviour.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
