### PR TITLE
[Data Cleaning] organize imports and run ruff on all of `data_cleaning`

### DIFF
--- a/corehq/apps/data_cleaning/columns.py
+++ b/corehq/apps/data_cleaning/columns.py
@@ -10,7 +10,7 @@ from corehq.toggles import mark_safe
 
 
 class EditableHtmxColumn(TemplateColumn):
-    template_name = "data_cleaning/columns/column_main.html"
+    template_name = 'data_cleaning/columns/column_main.html'
 
     def __init__(self, column_spec, *args, **kwargs):
         """
@@ -23,7 +23,8 @@ class EditableHtmxColumn(TemplateColumn):
             template_name=self.template_name,
             accessor=column_spec.prop_id,
             verbose_name=column_spec.label,
-            *args, **kwargs
+            *args,
+            **kwargs,
         )
         self.column_spec = column_spec
 
@@ -41,17 +42,17 @@ class EditableHtmxColumn(TemplateColumn):
         bound_column = BoundColumn(table, column, column_spec.slug)
         value = record[column_spec.prop_id]
         return {
-            "column": bound_column,
-            "record": record,
-            "value": value,
+            'column': bound_column,
+            'record': record,
+            'value': value,
         }
 
 
 class SelectableHtmxColumn(CheckBoxColumn):
-    template_column = "data_cleaning/columns/selection.html"
-    template_header = "data_cleaning/columns/selection_header.html"
-    template_read_only = "data_cleaning/columns/selection_read_only.html"
-    select_page_checkbox_id = "id-select-page-checkbox"
+    template_column = 'data_cleaning/columns/selection.html'
+    template_header = 'data_cleaning/columns/selection_header.html'
+    template_read_only = 'data_cleaning/columns/selection_read_only.html'
+    select_page_checkbox_id = 'id-select-page-checkbox'
 
     def __init__(self, session, request, select_record_action, select_page_action, *args, **kwargs):
         """
@@ -89,8 +90,8 @@ class SelectableHtmxColumn(CheckBoxColumn):
     def header(self):
         if self.session.is_read_only:
             return self.read_only_response()
-        general = self.attrs.get("input")
-        specific = self.attrs.get("th__input")
+        general = self.attrs.get('input')
+        specific = self.attrs.get('th__input')
         attrs = AttributeDict(specific or general or {})
         return mark_safe(  # nosec: render_to_string below will handle escaping
             render_to_string(
@@ -107,8 +108,8 @@ class SelectableHtmxColumn(CheckBoxColumn):
     def render(self, value, bound_column, record):
         if self.session.is_read_only:
             return self.read_only_response()
-        general = self.attrs.get("input")
-        specific = self.attrs.get("td__input")
+        general = self.attrs.get('input')
+        specific = self.attrs.get('td__input')
         attrs = AttributeDict(specific or general or {})
         return mark_safe(  # nosec: render_to_string below will handle escaping
             render_to_string(

--- a/corehq/apps/data_cleaning/columns.py
+++ b/corehq/apps/data_cleaning/columns.py
@@ -1,12 +1,12 @@
+from couchexport.writers import render_to_string
 from django_tables2.columns import (
-    TemplateColumn,
-    CheckBoxColumn,
     BoundColumn,
+    CheckBoxColumn,
+    TemplateColumn,
 )
 from django_tables2.utils import AttributeDict
 
 from corehq.toggles import mark_safe
-from couchexport.writers import render_to_string
 
 
 class EditableHtmxColumn(TemplateColumn):

--- a/corehq/apps/data_cleaning/decorators.py
+++ b/corehq/apps/data_cleaning/decorators.py
@@ -19,7 +19,7 @@ def require_bulk_data_cleaning_cases(view_func):
 
 def bulk_data_cleaning_enabled_for_request(request):
     if domain_has_privilege(request.domain, BULK_DATA_EDITING):
-        if hasattr(request, "couch_user"):
+        if hasattr(request, 'couch_user'):
             if request.couch_user.can_edit_data(request.domain):
                 return True
 

--- a/corehq/apps/data_cleaning/decorators.py
+++ b/corehq/apps/data_cleaning/decorators.py
@@ -1,4 +1,5 @@
 from functools import wraps
+
 from no_exceptions.exceptions import Http403
 
 from corehq.apps.accounting.utils import domain_has_privilege

--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -17,7 +17,6 @@ from corehq.apps.users.models import CouchUser
 
 
 class SessionPinnedFilterMixin(ABC):
-
     def __init__(self, session, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.session = session
@@ -30,7 +29,7 @@ class SessionPinnedFilterMixin(ABC):
         `BulkEditSession`
         :return: `PinnedFilterType`
         """
-        raise NotImplementedError("please specify a filter_type")
+        raise NotImplementedError('please specify a filter_type')
 
     @property
     @memoized
@@ -50,7 +49,7 @@ class SessionPinnedFilterMixin(ABC):
         :param pinned_filter: Instance of `BulkEditPinnedFilter`
         :return: `ESQuery` of the same type as `query`
         """
-        raise NotImplementedError("please implement `filter_query")
+        raise NotImplementedError('please implement `filter_query')
 
     @abstractmethod
     def get_value_for_db(self):
@@ -64,7 +63,7 @@ class SessionPinnedFilterMixin(ABC):
         :return: None if the value is the default value,
             otherwise a list of at least one value
         """
-        raise NotImplementedError("please implement get_value_for_db")
+        raise NotImplementedError('please implement get_value_for_db')
 
     def update_stored_value(self):
         value = self.get_value_for_db()
@@ -75,10 +74,10 @@ class SessionPinnedFilterMixin(ABC):
 
 
 class CaseOwnersPinnedFilter(SessionPinnedFilterMixin, CaseListFilter):
-    template = "data_cleaning/filters/pinned/multi_option.html"
-    placeholder = gettext_lazy("Please add case owners to filter the list of cases.")
+    template = 'data_cleaning/filters/pinned/multi_option.html'
+    placeholder = gettext_lazy('Please add case owners to filter the list of cases.')
     filter_type = PinnedFilterType.CASE_OWNERS
-    default_selections = [('all_data', gettext_lazy("[All Data]"))]
+    default_selections = [('all_data', gettext_lazy('[All Data]'))]
 
     @property
     def filter_context(self):
@@ -113,9 +112,7 @@ class CaseOwnersPinnedFilter(SessionPinnedFilterMixin, CaseListFilter):
         """
         couch_user = CouchUser.get_by_username(pinned_filter.session.user.username)
         domain = pinned_filter.session.domain
-        can_access_all_locations = couch_user.has_permission(
-            domain, 'access_all_locations'
-        )
+        can_access_all_locations = couch_user.has_permission(domain, 'access_all_locations')
         emwf_slugs = pinned_filter.value or cls._get_default_db_value()
 
         if can_access_all_locations and cls.show_all_data(emwf_slugs):
@@ -125,9 +122,7 @@ class CaseOwnersPinnedFilter(SessionPinnedFilterMixin, CaseListFilter):
         case_owner_filters = []
 
         if can_access_all_locations and cls.show_project_data(emwf_slugs):
-            case_owner_filters.append(
-                all_project_data_filter(domain, emwf_slugs)
-            )
+            case_owner_filters.append(all_project_data_filter(domain, emwf_slugs))
 
         if can_access_all_locations and cls.show_deactivated_data(emwf_slugs):
             case_owner_filters.append(deactivated_case_owners(domain))
@@ -138,9 +133,7 @@ class CaseOwnersPinnedFilter(SessionPinnedFilterMixin, CaseListFilter):
             or cls.selected_group_ids(emwf_slugs)
             or cls.selected_location_ids(emwf_slugs)
         ):
-            case_owners = get_case_owners(
-                can_access_all_locations, domain, emwf_slugs
-            )
+            case_owners = get_case_owners(can_access_all_locations, domain, emwf_slugs)
             if case_owners:
                 case_owner_filters.append(case_es.owner(case_owners))
 
@@ -149,14 +142,16 @@ class CaseOwnersPinnedFilter(SessionPinnedFilterMixin, CaseListFilter):
 
         if not can_access_all_locations:
             query = query_location_restricted_cases(
-                query, domain, couch_user,
+                query,
+                domain,
+                couch_user,
             )
 
         return query
 
 
 class CaseStatusPinnedFilter(SessionPinnedFilterMixin, SelectOpenCloseFilter):
-    template = "data_cleaning/filters/pinned/single_option.html"
+    template = 'data_cleaning/filters/pinned/single_option.html'
     filter_type = PinnedFilterType.CASE_STATUS
 
     @property
@@ -168,7 +163,7 @@ class CaseStatusPinnedFilter(SessionPinnedFilterMixin, SelectOpenCloseFilter):
     @property
     @memoized
     def selected(self):
-        return self.pinned_filter.value[0] if self.pinned_filter.value else ""
+        return self.pinned_filter.value[0] if self.pinned_filter.value else ''
 
     def get_value_for_db(self):
         value = self.get_value(self.request, self.domain)

--- a/corehq/apps/data_cleaning/filters.py
+++ b/corehq/apps/data_cleaning/filters.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
-from memoized import memoized
 
 from django.utils.translation import gettext_lazy
+from memoized import memoized
 
 from corehq.apps.data_cleaning.models import PinnedFilterType
 from corehq.apps.es import cases as case_es

--- a/corehq/apps/data_cleaning/forms/bulk_edit.py
+++ b/corehq/apps/data_cleaning/forms/bulk_edit.py
@@ -24,51 +24,49 @@ class EditSelectedRecordsForm(forms.Form):
     with the same id is invalid HTML. Additionally, this scenario will result in select2s being
     applied to only ONE field.
     """
+
     edit_prop_id = forms.ChoiceField(
-        label=gettext_lazy("Select a property to edit"),
+        label=gettext_lazy('Select a property to edit'),
         required=False,
         help_text=gettext_lazy(
-            "You can only select editable case properties that are currently visible in "
-            "the table as a column. System properties cannot be edited."
+            'You can only select editable case properties that are currently visible in '
+            'the table as a column. System properties cannot be edited.'
         ),
     )
     edit_action = forms.ChoiceField(
-        label=gettext_lazy("Edit action"),
+        label=gettext_lazy('Edit action'),
         widget=AlpineSelect,
         choices=EditActionType.CHOICES,
-        required=False
+        required=False,
     )
     find_string = forms.CharField(
-        label=gettext_lazy("Find:"),
+        label=gettext_lazy('Find:'),
         strip=False,
         required=False,
     )
     use_regex = forms.CharField(
-        label="",
+        label='',
         required=False,
         widget=BootstrapSwitchInput(
-            inline_label=gettext_lazy(
-                "Use regular expression"
-            ),
+            inline_label=gettext_lazy('Use regular expression'),
         ),
     )
     replace_string = forms.CharField(
-        label=gettext_lazy("Replace with:"),
+        label=gettext_lazy('Replace with:'),
         strip=False,
         required=False,
     )
     replace_all_string = forms.CharField(
-        label=gettext_lazy("Replace existing value with:"),
+        label=gettext_lazy('Replace existing value with:'),
         strip=False,
         required=False,
     )
     copy_from_prop_id = forms.ChoiceField(
-        label=gettext_lazy("Copy from property:"),
+        label=gettext_lazy('Copy from property:'),
         choices=(),
         required=False,
         help_text=gettext_lazy(
-            "The value from this property will replace the "
-            "value from the selected property at the top."
+            'The value from this property will replace the value from the selected property at the top.'
         ),
     )
 
@@ -87,14 +85,14 @@ class EditSelectedRecordsForm(forms.Form):
 
         initial_prop_id = self.data.get('edit_prop_id')
 
-        offcanvas_selector = "#offcanvas-bulk-changes"
+        offcanvas_selector = '#offcanvas-bulk-changes'
 
         alpine_data_model = {
-            "propId": initial_prop_id,
-            "editAction": self.data.get('edit_action', EditActionType.CHOICES[0][0]),
-            "replaceActions": [EditActionType.REPLACE],
-            "findActions": [EditActionType.FIND_REPLACE],
-            "copyActions": [EditActionType.COPY_REPLACE],
+            'propId': initial_prop_id,
+            'editAction': self.data.get('edit_action', EditActionType.CHOICES[0][0]),
+            'replaceActions': [EditActionType.REPLACE],
+            'findActions': [EditActionType.FIND_REPLACE],
+            'copyActions': [EditActionType.COPY_REPLACE],
         }
 
         self.helper = FormHelper()
@@ -103,63 +101,73 @@ class EditSelectedRecordsForm(forms.Form):
             crispy.Div(
                 crispy.Field(
                     'edit_prop_id',
-                    x_select2=json.dumps({
-                        "placeholder": _("Select a case property..."),
-                        "dropdownParent": offcanvas_selector,
-                    }),
-                    **({
-                        "@select2change": "propId = $event.detail;",
-                    })
+                    x_select2=json.dumps(
+                        {
+                            'placeholder': _('Select a case property...'),
+                            'dropdownParent': offcanvas_selector,
+                        }
+                    ),
+                    **(
+                        {
+                            '@select2change': 'propId = $event.detail;',
+                        }
+                    ),
                 ),
                 crispy.Div(
                     crispy.Field(
                         'edit_action',
-                        x_select2=json.dumps({
-                            "placeholder": _("Select an edit action..."),
-                            "dropdownParent": offcanvas_selector,
-                        }),
-                        **({
-                            "@select2change": "editAction = $event.detail;",
-                        })
+                        x_select2=json.dumps(
+                            {
+                                'placeholder': _('Select an edit action...'),
+                                'dropdownParent': offcanvas_selector,
+                            }
+                        ),
+                        **(
+                            {
+                                '@select2change': 'editAction = $event.detail;',
+                            }
+                        ),
                     ),
                     crispy.Div(
                         crispy.Div(
                             'replace_all_string',
-                            css_class="card-body",
+                            css_class='card-body',
                         ),
-                        x_show="replaceActions.includes(editAction)",
-                        css_class="card mb-3",
+                        x_show='replaceActions.includes(editAction)',
+                        css_class='card mb-3',
                     ),
                     crispy.Div(
                         crispy.Div(
                             'find_string',
                             hqcrispy.CheckboxField('use_regex'),
                             'replace_string',
-                            css_class="card-body",
+                            css_class='card-body',
                         ),
-                        x_show="findActions.includes(editAction)",
-                        css_class="card mb-3",
+                        x_show='findActions.includes(editAction)',
+                        css_class='card mb-3',
                     ),
                     crispy.Div(
                         crispy.Div(
                             crispy.Field(
                                 'copy_from_prop_id',
-                                x_select2=json.dumps({
-                                    "placeholder": _("Select a case property..."),
-                                    "dropdownParent": offcanvas_selector,
-                                }),
+                                x_select2=json.dumps(
+                                    {
+                                        'placeholder': _('Select a case property...'),
+                                        'dropdownParent': offcanvas_selector,
+                                    }
+                                ),
                             ),
-                            css_class="card-body",
+                            css_class='card-body',
                         ),
-                        x_show="copyActions.includes(editAction)",
-                        css_class="card mb-3",
+                        x_show='copyActions.includes(editAction)',
+                        css_class='card mb-3',
                     ),
                     twbscrispy.StrictButton(
-                        _("Preview Edits"),
-                        type="submit",
-                        css_class="btn-primary",
+                        _('Preview Edits'),
+                        type='submit',
+                        css_class='btn-primary',
                     ),
-                    x_show="propId",
+                    x_show='propId',
                 ),
                 x_data=json.dumps(alpine_data_model),
             )
@@ -167,69 +175,65 @@ class EditSelectedRecordsForm(forms.Form):
 
     def clean(self):
         cleaned_data = super().clean()
-        edit_action = cleaned_data.get("edit_action")
+        edit_action = cleaned_data.get('edit_action')
 
         if edit_action == EditActionType.REPLACE:
-            if not cleaned_data.get("replace_all_string"):
+            if not cleaned_data.get('replace_all_string'):
                 self.add_error(
-                    "replace_all_string",
-                    _(
-                        "Please specify a value you would like to replace the existing property value with."
-                    ),
+                    'replace_all_string',
+                    _('Please specify a value you would like to replace the existing property value with.'),
                 )
                 return cleaned_data
 
         if edit_action == EditActionType.FIND_REPLACE:
             # note: allow empty replace_string
 
-            find_string = cleaned_data.get("find_string")
+            find_string = cleaned_data.get('find_string')
             if not find_string:
-                self.add_error(
-                    "find_string", _("Please specify the value you would like to find.")
-                )
+                self.add_error('find_string', _('Please specify the value you would like to find.'))
                 return cleaned_data
 
-            use_regex = cleaned_data.get("use_regex")
+            use_regex = cleaned_data.get('use_regex')
             if use_regex:
                 try:
                     re.compile(find_string)
                 except re.error:
-                    self.add_error("find_string", _("Not a valid regular expression."))
+                    self.add_error('find_string', _('Not a valid regular expression.'))
                     return cleaned_data
 
         if edit_action == EditActionType.COPY_REPLACE:
-            copy_from_prop_id = cleaned_data.get("copy_from_prop_id")
+            copy_from_prop_id = cleaned_data.get('copy_from_prop_id')
             if not copy_from_prop_id:
                 self.add_error(
-                    "copy_from_prop_id",
-                    _("Please select a property to copy from."),
+                    'copy_from_prop_id',
+                    _('Please select a property to copy from.'),
                 )
                 return cleaned_data
-            if copy_from_prop_id == cleaned_data.get("edit_prop_id"):
+            if copy_from_prop_id == cleaned_data.get('edit_prop_id'):
                 self.add_error(
-                    "copy_from_prop_id",
-                    _("You cannot copy from the same property."),
+                    'copy_from_prop_id',
+                    _('You cannot copy from the same property.'),
                 )
                 return cleaned_data
 
         return cleaned_data
 
     def get_bulk_edit_change(self):
-        prop_id = self.cleaned_data["edit_prop_id"]
-        action_type = self.cleaned_data["edit_action"]
+        prop_id = self.cleaned_data['edit_prop_id']
+        action_type = self.cleaned_data['edit_action']
         if action_type == EditActionType.REPLACE:
             action_options = {
-                "replace_string": self.cleaned_data["replace_all_string"],
+                'replace_string': self.cleaned_data['replace_all_string'],
             }
         elif action_type == EditActionType.FIND_REPLACE:
             action_options = {
-                "find_string": self.cleaned_data["find_string"],
-                "replace_string": self.cleaned_data["replace_string"],
-                "use_regex": self.cleaned_data["use_regex"],
+                'find_string': self.cleaned_data['find_string'],
+                'replace_string': self.cleaned_data['replace_string'],
+                'use_regex': self.cleaned_data['use_regex'],
             }
         elif action_type == EditActionType.COPY_REPLACE:
             action_options = {
-                "copy_from_prop_id": self.cleaned_data["copy_from_prop_id"],
+                'copy_from_prop_id': self.cleaned_data['copy_from_prop_id'],
             }
         else:
             action_options = {}

--- a/corehq/apps/data_cleaning/forms/bulk_edit.py
+++ b/corehq/apps/data_cleaning/forms/bulk_edit.py
@@ -1,12 +1,12 @@
 import json
 import re
 
-from django import forms
-from django.utils.translation import gettext as _, gettext_lazy
-
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
+from django import forms
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from corehq.apps.data_cleaning.models import (
     BulkEditChange,

--- a/corehq/apps/data_cleaning/forms/columns.py
+++ b/corehq/apps/data_cleaning/forms/columns.py
@@ -26,19 +26,11 @@ class AddColumnForm(forms.Form):
     with the same id is invalid HTML. Additionally, this scenario will result in select2s being
     applied to only ONE field.
     """
-    column_prop_id = forms.ChoiceField(
-        label=gettext_lazy("Case Property"),
-        required=False
-    )
-    column_label = forms.CharField(
-        label=gettext_lazy("Label"),
-        required=False
-    )
+
+    column_prop_id = forms.ChoiceField(label=gettext_lazy('Case Property'), required=False)
+    column_label = forms.CharField(label=gettext_lazy('Label'), required=False)
     column_data_type = forms.ChoiceField(
-        label=gettext_lazy("Data Type"),
-        widget=AlpineSelect,
-        choices=DataType.CASE_CHOICES,
-        required=False
+        label=gettext_lazy('Data Type'), widget=AlpineSelect, choices=DataType.CASE_CHOICES, required=False
     )
 
     def __init__(self, session, *args, **kwargs):
@@ -52,27 +44,21 @@ class AddColumnForm(forms.Form):
         ]
 
         initial_prop_id = self.data.get('column_prop_id')
-        is_initial_editable = (
-            property_details[initial_prop_id]['is_editable'] if initial_prop_id else True
-        )
-        default_label = (
-            property_details[initial_prop_id]['label'] if initial_prop_id else ""
-        )
+        is_initial_editable = property_details[initial_prop_id]['is_editable'] if initial_prop_id else True
+        default_label = property_details[initial_prop_id]['label'] if initial_prop_id else ''
         initial_label = self.data.get('column_label', default_label)
 
-        offcanvas_selector = "#offcanvas-configure-columns"
+        offcanvas_selector = '#offcanvas-configure-columns'
 
         alpine_data_model = {
-            "propId": initial_prop_id,
-            "dataType": self.data.get(
-                'data_type', DataType.CASE_CHOICES[0][0]
-            ),
+            'propId': initial_prop_id,
+            'dataType': self.data.get('data_type', DataType.CASE_CHOICES[0][0]),
             'label': initial_label,
-            "casePropertyDetails": property_details,
-            "isEditable": is_initial_editable,
+            'casePropertyDetails': property_details,
+            'isEditable': is_initial_editable,
             # todo: for now, don't show data type to user since we don't use it in the table UI (yet)
             # we will implement this in the future, so we want to store it in the db
-            "isDataTypeVisible": False,
+            'isDataTypeVisible': False,
         }
 
         self.helper = FormHelper()
@@ -81,35 +67,39 @@ class AddColumnForm(forms.Form):
             crispy.Div(
                 crispy.Field(
                     'column_prop_id',
-                    x_select2=json.dumps({
-                        "placeholder": _("Select a Case Property"),
-                        "dropdownParent": offcanvas_selector,
-                    }),
-                    **({
-                        "@select2change": "propId = $event.detail; "
-                                          "dataType = casePropertyDetails[$event.detail].data_type; "
-                                          "label = casePropertyDetails[$event.detail].label; "
-                                          "isEditable = casePropertyDetails[$event.detail].is_editable;",
-                    })
+                    x_select2=json.dumps(
+                        {
+                            'placeholder': _('Select a Case Property'),
+                            'dropdownParent': offcanvas_selector,
+                        }
+                    ),
+                    **(
+                        {
+                            '@select2change': 'propId = $event.detail; '
+                            'dataType = casePropertyDetails[$event.detail].data_type; '
+                            'label = casePropertyDetails[$event.detail].label; '
+                            'isEditable = casePropertyDetails[$event.detail].is_editable;',
+                        }
+                    ),
                 ),
                 crispy.Div(
                     crispy.Field(
                         'column_label',
-                        x_model="label",
+                        x_model='label',
                     ),
                     crispy.Div(
                         crispy.Field(
                             'column_data_type',
-                            x_model="dataType",
+                            x_model='dataType',
                         ),
-                        x_show="isEditable && isDataTypeVisible",
+                        x_show='isEditable && isDataTypeVisible',
                     ),
                     twbscrispy.StrictButton(
-                        _("Add Column"),
-                        type="submit",
-                        css_class="btn-primary",
+                        _('Add Column'),
+                        type='submit',
+                        css_class='btn-primary',
                     ),
-                    x_show="propId",
+                    x_show='propId',
                 ),
                 x_data=json.dumps(alpine_data_model),
             )
@@ -118,21 +108,21 @@ class AddColumnForm(forms.Form):
     def clean_column_label(self):
         column_label = self.cleaned_data.get('column_label')
         if not column_label:
-            raise forms.ValidationError(_("Please specify a label for the column."))
+            raise forms.ValidationError(_('Please specify a label for the column.'))
         return column_label
 
     def clean_column_data_type(self):
         data_type = self.cleaned_data.get('column_data_type')
         if not data_type:
-            raise forms.ValidationError(_("Please specify a data type."))
+            raise forms.ValidationError(_('Please specify a data type.'))
         return data_type
 
     def clean_column_prop_id(self):
         prop_id = self.cleaned_data.get('column_prop_id')
         if not prop_id:
-            raise forms.ValidationError(_("Please specify a case property."))
+            raise forms.ValidationError(_('Please specify a case property.'))
         if prop_id in self.existing_columns:
-            raise forms.ValidationError(_("This case property is already a column."))
+            raise forms.ValidationError(_('This case property is already a column.'))
         return prop_id
 
     def clean(self):
@@ -146,9 +136,8 @@ class AddColumnForm(forms.Form):
                 self.add_error(
                     'column_data_type',
                     _("Incorrect data type for '{prop_id}', should be '{expected_data_type}'").format(
-                        prop_id=prop_id,
-                        expected_data_type=expected_data_type
-                    )
+                        prop_id=prop_id, expected_data_type=expected_data_type
+                    ),
                 )
         return cleaned_data
 
@@ -156,5 +145,5 @@ class AddColumnForm(forms.Form):
         self.session.add_column(
             self.cleaned_data['column_prop_id'],
             self.cleaned_data['column_label'],
-            self.cleaned_data['column_data_type']
+            self.cleaned_data['column_data_type'],
         )

--- a/corehq/apps/data_cleaning/forms/columns.py
+++ b/corehq/apps/data_cleaning/forms/columns.py
@@ -1,15 +1,15 @@
 import json
 
-from django import forms
-from django.utils.translation import gettext as _, gettext_lazy
-
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
+from django import forms
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from corehq.apps.data_cleaning.models import (
-    DataType,
     BulkEditColumn,
+    DataType,
 )
 from corehq.apps.data_cleaning.utils.cases import (
     get_case_property_details,

--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -34,62 +34,43 @@ class DynamicMultipleChoiceField(forms.MultipleChoiceField):
 
 
 class AddFilterForm(forms.Form):
-    prop_id = forms.ChoiceField(
-        label=gettext_lazy("Case Property"),
-        required=False
-    )
+    prop_id = forms.ChoiceField(label=gettext_lazy('Case Property'), required=False)
     data_type = forms.ChoiceField(
-        label=gettext_lazy("Data Type"),
-        widget=AlpineSelect,
-        choices=DataType.CASE_CHOICES,
-        required=False
+        label=gettext_lazy('Data Type'), widget=AlpineSelect, choices=DataType.CASE_CHOICES, required=False
     )
 
     text_match_type = forms.ChoiceField(
-        label=gettext_lazy("Match Type"),
+        label=gettext_lazy('Match Type'),
         choices=FilterMatchType.TEXT_CHOICES + FilterMatchType.ALL_DATA_TYPES_CHOICES,
-        required=False
+        required=False,
     )
-    text_value = forms.CharField(
-        label=gettext_lazy("Value"),
-        strip=False,
-        required=False
-    )
+    text_value = forms.CharField(label=gettext_lazy('Value'), strip=False, required=False)
 
     number_match_type = forms.ChoiceField(
-        label=gettext_lazy("Match Type"),
+        label=gettext_lazy('Match Type'),
         choices=FilterMatchType.NUMBER_CHOICES + FilterMatchType.ALL_DATA_TYPES_CHOICES,
-        required=False
+        required=False,
     )
     number_value = forms.CharField(
-        label=gettext_lazy("Value"),
+        label=gettext_lazy('Value'),
         required=False,
         widget=forms.NumberInput,
     )
 
     date_match_type = forms.ChoiceField(
-        label=gettext_lazy("Match Type"),
+        label=gettext_lazy('Match Type'),
         choices=FilterMatchType.DATE_CHOICES + FilterMatchType.ALL_DATA_TYPES_CHOICES,
-        required=False
+        required=False,
     )
-    date_value = forms.CharField(
-        label=gettext_lazy("Value"),
-        required=False
-    )
-    datetime_value = forms.CharField(
-        label=gettext_lazy("Value"),
-        required=False
-    )
+    date_value = forms.CharField(label=gettext_lazy('Value'), required=False)
+    datetime_value = forms.CharField(label=gettext_lazy('Value'), required=False)
 
     multi_select_match_type = forms.ChoiceField(
-        label=gettext_lazy("Match Type"),
+        label=gettext_lazy('Match Type'),
         choices=FilterMatchType.MULTI_SELECT_CHOICES + FilterMatchType.ALL_DATA_TYPES_CHOICES,
-        required=False
+        required=False,
     )
-    multi_select_value = DynamicMultipleChoiceField(
-        label=gettext_lazy("Value"),
-        required=False
-    )
+    multi_select_value = DynamicMultipleChoiceField(label=gettext_lazy('Value'), required=False)
 
     def __init__(self, session, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -101,48 +82,28 @@ class AddFilterForm(forms.Form):
         ]
 
         initial_prop_id = self.data.get('prop_id')
-        is_initial_editable = (
-            property_details[initial_prop_id]['is_editable'] if initial_prop_id else True
-        )
+        is_initial_editable = property_details[initial_prop_id]['is_editable'] if initial_prop_id else True
 
-        offcanvas_selector = "#offcanvas-filter"
+        offcanvas_selector = '#offcanvas-filter'
 
         alpine_data_model = {
-            "dataType": self.data.get(
-                'data_type', DataType.CASE_CHOICES[0][0]
-            ),
-            "propId": initial_prop_id,
-            "casePropertyDetails": property_details,
-            "isEditable": is_initial_editable,
-            "datetimeTypes": [DataType.DATETIME],
-            "dateTypes": [DataType.DATE],
-            "textDataTypes": DataType.FILTER_CATEGORY_DATA_TYPES[
-                DataType.FILTER_CATEGORY_TEXT
-            ],
-            "numberDataTypes": DataType.FILTER_CATEGORY_DATA_TYPES[
-                DataType.FILTER_CATEGORY_NUMBER
-            ],
-            "dateDataTypes": DataType.FILTER_CATEGORY_DATA_TYPES[
-                DataType.FILTER_CATEGORY_DATE
-            ],
-            "multiSelectDataTypes": DataType.FILTER_CATEGORY_DATA_TYPES[
-                DataType.FILTER_CATEGORY_MULTI_SELECT
-            ],
-            "textMatchType": self.data.get(
-                'text_match_type', FilterMatchType.TEXT_CHOICES[0][0]
-            ),
-            "numberMatchType": self.data.get(
-                'number_match_type', FilterMatchType.NUMBER_CHOICES[0][0]
-            ),
-            "dateMatchType": self.data.get(
-                'date_match_type', FilterMatchType.DATE_CHOICES[0][0]
-            ),
-            "multiSelectMatchType": self.data.get(
+            'dataType': self.data.get('data_type', DataType.CASE_CHOICES[0][0]),
+            'propId': initial_prop_id,
+            'casePropertyDetails': property_details,
+            'isEditable': is_initial_editable,
+            'datetimeTypes': [DataType.DATETIME],
+            'dateTypes': [DataType.DATE],
+            'textDataTypes': DataType.FILTER_CATEGORY_DATA_TYPES[DataType.FILTER_CATEGORY_TEXT],
+            'numberDataTypes': DataType.FILTER_CATEGORY_DATA_TYPES[DataType.FILTER_CATEGORY_NUMBER],
+            'dateDataTypes': DataType.FILTER_CATEGORY_DATA_TYPES[DataType.FILTER_CATEGORY_DATE],
+            'multiSelectDataTypes': DataType.FILTER_CATEGORY_DATA_TYPES[DataType.FILTER_CATEGORY_MULTI_SELECT],
+            'textMatchType': self.data.get('text_match_type', FilterMatchType.TEXT_CHOICES[0][0]),
+            'numberMatchType': self.data.get('number_match_type', FilterMatchType.NUMBER_CHOICES[0][0]),
+            'dateMatchType': self.data.get('date_match_type', FilterMatchType.DATE_CHOICES[0][0]),
+            'multiSelectMatchType': self.data.get(
                 'multi_select_match_type', FilterMatchType.MULTI_SELECT_CHOICES[0][0]
             ),
-            "matchTypesWithNoValue": [
-                f[0] for f in FilterMatchType.ALL_DATA_TYPES_CHOICES
-            ],
+            'matchTypesWithNoValue': [f[0] for f in FilterMatchType.ALL_DATA_TYPES_CHOICES],
         }
 
         self.helper = FormHelper()
@@ -151,71 +112,87 @@ class AddFilterForm(forms.Form):
             crispy.Div(
                 crispy.Field(
                     'prop_id',
-                    x_select2=json.dumps({
-                        "placeholder": _("Select a Case Property"),
-                        "dropdownParent": offcanvas_selector,
-                    }),
-                    **({
-                        "@select2change": "propId = $event.detail; "
-                                          "dataType = casePropertyDetails[$event.detail].data_type; "
-                                          "isEditable = casePropertyDetails[$event.detail].is_editable;",
-                    })
+                    x_select2=json.dumps(
+                        {
+                            'placeholder': _('Select a Case Property'),
+                            'dropdownParent': offcanvas_selector,
+                        }
+                    ),
+                    **(
+                        {
+                            '@select2change': 'propId = $event.detail; '
+                            'dataType = casePropertyDetails[$event.detail].data_type; '
+                            'isEditable = casePropertyDetails[$event.detail].is_editable;',
+                        }
+                    ),
                 ),
                 crispy.Div(
                     crispy.Div(
                         crispy.Field(
                             'data_type',
-                            x_model="dataType",
+                            x_model='dataType',
                         ),
-                        x_show="isEditable",
+                        x_show='isEditable',
                     ),
                     crispy.Div(
                         crispy.Field(
                             'text_match_type',
-                            x_select2=json.dumps({
-                                "dropdownParent": offcanvas_selector,
-                            }),
-                            **({
-                                "@select2change": "textMatchType = $event.detail",
-                            })
+                            x_select2=json.dumps(
+                                {
+                                    'dropdownParent': offcanvas_selector,
+                                }
+                            ),
+                            **(
+                                {
+                                    '@select2change': 'textMatchType = $event.detail',
+                                }
+                            ),
                         ),
                         crispy.Div(
                             crispy.Field(
                                 'text_value',
-                                autocomplete="off",
+                                autocomplete='off',
                             ),
-                            x_show="!matchTypesWithNoValue.includes(textMatchType)"
+                            x_show='!matchTypesWithNoValue.includes(textMatchType)',
                         ),
-                        x_show="textDataTypes.includes(dataType)",
+                        x_show='textDataTypes.includes(dataType)',
                     ),
                     crispy.Div(
                         crispy.Field(
                             'number_match_type',
-                            x_select2=json.dumps({
-                                "dropdownParent": offcanvas_selector,
-                            }),
-                            **({
-                                "@select2change": "numberMatchType = $event.detail",
-                            })
+                            x_select2=json.dumps(
+                                {
+                                    'dropdownParent': offcanvas_selector,
+                                }
+                            ),
+                            **(
+                                {
+                                    '@select2change': 'numberMatchType = $event.detail',
+                                }
+                            ),
                         ),
                         crispy.Div(
                             crispy.Field(
                                 'number_value',
-                                autocomplete="off",
+                                autocomplete='off',
                             ),
-                            x_show="!matchTypesWithNoValue.includes(numberMatchType)"
+                            x_show='!matchTypesWithNoValue.includes(numberMatchType)',
                         ),
-                        x_show="numberDataTypes.includes(dataType)",
+                        x_show='numberDataTypes.includes(dataType)',
                     ),
                     crispy.Div(
                         crispy.Field(
                             'date_match_type',
-                            x_select2=json.dumps({
-                                "dropdownParent": offcanvas_selector,
-                            }),
-                            **({
-                                "@select2change": "dateMatchType = $event.detail",
-                            })
+                            x_select2=json.dumps(
+                                {
+                                    'dropdownParent': offcanvas_selector,
+                                }
+                            ),
+                            **(
+                                {
+                                    '@select2change': 'dateMatchType = $event.detail',
+                                }
+                            ),
                         ),
                         crispy.Div(
                             twbscrispy.AppendedText(
@@ -223,13 +200,16 @@ class AddFilterForm(forms.Form):
                                 mark_safe(  # nosec: no user input
                                     '<i class="fa-solid fa-calendar-days"></i>'
                                 ),
-                                x_datepicker=json.dumps({
-                                    "container": offcanvas_selector,
-                                    "useInputGroup": True,
-                                }),
+                                x_datepicker=json.dumps(
+                                    {
+                                        'container': offcanvas_selector,
+                                        'useInputGroup': True,
+                                    }
+                                ),
                             ),
-                            x_show="!matchTypesWithNoValue.includes(dateMatchType) "
-                                   "&& dateTypes.includes(dataType)"
+                            x_show=(
+                                '!matchTypesWithNoValue.includes(dateMatchType) && dateTypes.includes(dataType)'
+                            ),
                         ),
                         crispy.Div(
                             twbscrispy.AppendedText(
@@ -237,51 +217,60 @@ class AddFilterForm(forms.Form):
                                 mark_safe(  # nosec: no user input
                                     '<i class="fcc fcc-fd-datetime"></i>'
                                 ),
-                                x_datepicker=json.dumps({
-                                    "datetime": True,
-                                    "container": offcanvas_selector,
-                                    "useInputGroup": True,
-                                }),
+                                x_datepicker=json.dumps(
+                                    {
+                                        'datetime': True,
+                                        'container': offcanvas_selector,
+                                        'useInputGroup': True,
+                                    }
+                                ),
                             ),
-                            x_show="!matchTypesWithNoValue.includes(dateMatchType) "
-                                   "&& datetimeTypes.includes(dataType)"
+                            x_show=(
+                                '!matchTypesWithNoValue.includes(dateMatchType) '
+                                '&& datetimeTypes.includes(dataType)',
+                            ),
                         ),
-                        x_show="dateDataTypes.includes(dataType)",
+                        x_show='dateDataTypes.includes(dataType)',
                     ),
                     crispy.Div(
                         crispy.Field(
                             'multi_select_match_type',
-                            x_select2=json.dumps({
-                                "dropdownParent": offcanvas_selector,
-                            }),
-                            **({
-                                "@select2change": "multiSelectMatchType = $event.detail",
-                            })
+                            x_select2=json.dumps(
+                                {
+                                    'dropdownParent': offcanvas_selector,
+                                }
+                            ),
+                            **(
+                                {
+                                    '@select2change': 'multiSelectMatchType = $event.detail',
+                                }
+                            ),
                         ),
                         crispy.Div(
                             crispy.Field(
                                 'multi_select_value',
-                                x_init="$watch("
-                                       "  'propId',"
-                                       "  value => $dispatch('updateAddFilterPropId', { value: value })"
-                                       ")",
-                                x_dynamic_options_select2=json.dumps({
-                                    "details": property_details,
-                                    "eventName": 'updateAddFilterPropId',
-                                    "initialPropId": initial_prop_id,
-                                }),
+                                x_init='$watch('
+                                "  'propId',"
+                                "  value => $dispatch('updateAddFilterPropId', { value: value })"
+                                ')',
+                                x_dynamic_options_select2=json.dumps(
+                                    {
+                                        'details': property_details,
+                                        'eventName': 'updateAddFilterPropId',
+                                        'initialPropId': initial_prop_id,
+                                    }
+                                ),
                             ),
-                            x_show="!matchTypesWithNoValue.includes(multiSelectMatchType)",
-
+                            x_show='!matchTypesWithNoValue.includes(multiSelectMatchType)',
                         ),
-                        x_show="multiSelectDataTypes.includes(dataType)",
+                        x_show='multiSelectDataTypes.includes(dataType)',
                     ),
                     twbscrispy.StrictButton(
-                        _("Add Filter"),
-                        type="submit",
-                        css_class="btn-primary",
+                        _('Add Filter'),
+                        type='submit',
+                        css_class='btn-primary',
                     ),
-                    x_show="propId",
+                    x_show='propId',
                 ),
                 x_data=json.dumps(alpine_data_model),
             ),
@@ -290,7 +279,7 @@ class AddFilterForm(forms.Form):
     def clean_prop_id(self):
         prop_id = self.cleaned_data['prop_id']
         if not prop_id:
-            raise forms.ValidationError(_("Please select a case property to filter on."))
+            raise forms.ValidationError(_('Please select a case property to filter on.'))
         return prop_id
 
     def clean_data_type(self):
@@ -301,7 +290,7 @@ class AddFilterForm(forms.Form):
         cleaned_data = super().clean()
         data_type = cleaned_data.get('data_type')
         if data_type is None:
-            self.add_error('data_type', _("Please specify a data type."))
+            self.add_error('data_type', _('Please specify a data type.'))
             return cleaned_data
 
         category = DataType.get_filter_category(data_type)
@@ -313,7 +302,7 @@ class AddFilterForm(forms.Form):
         }.get(category)
         if not clean_fn:
             # should never be reached unless a user manually edits the form
-            self.add_error('data_type', _("Unrecognized data type."))
+            self.add_error('data_type', _('Unrecognized data type.'))
             return cleaned_data
 
         return clean_fn(cleaned_data)
@@ -325,8 +314,10 @@ class AddFilterForm(forms.Form):
             try:
                 BulkEditFilter.get_quoted_value(value)
             except UnsupportedFilterValueException:
-                self.add_error('text_value', _("This value cannot contain both single quotes (') "
-                                               "and double quotes (\") at the same time."))
+                self.add_error(
+                    'text_value',
+                    _('This value cannot contain both single quotes (\') and double quotes (") at the same time.'),
+                )
         return self._save_to_cleaned_data(cleaned_data, match_type, value)
 
     def _clean_number_filter(self, cleaned_data):
@@ -337,7 +328,7 @@ class AddFilterForm(forms.Form):
                 # we currently do not differentiate between integer or decimal
                 float(value)
             except ValueError:
-                self.add_error('number_value', _("Not a valid number."))
+                self.add_error('number_value', _('Not a valid number.'))
         return self._save_to_cleaned_data(cleaned_data, match_type, value)
 
     def _clean_date_filter(self, cleaned_data):
@@ -349,16 +340,17 @@ class AddFilterForm(forms.Form):
         }.get(data_type)
         if not value_field_name:
             # we should never arrive here, but just in case
-            self.add_error('data_type', _("Unknown date type."))
+            self.add_error('data_type', _('Unknown date type.'))
             return cleaned_data
         value = self._clean_value_for_match_type(value_field_name, cleaned_data, match_type)
         valid_format, error_message = {
-            DataType.DATE: (
-                "%Y-%m-%d", _("Date format should be 'YYYY-MM-DD'")
-            ),
+            DataType.DATE: ('%Y-%m-%d', _("Date format should be 'YYYY-MM-DD'")),
             DataType.DATETIME: (
-                "%Y-%m-%d %H:%M:%S", _("Date and Time format should be 'YYYY-MM-DD HH:MM:SS', "
-                                       "where the hour is the 24-hour format, 00 to 23.")
+                '%Y-%m-%d %H:%M:%S',
+                _(
+                    "Date and Time format should be 'YYYY-MM-DD HH:MM:SS', "
+                    'where the hour is the 24-hour format, 00 to 23.'
+                ),
             ),
         }[data_type]
         if value is not None:
@@ -371,22 +363,24 @@ class AddFilterForm(forms.Form):
     def _clean_required_match_type(self, match_type_field_name, cleaned_data):
         match_type = cleaned_data.get(match_type_field_name)
         if not match_type:
-            self.add_error(match_type_field_name, _("Please select a match type."))
+            self.add_error(match_type_field_name, _('Please select a match type.'))
         return match_type
 
     def _clean_multi_select_filter(self, cleaned_data):
         match_type = self._clean_required_match_type('multi_select_match_type', cleaned_data)
         value = self._clean_value_for_match_type('multi_select_value', cleaned_data, match_type)
         if value is not None:
-            value = " ".join(value)
+            value = ' '.join(value)
         return self._save_to_cleaned_data(cleaned_data, match_type, value)
 
     def _clean_value_for_match_type(self, value_field_name, cleaned_data, match_type):
         is_value_required = match_type not in dict(FilterMatchType.ALL_DATA_TYPES_CHOICES)
         value = cleaned_data.get(value_field_name)
         if is_value_required and not value:
-            self.add_error(value_field_name, _("Please provide a value or use the "
-                                               "'empty' or 'missing' match types."))
+            self.add_error(
+                value_field_name,
+                _("Please provide a value or use the 'empty' or 'missing' match types."),
+            )
         return value if is_value_required else None
 
     def _save_to_cleaned_data(self, cleaned_data, match_type, value):
@@ -394,12 +388,11 @@ class AddFilterForm(forms.Form):
         cleaned_data['match_type'] = match_type
         cleaned_data['value'] = value
         # one last check
-        if not BulkEditFilter.is_data_and_match_type_valid(
-            match_type, data_type
-        ):
-            self.add_error('data_type', _("Data type '{}' cannot have match type '{}'.").format(
-                data_type, match_type
-            ))
+        if not BulkEditFilter.is_data_and_match_type_valid(match_type, data_type):
+            self.add_error(
+                'data_type',
+                _("Data type '{}' cannot have match type '{}'.").format(data_type, match_type),
+            )
         return cleaned_data
 
     def create_filter(self):
@@ -407,5 +400,5 @@ class AddFilterForm(forms.Form):
             self.cleaned_data['prop_id'],
             self.cleaned_data['data_type'],
             self.cleaned_data['match_type'],
-            self.cleaned_data['value']
+            self.cleaned_data['value'],
         )

--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -1,19 +1,19 @@
 import datetime
 import json
 
-from django import forms
-from django.utils.safestring import mark_safe
-from django.utils.translation import gettext as _, gettext_lazy
-
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
+from django import forms
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from corehq.apps.data_cleaning.exceptions import UnsupportedFilterValueException
 from corehq.apps.data_cleaning.models import (
+    BulkEditFilter,
     DataType,
     FilterMatchType,
-    BulkEditFilter,
 )
 from corehq.apps.data_cleaning.utils.cases import get_case_property_details
 from corehq.apps.hqwebapp.widgets import AlpineSelect

--- a/corehq/apps/data_cleaning/forms/start_session.py
+++ b/corehq/apps/data_cleaning/forms/start_session.py
@@ -13,39 +13,39 @@ from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain
 
 class SelectCaseTypeForm(forms.Form):
     case_type = forms.ChoiceField(
-        label=gettext_lazy("Case Type"),
+        label=gettext_lazy('Case Type'),
         required=False,
     )
 
     def __init__(self, domain, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.allowed_case_types = sorted(get_case_types_for_domain(domain))
-        self.fields['case_type'].choices = [(None, None)] + [
-            (c, c) for c in self.allowed_case_types
-        ]
+        self.fields['case_type'].choices = [(None, None)] + [(c, c) for c in self.allowed_case_types]
         self.helper = hqcrispy.HQFormHelper()
         self.helper.form_tag = False
         self.helper.layout = crispy.Layout(
             crispy.Field(
                 'case_type',
-                x_select2=json.dumps({
-                    "placeholder": _("Select a Case Type"),
-                }),
+                x_select2=json.dumps(
+                    {
+                        'placeholder': _('Select a Case Type'),
+                    }
+                ),
             ),
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
-                    _("Next"),
-                    type="submit",
-                    css_class="btn btn-primary",
+                    _('Next'),
+                    type='submit',
+                    css_class='btn btn-primary',
                 ),
-                css_class="mb-0"
+                css_class='mb-0',
             ),
         )
 
     def clean_case_type(self):
         case_type = self.cleaned_data['case_type']
         if not self.cleaned_data['case_type']:
