### PR TITLE
Style web apps checkbox and radio inputs correctly when printing

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/form.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/form.scss
@@ -172,6 +172,18 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
     color: #52616f !important;
     font-size: 14px;
   }
+
+  input.form-check-input:checked {
+    background-color: $primary !important;
+
+    &[type="checkbox"] {
+      background-image: #{escape-svg($form-check-input-checked-bg-image)} !important;
+    }
+
+    &[type="radio"] {
+      background-image: #{escape-svg($form-check-radio-checked-bg-image)} !important;
+    }
+  }
 }
 
 .question-tile-row:has(div.q) {

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/form.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/form.scss
@@ -2,8 +2,8 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
 
 .form-container {
   background-color: white;
-  box-shadow: 0 0 10px 2px rgba(0,0,0,.1);
-  font-size: $form-text-size;   // Don't overshadow inputs
+  box-shadow: 0 0 10px 2px rgba(0, 0, 0, 0.1);
+  font-size: $form-text-size; // Don't overshadow inputs
 
   .page-header h1 {
     padding-left: $form-text-indent - 8px;
@@ -13,7 +13,8 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
     padding-top: 3px;
   }
 
-  .form-control, .form-select {
+  .form-control,
+  .form-select {
     font-size: $form-text-size;
   }
 
@@ -67,7 +68,6 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
       &:hover {
         background-color: var(--bsbtn-hover-bg);
       }
-
     }
   }
 
@@ -75,7 +75,6 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
     border-top-left-radius: 0px;
     border-top-right-radius: 0px;
   }
-
 }
 
 .has-debugger {
@@ -97,7 +96,7 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
   }
 
   .q.required {
-    transition: all .5s;
+    transition: all 0.5s;
     margin-bottom: 0;
     label:before {
       display: none;
@@ -120,7 +119,7 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
   .form-group-required-label {
     display: block;
     opacity: 0;
-    transition: all .5s;
+    transition: all 0.5s;
   }
 
   .form-group-required-label.on {
@@ -137,7 +136,6 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
     margin-top: 0;
     border: none;
   }
-
 }
 
 @media print {
@@ -194,7 +192,9 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
 .question-tile-row {
   display: flex;
   align-items: start;
-  * .q, * p, * .caption {
+  * .q,
+  * p,
+  * .caption {
     padding-top: 0px !important;
     padding-bottom: 0px !important;
     margin-top: 0px !important;
@@ -202,8 +202,10 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
   }
 }
 
-.checkbox, .radio {
-  input[type="checkbox"], input[type="radio"] {
+.checkbox,
+.radio {
+  input[type="checkbox"],
+  input[type="radio"] {
     margin-top: 3.15px;
   }
   // Overrides Bootstrap defaults
@@ -218,8 +220,13 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
 }
 
 .my-05em-for-hs {
-    h1, h2, h3, h4, h5, h6 {
-        margin-top: 0.5em !important;
-        margin-bottom: 0.5em !important;
-    }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-top: 0.5em !important;
+    margin-bottom: 0.5em !important;
+  }
 }


### PR DESCRIPTION
## Product Description
When printing forms in web apps, makes the appearance of checkbox and radio buttons match what appears in the browser.
Before:
![image](https://github.com/user-attachments/assets/901c6661-1479-4a7a-8b48-c1ae34adf88e)
![image](https://github.com/user-attachments/assets/49670675-a926-4bc5-adf7-4e8ac2cce418)

After:
![image](https://github.com/user-attachments/assets/5e9fc5bf-558a-49a4-b769-8beece084473)
![image](https://github.com/user-attachments/assets/4fdc3717-632e-4cf0-a388-c964dd82cfe2)


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17666
When printed, background colors and images, but not border colors get stripped from these inputs – even with “Background graphics” checked in the print options. If applied explicitly with `!important`, these styles are retained when printing.

## Safety Assurance

### Safety story
This is just a styling change (plus a little auto-formatting of a stylesheet file). The scope of the style change is quite limited, so the only effects would be seen on `<input>` elements with the `form-check-input` class, only when `:checked`, and only while printing (`@media print` surrounds the new style). Checked locally and on staging that styles are applied correctly.

### Automated test coverage
Nada

### QA Plan
Nope.


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
