### PR TITLE
[Data Cleaning] fix: weighted_percent_complete in status check

### DIFF
--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -44,18 +44,20 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
     @property
     def weighted_percent_complete(self):
         """
-        This gives the user the illusion of progress while we artificially buffer the completion time.
+        Returns an integer between 0 and 100.
 
-        The buffer allows the change feed to catch up to the form submissions,
-        so that the user doesn't refresh and see that their data hasn't updated due to a slow change feed.
+        While the session is in progress we “pad” the percentage so
+        the UI doesn't jump backward when the change feed catches up.
 
         TODO: update this buffer (APPLY_CHANGES_WAIT_TIME) dynamically based on change feed status.
         """
-        if self.is_session_in_progress:
-            return int(0.9 * self.session.percent_complete + 10 * (
-                float(self.seconds_since_complete) / float(APPLY_CHANGES_WAIT_TIME)
-            ))
-        return self.session.percent_complete or 0
+        base = self.session.percent_complete or 0
+        if not self.is_session_in_progress:
+            return base
+
+        buffer = float(self.seconds_since_complete) / APPLY_CHANGES_WAIT_TIME
+        weighted_percent = int(0.9 * base + 10 * buffer)
+        return max(0, min(weighted_percent, 100))
 
     def get_template_names(self):
         if self.is_session_in_progress:

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -56,7 +56,8 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
             return base
 
         buffer = float(self.seconds_since_complete) / APPLY_CHANGES_WAIT_TIME
-        return int(0.9 * base + 10 * buffer)
+        weighted_percent = int(0.9 * base + 10 * buffer)
+        return min(weighted_percent, 100)
 
     def get_template_names(self):
         if self.is_session_in_progress:

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -56,8 +56,7 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
             return base
 
         buffer = float(self.seconds_since_complete) / APPLY_CHANGES_WAIT_TIME
-        weighted_percent = int(0.9 * base + 10 * buffer)
-        return max(0, min(weighted_percent, 100))
+        return int(0.9 * base + 10 * buffer)
 
     def get_template_names(self):
         if self.is_session_in_progress:


### PR DESCRIPTION
## Technical Summary
It is possible for self.session.percent_complete to return None right at the beginning of checking a committed session status. This results in a TypeError in the weighted_percent calculation...resulting in an intermitted HTMX error that is sometimes raised when the first status modal is shown.

This PR ensures that doesn't happen (fixing a bug people were noticing yesterday), and improves readability.

## Safety Assurance

### Safety story
safe change, tested on staging.

### Automated test coverage
this bit is not tested, and I will add this to my tests I'll be writing in the followup from release

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