-            raise forms.ValidationError(_("Please select a case type to continue."))
+            raise forms.ValidationError(_('Please select a case type to continue.'))
         if case_type not in self.allowed_case_types:
             raise forms.ValidationError(_("'{}' is not a valid case type").format(case_type))
         return case_type
@@ -53,16 +53,16 @@ class SelectCaseTypeForm(forms.Form):
 
 class ResumeOrRestartCaseSessionForm(forms.Form):
     case_type = forms.CharField(
-        label=gettext_lazy("Case Type"),
+        label=gettext_lazy('Case Type'),
         required=False,
     )
     next_step = forms.ChoiceField(
-        label=gettext_lazy("Next Step"),
+        label=gettext_lazy('Next Step'),
         required=False,
         widget=forms.RadioSelect,
         choices=(
-            ('resume', gettext_lazy("Resume the session.")),
-            ('new', gettext_lazy("Start a new session and delete the existing session.")),
+            ('resume', gettext_lazy('Resume the session.')),
+            ('new', gettext_lazy('Start a new session and delete the existing session.')),
         ),
     )
 
@@ -71,43 +71,41 @@ class ResumeOrRestartCaseSessionForm(forms.Form):
         self.allowed_case_types = sorted(get_case_types_for_domain(domain))
 
         alpine_data_model = {
-            "nextStep": self.data.get('next_step', 'resume'),
+            'nextStep': self.data.get('next_step', 'resume'),
         }
