### PR TITLE
Remove support for v3 bitly

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4452,18 +4452,15 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
 
     def generate_shortened_url(self, view_name, build_profile_id=None):
         try:
-            if bitly.BITLY_CONFIGURED:
-                view_url = reverse(view_name, args=[self.domain, self._id])
-                if build_profile_id is not None:
-                    long_url = urljoin(
-                        self.url_base,
-                        f'{view_url}?profile={build_profile_id}'
-                    )
-                else:
-                    long_url = urljoin(self.url_base, view_url)
-                shortened_url = bitly.shorten(long_url)
+            view_url = reverse(view_name, args=[self.domain, self._id])
+            if build_profile_id is not None:
+                long_url = urljoin(
+                    self.url_base,
+                    f'{view_url}?profile={build_profile_id}'
+                )
             else:
-                shortened_url = None
+                long_url = urljoin(self.url_base, view_url)
+            shortened_url = bitly.shorten(long_url)
         except Exception:
             logging.exception("Problem creating bitly url for app %s. Do you have network?" % self.get_id)
         else:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
As far as I can tell Bitly's v3 API is no longer supported/functional. This seems pretty safe to remove. I confirmed that all of our envs don't have `BITLY_LOGIN` or `BITLY_APIKEY` set to anything.

I also got rid of the BITLY_CONFIGURED var and just had `shorten` return None if `BITLY_OAUTH_TOKEN` isn't set.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The blast radius of this change is app installs via app codes (not QR codes). There is a workaround if this does break, but realistically this shouldn't change anything.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Not that I'm aware of.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No, I'll test on staging to make sure app codes still code.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
