### PR TITLE
Updated bootstrap migration test

### DIFF
--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -97,12 +97,12 @@ def test_make_javascript_dependency_renames():
     eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 
-def test_make_javascript_dependency_renames_hqdefine():
-    line = """hqDefine("hqwebapp/js/bootstrap3/prepaid_modal", [\n"""
+def test_make_javascript_dependency_renames_amd():
+    line = """define("hqwebapp/js/bootstrap3/prepaid_modal", [\n"""
     final_line, renames = make_javascript_dependency_renames(
         line, get_spec('bootstrap_3_to_5')
     )
-    eq(final_line, """hqDefine("hqwebapp/js/bootstrap5/prepaid_modal", [\n""")
+    eq(final_line, """define("hqwebapp/js/bootstrap5/prepaid_modal", [\n""")
     eq(renames, ['renamed bootstrap3 to bootstrap5'])
 
 


### PR DESCRIPTION
## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/36534, removing usage of `hqDefine` in some tests.

## Safety Assurance

### Safety story
Only affects tests.

### Automated test coverage
Yes.

### QA Plan
No.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
