### PR TITLE
AI Guidelines file

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,0 +1,1 @@
+../ai_guidelines.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+ai_guidelines.md

--- a/ai_guidelines.md
+++ b/ai_guidelines.md
@@ -31,9 +31,8 @@ codebase. These guidelines apply in the following circumstances:
 
 ## Tech Stack
 
-- Backend: Python 3.9, Django 4.2
-- Frontend: JavaScript (ECMAScript 2015 (ES6)), HTMX, Alpine.js, Knockout.js
-  (legacy)
+- Backend: Python, Django
+- Frontend: JavaScript, HTMX, Alpine.js, Knockout.js (legacy)
 - Databases: PostgreSQL, Elasticsearch, CouchDB (legacy)
 - Asynchronous task queue: Celery
 - Cache & message broker: Redis

--- a/ai_guidelines.md
+++ b/ai_guidelines.md
@@ -14,25 +14,19 @@ codebase. These guidelines apply in the following circumstances:
 
 ## Communication
 
-### For the AI Assistant
-
-- The AI Assistant should maintain professional, focused communication.
 - The AI Assistant should ask clarifying questions whenever details are unclear,
   or choices are not obvious.
 - When appropriate, the AI Assistant should make recommendations on how the
   Developer can improve their prompt to get a more effective response.
 
-### For the Developer
-
-- The Developer should provide feedback to the AI Assistant to improve future
-  responses.
-- The Developer should update this document to assist the AI Assistant across
-  sessions, and to improve the interactions of other Developers.
-
 ## Tech Stack
 
 - Backend: Python, Django
-- Frontend: JavaScript, HTMX, Alpine.js, Knockout.js (legacy)
+- Python dependency management: uv
+- Testing: pytest
+- Linting & formatting: Flake8, isort, YAPF
+- Frontend: JavaScript, HTMX, Alpine.js, Knockout.js (legacy), Bootstrap
+- JavaScript bundling & dependency management: Webpack, Yarn
 - Databases: PostgreSQL, Elasticsearch, CouchDB (legacy)
 - Asynchronous task queue: Celery
 - Cache & message broker: Redis
@@ -43,17 +37,20 @@ codebase. These guidelines apply in the following circumstances:
 
 ### Code Clarity
 
-- Is the code readable and well-structured?
-- Does it follow codebase conventions?
-- Are there any potential bugs or edge cases?
+- Code should be readable and well-structured.
+- Code should follow the conventions used in the rest of the module.
+- When writing or reviewing code, consider any potential bugs or edge cases.
 - Keep functions and methods focused on a single responsibility. Break up
   longer functions where appropriate.
 
 ### Performance
 
-- Are there any potential performance bottlenecks?
-- For database operations, are queries optimized?
-- For front-end code, are there rendering or loading concerns?
+- Consider potential performance bottlenecks.
+- For database operations, queries should be optimized. In rare instances this
+  could require the Developer to test the performance of the query in an
+  environment similar to production. If the AI Assistant is writing code, then
+  notify the Developer when this would be beneficial.
+- For front-end code, be mindful of rendering or loading concerns.
 
 ### Maintainability
 
@@ -70,19 +67,19 @@ codebase. These guidelines apply in the following circumstances:
 
 ### Security
 
-- Are there any security vulnerabilities?
-- Is user input properly validated and sanitized?
-- Are permissions and access controls properly implemented?
+- Always consider security vulnerabilities.
+- Ensure that user input is properly validated and sanitized.
+- Ensure that permissions and access controls are properly implemented.
 
 ### Testing
 
-- Are there appropriate tests for the changes?
-- Do the tests cover edge cases and failure scenarios?
-- Are the tests clear and maintainable?
-- Are doctests tested?
-- Run the test suite before submitting changes
+- Changes must be covered by appropriate tests.
+- Tests need to cover edge cases and failure scenarios.
+- Tests should be clear and maintainable.
+- Doctests should be tested.
+- Run the tests that cover the changes before considering any changes complete.
 - Use pytest features and pytest conventions, like Pythonic `assert`
-  statements, and parametrized tests for repetitive parameter values.
+  statements, and parametrized tests for repetitive test cases.
 - Use [pytest-unmagic][1] for explicit test fixtures.
 
 [1]: https://github.com/dimagi/pytest-unmagic/blob/main/README.md#usage

