### PR TITLE
Add description attribute to reports so they will show a tooltip when…

### DIFF
--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -128,6 +128,7 @@ class CaseListReport(CaseListMixin, ProjectReport, ReportDataSource):
     # request. but currently these are too tightly bound to decouple
 
     name = gettext_lazy('Case List')
+    description = gettext_lazy('View all cases within your project space.')
     slug = 'case_list'
     use_bootstrap5 = True
 

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -65,7 +65,8 @@ class DeploymentsReport(GenericTabularReport, ProjectReport, ProjectReportParame
 
 @location_safe
 class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsReport):
-    name = gettext_lazy("Application Status")
+    name = gettext_lazy("User Last Activity Report")
+    description = gettext_lazy("View last sync and last submission by user.")
     slug = "app_status"
     emailable = True
     exportable = True

--- a/corehq/apps/reports/standard/forms/reports.py
+++ b/corehq/apps/reports/standard/forms/reports.py
@@ -7,6 +7,7 @@ from django.views import View
 from memoized import memoized
 
 from dimagi.utils.parsing import string_to_utc_datetime
+from django.utils.translation import gettext_lazy
 from dimagi.utils.web import json_response
 
 from corehq import toggles
@@ -32,6 +33,7 @@ def _compare_submissions(x, y):
 
 class SubmissionErrorReport(DeploymentsReport, MultiFormDrilldownMixin):
     name = gettext_noop("Raw Forms, Errors & Duplicates")
+    description = gettext_lazy("View all submissions, including errors and archived forms.")
     slug = "submit_errors"
     ajax_pagination = True
     asynchronous = False

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -1,6 +1,7 @@
 from django.utils.translation import get_language
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_noop
+from django.utils.translation import gettext_lazy
 
 from memoized import memoized
 
@@ -34,6 +35,7 @@ class SubmitHistoryMixin(ElasticProjectInspectionReport,
                          CompletionOrSubmissionTimeMixin, MultiFormDrilldownMixin,
                          DatespanMixin):
     name = gettext_noop('Submission History')
+    description = gettext_lazy('View all submitted data.')
     slug = 'submit_history'
     fields = [
         'corehq.apps.reports.filters.users.SubmittedByExpandedMobileWorkerFilter',


### PR DESCRIPTION
… hover over

## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

This PR adds description attributes to reports, with description attributes, the report navigation column will show a tooltip when hover over.
It also renames "Application Status" report to "User Last Activity Report"

<img width="580" alt="image" src="https://github.com/user-attachments/assets/4e804c4c-cec9-4d26-a362-154a8944c7da" />
<img width="586" alt="image" src="https://github.com/user-attachments/assets/603fbfae-b7b5-4e4e-ab8a-d6de47a06e9e" />
<img width="581" alt="image" src="https://github.com/user-attachments/assets/f561149f-ace7-4322-8b77-fe6b15bc5b95" />
<img width="582" alt="image" src="https://github.com/user-attachments/assets/cd5c59df-340b-4541-8df3-74abb3d4ecea" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17586

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe, no functional change, just adding attributes and rename.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
