### PR TITLE
Removed the “Delete” option from the ChangeActionFilter

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -568,7 +568,6 @@ class ChangeActionFilter(BaseMultipleOptionFilter):
         (ALL, gettext_noop('All')),
         (str(UserHistory.CREATE), gettext_noop('Create')),
         (str(UserHistory.UPDATE), gettext_noop('Update')),
-        (str(UserHistory.DELETE), gettext_noop('Delete')),
     ]
     default_options = ['0']
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Technically, deletion actions are still recorded in UserHistory. However, since deleted users no longer exist in the user db, it’s not possible to select them from the User(s) filter. Keeping the “Delete” option in the Action filter could give users the misleading impression that they can view history for deleted users, which currently isn’t fully supported.

Before
![image](https://github.com/user-attachments/assets/1a7ea360-51c0-409b-bf7f-5b02dca93910)

After
<img width="576" alt="image" src="https://github.com/user-attachments/assets/75656420-9bdf-4412-b6a3-5f323cd26f80" />

The “All” option remains, but since deleted users cannot be selected in the User filter, no results will ever be returned for deletion actions. In effect, selecting “All” will only return “Create” and “Update” actions for selectable users.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-16852

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`USER_HISTORY_REPORT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
UI-only change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
