### PR TITLE
Generate prorated prepayment invoice when moving from Pay Annually -> Pay Annually subscription

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -3349,14 +3349,13 @@ class InvoicePdf(BlobMixin, SafeSaveDocument):
                     )
 
         if invoice.is_wire and invoice.is_prepayment:
-            applied_credit = 0
             for item in invoice.items:
                 template.add_item(item['type'],
                                   item['quantity'],
                                   item['unit_cost'],
                                   item['amount'],
-                                  applied_credit,
-                                  item['amount'])
+                                  item['applied_credit'],
+                                  item['total'])
 
         template.get_pdf()
         filename = self.get_filename(invoice)

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -490,13 +490,19 @@ def create_wire_credits_invoice(domain_name,
         general_credit_cost = item['unit_cost']
         general_credit_qty = item['quantity']
         general_credit_amount = item['amount']
+        general_credit_prepaid = item['applied_credit']
+        general_credit_total = item['total']
         deserialized_credit_amount = deserialize_decimal(general_credit_amount)
         deserialized_credit_cost = deserialize_decimal(general_credit_cost)
+        deserialized_prepaid_credit = deserialize_decimal(general_credit_prepaid)
+        deserialized_total = deserialize_decimal(general_credit_total)
         deserialized_items.append({
             'type': item['type'],
             'amount': deserialized_credit_amount,
             'unit_cost': deserialized_credit_cost,
             'quantity': general_credit_qty,
+            'applied_credit': deserialized_prepaid_credit,
+            'total': deserialized_total,
         })
 
     wire_invoice.items = deserialized_items

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -488,21 +488,16 @@ def create_wire_credits_invoice(domain_name,
     deserialized_items = []
     for item in invoice_items:
         general_credit_cost = item['unit_cost']
-        general_credit_qty = item['quantity']
         general_credit_amount = item['amount']
         general_credit_prepaid = item['applied_credit']
         general_credit_total = item['total']
-        deserialized_credit_amount = deserialize_decimal(general_credit_amount)
-        deserialized_credit_cost = deserialize_decimal(general_credit_cost)
-        deserialized_prepaid_credit = deserialize_decimal(general_credit_prepaid)
-        deserialized_total = deserialize_decimal(general_credit_total)
         deserialized_items.append({
             'type': item['type'],
-            'amount': deserialized_credit_amount,
-            'unit_cost': deserialized_credit_cost,
-            'quantity': general_credit_qty,
-            'applied_credit': deserialized_prepaid_credit,
-            'total': deserialized_total,
+            'quantity': item['quantity'],
+            'unit_cost': deserialize_decimal(general_credit_cost),
+            'amount': deserialize_decimal(general_credit_amount),
+            'applied_credit': deserialize_decimal(general_credit_prepaid),
+            'total': deserialize_decimal(general_credit_total),
         })
 
     wire_invoice.items = deserialized_items

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.core import mail
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 
 from dateutil.relativedelta import relativedelta
 
@@ -37,6 +37,7 @@ from corehq.apps.accounting.tests.base_tests import (
 )
 from corehq.apps.accounting.utils.invoicing import (
     get_flagged_pay_annually_prepay_invoice,
+    get_prorated_software_plan_cost,
 )
 from corehq.apps.users.models import WebUser
 from corehq.util.dates import get_previous_month_date_range
@@ -489,3 +490,42 @@ class TestFlaggedPayAnnuallyPrepayInvoice(BaseInvoiceTestCase):
         )
         result = get_flagged_pay_annually_prepay_invoice(self.invoice)
         self.assertEqual(result, prepay_invoice)
+
+
+class TestGetProratedSoftwarePlanCost(SimpleTestCase):
+
+    def test_full_month(self):
+        date_start = datetime.date(2025, 6, 1)
+        date_end = datetime.date(2025, 7, 1)
+        monthly_fee = Decimal('100.00')
+        expected = Decimal('100.00')
+        result = get_prorated_software_plan_cost(date_start, date_end, monthly_fee)
+        self.assertEqual(result, expected)
+
+    def test_partial_month(self):
+        date_start = datetime.date(2025, 6, 1)
+        date_end = datetime.date(2025, 6, 16)
+        monthly_fee = Decimal('100.00')
+        expected = Decimal('50.00')  # 15 days is half of June
+        result = get_prorated_software_plan_cost(date_start, date_end, monthly_fee)
+        self.assertEqual(result, expected)
+
+    def test_multiple_months(self):
+        date_start = datetime.date(2025, 6, 16)
+        date_end = datetime.date(2025, 8, 4)
+        monthly_fee = Decimal('100.00')
+        expected = (
+            Decimal('50.00')  # half of June
+            + Decimal('100.00')  # all of July
+            + monthly_fee / 31 * 3  # 3 days of August
+        ).quantize(Decimal('0.00'))
+        result = get_prorated_software_plan_cost(date_start, date_end, monthly_fee)
+        self.assertEqual(result, expected)
+
+    def test_zero_days(self):
+        date_start = datetime.date(2025, 6, 1)
+        date_end = datetime.date(2025, 6, 1)
+        monthly_fee = Decimal('100.00')
+        expected = Decimal('0.00')
+        result = get_prorated_software_plan_cost(date_start, date_end, monthly_fee)
+        self.assertEqual(result, expected)

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -1,6 +1,6 @@
 import datetime
 import random
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 
 from django.conf import settings
 from django.core import mail
@@ -518,7 +518,7 @@ class TestGetProratedSoftwarePlanCost(SimpleTestCase):
             Decimal('50.00')  # half of June
             + Decimal('100.00')  # all of July
             + monthly_fee / 31 * 3  # 3 days of August
-        ).quantize(Decimal('0.00'))
+        ).quantize(Decimal('0.00'), ROUND_HALF_UP)
         result = get_prorated_software_plan_cost(date_start, date_end, monthly_fee)
         self.assertEqual(result, expected)
 

