### PR TITLE
Use search_after in case/v2 api

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -416,7 +416,7 @@ class ESQuery(object):
 
     def search_after(self, *sort_values):
         query = self.clone()
-        query.es_query['search_after'] = sort_values
+        query.es_query['search_after'] = list(sort_values)
         return query
 
     def nested_sort(self, path, field_name, nested_filter, desc=False, reset_sort=True, sort_missing=None):

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -414,6 +414,11 @@ class ESQuery(object):
         }
         return self._sort(sort_field, reset_sort)
 
+    def search_after(self, *sort_values):
+        query = self.clone()
+        query.es_query['search_after'] = sort_values
+        return query
+
     def nested_sort(self, path, field_name, nested_filter, desc=False, reset_sort=True, sort_missing=None):
         """Order results by the value of a nested field
         """

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -116,7 +116,8 @@ def get_list(domain, couch_user, params):
     }
 
     cases_in_result = len(hits)
-    if cases_in_result and es_result.total > cases_in_result:
+    # we need to paginate until there are no hits in the result
+    if cases_in_result:
         last_date, last_id = es_result.raw_hits[-1]['sort']
         params.update({
             INDEXED_AFTER: last_date,

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -135,7 +135,7 @@ def _get_cursor_query(domain, params, last_date, last_id):
         # this can be removed after this PR is deployed. This ensures backward compatibility
         timestamp_in_secs = datetime.fromisoformat(last_date.replace("Z", "+00:00")).timestamp()
         timestamp = int(timestamp_in_secs * 1000)  # ES accepts timestamp in milliseconds
-    query = query.search_after([timestamp, last_id])
+    query = query.search_after(timestamp, last_id)
     return query
 
 

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -1,4 +1,5 @@
 from base64 import b64decode, b64encode
+from datetime import datetime
 
 from django.http import QueryDict
 
@@ -129,7 +130,12 @@ def get_list(domain, couch_user, params):
 
 def _get_cursor_query(domain, params, last_date, last_id):
     query = _get_query(domain, params)
-    query = query.search_after([last_date, last_id])
+    timestamp = last_date
+    if not timestamp.isdigit():
+        # this can be removed after this PR is deployed. This ensures backward compatibility
+        timestamp_in_secs = datetime.fromisoformat(last_date.replace("Z", "+00:00")).timestamp()
+        timestamp = int(timestamp_in_secs * 1000)  # ES accepts timestamp in milliseconds
+    query = query.search_after([timestamp, last_id])
     return query
 
 

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -3,12 +3,11 @@ from base64 import b64decode, b64encode
 from django.http import QueryDict
 
 from corehq.apps.api.util import make_date_filter
-from corehq.apps.case_search.const import CASE_PROPERTIES_PATH
 from corehq.apps.case_search.filter_dsl import (
     build_filter_from_xpath,
 )
 from corehq.apps.case_search.exceptions import CaseFilterError
-from corehq.apps.es import case_search, filters, queries
+from corehq.apps.es import case_search, filters
 from corehq.apps.es import cases as case_es
 from corehq.apps.reports.standard.cases.utils import (
     query_location_restricted_cases,
@@ -117,9 +116,10 @@ def get_list(domain, couch_user, params):
 
     cases_in_result = len(hits)
     if cases_in_result and es_result.total > cases_in_result:
+        last_date, last_id = es_result.raw_hits[-1]['sort']
         params.update({
-            INDEXED_AFTER: hits[-1]["@indexed_on"],
-            LAST_CASE_ID: hits[-1]["_id"],
+            INDEXED_AFTER: last_date,
+            LAST_CASE_ID: last_id
         })
         cursor = params.urlencode()
         ret['next'] = {'cursor': b64encode(cursor.encode('utf-8'))}
@@ -129,22 +129,8 @@ def get_list(domain, couch_user, params):
 
 def _get_cursor_query(domain, params, last_date, last_id):
     query = _get_query(domain, params)
-    id_filter = queries.nested(
-        CASE_PROPERTIES_PATH,
-        filters.AND(
-            filters.term(case_search.PROPERTY_KEY, '@case_id'),
-            filters.range_filter(case_search.PROPERTY_VALUE_EXACT, gt=last_id),
-        )
-    )
-    return query.filter(
-        filters.OR(
-            filters.AND(
-                filters.term('@indexed_on', last_date),
-                id_filter,
-            ),
-            case_search.indexed_on(gt=last_date),
-        )
-    )
+    query = query.search_after([last_date, last_id])
+    return query
 
 
 def _get_query(domain, params):

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -116,8 +116,8 @@ def get_list(domain, couch_user, params):
     }
 
     cases_in_result = len(hits)
-    # we need to paginate until there are no hits in the result
-    if cases_in_result:
+    limit = query._size or MAX_PAGE_SIZE
+    if cases_in_result == limit:
         last_date, last_id = es_result.raw_hits[-1]['sort']
         params.update({
             INDEXED_AFTER: last_date,

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -104,12 +104,7 @@ class TestCaseListAPI(TestCase):
             ['chaney', 'ned'],
             [c['external_id'] for c in res['cases']]
         )
-        self.assertIn('next', res)  # We need to paginate until results are empty
-
-        res = get_list(self.domain, self.couch_user, res['next'])
-        self.assertEqual(res['matching_records'], 5)
-        self.assertFalse(res['cases'])
-        self.assertNotIn('next', res)  # Now that results are empty, no next value
+        self.assertNotIn('next', res)  # No pages after this one
 
     def test_deprecated_case_type(self):
         self.case_type_obj.is_deprecated = True

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -106,6 +106,21 @@ class TestCaseListAPI(TestCase):
         )
         self.assertNotIn('next', res)  # No pages after this one
 
+    def test_pagination_continues(self):
+        """
+        If the page size is a divisor of the total number of docs, the user will need to paginate until the
+        result set is empty
+        """
+        query_dict = QueryDict('limit=1&case_type=person&case_type=household')
+        res = get_list(self.domain, self.couch_user, query_dict)
+        for _ in range(4):
+            res = get_list(self.domain, self.couch_user, res['next'])
+        # after iterating through all 5 docs, we still have a next param
+        self.assertIn('next', res)
+        res = get_list(self.domain, self.couch_user, res['next'])
+        self.assertFalse(res['cases'])  # empty result set
+        self.assertNotIn('next', res)  # no next param
+
     def test_deprecated_case_type(self):
         self.case_type_obj.is_deprecated = True
         self.case_type_obj.save()

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -99,12 +99,17 @@ class TestCaseListAPI(TestCase):
         self.assertIn('last_case_id', cursor)
 
         res = get_list(self.domain, self.couch_user, res['next'])
-        self.assertEqual(res['matching_records'], 2)
+        self.assertEqual(res['matching_records'], 5)
         self.assertEqual(
             ['chaney', 'ned'],
             [c['external_id'] for c in res['cases']]
         )
-        self.assertNotIn('next', res)  # No pages after this one
+        self.assertIn('next', res)  # We need to paginate until results are empty
+
+        res = get_list(self.domain, self.couch_user, res['next'])
+        self.assertEqual(res['matching_records'], 5)
+        self.assertFalse(res['cases'])
+        self.assertNotIn('next', res)  # Now that results are empty, no next value
 
     def test_deprecated_case_type(self):
         self.case_type_obj.is_deprecated = True


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-17682

### Change in behavior
Due to how `search_after` works, within any given request we know the total number of results that match the underlying query, the page size, and the number of results returned. This means if we have 20 total results, and a page size of 10, we won't know to stop after the second pagination since we aren't tracking how many total elements we've paginated over. This means there will be one additional `next` url returned the user that will return an empty result set.

### Summary

[search_after](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/paginate-search-results#search-after) is the replacement for the scroll API for deep pagination. The case/v2 API has been using range queries to paginate, but performance of that has been poor lately. It isn't entirely clear to us why `search_after` is more performant than range queries, but based on testing (see the ticket) it is definitely the case. My understanding is that `search_after` can take advantage of the ordering of docs (or doc_values) on the segment itself, so that it can efficiently pickup where the last request left off.

As far as how this change impacts users, this code is used when paginating a list of cases in the case/v2 api. We return a `next` url which has a `cursor` parameter that is base64 encoded. Looks like this
```
https://www.commcarehq.org/a/gherceg/api/case/v2?cursor=Y2FzZV90eXBlPWNhc2UmbGltaXQ9MSZpbmRleGVkX29uLmd0ZT0yMDI0LTA1LTMxVDE4JTNBMDQlM0EyMS45MjQ2MDJaJmxhc3RfY2FzZV9pZD04ZjE4MDUzMy1hYjkxLTRhMTItYTgwOC1mMjhiZTViYjVkMGI%3D"
```
When that `cursor` parameter is decoded, it looks something like this 
```
case_type=case&limit=1&indexed_on.gte=b'case_type=case&limit=1&indexed_on.gte=2024-05-31T18%3A04%3A21.924602Z&last_case_id=8f180533-ab91-4a12-a808-f28be5bb5d0b'
&last_case_id=8f180533-ab91-4a12-a808-f28be5bb5d0b
```

Notably, the value of `indexed_on.gte` is what will change with change. So the new decoded parameters will look like
```
case_type=case&limit=1&indexed_on.gte=b'case_type=case&limit=1&indexed_on.gte=1717178661924&last_case_id=8f180533-ab91-4a12-a808-f28be5bb5d0b'
&last_case_id=8f180533-ab91-4a12-a808-f28be5bb5d0b
```

This value is certainly less user friendly as you can't easily determine the date, but the user shouldn't have to interact with this value anyway, since they only need to execute the request with the encoded `cursor` parameter.

In 17170ae447bfbccf93978f9a0ea5f49252acda2c I added backwards compatibility in case anyone triggers a request with a `cursor` parameter that was generated prior to this being deployed. It is a bit messy, but based on my testing does the job. Plus we can remove this pretty shortly after deploying this (a day later?). Here is an example from the shell:
```
In [90]: indexed_on = "2024-06-07T19:11:37.757028Z"
In [91]: timestamp_from_es = 1717787497757
In [92]: timestamp_in_secs = datetime.fromisoformat(indexed_on.replace("Z", "+00:00")).timestamp()
In [93]: timestamp = int(timestamp_in_ms * 1000)
In [94]: timestamp == timestamp_from_es
Out[94]: True
In [95]: timestamp
Out[95]: 1717787497757
```
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- I've confirmed that elasticsearch can handle the timestamp as either a string or int when passed into the query.
- will test on staging

 I've run a lot of es queries from the django shell that use `search_after` so that gives me confidence, though still need to make sure this works as expected end to end.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
If we revert it, there won't be backwards compatibility for `cursor` parameters that use a timestamp instead of an isoformat date.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