--- a/ai_guidelines.md
+++ b/ai_guidelines.md
@@ -1,0 +1,140 @@
+# Guidelines for CommCare HQ
+
+This document outlines recommended practices for working with the CommCare HQ
+codebase. These guidelines apply in the following circumstances:
+
+- Reviewing code or suggesting changes
+- Writing code and making changes
+- Assisting with version control
+
+## General Principles
+
+- Focus on clarity, maintainability, and performance
+- Consider both immediate needs and long-term implications
+
+## Communication
+
+### For the AI Assistant
+
+- The AI Assistant should maintain professional, focused communication.
+- The AI Assistant should ask clarifying questions whenever details are unclear,
+  or choices are not obvious.
+- When appropriate, the AI Assistant should make recommendations on how the
+  Developer can improve their prompt to get a more effective response.
+
+### For the Developer
+
+- The Developer should provide feedback to the AI Assistant to improve future
+  responses.
+- The Developer should update this document to assist the AI Assistant across
+  sessions, and to improve the interactions of other Developers.
+
+## Tech Stack
+
+- Backend: Python 3.9, Django 4.2
+- Frontend: JavaScript (ECMAScript 2015 (ES6)), HTMX, Alpine.js, Knockout.js
+  (legacy)
+- Databases: PostgreSQL, Elasticsearch, CouchDB (legacy)
+- Asynchronous task queue: Celery
+- Cache & message broker: Redis
+- Stream processing: Kafka
+- Version Control: Git
+
+## Writing and Reviewing Code
+
+### Code Clarity
+
+- Is the code readable and well-structured?
+- Does it follow codebase conventions?
+- Are there any potential bugs or edge cases?
+- Keep functions and methods focused on a single responsibility. Break up
+  longer functions where appropriate.
+
+### Performance
+
+- Are there any potential performance bottlenecks?
+- For database operations, are queries optimized?
+- For front-end code, are there rendering or loading concerns?
+
+### Maintainability
+
+- Have comments or docstrings that are affected by the change been updated?
+- Document complex logic, algorithms, and business rules.
+- Not all functions, classes and methods ought to have docstrings. Where
+  functionality is not obvious just from the name, a docstring should be
+  present and helpful. For usage examples, include one, or at most two, short
+  doctests where appropriate.
+- Comments should explain "why" rather than "what": As much as possible,
+  "what" should be clear from the code.
+- Keep module README files and project documentation under `docs/`
+  up-to-date.
+
+### Security
+
+- Are there any security vulnerabilities?
+- Is user input properly validated and sanitized?
+- Are permissions and access controls properly implemented?
+
+### Testing
+
+- Are there appropriate tests for the changes?
+- Do the tests cover edge cases and failure scenarios?
+- Are the tests clear and maintainable?
+- Are doctests tested?
+- Run the test suite before submitting changes
+- Use pytest features and pytest conventions, like Pythonic `assert`
+  statements, and parametrized tests for repetitive parameter values.
+- Use [pytest-unmagic][1] for explicit test fixtures.
+
+[1]: https://github.com/dimagi/pytest-unmagic/blob/main/README.md#usage
+
+## Codebase Conventions & Coding Guides
+
+- The JavaScript Guide is documented under the `docs/js-guide/` directory.
+
+- Python is _optionally_ formatted using **yapf**:
+
+  ```shell
+  source .venv/bin/activate
+  yapf -i example/path/filename.py
+  ```
+
+  AI Tool and Developer discretion is required:
+
+  - A line length of 115 is enforced. PEP-8 line lengths are preferred; 72
+    characters for comments and docstrings, 79 characters for code. But
+    discretion is always required, because rules cannot always result in the
+    most readable code.
+
+  - Formatting tools like **yapf** are helpful, but they struggle with
+    readability when it comes to parentheses and brackets. For example,
+
+    **yapf** (less readable):
+    ```python
+    repeat_records = (
+        self.get_queryset().filter(is_paused=False
+                                  ).filter(next_attempt_at__lte=timezone.now()
+                                          ).filter(repeat_records__state__in=RECORD_QUEUED_STATES)
+    )
+    ```
+
+    **Developer** (more readable):
+    ```python
+    repeat_records = (
+        self.get_queryset()
+        .filter(is_paused=False)
+        .filter(next_attempt_at__lte=timezone.now())
+        .filter(repeat_records__state__in=RECORD_QUEUED_STATES)
+    )
+    ```
+
+    The AI Assistant should prioritize readability over rules and the output of
+    formatting tools.
+
+## Version Control
+
+- When changes are ready to be committed, the changes should be broken into
+  logical steps to make reviewing easier. Each step should be staged with a
+  suggested commit message that summarizes the step.
+- The AI Assistant should leave it to the developer to commit the staged
+  changes, and to sign the commit if applicable.

