### PR TITLE
Remove support for old indexed_on.gte format in case/v2 cursor parameter

### DIFF
--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -1,5 +1,4 @@
 from base64 import b64decode, b64encode
-from datetime import datetime
 
 from django.http import QueryDict
 
@@ -119,12 +118,7 @@ def get_list(domain, couch_user, params):
 
 def _get_cursor_query(domain, params, last_date, last_id):
     query = _get_query(domain, params)
-    timestamp = last_date
-    if not timestamp.isdigit():
-        # this can be removed after this PR is deployed. This ensures backward compatibility
-        timestamp_in_secs = datetime.fromisoformat(last_date.replace("Z", "+00:00")).timestamp()
-        timestamp = int(timestamp_in_secs * 1000)  # ES accepts timestamp in milliseconds
-    query = query.search_after(timestamp, last_id)
+    query = query.search_after(last_date, last_id)
     return query
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Simple followup to https://github.com/dimagi/commcare-hq/pull/36552

That PR changed the format of the `indexed_on.gte` value used in the `cursor` parameter, from an pseudo iso datetime format to a timestamp in milliseconds.

The original change catered to both formats in case any users were resuming pagination using the old format. This change was just deployed, so we can wait a few days, but it should then be safe to merge this without worrying about causing issues.
 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I've already tested that this API works when indexed_on.gte is a timestamp. The real risk with this change is if a user attempts to trigger a request that uses the old format. The elasticsearch request will fail with the error:
```
RequestError(400, 'search_phase_execution_exception', 'Failed to parse search_after value for field [@indexed_on].')
```
which will bubble up as a 500 to the user. Granted that shouldn't happen unless someone has the response for a pagination request hanging around and attempts to use it. I suppose if we really wanted to, we could return a 400 to the user explaining that this format is no longer supported.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
corehq.apps.hqcase.tests.test_case_list_api.TestCaseListAPI

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
