### PR TITLE
Standardize warning sign

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -3,36 +3,34 @@
 {% load xforms_extras %}
 
 {% comment %}
-  This file displays errors found during app validation, which is handled by the validators in corehq.apps.app_manager.helpers.validators.
-  Each error is a dict containing:
-  - type (required)
-  - message (optional)
-  - module (optional): a dict containing the module's id, name dict, and unique_id
-  - form (optional): possibly a form, possibly just a dict containing id and name dict
-  - ...and occasionally other data
-
-  This file is primarily a giant case statement that switches on the error type.
-  It's inconsistent. Best practices for new errors:
-  - This file is included in several contexts, some general to the whole app and some
-    specific to a single form or module. The flag not_actual_build is set when we're
-    only looking at part of an app. This is used to make messages less redundant: you
-    might say "Form X in menu Y is broken" in an app context, but in a form context
-    that can just become "This form is broken."
-  - For menu or form-specific errors, always link to the menu or form.
-  - For form specific errors, display the menu name ("Form X in menu Y") but only link to
-    the place where the user would go to fix the error (probably the form).
-  - For form errors, consider whether the message should link to form_source or to
-    form_settings (probably form settings).
-  - Aim to translate error messages, even though it can get complex to handle the
-    not_actual_build flag and links to menus/forms. For this reason, avoid including
-    templates like form_error_message.html.
+  This file displays errors found during app validation, which is handled by the
+  validators in corehq.apps.app_manager.helpers.validators. Each error is a dict
+  containing: - type (required) - message (optional) - module (optional): a dict
+  containing the module's id, name dict, and unique_id - form (optional):
+  possibly a form, possibly just a dict containing id and name dict - ...and
+  occasionally other data This file is primarily a giant case statement that
+  switches on the error type. It's inconsistent. Best practices for new errors:
+  - This file is included in several contexts, some general to the whole app and
+  some specific to a single form or module. The flag not_actual_build is set
+  when we're only looking at part of an app. This is used to make messages less
+  redundant: you might say "Form X in menu Y is broken" in an app context, but
+  in a form context that can just become "This form is broken." - For menu or
+  form-specific errors, always link to the menu or form. - For form specific
+  errors, display the menu name ("Form X in menu Y") but only link to the place
+  where the user would go to fix the error (probably the form). - For form
+  errors, consider whether the message should link to form_source or to
+  form_settings (probably form settings). - Aim to translate error messages,
+  even though it can get complex to handle the not_actual_build flag and links
+  to menus/forms. For this reason, avoid including templates like
+  form_error_message.html.
 {% endcomment %}
 
 {% if build_errors %}
   <div class="alert alert-warning alert-build">
     <h4 class="alert-heading">
       <i class="fa fa-exclamation-triangle"></i>
-      {% trans "Cannot make new version" %}</h4>
+      {% trans "Cannot make new version" %}
+    </h4>
     <ul class="list-unstyled" id="build-errors">
       {% for error in build_errors %}
         {% if error.module %}
@@ -44,488 +42,605 @@
         <li>
           <span>
             {% case error.type "blank form" %}
-              <strong>Add a question</strong> to the {% include "app_manager/partials/form_error_message.html" %}
+            <strong>Add a question</strong> to the
+            {% include "app_manager/partials/form_error_message.html" %}
             {% case "invalid xml" %}
-              {% if not error.message %}
-                {% blocktrans %}
-                  If you don't know why this happened, please report an issue.
-                {% endblocktrans %}
-              {% endif %}
-              {% include "app_manager/partials/form_error_message.html" %}
+            {% if not error.message %}
+              {% blocktrans %}
+                If you don't know why this happened, please report an issue.
+              {% endblocktrans %}
+            {% endif %}
+            {% include "app_manager/partials/form_error_message.html" %}
             {% case "validation error" %}
-              {{ error.validation_message|linebreaksbr }} in form
-              {% include "app_manager/partials/form_error_message.html" %}
+            {{ error.validation_message|linebreaksbr }}
+            in form {% include "app_manager/partials/form_error_message.html" %}
             {% case "no form links" %}
-              {% blocktrans %}
-                Link to other form or menu is selected, but no links have been provided.
-              {% endblocktrans %}
-              {% include "app_manager/partials/form_error_message.html" %}
+            {% blocktrans %}
+              Link to other form or menu is selected, but no links have been
+              provided.
+            {% endblocktrans %}
+            {% include "app_manager/partials/form_error_message.html" %}
             {% case "bad form link" %}
-              {% blocktrans %}
-                Link to other form or menu is selected, but we don't recognize the form or menu you provided.
-              {% endblocktrans %}
-              {% include "app_manager/partials/form_error_message.html" %}
+            {% blocktrans %}
+              Link to other form or menu is selected, but we don't recognize the
+              form or menu you provided.
+            {% endblocktrans %}
+            {% include "app_manager/partials/form_error_message.html" %}
             {% case "form link to missing root" %}
-              {% blocktrans %}
-                Please check that end of form navigation is correct. It appears to be pointing
-                to a parent menu form, but the menu doesn't have a parent.
-              {% endblocktrans %}
-              {% include "app_manager/partials/form_error_message.html" %}
+            {% blocktrans %}
+              Please check that end of form navigation is correct. It appears to
+              be pointing to a parent menu form, but the menu doesn't have a
+              parent.
+            {% endblocktrans %}
+            {% include "app_manager/partials/form_error_message.html" %}
             {% case "form link to display only forms" %}
-              {% blocktrans %}
-                Please check that end of form navigation is correct. It appears to be pointing
-                to a menu using "Display only forms," which makes that menu an invalid choice.
-              {% endblocktrans %}
-              {% include "app_manager/partials/form_error_message.html" %}
+            {% blocktrans %}
+              Please check that end of form navigation is correct. It appears to
+              be pointing to a menu using "Display only forms," which makes that
+              menu an invalid choice.
+            {% endblocktrans %}
+            {% include "app_manager/partials/form_error_message.html" %}
             {% case "mismatch multi select form links" %}
-              {% blocktrans %}
-                Please check that end of form navigation is correct. It appears to involve both
-                a multi-select form and a single select-form, which is not supported.
-              {% endblocktrans %}
-              {% include "app_manager/partials/form_error_message.html" %}
+            {% blocktrans %}
+              Please check that end of form navigation is correct. It appears to
+              involve both a multi-select form and a single select-form, which
+              is not supported.
+            {% endblocktrans %}
+            {% include "app_manager/partials/form_error_message.html" %}
             {% case "workflow previous inline search" %}
