### PR TITLE
Add performance warning for too many case properties

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -172,7 +172,7 @@ $(function () {
 
     $('#performance-warning-toggle').on('click', function () {
         let $icon = $(this).find('i');
-        if ($icon.hasClass('fa-chevron-down')) {
+        if (this.classList.contains('collapsed')) {
             $icon.removeClass('fa-chevron-down').addClass('fa-chevron-up');
         } else {
             $icon.removeClass('fa-chevron-up').addClass('fa-chevron-down');

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -1,7 +1,7 @@
 import "commcarehq";
 import $ from "jquery";
 import ko from "knockout";
-import _ from "underscore";
+import _, { initial } from "underscore";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import appManagerUtils from "app_manager/js/app_manager";
 import kissmetrix from "analytix/js/kissmetrix";
@@ -18,6 +18,7 @@ import "app_manager/js/custom_assertions";
 import "hqwebapp/js/components/pagination";
 import "hqwebapp/js/components/search_box";
 import "hqwebapp/js/bootstrap3/knockout_bindings.ko";  // sortable binding
+import casePropertyWarningViewModel from "data_dictionary/js/partials/case_property_warning";
 
 appManagerUtils.setPrependedPageTitle("\u2699 ", true);
 appManagerUtils.setAppendedPageTitle(gettext("Form Settings"));
@@ -170,14 +171,13 @@ $(function () {
     // Case Management > Data dictionary descriptions for case properties
     $('.property-description').popover();
 
-    $('#performance-warning-toggle').on('click', function () {
-        let $icon = $(this).find('i');
-        if (this.classList.contains('collapsed')) {
-            $icon.removeClass('fa-chevron-down').addClass('fa-chevron-up');
-        } else {
-            $icon.removeClass('fa-chevron-up').addClass('fa-chevron-down');
-        }
-    });
+
+    var $casePropertyWarning = $('#case-property-warning');
+    const initialWarningData = initialPageData.get('case_property_warning');
+    const warningViewModel= new casePropertyWarningViewModel(initialWarningData.limit);
+    warningViewModel.updateViewModel(initialWarningData.type, initialWarningData.count)
+    $casePropertyWarning.koApplyBindings(warningViewModel);
+
 
     // Advanced > XForm > Upload
     $("#xform_file_input").change(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -170,6 +170,15 @@ $(function () {
     // Case Management > Data dictionary descriptions for case properties
     $('.property-description').popover();
 
+    $('#performance-warning-toggle').on('click', function () {
+        let $icon = $(this).find('i');
+        if ($icon.hasClass('fa-chevron-down')) {
+            $icon.removeClass('fa-chevron-down').addClass('fa-chevron-up');
+        } else {
+            $icon.removeClass('fa-chevron-up').addClass('fa-chevron-down');
+        }
+    });
+
     // Advanced > XForm > Upload
     $("#xform_file_input").change(function () {
         if ($(this).val()) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -1,7 +1,7 @@
 import "commcarehq";
 import $ from "jquery";
 import ko from "knockout";
-import _, { initial } from "underscore";
+import _ from "underscore";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import appManagerUtils from "app_manager/js/app_manager";
 import kissmetrix from "analytix/js/kissmetrix";
@@ -174,8 +174,8 @@ $(function () {
 
     var $casePropertyWarning = $('#case-property-warning');
     const initialWarningData = initialPageData.get('case_property_warning');
-    const warningViewModel= new casePropertyWarningViewModel(initialWarningData.limit);
-    warningViewModel.updateViewModel(initialWarningData.type, initialWarningData.count)
+    const warningViewModel = new casePropertyWarningViewModel(initialWarningData.limit);
+    warningViewModel.updateViewModel(initialWarningData.type, initialWarningData.count);
     $casePropertyWarning.koApplyBindings(warningViewModel);
 
 

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -97,6 +97,7 @@
   {% initial_page_data 'is_release_notes_form' form.is_release_notes_form %}
   {% initial_page_data 'is_allowed_to_be_release_notes_form' is_allowed_to_be_release_notes_form %}
   {% initial_page_data 'is_training_module' is_training_module %}
+  {% initial_page_data 'case_property_warning' case_property_warning %}
   {% if allow_form_copy and request|toggle_enabled:"COPY_FORM_TO_APP" %}
     {% initial_page_data 'apps_modules' apps_modules %}
   {% endif %}
@@ -165,38 +166,7 @@
     <div class="tab-content appmanager-tab-content">
       {% if form.uses_cases %}
         <div class="tab-pane" id="case-configuration">
-          {% if case_property_warning.show %}
-            <div class="alert alert-warning">
-              <i class="fa fa-exclamation-triangle"></i>
-              {% trans "Performance warning" %}
-              <button
-                id="performance-warning-toggle"
-                type="button"
-                class="close collapsed"
-                data-toggle="collapse"
-                data-target="#performance-warning-content"
-              >
-                <i class="fa fa-chevron-down"></i>
-              </button>
-              <div id="performance-warning-content" class="collapse">
-                <p>
-                  {% blocktrans with type=case_property_warning.type count=case_property_warning.count limit=case_property_warning.limit %}
-                    The '{{ type }}' case has a total of {{ count }} custom properties. We
-                    recommend at most {{ limit }} custom properties per case type, otherwise
-                    you may run into performance issues at the time of data
-                    collection and analysis.
-                </p>
-                <p>
-                    See
-                    <a target="_blank"
-                      href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143947182/Case+Configuration"
-                      >case configuration</a>
-                    documentation for more information.
-                  {% endblocktrans %}
-                </p>
-              </div>
-            </div>
-          {% endif %}
+          {% include "data_dictionary/partials/case_property_warning.html" %}
           {% if xform_validation_missing %}
             <p class="alert alert-warning">
               {% trans "We were unable to validate your form due an error on the server. Proceed with caution." %}

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -181,8 +181,8 @@
               <div id="warningContent" class="collapse">
                 <p>
                   {% blocktrans with type=case_property_warning.type count=case_property_warning.count limit=case_property_warning.limit %}
-                    The '{{ type }}' case has {{ count }} properties. We
-                    recommend keeping case properties below {{ limit }}, otherwise
+                    The '{{ type }}' case has a total of {{ count }} custom properties. We
+                    recommend at most {{ limit }} custom properties per case type, otherwise
                     you may run into performance issues at the time of data
                     collection and analysis.
                 </p>

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -5,7 +5,6 @@
 {% load i18n %}
 
 {% block title %}{# controlled by app_manager/js/forms/form_view.js #}{% endblock %}
-
 {% js_entry_b3 "app_manager/js/forms/form_view" %}
 
 {% block stylesheets %}
@@ -166,6 +165,38 @@
     <div class="tab-content appmanager-tab-content">
       {% if form.uses_cases %}
         <div class="tab-pane" id="case-configuration">
+          {% if case_property_warning.show %}
+            <div class="alert alert-warning">
+              <button
+                id="performance-warning-toggle"
+                type="button"
+                class="close"
+                data-toggle="collapse"
+                data-target="#warningContent"
+              >
+                <i class="fa fa-chevron-down"></i>
+              </button>
+              <i class="fa fa-exclamation-triangle"></i>
+              {% trans "Performance warning" %}
+              <div id="warningContent" class="collapse">
+                <p>
+                  {% blocktrans with type=case_property_warning.type count=case_property_warning.count limit=case_property_warning.limit %}
+                    The '{{ type }}' case has {{ count }} properties. We
+                    recommend keeping case properties below {{ limit }}, otherwise
+                    you may run into performance issues at the time of data
+                    collection and analysis.
+                </p>
+                <p>
+                    See
+                    <a target="_blank"
+                      href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143947182/Case+Configuration"
+                      >case configuration</a>
+                    documentation for more information.
+                  {% endblocktrans %}
+                </p>
+              </div>
+            </div>
+          {% endif %}
           {% if xform_validation_missing %}
             <p class="alert alert-warning">
               {% trans "We were unable to validate your form due an error on the server. Proceed with caution." %}

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -167,18 +167,18 @@
         <div class="tab-pane" id="case-configuration">
           {% if case_property_warning.show %}
             <div class="alert alert-warning">
+              <i class="fa fa-exclamation-triangle"></i>
+              {% trans "Performance warning" %}
               <button
                 id="performance-warning-toggle"
                 type="button"
-                class="close"
+                class="close collapsed"
                 data-toggle="collapse"
-                data-target="#warningContent"
+                data-target="#performance-warning-content"
               >
                 <i class="fa fa-chevron-down"></i>
               </button>
-              <i class="fa fa-exclamation-triangle"></i>
-              {% trans "Performance warning" %}
-              <div id="warningContent" class="collapse">
+              <div id="performance-warning-content" class="collapse">
                 <p>
                   {% blocktrans with type=case_property_warning.type count=case_property_warning.count limit=case_property_warning.limit %}
                     The '{{ type }}' case has a total of {{ count }} custom properties. We

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -744,7 +744,7 @@ class TestViewGeneric(ViewsBase):
         'secure_cookies', 'langs', 'None', 'CUSTOM_LOGO_URL', 'allow_form_copy', 'selected_form', 'slug',
         'env', 'False', 'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'is_usercase_in_use',
         'module_loads_registry_case', 'EULA_COMPLIANCE', 'sentry', 'show_shadow_modules', 'show_custom_ref',
-        'block', 'IS_ANALYTICS_ENVIRONMENT', 'module_type', 'icon_class',
+        'block', 'IS_ANALYTICS_ENVIRONMENT', 'module_type', 'icon_class', 'case_property_warning',
     }
 
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -122,7 +122,7 @@ from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.programs.models import Program
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
-from corehq.project_limits.const import CASE_PROPERTIES_PER_CASE_KEY, DEFAULT_CASE_PROPERTIES_PER_CASE
+from corehq.project_limits.const import CASE_PROP_LIMIT_PER_CASE_TYPE_KEY, DEFAULT_CASE_PROPS_PER_CASE_TYPE
 from corehq.project_limits.models import SystemLimit
 from corehq.util.view_utils import set_file_download
 
@@ -884,7 +884,7 @@ def get_form_view_context(
 
 def _get_case_property_limit(domain):
     return SystemLimit.get_limit_for_key(
-        CASE_PROPERTIES_PER_CASE_KEY, DEFAULT_CASE_PROPERTIES_PER_CASE, domain=domain
+        CASE_PROP_LIMIT_PER_CASE_TYPE_KEY, DEFAULT_CASE_PROPS_PER_CASE_TYPE, domain=domain
     )
 
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -121,6 +121,8 @@ from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.programs.models import Program
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
+from corehq.project_limits.const import CASE_PROPERTIES_PER_CASE_KEY, DEFAULT_CASE_PROPERTIES_PER_CASE
+from corehq.project_limits.models import SystemLimit
 from corehq.util.view_utils import set_file_download
 
 
@@ -776,6 +778,7 @@ def get_form_view_context(
         'reserved_words': load_case_reserved_words(),
         'usercasePropertiesMap': usercase_properties_map,
     }
+    case_property_count = len(case_properties_map.get(case_config_options['caseType'], []))
     context = {
         'nav_form': form,
         'xform_languages': languages,
@@ -809,6 +812,12 @@ def get_form_view_context(
         'session_endpoints_enabled': toggles.SESSION_ENDPOINTS.enabled(domain),
         'module_is_multi_select': module.is_multi_select(),
         'module_loads_registry_case': module_loads_registry_case(module),
+        'case_property_warning': {
+            'count': case_property_count,
+            'limit': _get_case_property_limit(domain),
+            'show': case_property_count > _get_case_property_limit(domain),
+            'type': case_config_options['caseType'],
+        }
     }
 
     if toggles.CUSTOM_ICON_BADGES.enabled(domain):
@@ -870,6 +879,12 @@ def get_form_view_context(
 
     context.update({'case_config_options': case_config_options})
     return context
+
+
+def _get_case_property_limit(domain):
+    return SystemLimit.get_limit_for_key(
+        CASE_PROPERTIES_PER_CASE_KEY, DEFAULT_CASE_PROPERTIES_PER_CASE, domain=domain
+    )
 
 
 def _get_form_link_context(app, module, form, langs):

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -816,7 +816,6 @@ def get_form_view_context(
         'case_property_warning': {
             'count': case_property_count,
             'limit': _get_case_property_limit(domain),
-            'show': case_property_count > _get_case_property_limit(domain),
             'type': case_config_options['caseType'],
         }
     }

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -110,6 +110,7 @@ from corehq.apps.app_manager.xform import (
 from corehq.apps.data_dictionary.util import (
     get_case_property_deprecated_dict,
     get_case_property_description_dict,
+    get_custom_case_property_count,
 )
 from corehq.apps.domain.decorators import (
     LoginAndDomainMixin,
@@ -778,7 +779,7 @@ def get_form_view_context(
         'reserved_words': load_case_reserved_words(),
         'usercasePropertiesMap': usercase_properties_map,
     }
-    case_property_count = len(case_properties_map.get(case_config_options['caseType'], []))
+    case_property_count = get_custom_case_property_count(domain, case_config_options['caseType'])
     context = {
         'nav_form': form,
         'xform_languages': languages,

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -633,9 +633,9 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
     };
 
     self.toggleCasePropertyWarning = function () {
-        let toggle = document.getElementById("performance-warning-toggle");
-        let icon = toggle.querySelector('i');
-        if (icon.classList.contains('fa-chevron-down')) {
+        const toggle = document.getElementById("performance-warning-toggle");
+        const icon = toggle.querySelector('i');
+        if (toggle.classList.contains('collapsed')) {
             icon.classList.remove('fa-chevron-down');
             icon.classList.add('fa-chevron-up');
         } else {

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -612,10 +612,10 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
         }
     };
 
-    self.activeCaseType.subscribe( function () {
+    self.activeCaseType.subscribe(function () {
         let caseType = self.getActiveCaseType();
         self.casePropertyWarningViewModel.updateViewModel(caseType.name, caseType.propertyCount);
-    })
+    });
 
     self.showDeprecated = function () {
         self.showAll(true);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -616,11 +616,15 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
     self.showCasePropertyWarningIfNeeded = function () {
         let caseType = self.getActiveCaseType();
         if (caseType.propertyCount > self.casePropertyLimit) {
-            let content = gettext(
-                "The '" + caseType.name + "' case has a total of " + caseType.propertyCount + " custom properties. " +
-                "We recommend at most " + self.casePropertyLimit + " custom properties per case type, " +
+            let content = _.template(gettext(
+                "The '<%- type %>' case has a total of <%- count %> custom properties. " +
+                "We recommend at most <%- limit %> custom properties per case type, " +
                 "otherwise you may run into performance issues at the time of data collection and analysis."
-            );
+            ))({
+                type: caseType.name,
+                count:caseType.propertyCount,
+                limit: self.casePropertyLimit,
+            });
             self.casePropertyWarningContent(content);
             self.showCasePropertyWarning(true);
         } else {

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -617,8 +617,8 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
         let caseType = self.getActiveCaseType();
         if (caseType.propertyCount > self.casePropertyLimit) {
             let content = gettext(
-                "The '" + caseType.name + "' case has " + caseType.propertyCount + " properties. " +
-                "We recommend keeping case properties below " + self.casePropertyLimit + ", " +
+                "The '" + caseType.name + "' case has a total of " + caseType.propertyCount + " custom properties. " +
+                "We recommend at most " + self.casePropertyLimit + " custom properties per case type, " +
                 "otherwise you may run into performance issues at the time of data collection and analysis."
             );
             self.casePropertyWarningContent(content);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -23,7 +23,7 @@ var caseType = function (
     isSafeToDelete,
     changeSaveButton,
     resetSaveButton,
-    dataUrl
+    dataUrl,
 ) {
     var self = {};
     self.name = name || gettext("No Name");
@@ -71,7 +71,7 @@ var caseType = function (
                     group.name,
                     group.description,
                     group.deprecated,
-                    self.changeSaveButton
+                    self.changeSaveButton,
                 );
                 self.groups.push(groupObj);
             }
@@ -89,7 +89,7 @@ var caseType = function (
                     self.name,
                     isGeoCaseProp,
                     groupObj.name(),
-                    self.changeSaveButton
+                    self.changeSaveButton,
                 );
                 groupObj.properties.push(propObj);
             }
@@ -105,7 +105,7 @@ var groupsViewModel = function (
     name,
     description,
     deprecated,
-    changeSaveButton
+    changeSaveButton,
 ) {
     var self = {};
     self.id = id;
@@ -145,7 +145,7 @@ var groupsViewModel = function (
                 self.caseType,
                 false,
                 self.name(),
-                changeSaveButton
+                changeSaveButton,
             );
             self.newPropertyName(undefined);
             self.properties.push(propObj);
@@ -167,7 +167,7 @@ var propertyListItem = function (
     caseType,
     isGeoCaseProp,
     loadedGroup,
-    changeSaveButton
+    changeSaveButton,
 ) {
     var self = {};
     self.id = prop.id;
@@ -222,7 +222,7 @@ var propertyListItem = function (
         interpolate('Edit valid values for "%s"', [name]), /* modalTitle */
         subTitle, /* subTitle */
         {"key": gettext("valid value"), "value": gettext("description")}, /* placeholders */
-        10 /* maxDisplay */
+        10, /* maxDisplay */
     );
     self.allowedValues.val(prop.allowed_values);
     if (initialPageData.get('read_only_mode')) {
@@ -305,7 +305,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
     self.newPropertyName = ko.observable();
     self.newGroupName = ko.observable();
     self.showAll = ko.observable(false);
-    self.showCasePropertyWarning= ko.observable(false);
+    self.showCasePropertyWarning = ko.observable(false);
     self.casePropertyWarningContent = ko.observable();
     self.availableDataTypes = typeChoices;
     self.fhirResourceTypes = ko.observableArray(fhirResourceTypes);
@@ -412,7 +412,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                         caseTypeData.is_safe_to_delete,
                         changeSaveButton,
                         resetSaveButton,
-                        dataUrl
+                        dataUrl,
                     );
                     self.caseTypes.push(caseTypeObj);
                 });
@@ -591,7 +591,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                 self.newGroupName(),
                 '',
                 false,
-                changeSaveButton
+                changeSaveButton,
             );
             let groupsObs = self.getCaseTypeGroupsObservable();
             groupsObs.push(group);  // TODO: Broken for computed value

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/partials/case_property_warning.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/partials/case_property_warning.js
@@ -1,4 +1,5 @@
 import "commcarehq";
+import $ from "jquery";
 import ko from "knockout";
 import _ from "underscore";
 
@@ -34,17 +35,17 @@ function casePropertyWarningViewModel (propertyLimit) {
         self.showWarning(shouldShow);
     };
 
-    self.toggleWarningCollapse = function () {
-        const toggle = document.getElementById("performance-warning-toggle");
-        const icon = toggle.querySelector('i');
-        if (toggle.classList.contains('collapsed')) {
-            icon.classList.remove('fa-chevron-down');
-            icon.classList.add('fa-chevron-up');
-        } else {
-            icon.classList.remove('fa-chevron-up');
-            icon.classList.add('fa-chevron-down');
-        }
-    };
+    $('#performance-warning-content').on('show.bs.collapse', function () {
+        $('#performance-warning-toggle i')
+            .removeClass('fa-chevron-down')
+            .addClass('fa-chevron-up');
+    });
+
+    $('#performance-warning-content').on('hide.bs.collapse', function () {
+        $('#performance-warning-toggle i')
+            .removeClass('fa-chevron-up')
+            .addClass('fa-chevron-down');
+    });
 
     self.updateViewModel(self.caseType, self.propertyCount);
 

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/partials/case_property_warning.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/partials/case_property_warning.js
@@ -3,25 +3,25 @@ import $ from "jquery";
 import ko from "knockout";
 import _ from "underscore";
 
-function casePropertyWarningViewModel (propertyLimit) {
+function casePropertyWarningViewModel(propertyLimit) {
     self.caseType = '';
     self.propertyCount = 0;
     self.propertyLimit = propertyLimit;
     self.showWarning = ko.observable(false);
     self.warningContent = ko.observable();
 
-    self.updateViewModel = function(caseType, propertyCount) {
+    self.updateViewModel = function (caseType, propertyCount) {
         self.caseType = caseType;
         self.propertyCount = propertyCount;
         self.updateWarningText();
         self.showWarningIfNecessary();
     };
 
-    self.updateWarningText = function() {
+    self.updateWarningText = function () {
         let content = _.template(gettext(
             "You've saved <%- count %> case properties to the '<%- type %>' case. " +
             "We recommend at most <%- limit %> case properties per case type, " +
-            "otherwise you may run into performance issues at the time of data collection and analysis."
+            "otherwise you may run into performance issues at the time of data collection and analysis.",
         ))({
             count: self.propertyCount,
             type: self.caseType,
@@ -30,7 +30,7 @@ function casePropertyWarningViewModel (propertyLimit) {
         self.warningContent(content);
     };
 
-    self.showWarningIfNecessary = function() {
+    self.showWarningIfNecessary = function () {
         const shouldShow = self.propertyCount > self.propertyLimit;
         self.showWarning(shouldShow);
     };
@@ -50,6 +50,6 @@ function casePropertyWarningViewModel (propertyLimit) {
     self.updateViewModel(self.caseType, self.propertyCount);
 
     return self;
-};
+}
 
 export default casePropertyWarningViewModel;

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/partials/case_property_warning.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/partials/case_property_warning.js
@@ -1,0 +1,54 @@
+import "commcarehq";
+import ko from "knockout";
+import _ from "underscore";
+
+function casePropertyWarningViewModel (propertyLimit) {
+    self.caseType = '';
+    self.propertyCount = 0;
+    self.propertyLimit = propertyLimit;
+    self.showWarning = ko.observable(false);
+    self.warningContent = ko.observable();
+
+    self.updateViewModel = function(caseType, propertyCount) {
+        self.caseType = caseType;
+        self.propertyCount = propertyCount;
+        self.updateWarningText();
+        self.showWarningIfNecessary();
+    };
+
+    self.updateWarningText = function() {
+        let content = _.template(gettext(
+            "The '<%- type %>' case has a total of <%- count %> custom properties. " +
+            "We recommend at most <%- limit %> custom properties per case type, " +
+            "otherwise you may run into performance issues at the time of data collection and analysis."
+        ))({
+            type: self.caseType,
+            count: self.propertyCount,
+            limit: self.propertyLimit,
+        });
+        self.warningContent(content);
+    };
+
+    self.showWarningIfNecessary = function() {
+        const shouldShow = self.propertyCount > self.propertyLimit;
+        self.showWarning(shouldShow);
+    };
+
+    self.toggleWarningCollapse = function () {
+        const toggle = document.getElementById("performance-warning-toggle");
+        const icon = toggle.querySelector('i');
+        if (toggle.classList.contains('collapsed')) {
+            icon.classList.remove('fa-chevron-down');
+            icon.classList.add('fa-chevron-up');
+        } else {
+            icon.classList.remove('fa-chevron-up');
+            icon.classList.add('fa-chevron-down');
+        }
+    };
+
+    self.updateViewModel(self.caseType, self.propertyCount);
+
+    return self;
+};
+
+export default casePropertyWarningViewModel;

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/partials/case_property_warning.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/partials/case_property_warning.js
@@ -19,12 +19,12 @@ function casePropertyWarningViewModel (propertyLimit) {
 
     self.updateWarningText = function() {
         let content = _.template(gettext(
-            "The '<%- type %>' case has a total of <%- count %> custom properties. " +
-            "We recommend at most <%- limit %> custom properties per case type, " +
+            "You've saved <%- count %> case properties to the '<%- type %>' case. " +
+            "We recommend at most <%- limit %> case properties per case type, " +
             "otherwise you may run into performance issues at the time of data collection and analysis."
         ))({
-            type: self.caseType,
             count: self.propertyCount,
+            type: self.caseType,
             limit: self.propertyLimit,
         });
         self.warningContent(content);

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -60,7 +60,7 @@
         </div>
         <form class="form-horizontal" id="create-case-type-form"
                 style="margin: 0; padding: 0"
-                action="{% url "create_case_type" domain %}"
+                action="{% url 'create_case_type' domain %}"
                 method="post"
                 data-bind="submit: submitCreate"
         >
@@ -350,7 +350,7 @@
                 </div>
               {% if fhir_integration_enabled %}
                 <div class="row-item fhir-path">
-                  <input class="form-control" data-bind="value: $data.fhirResourcePropPath, disable: removeFHIRResourcePropertyPath"></input>
+                  <input class="form-control" data-bind="value: $data.fhirResourcePropPath, disable: removeFHIRResourcePropertyPath">
                   <!-- ko if: fhirResourcePropPath() && !removeFHIRResourcePropertyPath() -->
                   <button title="{% trans_html_attr 'Remove Path' %}" data-bind="click: removePath" class="fa-solid fa-xmark"></button>
                   <!-- /ko -->

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -154,27 +154,8 @@
           <h3 data-bind="text: $root.activeCaseType()" style="display: inline-block;"></h3>
           <span data-bind="visible: $root.isActiveCaseTypeDeprecated()" class="deprecate-case-type hidden label label-warning" style="display: inline-block;">{% trans "deprecated" %}</span>
         </div>
-        <div class="alert alert-warning" data-bind="visible: showCasePropertyWarning()">
-          <i class="fa fa-exclamation-triangle"></i>
-          {% trans "Performance warning" %}
-          <button
-            id="performance-warning-toggle"
-            type="button"
-            class="close collapsed"
-            data-toggle="collapse"
-            data-target="#performance-warning-content"
-            data-bind="click: toggleCasePropertyWarning"
-          >
-            <i class="fa fa-chevron-down"></i>
-          </button>
-          <div id="performance-warning-content" class="collapse">
-            <p data-bind="text: casePropertyWarningContent()"></p>
-            <p>
-            {% blocktrans %}
-            See <a target="_blank" href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143947182/Case+Configuration">case configuration</a> documentation for more information.
-            {% endblocktrans %}
-            </p>
-          </div>
+        <div data-bind="with: casePropertyWarningViewModel">
+        {% include "data_dictionary/partials/case_property_warning.html" %}
         </div>
         {% if fhir_integration_enabled %}
           <div id="fhir-resource-type-form" class="form-inline" data-bind="visible: fhirResourceTypes().length">

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -155,19 +155,19 @@
           <span data-bind="visible: $root.isActiveCaseTypeDeprecated()" class="deprecate-case-type hidden label label-warning" style="display: inline-block;">{% trans "deprecated" %}</span>
         </div>
         <div class="alert alert-warning" data-bind="visible: showCasePropertyWarning()">
+          <i class="fa fa-exclamation-triangle"></i>
+          {% trans "Performance warning" %}
           <button
             id="performance-warning-toggle"
             type="button"
-            class="close"
+            class="close collapsed"
             data-toggle="collapse"
-            data-target="#warningContent"
+            data-target="#performance-warning-content"
             data-bind="click: toggleCasePropertyWarning"
           >
             <i class="fa fa-chevron-down"></i>
           </button>
-          <i class="fa fa-exclamation-triangle"></i>
-          {% trans "Performance warning" %}
-          <div id="warningContent" class="collapse">
+          <div id="performance-warning-content" class="collapse">
             <p data-bind="text: casePropertyWarningContent()"></p>
             <p>
             {% blocktrans %}

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -134,6 +134,7 @@
   {% registerurl 'data_dictionary' domain %}
   {% initial_page_data 'typeChoices' question_types %}
   {% initial_page_data 'fhirResourceTypes' fhir_resource_types %}
+  {% initial_page_data 'casePropertyLimit' case_property_limit %}
   {% initial_page_data 'read_only_mode' request.is_view_only %}
   {% url 'geospatial_settings' domain as geospatial_settings_url %}
   <div class="ko-template">
@@ -152,6 +153,28 @@
         <div>
           <h3 data-bind="text: $root.activeCaseType()" style="display: inline-block;"></h3>
           <span data-bind="visible: $root.isActiveCaseTypeDeprecated()" class="deprecate-case-type hidden label label-warning" style="display: inline-block;">{% trans "deprecated" %}</span>
+        </div>
+        <div class="alert alert-warning" data-bind="visible: showCasePropertyWarning()">
+          <button
+            id="performance-warning-toggle"
+            type="button"
+            class="close"
+            data-toggle="collapse"
+            data-target="#warningContent"
+            data-bind="click: toggleCasePropertyWarning"
+          >
+            <i class="fa fa-chevron-down"></i>
+          </button>
+          <i class="fa fa-exclamation-triangle"></i>
+          {% trans "Performance warning" %}
+          <div id="warningContent" class="collapse">
+            <p data-bind="text: casePropertyWarningContent()"></p>
+            <p>
+            {% blocktrans %}
+            See <a target="_blank" href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143947182/Case+Configuration">case configuration</a> documentation for more information.
+            {% endblocktrans %}
+            </p>
+          </div>
         </div>
         {% if fhir_integration_enabled %}
           <div id="fhir-resource-type-form" class="form-inline" data-bind="visible: fhirResourceTypes().length">

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/case_property_warning.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/case_property_warning.html
@@ -12,7 +12,7 @@
   <button
     id="performance-warning-toggle"
     type="button"
-    class="close collapsed"
+    class="close"
     data-toggle="collapse"
     data-target="#performance-warning-content"
   >

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/case_property_warning.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/case_property_warning.html
@@ -15,7 +15,6 @@
     class="close collapsed"
     data-toggle="collapse"
     data-target="#performance-warning-content"
-    data-bind="click: toggleWarningCollapse"
   >
     <i class="fa fa-chevron-down"></i>
   </button>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/case_property_warning.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/case_property_warning.html
@@ -1,0 +1,36 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+{% load crispy_forms_tags %}
+
+<div
+  id="case-property-warning"
+  class="alert alert-warning"
+  data-bind="visible: showWarning()"
+>
+  <i class="fa fa-exclamation-triangle"></i>
+  {% trans "Performance warning" %}
+  <button
+    id="performance-warning-toggle"
+    type="button"
+    class="close collapsed"
+    data-toggle="collapse"
+    data-target="#performance-warning-content"
+    data-bind="click: toggleWarningCollapse"
+  >
+    <i class="fa fa-chevron-down"></i>
+  </button>
+  <div id="performance-warning-content" class="collapse">
+    <p id="dynamic-content" data-bind="text: warningContent"></p>
+    <p>
+      {% blocktrans %}
+        See
+        <a
+          target="_blank"
+          href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143947182/Case+Configuration"
+          >case configuration</a
+        >
+        documentation for more information.
+      {% endblocktrans %}
+    </p>
+  </div>
+</div>

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -420,3 +420,13 @@ def update_url_query_params(url, params):
     merged_params = urlencode({**current_params, **params})
     # Note: _replace is a public method of namedtuple. Starts with _ to avoid conflicts with field names.
     return parsed_url._replace(query=merged_params).geturl()
+
+
+def get_custom_case_property_count(domain, case_type):
+    """This excludes system properties"""
+    try:
+        case_type = CaseType.objects.get(domain=domain, name=case_type)
+    except CaseType.DoesNotExist:
+        return 0
+
+    return case_type.properties.count()

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -52,6 +52,8 @@ from corehq.motech.fhir.utils import (
     remove_fhir_resource_type,
     update_fhir_resource_type,
 )
+from corehq.project_limits.const import CASE_PROPERTIES_PER_CASE_KEY, DEFAULT_CASE_PROPERTIES_PER_CASE
+from corehq.project_limits.models import SystemLimit
 
 from .bulk import (
     ALLOWED_VALUES_SHEET_SUFFIX,
@@ -508,6 +510,11 @@ class DataDictionaryView(BaseProjectDataView):
                                for t in CaseProperty.DataType
                                if t != CaseProperty.DataType.UNDEFINED],
             'fhir_integration_enabled': fhir_integration_enabled,
+            'case_property_limit': SystemLimit.get_limit_for_key(
+                CASE_PROPERTIES_PER_CASE_KEY,
+                DEFAULT_CASE_PROPERTIES_PER_CASE,
+                domain=self.domain
+            )
         })
         return main_context
 

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -52,7 +52,7 @@ from corehq.motech.fhir.utils import (
     remove_fhir_resource_type,
     update_fhir_resource_type,
 )
-from corehq.project_limits.const import CASE_PROPERTIES_PER_CASE_KEY, DEFAULT_CASE_PROPERTIES_PER_CASE
+from corehq.project_limits.const import CASE_PROP_LIMIT_PER_CASE_TYPE_KEY, DEFAULT_CASE_PROPS_PER_CASE_TYPE
 from corehq.project_limits.models import SystemLimit
 
 from .bulk import (
@@ -511,8 +511,8 @@ class DataDictionaryView(BaseProjectDataView):
                                if t != CaseProperty.DataType.UNDEFINED],
             'fhir_integration_enabled': fhir_integration_enabled,
             'case_property_limit': SystemLimit.get_limit_for_key(
-                CASE_PROPERTIES_PER_CASE_KEY,
-                DEFAULT_CASE_PROPERTIES_PER_CASE,
+                CASE_PROP_LIMIT_PER_CASE_TYPE_KEY,
+                DEFAULT_CASE_PROPS_PER_CASE_TYPE,
                 domain=self.domain
             )
         })

--- a/corehq/project_limits/const.py
+++ b/corehq/project_limits/const.py
@@ -1,6 +1,6 @@
 # SystemLimit keys
-CASE_PROPERTIES_PER_CASE_KEY = "case_properties_per_case"
+CASE_PROP_LIMIT_PER_CASE_TYPE_KEY = "case_prop_limit_per_case_type"
 DEVICE_LIMIT_PER_USER_KEY = "device_limit_per_user"
 
 # SystemLimit defaults
-DEFAULT_CASE_PROPERTIES_PER_CASE = 250
+DEFAULT_CASE_PROPS_PER_CASE_TYPE = 250

--- a/corehq/project_limits/const.py
+++ b/corehq/project_limits/const.py
@@ -1,3 +1,6 @@
 # SystemLimit keys
 CASE_PROPERTIES_PER_CASE_KEY = "case_properties_per_case"
 DEVICE_LIMIT_PER_USER_KEY = "device_limit_per_user"
+
+# SystemLimit defaults
+DEFAULT_CASE_PROPERTIES_PER_CASE = 250

--- a/corehq/project_limits/const.py
+++ b/corehq/project_limits/const.py
@@ -1,2 +1,3 @@
 # SystemLimit keys
+CASE_PROPERTIES_PER_CASE_KEY = "case_properties_per_case"
 DEVICE_LIMIT_PER_USER_KEY = "device_limit_per_user"


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
https://www.loom.com/share/62f8465ff8fc4275934096ca2717daa4

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-17714

Review by commit 🐟 

We want to provide a warning to users once they hit a certain number of case properties on a case type. This is set to 250 in this PR but is something we can change per environment if needed.

The idea is that users might add case properties without thinking twice about it, so this provides a warning for them to re-evaluate their usage of case properties, link to some docs, and possibly alter their path.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The blast radius is pretty low given this is an isolated alert that if it breaks, shouldn't cause issues on the page itself. I've tested this on staging quite a bit and it behaves as expected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
