### PR TITLE
Show confirmation and send prepayment invoice when renewing to Pay Annually

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -316,6 +316,14 @@ class DomainWireInvoiceFactory(object):
             date_due=date_due,
         )
 
+    def create_subscription_credits_invoice(self, plan_version, date_start, date_end, date_due):
+        label = f"One month of {plan_version.plan.name}"
+        monthly_fee = plan_version.product_rate.monthly_fee
+        duration = relativedelta(date_end, date_start)
+        num_months = duration.years * 12 + duration.months
+        amount = monthly_fee * num_months
+        self.create_wire_credits_invoice(amount, label, monthly_fee, num_months, date_due=date_due)
+
     def create_prorated_subscription_change_credits_invoice(self, old_date_start, new_date_start, date_end,
                                                             old_plan_version, new_plan_version, date_due):
         old_monthly_fee = old_plan_version.product_rate.monthly_fee

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -999,6 +999,7 @@ class SoftwarePlanVersion(models.Model):
                        'included': 'Infinite' if r.monthly_limit == UNLIMITED_FEATURE_USAGE else r.monthly_limit}
                       for r in self.feature_rates.all()],
             'edition': self.plan.edition,
+            'is_annual_plan': self.plan.is_annual_plan,
         })
         return desc
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1,5 +1,6 @@
 import datetime
 import itertools
+from dateutil.relativedelta import relativedelta
 from decimal import Decimal
 from io import BytesIO
 from tempfile import NamedTemporaryFile
@@ -30,6 +31,7 @@ from dimagi.utils.web import get_site_domain
 
 from corehq.apps.accounting.const import (
     EXCHANGE_RATE_DECIMAL_PLACES,
+    PAY_ANNUALLY_SUBSCRIPTION_MONTHS,
     SMALL_INVOICE_THRESHOLD,
 )
 from corehq.apps.accounting.emails import (
@@ -1625,7 +1627,7 @@ class Subscription(models.Model):
             )
 
         if new_version.plan.is_annual_plan:
-            new_date_end = self.date_end.replace(year=self.date_end.year + 1)
+            new_date_end = self.date_end + relativedelta(months=PAY_ANNUALLY_SUBSCRIPTION_MONTHS)
         else:
             new_date_end = None
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -2003,13 +2003,8 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
                 self.current_subscription.plan_version, self.plan_version, date_due,
             )
         else:
-            label = f"One month of {self.plan_version.plan.name}"
-            monthly_fee = self.plan_version.product_rate.monthly_fee
-            duration = relativedelta(date_end, new_date_start)
-            num_months = duration.years * 12 + duration.months
-            amount = monthly_fee * num_months
-            invoice_factory.create_wire_credits_invoice(
-                amount, label, monthly_fee, num_months, date_due
+            invoice_factory.create_subscription_credits_invoice(
+                self.plan_version, new_date_start, date_end, date_due
             )
 
     def new_subscription_start_end_dates(self):
@@ -2143,13 +2138,8 @@ class ConfirmSubscriptionRenewalForm(EditBillingAccountInfoForm):
         )
         date_due = max(date_start,
                        datetime.date.today() + datetime.timedelta(days=SUBSCRIPTION_PREPAY_MIN_DAYS_UNTIL_DUE))
