### PR TITLE
Release DEVICE_RATE_LIMITER to all envs

### DIFF
--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -15,7 +15,7 @@ DEVICE_RATE_LIMIT_MESSAGE = "Current usage for this user is too high. Please try
 DEVICE_SET_CACHE_TIMEOUT = 2 * 60  # 2 minutes
 
 DEVICE_LIMIT_PER_USER_KEY = "device_limit_per_user"
-DEVICE_LIMIT_PER_USER_DEFAULT = 50
+DEVICE_LIMIT_PER_USER_DEFAULT = 10
 REDIS_KEY_PREFIX = "device-limiter"
 
 

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -29,7 +29,7 @@ class DeviceRateLimiter:
         self.client = get_redis_connection()
 
     def device_limit_per_user(self, domain):
-        return SystemLimit.for_key(DEVICE_LIMIT_PER_USER_KEY, domain=domain) or DEVICE_LIMIT_PER_USER_DEFAULT
+        return SystemLimit.for_key(DEVICE_LIMIT_PER_USER_KEY, DEVICE_LIMIT_PER_USER_DEFAULT, domain=domain)
 
     def rate_limit_device(self, domain, user, device_id):
         """

--- a/corehq/apps/users/device_rate_limiter.py
+++ b/corehq/apps/users/device_rate_limiter.py
@@ -3,7 +3,6 @@ from datetime import datetime, timezone
 
 from django_redis import get_redis_connection
 
-from corehq import toggles
 from corehq.apps.cloudcare.const import DEVICE_ID as CLOUDCARE_DEVICE_ID
 from corehq.project_limits.models import SystemLimit
 from corehq.util.metrics import metrics_counter
@@ -66,12 +65,11 @@ class DeviceRateLimiter:
             self._track_usage(key, device_id)
             return False
 
-        is_enabled = toggles.DEVICE_RATE_LIMITER.enabled(domain, toggles.NAMESPACE_DOMAIN)
         metrics_counter(
             'commcare.devices_per_user.rate_limited',
-            tags={'domain': domain, 'user_id': user.user_id, 'enabled': str(is_enabled)},
+            tags={'domain': domain, 'user_id': user.user_id},
         )
-        return is_enabled
+        return True
 
     def _get_redis_key(self, domain, user_id):
         """

--- a/corehq/apps/users/tests/test_device_rate_limiter.py
+++ b/corehq/apps/users/tests/test_device_rate_limiter.py
@@ -5,11 +5,9 @@ from corehq.apps.cloudcare.const import DEVICE_ID as CLOUDCARE_DEVICE_ID
 from corehq.apps.users.device_rate_limiter import DEVICE_LIMIT_PER_USER_KEY, REDIS_KEY_PREFIX, device_rate_limiter
 from corehq.apps.users.models import CommCareUser
 from corehq.project_limits.models import SystemLimit
-from corehq.util.test_utils import flag_disabled, flag_enabled
 
 
 @freeze_time("2024-12-10 12:05:43")
-@flag_enabled("DEVICE_RATE_LIMITER")
 class TestDeviceRateLimiter(TestCase):
 
     domain = 'device-rate-limit-test'
@@ -85,11 +83,6 @@ class TestDeviceRateLimiter(TestCase):
 
         device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
         self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
-
-    @flag_disabled("DEVICE_RATE_LIMITER")
-    def test_allowed_if_rate_limiter_is_disabled(self):
-        device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
-        self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
 
     def test_allowed_if_user_or_device_id_is_none(self):
         device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')

--- a/corehq/project_limits/models.py
+++ b/corehq/project_limits/models.py
@@ -137,7 +137,7 @@ class SystemLimit(models.Model):
         return SystemLimit._get_global_limit(key, default)
 
     @staticmethod
-    @quickcache(['key', 'default'], timeout=FIVE_MINUTES, skip_arg=lambda *args: settings.UNIT_TESTING)
+    @quickcache(['key'], timeout=FIVE_MINUTES, skip_arg=lambda *args: settings.UNIT_TESTING)
     def _get_global_limit(key, default):
         system_limit, _ = SystemLimit.objects.get_or_create(key=key, domain='', defaults={"limit": default})
         return system_limit.limit

--- a/corehq/project_limits/models.py
+++ b/corehq/project_limits/models.py
@@ -127,7 +127,7 @@ class SystemLimit(models.Model):
                 )
 
     @classmethod
