### PR TITLE
Update info message for user language setting

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -72,7 +72,7 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
 
             if letter_code in CUSTOM_LANGUAGE_NAMES.keys():
                 # These are languages not installed on our machines, so localize does not understand them.
-                # Though we don't want to install these langauges, we still want to support projects
+                # Though we don't want to install these languages, we still want to support projects
                 # who want to see the name written properly.
                 name = CUSTOM_LANGUAGE_NAMES[letter_code]
             else:

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1458,10 +1458,10 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
 
         if not self.user.is_staff:
             self.fields['auto_case_update_limit'].disabled = True
-            self.fields['auto_case_update_limit'].help_text = (
+            self.fields['auto_case_update_limit'].help_text = _(
                 'Case update rule limits are only modifiable by Dimagi admins. '
-                'Please reach out to support@dimagi.com if you wish to update this setting.'
-            )
+                'Please reach out to {support_email} if you wish to update this setting.'
+            ).format(support_email=settings.SUPPORT_EMAIL)
 
     @property
     def current_values(self):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -316,7 +316,7 @@ class BaseUserInfoForm(forms.Form):
         help_text=gettext_lazy(
             "<i class=\"fa fa-info-circle\"></i> "
             "Changes the default language seen in Web Apps and reports (if supported). "
-            "CommCare HQ supports <a href='https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3085697055/Account+Level+CommCare+HQ+UI+Translations'>these langauges</a>. "  # noqa: E501
+            "CommCare HQ supports <a href='https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3085697055/Account+Level+CommCare+HQ+UI+Translations'>these languages</a>. "  # noqa: E501
             "Please reach out to {support_email} if you notice any mistakes in our translations."
         ).format(support_email=settings.SUPPORT_EMAIL),
     )

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -317,8 +317,8 @@ class BaseUserInfoForm(forms.Form):
             "<i class=\"fa fa-info-circle\"></i> "
             "Changes the default language seen in Web Apps and reports (if supported). "
             "CommCare HQ supports <a href='https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3085697055/Account+Level+CommCare+HQ+UI+Translations'>these langauges</a>. "  # noqa: E501
-            f"Please reach out to {settings.SUPPORT_EMAIL} if you notice any mistakes in our translations."
-        ),
+            "Please reach out to {support_email} if you notice any mistakes in our translations."
+        ).format(support_email=settings.SUPPORT_EMAIL),
     )
 
     def load_language(self, language_choices=None):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -315,10 +315,10 @@ class BaseUserInfoForm(forms.Form):
         required=False,
         help_text=gettext_lazy(
             "<i class=\"fa fa-info-circle\"></i> "
-            "Becomes default language seen in Web Apps and reports (if applicable), "
-            "but does not affect mobile applications. "
-            "Supported languages for reports are en, fra (partial), and hin (partial)."
-        )
+            "Changes the default language seen in Web Apps and reports (if supported). "
+            "CommCare HQ supports <a href='https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3085697055/Account+Level+CommCare+HQ+UI+Translations'>these langauges</a>. "  # noqa: E501
+            f"Please reach out to {settings.SUPPORT_EMAIL} if you notice any mistakes in our translations."
+        ),
     )
 
     def load_language(self, language_choices=None):

--- a/docs/translations.rst
+++ b/docs/translations.rst
@@ -285,7 +285,7 @@ Keeping translations up to date
 Once a string has been added to the code, we can update the .po file by
 running `makemessages`.
 
-To do this for all langauges::
+To do this for all languages::
 
         $ django-admin makemessages --all
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
User account level settings
![image](https://github.com/user-attachments/assets/4dc0278b-5dd5-4a16-910b-184b28f000d9)

Mobile worker settings
![image](https://github.com/user-attachments/assets/12ca3ba0-f099-4bc6-a2a2-ecedf3690967)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-17654

This main motivation for this change was to encourage users to reach out to support if they notice any issues with translations. However we also observed that this message was outdated since we now support more languages.

We decided to update the message to link to the list of supported languages. There is a lot of nuance with how this setting is used in reports and web apps, which made it difficult to just change the drop down to only show the list of supported languages unfortunately. See the ticket for more details on that.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally, just a simple text change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