-        start_new_session = _("Start New Session")
-        resume_session = _("Resume Session")
+        start_new_session = _('Start New Session')
+        resume_session = _('Resume Session')
 
         self.helper = hqcrispy.HQFormHelper()
         self.helper.form_tag = False
         self.helper.layout = crispy.Layout(
             crispy.Div(
-                crispy.HTML(render_to_string(
-                    'data_cleaning/forms/partials/active_session_exists.html', {}
-                )),
+                crispy.HTML(render_to_string('data_cleaning/forms/partials/active_session_exists.html', {})),
                 crispy.Field(
                     'case_type',
-                    readonly="",
-                    css_class="form-control-plaintext",
+                    readonly='',
+                    css_class='form-control-plaintext',
                 ),
                 crispy.Field(
                     'next_step',
-                    x_model="nextStep",
+                    x_model='nextStep',
                 ),
                 hqcrispy.FormActions(
                     twbscrispy.StrictButton(
                         start_new_session,
-                        type="submit",
-                        css_class="btn btn-primary",
+                        type='submit',
+                        css_class='btn btn-primary',
                         x_text=f"(nextStep === 'new') ? '{start_new_session}' : '{resume_session}'",
                     ),
                     twbscrispy.StrictButton(
-                        _("Go Back"),
-                        type="button",
-                        css_class="btn btn-outline-primary",
+                        _('Go Back'),
+                        type='button',
+                        css_class='btn btn-outline-primary',
                         hx_get=cancel_url,
-                        hx_target=f"#{container_id}",
+                        hx_target=f'#{container_id}',
                         hx_disabled_elt='this',
                     ),
-                    css_class="mb-0"
+                    css_class='mb-0',
                 ),
                 x_data=json.dumps(alpine_data_model),
             ),

--- a/corehq/apps/data_cleaning/forms/start_session.py
+++ b/corehq/apps/data_cleaning/forms/start_session.py
@@ -1,9 +1,11 @@
 import json
 
-from crispy_forms import bootstrap as twbscrispy, layout as crispy
+from crispy_forms import bootstrap as twbscrispy
+from crispy_forms import layout as crispy
 from django import forms
 from django.template.loader import render_to_string
-from django.utils.translation import gettext_lazy, gettext as _
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain

--- a/corehq/apps/data_cleaning/models/__init__.py
+++ b/corehq/apps/data_cleaning/models/__init__.py
@@ -1,27 +1,26 @@
-from .types import (
-    BulkEditSessionType,
-    PinnedFilterType,
-    DataType,
-    FilterMatchType,
-    EditActionType,
+from .change import (
+    BulkEditChange,
 )
-from .session import (
-    BulkEditSession,
+from .column import (
+    BulkEditColumn,
 )
 from .filters import (
     BulkEditFilter,
     BulkEditPinnedFilter,
 )
-from .column import (
-    BulkEditColumn,
-)
 from .record import (
     BulkEditRecord,
 )
-from .change import (
-    BulkEditChange,
+from .session import (
+    BulkEditSession,
 )
-
+from .types import (
+    BulkEditSessionType,
+    DataType,
+    EditActionType,
+    FilterMatchType,
+    PinnedFilterType,
+)
 
 __all__ = [
     "BulkEditSessionType",

--- a/corehq/apps/data_cleaning/models/__init__.py
+++ b/corehq/apps/data_cleaning/models/__init__.py
@@ -23,15 +23,15 @@ from .types import (
 )
 
 __all__ = [
-    "BulkEditSessionType",
-    "PinnedFilterType",
-    "DataType",
-    "FilterMatchType",
-    "EditActionType",
-    "BulkEditSession",
-    "BulkEditFilter",
-    "BulkEditPinnedFilter",
-    "BulkEditColumn",
-    "BulkEditRecord",
-    "BulkEditChange",
+    'BulkEditSessionType',
+    'PinnedFilterType',
+    'DataType',
+    'FilterMatchType',
+    'EditActionType',
+    'BulkEditSession',
+    'BulkEditFilter',
+    'BulkEditPinnedFilter',
+    'BulkEditColumn',
+    'BulkEditRecord',
+    'BulkEditChange',
 ]

--- a/corehq/apps/data_cleaning/models/change.py
+++ b/corehq/apps/data_cleaning/models/change.py
@@ -4,8 +4,8 @@ import uuid
 from django.db import models, transaction
 from django.utils.translation import gettext as _
 
-from corehq.apps.data_cleaning.models.types import EditActionType
 from corehq.apps.data_cleaning.exceptions import UnsupportedActionException
+from corehq.apps.data_cleaning.models.types import EditActionType
 from corehq.apps.data_cleaning.utils.decorators import retry_on_integrity_error
 
 

--- a/corehq/apps/data_cleaning/models/change.py
+++ b/corehq/apps/data_cleaning/models/change.py
@@ -48,10 +48,10 @@ class BulkEditChangeManager(models.Manager):
 
 
 class BulkEditChange(models.Model):
-    session = models.ForeignKey("data_cleaning.BulkEditSession", related_name="changes", on_delete=models.CASCADE)
+    session = models.ForeignKey('data_cleaning.BulkEditSession', related_name='changes', on_delete=models.CASCADE)
     change_id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
     created_on = models.DateTimeField(auto_now_add=True, db_index=True)
-    records = models.ManyToManyField("data_cleaning.BulkEditRecord", related_name="changes")
+    records = models.ManyToManyField('data_cleaning.BulkEditRecord', related_name='changes')
     prop_id = models.CharField(max_length=255)  # case property or form question_id
     action_type = models.CharField(
         max_length=12,
@@ -65,14 +65,14 @@ class BulkEditChange(models.Model):
     objects = BulkEditChangeManager()
 
     class Meta:
-        ordering = ["created_on"]
+        ordering = ['created_on']
 
     @property
     def action_title(self):
         """
         Returns a human-readable title of the action.
         """
-        return dict(EditActionType.CHOICES).get(self.action_type, _("Unknown action"))
+        return dict(EditActionType.CHOICES).get(self.action_type, _('Unknown action'))
 
     @property
     def action_detail(self):
@@ -88,13 +88,13 @@ class BulkEditChange(models.Model):
             return _('"{find_string}" with "{replace_string}"{use_regex}.').format(
                 find_string=self.find_string,
                 replace_string=self.replace_string,
-                use_regex=_(" (using regex)") if self.use_regex else "",
+                use_regex=_(' (using regex)') if self.use_regex else '',
             )
         elif self.action_type == EditActionType.COPY_REPLACE:
             return _('from case property "{copy_from_prop_id}".').format(
                 copy_from_prop_id=self.copy_from_prop_id,
             )
-        return ""
+        return ''
 
     @property
     def num_records(self):
@@ -111,7 +111,7 @@ class BulkEditChange(models.Model):
 
         simple_transformations = {
             EditActionType.REPLACE: lambda x: self.replace_string,
-            EditActionType.MAKE_EMPTY: lambda x: "",
+            EditActionType.MAKE_EMPTY: lambda x: '',
             EditActionType.MAKE_NULL: lambda x: None,
         }
 
@@ -119,9 +119,7 @@ class BulkEditChange(models.Model):
             return simple_transformations[self.action_type](old_value)
 
         if self.action_type == EditActionType.COPY_REPLACE:
-            return edited_properties.get(
-                self.copy_from_prop_id, case.get_case_property(self.copy_from_prop_id)
-            )
+            return edited_properties.get(self.copy_from_prop_id, case.get_case_property(self.copy_from_prop_id))
 
         if self.action_type == EditActionType.RESET:
             return case.get_case_property(self.prop_id)
@@ -136,9 +134,7 @@ class BulkEditChange(models.Model):
         old_value = str(old_value)
 
         string_regex_transformations = {
-            EditActionType.FIND_REPLACE: lambda x: re.sub(
-                re.compile(self.find_string), self.replace_string, x
-            ),
+            EditActionType.FIND_REPLACE: lambda x: re.sub(re.compile(self.find_string), self.replace_string, x),
         }
         if self.use_regex and self.action_type in string_regex_transformations:
             return string_regex_transformations[self.action_type](old_value)
@@ -153,4 +149,4 @@ class BulkEditChange(models.Model):
         if self.action_type in string_transformations:
             return string_transformations[self.action_type](old_value)
 
-        raise UnsupportedActionException(f"edited_value did not recognize action_type {self.action_type}")
+        raise UnsupportedActionException(f'edited_value did not recognize action_type {self.action_type}')

--- a/corehq/apps/data_cleaning/models/column.py
+++ b/corehq/apps/data_cleaning/models/column.py
@@ -15,18 +15,23 @@ class BulkEditColumnManager(models.Manager):
     def create_session_defaults(self, session):
         default_properties = {
             BulkEditSessionType.CASE: (
-                'name', 'owner_name', 'date_opened', 'opened_by_username',
-                'last_modified', '@status',
+                'name',
+                'owner_name',
+                'date_opened',
+                'opened_by_username',
+                'last_modified',
+                '@status',
             ),
         }.get(session.session_type)
 
         if not default_properties:
-            raise NotImplementedError(f"{session.session_type} default columns not yet supported")
+            raise NotImplementedError(f'{session.session_type} default columns not yet supported')
 
         from corehq.apps.data_cleaning.utils.cases import (
-            get_system_property_label,
             get_system_property_data_type,
+            get_system_property_label,
         )
+
         for index, prop_id in enumerate(default_properties):
             self.create(
                 session=session,
@@ -51,6 +56,7 @@ class BulkEditColumnManager(models.Manager):
     def create_for_session(self, session, prop_id, label, data_type=None):
         is_system_property = self.model.is_system_property(prop_id)
         from corehq.apps.data_cleaning.utils.cases import get_system_property_data_type
+
         data_type = get_system_property_data_type(prop_id) if is_system_property else data_type
         return self.create(
             session=session,
@@ -63,7 +69,7 @@ class BulkEditColumnManager(models.Manager):
 
 
 class BulkEditColumn(models.Model):
-    session = models.ForeignKey("data_cleaning.BulkEditSession", related_name="columns", on_delete=models.CASCADE)
+    session = models.ForeignKey('data_cleaning.BulkEditSession', related_name='columns', on_delete=models.CASCADE)
     column_id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True, db_index=True)
     index = models.IntegerField(default=0)
     prop_id = models.CharField(max_length=255)  # case property or form question_id
@@ -78,24 +84,28 @@ class BulkEditColumn(models.Model):
     objects = BulkEditColumnManager()
 
     class Meta:
-        ordering = ["index"]
+        ordering = ['index']
 
     @staticmethod
     def is_system_property(prop_id):
-        return prop_id in set(METADATA_IN_REPORTS).difference({
-            'name', 'case_name', 'external_id',
-        })
+        return prop_id in set(METADATA_IN_REPORTS).difference(
+            {
+                'name',
+                'case_name',
+                'external_id',
+            }
+        )
 
     @property
     def slug(self):
         """
         Returns a slugified version of the prop_id.
         """
-        return self.prop_id.replace("@", "")
+        return self.prop_id.replace('@', '')
 
     @property
     def choice_label(self):
         """
         Returns the human-readable option visible in a select field.
         """
-        return self.label if self.label == self.prop_id else f"{self.label} ({self.prop_id})"
+        return self.label if self.label == self.prop_id else f'{self.label} ({self.prop_id})'

--- a/corehq/apps/data_cleaning/models/column.py
+++ b/corehq/apps/data_cleaning/models/column.py
@@ -2,11 +2,11 @@ import uuid
 
 from django.db import models
 
+from corehq.apps.case_search.const import METADATA_IN_REPORTS
 from corehq.apps.data_cleaning.models.types import (
     BulkEditSessionType,
     DataType,
 )
-from corehq.apps.case_search.const import METADATA_IN_REPORTS
 
 
 class BulkEditColumnManager(models.Manager):

--- a/corehq/apps/data_cleaning/models/filters.py
+++ b/corehq/apps/data_cleaning/models/filters.py
@@ -4,13 +4,13 @@ from django.contrib.postgres.fields import ArrayField
 from django.db import models, transaction
 from django.utils.translation import gettext as _
 
+from corehq.apps.data_cleaning.exceptions import UnsupportedFilterValueException
 from corehq.apps.data_cleaning.models.types import (
     BulkEditSessionType,
     DataType,
     FilterMatchType,
     PinnedFilterType,
 )
-from corehq.apps.data_cleaning.exceptions import UnsupportedFilterValueException
 from corehq.apps.data_cleaning.utils.decorators import retry_on_integrity_error
 from corehq.apps.es.case_search import (
     case_property_missing,

--- a/corehq/apps/data_cleaning/models/filters.py
+++ b/corehq/apps/data_cleaning/models/filters.py
@@ -42,7 +42,7 @@ class BulkEditFilterManager(models.Manager):
             if column_xpath is not None:
                 xpath_expressions.append(column_xpath)
         if xpath_expressions:
-            query = query.xpath_query(session.domain, " and ".join(xpath_expressions))
+            query = query.xpath_query(session.domain, ' and '.join(xpath_expressions))
         return query
 
     def copy_to_session(self, source_session, dest_session):
@@ -58,7 +58,7 @@ class BulkEditFilterManager(models.Manager):
 
 
 class BulkEditFilter(models.Model):
-    session = models.ForeignKey("data_cleaning.BulkEditSession", related_name="filters", on_delete=models.CASCADE)
+    session = models.ForeignKey('data_cleaning.BulkEditSession', related_name='filters', on_delete=models.CASCADE)
     filter_id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True, db_index=True)
     index = models.IntegerField(default=0)
     prop_id = models.CharField(max_length=255)  # case property or form question_id
@@ -77,7 +77,7 @@ class BulkEditFilter(models.Model):
     objects = BulkEditFilterManager()
 
     class Meta:
-        ordering = ["index"]
+        ordering = ['index']
 
     @property
     def human_readable_match_type(self):
@@ -96,7 +96,7 @@ class BulkEditFilter(models.Model):
                 FilterMatchType.MULTI_SELECT_CHOICES + FilterMatchType.ALL_DATA_TYPES_CHOICES
             ),
         }.get(category, {})
-        return match_to_text.get(self.match_type, _("unknown"))
+        return match_to_text.get(self.match_type, _('unknown'))
 
     def filter_query(self, query):
         filter_query_functions = {
@@ -168,7 +168,7 @@ class BulkEditFilter(models.Model):
             is_number = self.data_type in DataType.FILTER_CATEGORY_DATA_TYPES[DataType.FILTER_CATEGORY_NUMBER]
             value = self.value if is_number else self.get_quoted_value(self.value)
             operator = match_operators[self.match_type]
-            return f"{self.prop_id} {operator} {value}"
+            return f'{self.prop_id} {operator} {value}'
 
         match_expression = {
             FilterMatchType.STARTS: lambda x: f'starts-with({self.prop_id}, {x})',
@@ -196,7 +196,7 @@ class BulkEditPinnedFilterManager(models.Manager):
         }.get(session.session_type)
 
         if not default_types:
-            raise NotImplementedError(f"{session.session_type} default pinned filters not yet supported")
+            raise NotImplementedError(f'{session.session_type} default pinned filters not yet supported')
 
         for index, filter_type in enumerate(default_types):
             self.create(
@@ -222,7 +222,7 @@ class BulkEditPinnedFilterManager(models.Manager):
 
 class BulkEditPinnedFilter(models.Model):
     session = models.ForeignKey(
-        "data_cleaning.BulkEditSession", related_name="pinned_filters", on_delete=models.CASCADE
+        'data_cleaning.BulkEditSession', related_name='pinned_filters', on_delete=models.CASCADE
     )
     index = models.IntegerField(default=0)
     filter_type = models.CharField(
@@ -238,13 +238,14 @@ class BulkEditPinnedFilter(models.Model):
     objects = BulkEditPinnedFilterManager()
 
     class Meta:
-        ordering = ["index"]
+        ordering = ['index']
 
     def get_report_filter_class(self):
         from corehq.apps.data_cleaning.filters import (
             CaseOwnersPinnedFilter,
             CaseStatusPinnedFilter,
         )
+
         return {
             PinnedFilterType.CASE_OWNERS: CaseOwnersPinnedFilter,
             PinnedFilterType.CASE_STATUS: CaseStatusPinnedFilter,

--- a/corehq/apps/data_cleaning/models/session.py
+++ b/corehq/apps/data_cleaning/models/session.py
@@ -1,13 +1,12 @@
 import uuid
 
+from dimagi.utils.chunked import chunked
 from django.contrib.auth.models import User
 from django.db import models, transaction
 
 from corehq.apps.data_cleaning.models.types import (
     BulkEditSessionType,
 )
-from dimagi.utils.chunked import chunked
-
 from corehq.apps.data_cleaning.utils.decorators import retry_on_integrity_error
 from corehq.apps.es import CaseSearchES
 

--- a/corehq/apps/data_cleaning/models/types.py
+++ b/corehq/apps/data_cleaning/models/types.py
@@ -5,8 +5,8 @@ class BulkEditSessionType:
     CASE = 'case'
     FORM = 'form'
     CHOICES = (
-        (CASE, "Case"),
-        (FORM, "Form"),
+        (CASE, 'Case'),
+        (FORM, 'Form'),
     )
 
 
@@ -19,9 +19,7 @@ class PinnedFilterType:
         (CASE_STATUS, CASE_STATUS),
     )
 
-    DEFAULT_FOR_CASE = (
-        CASE_OWNERS, CASE_STATUS
-    )
+    DEFAULT_FOR_CASE = (CASE_OWNERS, CASE_STATUS)
 
 
 class DataType:
@@ -54,30 +52,30 @@ class DataType:
     )
 
     FORM_CHOICES = (
-        (TEXT, gettext_lazy("Text")),
-        (INTEGER, gettext_lazy("Integer")),
-        (DECIMAL, gettext_lazy("Decimal")),
-        (PHONE_NUMBER, gettext_lazy("Phone Number or Numeric ID")),
-        (DATE, gettext_lazy("Date")),
-        (TIME, gettext_lazy("Time")),
-        (DATETIME, gettext_lazy("Date and Time")),
-        (SINGLE_OPTION, gettext_lazy("Single Option")),
-        (MULTIPLE_OPTION, gettext_lazy("Multiple Option")),
-        (GPS, gettext_lazy("GPS")),
-        (BARCODE, gettext_lazy("Barcode")),
-        (PASSWORD, gettext_lazy("Password")),
+        (TEXT, gettext_lazy('Text')),
+        (INTEGER, gettext_lazy('Integer')),
+        (DECIMAL, gettext_lazy('Decimal')),
+        (PHONE_NUMBER, gettext_lazy('Phone Number or Numeric ID')),
+        (DATE, gettext_lazy('Date')),
+        (TIME, gettext_lazy('Time')),
+        (DATETIME, gettext_lazy('Date and Time')),
+        (SINGLE_OPTION, gettext_lazy('Single Option')),
+        (MULTIPLE_OPTION, gettext_lazy('Multiple Option')),
+        (GPS, gettext_lazy('GPS')),
+        (BARCODE, gettext_lazy('Barcode')),
+        (PASSWORD, gettext_lazy('Password')),
     )
 
     CASE_CHOICES = (
-        (TEXT, gettext_lazy("Text")),
-        (INTEGER, gettext_lazy("Number")),
-        (DATE, gettext_lazy("Date")),
-        (DATETIME, gettext_lazy("Date and Time")),
-        (MULTIPLE_OPTION, gettext_lazy("Multiple Choice")),
-        (BARCODE, gettext_lazy("Barcode")),
-        (GPS, gettext_lazy("GPS")),
-        (PHONE_NUMBER, gettext_lazy("Phone Number or Numeric ID")),
-        (PASSWORD, gettext_lazy("Password")),
+        (TEXT, gettext_lazy('Text')),
+        (INTEGER, gettext_lazy('Number')),
+        (DATE, gettext_lazy('Date')),
+        (DATETIME, gettext_lazy('Date and Time')),
+        (MULTIPLE_OPTION, gettext_lazy('Multiple Choice')),
+        (BARCODE, gettext_lazy('Barcode')),
+        (GPS, gettext_lazy('GPS')),
+        (PHONE_NUMBER, gettext_lazy('Phone Number or Numeric ID')),
+        (PASSWORD, gettext_lazy('Password')),
     )
 
     FILTER_CATEGORY_TEXT = 'filter_text'
@@ -86,9 +84,23 @@ class DataType:
     FILTER_CATEGORY_MULTI_SELECT = 'filter_multi_select'
 
     FILTER_CATEGORY_DATA_TYPES = {
-        FILTER_CATEGORY_TEXT: (TEXT, PHONE_NUMBER, BARCODE, PASSWORD, GPS, SINGLE_OPTION, TIME,),
-        FILTER_CATEGORY_NUMBER: (INTEGER, DECIMAL,),
-        FILTER_CATEGORY_DATE: (DATE, DATETIME,),
+        FILTER_CATEGORY_TEXT: (
+            TEXT,
+            PHONE_NUMBER,
+            BARCODE,
+            PASSWORD,
+            GPS,
+            SINGLE_OPTION,
+            TIME,
+        ),
+        FILTER_CATEGORY_NUMBER: (
+            INTEGER,
+            DECIMAL,
+        ),
+        FILTER_CATEGORY_DATE: (
+            DATE,
+            DATETIME,
+        ),
         FILTER_CATEGORY_MULTI_SELECT: (MULTIPLE_OPTION,),
     }
 
@@ -115,35 +127,35 @@ class DataType:
 
 
 class FilterMatchType:
-    EXACT = "exact"
-    IS_NOT = "is_not"
+    EXACT = 'exact'
+    IS_NOT = 'is_not'
 
-    STARTS = "starts"
-    STARTS_NOT = "starts_not"
+    STARTS = 'starts'
+    STARTS_NOT = 'starts_not'
 
-    IS_EMPTY = "is_empty"  # empty string
-    IS_NOT_EMPTY = "is_not_empty"
+    IS_EMPTY = 'is_empty'  # empty string
+    IS_NOT_EMPTY = 'is_not_empty'
 
-    IS_MISSING = "missing"  # un-set
-    IS_NOT_MISSING = "not_missing"
+    IS_MISSING = 'missing'  # un-set
+    IS_NOT_MISSING = 'not_missing'
 
-    FUZZY = "fuzzy"  # will use fuzzy-match from CQL
-    FUZZY_NOT = "not_fuzzy"  # will use not(fuzzy-match()) from CQL
+    FUZZY = 'fuzzy'  # will use fuzzy-match from CQL
+    FUZZY_NOT = 'not_fuzzy'  # will use not(fuzzy-match()) from CQL
 
-    PHONETIC = "phonetic"  # will use phonetic-match from CQL
-    PHONETIC_NOT = "not_phonetic"  # will use not(phonetic-match()) from CQL
+    PHONETIC = 'phonetic'  # will use phonetic-match from CQL
+    PHONETIC_NOT = 'not_phonetic'  # will use not(phonetic-match()) from CQL
 
-    LESS_THAN = "lt"
-    GREATER_THAN = "gt"
+    LESS_THAN = 'lt'
+    GREATER_THAN = 'gt'
 
-    LESS_THAN_EQUAL = "lte"
-    GREATER_THAN_EQUAL = "gte"
+    LESS_THAN_EQUAL = 'lte'
+    GREATER_THAN_EQUAL = 'gte'
 
-    IS_ANY = "is_any"  # we will use selected-any from CQL
-    IS_NOT_ANY = "is_not_any"  # we will use not(selected-any()) from CQL
+    IS_ANY = 'is_any'  # we will use selected-any from CQL
+    IS_NOT_ANY = 'is_not_any'  # we will use not(selected-any()) from CQL
 
-    IS_ALL = "is_all"  # we will use selected-all from CQL
-    IS_NOT_ALL = "is_not_all"  # we will use not(selected-all()) from CQL
+    IS_ALL = 'is_all'  # we will use selected-all from CQL
+    IS_NOT_ALL = 'is_not_all'  # we will use not(selected-all()) from CQL
 
     ALL_CHOICES = (
         (EXACT, EXACT),
@@ -170,45 +182,45 @@ class FilterMatchType:
 
     # choices valid for all data types
     ALL_DATA_TYPES_CHOICES = (
-        (IS_EMPTY, gettext_lazy("is empty")),
-        (IS_NOT_EMPTY, gettext_lazy("is not empty")),
-        (IS_MISSING, gettext_lazy("is missing")),
-        (IS_NOT_MISSING, gettext_lazy("is not missing")),
+        (IS_EMPTY, gettext_lazy('is empty')),
+        (IS_NOT_EMPTY, gettext_lazy('is not empty')),
+        (IS_MISSING, gettext_lazy('is missing')),
+        (IS_NOT_MISSING, gettext_lazy('is not missing')),
     )
 
     TEXT_CHOICES = (
-        (EXACT, gettext_lazy("is exactly")),
-        (IS_NOT, gettext_lazy("is not")),
-        (STARTS, gettext_lazy("starts with")),
-        (STARTS_NOT, gettext_lazy("does not start with")),
-        (FUZZY, gettext_lazy("is like")),
-        (FUZZY_NOT, gettext_lazy("is not like")),
-        (PHONETIC, gettext_lazy("sounds like")),
-        (PHONETIC_NOT, gettext_lazy("does not sound like")),
+        (EXACT, gettext_lazy('is exactly')),
+        (IS_NOT, gettext_lazy('is not')),
+        (STARTS, gettext_lazy('starts with')),
+        (STARTS_NOT, gettext_lazy('does not start with')),
+        (FUZZY, gettext_lazy('is like')),
+        (FUZZY_NOT, gettext_lazy('is not like')),
+        (PHONETIC, gettext_lazy('sounds like')),
+        (PHONETIC_NOT, gettext_lazy('does not sound like')),
     )
 
     MULTI_SELECT_CHOICES = (
-        (IS_ANY, gettext_lazy("is any")),
-        (IS_NOT_ANY, gettext_lazy("is not any")),
-        (IS_ALL, gettext_lazy("is all")),
-        (IS_NOT_ALL, gettext_lazy("is not all")),
+        (IS_ANY, gettext_lazy('is any')),
+        (IS_NOT_ANY, gettext_lazy('is not any')),
+        (IS_ALL, gettext_lazy('is all')),
+        (IS_NOT_ALL, gettext_lazy('is not all')),
     )
 
     NUMBER_CHOICES = (
-        (EXACT, gettext_lazy("equals")),
-        (IS_NOT, gettext_lazy("does not equal")),
-        (LESS_THAN, gettext_lazy("less than")),
-        (LESS_THAN_EQUAL, gettext_lazy("less than or equal to")),
-        (GREATER_THAN, gettext_lazy("greater than")),
-        (GREATER_THAN_EQUAL, gettext_lazy("greater than or equal to")),
+        (EXACT, gettext_lazy('equals')),
+        (IS_NOT, gettext_lazy('does not equal')),
+        (LESS_THAN, gettext_lazy('less than')),
+        (LESS_THAN_EQUAL, gettext_lazy('less than or equal to')),
+        (GREATER_THAN, gettext_lazy('greater than')),
+        (GREATER_THAN_EQUAL, gettext_lazy('greater than or equal to')),
     )
 
     DATE_CHOICES = (
-        (EXACT, gettext_lazy("on")),
-        (LESS_THAN, gettext_lazy("before")),
-        (LESS_THAN_EQUAL, gettext_lazy("before or on")),
-        (GREATER_THAN, gettext_lazy("after")),
-        (GREATER_THAN_EQUAL, gettext_lazy("on or after")),
+        (EXACT, gettext_lazy('on')),
+        (LESS_THAN, gettext_lazy('before')),
+        (LESS_THAN_EQUAL, gettext_lazy('before or on')),
+        (GREATER_THAN, gettext_lazy('after')),
+        (GREATER_THAN_EQUAL, gettext_lazy('on or after')),
     )
 
 
@@ -238,14 +250,14 @@ class EditActionType:
     )
 
     CHOICES = (
-        (REPLACE, gettext_lazy("Replace")),
-        (FIND_REPLACE, gettext_lazy("Find & Replace")),
-        (COPY_REPLACE, gettext_lazy("Copy & Replace")),
-        (STRIP, gettext_lazy("Strip Whitespaces")),
-        (TITLE_CASE, gettext_lazy("Make Title Case")),
-        (UPPER_CASE, gettext_lazy("Make Upper Case")),
-        (LOWER_CASE, gettext_lazy("Make Lower Case")),
-        (MAKE_EMPTY, gettext_lazy("Make Value Empty")),
-        (MAKE_NULL, gettext_lazy("Make Value NULL")),
-        (RESET, gettext_lazy("Reset Changes")),
+        (REPLACE, gettext_lazy('Replace')),
+        (FIND_REPLACE, gettext_lazy('Find & Replace')),
+        (COPY_REPLACE, gettext_lazy('Copy & Replace')),
+        (STRIP, gettext_lazy('Strip Whitespaces')),
+        (TITLE_CASE, gettext_lazy('Make Title Case')),
+        (UPPER_CASE, gettext_lazy('Make Upper Case')),
+        (LOWER_CASE, gettext_lazy('Make Lower Case')),
+        (MAKE_EMPTY, gettext_lazy('Make Value Empty')),
+        (MAKE_NULL, gettext_lazy('Make Value NULL')),
+        (RESET, gettext_lazy('Reset Changes')),
     )

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -1,7 +1,6 @@
-from memoized import memoized
-
 from django.utils.translation import gettext_lazy
 from django_tables2 import columns, tables
+from memoized import memoized
 
 from corehq.apps.data_cleaning.columns import (
     EditableHtmxColumn,

--- a/corehq/apps/data_cleaning/tables.py
+++ b/corehq/apps/data_cleaning/tables.py
@@ -21,13 +21,13 @@ class EditCasesTable(BaseHtmxTable, ElasticTable):
     max_recorded_limit = MAX_RECORDED_LIMIT
 
     class Meta(BaseHtmxTable.Meta):
-        template_name = "data_cleaning/tables/bulk_edit_session.html"
+        template_name = 'data_cleaning/tables/bulk_edit_session.html'
         attrs = {
-            "class": "table table-striped align-middle",
+            'class': 'table table-striped align-middle',
         }
         row_attrs = {
-            "x-data": "{ isRowSelected: $el.querySelector('input[type=checkbox]').checked }",
-            ":class": "{ 'table-primary': isRowSelected }",
+            'x-data': "{ isRowSelected: $el.querySelector('input[type=checkbox]').checked }",
+            ':class': "{ 'table-primary': isRowSelected }",
         }
 
     def __init__(self, session=None, **kwargs):
@@ -37,25 +37,29 @@ class EditCasesTable(BaseHtmxTable, ElasticTable):
     @classmethod
     def get_select_column(cls, session, request, select_record_action, select_page_action):
         return SelectableHtmxColumn(
-            session, request, select_record_action, select_page_action, accessor="case_id",
+            session,
+            request,
+            select_record_action,
+            select_page_action,
+            accessor='case_id',
             attrs={
                 'td__input': {
                     # `pageNumRecordsSelected` defined in template
-                    "x-init": "if($el.checked) { pageNumRecordsSelected++; }",
-                    "@click": (
-                        "if ($el.checked !== isRowSelected) {"
+                    'x-init': 'if($el.checked) { pageNumRecordsSelected++; }',
+                    '@click': (
+                        'if ($el.checked !== isRowSelected) {'
                         # `numRecordsSelected` defined in template
-                        "  $el.checked ? numRecordsSelected++ : numRecordsSelected--;"
+                        '  $el.checked ? numRecordsSelected++ : numRecordsSelected--;'
                         # `pageNumRecordsSelected` defined in template
-                        "  $el.checked ? pageNumRecordsSelected++ : pageNumRecordsSelected--; "
-                        "} "
+                        '  $el.checked ? pageNumRecordsSelected++ : pageNumRecordsSelected--; '
+                        '} '
                         # `isRowSelected` defined in `row_attrs` in `class Meta`
-                        "isRowSelected = $el.checked;"
+                        'isRowSelected = $el.checked;'
                     ),
                 },
                 'th__input': {
                     # `pageNumRecordsSelected`, `pageTotalRecords`: defined in template
-                    ":checked": "pageNumRecordsSelected == pageTotalRecords && pageTotalRecords > 0",
+                    ':checked': 'pageNumRecordsSelected == pageTotalRecords && pageTotalRecords > 0',
                 },
             },
         )
@@ -64,9 +68,7 @@ class EditCasesTable(BaseHtmxTable, ElasticTable):
     def get_columns_from_session(cls, session):
         visible_columns = []
         for column_spec in session.columns.all():
-            visible_columns.append(
-                (column_spec.slug, EditableHtmxColumn(column_spec))
-            )
+            visible_columns.append((column_spec.slug, EditableHtmxColumn(column_spec)))
         return visible_columns
 
     @property
@@ -106,30 +108,29 @@ class EditCasesTable(BaseHtmxTable, ElasticTable):
 
 
 class RecentCaseSessionsTable(BaseHtmxTable, tables.Table):
-
     class Meta(BaseHtmxTable.Meta):
-        template_name = "data_cleaning/tables/recent_sessions.html"
+        template_name = 'data_cleaning/tables/recent_sessions.html'
         attrs = {
-            "class": "table table-striped align-middle",
+            'class': 'table table-striped align-middle',
         }
 
     status = columns.TemplateColumn(
-        template_name="data_cleaning/columns/task_status.html",
-        verbose_name=gettext_lazy("Status"),
+        template_name='data_cleaning/columns/task_status.html',
+        verbose_name=gettext_lazy('Status'),
     )
     case_type = columns.Column(
-        verbose_name=gettext_lazy("Case Type"),
+        verbose_name=gettext_lazy('Case Type'),
     )
     committed_on = columns.Column(
-        verbose_name=gettext_lazy("Committed On"),
+        verbose_name=gettext_lazy('Committed On'),
     )
     completed_on = columns.Column(
-        verbose_name=gettext_lazy("Completed On"),
+        verbose_name=gettext_lazy('Completed On'),
     )
     case_count = columns.Column(
-        verbose_name=gettext_lazy("# Cases Edited"),
+        verbose_name=gettext_lazy('# Cases Edited'),
     )
     form_ids = columns.TemplateColumn(
-        template_name="data_cleaning/columns/task_form_ids.html",
-        verbose_name=gettext_lazy("Form IDs"),
+        template_name='data_cleaning/columns/task_form_ids.html',
+        verbose_name=gettext_lazy('Form IDs'),
     )

--- a/corehq/apps/data_cleaning/tasks.py
+++ b/corehq/apps/data_cleaning/tasks.py
@@ -1,13 +1,12 @@
 import logging
-from corehq.apps.celery import task
-
-from django.utils import timezone
-from django.db import transaction
-from django.db.models import Q
-
-from dimagi.utils.chunked import chunked
 
 from casexml.apps.case.mock import CaseBlock
+from dimagi.utils.chunked import chunked
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+
+from corehq.apps.celery import task
 from corehq.apps.data_cleaning.models import (
     BulkEditSession,
 )

--- a/corehq/apps/data_cleaning/templatetags/data_cleaning.py
+++ b/corehq/apps/data_cleaning/templatetags/data_cleaning.py
@@ -3,7 +3,7 @@ import re
 
 from django import template
 from django.template.loader import render_to_string
-from django.utils.html import format_html, escape
+from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 

--- a/corehq/apps/data_cleaning/templatetags/data_cleaning.py
+++ b/corehq/apps/data_cleaning/templatetags/data_cleaning.py
@@ -14,7 +14,7 @@ from corehq.apps.hqwebapp.tables.elasticsearch.records import BaseElasticRecord
 register = template.Library()
 NO_VALUE = Ellipsis
 NULL_VALUE = None
-EMPTY_VALUE = ""
+EMPTY_VALUE = ''
 
 
 @register.filter
@@ -24,35 +24,25 @@ def dc_filter_value(dc_filter):
     `BulkEditFilter` based on the `data_type`.
     """
     if dc_filter.value is None:
-        return ""
+        return ''
     context = {}
     if dc_filter.data_type == DataType.MULTIPLE_OPTION:
-        context['values_list'] = dc_filter.value.split(" ")
+        context['values_list'] = dc_filter.value.split(' ')
     else:
         context['value'] = dc_filter.value
     return mark_safe(  # nosec: render_to_string below will handle escaping
-        render_to_string(
-            "data_cleaning/filters/formatted_value.html",
-            context
-        )
+        render_to_string('data_cleaning/filters/formatted_value.html', context)
     )
 
 
 @register.filter
 def dc_data_type_icon(data_type):
     context = {
-        'icon_class': DataType.ICON_CLASSES.get(
-            data_type, DataType.ICON_CLASSES[DataType.TEXT]
-        ),
-        'data_type_label': dict(DataType.CASE_CHOICES).get(
-            data_type, _("unknown")
-        ),
+        'icon_class': DataType.ICON_CLASSES.get(data_type, DataType.ICON_CLASSES[DataType.TEXT]),
+        'data_type_label': dict(DataType.CASE_CHOICES).get(data_type, _('unknown')),
     }
     return mark_safe(  # nosec: render_to_string below will handle escaping
-        render_to_string(
-            "data_cleaning/partials/data_type_icon.html",
-            context
-        )
+        render_to_string('data_cleaning/partials/data_type_icon.html', context)
     )
 
 
@@ -92,8 +82,7 @@ def has_edits(edited_value):
 def _validate_htmx_column(bound_column):
     if not isinstance(bound_column.column, EditableHtmxColumn):
         raise template.TemplateSyntaxError(
-            f"Expected bound_column.column to be a EditableHtmxColumn, "
-            f"got {type(bound_column.column)} instead."
+            f'Expected bound_column.column to be a EditableHtmxColumn, got {type(bound_column.column)} instead.'
         )
 
 
@@ -116,13 +105,13 @@ def cell_request_params(record, bound_column):
     """
     if not isinstance(record, BaseElasticRecord):
         raise template.TemplateSyntaxError(
-            f"Expected an instance of BaseElasticRecord, got {type(record)} instead."
+            f'Expected an instance of BaseElasticRecord, got {type(record)} instead.'
         )
     _validate_htmx_column(bound_column)
     return json.dumps(
         {
-            "record_id": record.record_id,
-            "column_id": str(bound_column.column.column_spec.column_id),
+            'record_id': record.record_id,
+            'column_id': str(bound_column.column.column_spec.column_id),
         }
     )
 
@@ -152,14 +141,14 @@ def display_dc_value(value):
 
     """
     context = {
-        "value": value,
+        'value': value,
     }
     if value is NULL_VALUE:
-        template = "data_cleaning/columns/values/null.html"
+        template = 'data_cleaning/columns/values/null.html'
     elif value is EMPTY_VALUE:
-        template = "data_cleaning/columns/values/empty.html"
+        template = 'data_cleaning/columns/values/empty.html'
     else:
-        template = "data_cleaning/columns/values/text.html"
+        template = 'data_cleaning/columns/values/text.html'
     return mark_safe(  # nosec: render_to_string below will handle escaping
         render_to_string(template, context)
     )
@@ -169,12 +158,12 @@ def _replace_whitespace(css_class, character, help_text):
     def _replace_fn(_match):
         spaces = character * len(_match.group())
         return format_html(
-            "&#8203;<span "  # &#8203; is a zero-width space, needed for line breaking
+            '&#8203;<span '  # &#8203; is a zero-width space, needed for line breaking
             '  class="dc-spaces dc-spaces-{}"'
             '  x-tooltip=""'
             '  data-bs-placement="top"'
             '  data-bs-title="{}"'
-            ">{}</span>&#8203;",  # &#8203; is a zero-width space, needed for line breaking
+            '>{}</span>&#8203;',  # &#8203; is a zero-width space, needed for line breaking
             css_class,
             help_text,
             mark_safe(spaces),  # nosec: no user input
@@ -189,16 +178,16 @@ def whitespaces(value):
     Returns a template that styles the whitespaces, given a value.
     """
     if value in [NULL_VALUE, EMPTY_VALUE, NO_VALUE]:
-        return ""
+        return ''
 
     # IMPORTANT (security): first, escape the string
     # we only want to mark_safe markup related to spaces
     value = escape(value)
 
     patterns = [
-        (r"([ ]+)", "space", "&centerdot;", _("space")),
-        (r"([\n]+)", "newline", "&crarr;", _("new line")),
-        (r"([\t]+)", "tab", "&rarr;", _("tab")),
+        (r'([ ]+)', 'space', '&centerdot;', _('space')),
+        (r'([\n]+)', 'newline', '&crarr;', _('new line')),
+        (r'([\t]+)', 'tab', '&rarr;', _('tab')),
     ]
     for pattern, *args in patterns:
         value = re.sub(pattern=pattern, repl=_replace_whitespace(*args), string=value)

--- a/corehq/apps/data_cleaning/tests/test_changes.py
+++ b/corehq/apps/data_cleaning/tests/test_changes.py
@@ -46,10 +46,14 @@ class BulkEditChangeTest(TestCase):
             replace_string='Esperanza',
         )
         self.assertEqual(change.edited_value(self.case), 'Esperanza')
-        self.assertEqual(change.edited_value(
-            self.case, edited_properties={
-                'town': 'Segunda',
-            }), 'Esperanza'
+        self.assertEqual(
+            change.edited_value(
+                self.case,
+                edited_properties={
+                    'town': 'Segunda',
+                },
+            ),
+            'Esperanza',
         )
 
     def test_replace_none(self):
@@ -68,10 +72,14 @@ class BulkEditChangeTest(TestCase):
             replace_string='Punta',
         )
         self.assertEqual(change.edited_value(self.case), 'Punta Bastimento')
-        self.assertEqual(change.edited_value(
-            self.case, edited_properties={
-                'favorite_beach': 'Bastimento Playa',
-            }), 'Bastimento Punta'
+        self.assertEqual(
+            change.edited_value(
+                self.case,
+                edited_properties={
+                    'favorite_beach': 'Bastimento Playa',
+                },
+            ),
+            'Bastimento Punta',
         )
 
     def test_find_replace_none(self):
@@ -92,10 +100,14 @@ class BulkEditChangeTest(TestCase):
             replace_string=' ',
         )
         self.assertEqual(change.edited_value(self.case), 'Brittney Claasen')
-        self.assertEqual(change.edited_value(
-            self.case, edited_properties={
-                'friend': 'brittney \t\nclaasen',
-            }), 'brittney claasen'
+        self.assertEqual(
+            change.edited_value(
+                self.case,
+                edited_properties={
+                    'friend': 'brittney \t\nclaasen',
+                },
+            ),
+            'brittney claasen',
         )
 
     def test_find_replace_regex_none(self):
@@ -114,10 +126,14 @@ class BulkEditChangeTest(TestCase):
             action_type=EditActionType.STRIP,
         )
         self.assertEqual(change.edited_value(self.case), ':)')
-        self.assertEqual(change.edited_value(
-            self.case, edited_properties={
-                'art': '    :-)\t\n  ',
-            }), ':-)'
+        self.assertEqual(
+            change.edited_value(
+                self.case,
+                edited_properties={
+                    'art': '    :-)\t\n  ',
+                },
+            ),
+            ':-)',
         )
 
     def test_strip_none(self):
@@ -134,11 +150,15 @@ class BulkEditChangeTest(TestCase):
             copy_from_prop_id='favorite_beach',
         )
         self.assertEqual(change.edited_value(self.case), 'Playa Bastimento')
-        self.assertEqual(change.edited_value(
-            self.case, edited_properties={
-                'favorite_beach': 'playa bastimento',
-                'nearest_ocean': 'Atlantic',
-            }), 'playa bastimento'
+        self.assertEqual(
+            change.edited_value(
+                self.case,
+                edited_properties={
+                    'favorite_beach': 'playa bastimento',
+                    'nearest_ocean': 'Atlantic',
+                },
+            ),
+            'playa bastimento',
         )
 
     def test_copy_replace_none(self):
@@ -155,10 +175,14 @@ class BulkEditChangeTest(TestCase):
             action_type=EditActionType.TITLE_CASE,
         )
         self.assertEqual(change.edited_value(self.case), 'Atlantic')
-        self.assertEqual(change.edited_value(
-            self.case, edited_properties={
-                'nearest_ocean': 'atlantic  ',
-            }), 'Atlantic  '
+        self.assertEqual(
+            change.edited_value(
+                self.case,
+                edited_properties={
+                    'nearest_ocean': 'atlantic  ',
+                },
+            ),
+            'Atlantic  ',
         )
 
     def test_title_case_none(self):
@@ -174,10 +198,14 @@ class BulkEditChangeTest(TestCase):
             action_type=EditActionType.UPPER_CASE,
         )
         self.assertEqual(change.edited_value(self.case), 'ISABEL SEGUNDA')
-        self.assertEqual(change.edited_value(
-            self.case, edited_properties={
-                'town': 'isbel',
-            }), 'ISBEL'
+        self.assertEqual(
+            change.edited_value(
+                self.case,
+                edited_properties={
+                    'town': 'isbel',
+                },
+            ),
+            'ISBEL',
         )
 
     def test_upper_case_none(self):
@@ -193,10 +221,14 @@ class BulkEditChangeTest(TestCase):
             action_type=EditActionType.LOWER_CASE,
         )
         self.assertEqual(change.edited_value(self.case), 'isabel segunda')
-        self.assertEqual(change.edited_value(
-            self.case, edited_properties={
-                'town': 'SEGUNDA',
-            }), 'segunda'
+        self.assertEqual(
+            change.edited_value(
+                self.case,
+                edited_properties={
+                    'town': 'SEGUNDA',
+                },
+            ),
+            'segunda',
         )
 
     def test_lower_case_none(self):
@@ -212,10 +244,14 @@ class BulkEditChangeTest(TestCase):
             action_type=EditActionType.MAKE_EMPTY,
         )
         self.assertEqual(change.edited_value(self.case), '')
-        self.assertEqual(change.edited_value(
-            self.case, edited_properties={
-                'nearest_ocean': 'pacific',
-            }), ''
+        self.assertEqual(
+            change.edited_value(
+                self.case,
+                edited_properties={
+                    'nearest_ocean': 'pacific',
+                },
+            ),
+            '',
         )
 
     def test_empty_none(self):
@@ -231,10 +267,14 @@ class BulkEditChangeTest(TestCase):
             action_type=EditActionType.MAKE_NULL,
         )
         self.assertEqual(change.edited_value(self.case), None)
-        self.assertEqual(change.edited_value(
-            self.case, edited_properties={
-                'nearest_ocean': 'pacific',
-            }), None
+        self.assertEqual(
+            change.edited_value(
+                self.case,
+                edited_properties={
+                    'nearest_ocean': 'pacific',
+                },
+            ),
+            None,
         )
 
     def test_make_null_none(self):
@@ -250,10 +290,14 @@ class BulkEditChangeTest(TestCase):
             action_type=EditActionType.RESET,
         )
         self.assertEqual(change.edited_value(self.case), 'atlantic')
-        self.assertEqual(change.edited_value(
-            self.case, edited_properties={
-                'nearest_ocean': 'pacific',
-            }), 'atlantic'
+        self.assertEqual(
+            change.edited_value(
+                self.case,
+                edited_properties={
+                    'nearest_ocean': 'pacific',
+                },
+            ),
+            'atlantic',
         )
 
     def test_reset_none(self):
@@ -274,17 +318,13 @@ class BulkEditRecordChangesTest(TestCase):
         cls.domain = create_domain(cls.domain_name)
         cls.addClassCleanup(cls.domain.delete)
 
-        cls.web_user = WebUser.create(
-            cls.domain.name, 'leaf@treeeeees.com', 'testpwd', None, None
-        )
+        cls.web_user = WebUser.create(cls.domain.name, 'leaf@treeeeees.com', 'testpwd', None, None)
         cls.user = User.objects.get(username=cls.web_user.username)
         cls.addClassCleanup(cls.web_user.delete, cls.domain.name, deleted_by=None)
 
     def setUp(self):
         super().setUp()
-        self.session = BulkEditSession.objects.new_case_session(
-            self.user, self.domain_name, self.case_type
-        )
+        self.session = BulkEditSession.objects.new_case_session(self.user, self.domain_name, self.case_type)
         factory = CaseFactory(domain=self.domain_name)
         self.case = factory.create_case(
             case_type=self.case_type,
@@ -304,7 +344,7 @@ class BulkEditRecordChangesTest(TestCase):
                 'pot_type': 'terra Cotta',
                 'friend': 'sugar  \n  wormWood  ',
                 'light_level': 'full_sun',
-            }
+            },
         )
 
     def tearDown(self):

--- a/corehq/apps/data_cleaning/tests/test_changes.py
+++ b/corehq/apps/data_cleaning/tests/test_changes.py
@@ -1,12 +1,12 @@
+from casexml.apps.case.mock import CaseFactory
 from django.contrib.auth.models import User
 from django.test import TestCase
 
-from casexml.apps.case.mock import CaseFactory
 from corehq.apps.data_cleaning.models import (
     BulkEditChange,
-    EditActionType,
-    BulkEditSession,
     BulkEditRecord,
+    BulkEditSession,
+    EditActionType,
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -45,67 +45,78 @@ from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
 
-@pytest.mark.parametrize("category, valid_match_types", [
-    (DataType.FILTER_CATEGORY_TEXT, (
-        FilterMatchType.EXACT,
-        FilterMatchType.IS_NOT,
-        FilterMatchType.STARTS,
-        FilterMatchType.STARTS_NOT,
-        FilterMatchType.FUZZY,
-        FilterMatchType.FUZZY_NOT,
-        FilterMatchType.PHONETIC,
-        FilterMatchType.PHONETIC_NOT,
-        FilterMatchType.IS_EMPTY,
-        FilterMatchType.IS_NOT_EMPTY,
-        FilterMatchType.IS_MISSING,
-        FilterMatchType.IS_NOT_MISSING,
-    )),
-    (DataType.FILTER_CATEGORY_NUMBER, (
-        FilterMatchType.EXACT,
-        FilterMatchType.IS_NOT,
-        FilterMatchType.LESS_THAN,
-        FilterMatchType.LESS_THAN_EQUAL,
-        FilterMatchType.GREATER_THAN,
-        FilterMatchType.GREATER_THAN_EQUAL,
-        FilterMatchType.IS_EMPTY,
-        FilterMatchType.IS_NOT_EMPTY,
-        FilterMatchType.IS_MISSING,
-        FilterMatchType.IS_NOT_MISSING,
-    )),
-    (DataType.FILTER_CATEGORY_DATE, (
-        FilterMatchType.EXACT,
-        FilterMatchType.LESS_THAN,
-        FilterMatchType.LESS_THAN_EQUAL,
-        FilterMatchType.GREATER_THAN,
-        FilterMatchType.GREATER_THAN_EQUAL,
-        FilterMatchType.IS_EMPTY,
-        FilterMatchType.IS_NOT_EMPTY,
-        FilterMatchType.IS_MISSING,
-        FilterMatchType.IS_NOT_MISSING,
-    )),
-    (DataType.FILTER_CATEGORY_MULTI_SELECT, (
-        FilterMatchType.IS_ANY,
-        FilterMatchType.IS_NOT_ANY,
-        FilterMatchType.IS_ALL,
-        FilterMatchType.IS_NOT_ALL,
-        FilterMatchType.IS_EMPTY,
-        FilterMatchType.IS_NOT_EMPTY,
-        FilterMatchType.IS_MISSING,
-        FilterMatchType.IS_NOT_MISSING,
-    )),
-])
+@pytest.mark.parametrize(
+    'category, valid_match_types',
+    [
+        (
+            DataType.FILTER_CATEGORY_TEXT,
+            (
+                FilterMatchType.EXACT,
+                FilterMatchType.IS_NOT,
+                FilterMatchType.STARTS,
+                FilterMatchType.STARTS_NOT,
+                FilterMatchType.FUZZY,
+                FilterMatchType.FUZZY_NOT,
+                FilterMatchType.PHONETIC,
+                FilterMatchType.PHONETIC_NOT,
+                FilterMatchType.IS_EMPTY,
+                FilterMatchType.IS_NOT_EMPTY,
+                FilterMatchType.IS_MISSING,
+                FilterMatchType.IS_NOT_MISSING,
+            ),
+        ),
+        (
+            DataType.FILTER_CATEGORY_NUMBER,
+            (
+                FilterMatchType.EXACT,
+                FilterMatchType.IS_NOT,
+                FilterMatchType.LESS_THAN,
+                FilterMatchType.LESS_THAN_EQUAL,
+                FilterMatchType.GREATER_THAN,
+                FilterMatchType.GREATER_THAN_EQUAL,
+                FilterMatchType.IS_EMPTY,
+                FilterMatchType.IS_NOT_EMPTY,
+                FilterMatchType.IS_MISSING,
+                FilterMatchType.IS_NOT_MISSING,
+            ),
+        ),
+        (
+            DataType.FILTER_CATEGORY_DATE,
+            (
+                FilterMatchType.EXACT,
+                FilterMatchType.LESS_THAN,
+                FilterMatchType.LESS_THAN_EQUAL,
+                FilterMatchType.GREATER_THAN,
+                FilterMatchType.GREATER_THAN_EQUAL,
+                FilterMatchType.IS_EMPTY,
+                FilterMatchType.IS_NOT_EMPTY,
+                FilterMatchType.IS_MISSING,
+                FilterMatchType.IS_NOT_MISSING,
+            ),
+        ),
+        (
+            DataType.FILTER_CATEGORY_MULTI_SELECT,
+            (
+                FilterMatchType.IS_ANY,
+                FilterMatchType.IS_NOT_ANY,
+                FilterMatchType.IS_ALL,
+                FilterMatchType.IS_NOT_ALL,
+                FilterMatchType.IS_EMPTY,
+                FilterMatchType.IS_NOT_EMPTY,
+                FilterMatchType.IS_MISSING,
+                FilterMatchType.IS_NOT_MISSING,
+            ),
+        ),
+    ],
+)
 def test_data_and_match_type_validation(category, valid_match_types):
     for data_type in DataType.FILTER_CATEGORY_DATA_TYPES[category]:
         for match_type, _ in FilterMatchType.ALL_CHOICES:
-            is_valid = BulkEditFilter.is_data_and_match_type_valid(
-                match_type, data_type
-            )
+            is_valid = BulkEditFilter.is_data_and_match_type_valid(match_type, data_type)
             if match_type in valid_match_types:
-                eq(is_valid, True,
-                   text=f"FilterMatchType {match_type} should support DataType {data_type}")
+                eq(is_valid, True, text=f'FilterMatchType {match_type} should support DataType {data_type}')
             else:
-                eq(is_valid, False,
-                   text=f"FilterMatchType {match_type} should NOT support DataType {data_type}")
+                eq(is_valid, False, text=f'FilterMatchType {match_type} should NOT support DataType {data_type}')
 
 
 @es_test(requires=[case_search_adapter], setup_class=True)
@@ -118,9 +129,7 @@ class BulkEditFilterQueryTests(TestCase):
         cls.domain_obj = create_domain(cls.domain)
         cls.addClassCleanup(cls.domain_obj.delete)
 
-        cls.web_user = WebUser.create(
-            cls.domain, 'tester@datacleaning.org', 'testpwd', None, None
-        )
+        cls.web_user = WebUser.create(cls.domain, 'tester@datacleaning.org', 'testpwd', None, None)
         cls.addClassCleanup(cls.web_user.delete, cls.domain, deleted_by=None)
 
         case_search_es_setup(cls.domain, get_case_blocks())
@@ -128,7 +137,9 @@ class BulkEditFilterQueryTests(TestCase):
     def setUp(self):
         super().setUp()
         self.session = BulkEditSession.objects.new_case_session(
-            self.web_user.get_django_user(), self.domain, 'plants',
+            self.web_user.get_django_user(),
+            self.domain,
+            'plants',
         )
 
     @classmethod
@@ -148,9 +159,9 @@ class BulkEditFilterQueryTests(TestCase):
             filtered_query = active_filter.filter_query(query)
             expected_query = query.filter(exact_case_property_text_query('soil_contents', ''))
             self.assertEqual(
-                filtered_query.es_query, expected_query.es_query,
-                msg=f"{data_type} failed to filter the query "
-                    f"properly for FilterMatchType.IS_EMPTY"
+                filtered_query.es_query,
+                expected_query.es_query,
+                msg=f'{data_type} failed to filter the query properly for FilterMatchType.IS_EMPTY',
             )
 
     def test_filter_query_is_not_empty(self):
@@ -165,9 +176,9 @@ class BulkEditFilterQueryTests(TestCase):
             filtered_query = active_filter.filter_query(query)
             expected_query = query.NOT(exact_case_property_text_query('soil_contents', ''))
             self.assertEqual(
-                filtered_query.es_query, expected_query.es_query,
-                msg=f"{data_type} failed to filter the query "
-                    f"properly for FilterMatchType.IS_NOT_EMPTY"
+                filtered_query.es_query,
+                expected_query.es_query,
+                msg=f'{data_type} failed to filter the query properly for FilterMatchType.IS_NOT_EMPTY',
             )
 
     def test_filter_query_is_missing(self):
@@ -182,9 +193,9 @@ class BulkEditFilterQueryTests(TestCase):
             filtered_query = active_filter.filter_query(query)
             expected_query = query.filter(case_property_missing('soil_contents'))
             self.assertEqual(
-                filtered_query.es_query, expected_query.es_query,
-                msg=f"{data_type} failed to filter the query "
-                    f"properly for FilterMatchType.IS_MISSING"
+                filtered_query.es_query,
+                expected_query.es_query,
+                msg=f'{data_type} failed to filter the query properly for FilterMatchType.IS_MISSING',
             )
 
     def test_filter_query_is_not_missing(self):
@@ -199,9 +210,9 @@ class BulkEditFilterQueryTests(TestCase):
             filtered_query = active_filter.filter_query(query)
             expected_query = query.NOT(case_property_missing('soil_contents'))
             self.assertEqual(
-                filtered_query.es_query, expected_query.es_query,
-                msg=f"{data_type} failed to filter the query "
-                    f"properly for FilterMatchType.IS_NOT_MISSING"
+                filtered_query.es_query,
+                expected_query.es_query,
+                msg=f'{data_type} failed to filter the query properly for FilterMatchType.IS_NOT_MISSING',
             )
 
     def filter_query_remains_unchanged_for_other_match_types(self):
@@ -218,13 +229,13 @@ class BulkEditFilterQueryTests(TestCase):
                 )
                 filtered_query = active_filter.filter_query(query)
                 self.assertEqual(
-                    filtered_query.es_query, query.es_query,
-                    msg=f"filtered query should remain unchanged for {data_type}, {match_type}"
+                    filtered_query.es_query,
+                    query.es_query,
+                    msg=f'filtered query should remain unchanged for {data_type}, {match_type}',
                 )
 
 
 class BulkEditFilterXpathTest(TestCase):
-
     def test_exact_text_xpath(self):
         active_filter = BulkEditFilter(
             prop_id='name',
@@ -232,10 +243,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.EXACT,
             value='Riny Iola',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "name = 'Riny Iola'"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "name = 'Riny Iola'")
 
     def test_single_quote_xpath(self):
         active_filter = BulkEditFilter(
@@ -244,14 +252,8 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.EXACT,
             value="Happy's",
         )
-        self.assertEqual(
-            active_filter.get_quoted_value(active_filter.value),
-            '''"Happy's"'''
-        )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            '''name = "Happy's"'''
-        )
+        self.assertEqual(active_filter.get_quoted_value(active_filter.value), '''"Happy's"''')
+        self.assertEqual(active_filter.get_xpath_expression(), '''name = "Happy's"''')
 
     def test_double_quote_xpath(self):
         active_filter = BulkEditFilter(
@@ -260,21 +262,15 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.EXACT,
             value='Zesty "orange" Flora',
         )
-        self.assertEqual(
-            active_filter.get_quoted_value(active_filter.value),
-            """'Zesty "orange" Flora'"""
-        )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            """name = 'Zesty "orange" Flora'"""
-        )
+        self.assertEqual(active_filter.get_quoted_value(active_filter.value), """'Zesty "orange" Flora'""")
+        self.assertEqual(active_filter.get_xpath_expression(), """name = 'Zesty "orange" Flora'""")
 
     def test_mixed_quote_xpath(self):
         active_filter = BulkEditFilter(
             prop_id='name',
             data_type=DataType.TEXT,
             match_type=FilterMatchType.EXACT,
-            value='''Zesty's "orange" Flora''',
+            value="""Zesty's "orange" Flora""",
         )
         with self.assertRaises(UnsupportedFilterValueException):
             active_filter.get_quoted_value(active_filter.value)
@@ -283,27 +279,15 @@ class BulkEditFilterXpathTest(TestCase):
 
     def test_exact_number_xpath(self):
         active_filter = BulkEditFilter(
-            prop_id='height_cm',
-            data_type=DataType.DECIMAL,
-            match_type=FilterMatchType.EXACT,
-            value='11.2'
+            prop_id='height_cm', data_type=DataType.DECIMAL, match_type=FilterMatchType.EXACT, value='11.2'
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "height_cm = 11.2"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), 'height_cm = 11.2')
 
     def test_exact_date_xpath(self):
         active_filter = BulkEditFilter(
-            prop_id='watered_on',
-            data_type=DataType.DATE,
-            match_type=FilterMatchType.EXACT,
-            value='2024-12-11'
+            prop_id='watered_on', data_type=DataType.DATE, match_type=FilterMatchType.EXACT, value='2024-12-11'
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "watered_on = '2024-12-11'"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "watered_on = '2024-12-11'")
 
     def test_is_not_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -312,10 +296,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.IS_NOT,
             value='11245523233',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "phone_num != '11245523233'"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "phone_num != '11245523233'")
 
     def test_is_not_number_xpath(self):
         active_filter = BulkEditFilter(
@@ -324,10 +305,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.IS_NOT,
             value='5',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "num_leaves != 5"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), 'num_leaves != 5')
 
     def test_less_than_number_xpath(self):
         active_filter = BulkEditFilter(
@@ -336,10 +314,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.LESS_THAN,
             value='12.35',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "height_cm < 12.35"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), 'height_cm < 12.35')
 
     def test_less_than_date_xpath(self):
         active_filter = BulkEditFilter(
@@ -348,10 +323,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.LESS_THAN,
             value='2025-02-03 16:43',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "watered_on < '2025-02-03 16:43'"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "watered_on < '2025-02-03 16:43'")
 
     def test_less_than_equal_number_xpath(self):
         active_filter = BulkEditFilter(
@@ -360,10 +332,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.LESS_THAN_EQUAL,
             value='35.5',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "weight_kg <= 35.5"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), 'weight_kg <= 35.5')
 
     def test_less_than_equal_date_xpath(self):
         active_filter = BulkEditFilter(
@@ -372,10 +341,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.LESS_THAN_EQUAL,
             value='2025-02-20 16:55',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "last_modified <= '2025-02-20 16:55'"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "last_modified <= '2025-02-20 16:55'")
 
     def test_greater_than_number_xpath(self):
         active_filter = BulkEditFilter(
@@ -384,10 +350,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.GREATER_THAN,
             value='15',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "amount > 15"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), 'amount > 15')
 
     def test_greater_than_date_xpath(self):
         active_filter = BulkEditFilter(
@@ -396,10 +359,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.GREATER_THAN,
             value='2025-01-22',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "modified_on > '2025-01-22'"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "modified_on > '2025-01-22'")
 
     def test_greater_than_equal_number_xpath(self):
         active_filter = BulkEditFilter(
@@ -408,10 +368,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.GREATER_THAN_EQUAL,
             value='23',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "num_branches >= 23"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), 'num_branches >= 23')
 
     def test_greater_than_equal_date_xpath(self):
         active_filter = BulkEditFilter(
@@ -420,10 +377,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.GREATER_THAN_EQUAL,
             value='2025-03-03',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "submitted_on >= '2025-03-03'"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "submitted_on >= '2025-03-03'")
 
     def test_starts_with_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -432,10 +386,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.STARTS,
             value='st',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "starts-with(name, 'st')"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "starts-with(name, 'st')")
 
     def test_starts_with_text_single_quote_xpath(self):
         active_filter = BulkEditFilter(
@@ -444,10 +395,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.STARTS,
             value="st's",
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            """starts-with(name, "st's")"""
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), """starts-with(name, "st's")""")
 
     def test_starts_with_text_double_quote_xpath(self):
         active_filter = BulkEditFilter(
@@ -456,17 +404,14 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.STARTS,
             value='st"s',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            """starts-with(name, 'st"s')"""
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), """starts-with(name, 'st"s')""")
 
     def test_starts_text_mixed_quote_xpath(self):
         active_filter = BulkEditFilter(
             prop_id='name',
             data_type=DataType.TEXT,
             match_type=FilterMatchType.STARTS,
-            value='''st"s m'd''',
+            value="""st"s m'd""",
         )
         with self.assertRaises(UnsupportedFilterValueException):
             active_filter.get_xpath_expression()
