### PR TITLE
Temporarily disable SUDCare EPIC integration

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2041,7 +2041,8 @@ DOMAIN_MODULE_MAP = {
 
     'epic-integration-test': 'custom.mgh_epic',
     'sudcare-dev': 'custom.mgh_epic',
-    'sudcare': 'custom.mgh_epic',
+    # Temporarily disabled SUDCare integration (paused 2025-06-13)
+    #'sudcare': 'custom.mgh_epic',
 }
 
 CUSTOM_DOMAINS_BY_MODULE = defaultdict(list)


### PR DESCRIPTION
Comment out the 'sudcare' domain entry in settings.py to pause automated appointment reminders per MGH/IRB guidance. This prevents any new EPIC-driven reminders for the SUDCare study until consent language and protocols are updated.

## Product Description
No user-facing changes. This only prevents automated reminders from firing.

## Technical Summary
Comments out the sudcare domain flag in settings.py per IRB pause.

## Feature Flag


## Safety Assurance

### Safety story
Change only affects the ‘sudcare’ key in a dict; no live data or database migrations.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
