### PR TITLE
Handle (bulk edit) HTMX erorrs more gracefully

### DIFF
--- a/corehq/apps/campaign/tests/test_views.py
+++ b/corehq/apps/campaign/tests/test_views.py
@@ -334,7 +334,7 @@ class TestNewWidget(TestDashboardWidgetView):
             headers={'hq-hx-action': self.HQ_ACTION_NEW_WIDGET},
             is_logged_in=True,
         )
-        assert response.context['htmx_error'].message == "Requested widget type is not supported"
+        assert response.content == b'Requested widget type is not supported'
 
     @flag_enabled('CAMPAIGN_DASHBOARD')
     @patch('corehq.apps.campaign.forms.DashboardMapForm._get_case_types')

--- a/corehq/apps/campaign/tests/test_views.py
+++ b/corehq/apps/campaign/tests/test_views.py
@@ -575,8 +575,8 @@ class TestDeleteWidget(TestDashboardWidgetView):
             headers={'hq-hx-action': self.HQ_ACTION_DELETE_WIDGET},
         )
 
-        assert response.context['htmx_error'].status_code == 400
-        assert response.context['htmx_error'].message == "Requested widget type is not supported"
+        assert response.status_code == 400
+        assert response.content == b'Requested widget type is not supported'
         assert DashboardMap.objects.filter(pk=map_widget.id).exists() is True
 
 

--- a/corehq/apps/campaign/views.py
+++ b/corehq/apps/campaign/views.py
@@ -6,7 +6,7 @@ from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.translation import gettext_lazy
+from django.utils.translation import gettext_lazy, gettext as _
 from django.views.decorators.http import require_GET
 
 from memoized import memoized
@@ -221,7 +221,7 @@ class DashboardWidgetView(HqHtmxActionMixin, BaseDomainView):
 
     def _validate_request_widget_type(self):
         if not any(choice[0] == self.widget_type for choice in WidgetType.choices):
-            raise HtmxResponseException(gettext_lazy("Requested widget type is not supported"))
+            raise HtmxResponseException(_("Requested widget type is not supported"))
 
     @cached_property
     def widget_type(self):

--- a/corehq/apps/data_cleaning/views/tables.py
+++ b/corehq/apps/data_cleaning/views/tables.py
@@ -90,7 +90,7 @@ class EditCasesTableView(
                 },
             )
             raise HtmxResponseException(
-                message=_('We are having trouble connecting to Elasticsearch. Please try again in a few minutes.'),
+                message=_('We are having trouble connecting to the server. Please try again in a few minutes.'),
                 status_code=503,
                 retry_after=1000,
             )

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_base.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_base.js
@@ -28,7 +28,7 @@ import 'hqwebapp/js/htmx_utils/hq_hx_action';
 import 'hqwebapp/js/htmx_utils/csrf_token';
 import 'hqwebapp/js/htmx_utils/hq_hx_loading';
 import 'hqwebapp/js/htmx_utils/hq_hx_refresh';
-import retryHtmxRequest from 'hqwebapp/js/htmx_utils/retry_request';
+import retryUtils from 'hqwebapp/js/htmx_utils/retry_request';
 import { showHtmxErrorModal } from 'hqwebapp/js/htmx_utils/errors';
 
 // By default, there is no timeout and requests hang indefinitely, so update to reasonable value.
