### PR TITLE
Use limit_domains on commcare.restores.fixture.duration.seconds

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -33,7 +33,7 @@ from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.exceptions import NotFound
 from corehq.const import LOADTEST_HARD_LIMIT
 from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
-from corehq.util.metrics import metrics_counter, metrics_histogram
+from corehq.util.metrics import metrics_counter, metrics_histogram, limit_domains
 from corehq.util.timer import TimingContext
 
 from .checksum import CaseStateHash
@@ -806,6 +806,7 @@ class RestoreConfig(object):
             'status_code': status,
             'device_type': 'webapps' if self.params.is_webapps else 'other',
             'domain': self.domain,
+            'domain_limited': limit_domains(self.domain),
         }
         timer_buckets = (1, 5, 20, 60, 120, 300, 600)
         for timer in timing.to_list(exclude_root=True):


### PR DESCRIPTION
## Product Description
N/A

## Technical Summary
Use `limit_domains` on `commcare.restores.fixture.duration.seconds` with a backup full domain tag which we can disable most of the time.

This works well with a feature I just learned about today that allows you to disable tags _in the DataDog console_ rather than in code. This makes it easy to disable tags that have a lot of values that are rarely useful, and then later enable them again if/when they're useful.

This PR follows a new potential pattern I want to try out, where we report both a limited domain tag (only domains with the `DETAILED_TAGGING` feature flag enabled) _and_ an unfiltered domain tag. In DataDog reports where the metric is used, we can group by both `domain` and `domain_limited`, which if both are enabled and the domain's uses the flag will always be the same thing. Then we can enable and disable the (full) domain tag within DataDog as a cost-optimization operation rather than an application code operation. It can always be re-enabled if and when we want to dig into the "__other__" category for this specific metric. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Small change, and hard to see how this would cause a problem!

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