--- a/corehq/apps/accounting/utils/invoicing.py
+++ b/corehq/apps/accounting/utils/invoicing.py
@@ -151,18 +151,18 @@ def get_flagged_pay_annually_prepay_invoice(invoice):
 
 def get_prorated_software_plan_cost(date_start, date_end, monthly_fee):
     total_cost = Decimal('0.00')
-    current = date_start
+    billing_range_start = date_start
 
-    while current < date_end:
-        days_in_month = calendar.monthrange(current.year, current.month)[1]
-        month_end = current.replace(day=days_in_month)
-        segment_end = min(month_end + datetime.timedelta(days=1), date_end)
+    while billing_range_start < date_end:
+        days_in_month = calendar.monthrange(billing_range_start.year, billing_range_start.month)[1]
+        last_day_of_month = billing_range_start.replace(day=days_in_month)
+        billing_range_end = min(last_day_of_month + datetime.timedelta(days=1), date_end)
 
-        days_active = (segment_end - current).days
+        days_active = (billing_range_end - billing_range_start).days
         daily_fee = (monthly_fee / days_in_month)
 
         total_cost += (daily_fee * days_active)
-        current = segment_end
+        billing_range_start = billing_range_end
 
     return total_cost.quantize(
         Decimal('0.01'), rounding=ROUND_HALF_UP,

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1982,26 +1982,31 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
             )
             return False
 
-    def send_prepayment_invoice(self, date_start, date_end):
-        label = f"One month of {self.plan_version.plan.name}"
-        monthly_fee = self.plan_version.product_rate.monthly_fee
-        duration = relativedelta(date_end, date_start)
-        num_months = getattr(duration, 'years', 0) * 12  # todo: support other subscription lengths
-        amount = monthly_fee * num_months
-        date_due = max(date_start,
-                       datetime.date.today() + datetime.timedelta(days=SUBSCRIPTION_PREPAY_MIN_DAYS_UNTIL_DUE))
-
+    def send_prepayment_invoice(self, new_date_start, date_end):
         email_list = self.cleaned_data['email_list']
         contact_emails = [email_list[0]]
         cc_emails = [email for email in email_list[1:]]
