### PR TITLE
Added name_update_multi to OpenCaseAction

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -417,6 +417,10 @@ class OpenReferralAction(UpdateReferralAction):
 
 class OpenCaseAction(FormAction):
 
+    # `name_update` is the "official" version, while `name_update_multi` is intended as a temporary option
+    # to allow the user to resolve conflicts. They should not be used together. Either the action is in a
+    # buildable state, where `name_update` is specified, or conflicts are waiting to be resolved, where
+    # `name_updatd_multi` will hold the updates.
     name_update = SchemaProperty(ConditionalCaseUpdate)
     name_update_multi = SchemaListProperty(ConditionalCaseUpdate)
     external_id = StringProperty()

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -418,7 +418,29 @@ class OpenReferralAction(UpdateReferralAction):
 class OpenCaseAction(FormAction):
 
     name_update = SchemaProperty(ConditionalCaseUpdate)
+    name_update_multi = SchemaListProperty(ConditionalCaseUpdate)
     external_id = StringProperty()
+
+    def make_multi(self):
+        '''
+        Moves any updates from `name_update` into `name_update_multi`
+        '''
+        if not (self.name_update):
+            return
+
+        self.name_update_multi = [self.name_update]
+        self.name_update = None
+
+    def normalize_name_update(self):
+        '''
+        Attempt to move `name_update_multi` to `name_update`
+        If `name_update_multi` contains multiple updates, no changes will occur
+        '''
+        if len(self.name_update_multi) > 1:
+            return
+
+        self.name_update = self.name_update_multi[0]
+        self.name_update_multi = []
 
 
 class OpenSubCaseAction(FormAction, IndexedSchema):

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -1,5 +1,54 @@
 from django.test import SimpleTestCase
-from corehq.apps.app_manager.models import UpdateCaseAction
+from corehq.apps.app_manager.models import UpdateCaseAction, OpenCaseAction
+
+
+class OpenCaseActionTests(SimpleTestCase):
+    def test_construction(self):
+        action = OpenCaseAction({
+            'name_update': {'question_path': 'name'}
+        })
+
+        self.assertEqual(action.name_update.question_path, 'name')
+
+    def test_multiple_name_updates(self):
+        action = OpenCaseAction({
+            'name_update_multi': [{'question_path': 'name1'}, {'question_path': 'name2'}]
+        })
+
+        multi_paths = [update.question_path for update in action.name_update_multi]
+        self.assertEqual(multi_paths, ['name1', 'name2'])
+
+    def test_make_multi_populates_multi(self):
+        action = OpenCaseAction({
+            'name_update': {'question_path': 'name'}
+        })
+
+        action.make_multi()
+
+        multi_paths = [update.question_path for update in action.name_update_multi]
+        self.assertEqual(multi_paths, ['name'])
+        self.assertIsNone(action.name_update)
+
+    def test_normalize_name_update_when_multiple_updates_exist_does_nothing(self):
+        action = OpenCaseAction({
+            'name_update_multi': [{'question_path': 'name1'}, {'question_path': 'name2'}]
+        })
+
+        action.normalize_name_update()
+
+        self.assertIsNone(action.name_update.question_path)
+        multi_paths = [update.question_path for update in action.name_update_multi]
+        self.assertEqual(multi_paths, ['name1', 'name2'])
+
+    def test_normalize_name_update_moves_name_update_multi_to_name_update(self):
+        action = OpenCaseAction({
+            'name_update_multi': [{'question_path': 'name'}]
+        })
+
+        action.normalize_name_update()
+
+        self.assertEqual(action.name_update.question_path, 'name')
+        self.assertEqual(len(action.name_update_multi), 0)
 
 
 class UpdateCaseActionTests(SimpleTestCase):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-17706

The current `name_update` field only allows a single update for the name. If we receive conflicting name updates, we want to store both to allow the user to choose the correct one, so we're adding a new field to the `OpenCaseAction` class to avoid migrating all apps.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
This adds a field which will only be used later. It won't affect any current logic.

### Automated test coverage
New test suite added

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
