### PR TITLE
Customize label for generator method

### DIFF
--- a/corehq/apps/hqwebapp/two_factor_methods.py
+++ b/corehq/apps/hqwebapp/two_factor_methods.py
@@ -1,4 +1,5 @@
 from django_otp.plugins.otp_totp.models import TOTPDevice
+from django.utils.translation import gettext_lazy as _
 
 from two_factor.plugins.phonenumber.method import PhoneCallMethod, SMSMethod
 from two_factor.plugins.registry import GeneratorMethod
@@ -11,6 +12,7 @@ class HQGeneratorMethod(GeneratorMethod):
 
     # only overriding this because it is set in GeneratorMethod
     form_path = 'corehq.apps.settings.forms.HQTOTPDeviceForm'
+    verbose_name = _("Authenticator App")
 
     def get_setup_forms(self, *args):
         return {self.code: HQTOTPDeviceForm}

--- a/corehq/apps/hqwebapp/two_factor_methods.py
+++ b/corehq/apps/hqwebapp/two_factor_methods.py
@@ -12,6 +12,7 @@ class HQGeneratorMethod(GeneratorMethod):
 
     # only overriding this because it is set in GeneratorMethod
     form_path = 'corehq.apps.settings.forms.HQTOTPDeviceForm'
+    # override the default verbose name "Token Generator"
     verbose_name = _("Authenticator App")
 
     def get_setup_forms(self, *args):

--- a/corehq/trans_override.py
+++ b/corehq/trans_override.py
@@ -1,6 +1,0 @@
-from django.utils.translation import gettext_noop
-
-messages_to_override = [
-    # two_factor/models.py#L47
-    gettext_noop("Token generator"),
-]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
**Before**
![image](https://github.com/user-attachments/assets/1df0a647-5576-4a1f-8389-8febf728288f)

**After:**
Users can use any authenticator app, not just Google Authenticator, so the label should be changed to the more generic "Authenticator App".
<img width="723" alt="image" src="https://github.com/user-attachments/assets/fa806bb1-3d91-45e3-904e-d547b4fced21" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17690

By default, the underlying library `django-two-factor-auth` uses the label "Token generator" for the generator authentication method. Previously, we overrode the default translation of this label in `trans_override.py`, mapping "Token generator" to "Google Authenticator".

Remove `trans_override.py` will only allow "Token generator" to be translated as it is.

The [MethodForm](https://github.com/jazzband/django-two-factor-auth/blob/227bb96dd91c405e9d5b47b3d2ff29c6184d86f9/two_factor/forms.py#L23-L25) collects all registered methods, use `code` and `verbose_name` to build the ChoiceField. our `HQTwoFactorMethodForm` which inherit `MethodForm` then [use the method field for the display label in the UI.](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/settings/forms.py#L162-L165)
Thus adding a `verbose_name` attribute to HQGeneratorMethod, is explicitly override the default `Token generator` label.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested it locally. The change is safe because there are no functionality change, just renaming.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->




### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
