### PR TITLE
Add user_domain_memberships field to user es model

### DIFF
--- a/corehq/apps/es/management/commands/populate_user_domain_memberships.py
+++ b/corehq/apps/es/management/commands/populate_user_domain_memberships.py
@@ -1,0 +1,32 @@
+from corehq.util.log import with_progress_bar
+from corehq.apps.es.utils import get_user_domain_memberships
+from corehq.apps.es.users import UserES, user_adapter
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = ("Migrates User ES models: add user_domain_memberships")
+
+    def handle(self, **options):
+        common_dm = 'user_domain_memberships'
+        mobile_dm = 'domain_membership'
+        web_dm = 'domain_memberships'
+
+        query_set = UserES().show_inactive()
+
+        for user in with_progress_bar(query_set.scroll_ids_to_disk_and_iter_docs(), query_set.count()):
+            update_common_dm = False
+            if common_dm not in user:
+                update_common_dm = True
+            elif common_dm in user and mobile_dm in user and [user[mobile_dm]] != user[common_dm]:
+                update_common_dm = True
+            elif common_dm in user and web_dm in user and user[web_dm] != user[common_dm]:
+                update_common_dm = True
+            if update_common_dm:
+                memberships = get_user_domain_memberships(user)
+                user_adapter.update(
+                    user['_id'],
+                    {common_dm: memberships},
+                    refresh=True
+                )

--- a/corehq/apps/es/management/commands/populate_user_domain_memberships.py
+++ b/corehq/apps/es/management/commands/populate_user_domain_memberships.py
@@ -15,23 +15,8 @@ class Command(BaseCommand):
 
 @once_off_migration("populate_user_domain_memberships")
 def _run_migration():
-    common_dm = 'user_domain_memberships'
-    mobile_dm = 'domain_membership'
-    web_dm = 'domain_memberships'
-
     query_set = UserES().show_inactive()
-
     for user in with_progress_bar(query_set.scroll_ids_to_disk_and_iter_docs(), query_set.count()):
-        update_common_dm = False
-        if common_dm not in user:
-            update_common_dm = True
-        elif common_dm in user and mobile_dm in user and [user[mobile_dm]] != user[common_dm]:
-            update_common_dm = True
-        elif common_dm in user and web_dm in user and user[web_dm] != user[common_dm]:
-            update_common_dm = True
-        if update_common_dm:
+        if 'user_domain_memberships' not in user:
             memberships = get_user_domain_memberships(user)
-            user_adapter.update(
-                user['_id'],
-                {common_dm: memberships},
-            )
+            user_adapter.update(user['_id'], {'user_domain_memberships': memberships})

--- a/corehq/apps/es/management/commands/populate_user_domain_memberships.py
+++ b/corehq/apps/es/management/commands/populate_user_domain_memberships.py
@@ -34,5 +34,4 @@ def _run_migration():
             user_adapter.update(
                 user['_id'],
                 {common_dm: memberships},
-                refresh=True
             )

--- a/corehq/apps/es/management/commands/populate_user_domain_memberships.py
+++ b/corehq/apps/es/management/commands/populate_user_domain_memberships.py
@@ -1,32 +1,38 @@
-from corehq.util.log import with_progress_bar
-from corehq.apps.es.utils import get_user_domain_memberships
-from corehq.apps.es.users import UserES, user_adapter
-
 from django.core.management.base import BaseCommand
+
+from corehq.apps.domain_migration_flags.api import once_off_migration
+from corehq.apps.es.users import UserES, user_adapter
+from corehq.apps.es.utils import get_user_domain_memberships
+from corehq.util.log import with_progress_bar
 
 
 class Command(BaseCommand):
     help = ("Migrates User ES models: add user_domain_memberships")
 
     def handle(self, **options):
-        common_dm = 'user_domain_memberships'
-        mobile_dm = 'domain_membership'
-        web_dm = 'domain_memberships'
+        _run_migration()
 
-        query_set = UserES().show_inactive()
 
