### PR TITLE
Skip syncing RemoteApp to Data Dictionary

### DIFF
--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -93,6 +93,11 @@ def refresh_data_dictionary_from_app(domain, app_id):
         # If there's no app in the domain, there's nothing to do
         return
 
+    # RemoteApp does not implement get_modules()/get_forms() (would raise AttributeError).
+    # As RemoteApp has not been actively used since 2016, it's safe to skip syncing it.
+    if app.is_remote_app():
+        return
+
     from corehq.apps.app_manager.util import actions_use_usercase
     from corehq.apps.data_dictionary.util import create_properties_for_case_types
     from corehq.apps.data_cleaning.utils.cases import clear_caches_case_data_cleaning


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17717

This PR fixes an AttributeError when running the `refresh_data_dictionary_from_app task` for RemoteApp.

**Context**
The `refresh_data_dictionary_from_app` task attempts to extract case types and case properties by calling `get_modules()` and `get_forms()` on the application object. However, `RemoteApp` class does not implement these methods — they are only available on the `Application` class. As a result, when the task encounters a RemoteApp, it raises an AttributeError.

**Decision**
Instead of adding special handling to support syncing RemoteApp to Data Dictionary, I propose to simply skip syncing RemoteApp entirely for the following reasons:
- Based on a review of Sentry events, all existing events related to this error are from the domain cory.
- I ran a shell query to check how many RemoteApp documents exist and when they were last built. The query shows that we have 774 RemoteApp documents, but the most recent one was last built in May 2016. This suggests that RemoteApp is rarely used by customers anymore and is likely deprecated in practice.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The change only skips syncing RemoteApp apps to Data Dictionary, which have not been actively used since 2016. Existing data and active app types are not affected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
