### PR TITLE
Added remaining textchange imports

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
@@ -3,6 +3,7 @@ import ko from "knockout";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import google from "analytix/js/google";
 import uploaders from "app_manager/js/nav_menu_media_common";
+import "jquery-textchange/jquery.textchange";
 
 var appMenuMediaManager = function (o) {
     /* This interfaces the media reference for a form or module menu

--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -23,6 +23,7 @@ import "app_manager/js/settings/translations";
 import "app_manager/js/custom_assertions";
 import "hqwebapp/js/components/select_toggle";
 import "hqwebapp/js/bootstrap3/knockout_bindings.ko";
+import "jquery-textchange/jquery.textchange";
 
 $(function () {
     // App name

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
@@ -8,6 +8,7 @@ define('hqwebapp/js/bootstrap3/main', [
     "analytix/js/google",
     "hqwebapp/js/hq_extensions.jquery",
     "jquery.cookie/jquery.cookie",
+    "jquery-textchange/jquery.textchange",
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
@@ -9,6 +9,7 @@ define('hqwebapp/js/bootstrap5/main', [
     "bootstrap5",
     "hqwebapp/js/hq_extensions.jquery",
     "jquery.cookie/jquery.cookie",
+    "jquery-textchange/jquery.textchange",
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select2_knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select2_knockout_bindings.ko.js
@@ -1,9 +1,9 @@
-
 define("hqwebapp/js/select2_knockout_bindings.ko", [
     'jquery',
     'underscore',
     'knockout',
     'dompurify',
+    'jquery-textchange/jquery.textchange',
     'select2/dist/js/select2.full.min',
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap3/ui-element-input.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap3/ui-element-input.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import hqMain from "hqwebapp/js/bootstrap3/main";
 import langcodeButton from "hqwebapp/js/ui_elements/ui-element-langcode-button";
+import "jquery-textchange/jquery.textchange";
 
 var module = {};
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-mapping.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-mapping.js
@@ -32,6 +32,7 @@ import ko from "knockout";
 import _ from "underscore";
 import hqMain from "hqwebapp/js/bootstrap3/main";
 import assertProperties from "hqwebapp/js/assert_properties";
+import "jquery-textchange/jquery.textchange";
 
 var module = {};
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap5/ui-element-input.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap5/ui-element-input.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import hqMain from "hqwebapp/js/bootstrap5/main";
 import langcodeButton from "hqwebapp/js/ui_elements/ui-element-langcode-button";
+import "jquery-textchange/jquery.textchange";
 
 var module = {};
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap5/ui-element-key-val-mapping.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap5/ui-element-key-val-mapping.js
@@ -32,6 +32,7 @@ import ko from "knockout";
 import _ from "underscore";
 import hqMain from "hqwebapp/js/bootstrap5/main";
 import assertProperties from "hqwebapp/js/assert_properties";
+import "jquery-textchange/jquery.textchange";
 
 var module = {};
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
@@ -14,8 +14,8 @@
 +    "bootstrap5",
      "hqwebapp/js/hq_extensions.jquery",
      "jquery.cookie/jquery.cookie",
- ], function (
-@@ -16,6 +17,7 @@
+     "jquery-textchange/jquery.textchange",
+@@ -17,6 +18,7 @@
      initialPageData,
      alertUser,
      googleAnalytics,
@@ -23,7 +23,7 @@
  ) {
      var eventize = function (that) {
          var events = {};
-@@ -42,11 +44,11 @@
+@@ -43,11 +45,11 @@
          wrap = wrap === undefined ? true : wrap;
          var el = $(
              '<div class="hq-help">' +
@@ -37,7 +37,7 @@
          });
          if (wrap) {
              el.hqHelp();
-@@ -101,6 +103,7 @@
+@@ -102,6 +104,7 @@
      ko.virtualElements.allowedBindings.allowDescendantBindings = true;
  
      var initBlock = function ($elem) {
@@ -45,7 +45,7 @@
          $('.submit').click(function (e) {
              var $form = $(this).closest('.form, form'),
                  data = $form.find('[name]').serialize(),
-@@ -110,8 +113,6 @@
+@@ -111,8 +114,6 @@
              $.postGo(action, $.unparam(data));
          });
  
@@ -54,7 +54,7 @@
          $("input[type='text'], input[type='password'], textarea", $elem);
          $('.config', $elem).wrap('<div />').parent().addClass('container block ui-corner-all');
  
-@@ -123,7 +124,7 @@
+@@ -124,7 +125,7 @@
      var updateDOM = function (update) {
          var key;
          for (key in update) {
@@ -63,7 +63,7 @@
                  $(key).text(update[key]).val(update[key]);
              }
          }
-@@ -154,7 +155,7 @@
+@@ -155,7 +156,7 @@
                      }).addClass(cssClass),
                      $saving: $('<div/>').text(SaveButton.message.SAVING).addClass('btn btn-primary disabled'),
                      $saved: $('<div/>').text(SaveButton.message.SAVED).addClass('btn btn-primary disabled'),
@@ -72,7 +72,7 @@
                      setStateWhenReady: function (state) {
                          if (this.state === 'saving') {
                              this.nextState = state;
-@@ -172,7 +173,7 @@
+@@ -173,7 +174,7 @@
                          this.$saved.detach();
                          this.$retry.detach();
                          var buttonUi = this.ui;
@@ -81,7 +81,7 @@
                              buttonUi.removeClass(v);
                          });
                          if (state === 'save') {
-@@ -200,7 +201,7 @@
+@@ -201,7 +202,7 @@
                              $.ajaxSettings.beforeSend(jqXHR, settings);
                              beforeSend.apply(this, arguments);
                          };
@@ -90,7 +90,7 @@
                              that.setState(that.nextState);
                              success.apply(this, arguments);
                          };
-@@ -248,11 +249,9 @@
+@@ -249,11 +250,9 @@
                  $(window).on('beforeunload', function () {
                      var lastParent = button.ui.parents()[button.ui.parents().length - 1];
                      if (lastParent) {
@@ -104,7 +104,7 @@
                              return options.unsavedMessage || "";
                          }
                      }
-@@ -376,7 +375,12 @@
+@@ -377,7 +376,12 @@
          $(window).on('beforeunload', beforeUnloadCallback);
          initBlock($("body"));
  
@@ -118,7 +118,7 @@
  
          $(document).on('click', '.track-usage-link', function (e) {
              var $link = $(e.currentTarget),
-@@ -443,8 +447,13 @@
+@@ -444,8 +448,13 @@
          // EULA modal
          var eulaCookie = "gdpr_rollout";
          if (!$.cookie(eulaCookie)) {
@@ -134,7 +134,7 @@
                  $("body").addClass("has-eula");
                  $("#eula-agree").click(function () {
                      $(this).disableButton();
-@@ -452,7 +461,7 @@
+@@ -453,7 +462,7 @@
                          url: initialPageData.reverse("agree_to_eula"),
                          method: "POST",
                          success: function () {
@@ -143,7 +143,7 @@
                              $("body").removeClass("has-eula");
                          },
                          error: function (xhr) {
-@@ -468,21 +477,22 @@
+@@ -469,21 +478,22 @@
                          },
                      });
                  });

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/ui_elements/ui-element-input.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/ui_elements/ui-element-input.js.diff.txt
@@ -5,5 +5,5 @@
 -import hqMain from "hqwebapp/js/bootstrap3/main";
 +import hqMain from "hqwebapp/js/bootstrap5/main";
  import langcodeButton from "hqwebapp/js/ui_elements/ui-element-langcode-button";
+ import "jquery-textchange/jquery.textchange";
  
- var module = {};

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js.diff.txt
@@ -7,5 +7,5 @@
 -import hqMain from "hqwebapp/js/bootstrap3/main";
 +import hqMain from "hqwebapp/js/bootstrap5/main";
  import assertProperties from "hqwebapp/js/assert_properties";
+ import "jquery-textchange/jquery.textchange";
  
- var module = {};

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
@@ -5,6 +5,7 @@ import atwho from "hqwebapp/js/atwho";
 import ace from "ace-builds/src-min-noconflict/ace";
 import "ace-builds/src-min-noconflict/mode-xquery";
 import "ace-builds/src-min-noconflict/ext-language_tools";
+import "jquery-textchange/jquery.textchange";
 
 ko.bindingHandlers.xPathAutocomplete = {
     init: function (element, valueAccessor, allBindings, viewModel) {


### PR DESCRIPTION
## Technical Summary
This is something of a followup for https://github.com/dimagi/commcare-hq/pull/36502 and https://github.com/dimagi/commcare-hq/pull/36474

As a best practice, all modules should be imported where they're used. RequireJS was lax about some imports, particularly jQuery plugins. Webpack is generally stricter.

I grepped for `textchange` and then added the module to the handful of js files that were not already importing it. This included adding it to a couple of JS files that correspond to areas that are using `textchange` in HTML in knockout bindings.

The only place I didn't add it was [atwho.js](https://github.com/dimagi/commcare-hq/blob/e43ad05beed38c53de299c28537ee05371712d18/corehq/apps/hqwebapp/static/hqwebapp/js/atwho.js#L79-L89), where "textchange" is used as a custom local event, I don't think this code is meant to be using the textchange plugin (though I also don't think it'll be harmful to have the plugin loaded on that page, which it probably will be because it's a dependency of `main.js` which is imported virtually everywhere).

## Safety Assurance

### Safety story
This is very safe.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
