### PR TITLE
Gracefully handle error decoding cursor parameter

### DIFF
--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -15,7 +15,7 @@ from corehq.apps.reports.standard.cases.utils import (
     query_location_restricted_cases,
 )
 from corehq.apps.data_dictionary.util import get_data_dict_deprecated_case_types
-from dimagi.utils.logging import notify_exception
+from dimagi.utils.logging import notify_error
 from dimagi.utils.parsing import FALSE_STRINGS
 from .core import UserError, serialize_es_case
 
@@ -87,8 +87,8 @@ def get_list(domain, couch_user, params):
     if 'cursor' in params:
         try:
             params_string = b64decode(params['cursor']).decode('utf-8')
-        except binascii.Error as e:
-            notify_exception(None, message=f"Failed to decode 'cursor' parameter: {params['cursor']}", exec_info=e)
+        except binascii.Error:
+            notify_error(message=f"Failed to decode 'cursor' parameter in case api: {params['cursor']}")
             return JsonResponse({'error': "Failed to decode 'cursor' parameter"}, status=400)
         params = QueryDict(params_string, mutable=True)
         # QueryDict.pop() returns a list

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -1,7 +1,8 @@
+import binascii
 from base64 import b64decode, b64encode
 from datetime import datetime
 
-from django.http import QueryDict
+from django.http import JsonResponse, QueryDict
 
 from corehq.apps.api.util import make_date_filter
 from corehq.apps.case_search.filter_dsl import (
@@ -14,6 +15,7 @@ from corehq.apps.reports.standard.cases.utils import (
     query_location_restricted_cases,
 )
 from corehq.apps.data_dictionary.util import get_data_dict_deprecated_case_types
+from dimagi.utils.logging import notify_exception
 from dimagi.utils.parsing import FALSE_STRINGS
 from .core import UserError, serialize_es_case
 
@@ -83,7 +85,11 @@ COMPOUND_FILTERS = {
 
 def get_list(domain, couch_user, params):
     if 'cursor' in params:
-        params_string = b64decode(params['cursor']).decode('utf-8')
+        try:
+            params_string = b64decode(params['cursor']).decode('utf-8')
+        except binascii.Error as e:
+            notify_exception(None, message=f"Failed to decode 'cursor' parameter: {params['cursor']}", exec_info=e)
+            return JsonResponse({'error': "Failed to decode 'cursor' parameter"}, status=400)
         params = QueryDict(params_string, mutable=True)
         # QueryDict.pop() returns a list
         last_date = params.pop(INDEXED_AFTER, [None])[0]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Currently this results in a 500 which in addition to being gross to receive when using the API (we return the html sad danny page), should be gracefully handled on our end.

Here's the relevant [sentry error](https://dimagi.sentry.io/issues/6624687069/?project=136860&referrer=github-open-pr-bot). It isn't that common, but directly user facing and easy enough to fix.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I double check that this is the error raised when failing to b64decode a value. We don't see it often, but it isn't helpful to the user currently.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
