### PR TITLE
Remove ko-template from descendants if applicable

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -15,37 +15,39 @@
 {% endblock %}
 
 {% block page_navigation %}
-  <h2 class="text-hq-nav-header">{% trans "Data Dictionary" %}</h2>
-  <ul class="nav nav-hq-sidebar">
-    <!-- ko foreach: caseTypes -->
-    <li data-bind="css: { active: $data.name == $root.activeCaseType() }">
-      {# navigation handle by URL hash #}
-      <a data-bind="attr: {href: $data.url}">
-        <span data-bind="text: $data.name" style="display: inline-block"></span>
-        <span data-bind="visible: $data.deprecated" class="hidden deprecate-case-type label label-warning">{% trans "deprecated" %}</span>
-      </a>
-    </li>
-    <!-- /ko -->
-    {% if not request.is_view_only %}
-      <li>
-        <a href="#" data-bind="openModal: 'create-case-type'">
-          <i class="fa fa-plus"></i>
-          {% trans "Add Case Type" %}
+  <div class=ko-template">
+    <h2 class="text-hq-nav-header">{% trans "Data Dictionary" %}</h2>
+    <ul class="nav nav-hq-sidebar">
+      <!-- ko foreach: caseTypes -->
+      <li data-bind="css: { active: $data.name == $root.activeCaseType() }">
+        {# navigation handle by URL hash #}
+        <a data-bind="attr: {href: $data.url}">
+          <span data-bind="text: $data.name" style="display: inline-block"></span>
+          <span data-bind="visible: $data.deprecated" class="hidden deprecate-case-type label label-warning">{% trans "deprecated" %}</span>
         </a>
       </li>
-      <li>
-        <a class="hidden deprecate-case-type" data-bind="click: $root.toggleShowDeprecatedCaseTypes">
-            <i class="fa fa-archive"></i>
-            <span data-bind="hidden: $root.showDeprecatedCaseTypes">
-              {% trans 'Show Deprecated Case Types' %}
-            </span>
-            <span data-bind="visible: $root.showDeprecatedCaseTypes">
-              {% trans 'Hide Deprecated Case Types' %}
-            </span>
-        </a>
-      </li>
-    {% endif %}
-  </ul>
+      <!-- /ko -->
+      {% if not request.is_view_only %}
+        <li>
+          <a href="#" data-bind="openModal: 'create-case-type'">
+            <i class="fa fa-plus"></i>
+            {% trans "Add Case Type" %}
+          </a>
+        </li>
+        <li>
+          <a class="hidden deprecate-case-type" data-bind="click: $root.toggleShowDeprecatedCaseTypes">
+              <i class="fa fa-archive"></i>
+              <span data-bind="hidden: $root.showDeprecatedCaseTypes">
+                {% trans 'Show Deprecated Case Types' %}
+              </span>
+              <span data-bind="visible: $root.showDeprecatedCaseTypes">
+                {% trans 'Hide Deprecated Case Types' %}
+              </span>
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </div>
 
   <script type="text/html" id="create-case-type">
     <div class="modal-dialog">
@@ -134,315 +136,317 @@
   {% initial_page_data 'fhirResourceTypes' fhir_resource_types %}
   {% initial_page_data 'read_only_mode' request.is_view_only %}
   {% url 'geospatial_settings' domain as geospatial_settings_url %}
-  <div id="case-type-error" class="alert alert-danger" hidden>
-    <p>
-      {% blocktrans %}
-        There was an error processing the request. Please try again.
-      {% endblocktrans %}
-    </p>
-  </div>
-  {% if not request.is_view_only %}
-    <div id="gtm-save-btn" data-bind="saveButton: saveButton, visible: $root.activeCaseType()"></div>
-  {% endif %}
-  <div class="row">
-    <div class="col-md-12">
-      <div>
-        <h3 data-bind="text: $root.activeCaseType()" style="display: inline-block;"></h3>
-        <span data-bind="visible: $root.isActiveCaseTypeDeprecated()" class="deprecate-case-type hidden label label-warning" style="display: inline-block;">{% trans "deprecated" %}</span>
-      </div>
-      {% if fhir_integration_enabled %}
-        <div id="fhir-resource-type-form" class="form-inline" data-bind="visible: fhirResourceTypes().length">
-          {% trans "FHIR Resource Type" %}
-          <select id="fhir-resource-types"
-                  class="form-control"
-                  data-bind="select2: fhirResourceTypes,
-                             optionsCaption: '{% trans_html_attr 'Select a resource type' %}',
-                             value: fhirResourceType,
-                             disable: removefhirResourceType,
-                            ">
-          </select>
-          <!-- ko if: fhirResourceType() && !removefhirResourceType() -->
-          <button data-bind="click: removeResourceType" class="btn btn-danger btn-sm">{% trans "Clear" %}
-          </button>
-          <!-- /ko -->
-          <!-- ko if: removefhirResourceType() -->
-          <button data-bind="click: restoreResourceType" class="btn btn-default btn-sm">{% trans "Restore" %}
-          </button>
-          <!-- /ko -->
+  <div class="ko-template">
+    <div id="case-type-error" class="alert alert-danger" hidden>
+      <p>
+        {% blocktrans %}
+          There was an error processing the request. Please try again.
+        {% endblocktrans %}
+      </p>
+    </div>
+    {% if not request.is_view_only %}
+      <div id="gtm-save-btn" data-bind="saveButton: saveButton, visible: $root.activeCaseType()"></div>
+    {% endif %}
+    <div class="row">
+      <div class="col-md-12">
+        <div>
+          <h3 data-bind="text: $root.activeCaseType()" style="display: inline-block;"></h3>
+          <span data-bind="visible: $root.isActiveCaseTypeDeprecated()" class="deprecate-case-type hidden label label-warning" style="display: inline-block;">{% trans "deprecated" %}</span>
         </div>
-        <br />
-      {% endif %}
-      <a class="btn btn-info" id="download-dict" href="{% url "export_data_dictionary" domain %}">
-        <i class="fa-solid fa-cloud-arrow-down"></i>
-        {% trans "Export to Excel" %}
-      </a>
-      {% if not request.is_view_only %}
-        <a class="btn btn-default" id="gtm-upload-dict" href="{% url "upload_data_dict" domain %}">
-          <i class="fa-solid fa-cloud-arrow-up"></i>
-          {% trans "Import from Excel" %}
-        </a>
-        <a class="btn btn-default" href="#" data-bind="openModal: 'deprecate-case-type', visible: !$root.isActiveCaseTypeDeprecated()">
-          <i class="fa fa-archive"></i>
-          {% trans "Deprecate Case Type" %}
-        </a>
-        <button class="btn btn-default" data-bind="click: restoreCaseType, visible: $root.isActiveCaseTypeDeprecated()">
-          <i class="fa fa-undo"></i>
-          {% trans "Restore Case Type" %}
-        </button>
-        <a class="btn btn-danger" href="#" data-bind="openModal: 'delete-case-type-modal', visible: $root.canDeleteActiveCaseType()">
-          <i class="fa fa-trash"></i>
-          {% trans "Delete Case Type" %}
-        </a>
-      {% endif %}
-      <div data-bind="visible: $root.activeCaseType()">
-        <button data-bind="click: $root.showDeprecated, visible: !showAll()" class="btn btn-default pull-right">{% trans "Show Deprecated" %}</button>
-        <button data-bind="click: $root.hideDeprecated, visible: showAll" class="btn btn-default pull-right">{% trans "Hide Deprecated" %}</button>
-        <div id="data-dictionary-table">
-          <div class="table-row table-header">
-          <div class="row-item-small"></div>
-          <div class="row-item">{% trans "Case Property" %}</div>
-          <div class="row-item">{% trans "Label" %}</div>
-          {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
-            <div class="row-item">{% trans "Data Type" %}</div>
-          {% endif %}
-          <div class="row-item-big">{% trans "Description" %}</div>
-          {% if fhir_integration_enabled %}
-            <div class="row-item">{% trans "FHIR Resource Property Path" %}</div>
-          {% endif %}
-          {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
-            <div class="row-item">{% include "data_dictionary/partials/valid_values_th_content.html" %}</div>
-          {% endif %}
-          {% if not request.is_view_only %}
-            <div class="row-item-small"></div>
-            <div class="row-item-small"></div>
-          {% endif %}
+        {% if fhir_integration_enabled %}
+          <div id="fhir-resource-type-form" class="form-inline" data-bind="visible: fhirResourceTypes().length">
+            {% trans "FHIR Resource Type" %}
+            <select id="fhir-resource-types"
+                    class="form-control"
+                    data-bind="select2: fhirResourceTypes,
+                              optionsCaption: '{% trans_html_attr 'Select a resource type' %}',
+                              value: fhirResourceType,
+                              disable: removefhirResourceType,
+                              ">
+            </select>
+            <!-- ko if: fhirResourceType() && !removefhirResourceType() -->
+            <button data-bind="click: removeResourceType" class="btn btn-danger btn-sm">{% trans "Clear" %}
+            </button>
+            <!-- /ko -->
+            <!-- ko if: removefhirResourceType() -->
+            <button data-bind="click: restoreResourceType" class="btn btn-default btn-sm">{% trans "Restore" %}
+            </button>
+            <!-- /ko -->
           </div>
-          <div data-bind="sortable: {
-                            data: activeCaseTypeData(),
-                            connectClass: 'groups',
-                            options: { handle: 'i.sortable-handle' }
-                          }">
-          <div>
-          <div class="group-deprecated" data-bind="visible: showGroupPropertyTransferWarning" style="display: none;">
-            {% blocktrans %}
-            <b data-bind="text: name()"></b> group's properties will be moved to <b>No Group</b>
-            {% endblocktrans %}
-          </div>
-          <div class="table-row group" data-bind="css: { 'group-deprecated': toBeDeprecated() }, visible: !deprecated || $root.showAll()">
-            <div class="row-item-small">
-              {% if not request.is_view_only %}
-              <i class="sortable-handle fa-solid fa-up-down"></i>
-              {% endif %}
-              <i class="fa-solid ms-2 fa-lg"
-                data-bind="css: { 'fa-square-plus': !expanded(), 'fa-square-minus': expanded() }, click: toggleExpanded"></i>
-            </div>
-            <div class="row-item">
-              <!-- ko if: name() == '' -->
-              <span>{% trans 'No Group' %}</span>
-              <!-- /ko -->
-              <!-- ko if: name() !== '' -->
-              <input class="form-control" data-bind="value: name,
-                            attr: {'placeholder': name}" id="group-name" />
-              <!-- /ko -->
-            </div>
-            <div class="row-item">
-              &nbsp;{# Empty cell where "Label" is in case property rows #}
-            </div>
+          <br />
+        {% endif %}
+        <a class="btn btn-info" id="download-dict" href="{% url "export_data_dictionary" domain %}">
+          <i class="fa-solid fa-cloud-arrow-down"></i>
+          {% trans "Export to Excel" %}
+        </a>
+        {% if not request.is_view_only %}
+          <a class="btn btn-default" id="gtm-upload-dict" href="{% url "upload_data_dict" domain %}">
+            <i class="fa-solid fa-cloud-arrow-up"></i>
+            {% trans "Import from Excel" %}
+          </a>
+          <a class="btn btn-default" href="#" data-bind="openModal: 'deprecate-case-type', visible: !$root.isActiveCaseTypeDeprecated()">
+            <i class="fa fa-archive"></i>
+            {% trans "Deprecate Case Type" %}
+          </a>
+          <button class="btn btn-default" data-bind="click: restoreCaseType, visible: $root.isActiveCaseTypeDeprecated()">
+            <i class="fa fa-undo"></i>
+            {% trans "Restore Case Type" %}
+          </button>
+          <a class="btn btn-danger" href="#" data-bind="openModal: 'delete-case-type-modal', visible: $root.canDeleteActiveCaseType()">
+            <i class="fa fa-trash"></i>
+            {% trans "Delete Case Type" %}
+          </a>
+        {% endif %}
+        <div data-bind="visible: $root.activeCaseType()">
+          <button data-bind="click: $root.showDeprecated, visible: !showAll()" class="btn btn-default pull-right">{% trans "Show Deprecated" %}</button>
+          <button data-bind="click: $root.hideDeprecated, visible: showAll" class="btn btn-default pull-right">{% trans "Hide Deprecated" %}</button>
+          <div id="data-dictionary-table">
+            <div class="table-row table-header">
+            <div class="row-item-small"></div>
+            <div class="row-item">{% trans "Case Property" %}</div>
+            <div class="row-item">{% trans "Label" %}</div>
             {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
-              <div class="row-item">{% trans "Case Property Group" %}</div>
+              <div class="row-item">{% trans "Data Type" %}</div>
             {% endif %}
-            <div class="row-item-big">
-              <!-- ko if: name() !== ''-->
-              <textarea class="form-control std-height vertical-resize"
-                        data-bind="value: $data.description, rows: 1"
-                        placeholder='{% trans "Click here to add a description" %}'></textarea>
-              <!-- /ko -->
-            </div>
+            <div class="row-item-big">{% trans "Description" %}</div>
             {% if fhir_integration_enabled %}
-              <div class="row-item"></div>
+              <div class="row-item">{% trans "FHIR Resource Property Path" %}</div>
             {% endif %}
             {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
-              <div class="row-item"></div>
+              <div class="row-item">{% include "data_dictionary/partials/valid_values_th_content.html" %}</div>
             {% endif %}
             {% if not request.is_view_only %}
-            <div class="row-item-small">
-              <!-- ko if: name() !== '' && !toBeDeprecated() -->
-              <button title="{% trans_html_attr 'Deprecate Group' %}"  data-bind="click: deprecateGroup" class="fa fa-archive"></button>
-              <!-- /ko -->
-              <!-- ko if: name() !== '' && toBeDeprecated() -->
-              <button title="{% trans_html_attr 'Restore Group' %}" data-bind="click: restoreGroup" class="fa fa-undo"></button>
-              <!-- /ko -->
-            </div>
-            <div class="row-item-small"></div>
+              <div class="row-item-small"></div>
+              <div class="row-item-small"></div>
             {% endif %}
-          </div>
-          <div data-bind="sortable: { data: properties, connectClass: 'properties', options: { handle: 'i.sortable-handle' } }, visible: expanded() && (!deprecated || $root.showAll())">
-            <div class="table-row" data-bind="visible: expanded() && (!deprecated() || $root.showAll()) && !deleted()">
+            </div>
+            <div data-bind="sortable: {
+                              data: activeCaseTypeData(),
+                              connectClass: 'groups',
+                              options: { handle: 'i.sortable-handle' }
+                            }">
+            <div>
+            <div class="group-deprecated" data-bind="visible: showGroupPropertyTransferWarning" style="display: none;">
+              {% blocktrans %}
+              <b data-bind="text: name()"></b> group's properties will be moved to <b>No Group</b>
+              {% endblocktrans %}
+            </div>
+            <div class="table-row group" data-bind="css: { 'group-deprecated': toBeDeprecated() }, visible: !deprecated || $root.showAll()">
               <div class="row-item-small">
-              {% if not request.is_view_only %}
+                {% if not request.is_view_only %}
                 <i class="sortable-handle fa-solid fa-up-down"></i>
-              {% endif %}
+                {% endif %}
+                <i class="fa-solid ms-2 fa-lg"
+                  data-bind="css: { 'fa-square-plus': !expanded(), 'fa-square-minus': expanded() }, click: toggleExpanded"></i>
               </div>
               <div class="row-item">
-                <div class="w-100">
-                <span data-bind="text: name"></span>
-                </div>
+                <!-- ko if: name() == '' -->
+                <span>{% trans 'No Group' %}</span>
+                <!-- /ko -->
+                <!-- ko if: name() !== '' -->
+                <input class="form-control" data-bind="value: name,
+                              attr: {'placeholder': name}" id="group-name" />
+                <!-- /ko -->
               </div>
               <div class="row-item">
-                <input class="form-control"
-                       id="prop-label"
-                       data-bind="
-                         value: $data.label,
-                         attr: {'placeholder': 'Click here to add a label'}" />
+                &nbsp;{# Empty cell where "Label" is in case property rows #}
               </div>
               {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
-                <div class="row-item main-form">
-                  <select class="form-control"
-                          data-bind="
-                            options: $root.availableDataTypes,
-                            optionsCaption: 'Select a data type',
-                            optionsText: 'display',
-                            optionsValue: 'value',
-                            value: dataType,
-                            disable: isGeoCaseProp,">
-                  </select>
-                  <span class="hq-help" style="height: fit-content"
+                <div class="row-item">{% trans "Case Property Group" %}</div>
+              {% endif %}
+              <div class="row-item-big">
+                <!-- ko if: name() !== ''-->
+                <textarea class="form-control std-height vertical-resize"
+                          data-bind="value: $data.description, rows: 1"
+                          placeholder='{% trans "Click here to add a description" %}'></textarea>
+                <!-- /ko -->
+              </div>
+              {% if fhir_integration_enabled %}
+                <div class="row-item"></div>
+              {% endif %}
+              {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+                <div class="row-item"></div>
+              {% endif %}
+              {% if not request.is_view_only %}
+              <div class="row-item-small">
+                <!-- ko if: name() !== '' && !toBeDeprecated() -->
+                <button title="{% trans_html_attr 'Deprecate Group' %}"  data-bind="click: deprecateGroup" class="fa fa-archive"></button>
+                <!-- /ko -->
+                <!-- ko if: name() !== '' && toBeDeprecated() -->
+                <button title="{% trans_html_attr 'Restore Group' %}" data-bind="click: restoreGroup" class="fa fa-undo"></button>
+                <!-- /ko -->
+              </div>
+              <div class="row-item-small"></div>
+              {% endif %}
+            </div>
+            <div data-bind="sortable: { data: properties, connectClass: 'properties', options: { handle: 'i.sortable-handle' } }, visible: expanded() && (!deprecated || $root.showAll())">
+              <div class="table-row" data-bind="visible: expanded() && (!deprecated() || $root.showAll()) && !deleted()">
+                <div class="row-item-small">
+                {% if not request.is_view_only %}
+                  <i class="sortable-handle fa-solid fa-up-down"></i>
+                {% endif %}
+                </div>
+                <div class="row-item">
+                  <div class="w-100">
+                  <span data-bind="text: name"></span>
+                  </div>
+                </div>
+                <div class="row-item">
+                  <input class="form-control"
+                        id="prop-label"
                         data-bind="
-                          popover: {
-                            content: '{% blocktrans %}This GPS case property is currently being used to store the geolocation for cases, so the data type cannot be changed.{% endblocktrans %}',
-                            trigger: 'hover' },
-                          visible: isGeoCaseProp">
-                    <i class="fa fa-question-circle icon-question-sign"></i>
-                  </span>
+                          value: $data.label,
+                          attr: {'placeholder': 'Click here to add a label'}" />
+                </div>
+                {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+                  <div class="row-item main-form">
+                    <select class="form-control"
+                            data-bind="
+                              options: $root.availableDataTypes,
+                              optionsCaption: 'Select a data type',
+                              optionsText: 'display',
+                              optionsValue: 'value',
+                              value: dataType,
+                              disable: isGeoCaseProp,">
+                    </select>
+                    <span class="hq-help" style="height: fit-content"
+                          data-bind="
+                            popover: {
+                              content: '{% blocktrans %}This GPS case property is currently being used to store the geolocation for cases, so the data type cannot be changed.{% endblocktrans %}',
+                              trigger: 'hover' },
+                            visible: isGeoCaseProp">
+                      <i class="fa fa-question-circle icon-question-sign"></i>
+                    </span>
+                  </div>
+                {% endif %}
+                <div class="row-item-big main-form">
+                  <textarea class="form-control std-height vertical-resize"
+                            placeholder="{% trans 'Click here to add a description' %}"
+                            data-bind=" value: $data.description, rows: 1">
+                  </textarea>
+                </div>
+              {% if fhir_integration_enabled %}
+                <div class="row-item fhir-path">
+                  <input class="form-control" data-bind="value: $data.fhirResourcePropPath, disable: removeFHIRResourcePropertyPath"></input>
+                  <!-- ko if: fhirResourcePropPath() && !removeFHIRResourcePropertyPath() -->
+                  <button title="{% trans_html_attr 'Remove Path' %}" data-bind="click: removePath" class="fa-solid fa-xmark"></button>
+                  <!-- /ko -->
+                  <!-- ko if: removeFHIRResourcePropertyPath() -->
+                  <button title="{% trans_html_attr 'Restore Path' %}" data-bind="click: restorePath" class="fa fa-undo"></button>
+                  <!-- /ko -->
                 </div>
               {% endif %}
-              <div class="row-item-big main-form">
-                <textarea class="form-control std-height vertical-resize"
-                          placeholder="{% trans 'Click here to add a description' %}"
-                          data-bind=" value: $data.description, rows: 1">
-                </textarea>
-              </div>
-            {% if fhir_integration_enabled %}
-              <div class="row-item fhir-path">
-                <input class="form-control" data-bind="value: $data.fhirResourcePropPath, disable: removeFHIRResourcePropertyPath"></input>
-                <!-- ko if: fhirResourcePropPath() && !removeFHIRResourcePropertyPath() -->
-                <button title="{% trans_html_attr 'Remove Path' %}" data-bind="click: removePath" class="fa-solid fa-xmark"></button>
-                <!-- /ko -->
-                <!-- ko if: removeFHIRResourcePropertyPath() -->
-                <button title="{% trans_html_attr 'Restore Path' %}" data-bind="click: restorePath" class="fa fa-undo"></button>
-                <!-- /ko -->
-              </div>
-            {% endif %}
-            {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
-              <div class="row-item">
-                <div data-bind="visible: canHaveAllowedValues()">
-                  <div data-bind="jqueryElement: $allowedValues"></div>
+              {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+                <div class="row-item">
+                  <div data-bind="visible: canHaveAllowedValues()">
+                    <div data-bind="jqueryElement: $allowedValues"></div>
+                  </div>
+                  <div data-bind="visible: dataType() === 'date'" class="help-block">
+                    {% trans "YYYY-MM-DD" %}
+                  </div>
                 </div>
-                <div data-bind="visible: dataType() === 'date'" class="help-block">
-                  {% trans "YYYY-MM-DD" %}
+              {% endif %}
+              {% if not request.is_view_only %}
+                <div class="row-item-small m-auto">
+                  <button title="{% trans_html_attr 'Delete Property' %}"
+                          data-bind="click: confirmDeleteProperty, visible: isSafeToDelete"
+                          class="btn btn-danger">
+                    <i class="fa fa-trash"></i>
+                    {% trans 'Delete' %}
+                  </button>
                 </div>
+                <div class="row-item-small m-auto">
+                  <!-- ko if: !deprecated() -->
+                  <button id="gtm-deprecate-case-property" title="{% trans_html_attr 'Deprecate Property' %}"  data-bind="click: deprecateProperty" class="btn btn-default">
+                    <i class="fa fa-archive"></i>
+                    {% trans 'Deprecate' %}
+                  </button>
+                  <!-- /ko -->
+                  <!-- ko if: deprecated() -->
+                  <button title="{% trans_html_attr 'Restore Property' %}" data-bind="click: restoreProperty" class="btn btn-default">
+                    <i class="fa fa-undo"></i>
+                    {% trans 'Restore' %}
+                  </button>
+                  <!-- /ko -->
+                </div>
+              {% endif %}
               </div>
-            {% endif %}
+            </div>
+
             {% if not request.is_view_only %}
-              <div class="row-item-small m-auto">
-                <button title="{% trans_html_attr 'Delete Property' %}"
-                        data-bind="click: confirmDeleteProperty, visible: isSafeToDelete"
-                        class="btn btn-danger">
-                  <i class="fa fa-trash"></i>
-                  {% trans 'Delete' %}
-                </button>
-              </div>
-              <div class="row-item-small m-auto">
-                <!-- ko if: !deprecated() -->
-                <button id="gtm-deprecate-case-property" title="{% trans_html_attr 'Deprecate Property' %}"  data-bind="click: deprecateProperty" class="btn btn-default">
-                  <i class="fa fa-archive"></i>
-                  {% trans 'Deprecate' %}
-                </button>
-                <!-- /ko -->
-                <!-- ko if: deprecated() -->
-                <button title="{% trans_html_attr 'Restore Property' %}" data-bind="click: restoreProperty" class="btn btn-default">
-                  <i class="fa fa-undo"></i>
-                  {% trans 'Restore' %}
-                </button>
-                <!-- /ko -->
+              <div class="table-row"
+                  data-bind="visible: !deprecated">
+                <div class="row-item">
+                  <form class="form-inline"
+                        data-bind="css: {
+                                    'has-error': !$root.newPropertyNameUnique(newPropertyName())
+                                                  || !$root.newPropertyNameValid(newPropertyName())
+                                  }">
+                    <input class="form-control"
+                          placeholder="Case Property"
+                          data-bind="value: newPropertyName">
+                    <button class="btn btn-default"
+                            id="gtm-add-case-property"
+                            data-bind="click: newCaseProperty,
+                                      enable: $root.newPropertyNameUnique(newPropertyName())
+                                              && $root.newPropertyNameValid(newPropertyName())">
+                      <i class="fa fa-plus"></i>
+                      {% trans "Add Case Property" %}
+                    </button>
+                    <div class="help-block">
+                      <span class="text-danger"
+                            data-bind="visible: !$root.newPropertyNameUnique(newPropertyName())">
+                        {% blocktrans %}
+                          A case property with this name already exists.
+                          If you don’t see it on the page, please click ‘Show Deprecated’ button to reveal deprecated
+                          properties.
+                        {% endblocktrans %}
+                      </span>
+                      <span class="text-danger" data-bind="visible: !$root.newPropertyNameValid(newPropertyName())">
+                        {% trans "Invalid case property name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
+                      </span>
+                    </div>
+
+                  </form>
+                </div>
               </div>
             {% endif %}
+
+            </div>
             </div>
           </div>
 
           {% if not request.is_view_only %}
-            <div class="table-row"
-                 data-bind="visible: !deprecated">
-              <div class="row-item">
-                <form class="form-inline"
-                      data-bind="css: {
-                                   'has-error': !$root.newPropertyNameUnique(newPropertyName())
-                                                || !$root.newPropertyNameValid(newPropertyName())
-                                 }">
-                  <input class="form-control"
-                         placeholder="Case Property"
-                         data-bind="value: newPropertyName">
-                  <button class="btn btn-default"
-                          id="gtm-add-case-property"
-                          data-bind="click: newCaseProperty,
-                                     enable: $root.newPropertyNameUnique(newPropertyName())
-                                             && $root.newPropertyNameValid(newPropertyName())">
-                    <i class="fa fa-plus"></i>
-                    {% trans "Add Case Property" %}
-                  </button>
-                  <div class="help-block">
-                    <span class="text-danger"
-                          data-bind="visible: !$root.newPropertyNameUnique(newPropertyName())">
-                      {% blocktrans %}
-                        A case property with this name already exists.
-                        If you don’t see it on the page, please click ‘Show Deprecated’ button to reveal deprecated
-                        properties.
-                      {% endblocktrans %}
-                    </span>
-                    <span class="text-danger" data-bind="visible: !$root.newPropertyNameValid(newPropertyName())">
-                      {% trans "Invalid case property name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
-                    </span>
-                  </div>
-
-                </form>
+            <form class="form-inline" data-bind="css: {'has-error': !newGroupNameUnique() || !newGroupNameValid()}">
+              <input class="form-control" placeholder="Group Name" data-bind="value: newGroupName">
+              <button class="btn btn-default" id="gtm-add-case-property-group" data-bind="click: $root.newGroup, enable: newGroupNameUnique() && newGroupNameValid()">
+                <i class="fa fa-plus"></i>
+                {% trans "Add Case Property Group" %}
+              </button>
+              <div class="help-block">
+                <span class="text-danger" data-bind="visible: !newGroupNameUnique()">
+                  {% blocktrans %}
+                    A case property group with this name already exists.
+                    If you don’t see it on the page, please click ‘Show Deprecated’ button to reveal deprecated
+                    groups.
+                  {% endblocktrans %}
+                </span>
+                <span class="text-danger" data-bind="visible: !newGroupNameValid()">
+                  {% trans "Invalid case group name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
+                </span>
               </div>
-            </div>
+            </form>
           {% endif %}
-
-          </div>
-          </div>
         </div>
-
         {% if not request.is_view_only %}
-          <form class="form-inline" data-bind="css: {'has-error': !newGroupNameUnique() || !newGroupNameValid()}">
-            <input class="form-control" placeholder="Group Name" data-bind="value: newGroupName">
-            <button class="btn btn-default" id="gtm-add-case-property-group" data-bind="click: $root.newGroup, enable: newGroupNameUnique() && newGroupNameValid()">
+          <div data-bind="hidden: $root.caseTypes().length > 0">
+            <button class="btn btn-primary" data-bind="openModal: 'create-case-type'">
               <i class="fa fa-plus"></i>
-              {% trans "Add Case Property Group" %}
+              {% trans "Add a new Case Type" %}
             </button>
-            <div class="help-block">
-              <span class="text-danger" data-bind="visible: !newGroupNameUnique()">
-                {% blocktrans %}
-                  A case property group with this name already exists.
-                  If you don’t see it on the page, please click ‘Show Deprecated’ button to reveal deprecated
-                  groups.
-                {% endblocktrans %}
-              </span>
-              <span class="text-danger" data-bind="visible: !newGroupNameValid()">
-                {% trans "Invalid case group name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
-              </span>
-            </div>
-          </form>
+          </div>
         {% endif %}
       </div>
-      {% if not request.is_view_only %}
-        <div data-bind="hidden: $root.caseTypes().length > 0">
-          <button class="btn btn-primary" data-bind="openModal: 'create-case-type'">
-            <i class="fa fa-plus"></i>
-            {% trans "Add a new Case Type" %}
-          </button>
-        </div>
-      {% endif %}
     </div>
   </div>
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js
@@ -135,7 +135,7 @@ $.fn.koApplyBindings = function (context) {
         throw new Error("Multiple elements passed to koApplyBindings");
     }
     ko.applyBindings(context, this.get(0));
-    this.removeClass('ko-template');
+    this.find('.ko-template').addBack().removeClass('ko-template');
 };
 
 $.ajaxSetup({

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/hq.helpers.js
@@ -129,7 +129,7 @@ define("hqwebapp/js/bootstrap5/hq.helpers", [
             throw new Error("Multiple elements passed to koApplyBindings");
         }
         ko.applyBindings(context, this.get(0));
-        this.removeClass('ko-template');
+        this.find('.ko-template').addBack().removeClass('ko-template');
     };
 
     $.ajaxSetup({

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/hq.helpers.js.diff.txt
@@ -245,7 +245,7 @@
 -        throw new Error("Multiple elements passed to koApplyBindings");
 -    }
 -    ko.applyBindings(context, this.get(0));
--    this.removeClass('ko-template');
+-    this.find('.ko-template').addBack().removeClass('ko-template');
 -};
 +    $.fn.koApplyBindings = function (context) {
 +        if (!this.length) {
@@ -255,7 +255,7 @@
 +            throw new Error("Multiple elements passed to koApplyBindings");
 +        }
 +        ko.applyBindings(context, this.get(0));
-+        this.removeClass('ko-template');
++        this.find('.ko-template').addBack().removeClass('ko-template');
 +    };
  
 -$.ajaxSetup({


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
**Hide whitespace**

For pages like the data dictionary where bindings are applied to a parent element that is not defined in the template:
```
$('#hq-content').parent().koApplyBindings(viewModel);
```

we don't have a good way of using the `ko-template` class to hide knockout elements prior to bindings initially being applied (which is what that class is intended for).

This PR enables removing the `ko-template` class from either the element we are applying bindings too, or any descendants of that element. This means we can use the `ko-template` class on elements within our custom template, but still rely on the generic hq helper to remove this class once bindings are applied.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The potential blast radius of this change is large given that `ko-template` is used in ~100 places in HQ, however knowing that knockout does not allow applying bindings to nested elements, this should be safe to do since we would only be removing `ko-template` from nested elements of the original element bindings are being applied to.


### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests that I'm aware of.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No, but will test on staging myself.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