-
         invoice_factory = DomainWireInvoiceFactory(
-            self.domain, date_start=date_start, date_end=date_end,
+            self.domain, date_start=new_date_start, date_end=date_end,
             contact_emails=contact_emails, cc_emails=cc_emails
         )
-        invoice_factory.create_wire_credits_invoice(
-            amount, label, monthly_fee, num_months, date_due
-        )
+        date_due = max(new_date_start,
+                       datetime.date.today() + datetime.timedelta(days=SUBSCRIPTION_PREPAY_MIN_DAYS_UNTIL_DUE))
+
+        if self.current_is_annual_plan():
+            invoice_factory.create_prorated_subscription_change_credits_invoice(
+                self.current_subscription.date_start, new_date_start, date_end,
+                self.current_subscription.plan_version, self.plan_version, date_due,
+            )
+        else:
+            label = f"One month of {self.plan_version.plan.name}"
+            monthly_fee = self.plan_version.product_rate.monthly_fee
+            duration = relativedelta(date_end, new_date_start)
+            num_months = duration.years * 12 + duration.months
+            amount = monthly_fee * num_months
+            invoice_factory.create_wire_credits_invoice(
+                amount, label, monthly_fee, num_months, date_due
+            )
 
     def new_subscription_start_end_dates(self):
         if self.is_downgrade_from_paid_plan() and self.current_subscription.is_below_minimum_subscription:

