### PR TITLE
Added textchange imports

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
@@ -4,6 +4,7 @@ hqDefine("app_manager/js/app_manager_media", [
     "hqwebapp/js/initial_page_data",
     "analytix/js/google",
     "app_manager/js/nav_menu_media_common",
+    "jquery-textchange/jquery.textchange",  // textchange is referenced in bindings in nav_menu_media_single_type.html
 ], function (
     $,
     ko,

--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -23,6 +23,7 @@ import "app_manager/js/settings/translations";
 import "app_manager/js/custom_assertions";
 import "hqwebapp/js/components/select_toggle";
 import "hqwebapp/js/bootstrap3/knockout_bindings.ko";
+import "jquery-textchange/jquery.textchange";   // textchange is referenced in ko bindings in app_settings.html
 
 $(function () {
     // App name

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
@@ -360,21 +360,7 @@ hqDefine('hqwebapp/js/bootstrap3/main', [
         },
     };
 
-    var beforeUnload = [];
-    var bindBeforeUnload = function (callback) {
-        beforeUnload.push(callback);
-    };
-    var beforeUnloadCallback = function () {
-        for (var i = 0; i < beforeUnload.length; i++) {
-            var message = beforeUnload[i]();
-            if (message !== null && message !== undefined) {
-                return message;
-            }
-        }
-    };
-
     $(function () {
-        $(window).on('beforeunload', beforeUnloadCallback);
         initBlock($("body"));
 
         $('#modalTrial30Day').modal('show');
@@ -493,7 +479,6 @@ hqDefine('hqwebapp/js/bootstrap3/main', [
     };
 
     return {
-        beforeUnloadCallback: beforeUnloadCallback,
         eventize: eventize,
         initBlock: initBlock,
         initDeleteButton: DeleteButton.init,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
@@ -124,7 +124,7 @@ hqDefine('hqwebapp/js/bootstrap3/main', [
     var updateDOM = function (update) {
         var key;
         for (key in update) {
-            if (_.has(update, key)) {
+            if (Object.prototype.hasOwnProperty.call(update, key)) {
                 $(key).text(update[key]).val(update[key]);
             }
         }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
@@ -8,6 +8,7 @@ hqDefine('hqwebapp/js/bootstrap3/main', [
     "analytix/js/google",
     "hqwebapp/js/hq_extensions.jquery",
     "jquery.cookie/jquery.cookie",
+    "jquery-textchange/jquery.textchange",
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
@@ -125,7 +125,7 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
     var updateDOM = function (update) {
         var key;
         for (key in update) {
-            if (update.hasOwnProperty(key)) {
+            if (Object.prototype.hasOwnProperty.call(update, key)) {
                 $(key).text(update[key]).val(update[key]);
             }
         }
@@ -174,7 +174,7 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
                         this.$saved.detach();
                         this.$retry.detach();
                         var buttonUi = this.ui;
-                        _.each(BAR_STATE, function (v, k) {
+                        _.each(BAR_STATE, function (v) {
                             buttonUi.removeClass(v);
                         });
                         if (state === 'save') {
@@ -202,7 +202,7 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
                             $.ajaxSettings.beforeSend(jqXHR, settings);
                             beforeSend.apply(this, arguments);
                         };
-                        options.success = function (data) {
+                        options.success = function () {
                             that.setState(that.nextState);
                             success.apply(this, arguments);
                         };
@@ -250,7 +250,7 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
                 $(window).on('beforeunload', function () {
                     var lastParent = button.ui.parents()[button.ui.parents().length - 1];
                     if (lastParent) {
-                        var stillAttached = lastParent.tagName.toLowerCase() == 'html';
+                        var stillAttached = lastParent.tagName.toLowerCase() === 'html';
                         if (button.state !== 'saved' && stillAttached) {
                             if ($('.js-unhide-on-unsaved').length > 0) {$('.js-unhide-on-unsaved').removeClass('hide');}
                             return options.unsavedMessage || "";

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
@@ -9,6 +9,7 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
     "bootstrap5",
     "hqwebapp/js/hq_extensions.jquery",
     "jquery.cookie/jquery.cookie",
+    "jquery-textchange/jquery.textchange",
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
@@ -359,21 +359,7 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
         },
     };
 
-    var beforeUnload = [];
-    var bindBeforeUnload = function (callback) {
-        beforeUnload.push(callback);
-    };
-    var beforeUnloadCallback = function () {
-        for (var i = 0; i < beforeUnload.length; i++) {
-            var message = beforeUnload[i]();
-            if (message !== null && message !== undefined) {
-                return message;
-            }
-        }
-    };
-
     $(function () {
-        $(window).on('beforeunload', beforeUnloadCallback);
         initBlock($("body"));
 
         var trialModalElement = $('#modalTrial30Day'),
@@ -503,7 +489,6 @@ hqDefine('hqwebapp/js/bootstrap5/main', [
     };
 
     return {
-        beforeUnloadCallback: beforeUnloadCallback,
         eventize: eventize,
         initBlock: initBlock,
         initDeleteButton: DeleteButton.init,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select2_knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select2_knockout_bindings.ko.js
@@ -1,9 +1,9 @@
-
 hqDefine("hqwebapp/js/select2_knockout_bindings.ko", [
     'jquery',
     'underscore',
     'knockout',
     'dompurify',
+    'jquery-textchange/jquery.textchange',
     'select2/dist/js/select2.full.min',
 ], function (
     $,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap3/ui-element-input.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap3/ui-element-input.js
@@ -1,8 +1,8 @@
-
 hqDefine('hqwebapp/js/ui_elements/bootstrap3/ui-element-input', [
     'jquery',
     'hqwebapp/js/bootstrap3/main',
     'hqwebapp/js/ui_elements/ui-element-langcode-button',
+    'jquery-textchange/jquery.textchange',
 ], function (
     $,
     hqMain,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-mapping.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-mapping.js
@@ -33,6 +33,7 @@ hqDefine('hqwebapp/js/ui_elements/bootstrap3/ui-element-key-val-mapping', [
     'underscore',
     'hqwebapp/js/bootstrap3/main',
     'hqwebapp/js/assert_properties',
+    'jquery-textchange/jquery.textchange',
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap5/ui-element-input.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap5/ui-element-input.js
@@ -1,8 +1,8 @@
-
 hqDefine('hqwebapp/js/ui_elements/bootstrap5/ui-element-input', [
     'jquery',
     'hqwebapp/js/bootstrap5/main',
     'hqwebapp/js/ui_elements/ui-element-langcode-button',
+    'jquery-textchange/jquery.textchange',
 ], function (
     $,
     hqMain,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap5/ui-element-key-val-mapping.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/bootstrap5/ui-element-key-val-mapping.js
@@ -33,6 +33,7 @@ hqDefine('hqwebapp/js/ui_elements/bootstrap5/ui-element-key-val-mapping', [
     'underscore',
     'hqwebapp/js/bootstrap5/main',
     'hqwebapp/js/assert_properties',
+    'jquery-textchange/jquery.textchange',
 ], function (
     $,
     ko,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
@@ -14,8 +14,8 @@
 +    "bootstrap5",
      "hqwebapp/js/hq_extensions.jquery",
      "jquery.cookie/jquery.cookie",
- ], function (
-@@ -16,6 +17,7 @@
+     "jquery-textchange/jquery.textchange",
+@@ -17,6 +18,7 @@
      initialPageData,
      alertUser,
      googleAnalytics,
@@ -23,7 +23,7 @@
  ) {
      var eventize = function (that) {
          var events = {};
-@@ -42,11 +44,11 @@
+@@ -43,11 +45,11 @@
          wrap = wrap === undefined ? true : wrap;
          var el = $(
              '<div class="hq-help">' +
@@ -37,7 +37,7 @@
          });
          if (wrap) {
              el.hqHelp();
-@@ -101,6 +103,7 @@
+@@ -102,6 +104,7 @@
      ko.virtualElements.allowedBindings.allowDescendantBindings = true;
  
      var initBlock = function ($elem) {
@@ -45,7 +45,7 @@
          $('.submit').click(function (e) {
              var $form = $(this).closest('.form, form'),
                  data = $form.find('[name]').serialize(),
-@@ -110,8 +113,6 @@
+@@ -111,8 +114,6 @@
              $.postGo(action, $.unparam(data));
          });
  
@@ -54,16 +54,7 @@
          $("input[type='text'], input[type='password'], textarea", $elem);
          $('.config', $elem).wrap('<div />').parent().addClass('container block ui-corner-all');
  
-@@ -123,7 +124,7 @@
-     var updateDOM = function (update) {
-         var key;
-         for (key in update) {
--            if (_.has(update, key)) {
-+            if (update.hasOwnProperty(key)) {
-                 $(key).text(update[key]).val(update[key]);
-             }
-         }
-@@ -154,7 +155,7 @@
+@@ -155,7 +156,7 @@
                      }).addClass(cssClass),
                      $saving: $('<div/>').text(SaveButton.message.SAVING).addClass('btn btn-primary disabled'),
                      $saved: $('<div/>').text(SaveButton.message.SAVED).addClass('btn btn-primary disabled'),
@@ -72,30 +63,9 @@
                      setStateWhenReady: function (state) {
                          if (this.state === 'saving') {
                              this.nextState = state;
-@@ -172,7 +173,7 @@
-                         this.$saved.detach();
-                         this.$retry.detach();
-                         var buttonUi = this.ui;
--                        _.each(BAR_STATE, function (v) {
-+                        _.each(BAR_STATE, function (v, k) {
-                             buttonUi.removeClass(v);
-                         });
-                         if (state === 'save') {
-@@ -200,7 +201,7 @@
-                             $.ajaxSettings.beforeSend(jqXHR, settings);
-                             beforeSend.apply(this, arguments);
-                         };
--                        options.success = function () {
-+                        options.success = function (data) {
-                             that.setState(that.nextState);
-                             success.apply(this, arguments);
-                         };
-@@ -248,11 +249,9 @@
-                 $(window).on('beforeunload', function () {
-                     var lastParent = button.ui.parents()[button.ui.parents().length - 1];
+@@ -251,9 +252,7 @@
                      if (lastParent) {
--                        var stillAttached = lastParent.tagName.toLowerCase() === 'html';
-+                        var stillAttached = lastParent.tagName.toLowerCase() == 'html';
+                         var stillAttached = lastParent.tagName.toLowerCase() === 'html';
                          if (button.state !== 'saved' && stillAttached) {
 -                            if ($('.js-unhide-on-unsaved').length > 0) {
 -                                $('.js-unhide-on-unsaved').removeClass('hide');
@@ -104,8 +74,8 @@
                              return options.unsavedMessage || "";
                          }
                      }
-@@ -376,7 +375,12 @@
-         $(window).on('beforeunload', beforeUnloadCallback);
+@@ -363,7 +362,12 @@
+     $(function () {
          initBlock($("body"));
  
 -        $('#modalTrial30Day').modal('show');
@@ -118,7 +88,7 @@
  
          $(document).on('click', '.track-usage-link', function (e) {
              var $link = $(e.currentTarget),
-@@ -443,8 +447,13 @@
+@@ -430,8 +434,13 @@
          // EULA modal
          var eulaCookie = "gdpr_rollout";
          if (!$.cookie(eulaCookie)) {
@@ -134,7 +104,7 @@
                  $("body").addClass("has-eula");
                  $("#eula-agree").click(function () {
                      $(this).disableButton();
-@@ -452,7 +461,7 @@
+@@ -439,7 +448,7 @@
                          url: initialPageData.reverse("agree_to_eula"),
                          method: "POST",
                          success: function () {
@@ -143,7 +113,7 @@
                              $("body").removeClass("has-eula");
                          },
                          error: function (xhr) {
-@@ -468,21 +477,22 @@
+@@ -455,21 +464,22 @@
                          },
                      });
                  });

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/ui_elements/ui-element-input.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/ui_elements/ui-element-input.js.diff.txt
@@ -1,12 +1,11 @@
 --- 
 +++ 
-@@ -1,7 +1,7 @@
- 
+@@ -1,6 +1,6 @@
 -hqDefine('hqwebapp/js/ui_elements/bootstrap3/ui-element-input', [
 +hqDefine('hqwebapp/js/ui_elements/bootstrap5/ui-element-input', [
      'jquery',
 -    'hqwebapp/js/bootstrap3/main',
 +    'hqwebapp/js/bootstrap5/main',
      'hqwebapp/js/ui_elements/ui-element-langcode-button',
+     'jquery-textchange/jquery.textchange',
  ], function (
-     $,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/ui_elements/ui-element-key-val-mapping.js.diff.txt
@@ -12,5 +12,5 @@
 -    'hqwebapp/js/bootstrap3/main',
 +    'hqwebapp/js/bootstrap5/main',
      'hqwebapp/js/assert_properties',
+     'jquery-textchange/jquery.textchange',
  ], function (
-     $,

--- a/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
+++ b/corehq/apps/reports/static/reports/js/filters/case_list_explorer_knockout_bindings.js
@@ -5,6 +5,7 @@ import atwho from "hqwebapp/js/atwho";
 import ace from "ace-builds/src-min-noconflict/ace";
 import "ace-builds/src-min-noconflict/mode-xquery";
 import "ace-builds/src-min-noconflict/ext-language_tools";
+import "jquery-textchange/jquery.textchange";
 
 ko.bindingHandlers.xPathAutocomplete = {
     init: function (element, valueAccessor, allBindings, viewModel) {


### PR DESCRIPTION
## Technical Summary
This re-releases https://github.com/dimagi/commcare-hq/pull/36522/ which was reverted due to a conflict with a problematic PR. It adds a bit of linting and dead code removal.

As a best practice, all modules should be imported where they're used. RequireJS was lax about some imports, particularly jQuery plugins. Webpack is generally stricter.

I grepped for `textchange` and then added the module to the handful of js files that were not already importing it. This included adding it to a couple of JS files that correspond to areas that are using `textchange` in HTML in knockout bindings.

The only place I didn't add it was [atwho.js](https://github.com/dimagi/commcare-hq/blob/e43ad05beed38c53de299c28537ee05371712d18/corehq/apps/hqwebapp/static/hqwebapp/js/atwho.js#L79-L89), where "textchange" is used as a custom local event, I don't think this code is meant to be using the textchange plugin (though I also don't think it'll be harmful to have the plugin loaded on that page, which it probably will be because it's a dependency of `main.js` which is imported virtually everywhere).

## Safety Assurance

### Safety story
This is very safe.

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
