### PR TITLE
Add afterEach to eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
         "it": false,
         "describe": false,
         "beforeEach": false,
+        "afterEach": false,
         "nv": false,
         "d3": false,
     },


### PR DESCRIPTION
## Product Description
Relevant to dev only.

## Technical Summary
Prevents lint errors [like this](https://github.com/dimagi/commcare-hq/actions/runs/15836484500/job/44641024022) for `afterEach` not being a valid identifier. Along with `it`, `describe`, and `beforeEach`, `afterEach` is a valid global identifier in the context of Mocha tests, so adding it here has it treated the same way.

## Safety Assurance

### Safety story
Small change to linter config only, nothing dangerous here.

### Automated test coverage
Not for the config itself, but will stop `afterEach` used in tests from being flagged by eslint.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