@@ -478,10 +423,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.STARTS_NOT,
             value='fo',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "not(starts-with(favorite_park, 'fo'))"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "not(starts-with(favorite_park, 'fo'))")
 
     def test_fuzzy_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -490,10 +432,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.FUZZY,
             value='ceremic',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "fuzzy-match(pot_type, 'ceremic')"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "fuzzy-match(pot_type, 'ceremic')")
 
     def test_fuzzy_not_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -502,10 +441,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.FUZZY_NOT,
             value='ceremic',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "not(fuzzy-match(pot_type, 'ceremic'))"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "not(fuzzy-match(pot_type, 'ceremic'))")
 
     def test_phonetic_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -514,10 +450,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.PHONETIC,
             value='hi',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "phonetic-match(light_level, 'hi')"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "phonetic-match(light_level, 'hi')")
 
     def test_phonetic_not_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -526,10 +459,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.PHONETIC_NOT,
             value='hi',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "not(phonetic-match(light_level, 'hi'))"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "not(phonetic-match(light_level, 'hi'))")
 
     def test_is_any_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -539,8 +469,7 @@ class BulkEditFilterXpathTest(TestCase):
             value='yellow_leaves root_rot',
         )
         self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "selected-any(health_issues, 'yellow_leaves root_rot')"
