### PR TITLE
[HTMX tables] fix paginator styling so that active page is rendered properly

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5_htmx.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5_htmx.html
@@ -54,7 +54,7 @@
 
 {% block pagination.range %}
   {% for p in table.page|table_page_range:table.paginator %}
-    <li class="page-item{% if table.page.number == p %}active{% endif %}">
+    <li class="page-item{% if table.page.number == p %} active{% endif %}">
       <a
         class="page-link"
         {% if p != '...' %}


### PR DESCRIPTION
## Product Description
looks like this finally:
![Screenshot 2025-05-28 at 5 36 08 PM](https://github.com/user-attachments/assets/a1bc5ef5-ee25-40bc-8d4c-1fc3cbca43e2)


## Technical Summary
- add space before active so the css class is properly rendered

## Safety Assurance

### Safety story
safe change, just css

### Automated test coverage
n/a

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
