### PR TITLE
Update and rename hqDefine.sh

### DIFF
--- a/corehq/apps/hqadmin/management/commands/static_analysis.py
+++ b/corehq/apps/hqadmin/management/commands/static_analysis.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
         self.logger.log("commcare.static_analysis.custom_domain_count", custom_domain_count)
 
     def show_js_dependencies(self):
-        proc = subprocess.Popen(["./scripts/codechecks/hqDefine.sh", "static-analysis"], stdout=subprocess.PIPE)
+        proc = subprocess.Popen(["./scripts/codechecks/amd.sh", "static-analysis"], stdout=subprocess.PIPE)
         output = proc.communicate()[0].strip().decode("utf-8")
         (step1, step2) = output.split(" ")
 

--- a/docs/js-guide/dependencies.rst
+++ b/docs/js-guide/dependencies.rst
@@ -254,12 +254,12 @@ How close are we to a world where we’ll just have one set of conventions?
 As above, most code is migrated, but most of the remaining areas have
 significant complexity.
 
-`hqDefine.sh <https://github.com/dimagi/commcare-hq/blob/master/scripts/codechecks/hqDefine.sh>`__
+`amd.sh <https://github.com/dimagi/commcare-hq/blob/master/scripts/codechecks/amd.sh>`__
 generates metrics for the current status of the migration and locates
 un-migrated files. At the time of writing:
 
 ::
 
-    $ ./scripts/codechecks/hqDefine.sh
+    $ ./scripts/codechecks/amd.sh
 
-19%     (123/660) of JS files use ESM format
+80%     (522/658) of JS files use ESM format

--- a/scripts/codechecks/amd.sh
+++ b/scripts/codechecks/amd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # run as
-# scripts/codechecks/hqDefine.sh
+# scripts/codechecks/amd.sh
 
 ## Count files by type
 
@@ -9,11 +9,11 @@ function list-js() {
 }
 
 function list-no-esm-js() {
-  list-js | xargs grep -l '^hqDefine.*'
+  list-js | xargs grep -l '^define.*'
 }
 
 function list-esm-js() {
-  list-js | xargs grep -L '^hqDefine.*'
+  list-js | xargs grep -L '^define.*'
 }
 
 ## Calculate migrated percentage for given statistic
@@ -26,7 +26,7 @@ function percent() {
 ## Main script
 
 command=${1:-""}
-help="Pass list-no-esm to list the files still using hqDefine, or list-esm to list ESM formatted files"
+help="Pass list-no-esm to list the files still using AMD format, or list-esm to list ESM formatted files"
 
 jsTotalCount=$(echo $(list-js | wc -l))
 noEsmJsTotalCount=$(echo $(list-no-esm-js | wc -l))
@@ -64,4 +64,4 @@ case $command in
     echo "Unrecognized command"
     echo $help
     ;;
-esac 
+esac


### PR DESCRIPTION
## Technical Summary
Followup for https://github.com/dimagi/commcare-hq/pull/36534: make the metrics script look for `define` instead of `hqDefine`.

## Safety Assurance

### Safety story
Only affects an internal engineering tool

### Automated test coverage
no

### QA Plan
no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