+            active_filter.get_xpath_expression(), "selected-any(health_issues, 'yellow_leaves root_rot')"
         )
 
     def test_is_not_any_text_xpath(self):
@@ -551,8 +480,7 @@ class BulkEditFilterXpathTest(TestCase):
             value='fungus root_rot',
         )
         self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "not(selected-any(health_issues, 'fungus root_rot'))"
+            active_filter.get_xpath_expression(), "not(selected-any(health_issues, 'fungus root_rot'))"
         )
 
     def test_is_all_text_xpath(self):
@@ -562,10 +490,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.IS_ALL,
             value='bark worm_castings',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "selected-all(soil_contents, 'bark worm_castings')"
-        )
+        self.assertEqual(active_filter.get_xpath_expression(), "selected-all(soil_contents, 'bark worm_castings')")
 
     def test_is_not_all_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -575,8 +500,7 @@ class BulkEditFilterXpathTest(TestCase):
             value='bark worm_castings',
         )
         self.assertEqual(
-            active_filter.get_xpath_expression(),
-            "not(selected-all(soil_contents, 'bark worm_castings'))"
+            active_filter.get_xpath_expression(), "not(selected-all(soil_contents, 'bark worm_castings'))"
         )
 
     def test_value_match_types_return_none_all_data_types_xpath(self):
@@ -589,7 +513,7 @@ class BulkEditFilterXpathTest(TestCase):
                 )
                 self.assertIsNone(
                     active_filter.get_xpath_expression(),
-                    msg=f"{match_type} for {data_type} should not return an xpath expression"
+                    msg=f'{match_type} for {data_type} should not return an xpath expression',
                 )
 
 
@@ -602,9 +526,7 @@ class TestReportFilterSubclasses(TestCase):
         cls.domain_obj = create_domain(cls.domain)
         cls.addClassCleanup(cls.domain_obj.delete)
 
-        cls.web_user = WebUser.create(
-            cls.domain, 'tester@datacleaning.org', 'testpwd', None, None
-        )
+        cls.web_user = WebUser.create(cls.domain, 'tester@datacleaning.org', 'testpwd', None, None)
         cls.addClassCleanup(cls.web_user.delete, cls.domain, deleted_by=None)
 
     def setUp(self):
@@ -615,19 +537,17 @@ class TestReportFilterSubclasses(TestCase):
         self.request.couch_user = self.web_user
         self.request.project = self.domain_obj
         self.session = BulkEditSession.objects.new_case_session(
-            self.web_user.get_django_user(), self.domain, 'plants',
+            self.web_user.get_django_user(),
+            self.domain,
+            'plants',
         )
 
     def test_case_owners_report_filter_context(self):
-        report_filter = CaseOwnersPinnedFilter(
-            self.session, self.request, self.domain, use_bootstrap5=True
-        )
+        report_filter = CaseOwnersPinnedFilter(self.session, self.request, self.domain, use_bootstrap5=True)
         expected_context = {
             'report_select2_config': {
                 'select': {
-                    'options': [
-                        {'val': 't__0', 'text': '[Active Mobile Workers]'}
-                    ],
+                    'options': [{'val': 't__0', 'text': '[Active Mobile Workers]'}],
                     'default_text': 'Filter by...',
                     'selected': [
                         {'id': 'all_data', 'text': '[All Data]'},
@@ -653,15 +573,11 @@ class TestReportFilterSubclasses(TestCase):
 
     @mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting
     def test_case_owners_report_filter_context_locations(self):
-        report_filter = CaseOwnersPinnedFilter(
-            self.session, self.request, self.domain, use_bootstrap5=True
-        )
+        report_filter = CaseOwnersPinnedFilter(self.session, self.request, self.domain, use_bootstrap5=True)
         expected_context = {
             'report_select2_config': {
                 'select': {
-                    'options': [
-                        {'val': 't__0', 'text': '[Active Mobile Workers]'}
-                    ],
+                    'options': [{'val': 't__0', 'text': '[Active Mobile Workers]'}],
                     'default_text': 'Filter by...',
                     'selected': [
                         {'id': 'all_data', 'text': '[All Data]'},
@@ -686,21 +602,17 @@ class TestReportFilterSubclasses(TestCase):
                 'specify multiple levels by separating with a "/". For example, '
                 '"Massachusetts/Suffolk/Boston". <a href="https://dimagi.atlassian'
                 '.net/wiki/spaces/commcarepublic/pages/2215051298/Organization+Data'
-                '+Management#Search-for-Locations"target="_blank">Learn more</a>.'
+                '+Management#Search-for-Locations"target="_blank">Learn more</a>.',
             ],
         }
         self.assertDictEqual(report_filter.filter_context, expected_context)
 
     def test_case_owners_update_stored_value(self):
-        self.request.POST = QueryDict(
-            'case_list_filter=project_data&case_list_filter=t__6&case_list_filter=t__3'
-        )
+        self.request.POST = QueryDict('case_list_filter=project_data&case_list_filter=t__6&case_list_filter=t__3')
         self.request.method = 'POST'
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
         self.assertIsNone(pinned_filter.value)
-        report_filter = CaseOwnersPinnedFilter(
-            self.session, self.request, self.domain, use_bootstrap5=True
-        )
+        report_filter = CaseOwnersPinnedFilter(self.session, self.request, self.domain, use_bootstrap5=True)
         report_filter.update_stored_value()
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
         self.assertEqual(pinned_filter.value, ['project_data', 't__6', 't__3'])
@@ -710,14 +622,11 @@ class TestReportFilterSubclasses(TestCase):
             {'id': 't__3', 'text': '[Unknown Users]'},
         ]
         self.assertEqual(
-            report_filter.filter_context['report_select2_config']['select']['selected'],
-            expected_value
+            report_filter.filter_context['report_select2_config']['select']['selected'], expected_value
         )
 
     def test_case_status_report_filter_context(self):
-        report_filter = CaseStatusPinnedFilter(
-            self.session, self.request, self.domain, use_bootstrap5=True
-        )
+        report_filter = CaseStatusPinnedFilter(self.session, self.request, self.domain, use_bootstrap5=True)
         expected_context = {
             'report_select2_config': {
                 'select': {
@@ -740,22 +649,15 @@ class TestReportFilterSubclasses(TestCase):
         self.assertDictEqual(report_filter.filter_context, expected_context)
 
     def test_case_status_update_stored_value(self):
-        self.request.POST = QueryDict(
-            'is_open=open'
-        )
+        self.request.POST = QueryDict('is_open=open')
         self.request.method = 'POST'
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_STATUS)
         self.assertIsNone(pinned_filter.value)
-        report_filter = CaseStatusPinnedFilter(
-            self.session, self.request, self.domain, use_bootstrap5=True
-        )
+        report_filter = CaseStatusPinnedFilter(self.session, self.request, self.domain, use_bootstrap5=True)
         report_filter.update_stored_value()
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_STATUS)
         self.assertEqual(pinned_filter.value, ['open'])
-        self.assertEqual(
-            report_filter.filter_context['report_select2_config']['select']['selected'],
-            'open'
-        )
+        self.assertEqual(report_filter.filter_context['report_select2_config']['select']['selected'], 'open')
 
 
 @es_test(requires=[case_search_adapter, user_adapter, group_adapter], setup_class=True)
@@ -766,17 +668,12 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.deactivated_user = CommCareUser.create(
-            cls.domain, 'deactivated-user-test', 'Passw0rd!', None, None
-        )
+        cls.deactivated_user = CommCareUser.create(cls.domain, 'deactivated-user-test', 'Passw0rd!', None, None)
         cls.deactivated_user.is_active = False
         user_adapter.index(cls.deactivated_user)
         cls.deactivated_user.save()
 
-        cls.web_location_user = WebUser.create(
-            cls.domain, 'restricted@datacleaning.org', 'Passw0rd!', None, None
-
-        )
+        cls.web_location_user = WebUser.create(cls.domain, 'restricted@datacleaning.org', 'Passw0rd!', None, None)
         cls.web_location_user.set_location(cls.domain, cls.locations['Suffolk'])
         cls.restrict_user_to_assigned_locations(cls.web_location_user)
         cls.web_location_user.save()
@@ -791,10 +688,14 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
     def setUp(self):
         super().setUp()
         self.session = BulkEditSession.objects.new_case_session(
-            self.session_user.get_django_user(), self.domain, 'plants',
+            self.session_user.get_django_user(),
+            self.domain,
+            'plants',
         )
         self.session_location_restricted = BulkEditSession.objects.new_case_session(
-            self.web_location_user.get_django_user(), self.domain, 'plants',
+            self.web_location_user.get_django_user(),
+            self.domain,
+            'plants',
         )
 
     @classmethod
@@ -802,6 +703,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         FormProcessorTestUtils.delete_all_cases()
 
         from couchdbkit import ResourceNotFound
+
         for user in [cls.deactivated_user, cls.web_location_user]:
             try:
                 user.delete(cls.domain, None)
@@ -812,9 +714,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
 
     def test_default(self):
         query = CaseSearchES().domain(self.domain)
-        pinned_filter = self.session.pinned_filters.get(
-            filter_type=PinnedFilterType.CASE_OWNERS
-        )
+        pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
         self.assertIsNone(pinned_filter.value)
         filtered_query = pinned_filter.filter_query(query)
         self.assertDictEqual(filtered_query.es_query, query.es_query)
@@ -831,9 +731,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
 
     def test_all_data(self):
         query = CaseSearchES().domain(self.domain)
-        pinned_filter = self.session.pinned_filters.get(
-            filter_type=PinnedFilterType.CASE_OWNERS
-        )
+        pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
         pinned_filter.value = ['project_data', 'all_data', 't__5']
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
@@ -848,9 +746,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.value = ['project_data', 'all_data', 't__5']
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
-        expected_query = query_location_restricted_cases(
-            query, self.domain, self.web_location_user
-        )
+        expected_query = query_location_restricted_cases(query, self.domain, self.web_location_user)
         self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
 
     def test_deactivated(self):
@@ -888,12 +784,15 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
             pinned_filter.value = [user_type]
             pinned_filter.save()
             filtered_query = pinned_filter.filter_query(query)
-            expected_query = query if is_owners_empty else query.OR(case_es.owner(get_case_owners(
-                True, self.domain, pinned_filter.value
-            )))
+            expected_query = (
+                query
+                if is_owners_empty
+                else query.OR(case_es.owner(get_case_owners(True, self.domain, pinned_filter.value)))
+            )
             self.assertDictEqual(
-                filtered_query.es_query, expected_query.es_query,
-                msg=f"expected query did not match for user type {user_type}"
+                filtered_query.es_query,
+                expected_query.es_query,
+                msg=f'expected query did not match for user type {user_type}',
             )
 
     def test_selected_user_types_location_restricted(self):
@@ -913,48 +812,37 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
             pinned_filter.value = [user_type]
             pinned_filter.save()
             filtered_query = pinned_filter.filter_query(query)
-            expected_query = query_location_restricted_cases(
-                query, self.domain, self.web_location_user
-            )
+            expected_query = query_location_restricted_cases(query, self.domain, self.web_location_user)
             self.assertDictEqual(
-                filtered_query.es_query, expected_query.es_query,
-                msg=f"expected query did not match for user type {user_type}"
+                filtered_query.es_query,
+                expected_query.es_query,
+                msg=f'expected query did not match for user type {user_type}',
             )
 
     def test_selected_user_ids(self):
-        selected_user_ids = [
-            self.users[0]._id,
-            self.users[3]._id,
-            self.users[4]._id
-        ]
+        selected_user_ids = [self.users[0]._id, self.users[3]._id, self.users[4]._id]
         query = CaseSearchES().domain(self.domain)
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
-        pinned_filter.value = [f"u__{user_id}" for user_id in selected_user_ids]
+        pinned_filter.value = [f'u__{user_id}' for user_id in selected_user_ids]
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
-        expected_query = query.OR(case_es.owner(get_case_owners(
-            True, self.domain, pinned_filter.value
-        )))
+        expected_query = query.OR(case_es.owner(get_case_owners(True, self.domain, pinned_filter.value)))
         self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
 
     def test_selected_user_ids_location_restricted(self):
-        selected_user_ids = [
-            self.users[0]._id,
-            self.users[3]._id,
-            self.users[4]._id
-        ]
+        selected_user_ids = [self.users[0]._id, self.users[3]._id, self.users[4]._id]
         query = CaseSearchES().domain(self.domain)
         pinned_filter = self.session_location_restricted.pinned_filters.get(
             filter_type=PinnedFilterType.CASE_OWNERS
         )
-        pinned_filter.value = [f"u__{user_id}" for user_id in selected_user_ids]
+        pinned_filter.value = [f'u__{user_id}' for user_id in selected_user_ids]
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
-        expected_query = query_location_restricted_cases(query.OR(
-            case_es.owner(get_case_owners(
-                False, self.domain, pinned_filter.value
-            ))
-        ), self.domain, self.web_location_user)
+        expected_query = query_location_restricted_cases(
+            query.OR(case_es.owner(get_case_owners(False, self.domain, pinned_filter.value))),
+            self.domain,
+            self.web_location_user,
+        )
         self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
 
     def test_groups(self):
@@ -963,9 +851,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.value = [f'g__{self.group1._id}']
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
-        expected_query = query.OR(case_es.owner(get_case_owners(
-            True, self.domain, pinned_filter.value
-        )))
+        expected_query = query.OR(case_es.owner(get_case_owners(True, self.domain, pinned_filter.value)))
         self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
 
     def test_groups_location_restricted(self):
@@ -976,9 +862,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.value = [f'g__{self.group1._id}']
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
-        expected_query = query_location_restricted_cases(
-            query, self.domain, self.web_location_user
-        )
+        expected_query = query_location_restricted_cases(query, self.domain, self.web_location_user)
         self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
 
     def test_location_ids(self):
@@ -988,9 +872,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.value = [f'l__{location_id}']
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
-        expected_query = query.OR(case_es.owner(get_case_owners(
-            True, self.domain, pinned_filter.value
-        )))
+        expected_query = query.OR(case_es.owner(get_case_owners(True, self.domain, pinned_filter.value)))
         self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
 
     def test_location_ids_location_restricted(self):
@@ -1002,11 +884,11 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.value = [f'l__{location_id}']
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
-        expected_query = query_location_restricted_cases(query.OR(
-            case_es.owner(get_case_owners(
-                False, self.domain, pinned_filter.value
-            ))
-        ), self.domain, self.web_location_user)
+        expected_query = query_location_restricted_cases(
+            query.OR(case_es.owner(get_case_owners(False, self.domain, pinned_filter.value))),
+            self.domain,
+            self.web_location_user,
+        )
         self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
 
 
@@ -1020,9 +902,7 @@ class TestCaseStatusPinnedFilterQuery(TestCase):
         cls.domain_obj = create_domain(cls.domain)
         cls.addClassCleanup(cls.domain_obj.delete)
 
-        cls.web_user = WebUser.create(
-            cls.domain, 'tester@datacleaning.org', 'testpwd', None, None
-        )
+        cls.web_user = WebUser.create(cls.domain, 'tester@datacleaning.org', 'testpwd', None, None)
         cls.addClassCleanup(cls.web_user.delete, cls.domain, deleted_by=None)
 
         case_search_es_setup(cls.domain, get_case_blocks())
@@ -1035,23 +915,21 @@ class TestCaseStatusPinnedFilterQuery(TestCase):
     def setUp(self):
         super().setUp()
         self.session = BulkEditSession.objects.new_case_session(
-            self.web_user.get_django_user(), self.domain, 'plants',
+            self.web_user.get_django_user(),
+            self.domain,
+            'plants',
         )
 
     def test_default(self):
         query = CaseSearchES().domain(self.domain)
-        pinned_filter = self.session.pinned_filters.get(
-            filter_type=PinnedFilterType.CASE_STATUS
-        )
+        pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_STATUS)
         self.assertIsNone(pinned_filter.value)
         filtered_query = pinned_filter.filter_query(query)
         self.assertDictEqual(filtered_query.es_query, query.es_query)
 
     def test_open(self):
         query = CaseSearchES().domain(self.domain)
-        pinned_filter = self.session.pinned_filters.get(
-            filter_type=PinnedFilterType.CASE_STATUS
-        )
+        pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_STATUS)
         pinned_filter.value = ['open']
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
@@ -1060,9 +938,7 @@ class TestCaseStatusPinnedFilterQuery(TestCase):
 
     def test_closed(self):
         query = CaseSearchES().domain(self.domain)
-        pinned_filter = self.session.pinned_filters.get(
-            filter_type=PinnedFilterType.CASE_STATUS
-        )
+        pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_STATUS)
         pinned_filter.value = ['closed']
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -1,9 +1,9 @@
-import pytest
-from testil import eq
 from unittest import mock
 
+import pytest
 from django.http import QueryDict
-from django.test import TestCase, RequestFactory
+from django.test import RequestFactory, TestCase
+from testil import eq
 
 from corehq.apps.data_cleaning.exceptions import UnsupportedFilterValueException
 from corehq.apps.data_cleaning.filters import (
@@ -12,14 +12,15 @@ from corehq.apps.data_cleaning.filters import (
 )
 from corehq.apps.data_cleaning.models import (
     BulkEditFilter,
+    BulkEditSession,
     DataType,
     FilterMatchType,
-    BulkEditSession,
     PinnedFilterType,
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.es import CaseSearchES, cases as case_es
+from corehq.apps.es import CaseSearchES
+from corehq.apps.es import cases as case_es
 from corehq.apps.es.case_search import (
     case_property_missing,
     case_search_adapter,
@@ -40,7 +41,7 @@ from corehq.apps.reports.standard.cases.utils import (
     query_location_restricted_cases,
 )
 from corehq.apps.reports.tests.standard.cases.test_utils import BaseCaseOwnersTest
-from corehq.apps.users.models import WebUser, CommCareUser
+from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
 

--- a/corehq/apps/data_cleaning/tests/test_records.py
+++ b/corehq/apps/data_cleaning/tests/test_records.py
@@ -133,12 +133,8 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
         case_ids = [self._get_case_id() for _ in range(10)]
         self.session.select_multiple_records(case_ids)
         unrecorded_case_ids = [self._get_case_id() for _ in range(5)]
-        self.assertListEqual(
-            self.session.records.get_unrecorded_doc_ids(self.session, case_ids),
-            []
-        )
+        self.assertListEqual(self.session.records.get_unrecorded_doc_ids(self.session, case_ids), [])
         all_case_ids = case_ids + unrecorded_case_ids
         self.assertEqual(
-            set(self.session.records.get_unrecorded_doc_ids(self.session, all_case_ids)),
-            set(unrecorded_case_ids)
+            set(self.session.records.get_unrecorded_doc_ids(self.session, all_case_ids)), set(unrecorded_case_ids)
         )

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -12,7 +12,7 @@ from corehq.apps.data_cleaning.models import (
     FilterMatchType,
 )
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.es import CaseSearchES, user_adapter, group_adapter
+from corehq.apps.es import CaseSearchES, group_adapter, user_adapter
 from corehq.apps.es.case_search import (
     case_property_missing,
     case_search_adapter,

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -37,9 +37,7 @@ class BulkEditSessionTest(TestCase):
         cls.domain = create_domain(cls.domain_name)
         cls.addClassCleanup(cls.domain.delete)
 
-        cls.web_user = WebUser.create(
-            cls.domain.name, 'tester@datacleaning.org', 'testpwd', None, None
-        )
+        cls.web_user = WebUser.create(cls.domain.name, 'tester@datacleaning.org', 'testpwd', None, None)
         cls.django_user = User.objects.get(username=cls.web_user.username)
         cls.addClassCleanup(cls.web_user.delete, cls.domain.name, deleted_by=None)
 
@@ -79,9 +77,7 @@ class BulkEditSessionTest(TestCase):
 
     def test_has_no_active_case_session_other_type(self):
         BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
-        active_session = BulkEditSession.objects.active_case_session(
-            self.django_user, self.domain_name, 'other'
-        )
+        active_session = BulkEditSession.objects.active_case_session(self.django_user, self.domain_name, 'other')
         self.assertIsNone(active_session)
 
     def test_has_no_active_case_session_after_committed(self):
@@ -126,9 +122,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         cls.domain = create_domain(cls.domain_name)
         cls.addClassCleanup(cls.domain.delete)
 
-        cls.web_user = WebUser.create(
-            cls.domain.name, 'tester@datacleaning.org', 'testpwd', None, None
-        )
+        cls.web_user = WebUser.create(cls.domain.name, 'tester@datacleaning.org', 'testpwd', None, None)
         cls.django_user = User.objects.get(username=cls.web_user.username)
         cls.addClassCleanup(cls.web_user.delete, cls.domain.name, deleted_by=None)
 
@@ -142,10 +136,10 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
     def test_add_filters(self):
         session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)
-        session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, "lowkey")
-        session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, "2")
+        session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, 'lowkey')
+        session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, '2')
         session.add_filter('pot_type', DataType.DATE, FilterMatchType.IS_EMPTY)
-        session.add_filter('height_cm', DataType.DECIMAL, FilterMatchType.LESS_THAN_EQUAL, "11.0")
+        session.add_filter('height_cm', DataType.DECIMAL, FilterMatchType.LESS_THAN_EQUAL, '11.0')
         filters = session.filters.all()
         for index, prop_id in enumerate(['watered_on', 'name', 'num_leaves', 'pot_type', 'height_cm']):
             self.assertEqual(filters[index].prop_id, prop_id)
@@ -154,10 +148,10 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
     def test_remove_filters(self):
         session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)
-        session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, "lowkey")
-        session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, "2")
+        session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, 'lowkey')
+        session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, '2')
         session.add_filter('pot_type', DataType.DATE, FilterMatchType.IS_EMPTY)
