### PR TITLE
Make entry point for pages without their own js available to bootstra…

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -1,6 +1,6 @@
 {% load menu_tags %}{% load i18n %}{% load hq_shared_tags %}{% load cache %}{% load compress %}{% load statici18n %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}
-{% js_entry "hqwebapp/js/base" %}
+{% js_entry "hqwebapp/js/base" %}{# Do not change. See special handling of this module in webpack/generateDetails.js #}
 <!--[if lt IE 7]><html lang="{{ LANGUAGE_CODE }}" class="lt-ie9 lt-ie8 lt-ie7"><![endif]-->
 <!--[if IE 7]><html lang="{{ LANGUAGE_CODE }}" class="lt-ie9 lt-ie8"><![endif]-->
 <!--[if IE 8]><html lang="{{ LANGUAGE_CODE }}" class="lt-ie9"><![endif]-->

--- a/webpack/generateDetails.js
+++ b/webpack/generateDetails.js
@@ -155,6 +155,11 @@ if (require.main === module) {
         isProductionMode
     );
 
+    // Directly copy the default entry point into B3.
+    // This makes it available to all B3 pages that inherit from hqwebapp/base.html,
+    // which uses js_entry and not js_entry_b3
+    b3Details.entries["hqwebapp/js/base"] = defaultDetails.entries["hqwebapp/js/base"];
+
     fs.writeFileSync(
         path.join(appPaths.BUILD_ARTIFACTS_DIR, 'details.json'),
         JSON.stringify({


### PR DESCRIPTION
…p 3 pages

## Product Description
https://dimagi.atlassian.net/browse/SAAS-17711

## Technical Summary
Introduced by https://github.com/dimagi/commcare-hq/pull/36570 which added a `js_entry` to `hqwebapp/js/base`, which the intention that entry point would be inherited by all descendants of that template that don't already provide their own entry point.

That change broke B3 descendants that didn't provide their own entry. Because no page used the new module (`hqwebapp/js/base`) with the `js_entry_b3` tag, that module wasn't available to B3 pages.

Part of webpack bundle generation is to scan all HTML files in HQ, find all lines with either the `js_entry` or `js_entry_b3` tag, and collect the js modules referenced in those lines. There are separate collections for B3 and B5 (see [here](https://github.com/dimagi/commcare-hq/blob/3df6f62b18bfd6859f28f5034fe20891895b43cc/webpack/generateDetails.js#L146-L156)). It's fine for a module to go in both collections (assuming it doesn't contain bootstrap-specific logic, which the new `hqwebapp/js/base` doesn't).

## Safety Assurance

### Safety story
Touching bundle generation makes this a high risk PR. I think this is a logical change, but I don't know that any reviewers are available who are familiar enough with this code to solidly confirm that. The main risk is that this PR will break js or cause 500s on some subset of pages. I've smoke tested these kinds of pages locally:
* B5 pages that inherit from `hqweabpp/base.html` (dashboard)
* B3 pages that inherit from `hqwebapp/base.html` (app manager)
* B5 pages that inherit from `hqwebapp/base.html` and don't provide their own entry point (main data forwarding page)
* B3 pages that inherit from `hqwebapp/base.html` and don't provide their own entry point (superuser management) <= these are the pages that have been 500ing, and that this PR is fixing
* Web apps (not using ESM)

So it's unlikely that any of these sets are fully affected, i.e., "all B3 pages", but it's possible that there's some subset of pages that use js in a way I'm not thinking of that will be affected negatively.

Tangentially, it's nice that the number of ways HQ uses js has dropped. Not long ago, the list of tested scenarios above would have been about three times longer (those scenarios, plus the same but for pages that use requirejs, plus the same but for pages that don't use a js bundler).

### Automated test coverage

no

### QA Plan

no

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
