### PR TITLE
Convert string to date when creating invoice

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -89,6 +89,7 @@ from corehq.util.dates import get_previous_month_date_range
 from corehq.util.log import send_HTML_email
 from corehq.util.serialization import deserialize_decimal
 from corehq.util.soft_assert import soft_assert
+from dimagi.utils.dates import force_to_date
 
 
 @transaction.atomic
@@ -473,6 +474,10 @@ def create_wire_credits_invoice(domain_name,
                                 date_due=None):
     deserialized_amount = deserialize_decimal(amount)
     date_due = date_due or datetime.date.today() + datetime.timedelta(days=30)
+
+    date_start = force_to_date(date_start)
+    date_end = force_to_date(date_end)
+
     wire_invoice = WirePrepaymentInvoice.objects.create(
         domain=domain_name,
         date_start=date_start,


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17684

Sentry issue:https://dimagi.sentry.io/issues/6641352341/events/9371e34cc5774d9d9ad7dd43fd326d7c/?project=136860

Function `create_wire_credits_invoice` will create `WirePrepaymentInvoice` object with both `date_start` and `date_end` attribute being string, while the base class `InvoiceBase` expect both filed to be date:
```
    date_start = models.DateField()
    date_end = models.DateField()
```

String will cause problem when other functions are called on the invoice object.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe. `WirePrepaymentInvoice` is expecting date object not string.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