-        session.add_filter('height_cm', DataType.DECIMAL, FilterMatchType.LESS_THAN_EQUAL, "11.0")
+        session.add_filter('height_cm', DataType.DECIMAL, FilterMatchType.LESS_THAN_EQUAL, '11.0')
         filter_to_remove = session.filters.all()[1]  # name
         self.assertEqual(filter_to_remove.prop_id, 'name')
         session.remove_filter(filter_to_remove.filter_id)
@@ -174,18 +168,17 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         session.remove_column(column_to_remove.column_id)
         columns = session.columns.all()
         self.assertEqual(len(columns), 5)
-        for index, prop_id in enumerate(['name', 'date_opened', 'opened_by_username',
-                                         'last_modified', '@status']):
+        for index, prop_id in enumerate(['name', 'date_opened', 'opened_by_username', 'last_modified', '@status']):
             self.assertEqual(columns[index].prop_id, prop_id)
             self.assertEqual(columns[index].index, index)
 
     def test_reorder_wrong_number_of_filter_ids_raises_error(self):
         session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)
-        session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, "lowkey")
-        session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, "2")
+        session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, 'lowkey')
+        session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, '2')
         session.add_filter('pot_type', DataType.DATE, FilterMatchType.IS_EMPTY)
-        session.add_filter('height_cm', DataType.DECIMAL, FilterMatchType.LESS_THAN_EQUAL, "11.0")
+        session.add_filter('height_cm', DataType.DECIMAL, FilterMatchType.LESS_THAN_EQUAL, '11.0')
         filters = session.filters.all()
         # the form that uses this method will always fetch a list of strings, and the field is a UUID
         new_order = [str(filter_id) for filter_id in [filters[1].filter_id, filters[2].filter_id]]
@@ -195,25 +188,25 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
     def test_reorder_filters(self):
         session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         session.add_filter('watered_on', DataType.DATE, FilterMatchType.IS_NOT_MISSING)
-        session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, "lowkey")
-        session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, "2")
+        session.add_filter('name', DataType.TEXT, FilterMatchType.PHONETIC, 'lowkey')
+        session.add_filter('num_leaves', DataType.INTEGER, FilterMatchType.GREATER_THAN, '2')
         session.add_filter('pot_type', DataType.DATE, FilterMatchType.IS_EMPTY)
-        session.add_filter('height_cm', DataType.DECIMAL, FilterMatchType.LESS_THAN_EQUAL, "11.0")
+        session.add_filter('height_cm', DataType.DECIMAL, FilterMatchType.LESS_THAN_EQUAL, '11.0')
         filters = session.filters.all()
         # the form that uses this method will always fetch a list of strings, and the field is a UUID
-        new_order = [str(filter_id) for filter_id in [
-            filters[1].filter_id,
-            filters[0].filter_id,
-            filters[2].filter_id,
-            filters[4].filter_id,
-            filters[3].filter_id,
-        ]]
+        new_order = [
+            str(filter_id)
+            for filter_id in [
+                filters[1].filter_id,
+                filters[0].filter_id,
+                filters[2].filter_id,
+                filters[4].filter_id,
+                filters[3].filter_id,
+            ]
+        ]
         session.update_filter_order(new_order)
         reordered_prop_ids = [c.prop_id for c in session.filters.all()]
-        self.assertEqual(
-            reordered_prop_ids,
-            ['name', 'watered_on', 'num_leaves', 'height_cm', 'pot_type']
-        )
+        self.assertEqual(reordered_prop_ids, ['name', 'watered_on', 'num_leaves', 'height_cm', 'pot_type'])
 
     def test_reorder_wrong_number_of_column_ids_raises_error(self):
         session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
@@ -227,19 +220,22 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
         session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
         columns = session.columns.all()
         # the form that uses this method will always fetch a list of strings, and the field is a UUID
-        new_order = [str(col_id) for col_id in [
-            columns[1].column_id,
-            columns[0].column_id,
-            columns[2].column_id,
-            columns[4].column_id,
-            columns[5].column_id,
-            columns[3].column_id,
-        ]]
+        new_order = [
+            str(col_id)
+            for col_id in [
+                columns[1].column_id,
+                columns[0].column_id,
+                columns[2].column_id,
+                columns[4].column_id,
+                columns[5].column_id,
+                columns[3].column_id,
+            ]
+        ]
         session.update_column_order(new_order)
         reordered_prop_ids = [c.prop_id for c in session.columns.all()]
         self.assertEqual(
             reordered_prop_ids,
-            ['owner_name', 'name', 'date_opened', 'last_modified', '@status', 'opened_by_username']
+            ['owner_name', 'name', 'date_opened', 'last_modified', '@status', 'opened_by_username'],
         )
 
     def test_get_queryset_multiple_filters(self):
@@ -257,8 +253,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             .NOT(case_property_missing('watered_on'))
             .filter(exact_case_property_text_query('pot_type', ''))
             .xpath_query(
-                self.domain_name,
-                "phonetic-match(name, 'lowkey') and num_leaves > 2 and height_cm <= 11.1"
+                self.domain_name, "phonetic-match(name, 'lowkey') and num_leaves > 2 and height_cm <= 11.1"
             )
         )
         self.assertEqual(query.es_query, expected_query.es_query)
@@ -283,10 +278,7 @@ class BulkEditSessionFilteredQuerysetTests(TestCase):
             CaseSearchES()
             .domain(self.domain_name)
             .case_type(self.case_type)
-            .xpath_query(
-                self.domain_name,
-                "num_leaves > 2"
-            )
+            .xpath_query(self.domain_name, 'num_leaves > 2')
         )
         self.assertEqual(query.es_query, expected_query.es_query)
 
@@ -333,9 +325,7 @@ class BaseBulkEditSessionTest(TestCase):
         cls.domain = create_domain(cls.domain_name)
         cls.addClassCleanup(cls.domain.delete)
 
-        cls.web_user = WebUser.create(
-            cls.domain.name, 'tester@datacleaning.org', 'testpwd', None, None
-        )
+        cls.web_user = WebUser.create(cls.domain.name, 'tester@datacleaning.org', 'testpwd', None, None)
         cls.django_user = User.objects.get(username=cls.web_user.username)
         cls.addClassCleanup(cls.web_user.delete, cls.domain.name, deleted_by=None)
 
@@ -347,9 +337,7 @@ class BaseBulkEditSessionTest(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.session = BulkEditSession.objects.new_case_session(
-            self.django_user, self.domain_name, self.case_type
-        )
+        self.session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
 
 
 class BulkEditSessionCaseColumnTests(BaseBulkEditSessionTest):
@@ -357,20 +345,20 @@ class BulkEditSessionCaseColumnTests(BaseBulkEditSessionTest):
 
     def test_add_column(self):
         self.assertEqual(self.session.columns.count(), 6)
-        new_column = self.session.add_column('num_leaves', "Number of Leaves", DataType.INTEGER)
+        new_column = self.session.add_column('num_leaves', 'Number of Leaves', DataType.INTEGER)
         self.assertEqual(new_column.index, 6)
         self.assertEqual(self.session.columns.count(), 7)
         self.assertEqual(new_column.prop_id, 'num_leaves')
-        self.assertEqual(new_column.label, "Number of Leaves")
+        self.assertEqual(new_column.label, 'Number of Leaves')
         self.assertEqual(new_column.data_type, DataType.INTEGER)
         self.assertFalse(new_column.is_system)
 
     def test_add_system_column(self):
-        new_column = self.session.add_column('@owner_id', "Owner ID", DataType.INTEGER)
+        new_column = self.session.add_column('@owner_id', 'Owner ID', DataType.INTEGER)
         self.assertEqual(new_column.index, 6)
         self.assertEqual(self.session.columns.count(), 7)
         self.assertEqual(new_column.prop_id, '@owner_id')
-        self.assertEqual(new_column.label, "Owner ID")
+        self.assertEqual(new_column.label, 'Owner ID')
         self.assertEqual(new_column.data_type, DataType.TEXT)
         self.assertTrue(new_column.is_system)
 

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -1,12 +1,13 @@
 from datetime import datetime
-from django.test import TestCase
 
 from casexml.apps.case.mock import CaseFactory
+from django.test import TestCase
+
 from corehq.apps.data_cleaning.models import (
     BulkEditChange,
     BulkEditRecord,
-    BulkEditSessionType,
     BulkEditSession,
+    BulkEditSessionType,
     EditActionType,
 )
 from corehq.apps.data_cleaning.tasks import commit_data_cleaning
@@ -16,11 +17,11 @@ from corehq.apps.es.tests.utils import (
     case_search_es_setup,
     es_test,
 )
+from corehq.apps.hqcase.utils import CASEBLOCK_CHUNKSIZE
 from corehq.apps.hqwebapp.tests.tables.generator import get_case_blocks
 from corehq.apps.users.models import WebUser
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
-from corehq.apps.hqcase.utils import CASEBLOCK_CHUNKSIZE
 
 
 @es_test(requires=[case_search_adapter, user_adapter], setup_class=True)

--- a/corehq/apps/data_cleaning/tests/test_tasks.py
+++ b/corehq/apps/data_cleaning/tests/test_tasks.py
@@ -127,13 +127,16 @@ class CommitCasesTest(TestCase):
         self.assertEqual(case.get_case_property('year'), '2023')
 
         self._refresh_session()
-        self.assertDictEqual(self.session.result, {
-            'errors': [],
-            'form_ids': form_ids,
-            'num_committed_records': 1,
-            'record_count': 1,
-            'percent': 100,
-        })
+        self.assertDictEqual(
+            self.session.result,
+            {
+                'errors': [],
+                'form_ids': form_ids,
+                'num_committed_records': 1,
+                'record_count': 1,
+                'percent': 100,
+            },
+        )
         self.assertEqual(self.session.percent_complete, 100)
         self.assertListEqual(list(self.session.form_ids), form_ids)
         self.assertIsNotNone(self.session.completed_on)
@@ -141,19 +144,23 @@ class CommitCasesTest(TestCase):
     def test_chunking(self):
         cases = [self.case]
         for i in range(0, CASEBLOCK_CHUNKSIZE):
-            cases.append(self.factory.create_case(
-                case_type=self.case_type,
-                owner_id='crj123',
-                case_name=f'case{i}',
-                update={'speed': f'{i}kph'},
-            ))
+            cases.append(
+                self.factory.create_case(
+                    case_type=self.case_type,
+                    owner_id='crj123',
+                    case_name=f'case{i}',
+                    update={'speed': f'{i}kph'},
+                )
+            )
 
         records = []
         for case in cases:
-            records.append(BulkEditRecord(
-                session=self.session,
-                doc_id=case.case_id,
-            ))
+            records.append(
+                BulkEditRecord(
+                    session=self.session,
+                    doc_id=case.case_id,
+                )
+            )
             records[-1].save()
 
         change = BulkEditChange(

--- a/corehq/apps/data_cleaning/tests/test_views.py
+++ b/corehq/apps/data_cleaning/tests/test_views.py
@@ -14,12 +14,15 @@ from corehq.apps.data_cleaning.views.columns import (
     ManageColumnsFormView,
 )
 from corehq.apps.data_cleaning.views.filters import (
-    ManagePinnedFiltersView,
     ManageFiltersView,
+    ManagePinnedFiltersView,
 )
 from corehq.apps.data_cleaning.views.main import (
     BulkEditCasesMainView,
     BulkEditCasesSessionView,
+)
+from corehq.apps.data_cleaning.views.start import (
+    StartCaseSessionView,
 )
 from corehq.apps.data_cleaning.views.status import (
     BulkEditSessionStatusView,
@@ -27,9 +30,6 @@ from corehq.apps.data_cleaning.views.status import (
 from corehq.apps.data_cleaning.views.tables import (
     EditCasesTableView,
     RecentCaseSessionsTableView,
-)
-from corehq.apps.data_cleaning.views.start import (
-    StartCaseSessionView,
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es import group_adapter

--- a/corehq/apps/data_cleaning/tests/test_views.py
+++ b/corehq/apps/data_cleaning/tests/test_views.py
@@ -95,7 +95,9 @@ class CleanCasesViewAccessTest(TestCase):
         )
         cls.client = Client()
         session = BulkEditSession.objects.new_case_session(
-            cls.user_in_domain.get_django_user(), cls.domain_name, 'plants',
+            cls.user_in_domain.get_django_user(),
+            cls.domain_name,
+            'plants',
         )
         cls.real_session_id = session.session_id
         cls.fake_session_id = uuid.uuid4()
@@ -103,21 +105,111 @@ class CleanCasesViewAccessTest(TestCase):
             (BulkEditCasesMainView, (cls.domain_name,)),
             (StartCaseSessionView, (cls.domain_name,)),
             (RecentCaseSessionsTableView, (cls.domain_name,)),
-            (BulkEditCasesSessionView, (cls.domain_name, cls.real_session_id,)),
-            (BulkEditCasesSessionView, (cls.domain_name, cls.fake_session_id,)),
-            (EditCasesTableView, (cls.domain_name, cls.real_session_id,)),
-            (EditCasesTableView, (cls.domain_name, cls.fake_session_id,)),
-            (ManagePinnedFiltersView, (cls.domain_name, cls.real_session_id,)),
-            (ManagePinnedFiltersView, (cls.domain_name, cls.fake_session_id,)),
-            (ManageFiltersView, (cls.domain_name, cls.real_session_id,)),
-            (ManageFiltersView, (cls.domain_name, cls.fake_session_id,)),
-            (ManageColumnsFormView, (cls.domain_name, cls.real_session_id,)),
-            (ManageColumnsFormView, (cls.domain_name, cls.fake_session_id,)),
-            (ManageFiltersView, (cls.domain_name, cls.fake_session_id,)),
-            (EditSelectedRecordsFormView, (cls.domain_name, cls.real_session_id,)),
-            (EditSelectedRecordsFormView, (cls.domain_name, cls.fake_session_id,)),
-            (BulkEditSessionStatusView, (cls.domain_name, cls.real_session_id,)),
-            (BulkEditSessionStatusView, (cls.domain_name, cls.fake_session_id,)),
+            (
+                BulkEditCasesSessionView,
+                (
+                    cls.domain_name,
+                    cls.real_session_id,
+                ),
+            ),
+            (
+                BulkEditCasesSessionView,
+                (
+                    cls.domain_name,
+                    cls.fake_session_id,
+                ),
+            ),
+            (
+                EditCasesTableView,
+                (
+                    cls.domain_name,
+                    cls.real_session_id,
+                ),
+            ),
+            (
+                EditCasesTableView,
+                (
+                    cls.domain_name,
+                    cls.fake_session_id,
+                ),
+            ),
+            (
+                ManagePinnedFiltersView,
+                (
+                    cls.domain_name,
+                    cls.real_session_id,
+                ),
+            ),
+            (
+                ManagePinnedFiltersView,
+                (
+                    cls.domain_name,
+                    cls.fake_session_id,
+                ),
+            ),
+            (
+                ManageFiltersView,
+                (
+                    cls.domain_name,
+                    cls.real_session_id,
+                ),
+            ),
+            (
+                ManageFiltersView,
+                (
+                    cls.domain_name,
+                    cls.fake_session_id,
+                ),
+            ),
+            (
+                ManageColumnsFormView,
+                (
+                    cls.domain_name,
+                    cls.real_session_id,
+                ),
+            ),
+            (
+                ManageColumnsFormView,
+                (
+                    cls.domain_name,
+                    cls.fake_session_id,
+                ),
+            ),
+            (
+                ManageFiltersView,
+                (
+                    cls.domain_name,
+                    cls.fake_session_id,
+                ),
+            ),
+            (
+                EditSelectedRecordsFormView,
+                (
+                    cls.domain_name,
+                    cls.real_session_id,
+                ),
+            ),
+            (
+                EditSelectedRecordsFormView,
+                (
+                    cls.domain_name,
+                    cls.fake_session_id,
+                ),
+            ),
+            (
+                BulkEditSessionStatusView,
+                (
+                    cls.domain_name,
+                    cls.real_session_id,
+                ),
+            ),
+            (
+                BulkEditSessionStatusView,
+                (
+                    cls.domain_name,
+                    cls.fake_session_id,
+                ),
+            ),
         ]
         cls.views_not_found_with_invalid_session = [
             EditCasesTableView,
@@ -144,22 +236,14 @@ class CleanCasesViewAccessTest(TestCase):
         for view_class, args in self.all_views:
             url = reverse(view_class.urlname, args=args)
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code,
-                403,
-                msg=f"{view_class.__name__} should NOT be accessible"
-            )
+            self.assertEqual(response.status_code, 403, msg=f'{view_class.__name__} should NOT be accessible')
 
     def test_has_no_access_without_privilege(self):
         self.client.login(username=self.user_in_domain.username, password=self.password)
         for view_class, args in self.all_views:
             url = reverse(view_class.urlname, args=args)
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code,
-                403,
-                msg=f"{view_class.__name__} should NOT be accessible"
-            )
+            self.assertEqual(response.status_code, 403, msg=f'{view_class.__name__} should NOT be accessible')
 
     @privilege_enabled(BULK_DATA_EDITING)
     def test_has_no_access_without_permission(self):
@@ -167,11 +251,7 @@ class CleanCasesViewAccessTest(TestCase):
         for view_class, args in self.all_views:
             url = reverse(view_class.urlname, args=args)
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code,
-                403,
-                msg=f"{view_class.__name__} should NOT be accessible"
-            )
+            self.assertEqual(response.status_code, 403, msg=f'{view_class.__name__} should NOT be accessible')
 
     @privilege_enabled(BULK_DATA_EDITING)
     def test_has_access_with_prereqs(self):
@@ -182,18 +262,11 @@ class CleanCasesViewAccessTest(TestCase):
                 continue
             url = reverse(view_class.urlname, args=args)
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code,
-                200,
-                msg=f"{view_class.__name__} should be accessible"
-            )
+            self.assertEqual(response.status_code, 200, msg=f'{view_class.__name__} should be accessible')
 
     @privilege_enabled(BULK_DATA_EDITING)
     def test_has_no_access_to_wrong_session(self):
-        self.client.login(
-            username=self.user_in_domain_not_in_session.username,
-            password=self.password
-        )
+        self.client.login(username=self.user_in_domain_not_in_session.username, password=self.password)
         for view_class, args in self.all_views:
             if self.fake_session_id in args or len(args) == 1:
                 # only test real sessions and session views
@@ -203,7 +276,7 @@ class CleanCasesViewAccessTest(TestCase):
             self.assertEqual(
                 response.status_code,
                 302 if view_class == BulkEditCasesSessionView else 404,
-                msg=f"{view_class.__name__} should NOT be accessible"
+                msg=f'{view_class.__name__} should NOT be accessible',
             )
 
     @privilege_enabled(BULK_DATA_EDITING)
@@ -218,17 +291,12 @@ class CleanCasesViewAccessTest(TestCase):
         self.client.login(username=self.user_in_domain.username, password=self.password)
 
         for view_class, args in self.all_views:
-            if not (self.fake_session_id in args
-                    and view_class in self.views_not_found_with_invalid_session):
+            if not (self.fake_session_id in args and view_class in self.views_not_found_with_invalid_session):
                 # only test views expected to 404 with invalid sessions
                 continue
             url = reverse(view_class.urlname, args=args)
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code,
-                404,
-                msg=f"{view_class.__name__} should NOT be accessible"
-            )
+            self.assertEqual(response.status_code, 404, msg=f'{view_class.__name__} should NOT be accessible')
 
     @privilege_enabled(BULK_DATA_EDITING)
     def test_has_no_access_with_other_domain(self):
@@ -236,8 +304,4 @@ class CleanCasesViewAccessTest(TestCase):
         for view_class, args in self.all_views:
             url = reverse(view_class.urlname, args=args)
             response = self.client.get(url)
-            self.assertEqual(
-                response.status_code,
-                403,
-                msg=f"{view_class.__name__} should NOT be accessible"
-            )
+            self.assertEqual(response.status_code, 403, msg=f'{view_class.__name__} should NOT be accessible')