-    def for_key(cls, key, default, domain=''):
+    def for_key(cls, key, default, *, domain=''):
         """
         Return the value associated with the given key, prioritizing the domain specific entry over the general one
         """

--- a/corehq/project_limits/tests/test_system_limit.py
+++ b/corehq/project_limits/tests/test_system_limit.py
@@ -7,23 +7,31 @@ from corehq.project_limits.models import SystemLimit
 
 class TestSystemLimitMethods(TestCase):
 
-    def test_for_key_returns_none_if_no_limit_set(self):
-        self.assertIsNone(SystemLimit.for_key("imaginary_limit"))
+    def test_creates_limit_if_does_not_exist(self):
+        self.assertFalse(SystemLimit.objects.filter(key="imaginary_limit", limit=10).exists())
+        SystemLimit.for_key("imaginary_limit", 10)
+        self.assertTrue(SystemLimit.objects.filter(key="imaginary_limit", limit=10).exists())
 
-    def test_for_key_returns_zero_if_limit_set_to_zero(self):
-        SystemLimit.objects.create(key="general_limit", limit=0)
-        self.assertEqual(SystemLimit.for_key("general_limit"), 0)
+    def test_only_one_limit_created(self):
+        SystemLimit.for_key("imaginary_limit", 10)
+        SystemLimit.for_key("imaginary_limit", 10)
+        SystemLimit.for_key("imaginary_limit", 10, domain="random")
+        self.assertEqual(SystemLimit.objects.filter(key="imaginary_limit", limit=10).count(), 1)
 
-    def test_for_key_returns_general_limit(self):
-        SystemLimit.objects.create(key="general_limit", limit=10)  # domain defaults to blank
-        self.assertEqual(SystemLimit.for_key("general_limit"), 10)
-        self.assertEqual(SystemLimit.for_key("general_limit", domain="no_match"), 10)
+    def test_existing_limit_is_not_updated_if_default_changes(self):
+        SystemLimit.for_key("imaginary_limit", 10)
+        limit = SystemLimit.for_key("imaginary_limit", 20)
+        self.assertEqual(limit, 10)
 
-    def test_for_key_returns_domain_specific_limit(self):
+    def test_global_limit_used_if_no_domain_limit_exists(self):
+        SystemLimit.for_key("general_limit", 10)
+        self.assertEqual(SystemLimit.for_key("general_limit", 10, domain="no_match"), 10)
+
+    def test_domain_specific_limit(self):
         SystemLimit.objects.create(key="general_limit", limit=10)
         SystemLimit.objects.create(key="general_limit", limit=20, domain="specific")
-        self.assertEqual(SystemLimit.for_key("general_limit"), 10)
-        self.assertEqual(SystemLimit.for_key("general_limit", domain="specific"), 20)
+        self.assertEqual(SystemLimit.for_key("general_limit", 10), 10)
+        self.assertEqual(SystemLimit.for_key("general_limit", 10, domain="specific"), 20)
 
     def test_raises_error_if_changing_scope_from_global_to_domain(self):
         global_limit = SystemLimit.objects.create(key="general_limit", limit=10)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2974,16 +2974,6 @@ INCLUDE_ALL_LOCATIONS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-DEVICE_RATE_LIMITER = FeatureRelease(
-    slug='device_rate_limiter',
-    label='Apply rate limiting to the number of devices a single user can use in a one minute time window.',
-    description='Form submissions, restores, and heartbeat requests count towards usage. View and update in the '
-                'django admin under the SystemLimit table. The key is "device_limit_per_user"',
-    tag=TAG_INTERNAL,
-    namespaces=[NAMESPACE_DOMAIN],
-    owner='Graham Herceg',
-)
-
 KYC_VERIFICATION = StaticToggle(
     slug='kyc_verification',
     label='Enable KYC verification',


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Review by commit 🐟 

We don't need this behind a feature flag. When I first created this SystemLimit I should have made sure that a default entry was inserted into the db, as opposed to only inserting it via manual operations (django shell or admin). This way it will be much easier to adjust limits in the future, including for self hosters since they just need to find the corresponding entry in the django admin interface and adjust as needed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
DEVICE_RATE_LIMITER (removes this flag)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
We've been using the device rate limiter on production for months now and it has been successful. It is set to 10, which inspired the change in the default from 50 to 10.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
test_system_limit.py and test_device_rate_limiter.py

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
