### PR TITLE
Default to showing annual pricing unless on a paid monthly plan

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -42,7 +42,8 @@ const PricingTable = function (options) {
     self.isNextPlanDowngrade = self.nextSubscription && !self.isNextPlanPaused;
 
     self.oSelectedEdition = ko.observable(options.currentEdition);
-    self.oShowAnnualPricing = ko.observable(options.currentIsAnnualPlan);
+    self.oShowAnnualPricing = ko.observable(
+        self.currentIsAnnualPlan || self.isCurrentPlanFreeEdition || self.isCurrentPlanPaused);
 
     self.oIsAnnualPlanSelected = ko.computed(function () {
         return self.oShowAnnualPricing() && self.oSelectedEdition() !== 'paused';


### PR DESCRIPTION
## Product Description
Defaults to "Pay Annually" on the Select Plan page unless a customer is already on a paid monthly plan.
![image](https://github.com/user-attachments/assets/f31348d9-4019-44d9-bdcc-62abc4105ebe)


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17760
Updates logic to default to Pay Annually pricing if currently on a paused or free plan.

## Safety Assurance

### Safety story
This is just a change to the initial value of an observable. Worst case, the initial value would not be correctly set but it is still be responsive to being changed in the UI. Tested locally to confirm this works.

### Automated test coverage
I don't believe so.

### QA Plan
Not planning.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