--- a/corehq/apps/data_cleaning/urls.py
+++ b/corehq/apps/data_cleaning/urls.py
@@ -33,24 +33,39 @@ bulk_edit_urlpatterns = [
     url(r'^cases/$', BulkEditCasesMainView.as_view(), name=BulkEditCasesMainView.urlname),
     url(r'^start/case/$', StartCaseSessionView.as_view(), name=StartCaseSessionView.urlname),
     url(r'^tasks/case/$', RecentCaseSessionsTableView.as_view(), name=RecentCaseSessionsTableView.urlname),
-    url(r'^cases/(?P<session_id>[\w\-]+)/$', BulkEditCasesSessionView.as_view(),
-        name=BulkEditCasesSessionView.urlname),
-    url(r'^cases/(?P<session_id>[\w\-]+)/table/$', EditCasesTableView.as_view(),
-        name=EditCasesTableView.urlname),
-    url(r'^cases/(?P<session_id>[\w\-]+)/summary/$', ChangesSummaryView.as_view(),
-        name=ChangesSummaryView.urlname),
-    url(r'^session/(?P<session_id>[\w\-]+)/status/$', BulkEditSessionStatusView.as_view(),
-        name=BulkEditSessionStatusView.urlname),
-    url(r'^session/(?P<session_id>[\w\-]+)/filters/$', ManageFiltersView.as_view(),
-        name=ManageFiltersView.urlname),
-    url(r'^session/(?P<session_id>[\w\-]+)/filters/pinned/$', ManagePinnedFiltersView.as_view(),
-        name=ManagePinnedFiltersView.urlname),
-    url(r'^session/(?P<session_id>[\w\-]+)/columns/$', ManageColumnsFormView.as_view(),
-        name=ManageColumnsFormView.urlname),
-    url(r'^session/(?P<session_id>[\w\-]+)/clean/$', EditSelectedRecordsFormView.as_view(),
-        name=EditSelectedRecordsFormView.urlname),
-    url(r'^session/(?P<session_id>[\w\-]+)/clear/$', clear_session_caches,
-        name="bulk_edit_clear_session_caches"),
+    url(
+        r'^cases/(?P<session_id>[\w\-]+)/$',
+        BulkEditCasesSessionView.as_view(),
+        name=BulkEditCasesSessionView.urlname,
+    ),
+    url(r'^cases/(?P<session_id>[\w\-]+)/table/$', EditCasesTableView.as_view(), name=EditCasesTableView.urlname),
+    url(
+        r'^cases/(?P<session_id>[\w\-]+)/summary/$', ChangesSummaryView.as_view(), name=ChangesSummaryView.urlname
+    ),
+    url(
+        r'^session/(?P<session_id>[\w\-]+)/status/$',
+        BulkEditSessionStatusView.as_view(),
+        name=BulkEditSessionStatusView.urlname,
+    ),
+    url(
+        r'^session/(?P<session_id>[\w\-]+)/filters/$', ManageFiltersView.as_view(), name=ManageFiltersView.urlname
+    ),
+    url(
+        r'^session/(?P<session_id>[\w\-]+)/filters/pinned/$',
+        ManagePinnedFiltersView.as_view(),
+        name=ManagePinnedFiltersView.urlname,
+    ),
+    url(
+        r'^session/(?P<session_id>[\w\-]+)/columns/$',
+        ManageColumnsFormView.as_view(),
+        name=ManageColumnsFormView.urlname,
+    ),
+    url(
+        r'^session/(?P<session_id>[\w\-]+)/clean/$',
+        EditSelectedRecordsFormView.as_view(),
+        name=EditSelectedRecordsFormView.urlname,
+    ),
+    url(r'^session/(?P<session_id>[\w\-]+)/clear/$', clear_session_caches, name='bulk_edit_clear_session_caches'),
     url(r'^form_ids/(?P<session_id>[\w\-]+)/$', download_form_ids, name='download_form_ids'),
 ]
 

--- a/corehq/apps/data_cleaning/urls.py
+++ b/corehq/apps/data_cleaning/urls.py
@@ -1,6 +1,6 @@
-from django.urls import re_path as url, include
+from django.urls import include
+from django.urls import re_path as url
 
-from corehq.apps.data_cleaning.views.summary import ChangesSummaryView
 from corehq.apps.data_cleaning.views.bulk_edit import (
     EditSelectedRecordsFormView,
 )
