### PR TITLE
[Data Cleaning] fix percent calculation in update_result / commit task

### DIFF
--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -442,8 +442,13 @@ class BulkEditSession(models.Model):
         # the most potentially expensive query is below:
         return num_records + self._get_num_unrecorded() <= MAX_RECORDED_LIMIT
 
-    def update_result(self, record_count, form_id=None, error=None):
+    def update_result(self, record_count, form_id=None, error=None, num_committed_records=None):
         result = self.result or {}
+
+        if 'num_committed_records' not in result and num_committed_records is not None:
+            result['num_committed_records'] = num_committed_records
+        elif 'num_committed_records' in result:
+            num_committed_records = result['num_committed_records']
 
         if 'form_ids' not in result:
             result['form_ids'] = []
@@ -459,10 +464,10 @@ class BulkEditSession(models.Model):
         if error:
             result['errors'].append(error)
         result['record_count'] += record_count
-        if self.records.count() == 0:
+        if num_committed_records == 0:
             result['percent'] = 100
-        else:
-            result['percent'] = result['record_count'] * 100 / self.records.count()
+        elif num_committed_records is not None:
+            result['percent'] = result['record_count'] * 100 / num_committed_records
 
         self.result = result
         self.save(update_fields=['result'])

--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -467,7 +467,7 @@ class BulkEditSession(models.Model):
         if num_committed_records == 0:
             result['percent'] = 100
         elif num_committed_records is not None:
-            result['percent'] = result['record_count'] * 100 / num_committed_records
+            result['percent'] = (result['record_count'] / num_committed_records) * 100
 
         self.result = result
         self.save(update_fields=['result'])

--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -445,10 +445,10 @@ class BulkEditSession(models.Model):
     def update_result(self, record_count, form_id=None, error=None, num_committed_records=None):
         result = self.result or {}
 
-        if 'num_committed_records' not in result and num_committed_records is not None:
-            result['num_committed_records'] = num_committed_records
-        elif 'num_committed_records' in result:
+        if 'num_committed_records' in result:
             num_committed_records = result['num_committed_records']
+        elif num_committed_records is not None:
+            result['num_committed_records'] = num_committed_records
 
         if 'form_ids' not in result:
             result['form_ids'] = []

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -33,9 +33,10 @@ def commit_data_cleaning(self, bulk_edit_session_id):
     })
 
     _purge_unedited_records(session)
+    num_committed_records = session.records.count()
 
     form_ids = []
-    session.update_result(0)
+    session.update_result(0, num_committed_records=num_committed_records)
     count_cases = case_load_counter("bulk_case_cleaning", session.domain)
 
     record_iter = session.records.iterator()

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -129,6 +129,7 @@ class CommitCasesTest(TestCase):
         self.assertDictEqual(self.session.result, {
             'errors': [],
             'form_ids': form_ids,
+            'num_committed_records': 1,
             'record_count': 1,
             'percent': 100,
         })


### PR DESCRIPTION
## Technical Summary
In production and staging, we noticed transient errors thrown after creating a single inline edit and applying changes. I looked into those errors and found this issue: https://github.com/dimagi/commcare-hq/pull/36519

While also looking at how the percent was calculated in `update_result`, I noticed a problematic calculation
```
if self.records.count() == 0:
    result['percent'] = 100
else:
    result['percent'] = result['record_count'] * 100 / self.records.count()
```

This bit of code was written when we still kept all the `BulkEditRecord`s around after a commit. However, we now purge unnecessary records during the commit data cleaning loop so that:
- we avoid keeping up to 100k `BulkEditRecord` objects for a session when they aren't needed anymore
- we can safely resume and retry the task, knowing that the committed records are already purged from the session

However, because the `percent` count was relying on `self.records.count()` the percentage would not be accurate throughout the commit loop or when retrying/resuming the task. Additionally, there is a small probability of the second `self.records.count()` call returning zero and throwing a `ZeroDvisionError`...

This PR change ensures the count remains accurate throughout the task, including when the task is resumed/retried (as we fetch the num committed records value from `result` once it is set the first time).


## Safety Assurance

### Safety story
we have tests for the commit task functionality. additionally i tested this on staging.

### Automated test coverage
yes

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
