### PR TITLE
Added default entry point for pages that don't use js_entry

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/base.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/base.js
@@ -1,0 +1,7 @@
+// This exists to provide a default entry point for hqwebapp/base, which
+// will be used on all pages that don't define their own entry point,
+// to provide behavior like bootstrap widget interactions.
+// It's convenient to have a single module that works for both
+// bootstrap 3 and bootstrap 5. Once that migration is complete,
+// hqwebapp/base can be updated to use commcarehq.js as its entry point.
+import "commcarehq";

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -1,6 +1,6 @@
 {% load menu_tags %}{% load i18n %}{% load hq_shared_tags %}{% load cache %}{% load compress %}{% load statici18n %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}
-{% js_entry %}
+{% js_entry "hqwebapp/js/base" %}
 <!--[if lt IE 7]><html lang="{{ LANGUAGE_CODE }}" class="lt-ie9 lt-ie8 lt-ie7"><![endif]-->
 <!--[if IE 7]><html lang="{{ LANGUAGE_CODE }}" class="lt-ie9 lt-ie8"><![endif]-->
 <!--[if IE 8]><html lang="{{ LANGUAGE_CODE }}" class="lt-ie9"><![endif]-->


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SAAS-17708

## Technical Summary
Introduced in https://github.com/dimagi/commcare-hq/pull/36544

Pages that don't use a `js_entry` aren't running HQ's global javascript (bootstrap interactions, etc.).

Any pages that don't inherit from `hqwebapp/base.html` and also don't use `js_entry` would also be affected, and would not be fixed by this PR. I don't think there are any of these, but acknowledging here that I haven't done an exhaustive search.

## Safety Assurance

### Safety story
Tested locally that the repeaters page now runs bootstrap properly (modals open, navigation dropdowns work) and, as a negative test case, did the same thing with the dashboard, a page that is not affected by this bug.

### Automated test coverage

not really

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