-        label = f"One month of {self.plan_version.plan.name}"
-        monthly_fee = self.plan_version.product_rate.monthly_fee
-        duration = relativedelta(date_end, date_start)
-        num_months = duration.years * 12 + duration.months
-        amount = monthly_fee * num_months
-        invoice_factory.create_wire_credits_invoice(
-            amount, label, monthly_fee, num_months, date_due
+        invoice_factory.create_subscription_credits_invoice(
+            self.renewed_version, date_start, date_end, date_due
         )
 
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1856,6 +1856,12 @@ class EditBillingAccountInfoForm(forms.ModelForm):
     def clean_email_list(self):
         return self.data.getlist('email_list')
 
+    def get_email_lists(self):
+        email_list = self.clean_email_list()
+        contact_email = email_list[:1]
+        cc_emails = email_list[1:]
+        return contact_email, cc_emails
+
     # Does not use the commit kwarg.
     # TODO - Should support it or otherwise change the function name
     @transaction.atomic
@@ -1983,9 +1989,7 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
             return False
 
     def send_prepayment_invoice(self, new_date_start, date_end):
-        email_list = self.cleaned_data['email_list']
-        contact_emails = [email_list[0]]
-        cc_emails = [email for email in email_list[1:]]
+        contact_emails, cc_emails = self.get_email_lists()
         invoice_factory = DomainWireInvoiceFactory(
             self.domain, date_start=new_date_start, date_end=date_end,
             contact_emails=contact_emails, cc_emails=cc_emails
@@ -2132,9 +2136,7 @@ class ConfirmSubscriptionRenewalForm(EditBillingAccountInfoForm):
             return False
 
     def send_prepayment_invoice(self, date_start, date_end):
-        email_list = self.cleaned_data['email_list']
-        contact_emails = [email_list[0]]
-        cc_emails = [email for email in email_list[1:]]
+        contact_emails, cc_emails = self.get_email_lists()
         invoice_factory = DomainWireInvoiceFactory(
             self.domain, date_start=date_start, date_end=date_end,
             contact_emails=contact_emails, cc_emails=cc_emails

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -47,10 +47,7 @@ from memoized import memoized
 from PIL import Image
 
 from corehq import privileges
-from corehq.apps.accounting.const import (
-    PAY_ANNUALLY_SUBSCRIPTION_MONTHS,
-    SUBSCRIPTION_PREPAY_MIN_DAYS_UNTIL_DUE,
-)
+from corehq.apps.accounting.const import PAY_ANNUALLY_SUBSCRIPTION_MONTHS
 from corehq.apps.accounting.exceptions import SubscriptionRenewalError
 from corehq.apps.accounting.invoicing import DomainWireInvoiceFactory
 from corehq.apps.accounting.models import (
@@ -1994,18 +1991,13 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
             self.domain, date_start=new_date_start, date_end=date_end,
             contact_emails=contact_emails, cc_emails=cc_emails
         )
-        date_due = max(new_date_start,
-                       datetime.date.today() + datetime.timedelta(days=SUBSCRIPTION_PREPAY_MIN_DAYS_UNTIL_DUE))
-
         if self.current_is_annual_plan():
             invoice_factory.create_prorated_subscription_change_credits_invoice(
                 self.current_subscription.date_start, new_date_start, date_end,
-                self.current_subscription.plan_version, self.plan_version, date_due,
+                self.current_subscription.plan_version, self.plan_version,
             )
         else:
-            invoice_factory.create_subscription_credits_invoice(
-                self.plan_version, new_date_start, date_end, date_due
-            )
+            invoice_factory.create_subscription_credits_invoice(self.plan_version, new_date_start, date_end)
 
     def new_subscription_start_end_dates(self):
         if self.is_downgrade_from_paid_plan() and self.current_subscription.is_below_minimum_subscription:
@@ -2136,11 +2128,7 @@ class ConfirmSubscriptionRenewalForm(EditBillingAccountInfoForm):
             self.domain, date_start=date_start, date_end=date_end,
             contact_emails=contact_emails, cc_emails=cc_emails
         )
-        date_due = max(date_start,
-                       datetime.date.today() + datetime.timedelta(days=SUBSCRIPTION_PREPAY_MIN_DAYS_UNTIL_DUE))
-        invoice_factory.create_subscription_credits_invoice(
-            self.renewed_version, date_start, date_end, date_due
-        )
+        invoice_factory.create_subscription_credits_invoice(self.renewed_version, date_start, date_end)
 
 
 class ProBonoForm(forms.Form):

--- a/corehq/apps/domain/templates/domain/bootstrap3/confirm_subscription_renewal.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/confirm_subscription_renewal.html
@@ -26,6 +26,22 @@
         <h4>Note: You are renewing to a different plan</h4>
         <p>The new plan will take effect on <strong>{{ start_date }}</strong> and will cost <strong>{{ monthly_fee }}</strong>/month.</p>
       {% endblocktrans %}
+      {% if next_plan.is_annual_plan %}
+        {% blocktrans %}
+          <p>
+            By continuing you are renewing to a Pay Annually plan and will
+            receive an invoice via email for plan fees due. <br />
+            In case you incur any on-demand fees for excess users or SMS, you
+            will receive invoices for these charges on a monthly basis. <br />
+            See
+            <a
+              href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Pay-Annually-Subscription"
+              >here</a
+            >
+            for more information about payment, cancellation, and refunds.
+          </p>
+        {% endblocktrans %}
+      {% endif %}
     </div>
   {% endif %}
   <div class="panel panel-modern-gray panel-form-only" id="billing-info">

--- a/corehq/apps/domain/templates/domain/bootstrap5/confirm_subscription_renewal.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/confirm_subscription_renewal.html
@@ -26,6 +26,22 @@
         <h4>Note: You are renewing to a different plan</h4>
         <p>The new plan will take effect on <strong>{{ start_date }}</strong> and will cost <strong>{{ monthly_fee }}</strong>/month.</p>
       {% endblocktrans %}
+      {% if next_plan.is_annual_plan %}
+        {% blocktrans %}
+          <p>
+            By continuing you are renewing to a Pay Annually plan and will
+            receive an invoice via email for plan fees due. <br />
+            In case you incur any on-demand fees for excess users or SMS, you
+            will receive invoices for these charges on a monthly basis. <br />
+            See
+            <a
+              href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Pay-Annually-Subscription"
+              >here</a
+            >
+            for more information about payment, cancellation, and refunds.
+          </p>
+        {% endblocktrans %}
+      {% endif %}
     </div>
   {% endif %}
   <div class="card card-modern-gray card-form-only" id="billing-info">  {# todo B5: css-panel #}

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from unittest.mock import Mock, patch
 
 from django.test import SimpleTestCase, TestCase
@@ -353,7 +353,7 @@ class TestConfirmSubscriptionRenewalForm(BaseTestSubscriptionForm):
     def setUp(self):
         super().setUp()
         self.subscription = generator.generate_domain_subscription(
-            self.account, self.domain, datetime.today(), datetime.today() + timedelta(days=7), is_active=True
+            self.account, self.domain, date.today(), date.today() + timedelta(days=7), is_active=True
         )
 
     def create_form(self, new_plan_version, **kwargs):

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -387,3 +387,20 @@ class TestConfirmSubscriptionRenewalForm(BaseTestSubscriptionForm):
         self.assertTrue(form.is_valid())
         self.assertTrue(self.subscription.is_renewed)
         self.assertEqual(self.subscription.next_subscription.plan_version, next_plan_version)
+
+    def test_pay_annually_creates_prepayment_invoice(self):
+        next_plan_version = DefaultProductPlan.get_default_plan_version(
+            edition=SoftwarePlanEdition.STANDARD, is_annual_plan=True
+        )
+        form = self.create_form_for_submission(next_plan_version)
+        form.save()
+        self.assertTrue(form.is_valid())
+
+        prepayment_invoice = WirePrepaymentInvoice.objects.get(domain=self.domain.name)
+        next_subscription = self.subscription.next_subscription
+        self.assertEqual(prepayment_invoice.date_start, next_subscription.date_start)
+        self.assertEqual(prepayment_invoice.date_end, next_subscription.date_end)
+        self.assertEqual(prepayment_invoice.date_due,
+                         date.today() + timedelta(days=SUBSCRIPTION_PREPAY_MIN_DAYS_UNTIL_DUE))
+        self.assertEqual(prepayment_invoice.balance,
+                         next_plan_version.product_rate.monthly_fee * PAY_ANNUALLY_SUBSCRIPTION_MONTHS)

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_subscription_renewal.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/confirm_subscription_renewal.html.diff.txt
@@ -12,8 +12,8 @@
  
  {% block plan_breadcrumbs %}{% endblock %}
  
-@@ -28,9 +28,9 @@
-       {% endblocktrans %}
+@@ -44,9 +44,9 @@
+       {% endif %}
      </div>
    {% endif %}
 -  <div class="panel panel-modern-gray panel-form-only" id="billing-info">


### PR DESCRIPTION
## Product Description
Makes renewals to Pay Annually plans more consistent with signups for Pay Annually plans by 
- showing a confirmation message about Pay Annually invoicing:
![image](https://github.com/user-attachments/assets/224fdf2a-9820-4819-9a80-b0a738164c02)

- automatically generating and sending a prepayment invoice when a customer renews to a Pay Annually software plan


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17639
Adds a step in the `ConfirmSubscriptionRenewalForm` during `save()` to generate and send a prepayment invoice, if the new plan is a Pay Annually plan. Adds a blurb in the confirm_subscription_renewal.html template with wording similar to what exists for Pay Annually signups. Also refactors some of the underlying code for DRYness and consistency between forms.

## Safety Assurance

### Safety story
Tested locally to see that renewals to Pay Annually plans still work, the confirmation message is shown when expected, and the prepayment invoice is generated and emailed as expected. Existing automated tests for the ConfirmNewSubscriptionForm and ConfirmSubscriptionRenewalForm help protect against regression.

### Automated test coverage
TestConfirmNewSubscriptionForm, TestConfirmSubscriptionRenewalForm -- added a test case in the latter to see that the prepayment invoice is generated when expected.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
