### PR TITLE
Container file builds use sh, not bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY pyproject.toml uv.lock package.json /vendor/
 RUN --mount=type=cache,target=/root/.cache/uv \
   uv venv --allow-existing /vendor \
   && UV_PROJECT=/vendor uv sync --locked --group=test --no-dev --no-install-project \
-  && rm /vendor/{pyproject.toml,uv.lock}
+  && rm /vendor/pyproject.toml /vendor/uv.lock
 
 # this keeps the image size down, make sure to set in mocha-headless-chrome options
 #   executablePath: 'google-chrome-stable'


### PR DESCRIPTION
The previous syntax caused the Docker Hub build to fail.

## Safety Assurance

### Safety story

Affects tests only.

### Automated test coverage

Indirect.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations