### PR TITLE
[Data Cleaning] Add HX-Trigger response helper to HqHtmxActionMixin

### DIFF
--- a/corehq/apps/data_cleaning/views/columns.py
+++ b/corehq/apps/data_cleaning/views/columns.py
@@ -1,4 +1,3 @@
-import json
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
 from django.views.generic import TemplateView
@@ -32,12 +31,14 @@ class ManageColumnsFormView(BulkEditSessionViewMixin,
         return context
 
     def _trigger_clean_form_refresh(self, response):
-        response['HX-Trigger'] = json.dumps({
-            'dcEditFormRefresh': {
-                'target': '#hq-hx-edit-selected-records-form',
+        return self.add_hx_trigger_to_response(
+            response,
+            {
+                "dcEditFormRefresh": {
+                    "target": "#hq-hx-edit-selected-records-form",
+                },
             },
-        })
-        return response
+        )
 
     @hq_hx_action('post')
     def add_column(self, request, *args, **kwargs):

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -1,5 +1,3 @@
-import json
-
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
@@ -99,11 +97,14 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
     def get(self, request, *args, **kwargs):
         response = super().get(request, *args, **kwargs)
         if self.session.is_read_only:
-            response['HX-Trigger'] = json.dumps({
-                'showDataCleaningModal': {
-                    'target': '#session-status-modal',
+            return self.add_hx_trigger_to_response(
+                response,
+                {
+                    "showDataCleaningModal": {
+                        "target": "#session-status-modal",
+                    },
                 },
-            })
+            )
         return response
 
     @hq_hx_action('get')

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -1,5 +1,3 @@
-import json
-
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -66,15 +64,17 @@ class EditCasesTableView(BulkEditSessionViewMixin,
     def clear_filters(self, request, *args, **kwargs):
         self.session.reset_filtering()
         response = self.get(request, *args, **kwargs)
-        response['HX-Trigger'] = json.dumps({
-            'dcPinnedFilterRefresh': {
-                'target': '#hq-hx-pinned-filters',
+        return self.add_hx_trigger_to_response(
+            response,
+            {
+                "dcPinnedFilterRefresh": {
+                    "target": "#hq-hx-pinned-filters",
+                },
+                "dcFilterRefresh": {
+                    "target": "#hq-hx-active-filters",
+                },
             },
-            'dcFilterRefresh': {
-                'target': '#hq-hx-active-filters',
-            },
-        })
-        return response
+        )
 
     @hq_hx_action('post')
     def select_record(self, request, *args, **kwargs):
@@ -121,12 +121,14 @@ class EditCasesTableView(BulkEditSessionViewMixin,
         ):
             self.session.select_all_records_in_queryset()
             return response
-        response['HX-Trigger'] = json.dumps({
-            'showDataCleaningModal': {
-                'target': '#select-all-not-possible-modal',
+        return self.add_hx_trigger_to_response(
+            response,
+            {
+                "showDataCleaningModal": {
+                    "target": "#select-all-not-possible-modal",
+                },
             },
-        })
-        return response
+        )
 
     @hq_hx_action("post")
     def apply_all_changes(self, request, *args, **kwargs):
@@ -136,12 +138,14 @@ class EditCasesTableView(BulkEditSessionViewMixin,
             self.session.save()
             commit_data_cleaning.delay(self.session.session_id)
         response = self.render_htmx_no_response(request, *args, **kwargs)
-        response['HX-Trigger'] = json.dumps({
-            'dcRefreshStatusModal': {
-                'target': '#session-status-modal-body',
+        return self.add_hx_trigger_to_response(
+            response,
+            {
+                "dcRefreshStatusModal": {
+                    "target": "#session-status-modal-body",
+                },
             },
-        })
-        return response
+        )
 
     @hq_hx_action("post")
     def undo_last_change(self, request, *args, **kwargs):
@@ -158,12 +162,14 @@ class EditCasesTableView(BulkEditSessionViewMixin,
         )
 
     def _trigger_clean_form_refresh(self, response):
-        response['HX-Trigger'] = json.dumps({
-            'dcEditFormRefresh': {
-                'target': '#hq-hx-edit-selected-records-form',
+        return self.add_hx_trigger_to_response(
+            response,
+            {
+                "dcEditFormRefresh": {
+                    "target": "#hq-hx-edit-selected-records-form",
+                },
             },
-        })
-        return response
+        )
 
     def _render_table_cell_response(self, doc_id, column, request, *args, **kwargs):
         """
@@ -184,12 +190,14 @@ class EditCasesTableView(BulkEditSessionViewMixin,
         response = self.render_htmx_partial_response(
             request, EditableHtmxColumn.template_name, context
         )
-        response['HX-Trigger'] = json.dumps({
-            "updateChanges": {
-                "hasChanges": self.session.has_changes(),
+        return self.add_hx_trigger_to_response(
+            response,
+            {
+                "updateChanges": {
+                    "hasChanges": self.session.has_changes(),
+                },
             },
-        })
-        return response
+        )
 
     def _get_cell_request_details(self, request):
         """

--- a/corehq/util/htmx_action.py
+++ b/corehq/util/htmx_action.py
@@ -1,3 +1,5 @@
+import json
+
 from django.http import HttpResponseForbidden, HttpResponse
 
 ANY_METHOD = 'any_method'
@@ -74,6 +76,10 @@ class HqHtmxActionMixin:
         :return: string (path to template)
         """
         return self.default_htmx_error_template
+
+    def add_hx_trigger_to_response(self, response, trigger_data):
+        response['HX-Trigger'] = json.dumps(trigger_data)
+        return response
 
     def render_htmx_redirect(self, url, response_message=None):
         response = HttpResponse(response_message or "")


### PR DESCRIPTION
## Technical Summary
A quick refactor before I introduce some GTM code that builds on this:
Swap out all usages of `HX-Trigger` headers in the response with this helper method: `add_hx_trigger_to_response`

## Safety Assurance

### Safety story
safe change, tested locally 

### Automated test coverage
n/a

### QA Plan
not blocking

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
