### PR TITLE
Migrate to case_knockout_bindings to ESM

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'underscore';
 import DOMPurify from 'dompurify';
+import "jquery-textchange/jquery.textchange";
 import 'hqwebapp/js/atwho';    // autocompleteAtwho
 import 'select2/dist/js/select2.full.min';
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
@@ -1,220 +1,215 @@
-hqDefine("app_manager/js/forms/case_knockout_bindings", [
-    'jquery',
-    'knockout',
-    'underscore',
-    'dompurify',
-    'hqwebapp/js/atwho',    // autocompleteAtwho
-    'select2/dist/js/select2.full.min',
-], function (
-    $,
-    ko,
-    _,
-    DOMPurify,
-) {
-    var utils = {
-        _getIcon: function (question) {
-            if (question.tag === 'upload') {
-                return '<i class="fa fa-paperclip"></i> ';
-            }
-            return '';
-        },
-        getDisplay: function (question, MAXLEN) {
-            return utils._getIcon(question) + utils._getLabel(question, MAXLEN)
-                    + " (" + (question.hashtagValue || question.value) + ")";
-        },
-        getTruncatedDisplay: function (question, MAXLEN) {
-            return utils._getIcon(question) + utils._getLabel(question, MAXLEN)
-                    + " (" + utils._truncateValue(question.hashtagValue || question.value, MAXLEN) + ")";
-        },
-        _getLabel: function (question, MAXLEN) {
-            return utils._truncateLabel((question.repeat ? '- ' : '')
-                    + question.label, question.tag === 'hidden' ? ' (Hidden)' : '', MAXLEN);
-        },
-        _truncateLabel: function (label, suffix, MAXLEN) {
-            suffix = suffix || "";
-            MAXLEN = MAXLEN || 40;
-            const maxlen = MAXLEN - suffix.length;
-            return ((label.length <= maxlen) ? (label) : (label.slice(0, maxlen) + "...")) + suffix;
-        },
-        _truncateValue: function (value, MAXLEN) {
-            MAXLEN = MAXLEN || 40;
-            return (value.length <= MAXLEN) ? (value) : (value.slice(0, MAXLEN / 2) + "..." + value.slice(value.length - MAXLEN / 2));
-        },
-    };
+import $ from 'jquery';
+import ko from 'knockout';
+import _ from 'underscore';
+import DOMPurify from 'dompurify';
+import 'hqwebapp/js/atwho';    // autocompleteAtwho
+import 'select2/dist/js/select2.full.min';
 
-    var questionsById = {};
+const utils = {
+    _getIcon: function (question) {
+        if (question.tag === 'upload') {
+            return '<i class="fa fa-paperclip"></i> ';
+        }
+        return '';
+    },
+    getDisplay: function (question, MAXLEN) {
+        return utils._getIcon(question) + utils._getLabel(question, MAXLEN)
+                + " (" + (question.hashtagValue || question.value) + ")";
+    },
+    getTruncatedDisplay: function (question, MAXLEN) {
+        return utils._getIcon(question) + utils._getLabel(question, MAXLEN)
+                + " (" + utils._truncateValue(question.hashtagValue || question.value, MAXLEN) + ")";
+    },
+    _getLabel: function (question, MAXLEN) {
+        return utils._truncateLabel((question.repeat ? '- ' : '')
+                + question.label, question.tag === 'hidden' ? ' (Hidden)' : '', MAXLEN);
+    },
+    _truncateLabel: function (label, suffix, MAXLEN) {
+        suffix = suffix || "";
+        MAXLEN = MAXLEN || 40;
+        const maxlen = MAXLEN - suffix.length;
+        return ((label.length <= maxlen) ? (label) : (label.slice(0, maxlen) + "...")) + suffix;
+    },
+    _truncateValue: function (value, MAXLEN) {
+        MAXLEN = MAXLEN || 40;
+        return (value.length <= MAXLEN) ? (value) : (value.slice(0, MAXLEN / 2) + "..." + value.slice(value.length - MAXLEN / 2));
+    },
+};
 
-    // Transforms contents of this binding's value into a list of objects to feed to select2
-    var _valueToSelect2Data = function (optionObjects) {
-        var data = _(optionObjects).map(function (o) {
-            o = _.extend(o, {
-                id: o.value,
-                text: utils.getDisplay(o),
-            });
-            questionsById[o.id] = o;
-            return o;
+const questionsById = {};
+
+// Transforms contents of this binding's value into a list of objects to feed to select2
+const _valueToSelect2Data = function (optionObjects) {
+    let data = _(optionObjects).map(function (o) {
+        o = _.extend(o, {
+            id: o.value,
+            text: utils.getDisplay(o),
         });
-        data = [{id: '', text: ''}].concat(data);    // prepend option for placeholder
-        return data;
-    };
+        questionsById[o.id] = o;
+        return o;
+    });
+    data = [{id: '', text: ''}].concat(data);    // prepend option for placeholder
+    return data;
+};
 
-    ko.bindingHandlers.questionsSelect = {
-        /*
-            The value used with this binding should be in the form:
-            [
-                {value: "someValue", label: "someLabel"},
-                ...
-            ]
-         */
-        init: function (element, valueAccessor, allBindingsAccessor) {
-            var optionObjects = ko.utils.unwrapObservable(valueAccessor()),
-                allBindings = ko.utils.unwrapObservable(allBindingsAccessor()),
-                value = ko.utils.unwrapObservable(allBindings.value);
+ko.bindingHandlers.questionsSelect = {
+    /*
+        The value used with this binding should be in the form:
+        [
+            {value: "someValue", label: "someLabel"},
+            ...
+        ]
+     */
+    init: function (element, valueAccessor, allBindingsAccessor) {
+        let optionObjects = ko.utils.unwrapObservable(valueAccessor()),
+            allBindings = ko.utils.unwrapObservable(allBindingsAccessor()),
+            value = ko.utils.unwrapObservable(allBindings.value);
 
-            // Add a warning if the current value isn't a legitimate question
-            if (value && !_.some(optionObjects, function (option) {
-                return option.value === value;
-            })) {
-                var option = {
-                    label: gettext('Unidentified Question') + ' (' + value + ')',
-                    value: value,
-                };
-                optionObjects = [option].concat(optionObjects);
-                var $warning = $('<div class="help-block"></div>').text(gettext(
-                    'We cannot find this question in the allowed questions for this field. ' +
-                    'It is likely that you deleted or renamed the question. ' +
-                    'Please choose a valid question from the dropdown.',
-                ));
-                $(element).after($warning);
-                $(element).parent().addClass('has-error');
-            }
+        // Add a warning if the current value isn't a legitimate question
+        if (value && !_.some(optionObjects, function (option) {
+            return option.value === value;
+        })) {
+            const option = {
+                label: gettext('Unidentified Question') + ' (' + value + ')',
+                value: value,
+            };
+            optionObjects = [option].concat(optionObjects);
+            const $warning = $('<div class="help-block"></div>').text(gettext(
+                'We cannot find this question in the allowed questions for this field. ' +
+                'It is likely that you deleted or renamed the question. ' +
+                'Please choose a valid question from the dropdown.',
+            ));
+            $(element).after($warning);
+            $(element).parent().addClass('has-error');
+        }
 
-            // Initialize select2
-            $(element).select2({
-                placeholder: gettext('Select a Question'),
-                dropdownCssClass: 'bigdrop',
-                escapeMarkup: function (m) {
-                    var paperclip = '<i class="fa fa-paperclip"></i> ';
-                    if (m.includes(paperclip)) {
-                        m = m.replace(paperclip, '');
-                    } else {
-                        paperclip = '';
-                    }
-                    return paperclip + DOMPurify.sanitize(m).replace(/</g, '&lt;').replace(/>/g, '&gt;');
-                },
-                data: _valueToSelect2Data(optionObjects),
-                width: '100%',
-                templateSelection: function (o) {
-                    if (!o.id) {
-                        // This is the placeholder
-                        return o.text;
-                    }
-                    return utils.getTruncatedDisplay(questionsById[o.id]);
-                },
-                templateResult: function (o) {
-                    if (!o.value) {
-                        // This is some select2 system option, like 'Searching...' text
-                        return o.text;
-                    }
-                    return utils.getTruncatedDisplay(questionsById[o.id], 90);
-                },
-            });
-            $(element).val(value).trigger('change.select2');
-        },
-        update: function (element, valueAccessor, allBindingsAccessor) {
-            var $element = $(element),
-                newSelect2Data = _valueToSelect2Data(ko.utils.unwrapObservable(valueAccessor())),
-                oldOptionElements = $element.find("option"),
-                oldValues = _.map(oldOptionElements, function (o) { return o.value; }),
-                newValues = _.pluck(newSelect2Data, 'id');
-
-            // Add any new options
-            _.each(newSelect2Data, function (option) {
-                if (!_.contains(oldValues, option.id)) {
-                    $element.append(new Option(option.text, option.id));
+        // Initialize select2
+        $(element).select2({
+            placeholder: gettext('Select a Question'),
+            dropdownCssClass: 'bigdrop',
+            escapeMarkup: function (m) {
+                let paperclip = '<i class="fa fa-paperclip"></i> ';
+                if (m.includes(paperclip)) {
+                    m = m.replace(paperclip, '');
+                } else {
+                    paperclip = '';
                 }
-            });
-
-            // Remove any options that are no longer relevant
-            _.each(oldOptionElements, function (option) {
-                if (option.value && !_.contains(newValues, option.value)) {
-                    $(option).remove();
+                return paperclip + DOMPurify.sanitize(m).replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            },
+            data: _valueToSelect2Data(optionObjects),
+            width: '100%',
+            templateSelection: function (o) {
+                if (!o.id) {
+                    // This is the placeholder
+                    return o.text;
                 }
-            });
-
-            // If there was an error but it's fixed now, remove it
-            var $container = $element.parent(),
-                allBindings = ko.utils.unwrapObservable(allBindingsAccessor()),
-                value = ko.utils.unwrapObservable(allBindings.value);
-            if ($container.hasClass("has-error") && _.contains(newValues, value)) {
-                $container.removeClass("has-error");
-                $container.find(".help-block").remove();
-            }
-
-            $element.trigger('change.select2');
-        },
-    };
-
-    ko.bindingHandlers.casePropertyAutocomplete = {
-        /*
-         * Strip "attachment:" prefix and show icon for attachment properties.
-         * Replace any spaces in free text with underscores.
-         */
-        init: function (element, valueAccessor) {
-            $(element).on('textchange', function () {
-                var $el = $(this);
-                if ($el.val().match(/\s/)) {
-                    var pos = $el.caret('pos');
-                    $el.val($el.val().replace(/\s/g, '_'));
-                    $el.caret('pos', pos);
+                return utils.getTruncatedDisplay(questionsById[o.id]);
+            },
+            templateResult: function (o) {
+                if (!o.value) {
+                    // This is some select2 system option, like 'Searching...' text
+                    return o.text;
                 }
-            });
-            ko.bindingHandlers.autocompleteAtwho.init(element, valueAccessor);
-        },
-        update: function (element, valueAccessor, allBindingsAccessor) {
-            function wrappedValueAccessor() {
-                return _.map(ko.unwrap(valueAccessor()), function (value) {
-                    if (value.indexOf("attachment:") === 0) {
-                        var text = value.substring(11),
-                            html = '<i class="fa fa-paperclip"></i> ' + text;
-                        return {name: text, content: html};
-                    }
-                    return {name: value, content: value};
-                });
+                return utils.getTruncatedDisplay(questionsById[o.id], 90);
+            },
+        });
+        $(element).val(value).trigger('change.select2');
+    },
+    update: function (element, valueAccessor, allBindingsAccessor) {
+        const $element = $(element),
+            newSelect2Data = _valueToSelect2Data(ko.utils.unwrapObservable(valueAccessor())),
+            oldOptionElements = $element.find("option"),
+            oldValues = _.map(oldOptionElements, function (o) { return o.value; }),
+            newValues = _.pluck(newSelect2Data, 'id');
+
+        // Add any new options
+        _.each(newSelect2Data, function (option) {
+            if (!_.contains(oldValues, option.id)) {
+                $element.append(new Option(option.text, option.id));
             }
-            ko.bindingHandlers.autocompleteAtwho.update(element, wrappedValueAccessor, allBindingsAccessor);
-        },
-    };
+        });
 
-    // Originally from http://stackoverflow.com/a/17998880
-    ko.extenders.withPrevious = function (target) {
-        // Define new properties for previous value and whether it's changed
-        target.previous = ko.observable();
+        // Remove any options that are no longer relevant
+        _.each(oldOptionElements, function (option) {
+            if (option.value && !_.contains(newValues, option.value)) {
+                $(option).remove();
+            }
+        });
 
-        // Subscribe to observable to update previous, before change.
-        target.subscribe(function (v) {
-            target.previous(v);
-        }, null, 'beforeChange');
+        // If there was an error but it's fixed now, remove it
+        const $container = $element.parent(),
+            allBindings = ko.utils.unwrapObservable(allBindingsAccessor()),
+            value = ko.utils.unwrapObservable(allBindings.value);
+        if ($container.hasClass("has-error") && _.contains(newValues, value)) {
+            $container.removeClass("has-error");
+            $container.find(".help-block").remove();
+        }
 
-        // Return modified observable
-        return target;
-    };
+        $element.trigger('change.select2');
+    },
+};
 
-    ko.bindingHandlers.numericValue = {
-        init: function (element, valueAccessor, allBindingsAccessor) {
-            var underlyingObservable = valueAccessor();
-            var interceptor = ko.dependentObservable({
-                read: underlyingObservable,
-                write: function (value) {
-                    if ($.isNumeric(value)) {
-                        underlyingObservable(parseFloat(value));
-                    } else if (value === '') {
-                        underlyingObservable(null);
-                    }
-                },
+ko.bindingHandlers.casePropertyAutocomplete = {
+    /*
+     * Strip "attachment:" prefix and show icon for attachment properties.
+     * Replace any spaces in free text with underscores.
+     */
+    init: function (element, valueAccessor) {
+        $(element).on('textchange', function () {
+            const $el = $(this);
+            if ($el.val().match(/\s/)) {
+                const pos = $el.caret('pos');
+                $el.val($el.val().replace(/\s/g, '_'));
+                $el.caret('pos', pos);
+            }
+        });
+        ko.bindingHandlers.autocompleteAtwho.init(element, valueAccessor);
+    },
+    update: function (element, valueAccessor, allBindingsAccessor) {
+        function wrappedValueAccessor() {
+            return _.map(ko.unwrap(valueAccessor()), function (value) {
+                if (value.indexOf("attachment:") === 0) {
+                    const text = value.substring(11),
+                        html = '<i class="fa fa-paperclip"></i> ' + text;
+                    return {name: text, content: html};
+                }
+                return {name: value, content: value};
             });
-            ko.bindingHandlers.value.init(element, function () { return interceptor; }, allBindingsAccessor);
-        },
-        update: ko.bindingHandlers.value.update,
-    };
-});
+        }
+        ko.bindingHandlers.autocompleteAtwho.update(element, wrappedValueAccessor, allBindingsAccessor);
+    },
+};
+
+// Originally from http://stackoverflow.com/a/17998880
+ko.extenders.withPrevious = function (target) {
+    // Define new properties for previous value and whether it's changed
+    target.previous = ko.observable();
+
+    // Subscribe to observable to update previous, before change.
+    target.subscribe(function (v) {
+        target.previous(v);
+    }, null, 'beforeChange');
+
+    // Return modified observable
+    return target;
+};
+
+ko.bindingHandlers.numericValue = {
+    init: function (element, valueAccessor, allBindingsAccessor) {
+        const underlyingObservable = valueAccessor();
+        const interceptor = ko.dependentObservable({
+            read: underlyingObservable,
+            write: function (value) {
+                if ($.isNumeric(value)) {
+                    underlyingObservable(parseFloat(value));
+                } else if (value === '') {
+                    underlyingObservable(null);
+                }
+            },
+        });
+        ko.bindingHandlers.value.init(element, function () { return interceptor; }, allBindingsAccessor);
+    },
+    update: ko.bindingHandlers.value.update,
+};
+
+export default ko.bindingHandlers;


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17649

This PR is to migrate this file from AMD module format to ESM module format, then explicitly import textchange plugin

Verified no AMD modules import this module
Verified one of the binding `casePropertyAutocomplete` works after the migration, but didn't verify all bindings in this file, due to not familiar with all the usage enough, and I think if one works then others should also work.

Recommend reviewing using "hide whitespace"
<img width="277" alt="image" src="https://github.com/user-attachments/assets/1a24c998-ba92-4ce0-b676-db722d511a3c" />


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
1) The file is imported in several places:
- `visit_scheduler.js` - uses numericValue binding
- `form_view.js` - uses casePropertyAutocomplete and questionsSelect bindings
- `actions.js` - uses withPrevious extender
- Various report configuration files - use questionsSelect binding

I tested casePropertyAutocomplete locally.

2) I checked on how we do other migrations, and the way I import each module followed what we already have.


### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not planning on QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
