### PR TITLE
Filter CSQL by Custom User Data

### DIFF
--- a/corehq/apps/case_search/forms.py
+++ b/corehq/apps/case_search/forms.py
@@ -39,9 +39,49 @@ class CSQLFixtureExpressionForm(forms.ModelForm):
         return super().save(commit)
 
 
+class UserDataCriteriaForm(forms.Form):
+    operator = forms.ChoiceField(
+        choices=[
+            (CSQLFixtureExpression.MATCH_IS, 'IS'),
+            (CSQLFixtureExpression.MATCH_IS_NOT, 'IS NOT'),
+        ],
+        widget=forms.Select(attrs={
+            'class': 'form-control user-data-operator',
+            'style': 'display: inline-block; width: auto; margin-right: 10px;'
+        })
+    )
+    property_name = forms.CharField(
+        max_length=128,
+        widget=forms.TextInput(attrs={
+            'class': 'form-control user-data-property',
+            'placeholder': 'property_name',
+            'style': 'display: inline-block; width: auto;'
+        })
+    )
+
+
 class CSQLFixtureFilterForm(forms.ModelForm):
     template_name = 'case_search/csql_modal_form.html'
 
     class Meta:
         model = CSQLFixtureExpression
         fields = ["user_data_criteria"]
+
+    def get_context(self):
+        context = super().get_context()
+        context.update({
+            'criteria_forms': self._get_criteria_forms(),
+        })
+        return context
+
+    def _get_criteria_forms(self):
+        if not self.instance or not self.instance.user_data_criteria:
+            return []
+
+        return [
+            UserDataCriteriaForm(initial={
+                'operator': criteria['operator'],
+                'property_name': criteria['property_name']
+            })
+            for criteria in self.instance.user_data_criteria
+        ]

--- a/corehq/apps/case_search/forms.py
+++ b/corehq/apps/case_search/forms.py
@@ -67,6 +67,14 @@ class CSQLFixtureFilterForm(forms.ModelForm):
         model = CSQLFixtureExpression
         fields = ["user_data_criteria"]
 