-        for user in with_progress_bar(query_set.scroll_ids_to_disk_and_iter_docs(), query_set.count()):
-            update_common_dm = False
-            if common_dm not in user:
-                update_common_dm = True
-            elif common_dm in user and mobile_dm in user and [user[mobile_dm]] != user[common_dm]:
-                update_common_dm = True
-            elif common_dm in user and web_dm in user and user[web_dm] != user[common_dm]:
-                update_common_dm = True
-            if update_common_dm:
-                memberships = get_user_domain_memberships(user)
-                user_adapter.update(
-                    user['_id'],
-                    {common_dm: memberships},
-                    refresh=True
-                )
+@once_off_migration("populate_user_domain_memberships")
+def _run_migration():
+    common_dm = 'user_domain_memberships'
+    mobile_dm = 'domain_membership'
+    web_dm = 'domain_memberships'
+
+    query_set = UserES().show_inactive()
+
+    for user in with_progress_bar(query_set.scroll_ids_to_disk_and_iter_docs(), query_set.count()):
+        update_common_dm = False
+        if common_dm not in user:
+            update_common_dm = True
+        elif common_dm in user and mobile_dm in user and [user[mobile_dm]] != user[common_dm]:
+            update_common_dm = True
+        elif common_dm in user and web_dm in user and user[web_dm] != user[common_dm]:
+            update_common_dm = True
+        if update_common_dm:
+            memberships = get_user_domain_memberships(user)
+            user_adapter.update(
+                user['_id'],
+                {common_dm: memberships},
+                refresh=True
+            )

--- a/corehq/apps/es/mappings/user_mapping.py
+++ b/corehq/apps/es/mappings/user_mapping.py
@@ -450,6 +450,44 @@ USER_MAPPING = {
                 }
             }
         },
+        "user_domain_memberships": {
+            "dynamic": False,
+            "type": "nested",
+            "properties": {
+                "assigned_location_ids": {
+                    "type": "keyword"
+                },
+                "doc_type": {
+                    "type": "keyword"
+                },
+                "domain": {
+                    "fields": {
+                        "exact": {
+                            "type": "keyword"
+                        }
+                    },
+                    "type": "text"
+                },
+                "is_admin": {
+                    "type": "boolean"
+                },
+                "location_id": {
+                    "type": "keyword"
+                },
+                "override_global_tz": {
+                    "type": "boolean"
+                },
+                "role_id": {
+                    "type": "keyword"
+                },
+                "timezone": {
+                    "type": "text"
+                },
+                "is_active": {
+                    "type": "boolean"
+                }
+            }
+        },
         "user_location_id": {
             "type": "keyword"
         },

--- a/corehq/apps/es/migrations/0015_add_user_domain_memberships.py
+++ b/corehq/apps/es/migrations/0015_add_user_domain_memberships.py
@@ -1,0 +1,21 @@
+import corehq.apps.es.migration_operations
+from corehq.apps.es.utils import index_runtime_name
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('es', '0014_enable_slowlogs'),
+    ]
+
+    operations = [
+        corehq.apps.es.migration_operations.UpdateIndexMapping(
+            name=index_runtime_name('users-2024-05-09'),
+            type_='user',
+            properties={
+                'user_domain_memberships': {'dynamic': False, 'properties': {'assigned_location_ids': {'type': 'keyword'}, 'doc_type': {'type': 'keyword'}, 'domain': {'fields': {'exact': {'type': 'keyword'}}, 'type': 'text'}, 'is_active': {'type': 'boolean'}, 'is_admin': {'type': 'boolean'}, 'location_id': {'type': 'keyword'}, 'override_global_tz': {'type': 'boolean'}, 'role_id': {'type': 'keyword'}, 'timezone': {'type': 'text'}}, 'type': 'nested'},
+            },
+            es_versions=[6],
+        )
+    ]

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -46,7 +46,7 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
             "size": SIZE_LIMIT
         }
         raw_query = query.raw_query
-        self.checkQuery(raw_query, json_output, is_raw_query=True)
+        self.checkQuery(raw_query, json_output, is_raw_query=True, validate_query=False)
 
     def test_basic_query(self):
         json_output = {
@@ -345,7 +345,8 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
             'base_username': 'u1',
             'user_data_es': [],
             '__group_ids': [],
-            '__group_names': []
+            '__group_names': [],
+            'user_domain_memberships': []
         })
         self.assertEqual([doc], list(query.scroll_ids_to_disk_and_iter_docs()))
 
@@ -368,7 +369,8 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
             'doc_id': 'test',
             'user_data_es': [],
             '__group_ids': [],
-            '__group_names': []
+            '__group_names': [],
+            'user_domain_memberships': []
         })
         real_scroll = query.scroll
         with patch.object(query, "scroll", scroll_then_delete_one):

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -31,6 +31,7 @@ from .const import (
     HQ_USERS_SECONDARY_INDEX_NAME,
 )
 from .es_query import HQESQuery