--- a/ai_guidelines.md
+++ b/ai_guidelines.md
@@ -9,8 +9,11 @@ codebase. These guidelines apply in the following circumstances:
 
 ## General Principles
 
-- Focus on clarity, maintainability, and performance
-- Consider both immediate needs and long-term implications
+- Clarity, maintainability and performance are important. Prioritize clarity
+  and maintainability higher than performance. Situations where performance
+  must come at the cost of clarity or maintainability should be documented
+  using comments.
+- Consider both immediate needs and long-term implications.
 
 ## Communication
 
@@ -25,7 +28,8 @@ codebase. These guidelines apply in the following circumstances:
 - Python dependency management: uv
 - Testing: pytest
 - Linting & formatting: Flake8, isort, YAPF
-- Frontend: JavaScript, HTMX, Alpine.js, Knockout.js (legacy), Bootstrap
+- Frontend: JavaScript, HTMX, Alpine.js, Knockout.js (legacy), Bootstrap 5
+  (Bootstrap 3 for legacy code)
 - JavaScript bundling & dependency management: Webpack, Yarn
 - Databases: PostgreSQL, Elasticsearch, CouchDB (legacy)
 - Asynchronous task queue: Celery
@@ -42,6 +46,10 @@ codebase. These guidelines apply in the following circumstances:
 - When writing or reviewing code, consider any potential bugs or edge cases.
 - Keep functions and methods focused on a single responsibility. Break up
   longer functions where appropriate.
+- Don't repeat yourself (DRY). If you suspect that similar code might have been
+  needed before, search the codebase for if before implementing it. If you find
+  functionality similar to what you are looking for, you may need to move it to
+  keep architectural layers or Django app dependencies structured well.
 
 ### Performance
 
@@ -54,7 +62,7 @@ codebase. These guidelines apply in the following circumstances:
 
 ### Maintainability
 
-- Have comments or docstrings that are affected by the change been updated?
+- Update comments and docstrings affected by incoming changes.
 - Document complex logic, algorithms, and business rules.
 - Not all functions, classes and methods ought to have docstrings. Where
   functionality is not obvious just from the name, a docstring should be
@@ -70,6 +78,9 @@ codebase. These guidelines apply in the following circumstances:
 - Always consider security vulnerabilities.
 - Ensure that user input is properly validated and sanitized.
 - Ensure that permissions and access controls are properly implemented.
+- Where a destructive action, like deleting an instance of an important class,
+  could have strong negative consequences, rather choose a less permanent
+  action, like disabling the instance instead.
 
 ### Testing
 


### PR DESCRIPTION
## Technical Summary

This PR adds a guidelines file for AI Assistants.

It was inspired by `CLAUDE.md` in the open-chat-studio repo. It was written in collaboration with Junie. Junie's suggestions and feedback turned out to be a lot less specific than the content of open-chat-studio's `CLAUDE.md`. I found that interesting, but I kept Junie's more general approach. (Also interesting was that Junie repeatedly suggested content intended for the developer, which I have kept.)

The PR also adds symlinks to the file for Claude and Junie. ( :blowfish: Review by commit.)

Cursor uses multiple rules files, for different contexts (e.g. rules for Python, rules for JavaScript, etc.) so this file would not be appropriate for Cursor.

I am keen to hear feedback on whether this file is useful to other developers.

I am cautiously curious to hear feedback on the content of the file. (I have found that my Python style is in some cases more conservative than other HQ devs, but that might do well for an AI Assistant because the style is the least likely to offend. My approach to commits by AI agents is also more conservative than some developers.)

## Safety Assurance

### Safety story

A documentation-only change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