+    def clean(self):
+        cleaned_data = super().clean()
+        user_data_criteria = cleaned_data.get('user_data_criteria')
+        if user_data_criteria is None:
+            cleaned_data['user_data_criteria'] = []
+
+        return cleaned_data
+
     def get_context(self):
         context = super().get_context()
         context.update({

--- a/corehq/apps/case_search/forms.py
+++ b/corehq/apps/case_search/forms.py
@@ -27,6 +27,21 @@ class CSQLFixtureExpressionForm(forms.ModelForm):
             'spellcheck': "false",
         }
 
+    def get_context(self):
+        context = super().get_context()
+        context.update({
+            'filter_modal_form': CSQLFixtureFilterForm(instance=self.instance),
+        })
+        return context
+
     def save(self, commit=True):
         self.instance.domain = self.domain
         return super().save(commit)
+
+
+class CSQLFixtureFilterForm(forms.ModelForm):
+    template_name = 'case_search/csql_modal_form.html'
+
+    class Meta:
+        model = CSQLFixtureExpression
+        fields = ["user_data_criteria"]

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -13,6 +13,8 @@ from django.utils.translation import gettext as _
 
 import attr
 
+from dimagi.utils.parsing import string_to_boolean
+
 from corehq.apps.case_search.exceptions import CaseSearchUserError
 from corehq.apps.case_search.filter_dsl import CaseFilterError
 from corehq.util.metrics.const import MODULE_NAME_TAG
@@ -471,6 +473,27 @@ class CSQLFixtureExpression(models.Model):
     @classmethod
     def by_domain(cls, domain):
         return cls.objects.filter(domain=domain, deleted=False)
+
+    @classmethod
+    def matches_user_data_criteria(cls, user_data, user_data_criteria):
+        for criteria in user_data_criteria:
+            operator = criteria['operator']
+            property_name = criteria['property_name']
+
+            value = user_data.get(property_name)
+
+            if value is None or value == '':
+                return False
+
+            try:
+                if operator == cls.MATCH_IS and not string_to_boolean(value):
+                    return False
+                elif operator == cls.MATCH_IS_NOT and string_to_boolean(value):
+                    return False
+            except ValueError:
+                return True
+
+        return True
 
     @atomic
     def soft_delete(self):

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -483,7 +483,7 @@ class CSQLFixtureExpression(models.Model):
             value = user_data.get(property_name)
 
             if value is None or value == '':
-                return False
+                continue
 
             try:
                 if operator == cls.MATCH_IS and not string_to_boolean(value):
@@ -491,7 +491,7 @@ class CSQLFixtureExpression(models.Model):
                 elif operator == cls.MATCH_IS_NOT and string_to_boolean(value):
                     return False
             except ValueError:
-                return True
+                continue
 
         return True
 

--- a/corehq/apps/case_search/templates/case_search/csql_expression_form.html
+++ b/corehq/apps/case_search/templates/case_search/csql_expression_form.html
@@ -17,6 +17,14 @@
     <div class="col-8">{{ form.csql }}</div>
     <div class="col-2">
       <button
+      type="button"
+      class="btn btn-outline-secondary"
+      data-bs-toggle="modal"
+      data-bs-target="#filterModal{{form.instance.pk}}"
+    >
+      <i class="fa-solid fa-filter"></i>
+    </button>
+      <button
         type="submit"
         class="btn btn-outline-primary"
         x-bind:disabled="!isUnsaved"
@@ -35,3 +43,13 @@
     </div>
   </div>
 </form>
+
+{% block modals %}
+  <div class="modal fade" id="filterModal{{form.instance.pk}}" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        {{filter_modal_form}}
+      </div>
+    </div>
+  </div>
+{% endblock modals %}

--- a/corehq/apps/case_search/templates/case_search/csql_expression_form.html
+++ b/corehq/apps/case_search/templates/case_search/csql_expression_form.html
@@ -14,8 +14,8 @@
   {% endif %}
   <div class="row pb-3">
     <div class="col-2">{{ form.name }}</div>
-    <div class="col-8">{{ form.csql }}</div>
-    <div class="col-2">
+    <div class="col-7">{{ form.csql }}</div>
+    <div class="col-3">
       <button
       type="button"
       class="btn btn-outline-secondary"

--- a/corehq/apps/case_search/templates/case_search/csql_modal_form.html
+++ b/corehq/apps/case_search/templates/case_search/csql_modal_form.html
@@ -1,7 +1,11 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<form>
+<form
+    hx-post="{{ request.path_info }}"
+    hq-hx-action="save_filter_modal"
+    hx-swap="outerHTML"
+>
   {% if form.instance.pk %}
   <input type="hidden" name="pk" value="{{ form.instance.pk }}" />
   {% endif %}

--- a/corehq/apps/case_search/templates/case_search/csql_modal_form.html
+++ b/corehq/apps/case_search/templates/case_search/csql_modal_form.html
@@ -5,6 +5,9 @@
     hx-post="{{ request.path_info }}"
     hq-hx-action="save_filter_modal"
     hx-swap="outerHTML"
+    x-data="{ isUnsaved: false }"
+    @change="isUnsaved = true;"
+    @submit="isUnsaved = false;"
 >
   {% if form.instance.pk %}
   <input type="hidden" name="pk" value="{{ form.instance.pk }}" />
@@ -32,6 +35,6 @@
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
-    <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
+    <button type="submit" class="btn btn-primary" x-bind:disabled="!isUnsaved">{% trans "Save" %}</button>
   </div>
 </form>

--- a/corehq/apps/case_search/templates/case_search/csql_modal_form.html
+++ b/corehq/apps/case_search/templates/case_search/csql_modal_form.html
@@ -10,7 +10,11 @@
     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
   </div>
   <div class="modal-body">
-
+    <div id="csql-criteria-rows{{form.instance.pk}}">
+        {% for form in criteria_forms %}
+            {% include 'case_search/csql_user_data_criteria_fields.html' with form=form %}
+        {% endfor %}
+    </div>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>

--- a/corehq/apps/case_search/templates/case_search/csql_modal_form.html
+++ b/corehq/apps/case_search/templates/case_search/csql_modal_form.html
@@ -15,6 +15,16 @@
             {% include 'case_search/csql_user_data_criteria_fields.html' with form=form %}
         {% endfor %}
     </div>
+    <button
+        type="button"
+        class="btn btn-outline-primary"
+        hx-post="{{ request.path_info }}"
+        hq-hx-action="new_criteria"
+        hx-target="#csql-criteria-rows{{form.instance.pk}}"
+        hx-swap="beforeend"
+        >
+        <i class="fa fa-plus"></i> {% trans "Add Criteria" %}
+  </button>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>

--- a/corehq/apps/case_search/templates/case_search/csql_modal_form.html
+++ b/corehq/apps/case_search/templates/case_search/csql_modal_form.html
@@ -1,0 +1,19 @@
+{% load hq_shared_tags %}
+{% load i18n %}
+
+<form>
+  {% if form.instance.pk %}
+  <input type="hidden" name="pk" value="{{ form.instance.pk }}" />
+  {% endif %}
+  <div class="modal-header">
+    <h5 class="modal-title">{% trans "Fixture Inclusion in Restore Criteria" %}</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+  </div>
+  <div class="modal-body">
+
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+    <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
+  </div>
+</form>

--- a/corehq/apps/case_search/templates/case_search/csql_user_data_criteria_fields.html
+++ b/corehq/apps/case_search/templates/case_search/csql_user_data_criteria_fields.html
@@ -1,6 +1,12 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
+<style>
+    .csql-criteria-row:last-of-type .and-text {
+      display: none;
+    }
+  </style>
+
 <div class="csql-criteria-row">
     <div class="d-flex align-items-center mb-2">
       <div class="me-2">
@@ -12,5 +18,8 @@
       <div class="me-2">
         {{ form.property_name }}
       </div>
+    </div>
+    <div class="text-center fw-bold small and-text">
+        AND
     </div>
 </div>

--- a/corehq/apps/case_search/templates/case_search/csql_user_data_criteria_fields.html
+++ b/corehq/apps/case_search/templates/case_search/csql_user_data_criteria_fields.html
@@ -1,0 +1,16 @@
+{% load hq_shared_tags %}
+{% load i18n %}
+
+<div class="csql-criteria-row">
+    <div class="d-flex align-items-center mb-2">
+      <div class="me-2">
+        User Property
+      </div>
+      <div class="me-2">
+        {{ form.operator }}
+      </div>
+      <div class="me-2">
+        {{ form.property_name }}
+      </div>
+    </div>
+</div>

--- a/corehq/apps/case_search/templates/case_search/csql_user_data_criteria_fields.html
+++ b/corehq/apps/case_search/templates/case_search/csql_user_data_criteria_fields.html
@@ -25,7 +25,7 @@
       <button
         type="button"
         class="btn btn-outline-danger"
-        @click="showElement = false; "
+        @click="isUnsaved = true; showElement = false;"
         >
         <i class="fa-regular fa-trash-can"></i> {% trans "Delete" %}
       </button>

--- a/corehq/apps/case_search/templates/case_search/csql_user_data_criteria_fields.html
+++ b/corehq/apps/case_search/templates/case_search/csql_user_data_criteria_fields.html
@@ -3,11 +3,15 @@
 
 <style>
     .csql-criteria-row:last-of-type .and-text {
-      display: none;
+        display: none;
     }
-  </style>
+</style>
 
-<div class="csql-criteria-row">
+<div
+  class="csql-criteria-row"
+  x-data="{ showElement: true }"
+>
+  <template x-if="showElement">
     <div class="d-flex align-items-center mb-2">
       <div class="me-2">
         User Property
@@ -18,8 +22,16 @@
       <div class="me-2">
         {{ form.property_name }}
       </div>
+      <button
+        type="button"
+        class="btn btn-outline-danger"
+        @click="showElement = false; "
+        >
+        <i class="fa-regular fa-trash-can"></i> {% trans "Delete" %}
+      </button>
     </div>
     <div class="text-center fw-bold small and-text">
         AND
     </div>
+  </template>
 </div>

--- a/corehq/apps/case_search/tests/test_fixtures.py
+++ b/corehq/apps/case_search/tests/test_fixtures.py
@@ -81,11 +81,11 @@ class TestCaseSearchFixtures(TestCase):
         res = self.render("selected(@owner_id, '{bha.user_clinic_ids}')")
         self.assertEqual(res, "selected(@owner_id, 'abc123 def456')")
 
-    @patch('corehq.apps.case_search.fixtures._get_indicators')
+    @patch('corehq.apps.case_search.fixtures._get_indicators_for_user')
     @patch('corehq.apps.case_search.fixtures._run_query')
-    def test_fixture_generator(self, run_query, get_indicators):
+    def test_fixture_generator(self, run_query, get_indicators_for_user):
         run_query.return_value = "42"
-        get_indicators.return_value = [
+        get_indicators_for_user.return_value = [
             ('pre_pandemic_births', "dob < '2020-01-01'"),
             ('owned_by_user', "@owner_id = '{user.uuid}'"),
         ]
@@ -101,8 +101,8 @@ class TestCaseSearchFixtures(TestCase):
         </TestRestore>"""
         assert_xml_equal(expected, self.generate_fixtures())
 
-    @patch('corehq.apps.case_search.fixtures._get_indicators')
-    def test_full_query(self, get_indicators):
+    @patch('corehq.apps.case_search.fixtures._get_indicators_for_user')
+    def test_full_query(self, get_indicators_for_user):
         indicators = [
             # (name, csql_template, expected_count)
             ('owned_by_user', "@owner_id = '{user.uuid}'", 3),
@@ -110,7 +110,7 @@ class TestCaseSearchFixtures(TestCase):
             ('own_clients', "@case_type = 'client' and @owner_id = '{user.uuid}'", 2),
             ('bad_query', "this is not a valid query", "ERROR"),
         ]
-        get_indicators.return_value = [(name, csql_template) for name, csql_template, _ in indicators]
+        get_indicators_for_user.return_value = [(name, csql_template) for name, csql_template, _ in indicators]
 
         res = self.generate_fixtures()
         for name, _, expected in indicators:

--- a/corehq/apps/case_search/tests/test_views.py
+++ b/corehq/apps/case_search/tests/test_views.py
@@ -46,3 +46,24 @@ class TestCSQLFixtureExpressionView(HtmxViewTestCase):
              (CSQLFixtureExpressionLog.Action.UPDATE.value, 'updated csql'),
              (CSQLFixtureExpressionLog.Action.DELETE.value, '')],
         )
+
+    def test_new_criteria(self):
+        response = self.hx_action('new_criteria', {})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('form', response.content.decode())
+
+    def test_save_filter_modal(self):
+        expression = CSQLFixtureExpression.objects.create(
+            domain=self.domain,
+            name='my_indicator_name',
+            csql='original csql'
+        )
+        response = self.hx_action('save_filter_modal', {
+            'pk': expression.pk,
+            'operator': ['IS'],
+            'property_name': ['my_property'],
+        })
+        self.assertEqual(response.status_code, 200)
+
+        expression.refresh_from_db()
+        self.assertEqual(expression.user_data_criteria, [{'operator': 'IS', 'property_name': 'my_property'}])

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -12,7 +12,11 @@ from dimagi.utils.web import json_response
 
 from corehq import toggles
 from corehq.apps.case_importer.views import require_can_edit_data
-from corehq.apps.case_search.forms import CSQLFixtureExpressionForm, UserDataCriteriaForm
+from corehq.apps.case_search.forms import (
+    CSQLFixtureExpressionForm,
+    UserDataCriteriaForm,
+    CSQLFixtureFilterForm,
+)
 from corehq.apps.case_search.models import (
     CSQLFixtureExpression,
     case_search_enabled_for_domain,
@@ -184,3 +188,23 @@ class CSQLFixtureExpressionView(HqHtmxActionMixin, BaseProjectDataView):
     @hq_hx_action('post')
     def new_criteria(self, request, *args, **kwargs):
         return render(request, 'case_search/csql_user_data_criteria_fields.html', {'form': UserDataCriteriaForm()})
+
+    @hq_hx_action('post')
+    def save_filter_modal(self, request, domain, *args, **kwargs):
+        mutable_post = request.POST.copy()
+
+        pk = request.POST.get('pk')
+        expression = CSQLFixtureExpression.objects.get(domain=domain, pk=pk) if pk else None
+
+        operators = request.POST.getlist('operator', [])
+        properties = request.POST.getlist('property_name', [])
+        mutable_post['user_data_criteria'] = [
+            {"operator": operator, "property_name": property}
+            for operator, property in zip(operators, properties)
+        ]
+
+        form = CSQLFixtureFilterForm(mutable_post, instance=expression)
+        if form.is_valid():
+            form.save()
+            return HttpResponse(form.render())
+        raise AssertionError("The user shouldn't be able to submit an invalid form")

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -3,6 +3,7 @@ import re
 from io import BytesIO
 
 from django.http import Http404, HttpResponse
+from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
@@ -11,7 +12,7 @@ from dimagi.utils.web import json_response
 
 from corehq import toggles
 from corehq.apps.case_importer.views import require_can_edit_data
-from corehq.apps.case_search.forms import CSQLFixtureExpressionForm
+from corehq.apps.case_search.forms import CSQLFixtureExpressionForm, UserDataCriteriaForm
 from corehq.apps.case_search.models import (
     CSQLFixtureExpression,
     case_search_enabled_for_domain,
@@ -179,3 +180,7 @@ class CSQLFixtureExpressionView(HqHtmxActionMixin, BaseProjectDataView):
         if pk := request.POST.get('pk'):
             CSQLFixtureExpression.objects.get(domain=domain, pk=pk).soft_delete()
         return self.render_htmx_no_response(request)
+
+    @hq_hx_action('post')
+    def new_criteria(self, request, *args, **kwargs):
+        return render(request, 'case_search/csql_user_data_criteria_fields.html', {'form': UserDataCriteriaForm()})


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Adds a UI for configuring custom user data criteria that determine which users receive the associated fixtures during restore. Clicking the "filter" button opens the modal.

<img width="1041" alt="Screenshot 2025-06-04 at 9 48 04 AM" src="https://github.com/user-attachments/assets/a6eefbf3-bef7-4824-8e61-40a8f4718c92" />
<img width="689" alt="Screenshot 2025-06-04 at 9 49 03 AM" src="https://github.com/user-attachments/assets/c338af20-1f14-4fdb-a9ea-e6fa5e67f3d4" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[USH-5839](https://dimagi.atlassian.net/browse/USH-5939)
This PR introduces a form for configuring user data criteria, such as `"IS clinic_user"` and `"IS NOT supervisor"`, where `clinic_user` and `supervisor` refer to custom user data properties with boolean-like values (e.g., `"true"`, `"yes"`, `"no"`).

During the restore process, a fixture is included if either no criteria are configured or if the user's custom data meets all specified criteria. The matching logic is intentionally permissive to reduce the risk of unintentionally excluding fixtures due to misconfiguration.

Specifically, the fixture will still be included in the following cases:

- The fixture filter references a user data field that does not exist on the user
- The user data field exists but contains a non-boolean value
- The user data field exists but is blank ('')

As a result, any non-exact match between the user's custom data and the fixture criteria will default to including the fixture. This lenient approach helps prevent app breakages caused by incomplete or inconsistent user data.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[CSQL Fixture AKA Module Badges](https://www.commcarehq.org/hq/flags/edit/module_badges/)
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change affects only projects that use CSQL Fixture. There are currently no real projects using it (co-carecoordination will eventually use it, but it is currently turned off).

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Tests exists that checks the fixture is correctly built and included in the restore.
I added tests that checks:
- UI views creates and saves the criterias to the model
- the correct expressions  are filtered when getting related fixture expressions for the user

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
There is not a migration in this PR, but this PR is dependent on this [previous migration](https://github.com/dimagi/commcare-hq/pull/36529)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

After this PR is reverted, users will need to sync to get the latest fixtures in their restore.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-5839]: https://dimagi.atlassian.net/browse/USH-5839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