--- a/corehq/apps/domain/tests/test_utils.py
+++ b/corehq/apps/domain/tests/test_utils.py
@@ -13,6 +13,7 @@ from corehq.apps.domain.utils import (
     encrypt_account_confirmation_info,
     get_domain_url_slug,
     get_serializable_wire_invoice_general_credit,
+    get_serializable_wire_invoice_prepaid_item,
     guess_domain_language,
     guess_domain_language_for_sms,
     is_domain_in_use,
@@ -124,6 +125,27 @@ class TestGetSerializableWireInvoiceItem(SimpleTestCase):
 
     def test_return_value_is_json_serializable(self):
         items = get_serializable_wire_invoice_general_credit(1.5, 'credit', 1.5, 1)
+        # exception would be raised here if there is an issue
+        serialized_items = json.dumps(items)
+        self.assertTrue(serialized_items)
+
+
+class TestGetSerializableWireInvoicePrepaidItem(SimpleTestCase):
+
+    def test_empty_list_is_returned_if_prepaid_amount_is_zero(self):
+        items = get_serializable_wire_invoice_prepaid_item(0, 'credit', 1)
+        self.assertFalse(items)
+
+    def test_empty_list_is_returned_if_prepaid_amount_is_greater_than_zero(self):
+        items = get_serializable_wire_invoice_prepaid_item(1, 'credit', 1)
+        self.assertFalse(items)
+
+    def test_item_is_returned_if_prepaid_amount_is_less_than_zero(self):
+        items = get_serializable_wire_invoice_prepaid_item(-1, 'credit', -1)
+        self.assertTrue(items)
+
+    def test_return_value_is_json_serializable(self):
+        items = get_serializable_wire_invoice_prepaid_item(-1.5, 'credit', -1.5)
         # exception would be raised here if there is an issue
         serialized_items = json.dumps(items)
         self.assertTrue(serialized_items)

--- a/corehq/apps/domain/utils.py
+++ b/corehq/apps/domain/utils.py
@@ -141,6 +141,20 @@ def clear_domain_names(*domain_names):
             domain.delete()
 
 
+def get_serializable_wire_invoice_prepaid_item(prepaid_total, prepaid_label, prepaid_credits):
+    if prepaid_total < 0:
+        return [{
+            'type': prepaid_label,
+            'unit_cost': "0.00",
+            'quantity': 0,
+            'amount': "0.00",
+            'applied_credit': simplejson.dumps(prepaid_credits, use_decimal=True),
+            'total': simplejson.dumps(prepaid_total, use_decimal=True),
+        }]
+
+    return []
+
+
 def get_serializable_wire_invoice_general_credit(credit_total, credit_label, unit_cost, quantity):
     if credit_total > 0:
         return [{
@@ -148,6 +162,8 @@ def get_serializable_wire_invoice_general_credit(credit_total, credit_label, uni
             'unit_cost': simplejson.dumps(unit_cost, use_decimal=True),
             'quantity': quantity,
             'amount': simplejson.dumps(credit_total, use_decimal=True),
+            'applied_credit': "0.00",
+            'total': simplejson.dumps(credit_total, use_decimal=True),
         }]
 
     return []

--- a/corehq/apps/domain/utils.py
+++ b/corehq/apps/domain/utils.py
@@ -142,6 +142,10 @@ def clear_domain_names(*domain_names):
 
 
 def get_serializable_wire_invoice_prepaid_item(prepaid_total, prepaid_label, prepaid_credits):
+    """
+    Returns a JSON serializable representation of a previously-paid item to be credited to the customer on a
+    prepayment invoice, or an empty list if not negative. Used with celery task `create_wire_credits_invoice`.
+    """
     if prepaid_total < 0:
         return [{
             'type': prepaid_label,
@@ -156,6 +160,10 @@ def get_serializable_wire_invoice_prepaid_item(prepaid_total, prepaid_label, pre
 
 
 def get_serializable_wire_invoice_general_credit(credit_total, credit_label, unit_cost, quantity):
+    """
+    Returns a JSON serializable representation of an item to be paid by the customer to purchase credits on a
+    prepayment invoice, or an empty list if not positive. Used with celery task `create_wire_credits_invoice`.
+    """
     if credit_total > 0:
         return [{
             'type': credit_label,


### PR DESCRIPTION
## Product Description
Allows generating prepayment invoices with line items that look like this:
![image](https://github.com/user-attachments/assets/e08cefce-85a7-45de-ab32-e9c4115b4e96)

Where line 1 (always positive) is the total amount owed for the new subscription based on the prepayment term, and line 2 (always negative) is the total amount owed for the old subscription minus the prepayment amount already billed.

This is to allow change from one subscription to another in the middle of a subscription term, where the original subscription was already prepaid - as of now, this means moving from one Pay Annually software plan to another. Note this is not possible in the UI until https://dimagi.atlassian.net/browse/SAAS-17589 is implemented, so this PR will have no directly visible impact to users.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17590
This adds three main pieces of functionality:
- `get_prorated_software_plan_cost` to prorate software plan fees across multiple months (we have some existing functionality for similar but it only operates with days in a single month)
- `get_serializable_wire_invoice_prepaid_item` to generate a negative (credits) line item for a prepayment invoice
- `create_prorated_subscription_change_credits_invoice` which uses these two functions and some pretty straightforward logic to call an existing task to generate the prepayment invoice

Additionally adds a couple of methods on the `ConfirmNewSubscriptionForm` as a convenience: to check if the current ("old") plan is a Pay Annually plan, and to determine the new subscription's correct start and end dates, rather than doing so inline in the `save` method.

## Safety Assurance

### Safety story
Tested these changes locally, moving from lower to higher tier Pay Annually software plans, which is the only situation we will allow. This code would still _work_ moving to a lower tier plan, but the customer would receive a negative invoice, so it will not be allowed. Added automated test coverage tests core functionality added here.

### Automated test coverage
Added `TestGetProratedSoftwarePlanCost` and `TestGetSerializableWireInvoicePrepaidItem`. There is some existing automated testing for `ConfirmNewSubscriptionForm` which will help prevent against regression.

### QA Plan
No QA planned for this, but could see an argument for it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
