### PR TITLE
User-friendly name for bulk case reassignment form

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -398,6 +398,7 @@ class SubmitCaseBlockHandler:
         record_form_callback=None,
         throttle=False,
         add_inferred_props_to_schema=True,
+        form_name=None,
     ):
         """
         Initialize ``SubmitCaseBlockHandler``.
@@ -426,6 +427,7 @@ class SubmitCaseBlockHandler:
         self.add_inferred_props_to_schema = add_inferred_props_to_schema
         self.case_type = case_type
         self.user = user
+        self.form_name = form_name
 
     def add_caseblock(self, caseblock):
         self._unsubmitted_caseblocks.append(caseblock)
@@ -522,6 +524,7 @@ class SubmitCaseBlockHandler:
             # Skip the rate-limiting because this importing code will
             # take care of any rate-limiting
             max_wait=None,
+            form_name=self.form_name,
         )
 
 

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -242,6 +242,7 @@ def bulk_case_reassign_async(domain, user_id, owner_id, download_id, report_url)
         user=user,
         record_form_callback=None,
         throttle=True,
+        form_name="Case Reassignment (via HQ)",
     )
     for idx, case_id in enumerate(case_ids):
         submission_handler.add_caseblock(


### PR DESCRIPTION
Changed for consistency with the other case reassignment workflow, which uses the same human-friendly "Case Reassignment (via HQ)" form name.

## Safety Assurance

### Safety story

Small change to add an optional form name parameter to an internal form submission class and function. Tested that this has the expected outcome via bulk case reassignment on staging.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations