### PR TITLE
[Data Cleaning] fix: remove comma causing js error

### DIFF
--- a/corehq/apps/data_cleaning/forms/filters.py
+++ b/corehq/apps/data_cleaning/forms/filters.py
@@ -227,7 +227,7 @@ class AddFilterForm(forms.Form):
                             ),
                             x_show=(
                                 '!matchTypesWithNoValue.includes(dateMatchType) '
-                                '&& datetimeTypes.includes(dataType)',
+                                '&& datetimeTypes.includes(dataType)'
                             ),
                         ),
                         x_show='dateDataTypes.includes(dataType)',


### PR DESCRIPTION

## Technical Summary
If the comma remains, the string becomes a tuple and we have js errors.


## Safety Assurance

### Safety story
tested locally, fixed the issue

### Automated test coverage
no, js

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
