### PR TITLE
ui bug fix: combined multi-choice questions in app preview

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -79,7 +79,7 @@ define("cloudcare/js/form_entry/entries", [
     Entry.prototype.getColStyle = function (numChoices) {
         // Account for number of choices plus column for clear button
         var colWidth = parseInt(12 / (numChoices + 1)) || 1;
-        return 'col-sm-' + colWidth;
+        return 'multi-choice col-sm-' + colWidth;
     };
 
     // This should set the answer value if the answer is valid. If the raw answer is valid, this

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_choice_label.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_choice_label.html
@@ -22,10 +22,13 @@
     <!-- /ko -->
     <!-- ko if: hideLabel -->
       <div data-bind="attr: { 'class': colStyle }">
-        <button class="btn btn-outline-primary btn-sm" data-bind="click: onClear, fadeVisible: rawAnswer()">
+        <button class="btn btn-outline-primary btn-sm multi-choice-clear" data-bind="click: onClear, fadeVisible: rawAnswer()">
           {% trans "Clear" %}
         </button>
       </div>
+    <!-- /ko -->
+    <!-- ko ifnot: hideLabel -->
+      <div class="multi-choice-spacer"></div>
     <!-- /ko -->
   </div>
 </script>

--- a/corehq/apps/hqwebapp/static/preview_app/scss/preview_app/form.scss
+++ b/corehq/apps/hqwebapp/static/preview_app/scss/preview_app/form.scss
@@ -116,7 +116,7 @@
   flex: 1;
   min-width: 0;
   text-align: center;
-  position: relative
+  position: relative;
 }
 
 .multi-choice-spacer {

--- a/corehq/apps/hqwebapp/static/preview_app/scss/preview_app/form.scss
+++ b/corehq/apps/hqwebapp/static/preview_app/scss/preview_app/form.scss
@@ -111,3 +111,23 @@
     padding-right: 5px;
   }
 }
+
+.multi-choice {
+  flex: 1;
+  min-width: 0;
+  text-align: center;
+  position: relative
+}
+
+.multi-choice-spacer {
+  flex: 1;
+}
+
+.multi-choice-clear {
+  width: max-content;
+  max-width: none;
+  transform: translateX(-50%);
+  left: 50%;
+  position: relative;
+  margin: -3px -5px;  // this is a hack to make the button look more centered
+}


### PR DESCRIPTION
## Product Description
This addresses the issue described here: https://dimagi.atlassian.net/browse/SAAS-16500

Previously:
<img width="495" alt="Screenshot 2025-06-27 at 1 11 01 AM" src="https://github.com/user-attachments/assets/e3c484c9-5328-4010-ad5e-10a2c04295ae" />
<img width="504" alt="Screenshot 2025-06-27 at 1 11 10 AM" src="https://github.com/user-attachments/assets/c49b42e3-4b25-4daf-a240-50eeb580a50d" />


After:
<img width="507" alt="Screenshot 2025-06-27 at 1 02 09 AM" src="https://github.com/user-attachments/assets/0918ceb3-59f5-4f37-8448-f034a484d36f" />
<img width="497" alt="Screenshot 2025-06-27 at 1 02 20 AM" src="https://github.com/user-attachments/assets/98501563-6f93-4f03-8f45-dbea25d28755" />


And the non-tablet preview....

Previously:
<img width="293" alt="Screenshot 2025-06-27 at 1 10 29 AM" src="https://github.com/user-attachments/assets/3069cf06-e029-448e-89e0-a899cafcefcc" />
<img width="290" alt="Screenshot 2025-06-27 at 1 10 37 AM" src="https://github.com/user-attachments/assets/55d4431c-70bb-45d0-8614-7ef6d0763ee6" />


After:
<img width="305" alt="Screenshot 2025-06-27 at 1 02 46 AM" src="https://github.com/user-attachments/assets/3e168f37-5a70-49e5-b45e-d4ba6091bfe9" />
<img width="310" alt="Screenshot 2025-06-27 at 1 02 54 AM" src="https://github.com/user-attachments/assets/b0175730-ba95-442e-9147-8800453cf269" />


## Technical Summary
I hate that this is the solution. Unfortunately, because app-previews overrides are so layered, it would be incredibly involved to extract the existing overrides of default `col`/`row` behaviors and not have this poorly affect other question types.  

This fix isolates the solution to the multi-choice question type for app preview, while leaving the current behavior and styling in web apps unaffected.

I tested web apps locally as well with the new changes, and everything looks the same
<img width="1044" alt="Screenshot 2025-06-27 at 1 09 40 AM" src="https://github.com/user-attachments/assets/2db5afc0-ad15-4572-921c-9352f10abed3" />

## Safety Assurance

### Safety story
safe styling change isolated to this question type in app preview only. tested locally in web apps as well

### Automated test coverage
n/a

### QA Plan
not needed

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
