### PR TITLE
Use ignore_conflicts=True when bulk creating CaseProperty

### DIFF
--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -107,7 +107,7 @@ def create_properties_for_case_types(domain, case_type_to_prop):
                     case_type=case_type_obj, name=prop
                 ))
 
-    CaseProperty.objects.bulk_create(new_case_properties)
+    CaseProperty.objects.bulk_create(new_case_properties, ignore_conflicts=True)
 
     for case_type, props in case_type_to_prop.items():
         if case_type:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17716 ( I left comments under ticket explaining how I tell this is race condition )

Previously, we manually queried existing case properties before calling bulk_create to avoid inserting duplicates. However, this approach was still vulnerable to race conditions: Between the time we query existing properties and perform the insert, another thread or process may insert the same property.

`ignore_conflicts=True` will skip inserting any rows that would violate uniqueness constraints, while still inserting all other valid rows.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
skipping existing CaseProperty is safe 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
