### PR TITLE
DataSourceUpdate model

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -489,6 +489,7 @@ DOMAIN_DELETE_OPERATIONS = [
         'FHIRImportResourceProperty',
     ]),
     ModelDeletion('repeaters', 'Repeater', 'domain', manager='all_objects'),
+    ModelDeletion('repeaters', 'DataSourceUpdate', 'domain'),
     ModelDeletion('motech', 'ConnectionSettings', 'domain', manager='all_objects'),
     ModelDeletion('couchforms', 'UnfinishedSubmissionStub', 'domain'),
     ModelDeletion('couchforms', 'UnfinishedArchiveStub', 'domain'),

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -229,6 +229,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('case_importer.CaseUploadRecord', SimpleFilter('domain')),
     # Repeat Records might foreign key to deleted repeaters, override default manager to include deleted repeaters
     FilteredModelIteratorBuilder('repeaters.Repeater', SimpleFilter('domain'), use_all_objects=True),
+    FilteredModelIteratorBuilder('repeaters.DataSourceUpdate', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('motech.ConnectionSettings', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('motech.RequestLog', SimpleFilter('domain')),
     # NH (2021-01-08): Including RepeatRecord because we dump (Couch)

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -9,7 +9,7 @@ from django.test import SimpleTestCase, TestCase
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from pillow_retry.models import PillowError
-from corehq.motech.repeaters.models import RepeatRecord
+
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.userreports.data_source_providers import (
     DynamicDataSourceProvider,
@@ -46,6 +46,8 @@ from corehq.form_processor.signals import sql_case_post_save
 from corehq.motech.repeaters.models import (
     ConnectionSettings,
     DataSourceRepeater,
+    DataSourceUpdate,
+    RepeatRecord,
 )
 from corehq.motech.repeaters.tests.test_repeater import BaseRepeaterTest
 from corehq.pillows.case import get_case_pillow
@@ -440,7 +442,6 @@ class IndicatorPillowTest(BaseRepeaterTest):
     @mock.patch('corehq.motech.repeaters.signals.create_repeat_records')
     @mock.patch('corehq.apps.userreports.specs.datetime')
     def test_datasource_change_triggers_change_signal(self, datetime_mock, create_repeat_records_mock):
-        from corehq.apps.userreports.util import DataSourceUpdateLog
         data_source_id = self.config._id
         num_repeaters = 2
         self._setup_data_source_subscription(self.config.domain, data_source_id, num_repeaters=num_repeaters)
@@ -454,7 +455,7 @@ class IndicatorPillowTest(BaseRepeaterTest):
         # Assert that it will be created with the expected args
         call_args = create_repeat_records_mock.call_args[0]
         self.assertEqual(call_args[0], DataSourceRepeater)
-        self.assertTrue(isinstance(call_args[1], DataSourceUpdateLog))
+        self.assertTrue(isinstance(call_args[1], DataSourceUpdate))
         update_log = call_args[1]
         self.assertEqual(update_log.domain, self.domain)
         self.assertEqual(update_log.data_source_id, self.config._id)

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -454,12 +454,12 @@ class IndicatorPillowTest(BaseRepeaterTest):
         create_repeat_records_mock.assert_called()
         # Assert that it will be created with the expected args
         call_args = create_repeat_records_mock.call_args[0]
-        self.assertEqual(call_args[0], DataSourceRepeater)
-        self.assertTrue(isinstance(call_args[1], DataSourceUpdate))
-        update_log = call_args[1]
-        self.assertEqual(update_log.domain, self.domain)
-        self.assertEqual(update_log.data_source_id, self.config._id)
-        self.assertEqual(update_log.doc_id, sample_doc["_id"])
+        assert call_args[0] == DataSourceRepeater
+        datasource_update = call_args[1]
+        assert type(datasource_update) is DataSourceUpdate
+        assert datasource_update.domain == self.domain
+        assert datasource_update.data_source_id == uuid.UUID(self.config._id)
+        assert datasource_update.doc_ids == [sample_doc["_id"]]
 
     @mock.patch('corehq.apps.userreports.specs.datetime')
     def test_rebuild_indicators(self, datetime_mock):

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -1,9 +1,8 @@
 import hashlib
 import logging
 import re
+import uuid
 from collections.abc import Mapping
-from dataclasses import dataclass
-from typing import Any, Optional
 
 from couchdbkit import ResourceNotFound
 from django_prbac.utils import has_privilege
@@ -31,18 +30,6 @@ from corehq.util.metrics.load_counters import ucr_load_counter
 
 UCR_TABLE_PREFIX = 'ucr_'
 LEGACY_UCR_TABLE_PREFIX = 'config_report_'
-
-
-@dataclass
-class DataSourceUpdateLog:
-    domain: str
-    data_source_id: str
-    doc_id: str
-    rows: Optional[list[dict[str, Any]]] = None
-
-    @property
-    def get_id(self):
-        return self.doc_id
 
 
 def localize(value, lang):
@@ -392,8 +379,12 @@ def get_domain_for_ucr_table_name(table_name):
 
 
 def register_data_source_row_change(domain, data_source_id, doc_ids):
-    from corehq.motech.repeaters.models import DataSourceRepeater
+    from corehq.motech.repeaters.models import (
+        DataSourceRepeater,
+        DataSourceUpdate,
+    )
     from corehq.motech.repeaters.signals import ucr_data_source_updated
+
     try:
         if not (
             toggles.SUPERSET_ANALYTICS.enabled(domain)
@@ -401,16 +392,15 @@ def register_data_source_row_change(domain, data_source_id, doc_ids):
         ):
             return
 
-        for doc_id in doc_ids:
-            update_log = DataSourceUpdateLog(
-                domain,
-                data_source_id=data_source_id,
-                doc_id=doc_id,
-                # We don't need to set `rows` here. We will determine
-                # them at send time. See DataSourceRepeater.payload_doc()
-                rows=None,
-            )
-            ucr_data_source_updated.send_robust(sender=None, update_log=update_log)
+        datasource_update = DataSourceUpdate.objects.create(
+            domain=domain,
+            data_source_id=uuid.UUID(data_source_id),
+            doc_ids=list(doc_ids),
+        )
+        ucr_data_source_updated.send_robust(
+            sender=None,
+            datasource_update=datasource_update
+        )
 
     except Exception as e:
         logging.exception(str(e))

--- a/corehq/motech/repeaters/migrations/0018_datasourceupdate.py
+++ b/corehq/motech/repeaters/migrations/0018_datasourceupdate.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+
+import jsonfield.fields
+from architect.commands import partition
+
+import corehq.sql_db.fields
+
+
+def add_partitions(apps, schema_editor):
+    partition.run({'module': 'corehq.motech.repeaters.models'})
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("repeaters", "0017_add_indexes"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DataSourceUpdate",
+            fields=[
+                ("id", models.BigAutoField(primary_key=True, serialize=False)),
+                (
+                    "domain",
+                    corehq.sql_db.fields.CharIdField(db_index=True, max_length=126),
+                ),
+                ("data_source_id", models.UUIDField()),
+                ("doc_ids", jsonfield.fields.JSONField(default=list)),
+                (
+                    "rows",
+                    jsonfield.fields.JSONField(blank=True, default=list, null=True),
+                ),
+                ("modified_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": "repeaters_datasourceupdate",
+            },
+        ),
+        migrations.RunPython(add_partitions),
+    ]

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -944,6 +944,26 @@ def get_all_repeater_types():
     return dict(REPEATER_CLASS_MAP)
 
 
+class DataSourceUpdate(models.Model):
+    """
+    ``DataSourceUpdate`` is the payload for ``DataSourceRepeater`` (as
+    ``XFormInstance`` is the payload for ``FormRepeater``).
+    """
+    id = models.BigAutoField(primary_key=True)
+    domain = CharIdField(max_length=126, db_index=True)
+    data_source_id = models.UUIDField()
+    doc_ids = JSONField(default=list)
+    rows = JSONField(default=list, blank=True, null=True)
+    modified_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = 'repeaters_datasourceupdate'
+
+    @property
+    def get_id(self):
+        return self.id
+
+
 class DataSourceRepeater(Repeater):
     """
     Forwards the UCR data source rows that are updated by a form

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -81,6 +81,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property, classproperty
 from django.utils.translation import gettext_lazy as _
 
+import architect
 from couchdbkit.exceptions import ResourceNotFound
 from jsonfield import JSONField
 from memoized import memoized
@@ -944,6 +945,13 @@ def get_all_repeater_types():
     return dict(REPEATER_CLASS_MAP)
 
 
+@architect.install(
+    'partition',
+    type='range',
+    subtype='date',
+    constraint='month',
+    column='modified_at',
+)
 class DataSourceUpdate(models.Model):
     """
     ``DataSourceUpdate`` is the payload for ``DataSourceRepeater`` (as
@@ -958,6 +966,8 @@ class DataSourceUpdate(models.Model):
 
     class Meta:
         db_table = 'repeaters_datasourceupdate'
+
+    MAX_AGE = timedelta(days=93)
 
     @property
     def get_id(self):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -75,6 +75,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from django.conf import settings
 from django.db import models, router
+from django.db.models import Min
 from django.db.models.base import Deferred
 from django.dispatch import receiver
 from django.utils import timezone
@@ -945,6 +946,12 @@ def get_all_repeater_types():
     return dict(REPEATER_CLASS_MAP)
 
 
+class DataSourceUpdateManager(models.Manager):
+
+    def get_oldest_date(self):
+        return self.aggregate(Min('modified_at'))['modified_at__min']
+
+
 @architect.install(
     'partition',
     type='range',
@@ -963,6 +970,8 @@ class DataSourceUpdate(models.Model):
     doc_ids = JSONField(default=list)
     rows = JSONField(default=list, blank=True, null=True)
     modified_at = models.DateTimeField(auto_now=True)
+
+    objects = DataSourceUpdateManager()
 
     class Meta:
         db_table = 'repeaters_datasourceupdate'

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -755,10 +755,4 @@ class DataSourcePayloadGenerator(BasePayloadGenerator):
         Returns the request body to be forwarded to CommCare Analytics
         for ``payload_doc``, which is a ``DataSourceUpdate``.
         """
-        data = {
-            "data": payload_doc.rows,
-            "data_source_id": payload_doc.data_source_id.hex,
-            "doc_id": "",  # CCA `DataSetChange` expects this key
-            "doc_ids": payload_doc.doc_ids,
-        }
-        return json.dumps(data, cls=CommCareJSONEncoder)
+        return json.dumps(payload_doc.to_json(), cls=CommCareJSONEncoder)

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -753,11 +753,12 @@ class DataSourcePayloadGenerator(BasePayloadGenerator):
     def get_payload(self, repeat_record, payload_doc):
         """
         Returns the request body to be forwarded to CommCare Analytics
-        for ``payload_doc``, which is a ``DataSourceUpdateLog``.
+        for ``payload_doc``, which is a ``DataSourceUpdate``.
         """
         data = {
             "data": payload_doc.rows,
-            "data_source_id": payload_doc.data_source_id,
-            "doc_id": payload_doc.doc_id,
+            "data_source_id": payload_doc.data_source_id.hex,
+            "doc_id": "",  # CCA `DataSetChange` expects this key
+            "doc_ids": payload_doc.doc_ids,
         }
         return json.dumps(data, cls=CommCareJSONEncoder)

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -106,9 +106,8 @@ def fire_synchronous_case_repeaters(sender, case, **kwargs):
     _create_repeat_records(DataRegistryCaseUpdateRepeater, case, fire_synchronously=True)
 
 
-def create_data_source_updated_repeat_record(sender, **kwargs):
-    """Creates a transaction log for the datasource that changed"""
-    create_repeat_records(DataSourceRepeater, kwargs["update_log"])
+def create_data_source_updated_repeat_record(sender, datasource_update, **kwargs):
+    create_repeat_records(DataSourceRepeater, datasource_update)
 
 
 successful_form_received.connect(create_form_repeat_records)

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -26,6 +26,7 @@ from ..const import (
 )
 from ..models import (
     HTTP_STATUS_BACK_OFF,
+    DataSourceUpdate,
     FormRepeater,
     Repeater,
     RepeatRecord,
@@ -1041,3 +1042,26 @@ class TestIsSuccessResponse(SimpleTestCase):
 
     def test_none_response(self):
         self.assertFalse(is_success_response(None))
+
+
+class TestDataSourceUpdateManager(TestCase):
+
+    def test_get_oldest_date(self):
+        ten_days_ago = datetime.today() - timedelta(days=10)
+        with freeze_time(ten_days_ago):
+            DataSourceUpdate.objects.create(
+                domain='test-domain',
+                data_source_id=uuid4(),
+                doc_ids=['doc_1']
+            )
+        DataSourceUpdate.objects.create(
+            domain='test-domain',
+            data_source_id=uuid4(),
+            doc_ids=['doc_2']
+        )
+        oldest_date = DataSourceUpdate.objects.get_oldest_date()
+        assert oldest_date.date() == ten_days_ago.date()
+
+    def test_get_oldest_date_none(self):
+        oldest_date = DataSourceUpdate.objects.get_oldest_date()
+        assert oldest_date is None

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1322,66 +1322,78 @@ class TestGetRetryInterval(SimpleTestCase):
 class DataSourceRepeaterTest(BaseRepeaterTest):
     domain = "user-reports"
 
-    def setUp(self):
-        super().setUp()
-        self.config = get_sample_data_source()
-        self.config.save()
-        self.addCleanup(self.config.delete)
-        self.adapter = get_indicator_adapter(self.config)
-        self.adapter.build_table()
-        self.addCleanup(self.adapter.drop_table)
-        self.fake_time_now = datetime(2015, 4, 24, 12, 30, 8, 24886)
-        self.pillow = _get_pillow([self.config], processor_chunk_size=100)
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.data_source = get_sample_data_source()
+        cls.data_source.save()
+        cls.addClassCleanup(cls.data_source.delete)
+        cls.adapter = get_indicator_adapter(cls.data_source)
+        cls.adapter.build_table()
+        cls.addClassCleanup(cls.adapter.drop_table)
+        cls.pillow = _get_pillow([cls.data_source], processor_chunk_size=100)
 
-        self.connx = ConnectionSettings.objects.create(
-            domain=self.domain,
+        cls.connx = ConnectionSettings.objects.create(
+            domain=cls.domain,
             url="case-repeater-url",
         )
-        self.data_source_id = self.config._id
-        self.repeater = DataSourceRepeater(
-            domain=self.domain,
-            connection_settings_id=self.connx.id,
-            data_source_id=self.data_source_id,
+        cls.data_source_id = cls.data_source._id
+        cls.repeater = DataSourceRepeater(
+            domain=cls.domain,
+            connection_settings_id=cls.connx.id,
+            data_source_id=cls.data_source_id,
         )
-        self.repeater.save()
+        cls.repeater.save()
 
     def test_datasource_is_subscribed_to(self):
-        self.assertTrue(self.repeater.datasource_is_subscribed_to(self.domain, self.data_source_id))
-        self.assertFalse(self.repeater.datasource_is_subscribed_to("malicious-domain", self.data_source_id))
+        assert self.repeater.datasource_is_subscribed_to(
+            self.domain,
+            self.data_source_id,
+        )
+        assert self.repeater.datasource_is_subscribed_to(
+            "malicious-domain",
+            self.data_source_id
+        ) is False
 
     @flag_enabled('SUPERSET_ANALYTICS')
     def test_payload_format(self):
-        sample_doc, expected_indicators = self._create_log_and_repeat_record()
-        later = datetime.utcnow() + timedelta(hours=50)
-        repeat_record = RepeatRecord.objects.filter(domain=self.domain, next_check__lt=later).first()
-        json_payload = self.repeater.get_payload(repeat_record)
-        payload = json.loads(json_payload)
+        doc_id, expected_indicators = self._create_log_and_repeat_record()
+        repeat_record = self.repeater.repeat_records_ready.first()
+        payload_str = repeat_record.get_payload()
+        payload = json.loads(payload_str)
 
-        # Clean expected_indicators:
-        # expected_indicators includes 'repeat_iteration'
-        del expected_indicators['repeat_iteration']
-        # Decimal expected indicator is not rounded, and will not match
-        del expected_indicators['estimate']
-        del payload['data'][0]['estimate']
-
-        self.assertEqual(payload, {
-            'data_source_id': self.data_source_id,
-            'doc_id': sample_doc['_id'],
-            'data': [expected_indicators]
-        })
+        # assert payload == {
+        #     'data_source_id': self.data_source._id,
+        #     'doc_id': doc_id,
+        #     'data': [expected_indicators],
+        # }
+        # ^^^ kinda like this, but accommodates the value of "estimate":
+        assert set(payload.keys()) == {'data_source_id', 'doc_id', 'data'}
+        assert payload['data_source_id'] == self.data_source._id
+        assert payload['doc_id'] == doc_id
+        assert len(payload['data']) == 1
+        for key, value in payload['data'][0].items():
+            if key == 'estimate':
+                # '2.3000000000000000' == '2.2999999999...1893310546875'
+                assert float(value) == float(expected_indicators[key])
+            else:
+                assert value == expected_indicators[key]
 
     def _create_log_and_repeat_record(self):
         from corehq.apps.userreports.tests.test_pillow import _save_sql_case
+
         with patch('corehq.apps.userreports.specs.datetime') as datetime_mock:
-            datetime_mock.utcnow.return_value = self.fake_time_now
-            sample_doc, expected_indicators = get_sample_doc_and_indicators(self.fake_time_now)
+            fake_time_now = datetime(2015, 4, 24, 12, 30, 8, 24886)
+            datetime_mock.utcnow.return_value = fake_time_now
+            sample_doc, expected_indicators = get_sample_doc_and_indicators(fake_time_now)
             since = self.pillow.get_change_feed().get_latest_offsets()
             _save_sql_case(sample_doc)
             self.pillow.process_changes(since=since, forever=False)
+
         # Serialize and deserialize to get objects as strings
         json_indicators = json.dumps(expected_indicators, cls=CommCareJSONEncoder)
         expected_indicators = json.loads(json_indicators)
-        return sample_doc, expected_indicators
+        return sample_doc['_id'], expected_indicators
 
 
 class TestSetBackoff(TestCase):

--- a/migrations.lock
+++ b/migrations.lock
@@ -889,6 +889,7 @@ repeaters
  0015_drop_receiverwrapper_couchdb
  0016_repeater_max_workers
  0017_add_indexes
+ 0018_datasourceupdate
 reports
  0001_initial
  0002_auto_20171121_1803


### PR DESCRIPTION
## Technical Summary

Context: [SC-3872](https://dimagi.atlassian.net/browse/SC-3872)

This is Part One of two pull requests to improve the performance of data forwarding to CommCare Analytics. It splits PR https://github.com/dimagi/commcare-hq/pull/36444 into two.

This PR is to give `DataSourceRepeater` a real payload model. `DataSourceRepeater` currently uses dataclass `DataSourceUpdateLog` as a kind of payload model, which it creates on the fly. This is different from all other Repeater classes. The `DataSourceUpdate` model brings `DataSourceRepeater` in line with other Repeater class behavior.

## Feature Flag

`SUPERSET_ANALYTICS`

## Safety Assurance

### Safety story

- [x] Tested old format payloads on Staging
- [x] Tested new format payloads on Staging

### Automated test coverage

Tests included

### QA Plan

No

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SC-3872]: https://dimagi.atlassian.net/browse/SC-3872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