@@ -8,8 +8,8 @@ from corehq.apps.data_cleaning.views.columns import (
     ManageColumnsFormView,
 )
 from corehq.apps.data_cleaning.views.filters import (
-    ManagePinnedFiltersView,
     ManageFiltersView,
+    ManagePinnedFiltersView,
 )
 from corehq.apps.data_cleaning.views.main import (
     BulkEditCasesMainView,
@@ -17,17 +17,17 @@ from corehq.apps.data_cleaning.views.main import (
     clear_session_caches,
     download_form_ids,
 )
-from corehq.apps.data_cleaning.views.tables import (
-    EditCasesTableView,
-    RecentCaseSessionsTableView,
-)
 from corehq.apps.data_cleaning.views.start import (
     StartCaseSessionView,
 )
 from corehq.apps.data_cleaning.views.status import (
     BulkEditSessionStatusView,
 )
-
+from corehq.apps.data_cleaning.views.summary import ChangesSummaryView
+from corehq.apps.data_cleaning.views.tables import (
+    EditCasesTableView,
+    RecentCaseSessionsTableView,
+)
 
 bulk_edit_urlpatterns = [
     url(r'^cases/$', BulkEditCasesMainView.as_view(), name=BulkEditCasesMainView.urlname),

--- a/corehq/apps/data_cleaning/utils/cases.py
+++ b/corehq/apps/data_cleaning/utils/cases.py
@@ -46,22 +46,22 @@ def get_system_property_data_type(prop_id):
 
 def get_system_property_label(prop_id):
     return {
-        '@case_id': _("Case ID"),
-        '@case_type': _("Case Type"),
-        '@owner_id': _("Owner ID"),
-        '@status': _("Open/Closed Status"),
-        'name': _("Name"),
-        'external_id': _("External ID"),
-        'date_opened': _("Date Opened"),
-        'closed_on': _("Closed On"),
-        'last_modified': _("Last Modified On"),
-        'closed_by_username': _("Closed By"),
-        'last_modified_by_user_username': _("Last Modified By"),
-        'opened_by_username': _("Opened By"),
-        'owner_name': _("Owner"),
-        'closed_by_user_id': _("Closed By User ID"),
-        'opened_by_user_id': _("Opened By User ID"),
-        'server_last_modified_date': _("Last Modified (UTC)"),
+        '@case_id': _('Case ID'),
+        '@case_type': _('Case Type'),
+        '@owner_id': _('Owner ID'),
+        '@status': _('Open/Closed Status'),
+        'name': _('Name'),
+        'external_id': _('External ID'),
+        'date_opened': _('Date Opened'),
+        'closed_on': _('Closed On'),
+        'last_modified': _('Last Modified On'),
+        'closed_by_username': _('Closed By'),
+        'last_modified_by_user_username': _('Last Modified By'),
+        'opened_by_username': _('Opened By'),
+        'owner_name': _('Owner'),
+        'closed_by_user_id': _('Closed By User ID'),
+        'opened_by_user_id': _('Opened By User ID'),
+        'server_last_modified_date': _('Last Modified (UTC)'),
     }.get(prop_id, prop_id)
 
 
@@ -82,6 +82,7 @@ def _get_system_property_details():
 
 def _get_data_type_from_data_dictionary(case_property):
     from corehq.apps.data_dictionary.models import CaseProperty
+
     return {
         CaseProperty.DataType.DATE: DataType.DATE,
         CaseProperty.DataType.PLAIN: DataType.TEXT,
@@ -103,6 +104,7 @@ def _get_property_details_from_data_dictionary(domain, case_type):
     if not domain_has_privilege(domain, privileges.DATA_DICTIONARY):
         return {}
     from corehq.apps.data_dictionary.models import CaseType
+
     try:
         case_properties = CaseType.objects.get(domain=domain, name=case_type).properties.all()
         details = {}
@@ -131,13 +133,14 @@ def get_case_property_details(domain, case_type):
     properties = set(properties).union(data_dictionary_details.keys())
     for prop_id in properties:
         details[prop_id] = data_dictionary_details.get(
-            prop_id, PropertyDetail(
+            prop_id,
+            PropertyDetail(
                 label=_get_default_label(prop_id),
                 data_type=DataType.TEXT,
                 prop_id=prop_id,
                 is_editable=True,
                 options=None,
-            )._asdict()
+            )._asdict(),
         )
     details.update(_get_system_property_details())
     return details

--- a/corehq/apps/data_cleaning/utils/decorators.py
+++ b/corehq/apps/data_cleaning/utils/decorators.py
@@ -1,4 +1,5 @@
 import time
+
 from django.db import IntegrityError
 
 

--- a/corehq/apps/data_cleaning/utils/decorators.py
+++ b/corehq/apps/data_cleaning/utils/decorators.py
@@ -7,6 +7,7 @@ def retry_on_integrity_error(max_retries=3, delay=0.1):
     """
     Decorator to retry a function call if an IntegrityError occurs.
     """
+
     def decorator(func):
         def wrapper(*args, **kwargs):
             # note: the zero-th 'attempt' is not a 'retry', it is the first call
@@ -18,5 +19,7 @@ def retry_on_integrity_error(max_retries=3, delay=0.1):
                         time.sleep(delay)
                     else:
                         raise
+
         return wrapper
+
     return decorator

--- a/corehq/apps/data_cleaning/views/bulk_edit.py
+++ b/corehq/apps/data_cleaning/views/bulk_edit.py
@@ -11,24 +11,30 @@ from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 
-@method_decorator([
-    use_bootstrap5,
-    require_bulk_data_cleaning_cases,
-], name='dispatch')
-class EditSelectedRecordsFormView(BulkEditSessionViewMixin,
-                                  LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
-    urlname = "bulk_edit_selected_records_form"
-    template_name = "data_cleaning/forms/edit_selected_records_form.html"
-    session_not_found_message = gettext_lazy("Cannot load edit selected records form, session was not found.")
+@method_decorator(
+    [
+        use_bootstrap5,
+        require_bulk_data_cleaning_cases,
+    ],
+    name='dispatch',
+)
+class EditSelectedRecordsFormView(
+    BulkEditSessionViewMixin, LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView
+):
+    urlname = 'bulk_edit_selected_records_form'
+    template_name = 'data_cleaning/forms/edit_selected_records_form.html'
+    session_not_found_message = gettext_lazy('Cannot load edit selected records form, session was not found.')
 
     def get_context_data(self, form=None, change=None, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({
-            'container_id': 'edit-selected-records',
-            'form': form or EditSelectedRecordsForm(self.session),
-            'are_bulk_edits_allowed': self.session.are_bulk_edits_allowed(),
-            'change': change,
-        })
+        context.update(
+            {
+                'container_id': 'edit-selected-records',
+                'form': form or EditSelectedRecordsForm(self.session),
+                'are_bulk_edits_allowed': self.session.are_bulk_edits_allowed(),
+                'change': change,
+            }
+        )
         return context
 
     @hq_hx_action('post')
@@ -36,15 +42,13 @@ class EditSelectedRecordsFormView(BulkEditSessionViewMixin,
         form = EditSelectedRecordsForm(self.session, request.POST)
         change = None
         if form.is_valid():
-            change = self.session.apply_change_to_selected_records(
-                form.get_bulk_edit_change()
-            )
+            change = self.session.apply_change_to_selected_records(form.get_bulk_edit_change())
             response = self.get(request, form=None, change=change, *args, **kwargs)
             return self.include_gtm_event_with_response(
                 response,
-                "bulk_edit_change_created",
+                'bulk_edit_change_created',
                 {
-                    "edit_action": form.cleaned_data.get('edit_action', None),
-                }
+                    'edit_action': form.cleaned_data.get('edit_action', None),
+                },
             )
         return self.get(request, form=form, change=change, *args, **kwargs)

--- a/corehq/apps/data_cleaning/views/columns.py
+++ b/corehq/apps/data_cleaning/views/columns.py
@@ -13,31 +13,39 @@ from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 
-@method_decorator([
-    use_bootstrap5,
-    require_bulk_data_cleaning_cases,
-], name='dispatch')
-class ManageColumnsFormView(BulkEditSessionViewMixin,
-                            LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
-    urlname = "bulk_edit_manage_columns_form"
-    template_name = "data_cleaning/forms/manage_columns_form.html"
-    session_not_found_message = gettext_lazy("Cannot retrieve columns, session was not found.")
+@method_decorator(
+    [
+        use_bootstrap5,
+        require_bulk_data_cleaning_cases,
+    ],
+    name='dispatch',
+)
+class ManageColumnsFormView(
+    BulkEditSessionViewMixin, LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView
+):
+    urlname = 'bulk_edit_manage_columns_form'
+    template_name = 'data_cleaning/forms/manage_columns_form.html'
+    session_not_found_message = gettext_lazy('Cannot retrieve columns, session was not found.')
 
     def get_context_data(self, column_form=None, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({
-            'container_id': 'manage-columns',
-            'active_columns': self.session.columns.all(),
-            'add_column_form': column_form or AddColumnForm(self.session),
-        })
+        context.update(
+            {
+                'container_id': 'manage-columns',
+                'active_columns': self.session.columns.all(),
+                'add_column_form': column_form or AddColumnForm(self.session),
+            }
+        )
         return context
 
     def _trigger_clean_form_refresh(self, response):
-        response['HX-Trigger'] = json.dumps({
-            'dcEditFormRefresh': {
-                'target': '#hq-hx-edit-selected-records-form',
-            },
-        })
+        response['HX-Trigger'] = json.dumps(
+            {
+                'dcEditFormRefresh': {
+                    'target': '#hq-hx-edit-selected-records-form',
+                },
+            }
+        )
         return response
 
     @hq_hx_action('post')
@@ -47,7 +55,7 @@ class ManageColumnsFormView(BulkEditSessionViewMixin,
             column_form.add_column()
             response = self.get(request, column_form=None, *args, **kwargs)
             response = self._trigger_clean_form_refresh(response)
-            return self.include_gtm_event_with_response(response, "bulk_edit_column_added")
+            return self.include_gtm_event_with_response(response, 'bulk_edit_column_added')
         return self.get(request, column_form=column_form, *args, **kwargs)
 
     @hq_hx_action('post')
@@ -56,11 +64,11 @@ class ManageColumnsFormView(BulkEditSessionViewMixin,
         self.session.update_column_order(column_ids)
         response = self.get(request, *args, **kwargs)
         response = self._trigger_clean_form_refresh(response)
-        return self.include_gtm_event_with_response(response, "bulk_edit_column_order_updated")
+        return self.include_gtm_event_with_response(response, 'bulk_edit_column_order_updated')
 
     @hq_hx_action('post')
     def remove_column(self, request, *args, **kwargs):
         self.session.remove_column(request.POST['delete_id'])
         response = self.get(request, *args, **kwargs)
         response = self._trigger_clean_form_refresh(response)
-        return self.include_gtm_event_with_response(response, "bulk_edit_column_removed")
+        return self.include_gtm_event_with_response(response, 'bulk_edit_column_removed')

--- a/corehq/apps/data_cleaning/views/columns.py
+++ b/corehq/apps/data_cleaning/views/columns.py
@@ -1,4 +1,5 @@
 import json
+
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
 from django.views.generic import TemplateView

--- a/corehq/apps/data_cleaning/views/filters.py
+++ b/corehq/apps/data_cleaning/views/filters.py
@@ -13,18 +13,21 @@ from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 from corehq.util.timezones.utils import get_timezone
 
 
-@method_decorator([
-    use_bootstrap5,
-    require_bulk_data_cleaning_cases,
-], name='dispatch')
+@method_decorator(
+    [
+        use_bootstrap5,
+        require_bulk_data_cleaning_cases,
+    ],
+    name='dispatch',
+)
 class BaseFilterFormView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
     pass
 
 
 class ManagePinnedFiltersView(BulkEditSessionViewMixin, BaseFilterFormView):
-    urlname = "bulk_edit_pinned_filters"
-    template_name = "data_cleaning/forms/pinned_filter_form.html"
-    session_not_found_message = gettext_lazy("Cannot retrieve pinned filters, session was not found.")
+    urlname = 'bulk_edit_pinned_filters'
+    template_name = 'data_cleaning/forms/pinned_filter_form.html'
+    session_not_found_message = gettext_lazy('Cannot retrieve pinned filters, session was not found.')
 
     @property
     def timezone(self):
@@ -35,46 +38,53 @@ class ManagePinnedFiltersView(BulkEditSessionViewMixin, BaseFilterFormView):
     def form_filters(self):
         return [
             f.get_report_filter_class()(
-                self.session, self.request, self.domain, self.timezone, use_bootstrap5=True
-            ) for f in self.session.pinned_filters.all()
+                self.session,
+                self.request,
+                self.domain,
+                self.timezone,
+                use_bootstrap5=True,
+            )
+            for f in self.session.pinned_filters.all()
         ]
 
     @hq_hx_action('post')
     def update_filters(self, request, *args, **kwargs):
         [f.update_stored_value() for f in self.form_filters]
         response = self.get(request, *args, **kwargs)
-        return self.include_gtm_event_with_response(response, "bulk_edit_pinned_filters_updated")
+        return self.include_gtm_event_with_response(response, 'bulk_edit_pinned_filters_updated')
 
     @hq_hx_action('post')
     def reset_filters(self, request, *args, **kwargs):
         self.session.reset_pinned_filters()
         response = self.get(request, *args, **kwargs)
-        return self.include_gtm_event_with_response(response, "bulk_edit_pinned_filters_reset")
+        return self.include_gtm_event_with_response(response, 'bulk_edit_pinned_filters_reset')
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({
-            'container_id': 'pinned-filters',
-            'form_filters': [
-                f.render() for f in self.form_filters
-            ],
-            'has_values': self.session.has_pinned_values,
-        })
+        context.update(
+            {
+                'container_id': 'pinned-filters',
+                'form_filters': [f.render() for f in self.form_filters],
+                'has_values': self.session.has_pinned_values,
+            }
+        )
         return context
 
 
 class ManageFiltersView(BulkEditSessionViewMixin, BaseFilterFormView):
-    urlname = "bulk_edit_manage_filters"
-    template_name = "data_cleaning/forms/manage_filters_form.html"
-    session_not_found_message = gettext_lazy("Cannot retrieve filters, session was not found.")
+    urlname = 'bulk_edit_manage_filters'
+    template_name = 'data_cleaning/forms/manage_filters_form.html'
+    session_not_found_message = gettext_lazy('Cannot retrieve filters, session was not found.')
 
     def get_context_data(self, filter_form=None, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({
-            'container_id': 'manage-filters',
-            'active_filters': self.session.filters.all(),
-            'add_filter_form': filter_form or AddFilterForm(self.session),
-        })
+        context.update(
+            {
+                'container_id': 'manage-filters',
+                'active_filters': self.session.filters.all(),
+                'add_filter_form': filter_form or AddFilterForm(self.session),
+            }
+        )
         return context
 
     @hq_hx_action('post')
@@ -85,10 +95,10 @@ class ManageFiltersView(BulkEditSessionViewMixin, BaseFilterFormView):
             response = self.get(request, filter_form=None, *args, **kwargs)
             return self.include_gtm_event_with_response(
                 response,
-                "bulk_edit_filter_added",
+                'bulk_edit_filter_added',
                 {
-                    "data_type": filter_form.cleaned_data.get("data_type"),
-                    "match_type": filter_form.cleaned_data.get("match_type"),
+                    'data_type': filter_form.cleaned_data.get('data_type'),
+                    'match_type': filter_form.cleaned_data.get('match_type'),
                 },
             )
         return self.get(request, filter_form=filter_form, *args, **kwargs)
@@ -98,10 +108,10 @@ class ManageFiltersView(BulkEditSessionViewMixin, BaseFilterFormView):
         filter_ids = request.POST.getlist('filter_ids')
         self.session.update_filter_order(filter_ids)
         response = self.get(request, *args, **kwargs)
-        return self.include_gtm_event_with_response(response, "bulk_edit_filter_order_updated")
+        return self.include_gtm_event_with_response(response, 'bulk_edit_filter_order_updated')
 
     @hq_hx_action('post')
     def delete_filter(self, request, *args, **kwargs):
         self.session.remove_filter(request.POST['delete_id'])
         response = self.get(request, *args, **kwargs)
-        return self.include_gtm_event_with_response(response, "bulk_edit_filter_deleted")
+        return self.include_gtm_event_with_response(response, 'bulk_edit_filter_deleted')

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -1,12 +1,12 @@
-from memoized import memoized
-
 from django.contrib import messages
-from django.shortcuts import redirect
 from django.http import StreamingHttpResponse
+from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 from django.views.decorators.http import require_GET
-from django.utils.translation import gettext_lazy, gettext as _
+from memoized import memoized
 
 from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
 from corehq.apps.data_cleaning.models import BulkEditSession
@@ -17,8 +17,7 @@ from corehq.apps.data_cleaning.views.filters import ManageFiltersView, ManagePin
 from corehq.apps.data_cleaning.views.mixins import BulkEditSessionViewMixin
 from corehq.apps.data_cleaning.views.start import StartCaseSessionView
 from corehq.apps.data_cleaning.views.status import BulkEditSessionStatusView
-from corehq.apps.data_cleaning.views.tables import RecentCaseSessionsTableView
-from corehq.apps.data_cleaning.views.tables import EditCasesTableView
+from corehq.apps.data_cleaning.views.tables import EditCasesTableView, RecentCaseSessionsTableView
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.settings.views import BaseProjectDataView

--- a/corehq/apps/data_cleaning/views/main.py
+++ b/corehq/apps/data_cleaning/views/main.py
@@ -24,45 +24,52 @@ from corehq.apps.settings.views import BaseProjectDataView
 from corehq.util.view_utils import set_file_download
 
 
-@method_decorator([
-    use_bootstrap5,
-    require_bulk_data_cleaning_cases,
-], name='dispatch')
+@method_decorator(
+    [
+        use_bootstrap5,
+        require_bulk_data_cleaning_cases,
+    ],
+    name='dispatch',
+)
 class BulkEditCasesMainView(BaseProjectDataView):
-    page_title = gettext_lazy("Bulk Edit Case Data")
-    urlname = "bulk_edit_cases_main"
-    template_name = "data_cleaning/bulk_edit_main.html"
+    page_title = gettext_lazy('Bulk Edit Case Data')
+    urlname = 'bulk_edit_cases_main'
+    template_name = 'data_cleaning/bulk_edit_main.html'
 
     @property
     def page_context(self):
         return {
-            "htmx_start_session_form_view_url": reverse(
+            'htmx_start_session_form_view_url': reverse(
                 StartCaseSessionView.urlname,
                 args=(self.domain,),
             ),
-            "htmx_recent_sessions_table_view_url": reverse(
+            'htmx_recent_sessions_table_view_url': reverse(
                 RecentCaseSessionsTableView.urlname,
                 args=(self.domain,),
             ),
         }
 
 
-@method_decorator([
-    use_bootstrap5,
-    require_bulk_data_cleaning_cases,
-], name='dispatch')
+@method_decorator(
+    [
+        use_bootstrap5,
+        require_bulk_data_cleaning_cases,
+    ],
+    name='dispatch',
+)
 class BulkEditCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
     """
     This view is a "host" view of several HTMX views that handle
     different parts of the Bulk Editing feature.
     """
-    page_title = gettext_lazy("Bulk Edit Case Type")
-    urlname = "bulk_edit_cases_session"
-    template_name = "data_cleaning/bulk_edit_session.html"
+
+    page_title = gettext_lazy('Bulk Edit Case Type')
+    urlname = 'bulk_edit_cases_session'
+    template_name = 'data_cleaning/bulk_edit_session.html'
     redirect_on_missing_session = True
 
     def get_redirect_url(self):
-        return reverse(BulkEditCasesMainView.urlname, args=(self.domain, ))
+        return reverse(BulkEditCasesMainView.urlname, args=(self.domain,))
 
     @property
     def case_type(self):
@@ -76,39 +83,47 @@ class BulkEditCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
     @memoized
     def page_url(self):
         if self.urlname:
-            return reverse(self.urlname, args=(self.domain, self.session_id,))
+            return reverse(
+                self.urlname,
+                args=(
+                    self.domain,
+                    self.session_id,
+                ),
+            )
 
     @property
     def parent_pages(self):
-        return [{
-            'title': BulkEditCasesMainView.page_title,
-            'url': reverse(BulkEditCasesMainView.urlname, args=(self.domain,)),
-        }]
+        return [
+            {
+                'title': BulkEditCasesMainView.page_title,
+                'url': reverse(BulkEditCasesMainView.urlname, args=(self.domain,)),
+            }
+        ]
 
     @property
     def page_context(self):
         return {
-            "htmx_primary_view_url": reverse(
+            'htmx_primary_view_url': reverse(
                 EditCasesTableView.urlname,
                 args=(self.domain, self.session_id),
             ),
-            "htmx_pinned_filters_view_url": reverse(
+            'htmx_pinned_filters_view_url': reverse(
                 ManagePinnedFiltersView.urlname,
                 args=(self.domain, self.session_id),
             ),
-            "htmx_filters_view_url": reverse(
+            'htmx_filters_view_url': reverse(
                 ManageFiltersView.urlname,
                 args=(self.domain, self.session_id),
             ),
-            "htmx_columns_view_url": reverse(
+            'htmx_columns_view_url': reverse(
                 ManageColumnsFormView.urlname,
                 args=(self.domain, self.session_id),
             ),
-            "htmx_edit_selected_records_view_url": reverse(
+            'htmx_edit_selected_records_view_url': reverse(
                 EditSelectedRecordsFormView.urlname,
                 args=(self.domain, self.session_id),
             ),
-            "htmx_session_status_view_url": reverse(
+            'htmx_session_status_view_url': reverse(
                 BulkEditSessionStatusView.urlname,
                 args=(self.domain, self.session_id),
             ),
@@ -120,7 +135,7 @@ class BulkEditCasesSessionView(BulkEditSessionViewMixin, BaseProjectDataView):
 def clear_session_caches(request, domain, session_id):
     session = BulkEditSession.objects.get(session_id=session_id)
     clear_caches_case_data_cleaning(session.domain, session.identifier)
-    messages.success(request, _("Caches successfully cleared."))
+    messages.success(request, _('Caches successfully cleared.'))
     return redirect(reverse(BulkEditCasesMainView.urlname, args=(domain,)))
 
 
@@ -132,6 +147,6 @@ def download_form_ids(request, domain, session_id):
 
     ids_stream = ('{}\n'.format(form_id) for form_id in session.form_ids)
     response = StreamingHttpResponse(ids_stream, content_type='text/plain')
-    set_file_download(response, f"{domain}-data_cleaning-form_ids.txt")
+    set_file_download(response, f'{domain}-data_cleaning-form_ids.txt')
 
     return response

--- a/corehq/apps/data_cleaning/views/mixins.py
+++ b/corehq/apps/data_cleaning/views/mixins.py
@@ -8,7 +8,7 @@ from corehq.apps.data_cleaning.models import BulkEditSession
 
 
 class BulkEditSessionViewMixin:
-    session_not_found_message = gettext_lazy("That session does not exist. Please start a new session.")
+    session_not_found_message = gettext_lazy('That session does not exist. Please start a new session.')
     redirect_on_missing_session = False
 
     @property
@@ -21,8 +21,8 @@ class BulkEditSessionViewMixin:
         Only used when `redirect_on_missing_session` is True.
         """
         raise NotImplementedError(
-            "get_redirect_url must be implemented in the subclass of BulkEditSessionViewMixin "
-            "in order to use redirect_on_missing_session"
+            'get_redirect_url must be implemented in the subclass of BulkEditSessionViewMixin '
+            'in order to use redirect_on_missing_session'
         )
 
     @property
@@ -36,10 +36,12 @@ class BulkEditSessionViewMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({
-            'session': self.session,
-            'session_id': self.session_id,
-        })
+        context.update(
+            {
+                'session': self.session,
+                'session_id': self.session_id,
+            }
+        )
         return context
 
     def get(self, request, *args, **kwargs):

--- a/corehq/apps/data_cleaning/views/mixins.py
+++ b/corehq/apps/data_cleaning/views/mixins.py
@@ -1,9 +1,9 @@
+from django.contrib import messages
+from django.http import Http404
+from django.shortcuts import redirect
+from django.utils.translation import gettext_lazy
 from memoized import memoized
 
-from django.contrib import messages
-from django.shortcuts import redirect
-from django.http import Http404
-from django.utils.translation import gettext_lazy
 from corehq.apps.data_cleaning.models import BulkEditSession
 
 

--- a/corehq/apps/data_cleaning/views/start.py
+++ b/corehq/apps/data_cleaning/views/start.py
@@ -5,8 +5,8 @@ from django.views.generic import TemplateView
 
 from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases
 from corehq.apps.data_cleaning.forms.start_session import (
-    SelectCaseTypeForm,
     ResumeOrRestartCaseSessionForm,
+    SelectCaseTypeForm,
 )
 from corehq.apps.data_cleaning.models import BulkEditSession
 from corehq.apps.domain.decorators import LoginAndDomainMixin

--- a/corehq/apps/data_cleaning/views/start.py
+++ b/corehq/apps/data_cleaning/views/start.py
@@ -15,22 +15,27 @@ from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 
-@method_decorator([
-    use_bootstrap5,
-    require_bulk_data_cleaning_cases,
-], name='dispatch')
+@method_decorator(
+    [
+        use_bootstrap5,
+        require_bulk_data_cleaning_cases,
+    ],
+    name='dispatch',
+)
 class StartCaseSessionView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
-    urlname = "start_bulk_edit_case_session"
-    template_name = "data_cleaning/forms/next_action_form.html"
-    container_id = "start-case-session"
+    urlname = 'start_bulk_edit_case_session'
+    template_name = 'data_cleaning/forms/next_action_form.html'
+    container_id = 'start-case-session'
 
     def get_context_data(self, form=None, next_action=None, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({
-            "form": form or SelectCaseTypeForm(self.domain),
-            "container_id": self.container_id,
-            "next_action": next_action or 'validate_session',
-        })
+        context.update(
+            {
+                'form': form or SelectCaseTypeForm(self.domain),
+                'container_id': self.container_id,
+                'next_action': next_action or 'validate_session',
+            }
+        )
         return context
 
     @hq_hx_action('post')
@@ -39,16 +44,15 @@ class StartCaseSessionView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMix
         next_action = 'validate_session'
         if form.is_valid():
             case_type = form.cleaned_data['case_type']
-            active_session = BulkEditSession.objects.active_case_session(
-                request.user, self.domain, case_type
-            )
+            active_session = BulkEditSession.objects.active_case_session(request.user, self.domain, case_type)
             if not active_session:
-                new_session = BulkEditSession.objects.new_case_session(
-                    request.user, self.domain, case_type
-                )
+                new_session = BulkEditSession.objects.new_case_session(request.user, self.domain, case_type)
                 return self.render_session_redirect(new_session, 'fresh')
             form = ResumeOrRestartCaseSessionForm(
-                self.domain, self.container_id, request.path_info, {
+                self.domain,
+                self.container_id,
+                request.path_info,
+                {
                     'case_type': case_type,
                     'next_step': 'resume',
                 },
@@ -58,9 +62,7 @@ class StartCaseSessionView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMix
 
     @hq_hx_action('post')
     def resume_or_restart(self, request, *args, **kwargs):
-        form = ResumeOrRestartCaseSessionForm(
-            self.domain, self.container_id, request.path_info, request.POST
-        )
+        form = ResumeOrRestartCaseSessionForm(self.domain, self.container_id, request.path_info, request.POST)
         next_action = 'resume_or_restart'
         if form.is_valid():
             case_type = form.cleaned_data['case_type']
@@ -69,9 +71,7 @@ class StartCaseSessionView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMix
                 'resume': lambda: BulkEditSession.objects.active_case_session(
                     request.user, self.domain, case_type
                 ),
-                'new': lambda: BulkEditSession.objects.restart_case_session(
-                    request.user, self.domain, case_type
-                ),
+                'new': lambda: BulkEditSession.objects.restart_case_session(request.user, self.domain, case_type),
             }[next_step]
             if get_session:
                 return self.render_session_redirect(get_session(), next_step)
@@ -79,15 +79,22 @@ class StartCaseSessionView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMix
 
     def render_session_redirect(self, session, creation_method):
         from corehq.apps.data_cleaning.views.main import BulkEditCasesSessionView
+
         response = self.render_htmx_redirect(
-            reverse(BulkEditCasesSessionView.urlname, args=(self.domain, session.session_id, )),
-            response_message=_("Starting Bulk Edit Session...")
+            reverse(
+                BulkEditCasesSessionView.urlname,
+                args=(
+                    self.domain,
+                    session.session_id,
+                ),
+            ),
+            response_message=_('Starting Bulk Edit Session...'),
         )
         return self.include_gtm_event_with_response(
             response,
-            "bulk_edit_session_started",
+            'bulk_edit_session_started',
             {
-                "creation_method": creation_method,
-                "session_type": session.session_type,
-            }
+                'creation_method': creation_method,
+                'session_type': session.session_type,
+            },
         )

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -1,10 +1,10 @@
 import json
 
 from django.urls import reverse
-from django.utils.decorators import method_decorator
-from django.views.generic import TemplateView
 from django.utils import timezone
+from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
+from django.views.generic import TemplateView
 from memoized import memoized
 
 from corehq.apps.data_cleaning.decorators import require_bulk_data_cleaning_cases

--- a/corehq/apps/data_cleaning/views/status.py
+++ b/corehq/apps/data_cleaning/views/status.py
@@ -16,19 +16,22 @@ from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 
-@method_decorator([
-    use_bootstrap5,
-    require_bulk_data_cleaning_cases,
-], name='dispatch')
+@method_decorator(
+    [
+        use_bootstrap5,
+        require_bulk_data_cleaning_cases,
+    ],
+    name='dispatch',
+)
 class BaseStatusView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
     pass
 
 
 class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
-    urlname = "bulk_edit_session_status"
-    template_name = "data_cleaning/status/complete.html"
-    template_in_progress = "data_cleaning/status/in_progress.html"
-    template_previous_session = "data_cleaning/status/previous_session.html"
+    urlname = 'bulk_edit_session_status'
+    template_name = 'data_cleaning/status/complete.html'
+    template_in_progress = 'data_cleaning/status/in_progress.html'
+    template_previous_session = 'data_cleaning/status/previous_session.html'
 
     @property
     def seconds_since_complete(self):
@@ -71,13 +74,12 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
     def active_session(self):
         if self.session.completed_on is None:
             return None
-        return BulkEditSession.objects.active_case_session(
-            self.request.user, self.domain, self.session.identifier
-        )
+        return BulkEditSession.objects.active_case_session(self.request.user, self.domain, self.session.identifier)
 
     @property
     def exit_url(self):
         from corehq.apps.data_cleaning.views.main import BulkEditCasesMainView
+
         return reverse(
             BulkEditCasesMainView.urlname,
             args=(self.domain,),
@@ -85,35 +87,37 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({
-            "num_records_changed": (
-                self.session.num_changed_records
-                if self.session.committed_on is not None
-                else 0
-            ),
-            "case_type": self.session.identifier,
-            "exit_url": self.exit_url,
-            "is_task_complete": self.session.percent_complete == 100,
-            "weighted_percent_complete": self.weighted_percent_complete,
-        })
+        context.update(
+            {
+                'num_records_changed': (
+                    self.session.num_changed_records if self.session.committed_on is not None else 0
+                ),
+                'case_type': self.session.identifier,
+                'exit_url': self.exit_url,
+                'is_task_complete': self.session.percent_complete == 100,
+                'weighted_percent_complete': self.weighted_percent_complete,
+            }
+        )
         return context
 
     def get(self, request, *args, **kwargs):
         response = super().get(request, *args, **kwargs)
         if self.session.is_read_only:
-            response['HX-Trigger'] = json.dumps({
-                'showDataCleaningModal': {
-                    'target': '#session-status-modal',
-                },
-            })
+            response['HX-Trigger'] = json.dumps(
+                {
+                    'showDataCleaningModal': {
+                        'target': '#session-status-modal',
+                    },
+                }
+            )
         return self.include_gtm_event_with_response(
             response,
-            "bulk_edit_session_status_viewed",
+            'bulk_edit_session_status_viewed',
             {
-                "session_type": self.session.session_type,
-                "commit_in_progress": self.is_session_in_progress,
-                "has_active_session": self.active_session is not None,
-            }
+                'session_type': self.session.session_type,
+                'commit_in_progress': self.is_session_in_progress,
+                'has_active_session': self.active_session is not None,
+            },
         )
 
     @hq_hx_action('get')
@@ -128,12 +132,13 @@ class BulkEditSessionStatusView(BulkEditSessionViewMixin, BaseStatusView):
         new_session = self.session.get_resumed_session()
 
         from corehq.apps.data_cleaning.views.main import BulkEditCasesSessionView
+
         new_session_url = reverse(
             BulkEditCasesSessionView.urlname,
             args=(self.domain, new_session.session_id),
         )
         query_string = request.META.get('QUERY_STRING', '')
         return self.render_htmx_redirect(
-            f"{new_session_url}?{query_string}",
-            response_message=_("Resuming Bulk Edit Session..."),
+            f'{new_session_url}?{query_string}',
+            response_message=_('Resuming Bulk Edit Session...'),
         )

--- a/corehq/apps/data_cleaning/views/summary.py
+++ b/corehq/apps/data_cleaning/views/summary.py
@@ -11,14 +11,18 @@ from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 
-@method_decorator([
-    use_bootstrap5,
-    require_bulk_data_cleaning_cases,
-], name='dispatch')
-class ChangesSummaryView(BulkEditSessionViewMixin,
-                         LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView):
-    urlname = "bulk_edit_changes_summary"
-    session_not_found_message = gettext_lazy("Cannot retrieve summary, session was not found.")
+@method_decorator(
+    [
+        use_bootstrap5,
+        require_bulk_data_cleaning_cases,
+    ],
+    name='dispatch',
+)
+class ChangesSummaryView(
+    BulkEditSessionViewMixin, LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin, TemplateView
+):
+    urlname = 'bulk_edit_changes_summary'
+    session_not_found_message = gettext_lazy('Cannot retrieve summary, session was not found.')
 
     def get(self, request, *args, **kwargs):
         # this view can only be POSTed to and accessed at specific hq_hx_action endpoints
@@ -28,9 +32,9 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
     def undo_changes_summary(self, request, *args, **kwargs):
         return self.render_htmx_partial_response(
             request,
-            "data_cleaning/summary/undo_changes.html",
+            'data_cleaning/summary/undo_changes.html',
             {
-                "change": self.session.changes.last(),
+                'change': self.session.changes.last(),
             },
         )
 
@@ -38,10 +42,10 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
     def clear_changes_summary(self, request, *args, **kwargs):
         return self.render_htmx_partial_response(
             request,
-            "data_cleaning/summary/clear_changes.html",
+            'data_cleaning/summary/clear_changes.html',
             {
-                "changes": self.session.changes.all(),
-                "num_changes": self.session.changes.count(),
+                'changes': self.session.changes.all(),
+                'num_changes': self.session.changes.count(),
             },
         )
 
@@ -49,9 +53,9 @@ class ChangesSummaryView(BulkEditSessionViewMixin,
     def apply_changes_summary(self, request, *args, **kwargs):
         return self.render_htmx_partial_response(
             request,
-            "data_cleaning/summary/apply_changes.html",
+            'data_cleaning/summary/apply_changes.html',
             {
-                "changes": self.session.changes.all(),
-                "num_changes": self.session.changes.count(),
+                'changes': self.session.changes.all(),
+                'num_changes': self.session.changes.count(),
             },
         )

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -23,33 +23,46 @@ from corehq.apps.hqwebapp.tables.pagination import (
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 
-@method_decorator([
-    use_bootstrap5,
-    require_bulk_data_cleaning_cases,
-], name='dispatch')
+@method_decorator(
+    [
+        use_bootstrap5,
+        require_bulk_data_cleaning_cases,
+    ],
+    name='dispatch',
+)
 class BaseDataCleaningTableView(LoginAndDomainMixin, DomainViewMixin, SelectablePaginatedTableView):
     pass
 
 
-class EditCasesTableView(BulkEditSessionViewMixin,
-                         HtmxInvalidPageRedirectMixin, HqHtmxActionMixin, BaseDataCleaningTableView):
-    urlname = "bulk_edit_cases_table"
+class EditCasesTableView(
+    BulkEditSessionViewMixin, HtmxInvalidPageRedirectMixin, HqHtmxActionMixin, BaseDataCleaningTableView
+):
+    urlname = 'bulk_edit_cases_table'
     table_class = EditCasesTable
 
     def get_host_url(self):
         from corehq.apps.data_cleaning.views.main import BulkEditCasesSessionView
-        return reverse(BulkEditCasesSessionView.urlname, args=(self.domain, self.session_id,))
+
+        return reverse(
+            BulkEditCasesSessionView.urlname,
+            args=(
+                self.domain,
+                self.session_id,
+            ),
+        )
 
     def get_table_kwargs(self):
-        extra_columns = [(
-            "selection",
-            self.table_class.get_select_column(
-                self.session,
-                self.request,
-                select_record_action="select_record",
-                select_page_action="select_page",
+        extra_columns = [
+            (
+                'selection',
+                self.table_class.get_select_column(
+                    self.session,
+                    self.request,
+                    select_record_action='select_record',
+                    select_page_action='select_page',
+                ),
             )
-        )]
+        ]
         extra_columns.extend(self.table_class.get_columns_from_session(self.session))
         return {
             'extra_columns': extra_columns,
@@ -66,19 +79,21 @@ class EditCasesTableView(BulkEditSessionViewMixin,
     def clear_filters(self, request, *args, **kwargs):
         self.session.reset_filtering()
         response = self.get(request, *args, **kwargs)
-        response['HX-Trigger'] = json.dumps({
-            'dcPinnedFilterRefresh': {
-                'target': '#hq-hx-pinned-filters',
-            },
-            'dcFilterRefresh': {
-                'target': '#hq-hx-active-filters',
-            },
-        })
+        response['HX-Trigger'] = json.dumps(
+            {
+                'dcPinnedFilterRefresh': {
+                    'target': '#hq-hx-pinned-filters',
+                },
+                'dcFilterRefresh': {
+                    'target': '#hq-hx-active-filters',
+                },
+            }
+        )
         return self.include_gtm_event_with_response(
             response,
-            "bulk_edit_clear_filters",
+            'bulk_edit_clear_filters',
             {
-                "session_type": self.session.session_type,
+                'session_type': self.session.session_type,
             },
         )
 
@@ -96,10 +111,10 @@ class EditCasesTableView(BulkEditSessionViewMixin,
         response = self.render_htmx_no_response(request, *args, **kwargs)
         return self.include_gtm_event_with_response(
             response,
-            "bulk_edit_select_record",
+            'bulk_edit_select_record',
             {
-                "session_type": self.session.session_type,
-                "is_selected": is_selected,
+                'session_type': self.session.session_type,
+                'is_selected': is_selected,
             },
         )
 
@@ -117,11 +132,11 @@ class EditCasesTableView(BulkEditSessionViewMixin,
         response = self.render_htmx_no_response(request, *args, **kwargs)
         return self.include_gtm_event_with_response(
             response,
-            "bulk_edit_select_page",
+            'bulk_edit_select_page',
             {
-                "session_type": self.session.session_type,
-                "selected": select_page,
-                "num_records": len(doc_ids),
+                'session_type': self.session.session_type,
+                'selected': select_page,
+                'num_records': len(doc_ids),
             },
         )
 
@@ -145,10 +160,10 @@ class EditCasesTableView(BulkEditSessionViewMixin,
         response = self.get(request, *args, **kwargs)
         return self.include_gtm_event_with_response(
             response,
-            "bulk_edit_deselect_all_records",
+            'bulk_edit_deselect_all_records',
             {
-                "session_type": self.session.session_type,
-                "num_records": self._get_record_count_from_response(response),
+                'session_type': self.session.session_type,
+                'num_records': self._get_record_count_from_response(response),
             },
         )
 
@@ -159,33 +174,33 @@ class EditCasesTableView(BulkEditSessionViewMixin,
         """
         response = self.get(request, *args, **kwargs)
         num_records = self._get_record_count_from_response(response)
-        if self.session.can_select_all(
-            table_num_records=num_records
-        ):
+        if self.session.can_select_all(table_num_records=num_records):
             self.session.select_all_records_in_queryset()
             return self.include_gtm_event_with_response(
                 response,
-                "bulk_edit_select_all_records",
+                'bulk_edit_select_all_records',
                 {
-                    "session_type": self.session.session_type,
-                    "num_records": num_records,
+                    'session_type': self.session.session_type,
+                    'num_records': num_records,
                 },
             )
-        response['HX-Trigger'] = json.dumps({
-            'showDataCleaningModal': {
-                'target': '#select-all-not-possible-modal',
-            },
-        })
+        response['HX-Trigger'] = json.dumps(
+            {
+                'showDataCleaningModal': {
+                    'target': '#select-all-not-possible-modal',
+                },
+            }
+        )
         return self.include_gtm_event_with_response(
             response,
-            "bulk_edit_select_all_records_not_possible",
+            'bulk_edit_select_all_records_not_possible',
             {
-                "session_type": self.session.session_type,
-                "num_records": num_records,
+                'session_type': self.session.session_type,
+                'num_records': num_records,
             },
         )
 
-    @hq_hx_action("post")
+    @hq_hx_action('post')
     def apply_all_changes(self, request, *args, **kwargs):
         # even if a user hacks their way to more edits in this session, they can never apply those edits
         if not self.session.is_read_only:
@@ -193,53 +208,53 @@ class EditCasesTableView(BulkEditSessionViewMixin,
             self.session.save()
             commit_data_cleaning.delay(self.session.session_id)
         response = self.render_htmx_no_response(request, *args, **kwargs)
-        response['HX-Trigger'] = json.dumps({
-            'dcRefreshStatusModal': {
-                'target': '#session-status-modal-body',
-            },
-        })
+        response['HX-Trigger'] = json.dumps(
+            {
+                'dcRefreshStatusModal': {
+                    'target': '#session-status-modal-body',
+                },
+            }
+        )
         return self.include_gtm_event_with_response(
             response,
-            "bulk_edit_apply_all_changes",
+            'bulk_edit_apply_all_changes',
             {
-                "session_type": self.session.session_type,
+                'session_type': self.session.session_type,
             },
         )
 
-    @hq_hx_action("post")
+    @hq_hx_action('post')
     def undo_last_change(self, request, *args, **kwargs):
         self.session.undo_last_change()
-        response = self._trigger_clean_form_refresh(
-            self.get(request, *args, **kwargs)
-        )
+        response = self._trigger_clean_form_refresh(self.get(request, *args, **kwargs))
         return self.include_gtm_event_with_response(
             response,
-            "bulk_edit_undo_last_change",
+            'bulk_edit_undo_last_change',
             {
-                "session_type": self.session.session_type,
+                'session_type': self.session.session_type,
             },
         )
 
-    @hq_hx_action("post")
+    @hq_hx_action('post')
     def clear_all_changes(self, request, *args, **kwargs):
         self.session.clear_all_changes()
-        response = self._trigger_clean_form_refresh(
-            self.get(request, *args, **kwargs)
-        )
+        response = self._trigger_clean_form_refresh(self.get(request, *args, **kwargs))
         return self.include_gtm_event_with_response(
             response,
-            "bulk_edit_clear_all_changes",
+            'bulk_edit_clear_all_changes',
             {
-                "session_type": self.session.session_type,
+                'session_type': self.session.session_type,
             },
         )
 
     def _trigger_clean_form_refresh(self, response):
-        response['HX-Trigger'] = json.dumps({
-            'dcEditFormRefresh': {
-                'target': '#hq-hx-edit-selected-records-form',
-            },
-        })
+        response['HX-Trigger'] = json.dumps(
+            {
+                'dcEditFormRefresh': {
+                    'target': '#hq-hx-edit-selected-records-form',
+                },
+            }
+        )
         return response
 
     def _render_table_cell_response(self, doc_id, column, request, *args, **kwargs):
@@ -258,25 +273,25 @@ class EditCasesTableView(BulkEditSessionViewMixin,
             record,
             table,
         )
-        response = self.render_htmx_partial_response(
-            request, EditableHtmxColumn.template_name, context
+        response = self.render_htmx_partial_response(request, EditableHtmxColumn.template_name, context)
+        response['HX-Trigger'] = json.dumps(
+            {
+                'updateChanges': {
+                    'hasChanges': self.session.has_changes(),
+                },
+            }
         )
-        response['HX-Trigger'] = json.dumps({
-            "updateChanges": {
-                "hasChanges": self.session.has_changes(),
-            },
-        })
         return response
 
     def _get_cell_request_details(self, request):
         """
         Returns the details of the cell request.
         """
-        doc_id = request.POST["record_id"]
-        column = self.session.columns.get(column_id=request.POST["column_id"])
+        doc_id = request.POST['record_id']
+        column = self.session.columns.get(column_id=request.POST['column_id'])
         return doc_id, column
 
-    @hq_hx_action("post")
+    @hq_hx_action('post')
     def cell_reset_changes(self, request, *args, **kwargs):
         """
         Effectively resets/removes any changes made to a record's prop_id.
@@ -284,25 +299,21 @@ class EditCasesTableView(BulkEditSessionViewMixin,
         doc_id, column = self._get_cell_request_details(request)
         edit_record = self.session.records.get(doc_id=doc_id)
         edit_record.reset_changes(column.prop_id)
-        return self._render_table_cell_response(
-            doc_id, column, request, *args, **kwargs
-        )
+        return self._render_table_cell_response(doc_id, column, request, *args, **kwargs)
 
-    @hq_hx_action("post")
+    @hq_hx_action('post')
     def cell_inline_edit(self, request, *args, **kwargs):
         """
         Commits the inline edit action for a cell.
         """
         doc_id, column = self._get_cell_request_details(request)
-        value = request.POST["newValue"]
+        value = request.POST['newValue']
         self.session.apply_inline_edit(doc_id, column.prop_id, value)
-        return self._render_table_cell_response(
-            doc_id, column, request, *args, **kwargs
-        )
+        return self._render_table_cell_response(doc_id, column, request, *args, **kwargs)
 
 
 class RecentCaseSessionsTableView(BaseDataCleaningTableView):
-    urlname = "recent_bulk_edit_case_sessions_table"
+    urlname = 'recent_bulk_edit_case_sessions_table'
     table_class = RecentCaseSessionsTable
 
     def get_queryset(self):
@@ -313,25 +324,26 @@ class RecentCaseSessionsTableView(BaseDataCleaningTableView):
 
     def _get_session_url(self, session):
         from corehq.apps.data_cleaning.views.main import BulkEditCasesSessionView
+
         return reverse(BulkEditCasesSessionView.urlname, args=(session.domain, session.session_id))
 
     def _get_record(self, session):
         return {
-            "is_active": False,
-            "committed_on": session.committed_on,
-            "completed_on": session.completed_on,
-            "case_type": session.identifier,
-            "case_count": session.num_changed_records,
-            "percent": session.percent_complete,
-            "form_ids_url": reverse('download_form_ids', args=(session.domain, session.session_id)),
-            "has_form_ids": bool(len(session.form_ids)),
-            "session_url": self._get_session_url(session),
+            'is_active': False,
+            'committed_on': session.committed_on,
+            'completed_on': session.completed_on,
+            'case_type': session.identifier,
+            'case_count': session.num_changed_records,
+            'percent': session.percent_complete,
+            'form_ids_url': reverse('download_form_ids', args=(session.domain, session.session_id)),
+            'has_form_ids': bool(len(session.form_ids)),
+            'session_url': self._get_session_url(session),
         }
 
     def _get_active_record(self, session):
         return {
-            "is_active": True,
-            "case_type": session.identifier,
-            "percent": 0,
-            "session_url": self._get_session_url(session),
+            'is_active': True,
+            'case_type': session.identifier,
+            'percent': 0,
+            'session_url': self._get_session_url(session),
         }


### PR DESCRIPTION
## Technical Summary
just doing some post-release cleanup to make sure this module is nice and tidy

ran some automated cleanup in vs code:
- organize imports
- ruff format (making sure I use single quotes everywhere instead of double)


## Safety Assurance

### Safety story
very safe, just automated formatting changes.

### Automated test coverage
yes

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
