### PR TITLE
Upgrade django-cte==2.0.0

### DIFF
--- a/corehq/apps/locations/adjacencylist.py
+++ b/corehq/apps/locations/adjacencylist.py
@@ -3,7 +3,7 @@ from django.db import models
 from django.db.models.expressions import Exists, F, Func, OuterRef, Value
 from django.db.models.query import Q, QuerySet
 
-from django_cte import With
+from django_cte import CTE, with_cte
 
 
 class str_array(Func):
@@ -68,10 +68,10 @@ class AdjListManager(models.Manager):
                 ),
             )
 
-        cte = With.recursive(make_cte_query)
-        return (
-            cte.queryset()
-            .with_cte(cte)
+        cte = CTE.recursive(make_cte_query)
+        return with_cte(
+            cte,
+            select=cte.queryset()
             .order_by(("" if ascending else "-") + "_depth")
         )
 
@@ -121,8 +121,8 @@ class AdjListManager(models.Manager):
                 ),
                 all=True,
             )
-        cte = With.recursive(make_cte_query)
-        query = cte.queryset().with_cte(cte)
+        cte = CTE.recursive(make_cte_query)
+        query = with_cte(cte, select=cte)
 
         if discard_dups:
             # Remove duplicates when the supplied Queryset or Q object
@@ -130,7 +130,7 @@ class AdjListManager(models.Manager):
             # id, retain the row with the longest path. TODO remove this
             # and ensure duplicates do not matter or the criteria never
             # matches both parents and children in all calling code.
-            xdups = With(
+            xdups = CTE(
                 cte.queryset().annotate(
                     max_len=array_length(
                         F("_cte_ordering"),
@@ -145,12 +145,12 @@ class AdjListManager(models.Manager):
                 ),
                 name="xdups"
             )
-            query = query.annotate(
+            query = with_cte(xdups, select=query).annotate(
                 _exclude_dups=Exists(SubQueryset(xdups.queryset().filter(
                     id=OuterRef("id"),
                     _cte_ordering=OuterRef("_cte_ordering"),
                 )))
-            ).filter(_exclude_dups=True).with_cte(xdups)
+            ).filter(_exclude_dups=True)
 
         return query.order_by(cte.col._cte_ordering)
 

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -3,11 +3,10 @@ from datetime import datetime
 from functools import partial
 
 from django.db import models, transaction
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 
 import jsonfield
 from django_bulk_update.helper import bulk_update as bulk_update_helper
-from django_cte import CTEQuerySet
 from memoized import memoized
 
 from corehq.apps.domain.models import Domain
@@ -284,7 +283,7 @@ class LocationQueriesMixin(object):
         return super(LocationQueriesMixin, self).delete(*args, **kwargs)
 
 
-class LocationQuerySet(LocationQueriesMixin, CTEQuerySet):
+class LocationQuerySet(LocationQueriesMixin, QuerySet):
 
     def accessible_to_user(self, domain, user):
         ids_query = super(LocationQuerySet, self).accessible_to_user(domain, user)

--- a/corehq/sql_db/tests/test_jsonops.py
+++ b/corehq/sql_db/tests/test_jsonops.py
@@ -7,7 +7,7 @@ from django.db.models.sql.compiler import SQLCompiler
 from django.forms import JSONField
 from django.test import TestCase
 
-from django_cte import CTEManager, With
+from django_cte import CTE, with_cte
 from django_cte.raw import raw_cte_sql
 
 from testil import assert_raises, eq
@@ -153,9 +153,11 @@ def eval_json_op(expression, data=None):
     data_cte.query.annotations = {}
     data_cte.query.values_select = []
     data_cte.query.annotation_select_mask = None
-    cte = With(data_cte)
-    qs = (
-        cte.queryset().with_cte(cte)
+    data_cte.query.deferred_loading = ()
+    cte = CTE(data_cte)
+    qs = with_cte(
+        cte,
+        select=cte.queryset()
         .annotate(val=expression)
         .values_list("val", flat=True)
     )
@@ -166,4 +168,4 @@ def eval_json_op(expression, data=None):
 
 @unregistered_django_model
 class _JsonModel(models.Model):
-    objects = CTEManager()
+    pass

--- a/uv.lock
+++ b/uv.lock
@@ -1295,11 +1295,14 @@ wheels = [
 
 [[package]]
 name = "django-cte"
-version = "1.3.2"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/d0/3cb605946f38a44f0b956892fa5f3d7485c3f5b20a0bb2e6ac66016141f9/django-cte-1.3.2.tar.gz", hash = "sha256:841b264f83417d421393c8c4644f76300962c6c3ddbc37339cf99672eb3696a2", size = 10374, upload-time = "2023-11-21T13:40:26.173Z" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/0c/c305d220c683fb69ccea94f3270a34b8eb8c4d8bdddd425f1d49608fc516/django_cte-2.0.0.tar.gz", hash = "sha256:24674655be4eaa1b091c19f256da7c2b134aa37a59914c6f902448139fe5d76a", size = 11216, upload-time = "2025-06-16T15:29:28.477Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/1f/896a48e4a18e4ca1c1f8a50daa1a1c3535f3a5134a81a3a71454f25e7ef6/django_cte-1.3.2-py2.py3-none-any.whl", hash = "sha256:9ca0a900df4819bbe86447a594f27272d67069f3ef13da61e905b0ace67704e9", size = 11340, upload-time = "2023-11-21T13:40:24.265Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/88/2f3510961fbfabe1441e69783ccca197a129a9705c539aaf019bf6d9fba5/django_cte-2.0.0-py3-none-any.whl", hash = "sha256:6de54525be8d9c8bd3d0a2d0422a733295f501bca0ae1c9351cf314d376e0111", size = 12975, upload-time = "2025-06-16T15:29:27.465Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The new version supports Django 5.2 and has new usage patterns. The second commit eliminates deprecated API usage.

## Safety Assurance

### Safety story

The changes are fairly mechanical. Our usage of django-cte, as well as the library itself, has good test coverage.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations