### PR TITLE
[Data Cleaning] Refactor `BulkEditSession` classmethods to be handled by object manager 

### DIFF
--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -74,6 +74,9 @@ class BulkEditSessionManager(models.Manager):
         new_session = self.new_case_session(user, domain_name, case_type)
         return new_session
 
+    def all_sessions(self, user, domain_name):
+        return self.filter(user=user, domain=domain_name).order_by('-created_on')
+
 
 class BulkEditSession(models.Model):
     user = models.ForeignKey(User, related_name="bulk_edit_sessions", on_delete=models.CASCADE)
@@ -95,10 +98,6 @@ class BulkEditSession(models.Model):
 
     class Meta:
         ordering = ["-created_on"]
-
-    @classmethod
-    def get_all_sessions(cls, user, domain_name):
-        return cls.objects.filter(user=user, domain=domain_name).order_by('-created_on')
 
     def get_resumed_session(self):
         new_session = BulkEditSession.objects.new_case_session(

--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -105,7 +105,7 @@ class BulkEditSession(models.Model):
         return cls.objects.filter(user=user, domain=domain_name).order_by('-created_on')
 
     def get_resumed_session(self):
-        new_session = self.objects.new_case_session(
+        new_session = BulkEditSession.objects.new_case_session(
             self.user,
             self.domain,
             self.identifier,

--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -17,6 +17,40 @@ MAX_SESSION_CHANGES = 200
 APPLY_CHANGES_WAIT_TIME = 3  # seconds
 
 
+class BulkEditSessionManager(models.Manager):
+    def _get_active_session(self, user, domain_name, identifier, session_type):
+        try:
+            return self.get(
+                user=user,
+                domain=domain_name,
+                identifier=identifier,
+                session_type=session_type,
+                committed_on=None,
+                completed_on=None,
+            )
+        except self.model.DoesNotExist:
+            return None
+
+    def active_case_session(self, user, domain_name, case_type):
+        return self._get_active_session(user, domain_name, case_type, BulkEditSessionType.CASE)
+
+    def active_form_session(self, user, domain_name, xmlns):
+        return self._get_active_session(user, domain_name, xmlns, BulkEditSessionType.FORM)
+
+    def _get_recent_session(self, user, domain_name, session_type):
+        return self.filter(
+            user=user,
+            domain=domain_name,
+            session_type=session_type,
+        ).order_by('-created_on').first()
+
+    def recent_case_session(self, user, domain_name):
+        return self._get_recent_session(user, domain_name, BulkEditSessionType.CASE)
+
+    def recent_form_session(self, user, domain_name):
+        return self._get_recent_session(user, domain_name, BulkEditSessionType.FORM)
+
+
 class BulkEditSession(models.Model):
     user = models.ForeignKey(User, related_name="bulk_edit_sessions", on_delete=models.CASCADE)
     domain = models.CharField(max_length=255, db_index=True)
@@ -33,30 +67,10 @@ class BulkEditSession(models.Model):
     result = models.JSONField(null=True, blank=True)
     completed_on = models.DateTimeField(null=True, blank=True)
 
+    objects = BulkEditSessionManager()
+
     class Meta:
         ordering = ["-created_on"]
-
-    @classmethod
-    def get_active_case_session(cls, user, domain_name, case_type):
-        return cls._get_active_session(user, domain_name, case_type, BulkEditSessionType.CASE)
-
-    @classmethod
-    def get_active_form_session(cls, user, domain_name, xmlns):
-        return cls._get_active_session(user, domain_name, xmlns, BulkEditSessionType.FORM)
-
-    @classmethod
-    def _get_active_session(cls, user, domain_name, identifier, session_type):
-        try:
-            return cls.objects.get(
-                user=user,
-                domain=domain_name,
-                identifier=identifier,
-                session_type=session_type,
-                committed_on=None,
-                completed_on=None,
-            )
-        except cls.DoesNotExist:
-            return None
 
     @classmethod
     def new_case_session(cls, user, domain_name, case_type, is_default=True):
@@ -75,7 +89,7 @@ class BulkEditSession(models.Model):
     @retry_on_integrity_error(max_retries=3, delay=0.1)
     def restart_case_session(cls, user, domain_name, case_type):
         with transaction.atomic():
-            previous_session = cls.get_active_case_session(user, domain_name, case_type)
+            previous_session = cls.objects.active_case_session(user, domain_name, case_type)
             if previous_session:
                 previous_session.delete()
             new_session = cls.new_case_session(user, domain_name, case_type)

--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -97,10 +97,6 @@ class BulkEditSession(models.Model):
         ordering = ["-created_on"]
 
     @classmethod
-    def get_committed_sessions(cls, user, domain_name):
-        return cls.objects.filter(user=user, domain=domain_name, committed_on__isnull=False)
-
-    @classmethod
     def get_all_sessions(cls, user, domain_name):
         return cls.objects.filter(user=user, domain=domain_name).order_by('-created_on')
 

--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -62,6 +62,9 @@ class BulkEditSessionManager(models.Manager):
             case_session.columns.create_session_defaults(case_session)
         return case_session
 
+    def new_form_session(self, user, domain_name, xmlns):
+        raise NotImplementedError("Form bulk edit sessions are not yet supported!")
+
 
 class BulkEditSession(models.Model):
     user = models.ForeignKey(User, related_name="bulk_edit_sessions", on_delete=models.CASCADE)
@@ -93,10 +96,6 @@ class BulkEditSession(models.Model):
                 previous_session.delete()
             new_session = cls.objects.new_case_session(user, domain_name, case_type)
         return new_session
-
-    @classmethod
-    def new_form_session(cls, user, domain_name, xmlns):
-        raise NotImplementedError("Form bulk edit sessions are not yet supported!")
 
     @classmethod
     def get_committed_sessions(cls, user, domain_name):

--- a/corehq/apps/data_cleaning/tests/test_changes.py
+++ b/corehq/apps/data_cleaning/tests/test_changes.py
@@ -282,7 +282,7 @@ class BulkEditRecordChangesTest(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.session = BulkEditSession.new_case_session(
+        self.session = BulkEditSession.objects.new_case_session(
             self.user, self.domain_name, self.case_type
         )
         factory = CaseFactory(domain=self.domain_name)

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -126,7 +126,7 @@ class BulkEditFilterQueryTests(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.session = BulkEditSession.new_case_session(
+        self.session = BulkEditSession.objects.new_case_session(
             self.web_user.get_django_user(), self.domain, 'plants',
         )
 
@@ -613,7 +613,7 @@ class TestReportFilterSubclasses(TestCase):
         self.request.can_access_all_locations = True
         self.request.couch_user = self.web_user
         self.request.project = self.domain_obj
-        self.session = BulkEditSession.new_case_session(
+        self.session = BulkEditSession.objects.new_case_session(
             self.web_user.get_django_user(), self.domain, 'plants',
         )
 
@@ -789,10 +789,10 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
 
     def setUp(self):
         super().setUp()
-        self.session = BulkEditSession.new_case_session(
+        self.session = BulkEditSession.objects.new_case_session(
             self.session_user.get_django_user(), self.domain, 'plants',
         )
-        self.session_location_restricted = BulkEditSession.new_case_session(
+        self.session_location_restricted = BulkEditSession.objects.new_case_session(
             self.web_location_user.get_django_user(), self.domain, 'plants',
         )
 
@@ -1033,7 +1033,7 @@ class TestCaseStatusPinnedFilterQuery(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.session = BulkEditSession.new_case_session(
+        self.session = BulkEditSession.objects.new_case_session(
             self.web_user.get_django_user(), self.domain, 'plants',
         )
 

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -106,7 +106,11 @@ class BulkEditSessionTest(TestCase):
     def test_restart_case_session(self):
         old_session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         old_session_id = old_session.session_id
-        new_session = BulkEditSession.restart_case_session(self.django_user, self.domain_name, self.case_type)
+        new_session = BulkEditSession.objects.restart_case_session(
+            self.django_user,
+            self.domain_name,
+            self.case_type,
+        )
         self.assertNotEqual(old_session_id, new_session.session_id)
 
 

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -59,7 +59,7 @@ class BulkEditSessionTest(TestCase):
         self.assertIsNone(active_session)
 
     def test_new_case_session(self):
-        new_session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        new_session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         self.assertEqual(new_session.session_type, BulkEditSessionType.CASE)
         self.assertEqual(new_session.columns.count(), 6)
         self.assertEqual(new_session.filters.count(), 0)
@@ -68,7 +68,7 @@ class BulkEditSessionTest(TestCase):
         self.assertEqual(new_session.changes.count(), 0)
 
     def test_has_active_case_session(self):
-        BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         active_session = BulkEditSession.objects.active_case_session(
             self.django_user, self.domain_name, self.case_type
         )
@@ -78,14 +78,14 @@ class BulkEditSessionTest(TestCase):
         self.assertEqual(active_session.identifier, self.case_type)
 
     def test_has_no_active_case_session_other_type(self):
-        BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         active_session = BulkEditSession.objects.active_case_session(
             self.django_user, self.domain_name, 'other'
         )
         self.assertIsNone(active_session)
 
     def test_has_no_active_case_session_after_committed(self):
-        case_session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        case_session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         case_session.committed_on = datetime.datetime.now()
         case_session.save()
         active_session = BulkEditSession.objects.active_case_session(
@@ -94,7 +94,7 @@ class BulkEditSessionTest(TestCase):
         self.assertIsNone(active_session)
 
     def test_has_no_active_case_session_after_completed(self):
-        case_session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        case_session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         case_session.committed_on = datetime.datetime.now()
         case_session.completed_on = datetime.datetime.now()
         case_session.save()
@@ -104,7 +104,7 @@ class BulkEditSessionTest(TestCase):
         self.assertIsNone(active_session)
 
     def test_restart_case_session(self):
-        old_session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        old_session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         old_session_id = old_session.session_id
         new_session = BulkEditSession.restart_case_session(self.django_user, self.domain_name, self.case_type)
         self.assertNotEqual(old_session_id, new_session.session_id)
@@ -136,7 +136,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         super().tearDownClass()
 
     def test_add_filters(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)
         session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, "lowkey")
         session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, "2")
@@ -148,7 +148,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             self.assertEqual(filters[index].index, index)
 
     def test_remove_filters(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)
         session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, "lowkey")
         session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, "2")
@@ -164,7 +164,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             self.assertEqual(filters[index].index, index)
 
     def test_remove_column(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         column_to_remove = session.columns.all()[1]  # owner_name
         self.assertEqual(column_to_remove.prop_id, 'owner_name')
         session.remove_column(column_to_remove.column_id)
@@ -176,7 +176,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             self.assertEqual(columns[index].index, index)
 
     def test_reorder_wrong_number_of_filter_ids_raises_error(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)
         session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, "lowkey")
         session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, "2")
@@ -189,7 +189,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             session.update_filter_order(new_order)
 
     def test_reorder_filters(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)
         session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, "lowkey")
         session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, "2")
@@ -212,7 +212,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         )
 
     def test_reorder_wrong_number_of_column_ids_raises_error(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         columns = session.columns.all()
         # the form that uses this method will always fetch a list of strings, and the field is a UUID
         new_order = [str(col_id) for col_id in [columns[1].column_id, columns[2].column_id]]
@@ -220,7 +220,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             session.update_column_order(new_order)
 
     def test_update_column_order(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         columns = session.columns.all()
         # the form that uses this method will always fetch a list of strings, and the field is a UUID
         new_order = [str(col_id) for col_id in [
@@ -239,7 +239,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         )
 
     def test_get_queryset_multiple_filters(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)
         session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, 'lowkey')
         session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, '2')
@@ -260,7 +260,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         self.assertEqual(query.es_query, expected_query.es_query)
 
     def test_get_queryset_filters_no_xpath(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)
         query = session.get_queryset()
         expected_query = (
@@ -272,7 +272,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         self.assertEqual(query.es_query, expected_query.es_query)
 
     def test_get_queryset_filters_xpath_only(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, '2')
         query = session.get_queryset()
         expected_query = (
@@ -287,7 +287,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         self.assertEqual(query.es_query, expected_query.es_query)
 
     def test_has_filters_and_reset(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         self.assertFalse(session.has_filters)
         session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, '2')
         self.assertTrue(session.has_filters)
@@ -295,7 +295,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         self.assertFalse(session.has_filters)
 
     def test_has_pinned_values_and_reset(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         self.assertFalse(session.has_pinned_values)
         pinned_filter = session.pinned_filters.all()[0]
         pinned_filter.value = ['t__1']
@@ -305,7 +305,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         self.assertFalse(session.has_pinned_values)
 
     def test_has_any_filtering_and_reset(self):
-        session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
+        session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         self.assertFalse(session.has_any_filtering)
         pinned_filter = session.pinned_filters.all()[0]
         pinned_filter.value = ['t__1']
@@ -343,7 +343,7 @@ class BaseBulkEditSessionTest(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.session = BulkEditSession.new_case_session(
+        self.session = BulkEditSession.objects.new_case_session(
             self.django_user, self.domain_name, self.case_type
         )
 

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -47,13 +47,13 @@ class BulkEditSessionTest(TestCase):
         cls.form_xmlns = 'http://openrosa.org/formdesigner/2423EFB5-2E8C-4B8F-9DA0-23FFFD4391AF'
 
     def test_has_no_active_case_session(self):
-        active_session = BulkEditSession.get_active_case_session(
+        active_session = BulkEditSession.objects.active_case_session(
             self.django_user, self.domain_name, self.case_type
         )
         self.assertIsNone(active_session)
 
     def test_has_no_active_form_session(self):
-        active_session = BulkEditSession.get_active_form_session(
+        active_session = BulkEditSession.objects.active_form_session(
             self.django_user, self.domain_name, self.form_xmlns
         )
         self.assertIsNone(active_session)
@@ -69,7 +69,7 @@ class BulkEditSessionTest(TestCase):
 
     def test_has_active_case_session(self):
         BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
-        active_session = BulkEditSession.get_active_case_session(
+        active_session = BulkEditSession.objects.active_case_session(
             self.django_user, self.domain_name, self.case_type
         )
         self.assertIsNotNone(active_session)
@@ -79,7 +79,7 @@ class BulkEditSessionTest(TestCase):
 
     def test_has_no_active_case_session_other_type(self):
         BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
-        active_session = BulkEditSession.get_active_case_session(
+        active_session = BulkEditSession.objects.active_case_session(
             self.django_user, self.domain_name, 'other'
         )
         self.assertIsNone(active_session)
@@ -88,7 +88,7 @@ class BulkEditSessionTest(TestCase):
         case_session = BulkEditSession.new_case_session(self.django_user, self.domain_name, self.case_type)
         case_session.committed_on = datetime.datetime.now()
         case_session.save()
-        active_session = BulkEditSession.get_active_case_session(
+        active_session = BulkEditSession.objects.active_case_session(
             self.django_user, self.domain_name, self.case_type
         )
         self.assertIsNone(active_session)
@@ -98,7 +98,7 @@ class BulkEditSessionTest(TestCase):
         case_session.committed_on = datetime.datetime.now()
         case_session.completed_on = datetime.datetime.now()
         case_session.save()
-        active_session = BulkEditSession.get_active_case_session(
+        active_session = BulkEditSession.objects.active_case_session(
             self.django_user, self.domain_name, self.case_type
         )
         self.assertIsNone(active_session)

--- a/corehq/apps/data_cleaning/tests/test_views.py
+++ b/corehq/apps/data_cleaning/tests/test_views.py
@@ -94,7 +94,7 @@ class CleanCasesViewAccessTest(TestCase):
             role_with_permission,
         )
         cls.client = Client()
-        session = BulkEditSession.new_case_session(
+        session = BulkEditSession.objects.new_case_session(
             cls.user_in_domain.get_django_user(), cls.domain_name, 'plants',
         )
         cls.real_session_id = session.session_id

--- a/corehq/apps/data_cleaning/views/start.py
+++ b/corehq/apps/data_cleaning/views/start.py
@@ -69,7 +69,7 @@ class StartCaseSessionView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMix
                 'resume': lambda: BulkEditSession.objects.active_case_session(
                     request.user, self.domain, case_type
                 ),
-                'new': lambda: BulkEditSession.restart_case_session(
+                'new': lambda: BulkEditSession.objects.restart_case_session(
                     request.user, self.domain, case_type
                 ),
             }[next_step]

--- a/corehq/apps/data_cleaning/views/start.py
+++ b/corehq/apps/data_cleaning/views/start.py
@@ -39,7 +39,7 @@ class StartCaseSessionView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMix
         next_action = 'validate_session'
         if form.is_valid():
             case_type = form.cleaned_data['case_type']
-            active_session = BulkEditSession.get_active_case_session(
+            active_session = BulkEditSession.objects.active_case_session(
                 request.user, self.domain, case_type
             )
             if not active_session:
@@ -66,7 +66,7 @@ class StartCaseSessionView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMix
             case_type = form.cleaned_data['case_type']
             next_step = form.cleaned_data['next_step']
             get_session = {
-                'resume': lambda: BulkEditSession.get_active_case_session(
+                'resume': lambda: BulkEditSession.objects.active_case_session(
                     request.user, self.domain, case_type
                 ),
                 'new': lambda: BulkEditSession.restart_case_session(

--- a/corehq/apps/data_cleaning/views/start.py
+++ b/corehq/apps/data_cleaning/views/start.py
@@ -43,7 +43,7 @@ class StartCaseSessionView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMix
                 request.user, self.domain, case_type
             )
             if not active_session:
-                new_session = BulkEditSession.new_case_session(
+                new_session = BulkEditSession.objects.new_case_session(
                     request.user, self.domain, case_type
                 )
                 return self.render_session_redirect(new_session)

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -69,7 +69,7 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
     def active_session(self):
         if self.session.completed_on is None:
             return None
-        return BulkEditSession.get_active_case_session(
+        return BulkEditSession.objects.active_case_session(
             self.request.user, self.domain, self.session.identifier
         )
 

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -231,7 +231,7 @@ class RecentCaseSessionsTableView(BaseDataCleaningTableView):
     def get_queryset(self):
         return [
             self._get_record(session) if session.committed_on else self._get_active_record(session)
-            for session in BulkEditSession.get_all_sessions(self.request.user, self.domain)
+            for session in BulkEditSession.objects.all_sessions(self.request.user, self.domain)
         ]
 
     def _get_session_url(self, session):


### PR DESCRIPTION
## Technical Summary
This moves several methods that were previously `classmethods` on `BulkEditSession` to the newly created `BulkEditSessionManager`, where it feels like a more appropriate home.

## Feature Flag
`DATA_CLEANING_CASES`

## Safety Assurance

### Safety story
tested locally and staging, part of a feature flagged workflow

### Automated test coverage
yes, tests cover majority of moved methods

### QA Plan
not blocking

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