@@ -64,7 +64,9 @@ document.body.addEventListener('htmx:timeout', (evt) => {
      * similar event listener there. Also, you may want to adjust the `htmx.config.timeout`
      * value as well.
      */
-    if (!retryHtmxRequest(evt.detail.elt, evt.detail.pathInfo, evt.detail.requestConfig) && evt.detail.requestConfig.verb === 'get') {
+    if (retryUtils.isRetryAllowed(evt) && evt.detail.requestConfig.verb === 'get') {
+        retryUtils.retryHtmxRequest(evt.detail.elt, evt.detail.pathInfo, evt.detail.requestConfig);
+    } else {
         showHtmxErrorModal(
             HTTP_REQUEST_TIMEOUT,
             gettext('Request timed out. Max retries exceeded.'),

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_base.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_base.js
@@ -39,19 +39,17 @@ const HTTP_REQUEST_TIMEOUT = 408;
 
 document.body.addEventListener('htmx:responseError', (evt) => {
     let errorCode = evt.detail.xhr.status;
+    let errorText = evt.detail.xhr.statusText;
     if (errorCode === HTTP_BAD_GATEWAY) {
-        if (!retryHtmxRequest(evt.detail.elt, evt.detail.pathInfo, evt.detail.requestConfig)) {
-            showHtmxErrorModal(
-                errorCode,
-                gettext('Gateway Timeout Error. Max retries exceeded.'),
-                evt,
-            );
+        if (retryUtils.isRetryAllowed(evt)) {
+            retryUtils.retryHtmxRequest(evt.detail.elt, evt.detail.pathInfo, evt.detail.requestConfig);
+            return;
         }
-        return;
+        errorText = gettext('Gateway Timeout Error. Max retries exceeded.');
     }
     showHtmxErrorModal(
         errorCode,
-        evt.detail.xhr.statusText,
+        errorText,
         evt,
     );
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/errors.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/errors.js
@@ -12,9 +12,10 @@ const DEFAULT_MODAL_ID = 'htmxRequestErrorModal';
  * @param {number} errorCode - The HTTP error code representing the type of error.
  * @param {string} errorText - A descriptive error message to display in the modal.
  * @param {CustomEvent} errorEvent - The event related to the error.
+ * @param {boolean} showDetails - Whether to show additional error details in the modal.
  * @param {string} [errorModalId=DEFAULT_MODAL_ID] - The ID of the modal element in the DOM (default is `DEFAULT_MODAL_ID`).
  */
-const showHtmxErrorModal = (errorCode, errorText, errorEvent, errorModalId = DEFAULT_MODAL_ID) => {
+const showHtmxErrorModal = (errorCode, errorText, errorEvent, showDetails = true, errorModalId = DEFAULT_MODAL_ID) => {
     const modalElem = document.getElementById(errorModalId);
     if (!modalElem) {return;} // Exit if modal element is not found
 
@@ -25,6 +26,7 @@ const showHtmxErrorModal = (errorCode, errorText, errorEvent, errorModalId = DEF
             errorText: errorText,
             eventError: errorEvent.detail.error || gettext("Unknown Event"),
             requestPath: (errorEvent.detail.pathInfo) ? errorEvent.detail.pathInfo.requestPath : gettext("Unknown Path"),
+            showDetails: showDetails,
         },
     }));
     errorModal.show();

--- a/corehq/apps/hqwebapp/templates/hqwebapp/htmx/error_modal.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/htmx/error_modal.html
@@ -16,6 +16,7 @@
         this.errorText = evt.detail.errorText;
         this.eventError = evt.detail.eventError;
         this.requestPath = evt.detail.requestPath;
+        this.showDetails = evt.detail.showDetails;
       },
     }"
     @update-htmx-request-error-modal.camel.window="updateError"
@@ -52,7 +53,7 @@
           <p x-text="errorText"></p>
           <div
             class="card"
-            x-show="eventError && requestPath"
+            x-show="eventError && requestPath && showDetails"
           >
             <div class="card-body">
               <h5>{% trans "Additional Details" %}</h5>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/htmx/error_modal.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/htmx/error_modal.html
@@ -35,7 +35,7 @@
         >
 
           {% block modal_title %}
-            {% trans "HTMX Request: Server Error Encountered" %}
+            {% trans "Server Error Encountered" %}
           {% endblock %}
 
         </h5>

--- a/corehq/util/htmx_action.py
+++ b/corehq/util/htmx_action.py
@@ -115,7 +115,10 @@ class HqHtmxActionMixin:
     def dispatch(self, request, *args, **kwargs):
         action = request.META.get('HTTP_HQ_HX_ACTION')
         if not action:
-            return super().dispatch(request, *args, **kwargs)
+            try:
+                return super().dispatch(request, *args, **kwargs)
+            except HtmxResponseException as err:
+                return self._return_error_response(err)
 
         handler = getattr(self, action, None)
         if not callable(handler):

--- a/corehq/util/htmx_action.py
+++ b/corehq/util/htmx_action.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from django.http import HttpResponseForbidden, HttpResponse
+from django.http import HttpResponse, HttpResponseForbidden
 from django.utils.encoding import force_str
 
 from corehq.util.htmx_gtm import get_htmx_gtm_event


### PR DESCRIPTION
## Product Description
With an uptick in elasticsearch issues lately, the bulk edit cases table can sometimes time out when reloading, throwing an HTMX error modal and confusing users.

This PR ensures that the bulk edit cases table handles this situation gracefully, by retrying the request 20 more times (1 request per second) and eventually showing the user the following modal (without the extra HTMX-related language):
<img width="525" alt="Screenshot 2025-06-04 at 11 49 53 PM" src="https://github.com/user-attachments/assets/d97a7c98-f1d2-468e-808b-95fa99353efb" />



## Technical Summary
In addition to gracefully handling the `ESError` in the bulk edit cases table, this PR makes a few more changes in order to make this happen:
- fixes HTMX retries. previously we incremented a value in an object based on the request path...this wasn't working at all. now we take a different approach by storing the retry count in an HTMX header.
- fixes the retry on bad gateway requests
- updates how we handle known errors in HTMX views. allows specifying a retry count and wait period for retry (`retry_after`)
- ensures we send additional `hq_hx_action` details to sentry and that partial responses actually send details to sentry to begin with.


## Safety Assurance

### Safety story
tested extensively locally. deploying to staging to test there too, but I'm pretty confident these changes are solid.

### Automated test coverage
not the client side things

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
