### PR TITLE
Ignore missing /vendor/{pyproject.toml,uv.lock}

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -36,7 +36,7 @@ function setup {
     fi
 
     # remove after change propagates from Dockerfile
-    unset UV_PROJECT; rm /vendor/{pyproject.toml,uv.lock}
+    unset UV_PROJECT; rm /vendor/{pyproject.toml,uv.lock} || true
 
     uv sync --locked --group=test --no-dev --no-progress
     python_preheat  # preheat the python libs


### PR DESCRIPTION
The previous syntax caused tests to fail if the files were missing, which happens with newer builds of the Docker image.

## Safety Assurance

### Safety story

Affects tests only.

### Automated test coverage

Indirect.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations