### PR TITLE
Cache and optimize `domain_has_submission_in_last_30_days`

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -469,6 +469,9 @@ class ESQuery(object):
     def exists(self):
         """Checks to see whether any documents match the query"""
         query = self.size(0)
+        # The "terminate_after" param instructs ES to terminate the query after
+        # finding one matching document per shard
+        # In ES7 this can be switched to use the `count` endpoint
         query.es_query['terminate_after'] = 1
         return query.run().total > 0
 

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -466,6 +466,12 @@ class ESQuery(object):
     def count(self):
         return self.adapter.count(self.raw_query)
 
+    def exists(self):
+        """Checks to see whether any documents match the query"""
+        query = self.size(0)
+        query.es_query['terminate_after'] = 1
+        return query.run().total > 0
+
     def get_ids(self):
         """Performs a minimal query to get the ids of the matching documents
 

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -397,5 +397,5 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
             query_created(lt="2025-04-01")
         # No docs returned
         self.assertEqual(ESQuerySet.call_args[0][0]['hits']['hits'], [])
-        # there are two docs, but only 1 was scanned
+        # there are two docs, but only 1 was scanned (per shard)
         self.assertEqual(ESQuerySet.call_args[0][0]['hits']['total'], 1)

--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from django.test import SimpleTestCase
 
@@ -375,3 +375,27 @@ class TestESQuery(ElasticTestMixin, SimpleTestCase):
         real_scroll = query.scroll
         with patch.object(query, "scroll", scroll_then_delete_one):
             self.assertEqual([doc1], list(query.scroll_ids_to_disk_and_iter_docs()))
+
+    def test_exists_query(self):
+
+        docs = [
+            {"_id": "123", "doc_type": "Something", "created_on": "2025-01-01", "username": "1"},
+            {"_id": "456", "doc_type": "Something", "created_on": "2025-01-01", "username": "1"},
+        ]
+        for doc in docs:
+            with patch('corehq.apps.groups.dbaccessors.get_group_id_name_map_by_user', return_value=[]):
+                users.user_adapter.index(doc, refresh=True)
+                self.addCleanup(users.user_adapter.delete, doc['_id'])
+
+        def query_created(**params):
+            return users.UserES().remove_default_filters().created(**params).exists()
+
+        self.assertFalse(query_created(gt="2025-04-01"))
+        self.assertTrue(query_created(lt="2025-04-01"))
+
+        with patch('corehq.apps.es.es_query.ESQuerySet', return_value=MagicMock(total=1)) as ESQuerySet:
+            query_created(lt="2025-04-01")
+        # No docs returned
+        self.assertEqual(ESQuerySet.call_args[0][0]['hits']['hits'], [])
+        # there are two docs, but only 1 was scanned
+        self.assertEqual(ESQuerySet.call_args[0][0]['hits']['total'], 1)

--- a/corehq/ex-submodules/couchforms/analytics.py
+++ b/corehq/ex-submodules/couchforms/analytics.py
@@ -18,13 +18,11 @@ experiment = Experiment(
 
 @quickcache(['domain'], timeout=10 * 60)
 def domain_has_submission_in_last_30_days(domain):
-    last_submission = get_last_form_submission_received(domain)
-    # if there have been any submissions in the past 30 days
-    if last_submission:
-        _30_days = datetime.timedelta(days=30)
-        return datetime.datetime.utcnow() <= last_submission + _30_days
-    else:
-        return False
+    thirty_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=30)
+    return bool(FormES()
+                .domain(domain)
+                .submitted(gte=thirty_days_ago)
+                .count())
 
 
 def get_number_of_forms_in_domain(domain):

--- a/corehq/ex-submodules/couchforms/analytics.py
+++ b/corehq/ex-submodules/couchforms/analytics.py
@@ -2,12 +2,11 @@ import datetime
 
 from corehq.apps.es import AppES, FormES
 from corehq.apps.es.aggregations import TermsAggregation
-from corehq.apps.experiments import Experiment, ES_FOR_EXPORTS
+from corehq.apps.experiments import ES_FOR_EXPORTS, Experiment
 from corehq.const import MISSING_APP_ID
-from corehq.util.quickcache import quickcache
-
 from corehq.util.couch import stale_ok
 from corehq.util.dates import iso_string_to_datetime
+from corehq.util.quickcache import quickcache
 
 experiment = Experiment(
     campaign=ES_FOR_EXPORTS,
@@ -17,6 +16,7 @@ experiment = Experiment(
 )
 
 
+@quickcache(['domain'], timeout=10 * 60)
 def domain_has_submission_in_last_30_days(domain):
     last_submission = get_last_form_submission_received(domain)
     # if there have been any submissions in the past 30 days

--- a/corehq/ex-submodules/couchforms/analytics.py
+++ b/corehq/ex-submodules/couchforms/analytics.py
@@ -19,10 +19,10 @@ experiment = Experiment(
 @quickcache(['domain'], timeout=10 * 60)
 def domain_has_submission_in_last_30_days(domain):
     thirty_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=30)
-    return bool(FormES()
-                .domain(domain)
-                .submitted(gte=thirty_days_ago)
-                .count())
+    return (FormES()
+            .domain(domain)
+            .submitted(gte=thirty_days_ago)
+            .exists())
 
 
 def get_number_of_forms_in_domain(domain):

--- a/corehq/ex-submodules/couchforms/tests/test_analytics.py
+++ b/corehq/ex-submodules/couchforms/tests/test_analytics.py
@@ -2,7 +2,8 @@ import datetime
 import uuid
 
 from django.test import TestCase
-from corehq.apps.app_manager.tests.util import delete_all_apps
+
+from freezegun import freeze_time
 
 from couchforms.analytics import (
     domain_has_submission_in_last_30_days,
@@ -14,6 +15,7 @@ from couchforms.analytics import (
     get_number_of_forms_in_domain,
 )
 
+from corehq.apps.app_manager.tests.util import delete_all_apps
 from corehq.apps.es.apps import app_adapter
 from corehq.apps.es.client import manager
 from corehq.apps.es.forms import form_adapter
@@ -214,8 +216,11 @@ class CouchformsESAnalyticsTest(TestCase):
         )
 
     def test_domain_has_submission_in_last_30_days(self):
-        self.assertEqual(
-            domain_has_submission_in_last_30_days(self.domain), True)
+        self.assertTrue(domain_has_submission_in_last_30_days(self.domain))
+
+    def test_not_domain_has_submission_in_last_30_days(self):
+        with freeze_time(self.now + self._60_days):
+            self.assertFalse(domain_has_submission_in_last_30_days(self.domain))
 
     def test_get_first_form_submission_received(self):
         self.assertEqual(


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/issue/SUPPORT-24686
https://dimagi.sentry.io/issues/6557293254/events/93802ed707b24a8fbfa5c65bec4cb26a/?project=136860
Getting shard failures from this query, and it seemed like an odd one to be occurring on a simple `/login/` request.  Turns out it's referenced in the base template for GTM:

https://github.com/dimagi/commcare-hq/blob/b1b95b4ae51d7b5f49ad2154c83111c8b956c5d6/corehq/apps/analytics/templates/analytics/initial/gtm.html#L23-L23

There's no reason we need to perform this query for every request, since it only varies by domain, and it simply searches for any form submissions over the last 30 days.  I put it on a 10 minute cache, but I'd wager we could bump that timeout to 24 hours if we so choose.

## Feature Flag


## Safety Assurance
Automated tests only

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
