### PR TITLE
Fixture Cache - tag by domain instead of cache key

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -168,7 +168,7 @@ class ItemListsProvider(FixtureProvider):
 
         if not overwrite_cache:
             data = get_cached_fixture_items(key)
-            record_datadog_metric('cache_miss' if data is None else 'cache_hit', key)
+            record_datadog_metric('cache_miss' if data is None else 'cache_hit', domain)
 
         if data is None:
             with CriticalSection([key]):
@@ -176,7 +176,7 @@ class ItemListsProvider(FixtureProvider):
                     # re-check cache to avoid re-computing it
                     data = get_cached_fixture_items(key)
                 if data is None:
-                    record_datadog_metric('generate', key)
+                    record_datadog_metric('generate', domain)
                     items = self._get_global_items(global_type, domain)
                     with write_fixture_items_to_io(items) as io_data:
                         data = io_data.getvalue()

--- a/corehq/ex-submodules/casexml/apps/phone/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/utils.py
@@ -16,7 +16,7 @@ from memoized import memoized
 
 from corehq.blobs import get_blob_db, CODES, NotFound
 from corehq.blobs.models import BlobMeta
-from corehq.util.metrics import metrics_counter
+from corehq.util.metrics import metrics_counter, limit_domains
 
 ITEMS_COMMENT_PREFIX = b'<!--items='
 ITESM_COMMENT_REGEX = re.compile(br'(<!--items=(\d+)-->)')
@@ -69,13 +69,13 @@ def get_cached_fixture_items(key):
 
 def clear_fixture_cache(domain, bucket_prefix):
     key = bucket_prefix + '/' + domain
-    record_datadog_metric('cache_clear', key)
+    record_datadog_metric('cache_clear', domain)
     get_blob_db().delete(key=key)
 
 
-def record_datadog_metric(name, cache_key):
+def record_datadog_metric(name, domain):
     metrics_counter('commcare.fixture.{}'.format(name), tags={
-        'cache_key': cache_key,
+        'domain': limit_domains(domain),
     })
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
None

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[A previous change](https://github.com/dimagi/commcare-hq/pull/36242) started caching fixtures individually instead of by domain. As a result, it led to an explosion of cache_keys which DD metrics are tagged by. This led to increased DataDog costs. The benefits we get from this metric is not worth the cost so this PR swaps to just tag by domain to still have some visibility into this metric but keeping costs down.

The effected metrics are `commcare.fixture.cache_hit`, `commcare.fixture.cache_miss`, `commcare.fixture.generate`

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
only affects DD tags
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
