### PR TITLE
Default DD_TRACE_ENABLED to false if not set

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -157,7 +157,7 @@ def patch_jsonfield():
 
 def unpatch_sys_modules():
     # until https://github.com/DataDog/dd-trace-py/issues/9143 is implemented
-    if os.environ.get("DD_TRACE_ENABLED", "").lower() == "false":
+    if os.environ.get("DD_TRACE_ENABLED", "false").lower() == "false":
         from ddtrace import ModuleWatchdog
         if isinstance(sys.modules, ModuleWatchdog):
             sys.modules.uninstall()


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Followup to https://github.com/dimagi/commcare-hq/pull/34961 (specifically https://github.com/dimagi/commcare-hq/commit/a5e0a9e1)

This should fix an issue where we were not uninstalling ModuleWatchdog if `DD_TRACE_ENABLED` was not set at all. In practice this only impacted our django manage machine where we do not explicitly set `DD_TRACE_ENABLED` to true or false.

This should make it so we no longer collect APM traces from the django manage machine.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is only changing the behavior for machines where this is not explicitly set. This will not impact machines where DD_TRACE_ENABLED is set to true which feels like the biggest concern with this change. It seems rational to assume dd trace is not enabled rather than enabled.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
