### PR TITLE
Don't hardcode mobile worker username validation

### DIFF
--- a/corehq/apps/users/tests/test_username_validation.py
+++ b/corehq/apps/users/tests/test_username_validation.py
@@ -9,6 +9,7 @@ from corehq.apps.users.validation import (
 )
 
 
+@override_settings(HQ_ACCOUNT_ROOT="commcarehq.org")
 class TestMobileUsernameValidation(TestCase):
 
     @classmethod
@@ -67,6 +68,7 @@ class TestMobileUsernameValidation(TestCase):
                          "Username 'retired@test-domain.commcarehq.org' is already taken or reserved.")
 
 
+@override_settings(HQ_ACCOUNT_ROOT="commcarehq.org")
 class TestValidateCompleteUsername(SimpleTestCase):
 
     def test_no_exception_raised_if_valid_email(self):

--- a/corehq/apps/users/tests/test_username_validation.py
+++ b/corehq/apps/users/tests/test_username_validation.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
@@ -97,3 +97,11 @@ class TestValidateCompleteUsername(SimpleTestCase):
 
         self.assertEqual(cm.exception.message,
                          "The username email domain '@domain2.commcarehq.org' should be '@domain.commcarehq.org'.")
+
+    @override_settings(HQ_ACCOUNT_ROOT="example.com")
+    def test_exception_raised_if_incorrect_account_root(self):
+        with self.assertRaises(ValidationError) as cm:
+            _validate_complete_username('user@domain.commcarehq.org', 'domain')
+
+        self.assertEqual(cm.exception.message,
+                         "The username email domain '@domain.commcarehq.org' should be '@domain.example.com'.")

--- a/corehq/apps/users/validation.py
+++ b/corehq/apps/users/validation.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.utils.translation import gettext as _
 
-from corehq.apps.users.util import is_username_available
+from corehq.apps.users.util import cc_user_domain, is_username_available
 from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.util import get_locations_from_ids
@@ -43,7 +43,7 @@ def _validate_complete_username(username, domain):
                 email_username, username)
         )
 
-    expected_domain = f"{domain}.commcarehq.org"
+    expected_domain = cc_user_domain(domain)
     if email_domain != expected_domain:
         raise ValidationError(
             _("The username email domain '@{}' should be '@{}'.").format(email_domain, expected_domain))


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
HQ_ACCOUNT_ROOT is used to determine the email domain for mobile workers, so not all environments will have {domain}.commcarehq.org. This change uses the same function we use when creating the username to obtain the domain for the mobile worker username, and this validation is useful for workers created via the API.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Straightforward change and added a test to ensure this behaves as expected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