-              {% blocktrans %}
-                Please check that end of form navigation is correct.
-                Modules configured to "make search input available after search" do not support
-                the "Previous Screen" workflow.
-              {% endblocktrans %}
-              {% include "app_manager/partials/form_error_message.html" %}
+            {% blocktrans %}
+              Please check that end of form navigation is correct. Modules
+              configured to "make search input available after search" do not
+              support the "Previous Screen" workflow.
+            {% endblocktrans %}
+            {% include "app_manager/partials/form_error_message.html" %}
             {% case "endpoint to display only forms" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses "Display only forms" and also has a Session Endpoint ID.
-                Session endpoints cannot be used with "Display only forms."
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses "Display only forms" and also has a Session Endpoint ID.
+              Session endpoints cannot be used with "Display only forms."
+            {% endblocktrans %}
             {% case "no ref detail" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses referrals but doesn't have detail screens configured for referrals.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses referrals but doesn't have detail screens configured for
+              referrals.
+            {% endblocktrans %}
             {% case "no case detail" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses cases but doesn't have detail screens configured for cases.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses cases but doesn't have detail screens configured for cases.
+            {% endblocktrans %}
             {% case "no product detail" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses CommCare Supply products but doesn't have detail screens configured for products.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses CommCare Supply products but doesn't have detail screens
+              configured for products.
+            {% endblocktrans %}
             {% case "invalid id key" %}
-              {% blocktrans with module_name=error.module.name|trans:langs key=error.key %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                has an incorrectly formatted ID key ({{ error_key }}).
-                Make sure your key has only letters, numbers, space characters, underscores, and dashes.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs key=error.key %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              has an incorrectly formatted ID key ({{ error_key }}). Make sure
+              your key has only letters, numbers, space characters, underscores,
+              and dashes.
+            {% endblocktrans %}
             {% case "no modules" %}
-              {% blocktrans %}
-                No menus are available. <br />
-                <i class="fa fa-arrow-left"></i>
-                Please click
-                <i class="fa fa-plus"></i> <strong>Add...</strong> to create
-                some menus.
-              {% endblocktrans %}
+            {% blocktrans %}
+              No menus are available. <br />
+              <i class="fa fa-arrow-left"></i>
+              Please click
+              <i class="fa fa-plus"></i> <strong>Add...</strong> to create some
+              menus.
+            {% endblocktrans %}
             {% case "missing module" %}
-              {% if not_actual_build %}
-                {% blocktrans %}
-                  This menu references a missing menu.
-                {% endblocktrans %}
-              {% else %}
-                {% blocktrans with module_name=error.module.name|trans:langs %}
-                  <a href="{{ module_url }}">{{ module_name }}</a> references a missing menu.
-                {% endblocktrans %}
-              {% endif %}
-              {% if error.message %}
-                {% trans "Details:" %}
-              {% endif %}
+            {% if not_actual_build %}
+              {% blocktrans %}
+                This menu references a missing menu.
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a> references a
+                missing menu.
+              {% endblocktrans %}
+            {% endif %}
+            {% if error.message %}
+              {% trans "Details:" %}
+            {% endif %}
             {% case "no forms or case list" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                has no forms or case list.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              has no forms or case list.
+            {% endblocktrans %}
             {% case "training module parent" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                cannot have a training module as a parent module.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              cannot have a training module as a parent module.
+            {% endblocktrans %}
             {% case "training module child" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                is a training module and therefore cannot have a parent module.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              is a training module and therefore cannot have a parent module.
+            {% endblocktrans %}
             {% case "no reports" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                has no reports.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              has no reports.
+            {% endblocktrans %}
             {% case "smart links missing endpoint" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses smart links but does not have a session endpoint id.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses smart links but does not have a session endpoint id.
+            {% endblocktrans %}
             {% case "smart links select parent first" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses both smart links and Parent Child Selection. These two
-                features are not compatible.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses both smart links and Parent Child Selection. These two
+              features are not compatible.
+            {% endblocktrans %}
             {% case "smart links multi select" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses both smart links and a multi-select case list. These two
-                features are not compatible.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses both smart links and a multi-select case list. These two
+              features are not compatible.
+            {% endblocktrans %}
             {% case "data registry multi select" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                loads a case from a data registry and uses a multi-select case list.
-                These two features are not compatible.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              loads a case from a data registry and uses a multi-select case
+              list. These two features are not compatible.
+            {% endblocktrans %}
             {% case "smart links inline search" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses smart links and is configured to make search input available after search.
-                These two features are not compatible.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses smart links and is configured to make search input available
+              after search. These two features are not compatible.
+            {% endblocktrans %}
             {% case "non-unique instance name with parent module" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-              The case list in <a href="{{ module_url }}">{{ module_name }}</a> can not use the same "search input instance name" as its Parent Menu.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              The case list in
+              <a href="{{ module_url }}">{{ module_name }}</a> can not use the
+              same "search input instance name" as its Parent Menu.
+            {% endblocktrans %}
             {% case "non-unique instance name with parent select module" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-              The case list in <a href="{{ module_url }}">{{ module_name }}</a> can not use the same "search input instance name" as its Parent Select Menu.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              The case list in
+              <a href="{{ module_url }}">{{ module_name }}</a> can not use the
+              same "search input instance name" as its Parent Select Menu.
+            {% endblocktrans %}
             {% case "search on clear with auto select" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-              The case list in <a href="{{ module_url }}">{{ module_name }}</a> uses both multi-select auto select and "Clearing search terms resets search results".
-              These two features are not compatible.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              The case list in
+              <a href="{{ module_url }}">{{ module_name }}</a> uses both
+              multi-select auto select and "Clearing search terms resets search
+              results". These two features are not compatible.
+            {% endblocktrans %}
             {% case "inline search to display only forms" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses "Display only forms" and is also configured with
-                "make search input available after search". This workflow is unsupported.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses "Display only forms" and is also configured with "make search
+              input available after search". This workflow is unsupported.
+            {% endblocktrans %}
             {% case "circular case hierarchy" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              The case hierarchy for
+              <a href="{{ module_url }}">{{ module_name }}</a> contains a
+              circular reference.
+            {% endblocktrans %}
             {% case "no case type" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses cases but doesn't have a case type defined.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses cases but doesn't have a case type defined.
+            {% endblocktrans %}
             {% case "case list form not registration" %}
-              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-                You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
-                as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>.
-                This form is not a registration form. You need to select a form which opens a case and
-                does not update an existing case. Please select a different form.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              You have selected the
+              <a href="{{ form_url }}">{{ form_name }}</a> form as the case
+              registration form for
+              <a href="{{ module_url }}">{{ module_name }}</a>. This form is not
+              a registration form. You need to select a form which opens a case
+              and does not update an existing case. Please select a different
+              form.
+            {% endblocktrans %}
             {% case "invalid case list followup form" %}
-              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-                You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
-                as the case list form for <a href="{{ module_url }}">{{ module_name }}</a>.
-                To select a followup form as case list form, the module must use the Select Parent First workflow and the form must follow up on the parent case type.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              You have selected the
+              <a href="{{ form_url }}">{{ form_name }}</a> form as the case list
+              form for <a href="{{ module_url }}">{{ module_name }}</a>. To
+              select a followup form as case list form, the module must use the
+              Select Parent First workflow and the form must follow up on the
+              parent case type.
+            {% endblocktrans %}
             {% case "case list form missing" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                The form you have selected as the case registration form for
-                <a href="{{ module_url }}">{{ module_name }}</a> does not exist.
-                Please select another form.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              The form you have selected as the case registration form for
+              <a href="{{ module_url }}">{{ module_name }}</a> does not exist.
+              Please select another form.
+            {% endblocktrans %}
             {% case "report config ref invalid" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                There are references to reports that are deleted in
-                <a href="{{ module_url }}">{{ module_name }}</a>.
-                You may re-save <a href="{{ module_url }}">{{ module_name }}</a> to delete them.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              There are references to reports that are deleted in
+              <a href="{{ module_url }}">{{ module_name }}</a>. You may re-save
+              <a href="{{ module_url }}">{{ module_name }}</a> to delete them.
+            {% endblocktrans %}
             {% case "report config id duplicated" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                There are multiple reports with the same report code in
-                <a href="{{ module_url }}">{{ module_name }}</a>.
-                These codes must be unique.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              There are multiple reports with the same report code in
+              <a href="{{ module_url }}">{{ module_name }}</a>. These codes must
+              be unique.
+            {% endblocktrans %}
             {% case "module filter has xpath error" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                The filter for <a href="{{ module_url }}">{{ module_name }}</a> has errors.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              The filter for
+              <a href="{{ module_url }}">{{ module_name }}</a> has errors.
+            {% endblocktrans %}
             {% case "form filter has xpath error" %}
-              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-                Display Condition has syntax errors
-                in the <a href="{{ form_url }}">{{ form_name }}</a> form
-                in <a href="{{ module_url }}">{{ module_name }}</a>.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              Display Condition has syntax errors in the
+              <a href="{{ form_url }}">{{ form_name }}</a> form in
+              <a href="{{ module_url }}">{{ module_name }}</a>.
+            {% endblocktrans %}
             {% case "all forms in case list module must load the same cases" %}
-              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-                The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-                loads different case types from the other forms. All forms in a case list that has a case registration form
-                selected must load the same case types.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              loads different case types from the other forms. All forms in a
+              case list that has a case registration form selected must load the
+              same case types.
+            {% endblocktrans %}
             {% case "case list module form must require case" %}
-              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-                The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-                must update a case. All forms in a case list that has a case registration form selected must update a case.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              must update a case. All forms in a case list that has a case
+              registration form selected must update a case.
+            {% endblocktrans %}
             {% case "case list module form can only load parent cases" %}
-              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-                The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-                can only load or update a single case and its parents. All forms in a case list that
-                has a case registration form selected can only update a single case and its parents.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              can only load or update a single case and its parents. All forms
+              in a case list that has a case registration form selected can only
+              update a single case and its parents.
+            {% endblocktrans %}
             {% case "case list module form must match module case type" %}
-              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-                The <a href="{{ form_url }}">{{ form_name }}</a> form loads a different case type than
-                <a href="{{ module_url }}">{{ module_name }}</a>. All forms in a case list that has a case registration form
-                selected must load a case of the same type as the case list.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form loads a
+              different case type than
+              <a href="{{ module_url }}">{{ module_name }}</a>. All forms in a
+              case list that has a case registration form selected must load a
+              case of the same type as the case list.
+            {% endblocktrans %}
             {% case "all forms in case list module must have same case management" %}
-              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs expected_tag=error.expected_tag %}
-                The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-                loads a case with a different case tag to the other forms in the case list.
-                All forms in a case list that has a case registration form selected must use the same case tag.
-                Expected case tag: <strong>{{ expected_tag }}</strong>
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs expected_tag=error.expected_tag %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form in
+              <a href="{{ module_url }}">{{ module_name }}</a> loads a case with
+              a different case tag to the other forms in the case list. All
+              forms in a case list that has a case registration form selected
+              must use the same case tag. Expected case tag:
+              <strong>{{ expected_tag }}</strong>
+            {% endblocktrans %}
             {% case "forms in case list module must use modules details" %}
-              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-                The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-                uses a details screen from another case list. All forms in a case list that has a case
-                registration form selected must use the details screen from that case list.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses a details screen from another case list. All forms in a case
+              list that has a case registration form selected must use the
+              details screen from that case list.
+            {% endblocktrans %}
             {% case "invalid filter xpath" %}
-              {% if error.filter %}
-                {% blocktrans with module_name=error.module.name|trans:langs error_filter=error.filter %}
-                  Case List has invalid filter xpath <code>{{ error_filter }}</code> in
-                  <a href="{{ module_url }}">{{ module_name }}</a>
-                {% endblocktrans %}
-              {% else %}
-                {% blocktrans with module_name=error.module.name|trans:langs %}
-                  Case List has blank filter in
-                  <a href="{{ module_url }}">{{ module_name }}</a>
-                {% endblocktrans %}
-              {% endif %}
+            {% if error.filter %}
+              {% blocktrans with module_name=error.module.name|trans:langs error_filter=error.filter %}
+                Case List has invalid filter xpath
+                <code>{{ error_filter }}</code> in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                Case List has blank filter in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+              {% endblocktrans %}
+            {% endif %}
             {% case "invalid sort field" %}
-              {% if error.field %}
-                {% blocktrans with module_name=error.module.name|trans:langs error_field=error.field %}
-                  Case List has invalid sort field <code>{{ error_field }}</code> in
-                  <a href="{{ module_url }}">{{ module_name }}</a>
-                {% endblocktrans %}
-              {% else %}
-                {% blocktrans with module_name=error.module.name|trans:langs %}
-                  Case List has blank sort field in
-                  <a href="{{ module_url }}">{{ module_name }}</a>
-                {% endblocktrans %}
-              {% endif %}
+            {% if error.field %}
+              {% blocktrans with module_name=error.module.name|trans:langs error_field=error.field %}
+                Case List has invalid sort field
+                <code>{{ error_field }}</code> in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                Case List has blank sort field in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+              {% endblocktrans %}
+            {% endif %}
             {% case "invalid tile configuration" %}
-              {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
-                The case list in
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                has an invalid case tile configuration. Reason: {{ error_reason }}
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
+              The case list in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              has an invalid case tile configuration. Reason: {{ error_reason }}
+            {% endblocktrans %}
             {% case "deprecated popup configuration" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                The case list in
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                has an address popup configuration that should be moved to case detail.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              The case list in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              has an address popup configuration that should be moved to case
+              detail.
+            {% endblocktrans %}
             {% case "invalid clickable icon configuration" %}
-              {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
-                The case list in
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                has an invalid clickable icon configuration. Reason: {{ error_reason }}
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
+              The case list in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              has an invalid clickable icon configuration. Reason:
+              {{ error_reason }}
+            {% endblocktrans %}
             {% case "no source module id" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                Shadow module
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                doesn't have a source module specified.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              Shadow module
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              doesn't have a source module specified.
+            {% endblocktrans %}
             {% case "invalid parent select id" %}
-              {% blocktrans with module_name=error.module.name|trans:langs %}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-                uses parent case selection but doesn't have a parent case list specified.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses parent case selection but doesn't have a parent case list
+              specified.
+            {% endblocktrans %}
             {% case "parent cycle" %}
-              {% blocktrans %}
-                The app's parent child case selection graph contains a cycle.
-              {% endblocktrans %}
+            {% blocktrans %}
+              The app's parent child case selection graph contains a cycle.
+            {% endblocktrans %}
             {% case "root cycle" %}
-              {% blocktrans %}
-                The app's parent child graph contains a cycle.
-              {% endblocktrans %}
+            {% blocktrans %}
+              The app's parent child graph contains a cycle.
+            {% endblocktrans %}
             {% case "unknown root" %}
-              {% blocktrans %}
-                A menu points to an unknown Parent Menu.
-              {% endblocktrans %}
+            {% blocktrans %}
+              A menu points to an unknown Parent Menu.
+            {% endblocktrans %}
             {% case "invalid location xpath" %}
-              {% blocktrans with module_name=error.module.name|trans:langs property=error.column.field_property details=error.details %}
-                Case List has invalid location reference <code>{{ property }}</code>.
-                Details: {{ details }}
-                <a href="{{ module_url }}">{{ module_name }}</a>
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs property=error.column.field_property details=error.details %}
+              Case List has invalid location reference
+              <code>{{ property }}</code>. Details: {{ details }}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+            {% endblocktrans %}
             {% case "case search instance used in casedb case details" %}
-              {% blocktrans with module_name=error.module.name|trans:langs property=error.column.field_property details=error.details %}
-                Case List uses an instance that is only available for case search <code>{{ property }}</code>.
-                Details: The {{ details }} instance(s) are only available in case lists using case search.
-                <a href="{{ module_url }}">{{ module_name }}</a>
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs property=error.column.field_property details=error.details %}
+              Case List uses an instance that is only available for case search
+              <code>{{ property }}</code>. Details: The {{ details }}
+              instance(s) are only available in case lists using case search.
+              <a href="{{ module_url }}">{{ module_name }}</a>
+            {% endblocktrans %}
             {% case "subcase has no case type" %}
-              Child case specifies no case list in form {% include "app_manager/partials/form_error_message.html" %}
+            Child case specifies no case list in form
+            {% include "app_manager/partials/form_error_message.html" %}
             {% case "form error" %}
-              {% blocktrans %}
-                One or more forms are invalid: check all your forms for error messages.
-              {% endblocktrans %}
+            {% blocktrans %}
+              One or more forms are invalid: check all your forms for error
+              messages.
+            {% endblocktrans %}
             {% case "missing languages" %}
-              {% include "app_manager/partials/form_error_message.html" %} missing languages:
-              {% for lang in error.missing_languages %}
-                {{ lang }}
-              {% endfor %}
+            {% include "app_manager/partials/form_error_message.html" %}
+            missing languages:
+            {% for lang in error.missing_languages %}
+              {{ lang }}
+            {% endfor %}
             {% case "duplicate xmlns" %}
-              {% if error.xmlns %}
-                {% blocktrans with xmlns=error.xmlns %}
-                  You have two forms with the xmlns "{{ xmlns }}"
-                {% endblocktrans %}
-              {% endif %}
+            {% if error.xmlns %}
+              {% blocktrans with xmlns=error.xmlns %}
+                You have two forms with the xmlns "{{ xmlns }}"
+              {% endblocktrans %}
+            {% endif %}
             {% case "update_case uses reserved word" %}
-              Case Update uses reserved word "{{ error.word }}"
-              {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            Case Update uses reserved word "{{ error.word }}"
+            {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "update_case word illegal" %}
-              Case Update "{{ error.word }}" should start with a letter and only contain letters, numbers, '-', and '_'
-              {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            Case Update "{{ error.word }}" should start with a letter and only
+            contain letters, numbers, '-', and '_'
+            {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "case_name required" %}
-              <strong>Every case must have a name.</strong> Please specify a value for the name property under
-              "Save data to the following case properties" {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            <strong>Every case must have a name.</strong> Please specify a value
+            for the name property under "Save data to the following case
+            properties"
+            {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "path error" %}
-              {% if error.path %}
-                The case management
-                {% if "VISIT_SCHEDULER" in toggles %} or visit scheduler {% endif %}
-                in form {% include "app_manager/partials/form_error_message.html" %}
-                references a question that no longer exists: "{{ error.path }}". It is likely that
-                this question has been renamed or deleted. Please update or delete this question
-                reference before you make a new version.
-              {% else %}
-                The case management
-                {% if "VISIT_SCHEDULER" in toggles %} or visit scheduler {% endif %}
-                in the form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
-                is missing a question.
-                Please choose a question from the dropdown next to the case property.
-              {% endif %}
+            {% if error.path %}
+              The case management
+              {% if "VISIT_SCHEDULER" in toggles %}or visit scheduler{% endif %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+              references a question that no longer exists: "{{ error.path }}".
+              It is likely that this question has been renamed or deleted.
+              Please update or delete this question reference before you make a
+              new version.
+            {% else %}
+              The case management
+              {% if "VISIT_SCHEDULER" in toggles %}or visit scheduler{% endif %}
+              in the
+              form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
+              is missing a question. Please choose a question from the dropdown
+              next to the case property.
+            {% endif %}
             {% case "multimedia case property not supported" %}
-              {% blocktrans with path=error.path %}
-                Multimedia case property "{{ path }}" is not supported on apps on or before v2.5.
-              {% endblocktrans %}
+            {% blocktrans with path=error.path %}
+              Multimedia case property "{{ path }}" is not supported on apps on
+              or before v2.5.
+            {% endblocktrans %}
             {% case "empty lang" %}
-              {% url "app_settings" domain app.id as app_url %}
-              {% blocktrans %}
-                One of your languages is empty. Check your <a href="{{ app_url }}">app settings</a>.
-              {% endblocktrans %}
+            {% url "app_settings" domain app.id as app_url %}
+            {% blocktrans %}
+              One of your languages is empty. Check your
+              <a href="{{ app_url }}">app settings</a>.
+            {% endblocktrans %}
             {% case "missing parent tag" %}
-              A subcase is referencing a parent case tag that does not exist: "{{ error.case_tag }}"
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            A subcase is referencing a parent case tag that does not exist:
+            "{{ error.case_tag }}"
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "missing relationship question" %}
-              A subcase's index relationship with parent case tag "{{ error.case_tag }}" is determined by a question,
-              but no question is specified.
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            A subcase's index relationship with parent case tag
+            "{{ error.case_tag }}" is determined by a question, but no question
+            is specified.
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "subcase repeat context" %}
-              The subcase "{{ error.case_tag }}" is in a different repeat context to its parent "{{ error.parent_tag }}"
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            The subcase "{{ error.case_tag }}" is in a different repeat context
+            to its parent "{{ error.parent_tag }}"
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "auto select key" %}
-              The auto-select case action is missing the "{{ error.key_name }}" value
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            The auto-select case action is missing the "{{ error.key_name }}"
+            value
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "auto select source" %}
-              The auto-select case action is missing the "{{ error.source_name }}" value
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            The auto-select case action is missing the "{{ error.source_name }}"
+            value
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "auto select case ref" %}
-              The case tag referenced in the auto-select expression of "{{ error.case_tag }}" was not found
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            The case tag referenced in the auto-select expression of
+            "{{ error.case_tag }}" was not found
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "no case type in action" %}
-              The form action "{{ error.case_tag }}" does not have a case type selected
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            The form action "{{ error.case_tag }}" does not have a case type
+            selected
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "filtering without case" %}
-              The form has filtering enabled but no cases are being loaded (excluding auto-loaded cases)
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}.
+            The form has filtering enabled but no cases are being loaded
+            (excluding auto-loaded cases)
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}.
             {% case "invalid case xpath reference" %}
-              {% if error.form %}
-                {% blocktrans with form_name=error.form.name|trans:langs %}
-                  Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a case,
-                  but cases are not available for this form. Please either remove the case reference or (1) make sure
-                  that the case list is set to display the case list first and then form, and (2) make sure that all forms in
-                  this case list update or close a case (which means registration forms must go in a different case list).
-                {% endblocktrans %}
-              {% else %}
-                {% blocktrans %}
-                  You have a display condition which refers to a case, but cases are not available. Please either remove
-                  the case reference or (1) make sure that the case list is set to display the case list first and then form,
-                  and (2) make sure that all forms in this case list update or close a case (which means registration forms
-                  must go in a different case list).
-                {% endblocktrans %}
-              {% endif %}
-            {% case "practice user config error" %}
-              {% if error.build_profile_id %}
-                {% blocktrans with profile=app.build_profiles|getattr:error.build_profile_id %}
-                  Error with Practice Mobile Worker in Application Profile {{ profile.name }}.
-                {% endblocktrans %}
-              {% else %}
-                {% blocktrans%}
-                  Error with Practice Mobile Worker in Application Settings.
-                {% endblocktrans %}
-              {% endif %}
-            {% case "invalid user property xpath reference" %}
-              {% if error.form %}
-                {% blocktrans with form_name=error.form.name|trans:langs %}
-                  Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a user property,
-                  but your project does not use user properties. Please remove the user property reference.
-                {% endblocktrans %}
-              {% else %}
-                {% blocktrans %}
-                  You have a display condition which refers to a user property, but your project does not use user properties.
-                  Please remove the user property reference.
-                {% endblocktrans %}
-              {% endif %}
-            {% case "subscription" %}
-              {% url 'domain_select_plan' domain as domain_url %}
+            {% if error.form %}
+              {% blocktrans with form_name=error.form.name|trans:langs %}
+                Your form display condition for form
+                <a href="{{ form_url }}">{{ form_name }}</a> refers to a case,
+                but cases are not available for this form. Please either remove
+                the case reference or (1) make sure that the case list is set to
+                display the case list first and then form, and (2) make sure
+                that all forms in this case list update or close a case (which
+                means registration forms must go in a different case list).
+              {% endblocktrans %}
+            {% else %}
               {% blocktrans %}
-                Your application uses a feature that is not available in your current subscription. You
-                can <a href="{{ domain_url }}">change your subscription</a>, or
-                remove the feature as follows.
+                You have a display condition which refers to a case, but cases
+                are not available. Please either remove the case reference or
+                (1) make sure that the case list is set to display the case list
+                first and then form, and (2) make sure that all forms in this
+                case list update or close a case (which means registration forms
+                must go in a different case list).
               {% endblocktrans %}
+            {% endif %}
+            {% case "practice user config error" %}
+            {% if error.build_profile_id %}
+              {% blocktrans with profile=app.build_profiles|getattr:error.build_profile_id %}
+                Error with Practice Mobile Worker in Application Profile
+                {{ profile.name }}.
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans %}
+                Error with Practice Mobile Worker in Application Settings.
+              {% endblocktrans %}
+            {% endif %}
+            {% case "invalid user property xpath reference" %}
+            {% if error.form %}
+              {% blocktrans with form_name=error.form.name|trans:langs %}
+                Your form display condition for form
+                <a href="{{ form_url }}">{{ form_name }}</a> refers to a user
+                property, but your project does not use user properties. Please
+                remove the user property reference.
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans %}
+                You have a display condition which refers to a user property,
+                but your project does not use user properties. Please remove the
+                user property reference.
+              {% endblocktrans %}
+            {% endif %}
+            {% case "subscription" %}
+            {% url 'domain_select_plan' domain as domain_url %}
+            {% blocktrans %}
+              Your application uses a feature that is not available in your
+              current subscription. You can
+              <a href="{{ domain_url }}">change your subscription</a>, or remove
+              the feature as follows.
+            {% endblocktrans %}
             {% case "missing shadow parent" %}
-              A shadow parent must be specified
-              {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-              Select a shadow parent in the "Advanced" section of the shadow form's settings tab.
-            {% case "shadow parent does not exist" %}
-              A shadow parent specified
-              {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-              does not exist. Select a new shadow parent in the "Advanced" section of the shadow form's settings tab.
-            {% case "missing shadow parent tag" %}
-              Shadow parent form action tags do not appear in the action configuration for the shadow form.
-              The missing tags are: {{ error.case_tags|join:", " }}
-              {% if not not_actual_build %}The shadow form is {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            A shadow parent must be specified
+            {% if not not_actual_build %}
+              for form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
+            Select a shadow parent in the "Advanced" section of the shadow
+            form's settings tab. {% case "shadow parent does not exist" %} A
+            shadow parent specified
+            {% if not not_actual_build %}
+              for form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
+            does not exist. Select a new shadow parent in the "Advanced" section
+            of the shadow form's settings tab.
+            {% case "missing shadow parent tag" %} Shadow parent form action
+            tags do not appear in the action configuration for the shadow form.
+            The missing tags are: {{ error.case_tags|join:", " }}
+            {% if not not_actual_build %}
+              The shadow form is
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "password_format" %}
-              {# Do nothing; the full message is contained in error.message #}
+            {# Do nothing; the full message is contained in error.message #}
             {% case "invalid grouping from ungrouped search property" %}
-              {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
-                <a href="{{ module_url }}">{{ module_name }}</a> has a case search property
-                <code>{{ property }}</code> that is not assigned to a group.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
+              <a href="{{ module_url }}">{{ module_name }}</a> has a case search
+              property <code>{{ property }}</code> that is not assigned to a
+              group.
+            {% endblocktrans %}
             {% case "case search nodeset invalid" %}
-              {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
-                <a href="{{ module_url }}">{{ module_name }}</a> has a case search property
-                <code>{{ property }}</code> that references an invalid instance.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
+              <a href="{{ module_url }}">{{ module_name }}</a> has a case search
+              property <code>{{ property }}</code> that references an invalid
+              instance.
+            {% endblocktrans %}
             {% case "case list field action endpoint missing" %}
-              {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
-                <a href="{{ module_url }}">{{ module_name }}</a> has a case list property
-                that references a missing form endpoint: <code>{{ column.header|trans:langs }}</code>.
-              {% endblocktrans %}
+            {% blocktrans with module_name=error.module.name|trans:langs property=error.property %}
+              <a href="{{ module_url }}">{{ module_name }}</a> has a case list
+              property that references a missing form endpoint:
+              <code>{{ column.header|trans:langs }}</code>.
+            {% endblocktrans %}
             {% case "error" %}
               Details: {{ error.message }}
             {% else %}
-              Unknown error: {{ error.type }}
-              Details: {{ error }}
+              Unknown error: {{ error.type }} Details: {{ error }}
             {% endcase %}
             {# And then show the optional `message` regardless #}
             {% if error.type != 'error' %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -31,7 +31,7 @@
 {% if build_errors %}
   <div class="alert alert-warning alert-build">
     <h4 class="alert-heading">
-      <i class="fa fa-exclamation-circle"></i>
+      <i class="fa fa-exclamation-triangle"></i>
       {% trans "Cannot make new version" %}</h4>
     <ul class="list-unstyled" id="build-errors">
       {% for error in build_errors %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
@@ -4,7 +4,7 @@
 
   <div class="alert alert-warning alert-build">
     <h4 class="alert-heading">
-      <i class="fa fa-exclamation-circle"></i>
+      <i class="fa fa-exclamation-triangle"></i>
       {% trans "Warning" %}</h4>
         <span>
           {{ warning_message }}

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
@@ -2,11 +2,10 @@
 {% load hq_shared_tags %}
 {% load xforms_extras %}
 
-  <div class="alert alert-warning alert-build">
-    <h4 class="alert-heading">
-      <i class="fa fa-exclamation-triangle"></i>
-      {% trans "Warning" %}</h4>
-        <span>
-          {{ warning_message }}
-        </span>
-  </div>
+<div class="alert alert-warning alert-build">
+  <h4 class="alert-heading">
+    <i class="fa fa-exclamation-triangle"></i>
+    {% trans "Warning" %}
+  </h4>
+  <span> {{ warning_message }} </span>
+</div>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap3/case_rule_actions.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap3/case_rule_actions.html
@@ -6,16 +6,16 @@
 
 <script type="text/html" id="case-actions">
   {% if form.errors %}
-    <div class="alert alert-danger">
-      <span class="help-block"><strong>{% trans "Error:" %}</strong></span>
-      {% for field, errors in form.errors.items %}
-        {% for error in errors %}
-          <span class="help-block">{{ error }}</span>
-        {% endfor %}
-      {% endfor %}
-    </div>
+  <div class="alert alert-danger">
+    <span class="help-block"><strong>{% trans "Error:" %}</strong></span>
+    {% for field, errors in form.errors.items %} {% for error in errors %}
+    <span class="help-block">{{ error }}</span>
+    {% endfor %} {% endfor %}
+  </div>
   {% endif %}
-  <div data-bind="template: {name: getKoTemplateId, foreach: actions, afterRender: disableActionField}"></div>
+  <div
+    data-bind="template: {name: getKoTemplateId, foreach: actions, afterRender: disableActionField}"
+  ></div>
   <div class="form-group">
     <div class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label">
       <div class="btn-group">
@@ -27,14 +27,21 @@
           <span class="caret"></span>
         </button>
         <ul class="dropdown-menu">
-          <li data-bind="click: function() { addAction('close-case-action'); }"><a>{% trans "Close the case" %}</a></li>
-          <li data-bind="click: function() { addAction('update-case-property-action'); }"><a>{% trans "Update case property" %}</a></li>
+          <li data-bind="click: function() { addAction('close-case-action'); }">
+            <a>{% trans "Close the case" %}</a>
+          </li>
+          <li
+            data-bind="click: function() { addAction('update-case-property-action'); }"
+          >
+            <a>{% trans "Update case property" %}</a>
+          </li>
           {% if form.is_system_admin %}
-            <li data-bind="click: function() { addAction('custom-action'); }"><a>{% trans "Custom action" %}</a></li>
+          <li data-bind="click: function() { addAction('custom-action'); }">
+            <a>{% trans "Custom action" %}</a>
+          </li>
           {% endif %}
         </ul>
       </div>
-
     </div>
   </div>
 </script>
@@ -43,7 +50,13 @@
 
 <script type="text/html" id="remove-action">
   <div class="col-xs-1">
-    <button type="button" class="btn btn-danger" data-bind="click: $parent.removeAction"><i class="fa-solid fa-xmark"></i></button>
+    <button
+      type="button"
+      class="btn btn-danger"
+      data-bind="click: $parent.removeAction"
+    >
+      <i class="fa-solid fa-xmark"></i>
+    </button>
   </div>
 </script>
 
@@ -55,9 +68,9 @@
     <div data-bind="template: {name: 'remove-action'}"></div>
     <label class="control-label col-xs-2">{% trans "Close the case" %}</label>
     <span class="help-block col-xs-8">
-            <i class="fa fa-exclamation-triangle"></i>
-            {% trans "All cases matching the above criteria will be closed" %}
-        </span>
+      <i class="fa fa-exclamation-triangle"></i>
+      {% trans "All cases matching the above criteria will be closed" %}
+    </span>
   </div>
 </script>
 
@@ -67,26 +80,45 @@
 <script type="text/html" id="update-case-property-action">
   <div class="form-group">
     <div data-bind="template: {name: 'remove-action'}"></div>
-    <label class="control-label col-xs-2">{% trans "Set case property" %}</label>
+    <label class="control-label col-xs-2"
+      >{% trans "Set case property" %}</label
+    >
     <div class="controls col-xs-2">
-      <case-property-input params="
+      <case-property-input
+        params="
         valueObservable: name,
         caseTypeObservable: $root.caseType,
-      "></case-property-input>
+      "
+      ></case-property-input>
     </div>
     <div class="controls col-xs-2">
-      <select class="select form-control" data-bind="value: value_type" required>
-        <option value="{{ form.constants.VALUE_TYPE_EXACT }}">{% trans 'to the exact value' %}</option>
-        <option value="{{ form.constants.VALUE_TYPE_CASE_PROPERTY }}">{% trans 'to the value from other case property' %}</option>
+      <select
+        class="select form-control"
+        data-bind="value: value_type"
+        required
+      >
+        <option value="{{ form.constants.VALUE_TYPE_EXACT }}">
+          {% trans 'to the exact value' %}
+        </option>
+        <option value="{{ form.constants.VALUE_TYPE_CASE_PROPERTY }}">
+          {% trans 'to the value from other case property' %}
+        </option>
       </select>
     </div>
     <div class="controls col-xs-2">
-      <input type="text" class="textinput form-control" data-bind="value: value, visible: value_type() === '{{ form.constants.VALUE_TYPE_EXACT }}'" required />
+      <input
+        type="text"
+        class="textinput form-control"
+        data-bind="value: value, visible: value_type() === '{{ form.constants.VALUE_TYPE_EXACT }}'"
+        required
+      />
       <!-- ko if: value_type() === '{{ form.constants.VALUE_TYPE_CASE_PROPERTY }}' -->
-        <case-property-input params="
+      <case-property-input
+        params="
           valueObservable: value,
           caseTypeObservable: $root.caseType,
-        "></case-property-input>
+        "
+      ></case-property-input>
       <!-- /ko -->
     </div>
   </div>
@@ -102,12 +134,14 @@
     <div class="controls col-xs-4">
       <select class="select form-control" data-bind="value: name">
         {% for custom_action in form.custom_actions %}
-          <option value="{{ custom_action }}">{{ custom_action }}</option>
+        <option value="{{ custom_action }}">{{ custom_action }}</option>
         {% endfor %}
       </select>
     </div>
     <label class="col-xs-1 control-label">
-      <span class="label label-primary">{% trans "Requires System Admin" %}</span>
+      <span class="label label-primary"
+        >{% trans "Requires System Admin" %}</span
+      >
     </label>
   </div>
 </script>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap3/case_rule_actions.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap3/case_rule_actions.html
@@ -55,7 +55,7 @@
     <div data-bind="template: {name: 'remove-action'}"></div>
     <label class="control-label col-xs-2">{% trans "Close the case" %}</label>
     <span class="help-block col-xs-8">
-            <i class="fa fa-exclamation-circle"></i>
+            <i class="fa fa-exclamation-triangle"></i>
             {% trans "All cases matching the above criteria will be closed" %}
         </span>
   </div>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap5/case_rule_actions.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap5/case_rule_actions.html
@@ -55,7 +55,7 @@
     <div data-bind="template: {name: 'remove-action'}"></div>
     <label class="form-label col-sm-2">{% trans "Close the case" %}</label>
     <span class="help-block col-sm-8">
-            <i class="fa fa-exclamation-circle"></i>
+            <i class="fa fa-exclamation-triangle"></i>
             {% trans "All cases matching the above criteria will be closed" %}
         </span>
   </div>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap5/case_rule_actions.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap5/case_rule_actions.html
@@ -6,35 +6,52 @@
 
 <script type="text/html" id="case-actions">
   {% if form.errors %}
-    <div class="alert alert-danger">
-      <span class="help-block"><strong>{% trans "Error:" %}</strong></span>
-      {% for field, errors in form.errors.items %}
-        {% for error in errors %}
-          <span class="help-block">{{ error }}</span>
-        {% endfor %}
-      {% endfor %}
-    </div>
+  <div class="alert alert-danger">
+    <span class="help-block"><strong>{% trans "Error:" %}</strong></span>
+    {% for field, errors in form.errors.items %} {% for error in errors %}
+    <span class="help-block">{{ error }}</span>
+    {% endfor %} {% endfor %}
+  </div>
   {% endif %}
-  <div data-bind="template: {name: getKoTemplateId, foreach: actions, afterRender: disableActionField}"></div>
-  <div class="form-group">  {# todo B5: css-form-group #}
+  <div
+    data-bind="template: {name: getKoTemplateId, foreach: actions, afterRender: disableActionField}"
+  ></div>
+  <div class="form-group">
+    {# todo B5: css-form-group #}
     <div class="col-sm-12 col-md-4 col-lg-4 col-xl-2 form-label">
       <div class="btn-group">
-        <button class="btn btn-outline-primary" type="button" data-bs-toggle="dropdown">  {# todo B5: css-dropdown #}
+        <button
+          class="btn btn-outline-primary"
+          type="button"
+          data-bs-toggle="dropdown"
+        >
+          {# todo B5: css-dropdown #}
           <i class="fa fa-plus"></i>
           {% trans "Add Action" %}
         </button>
-        <button class="btn btn-outline-primary dropdown-toggle" data-bs-toggle="dropdown">  {# todo B5: css-dropdown #}
+        <button
+          class="btn btn-outline-primary dropdown-toggle"
+          data-bs-toggle="dropdown"
+        >
+          {# todo B5: css-dropdown #}
           <span class="caret"></span>
         </button>
         <ul class="dropdown-menu">
-          <li data-bind="click: function() { addAction('close-case-action'); }"><a>{% trans "Close the case" %}</a></li>
-          <li data-bind="click: function() { addAction('update-case-property-action'); }"><a>{% trans "Update case property" %}</a></li>
+          <li data-bind="click: function() { addAction('close-case-action'); }">
+            <a>{% trans "Close the case" %}</a>
+          </li>
+          <li
+            data-bind="click: function() { addAction('update-case-property-action'); }"
+          >
+            <a>{% trans "Update case property" %}</a>
+          </li>
           {% if form.is_system_admin %}
-            <li data-bind="click: function() { addAction('custom-action'); }"><a>{% trans "Custom action" %}</a></li>
+          <li data-bind="click: function() { addAction('custom-action'); }">
+            <a>{% trans "Custom action" %}</a>
+          </li>
           {% endif %}
         </ul>
       </div>
-
     </div>
   </div>
 </script>
@@ -43,21 +60,28 @@
 
 <script type="text/html" id="remove-action">
   <div class="col-sm-1">
-    <button type="button" class="btn btn-outline-danger" data-bind="click: $parent.removeAction"><i class="fa-solid fa-xmark"></i></button>
+    <button
+      type="button"
+      class="btn btn-outline-danger"
+      data-bind="click: $parent.removeAction"
+    >
+      <i class="fa-solid fa-xmark"></i>
+    </button>
   </div>
 </script>
 
-{# Template for btn-close case action #}  {# todo B5: css-close #}
+{# Template for btn-close case action #} {# todo B5: css-close #}
 {# An instance of this template is bound to an instance of the js object CloseCaseDefinition #}
 
 <script type="text/html" id="close-case-action">
-  <div class="form-group">  {# todo B5: css-form-group #}
+  <div class="form-group">
+    {# todo B5: css-form-group #}
     <div data-bind="template: {name: 'remove-action'}"></div>
     <label class="form-label col-sm-2">{% trans "Close the case" %}</label>
     <span class="help-block col-sm-8">
-            <i class="fa fa-exclamation-triangle"></i>
-            {% trans "All cases matching the above criteria will be closed" %}
-        </span>
+      <i class="fa fa-exclamation-triangle"></i>
+      {% trans "All cases matching the above criteria will be closed" %}
+    </span>
   </div>
 </script>
 
@@ -65,28 +89,42 @@
 {# An instance of this template is bound to an instance of the js object UpdatePropertyDefinition #}
 
 <script type="text/html" id="update-case-property-action">
-  <div class="form-group">  {# todo B5: css-form-group #}
+  <div class="form-group">
+    {# todo B5: css-form-group #}
     <div data-bind="template: {name: 'remove-action'}"></div>
     <label class="form-label col-sm-2">{% trans "Set case property" %}</label>
     <div class="controls col-sm-2">
-      <case-property-input params="
+      <case-property-input
+        params="
         valueObservable: name,
         caseTypeObservable: $root.caseType,
-      "></case-property-input>
+      "
+      ></case-property-input>
     </div>
     <div class="controls col-sm-2">
       <select class="select form-select" data-bind="value: value_type" required>
-        <option value="{{ form.constants.VALUE_TYPE_EXACT }}">{% trans 'to the exact value' %}</option>
-        <option value="{{ form.constants.VALUE_TYPE_CASE_PROPERTY }}">{% trans 'to the value from other case property' %}</option>
+        <option value="{{ form.constants.VALUE_TYPE_EXACT }}">
+          {% trans 'to the exact value' %}
+        </option>
+        <option value="{{ form.constants.VALUE_TYPE_CASE_PROPERTY }}">
+          {% trans 'to the value from other case property' %}
+        </option>
       </select>
     </div>
     <div class="controls col-sm-2">
-      <input type="text" class="textinput form-control" data-bind="value: value, visible: value_type() === '{{ form.constants.VALUE_TYPE_EXACT }}'" required />
+      <input
+        type="text"
+        class="textinput form-control"
+        data-bind="value: value, visible: value_type() === '{{ form.constants.VALUE_TYPE_EXACT }}'"
+        required
+      />
       <!-- ko if: value_type() === '{{ form.constants.VALUE_TYPE_CASE_PROPERTY }}' -->
-        <case-property-input params="
+      <case-property-input
+        params="
           valueObservable: value,
           caseTypeObservable: $root.caseType,
-        "></case-property-input>
+        "
+      ></case-property-input>
       <!-- /ko -->
     </div>
   </div>
@@ -96,18 +134,21 @@
 {# An instance of this template is bound to an instance of the js object CustomActionDefinition #}
 
 <script type="text/html" id="custom-action">
-  <div class="form-group">  {# todo B5: css-form-group #}
+  <div class="form-group">
+    {# todo B5: css-form-group #}
     <div data-bind="template: {name: 'remove-action'}"></div>
     <label class="form-label col-sm-2">{% trans "Custom action ID" %}</label>
     <div class="controls col-sm-4">
       <select class="select form-select" data-bind="value: name">
         {% for custom_action in form.custom_actions %}
-          <option value="{{ custom_action }}">{{ custom_action }}</option>
+        <option value="{{ custom_action }}">{{ custom_action }}</option>
         {% endfor %}
       </select>
     </div>
     <label class="col-sm-1 form-label">
-      <span class="badge text-bg-primary">{% trans "Requires System Admin" %}</span>
+      <span class="badge text-bg-primary"
+        >{% trans "Requires System Admin" %}</span
+      >
     </label>
   </div>
 </script>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/data_interfaces/partials/case_rule_actions.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/data_interfaces/partials/case_rule_actions.html.diff.txt
@@ -1,85 +1,108 @@
 --- 
 +++ 
-@@ -16,14 +16,14 @@
-     </div>
-   {% endif %}
-   <div data-bind="template: {name: getKoTemplateId, foreach: actions, afterRender: disableActionField}"></div>
--  <div class="form-group">
+@@ -17,13 +17,23 @@
+     data-bind="template: {name: getKoTemplateId, foreach: actions, afterRender: disableActionField}"
+   ></div>
+   <div class="form-group">
 -    <div class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label">
-+  <div class="form-group">  {# todo B5: css-form-group #}
++    {# todo B5: css-form-group #}
 +    <div class="col-sm-12 col-md-4 col-lg-4 col-xl-2 form-label">
        <div class="btn-group">
 -        <button class="btn btn-default" type="button" data-toggle="dropdown">
-+        <button class="btn btn-outline-primary" type="button" data-bs-toggle="dropdown">  {# todo B5: css-dropdown #}
++        <button
++          class="btn btn-outline-primary"
++          type="button"
++          data-bs-toggle="dropdown"
++        >
++          {# todo B5: css-dropdown #}
            <i class="fa fa-plus"></i>
            {% trans "Add Action" %}
          </button>
 -        <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-+        <button class="btn btn-outline-primary dropdown-toggle" data-bs-toggle="dropdown">  {# todo B5: css-dropdown #}
++        <button
++          class="btn btn-outline-primary dropdown-toggle"
++          data-bs-toggle="dropdown"
++        >
++          {# todo B5: css-dropdown #}
            <span class="caret"></span>
          </button>
          <ul class="dropdown-menu">
-@@ -42,19 +42,19 @@
+@@ -49,10 +59,10 @@
  {# Template for the button that removes an action #}
  
  <script type="text/html" id="remove-action">
 -  <div class="col-xs-1">
--    <button type="button" class="btn btn-danger" data-bind="click: $parent.removeAction"><i class="fa-solid fa-xmark"></i></button>
 +  <div class="col-sm-1">
-+    <button type="button" class="btn btn-outline-danger" data-bind="click: $parent.removeAction"><i class="fa-solid fa-xmark"></i></button>
+     <button
+       type="button"
+-      class="btn btn-danger"
++      class="btn btn-outline-danger"
+       data-bind="click: $parent.removeAction"
+     >
+       <i class="fa-solid fa-xmark"></i>
+@@ -60,14 +70,15 @@
    </div>
  </script>
  
 -{# Template for close case action #}
-+{# Template for btn-close case action #}  {# todo B5: css-close #}
++{# Template for btn-close case action #} {# todo B5: css-close #}
  {# An instance of this template is bound to an instance of the js object CloseCaseDefinition #}
  
  <script type="text/html" id="close-case-action">
--  <div class="form-group">
-+  <div class="form-group">  {# todo B5: css-form-group #}
+   <div class="form-group">
++    {# todo B5: css-form-group #}
      <div data-bind="template: {name: 'remove-action'}"></div>
 -    <label class="control-label col-xs-2">{% trans "Close the case" %}</label>
 -    <span class="help-block col-xs-8">
 +    <label class="form-label col-sm-2">{% trans "Close the case" %}</label>
 +    <span class="help-block col-sm-8">
-             <i class="fa fa-exclamation-circle"></i>
-             {% trans "All cases matching the above criteria will be closed" %}
-         </span>
-@@ -65,22 +65,22 @@
- {# An instance of this template is bound to an instance of the js object UpdatePropertyDefinition #}
+       <i class="fa fa-exclamation-triangle"></i>
+       {% trans "All cases matching the above criteria will be closed" %}
+     </span>
+@@ -79,11 +90,10 @@
  
  <script type="text/html" id="update-case-property-action">
--  <div class="form-group">
-+  <div class="form-group">  {# todo B5: css-form-group #}
+   <div class="form-group">
++    {# todo B5: css-form-group #}
      <div data-bind="template: {name: 'remove-action'}"></div>
--    <label class="control-label col-xs-2">{% trans "Set case property" %}</label>
+-    <label class="control-label col-xs-2"
+-      >{% trans "Set case property" %}</label
+-    >
 -    <div class="controls col-xs-2">
 +    <label class="form-label col-sm-2">{% trans "Set case property" %}</label>
 +    <div class="controls col-sm-2">
-       <case-property-input params="
+       <case-property-input
+         params="
          valueObservable: name,
-         caseTypeObservable: $root.caseType,
-       "></case-property-input>
+@@ -91,12 +101,8 @@
+       "
+       ></case-property-input>
      </div>
 -    <div class="controls col-xs-2">
--      <select class="select form-control" data-bind="value: value_type" required>
+-      <select
+-        class="select form-control"
+-        data-bind="value: value_type"
+-        required
+-      >
 +    <div class="controls col-sm-2">
 +      <select class="select form-select" data-bind="value: value_type" required>
-         <option value="{{ form.constants.VALUE_TYPE_EXACT }}">{% trans 'to the exact value' %}</option>
-         <option value="{{ form.constants.VALUE_TYPE_CASE_PROPERTY }}">{% trans 'to the value from other case property' %}</option>
+         <option value="{{ form.constants.VALUE_TYPE_EXACT }}">
+           {% trans 'to the exact value' %}
+         </option>
+@@ -105,7 +111,7 @@
+         </option>
        </select>
      </div>
 -    <div class="controls col-xs-2">
 +    <div class="controls col-sm-2">
-       <input type="text" class="textinput form-control" data-bind="value: value, visible: value_type() === '{{ form.constants.VALUE_TYPE_EXACT }}'" required />
-       <!-- ko if: value_type() === '{{ form.constants.VALUE_TYPE_CASE_PROPERTY }}' -->
-         <case-property-input params="
-@@ -96,18 +96,18 @@
- {# An instance of this template is bound to an instance of the js object CustomActionDefinition #}
+       <input
+         type="text"
+         class="textinput form-control"
+@@ -129,17 +135,18 @@
  
  <script type="text/html" id="custom-action">
--  <div class="form-group">
-+  <div class="form-group">  {# todo B5: css-form-group #}
+   <div class="form-group">
++    {# todo B5: css-form-group #}
      <div data-bind="template: {name: 'remove-action'}"></div>
 -    <label class="control-label col-xs-2">{% trans "Custom action ID" %}</label>
 -    <div class="controls col-xs-4">
@@ -88,14 +111,14 @@
 +    <div class="controls col-sm-4">
 +      <select class="select form-select" data-bind="value: name">
          {% for custom_action in form.custom_actions %}
-           <option value="{{ custom_action }}">{{ custom_action }}</option>
+         <option value="{{ custom_action }}">{{ custom_action }}</option>
          {% endfor %}
        </select>
      </div>
 -    <label class="col-xs-1 control-label">
--      <span class="label label-primary">{% trans "Requires System Admin" %}</span>
+-      <span class="label label-primary"
 +    <label class="col-sm-1 form-label">
-+      <span class="badge text-bg-primary">{% trans "Requires System Admin" %}</span>
++      <span class="badge text-bg-primary"
+         >{% trans "Requires System Admin" %}</span
+       >
      </label>
-   </div>
- </script>

--- a/corehq/apps/registration/templates/registration/partials/register_new_user/submit_errors.html
+++ b/corehq/apps/registration/templates/registration/partials/register_new_user/submit_errors.html
@@ -1,17 +1,24 @@
 {% load i18n %}
 
 <fieldset class="submit-errors" data-bind="visible: hasSubmitErrors">
-  <legend><i class="fa fa-exclamation-triangle"></i> {% trans "Issue with registration" %}</legend>
+  <legend>
+    <i class="fa fa-exclamation-triangle"></i>
+    {% trans "Issue with registration" %}
+  </legend>
   <p>
     {% blocktrans %}
-      Please check that you have JavaScript enabled to use this site!
-      We found the following issues:
+      Please check that you have JavaScript enabled to use this site! We found
+      the following issues:
     {% endblocktrans %}
   </p>
   <ul data-bind="foreach: submitErrors">
     <li><span data-bind="text:errors"></span></li>
   </ul>
-  <button type="button"
-          class="btn btn-lg btn-primary"
-          data-bind="click: previousStep">{% trans "Go Back & Fix Form" %}</button>
+  <button
+    type="button"
+    class="btn btn-lg btn-primary"
+    data-bind="click: previousStep"
+  >
+    {% trans "Go Back & Fix Form" %}
+  </button>
 </fieldset>

--- a/corehq/apps/registration/templates/registration/partials/register_new_user/submit_errors.html
+++ b/corehq/apps/registration/templates/registration/partials/register_new_user/submit_errors.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <fieldset class="submit-errors" data-bind="visible: hasSubmitErrors">
-  <legend><i class="fa fa-exclamation-warning-sign"></i> {% trans "Issue with registration" %}</legend>
+  <legend><i class="fa fa-exclamation-triangle"></i> {% trans "Issue with registration" %}</legend>
   <p>
     {% blocktrans %}
       Please check that you have JavaScript enabled to use this site!

--- a/corehq/apps/styleguide/context.py
+++ b/corehq/apps/styleguide/context.py
@@ -236,8 +236,8 @@ def get_common_icons():
         {
             'name': 'Common FontAwesome secondary icons',
             'icons': _add_prefix_to_icons('fa-solid', [
-                'fa-cloud-arrow-down', 'fa-cloud-arrow-up', 'fa-warning', 'fa-info-circle', 'fa-question-circle',
-                'fa-check', 'fa-external-link',
+                'fa-cloud-arrow-down', 'fa-cloud-arrow-up', 'fa-exclamation-triangle', 'fa-info-circle',
+                'fa-question-circle', 'fa-check', 'fa-external-link',
             ]),
         }
     ]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Current usages of `fa-exclamation-circle` that should be `fa-exclamation-triangle`
![Screenshot from 2025-06-13 16-07-44](https://github.com/user-attachments/assets/56ff4acb-edaa-43b5-b74e-3173eab8c031)
![Screenshot from 2025-06-13 16-08-07](https://github.com/user-attachments/assets/1faf235a-ac28-4b26-8355-399fa5a6ade1)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
A [recent comment](https://docs.google.com/document/d/1JV3axUREj9Oi4imLwHQY5_3EQ6pDqmjhL8V5bLe1B8E/edit?disco=AAABlb7pd9s) on a spec made me realize we aren't consistent about using the triangle icon for warnings, and I wanted to change that.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