+from .utils import get_user_domain_memberships
 from .index.settings import IndexSettingsKey
 
 
@@ -106,6 +107,10 @@ class ElasticUser(ElasticDocumentAdapter):
         user_dict['__group_names'] = [res.name for res in results]
         user_dict['user_data_es'] = []
         user_dict.pop('password', None)
+
+        memberships = get_user_domain_memberships(user_dict)
+        user_dict['user_domain_memberships'] = memberships
+
         if user_dict.get('base_doc') == 'CouchUser' and user_dict['doc_type'] == 'CommCareUser':
             user_obj = self.model_cls.wrap_correctly(user_dict)
             user_data = user_obj.get_user_data(user_obj.domain)

--- a/corehq/apps/es/utils.py
+++ b/corehq/apps/es/utils.py
@@ -193,3 +193,13 @@ def get_es_reindex_setting_value(name, default):
     if ES_REINDEX_LOG[-1] != getattr(settings, 'ES_MULTIPLEX_TO_VERSION', None):
         return default
     return getattr(settings, name, default)
+
+
+def get_user_domain_memberships(user):
+    memberships = []
+    if user['doc_type'] == 'CommCareUser':
+        memberships.append(user['domain_membership'])
+    elif user['doc_type'] == 'WebUser':
+        for membership in user['domain_memberships']:
+            memberships.append(membership)
+    return memberships

--- a/corehq/apps/es/utils.py
+++ b/corehq/apps/es/utils.py
@@ -196,10 +196,8 @@ def get_es_reindex_setting_value(name, default):
 
 
 def get_user_domain_memberships(user):
-    memberships = []
     if user['doc_type'] == 'CommCareUser':
-        memberships.append(user['domain_membership'])
-    elif user['doc_type'] == 'WebUser':
-        for membership in user['domain_memberships']:
-            memberships.append(membership)
-    return memberships
+        return [user['domain_membership']]
+    if user['doc_type'] == 'WebUser':
+        return user['domain_memberships']
+    return []

--- a/migrations.lock
+++ b/migrations.lock
@@ -122,7 +122,6 @@ accounting
  0100_alter_customerinvoicecommunicationhistory_communication_type_and_more
  0101_update_standard_plan_pricing_users_and_privs
  0102_alter_defaultproductplan_edition_and_more
- 0103_bulk_data_cleaning_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add
@@ -460,6 +459,7 @@ es
  0012_add_new_index_for_bha
  0013_add_last_modifed
  0014_enable_slowlogs
+ 0015_add_user_domain_memberships
 events
  0001_add_events_model
  0002_attendancetrackingconfig
@@ -1321,7 +1321,6 @@ users
  0076_connectiduserlink_messaging_consent_and_more
  0077_invitationhistory
  0078_sqluserdata_deleted_on
- 0079_alter_sqluserdata_managers
 util
  0001_initial
  0002_complaintbouncemeta_permanentbouncemeta_transientbounceemail

--- a/migrations.lock
+++ b/migrations.lock
@@ -122,6 +122,7 @@ accounting
  0100_alter_customerinvoicecommunicationhistory_communication_type_and_more
  0101_update_standard_plan_pricing_users_and_privs
  0102_alter_defaultproductplan_edition_and_more
+ 0103_bulk_data_cleaning_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add
@@ -1321,6 +1322,7 @@ users
  0076_connectiduserlink_messaging_consent_and_more
  0077_invitationhistory
  0078_sqluserdata_deleted_on
+ 0079_alter_sqluserdata_managers
 util
  0001_initial
  0002_complaintbouncemeta_permanentbouncemeta_transientbounceemail


### PR DESCRIPTION
## Product Description

Add user_domain_memberships field to user es model and code to the adapter to populate it.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-5976

## Feature Flag

None

## Safety Assurance

### Safety story

Minha ran a variation of the command on staging as part of this [PR](https://github.com/dimagi/commcare-hq/pull/36397). It missed previously SSO disabled users. We ran the command in this PR without any issue and the previously missed users were also migrated.

### Automated test coverage

See changed files

### QA Plan

No user facing changes, so no QA.


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- If the mapping changes themselves cause issues we will need a second migration the reverts the changes made. For all other issues we can revert this PR without further consideration.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
