### PR TITLE
Fix group sorting in data dictionary UI

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -44,7 +44,7 @@ var caseType = function (
 
     self.fetchCaseProperties = function () {
         if (self.groups().length === 0) {
-            let caseTypeUrl = self.dataUrl + self.name + '/';
+            const caseTypeUrl = self.dataUrl + self.name + '/';
             recurseChunks(caseTypeUrl);
         }
     };
@@ -139,7 +139,7 @@ var groupsViewModel = function (
                 'label': self.newPropertyName(),
                 'allowedValues': {},
             };
-            let propObj = propertyListItem(
+            const propObj = propertyListItem(
                 prop,
                 false,
                 self.name(),
@@ -324,7 +324,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
             const properties = [];
             _.each(self.activeCaseTypeData(), function (group, index) {
                 if (group.name() !== "") {
-                    let groupData = {
+                    const groupData = {
                         'caseType': group.caseType,
                         'id': group.id,
                         'name': group.name(),
@@ -348,7 +348,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                     }
 
                     const allowedValues = element.allowedValues.val();
-                    let pureAllowedValues = {};
+                    const pureAllowedValues = {};
                     for (const key in allowedValues) {
                         pureAllowedValues[DOMPurify.sanitize(key)] = DOMPurify.sanitize(allowedValues[key]);
                     }
@@ -423,7 +423,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                 ) {
                     // `self.goToCaseType()` calls `caseType.fetchCaseProperties()`
                     // to fetch the case properties of the first case type
-                    let caseType = self.caseTypes()[0];
+                    const caseType = self.caseTypes()[0];
                     self.goToCaseType(caseType);
                 }
                 self.fhirResourceType.subscribe(changeSaveButton);
@@ -433,7 +433,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
     };
 
     self.getHashNavigationCaseType = function () {
-        let fullHash = window.location.hash.split('?')[0],
+        const fullHash = window.location.hash.split('?')[0],
             hash = fullHash.substring(1);
         return _.find(self.caseTypes(), function (prop) {
             return prop.name === hash;
@@ -479,7 +479,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
     };
 
     self.deprecateOrRestoreCaseType = function (shouldDeprecate) {
-        let activeCaseType = self.getActiveCaseType();
+        const activeCaseType = self.getActiveCaseType();
         if (!activeCaseType) {
             return;
         }
@@ -589,7 +589,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                 false,
                 changeSaveButton,
             );
-            let groupsObs = self.getCaseTypeGroupsObservable();
+            const groupsObs = self.getCaseTypeGroupsObservable();
             groupsObs.push(group);  // TODO: Broken for computed value
             self.newGroupName(undefined);
         }
@@ -610,7 +610,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
     };
 
     self.activeCaseType.subscribe(function () {
-        let caseType = self.getActiveCaseType();
+        const caseType = self.getActiveCaseType();
         self.casePropertyWarningViewModel.updateViewModel(caseType.name, caseType.propertyCount);
     });
 
@@ -654,7 +654,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
             self.nameChecked(false);
             return;
         }
-        let existing = _.find(self.caseTypes(), function (prop) {
+        const existing = _.find(self.caseTypes(), function (prop) {
             return prop.name === value;
         });
         self.nameUnique(!existing);
@@ -693,7 +693,7 @@ $(function () {
         viewModel = dataDictionaryModel(dataUrl, casePropertyUrl, typeChoices, fhirResourceTypes, casePropertyLimit);
 
     function doHashNavigation() {
-        let caseType = viewModel.getHashNavigationCaseType();
+        const caseType = viewModel.getHashNavigationCaseType();
         if (caseType) {
             viewModel.goToCaseType(caseType);
         }

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -45,19 +45,29 @@ var caseType = function (
     self.fetchCaseProperties = function () {
         if (self.groups().length === 0) {
             const caseTypeUrl = self.dataUrl + self.name + '/';
-            recurseChunks(caseTypeUrl);
+            recurseChunks(caseTypeUrl).then(() => self.groups.sort(sortGroupsFn));
         }
     };
 
     const recurseChunks = function (nextUrl) {
-        $.getJSON(nextUrl, function (data) {
+        return $.getJSON(nextUrl).then(function (data) {
             setCaseProperties(data.groups);
             self.resetSaveButton();
             nextUrl = data._links.next;
             if (nextUrl) {
-                recurseChunks(nextUrl);
+                return recurseChunks(nextUrl);
             }
         });
+    };
+
+    const sortGroupsFn = function (left, right) {
+        if (left.index === undefined || left.index > right.index) {
+            return 1;
+        }
+        if (right.index === undefined || right.index > left.index) {
+            return -1;
+        }
+        return 0;
     };
 
     const setCaseProperties = function (groupData) {

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -447,10 +447,8 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
     };
 
     self.getCaseTypeGroupsObservable = function () {
-        let caseType = self.getActiveCaseType();
-        if (caseType) {
-            return caseType.groups;  // The observable, not its value
-        }
+        const caseType = self.getActiveCaseType();
+        return caseType ? caseType.groups : ko.observableArray();
     };
 
     self.activeCaseTypeData = function () {

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -452,8 +452,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
     };
 
     self.activeCaseTypeData = function () {
-        const groupsObs = self.getCaseTypeGroupsObservable();
-        return (groupsObs) ? groupsObs() : [];
+        return ko.unwrap(self.getCaseTypeGroupsObservable());
     };
 
     self.isActiveCaseTypeDeprecated = function () {

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -42,23 +42,23 @@ var caseType = function (
 
     self.groups.subscribe(changeSaveButton);
 
-    self.fetchCaseProperties = function () {
+    self.loadCaseProperties = function () {
         if (self.groups().length === 0) {
             const caseTypeUrl = self.dataUrl + self.name + '/';
-            recurseChunks(caseTypeUrl).then(() => {
+            fetchCaseProperties(caseTypeUrl).then(() => {
                 self.groups.sort(sortGroupsFn);
                 self.resetSaveButton();
             });
         }
     };
 
-    const recurseChunks = function (nextUrl) {
+    const fetchCaseProperties = function (nextUrl) {
         return $.getJSON(nextUrl).then(function (data) {
             setCaseProperties(data.groups);
             self.resetSaveButton();
             nextUrl = data._links.next;
             if (nextUrl) {
-                return recurseChunks(nextUrl);
+                return fetchCaseProperties(nextUrl);
             }
         });
     };
@@ -437,7 +437,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                     // Check that hash navigation has not already loaded the first case type
                     && self.caseTypes()[0] !== self.getHashNavigationCaseType()
                 ) {
-                    // `self.goToCaseType()` calls `caseType.fetchCaseProperties()`
+                    // `self.goToCaseType()` calls `caseType.loadCaseProperties()`
                     // to fetch the case properties of the first case type
                     const caseType = self.caseTypes()[0];
                     self.goToCaseType(caseType);
@@ -538,7 +538,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                 return;
             }
         }
-        caseType.fetchCaseProperties();
+        caseType.loadCaseProperties();
         self.activeCaseType(caseType.name);
         self.fhirResourceType(caseType.fhirResourceType());
         self.removefhirResourceType(false);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -45,7 +45,10 @@ var caseType = function (
     self.fetchCaseProperties = function () {
         if (self.groups().length === 0) {
             const caseTypeUrl = self.dataUrl + self.name + '/';
-            recurseChunks(caseTypeUrl).then(() => self.groups.sort(sortGroupsFn));
+            recurseChunks(caseTypeUrl).then(() => {
+                self.groups.sort(sortGroupsFn);
+                self.resetSaveButton();
+            });
         }
     };
 

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -72,6 +72,7 @@ var caseType = function (
                     group.name,
                     group.description,
                     group.deprecated,
+                    group.index,
                     self.changeSaveButton,
                 );
                 self.groups.push(groupObj);
@@ -106,6 +107,7 @@ var groupsViewModel = function (
     name,
     description,
     deprecated,
+    index,
     changeSaveButton,
 ) {
     var self = {};
@@ -118,6 +120,7 @@ var groupsViewModel = function (
     self.expanded = ko.observable(true);
     self.toggleExpanded = () => self.expanded(!self.expanded());
     self.deprecated = deprecated;
+    self.index = index;
     // Ensures that groups are not directly hidden on clicking the deprecated button
     self.toBeDeprecated = ko.observable(deprecated || false);
     self.deprecateGroup = function () {
@@ -587,6 +590,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                 self.newGroupName(),
                 '',
                 false,
+                null,
                 changeSaveButton,
             );
             const groupsObs = self.getCaseTypeGroupsObservable();

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -7,10 +7,12 @@
 
 {% block stylesheets %}{{ block.super }}
   {% compress css %}
-  <link type="text/less"
-        rel="stylesheet"
-        media="all"
-        href="{% static 'data_dictionary/less/data_dictionary.less' %}" />
+    <link
+      type="text/less"
+      rel="stylesheet"
+      media="all"
+      href="{% static 'data_dictionary/less/data_dictionary.less' %}"
+    />
   {% endcompress %}
 {% endblock %}
 
@@ -22,8 +24,12 @@
       <li data-bind="css: { active: $data.name == $root.activeCaseType() }">
         {# navigation handle by URL hash #}
         <a data-bind="attr: {href: $data.url}">
-          <span data-bind="text: $data.name" style="display: inline-block"></span>
-          <span data-bind="visible: $data.deprecated" class="hidden deprecate-case-type label label-warning">{% trans "deprecated" %}</span>
+          <span data-bind="text: $data.name" style="display: inline-block">
+          </span>
+          <span
+            data-bind="visible: $data.deprecated"
+            class="hidden deprecate-case-type label label-warning"
+          >{% trans "deprecated" %}</span>
         </a>
       </li>
       <!-- /ko -->
@@ -35,14 +41,17 @@
           </a>
         </li>
         <li>
-          <a class="hidden deprecate-case-type" data-bind="click: $root.toggleShowDeprecatedCaseTypes">
-              <i class="fa fa-archive"></i>
-              <span data-bind="hidden: $root.showDeprecatedCaseTypes">
-                {% trans 'Show Deprecated Case Types' %}
-              </span>
-              <span data-bind="visible: $root.showDeprecatedCaseTypes">
-                {% trans 'Hide Deprecated Case Types' %}
-              </span>
+          <a
+            class="hidden deprecate-case-type"
+            data-bind="click: $root.toggleShowDeprecatedCaseTypes"
+          >
+            <i class="fa fa-archive"></i>
+            <span data-bind="hidden: $root.showDeprecatedCaseTypes">
+              {% trans 'Show Deprecated Case Types' %}
+            </span>
+            <span data-bind="visible: $root.showDeprecatedCaseTypes">
+              {% trans 'Hide Deprecated Case Types' %}
+            </span>
           </a>
         </li>
       {% endif %}
@@ -58,72 +67,111 @@
           </button>
           <h4 class="modal-title">{% trans "Create a new Case Type" %}</h4>
         </div>
-        <form class="form-horizontal" id="create-case-type-form"
-                style="margin: 0; padding: 0"
-                action="{% url 'create_case_type' domain %}"
-                method="post"
-                data-bind="submit: submitCreate"
+        <form
+          class="form-horizontal"
+          id="create-case-type-form"
+          style="margin: 0; padding: 0"
+          action="{% url 'create_case_type' domain %}"
+          method="post"
+          data-bind="submit: submitCreate"
         >
-            {% csrf_token %}
-            <div class="modal-body">
-              <fieldset>
-                <div class="form-group" data-bind="css: {'has-error': nameChecked() && (!nameValid() || !nameUnique())}">
-                  <label for="name" class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label">
-                    {% trans "Name" %}
-                  </label>
-                  <i class="fa" data-bind="
-                     visible: nameChecked(),
-                     css: {
-                         'fa-check': nameValid() && nameUnique(),
-                         'text-success': nameValid() && nameUnique(),
-                         'fa-remove': !nameValid() || !nameUnique(),
-                         'text-danger': !nameValid() || !nameUnique(),
-                     }
-                  "></i>
-                  <div class="col-xs-12 col-sm-6 col-md-6 col-lg-8 controls">
-                    <input type="text" name="name" class="form-control" required data-bind="textInput: name"/>
-                    <span class='help-block' data-bind="visible: nameChecked() && !nameUnique()">
-                      {% trans "A case type with this name already exists." %}
-                    </span>
-                    <span class="help-block" data-bind="visible: nameChecked() && !nameValid()">
-                      {% trans "Invalid case type name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
-                    </span>
-                  </div>
+          {% csrf_token %}
+          <div class="modal-body">
+            <fieldset>
+              <div
+                class="form-group"
+                data-bind="css: {
+                    'has-error': nameChecked() && (!nameValid() || !nameUnique())
+                }"
+              >
+                <label
+                  for="name"
+                  class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label"
+                >
+                  {% trans "Name" %}
+                </label>
+                <i
+                  class="fa"
+                  data-bind="
+                    visible: nameChecked(),
+                    css: {
+                        'fa-check': nameValid() && nameUnique(),
+                        'text-success': nameValid() && nameUnique(),
+                        'fa-remove': !nameValid() || !nameUnique(),
+                        'text-danger': !nameValid() || !nameUnique(),
+                    }"
+                ></i>
+                <div class="col-xs-12 col-sm-6 col-md-6 col-lg-8 controls">
+                  <input
+                    type="text"
+                    name="name"
+                    class="form-control"
+                    required
+                    data-bind="textInput: name"
+                  />
+                  <span
+                    class='help-block'
+                    data-bind="visible: nameChecked() && !nameUnique()"
+                  >
+                    {% trans "A case type with this name already exists." %}
+                  </span>
+                  <span
+                    class="help-block"
+                    data-bind="visible: nameChecked() && !nameValid()"
+                  >
+                    {% trans "Invalid case type name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
+                  </span>
                 </div>
-                <div class="form-group">
-                  <label for="description" class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label">
-                      {% trans "Description" %}
-                  </label>
-                  <div class="col-xs-12 col-sm-6 col-md-6 col-lg-8 controls">
-                    <textarea name="description"
-                              class="form-control std-height vertical-resize"></textarea>
-                  </div>
+              </div>
+              <div class="form-group">
+                <label
+                  for="description"
+                  class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label"
+                >
+                  {% trans "Description" %}
+                </label>
+                <div class="col-xs-12 col-sm-6 col-md-6 col-lg-8 controls">
+                  <textarea
+                    name="description"
+                    class="form-control std-height vertical-resize"
+                  ></textarea>
                 </div>
-              </fieldset>
-            </div>
-            <div class="modal-footer">
-              <a href="#" data-dismiss="modal" class="btn btn-default" data-bind="
+              </div>
+            </fieldset>
+          </div>
+          <div class="modal-footer">
+            <a
+              href="#"
+              data-dismiss="modal"
+              class="btn btn-default"
+              data-bind="
                 css: {disabled: formCreateCaseTypeSent()},
-                attr: {disabled: formCreateCaseTypeSent()}
-              ">{% trans 'Cancel' %}</a>
-              <button type="submit" class="btn btn-primary" id="gtm-create-case-type-btn" data-bind="
+                attr: {disabled: formCreateCaseTypeSent()}"
+            >{% trans 'Cancel' %}</a>
+            <button
+              type="submit"
+              class="btn btn-primary"
+              id="gtm-create-case-type-btn"
+              data-bind="
                 css: {disabled: formCreateCaseTypeSent() || !nameValid() || !nameUnique()},
-                attr: {disabled: formCreateCaseTypeSent() || !nameValid() || !nameUnique()}
-              ">
-                <i class="fa fa-plus" data-bind="
-                   css: {
-                       'fa-plus': !formCreateCaseTypeSent(),
-                       'fa-refresh': formCreateCaseTypeSent,
-                       'fa-spin': formCreateCaseTypeSent
-                   }
-                "></i>
-                {% trans "Create Case Type" %}
-              </button>
-            </div>
-          </form>
+                attr: {disabled: formCreateCaseTypeSent() || !nameValid() || !nameUnique()}"
+            >
+              <i
+                class="fa fa-plus"
+                data-bind="
+                  css: {
+                      'fa-plus': !formCreateCaseTypeSent(),
+                      'fa-refresh': formCreateCaseTypeSent,
+                      'fa-spin': formCreateCaseTypeSent
+                  }"
+              ></i>
+              {% trans "Create Case Type" %}
+            </button>
+          </div>
+        </form>
       </div>
     </div>
-</script>
+  </script>
 {% endblock %}
 
 {% block page_content %}
@@ -146,64 +194,107 @@
       </p>
     </div>
     {% if not request.is_view_only %}
-      <div id="gtm-save-btn" data-bind="saveButton: saveButton, visible: $root.activeCaseType()"></div>
+      <div
+        id="gtm-save-btn"
+        data-bind="saveButton: saveButton, visible: $root.activeCaseType()"
+      ></div>
     {% endif %}
     <div class="row">
       <div class="col-md-12">
         <div>
-          <h3 data-bind="text: $root.activeCaseType()" style="display: inline-block;"></h3>
-          <span data-bind="visible: $root.isActiveCaseTypeDeprecated()" class="deprecate-case-type hidden label label-warning" style="display: inline-block;">{% trans "deprecated" %}</span>
+          <h3
+            data-bind="text: $root.activeCaseType()"
+            style="display: inline-block;"
+          ></h3>
+          <span
+            data-bind="visible: $root.isActiveCaseTypeDeprecated()"
+            class="deprecate-case-type hidden label label-warning"
+            style="display: inline-block;"
+          >{% trans "deprecated" %}</span>
         </div>
         <div data-bind="with: casePropertyWarningViewModel">
-        {% include "data_dictionary/partials/case_property_warning.html" %}
+          {% include "data_dictionary/partials/case_property_warning.html" %}
         </div>
         {% if fhir_integration_enabled %}
-          <div id="fhir-resource-type-form" class="form-inline" data-bind="visible: fhirResourceTypes().length">
+          <div
+            id="fhir-resource-type-form" class="form-inline"
+            data-bind="visible: fhirResourceTypes().length"
+          >
             {% trans "FHIR Resource Type" %}
-            <select id="fhir-resource-types"
-                    class="form-control"
-                    data-bind="select2: fhirResourceTypes,
-                              optionsCaption: '{% trans_html_attr 'Select a resource type' %}',
-                              value: fhirResourceType,
-                              disable: removefhirResourceType,
-                              ">
-            </select>
+            <select
+              id="fhir-resource-types"
+              class="form-control"
+              data-bind="
+                select2: fhirResourceTypes,
+                optionsCaption: '{% trans_html_attr 'Select a resource type' %}',
+                value: fhirResourceType,
+                disable: removefhirResourceType,"
+            ></select>
             <!-- ko if: fhirResourceType() && !removefhirResourceType() -->
-            <button data-bind="click: removeResourceType" class="btn btn-danger btn-sm">{% trans "Clear" %}
-            </button>
+            <button
+              data-bind="click: removeResourceType"
+              class="btn btn-danger btn-sm"
+            >{% trans "Clear" %}</button>
             <!-- /ko -->
             <!-- ko if: removefhirResourceType() -->
-            <button data-bind="click: restoreResourceType" class="btn btn-default btn-sm">{% trans "Restore" %}
-            </button>
+            <button
+              data-bind="click: restoreResourceType"
+              class="btn btn-default btn-sm"
+            >{% trans "Restore" %}</button>
             <!-- /ko -->
           </div>
           <br />
         {% endif %}
-        <a class="btn btn-info" id="download-dict" href="{% url "export_data_dictionary" domain %}">
-          <i class="fa-solid fa-cloud-arrow-down"></i>
+        <a
+          class="btn btn-info"
+          id="download-dict"
+          href="{% url "export_data_dictionary" domain %}"
+        ><i class="fa-solid fa-cloud-arrow-down"></i>
           {% trans "Export to Excel" %}
         </a>
         {% if not request.is_view_only %}
-          <a class="btn btn-default" id="gtm-upload-dict" href="{% url "upload_data_dict" domain %}">
-            <i class="fa-solid fa-cloud-arrow-up"></i>
+          <a
+            class="btn btn-default"
+            id="gtm-upload-dict"
+            href="{% url "upload_data_dict" domain %}"
+          ><i class="fa-solid fa-cloud-arrow-up"></i>
             {% trans "Import from Excel" %}
           </a>
-          <a class="btn btn-default" href="#" data-bind="openModal: 'deprecate-case-type', visible: !$root.isActiveCaseTypeDeprecated()">
-            <i class="fa fa-archive"></i>
+          <a
+            class="btn btn-default"
+            href="#"
+            data-bind="
+              openModal: 'deprecate-case-type',
+              visible: !$root.isActiveCaseTypeDeprecated()"
+          ><i class="fa fa-archive"></i>
             {% trans "Deprecate Case Type" %}
           </a>
-          <button class="btn btn-default" data-bind="click: restoreCaseType, visible: $root.isActiveCaseTypeDeprecated()">
-            <i class="fa fa-undo"></i>
+          <button
+            class="btn btn-default"
+            data-bind="
+              click: restoreCaseType,
+              visible: $root.isActiveCaseTypeDeprecated()"
+          ><i class="fa fa-undo"></i>
             {% trans "Restore Case Type" %}
           </button>
-          <a class="btn btn-danger" href="#" data-bind="openModal: 'delete-case-type-modal', visible: $root.canDeleteActiveCaseType()">
-            <i class="fa fa-trash"></i>
+          <a
+            class="btn btn-danger"
+            href="#" data-bind="
+              openModal: 'delete-case-type-modal',
+              visible: $root.canDeleteActiveCaseType()"
+          ><i class="fa fa-trash"></i>
             {% trans "Delete Case Type" %}
           </a>
         {% endif %}
         <div data-bind="visible: $root.activeCaseType()">
-          <button data-bind="click: $root.showDeprecated, visible: !showAll()" class="btn btn-default pull-right">{% trans "Show Deprecated" %}</button>
-          <button data-bind="click: $root.hideDeprecated, visible: showAll" class="btn btn-default pull-right">{% trans "Hide Deprecated" %}</button>
+          <button
+            data-bind="click: $root.showDeprecated, visible: !showAll()"
+            class="btn btn-default pull-right"
+          >{% trans "Show Deprecated" %}</button>
+          <button
+            data-bind="click: $root.hideDeprecated, visible: showAll"
+            class="btn btn-default pull-right"
+          >{% trans "Hide Deprecated" %}</button>
           <div id="data-dictionary-table">
             <div class="table-row table-header">
             <div class="row-item-small"></div>
@@ -214,237 +305,347 @@
             {% endif %}
             <div class="row-item-big">{% trans "Description" %}</div>
             {% if fhir_integration_enabled %}
-              <div class="row-item">{% trans "FHIR Resource Property Path" %}</div>
+              <div class="row-item">
+                {% trans "FHIR Resource Property Path" %}
+              </div>
             {% endif %}
             {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
-              <div class="row-item">{% include "data_dictionary/partials/valid_values_th_content.html" %}</div>
+              <div class="row-item">
+                {% include "data_dictionary/partials/valid_values_th_content.html" %}
+              </div>
             {% endif %}
             {% if not request.is_view_only %}
               <div class="row-item-small"></div>
               <div class="row-item-small"></div>
             {% endif %}
             </div>
-            <div data-bind="sortable: {
-                              data: activeCaseTypeData(),
-                              connectClass: 'groups',
-                              options: { handle: 'i.sortable-handle' }
-                            }">
-            <div>
-            <div class="group-deprecated" data-bind="visible: showGroupPropertyTransferWarning" style="display: none;">
-              {% blocktrans %}
-              <b data-bind="text: name()"></b> group's properties will be moved to <b>No Group</b>
-              {% endblocktrans %}
-            </div>
-            <div class="table-row group" data-bind="css: { 'group-deprecated': toBeDeprecated() }, visible: !deprecated || $root.showAll()">
-              <div class="row-item-small">
-                {% if not request.is_view_only %}
-                <i class="sortable-handle fa-solid fa-up-down"></i>
-                {% endif %}
-                <i class="fa-solid ms-2 fa-lg"
-                  data-bind="css: { 'fa-square-plus': !expanded(), 'fa-square-minus': expanded() }, click: toggleExpanded"></i>
-              </div>
-              <div class="row-item">
-                <!-- ko if: name() == '' -->
-                <span>{% trans 'No Group' %}</span>
-                <!-- /ko -->
-                <!-- ko if: name() !== '' -->
-                <input class="form-control" data-bind="value: name,
-                              attr: {'placeholder': name}" id="group-name" />
-                <!-- /ko -->
-              </div>
-              <div class="row-item">
-                &nbsp;{# Empty cell where "Label" is in case property rows #}
-              </div>
-              {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
-                <div class="row-item">{% trans "Case Property Group" %}</div>
-              {% endif %}
-              <div class="row-item-big">
-                <!-- ko if: name() !== ''-->
-                <textarea class="form-control std-height vertical-resize"
-                          data-bind="value: $data.description, rows: 1"
-                          placeholder='{% trans "Click here to add a description" %}'></textarea>
-                <!-- /ko -->
-              </div>
-              {% if fhir_integration_enabled %}
-                <div class="row-item"></div>
-              {% endif %}
-              {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
-                <div class="row-item"></div>
-              {% endif %}
-              {% if not request.is_view_only %}
-              <div class="row-item-small">
-                <!-- ko if: name() !== '' && !toBeDeprecated() -->
-                <button title="{% trans_html_attr 'Deprecate Group' %}"  data-bind="click: deprecateGroup" class="fa fa-archive"></button>
-                <!-- /ko -->
-                <!-- ko if: name() !== '' && toBeDeprecated() -->
-                <button title="{% trans_html_attr 'Restore Group' %}" data-bind="click: restoreGroup" class="fa fa-undo"></button>
-                <!-- /ko -->
-              </div>
-              <div class="row-item-small"></div>
-              {% endif %}
-            </div>
-            <div data-bind="sortable: { data: properties, connectClass: 'properties', options: { handle: 'i.sortable-handle' } }, visible: expanded() && (!deprecated || $root.showAll())">
-              <div class="table-row" data-bind="visible: expanded() && (!deprecated() || $root.showAll()) && !deleted()">
-                <div class="row-item-small">
-                {% if not request.is_view_only %}
-                  <i class="sortable-handle fa-solid fa-up-down"></i>
-                {% endif %}
+            <div
+              data-bind="
+                sortable: {
+                    data: activeCaseTypeData(),
+                    connectClass: 'groups',
+                    options: { handle: 'i.sortable-handle' }
+                }"
+            >
+              <div>
+                <div
+                  class="group-deprecated"
+                  data-bind="visible: showGroupPropertyTransferWarning"
+                  style="display: none;"
+                >
+                  {% blocktrans %}
+                    <b data-bind="text: name()"></b> group's properties will be moved to <b>No Group</b>
+                  {% endblocktrans %}
                 </div>
-                <div class="row-item">
-                  <div class="w-100">
-                  <span data-bind="text: name"></span>
+                <div
+                  class="table-row group"
+                  data-bind="
+                    css: { 'group-deprecated': toBeDeprecated() },
+                    visible: !deprecated || $root.showAll()"
+                >
+                  <div class="row-item-small">
+                    {% if not request.is_view_only %}
+                      <i class="sortable-handle fa-solid fa-up-down"></i>
+                    {% endif %}
+                    <i
+                      class="fa-solid ms-2 fa-lg"
+                      data-bind="
+                        css: {
+                            'fa-square-plus': !expanded(),
+                            'fa-square-minus': expanded()
+                        },
+                        click: toggleExpanded"
+                    ></i>
                   </div>
+                  <div class="row-item">
+                    <!-- ko if: name() == '' -->
+                    <span>{% trans 'No Group' %}</span>
+                    <!-- /ko -->
+                    <!-- ko if: name() !== '' -->
+                    <input
+                      class="form-control"
+                      data-bind="
+                        value: name,
+                        attr: {'placeholder': name}" id="group-name"
+                    />
+                    <!-- /ko -->
+                  </div>
+                  <div class="row-item">
+                    &nbsp;{# Empty cell where "Label" is in case property rows #}
+                  </div>
+                  {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+                    <div class="row-item">
+                      {% trans "Case Property Group" %}
+                    </div>
+                  {% endif %}
+                  <div class="row-item-big">
+                    <!-- ko if: name() !== ''-->
+                    <textarea
+                      class="form-control std-height vertical-resize"
+                      data-bind="value: $data.description, rows: 1"
+                      placeholder='{% trans "Click here to add a description" %}'
+                    ></textarea>
+                    <!-- /ko -->
+                  </div>
+                  {% if fhir_integration_enabled %}
+                    <div class="row-item"></div>
+                  {% endif %}
+                  {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+                    <div class="row-item"></div>
+                  {% endif %}
+                  {% if not request.is_view_only %}
+                    <div class="row-item-small">
+                      <!-- ko if: name() !== '' && !toBeDeprecated() -->
+                      <button
+                        title="{% trans_html_attr 'Deprecate Group' %}"
+                        data-bind="click: deprecateGroup"
+                        class="fa fa-archive"
+                      ></button>
+                      <!-- /ko -->
+                      <!-- ko if: name() !== '' && toBeDeprecated() -->
+                      <button
+                        title="{% trans_html_attr 'Restore Group' %}"
+                        data-bind="click: restoreGroup"
+                        class="fa fa-undo"
+                      ></button>
+                      <!-- /ko -->
+                    </div>
+                    <div class="row-item-small"></div>
+                  {% endif %}
                 </div>
-                <div class="row-item">
-                  <input class="form-control"
+                <div
+                  data-bind="
+                    sortable: {
+                        data: properties,
+                        connectClass: 'properties',
+                        options: { handle: 'i.sortable-handle' }
+                    },
+                    visible: expanded() && (!deprecated || $root.showAll())"
+                >
+                  <div
+                    class="table-row"
+                    data-bind="visible: expanded() && (!deprecated() || $root.showAll()) && !deleted()"
+                  >
+                    <div class="row-item-small">
+                    {% if not request.is_view_only %}
+                      <i class="sortable-handle fa-solid fa-up-down"></i>
+                    {% endif %}
+                    </div>
+                    <div class="row-item">
+                      <div class="w-100">
+                        <span data-bind="text: name"></span>
+                      </div>
+                    </div>
+                    <div class="row-item">
+                      <input
+                        class="form-control"
                         id="prop-label"
                         data-bind="
                           value: $data.label,
-                          attr: {'placeholder': 'Click here to add a label'}" />
-                </div>
-                {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
-                  <div class="row-item main-form">
-                    <select class="form-control"
-                            data-bind="
-                              options: $root.availableDataTypes,
-                              optionsCaption: 'Select a data type',
-                              optionsText: 'display',
-                              optionsValue: 'value',
-                              value: dataType,
-                              disable: isGeoCaseProp,">
-                    </select>
-                    <span class="hq-help" style="height: fit-content"
+                          attr: {'placeholder': 'Click here to add a label'}"
+                      />
+                    </div>
+                    {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+                      <div class="row-item main-form">
+                        <select
+                          class="form-control"
+                          data-bind="
+                            options: $root.availableDataTypes,
+                            optionsCaption: 'Select a data type',
+                            optionsText: 'display',
+                            optionsValue: 'value',
+                            value: dataType,
+                            disable: isGeoCaseProp,"
+                        ></select>
+                        <span
+                          class="hq-help"
+                          style="height: fit-content"
                           data-bind="
                             popover: {
                               content: '{% blocktrans %}This GPS case property is currently being used to store the geolocation for cases, so the data type cannot be changed.{% endblocktrans %}',
-                              trigger: 'hover' },
-                            visible: isGeoCaseProp">
-                      <i class="fa fa-question-circle icon-question-sign"></i>
-                    </span>
-                  </div>
-                {% endif %}
-                <div class="row-item-big main-form">
-                  <textarea class="form-control std-height vertical-resize"
-                            placeholder="{% trans 'Click here to add a description' %}"
-                            data-bind=" value: $data.description, rows: 1">
-                  </textarea>
-                </div>
-              {% if fhir_integration_enabled %}
-                <div class="row-item fhir-path">
-                  <input class="form-control" data-bind="value: $data.fhirResourcePropPath, disable: removeFHIRResourcePropertyPath">
-                  <!-- ko if: fhirResourcePropPath() && !removeFHIRResourcePropertyPath() -->
-                  <button title="{% trans_html_attr 'Remove Path' %}" data-bind="click: removePath" class="fa-solid fa-xmark"></button>
-                  <!-- /ko -->
-                  <!-- ko if: removeFHIRResourcePropertyPath() -->
-                  <button title="{% trans_html_attr 'Restore Path' %}" data-bind="click: restorePath" class="fa fa-undo"></button>
-                  <!-- /ko -->
-                </div>
-              {% endif %}
-              {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
-                <div class="row-item">
-                  <div data-bind="visible: canHaveAllowedValues()">
-                    <div data-bind="jqueryElement: $allowedValues"></div>
-                  </div>
-                  <div data-bind="visible: dataType() === 'date'" class="help-block">
-                    {% trans "YYYY-MM-DD" %}
-                  </div>
-                </div>
-              {% endif %}
-              {% if not request.is_view_only %}
-                <div class="row-item-small m-auto">
-                  <button title="{% trans_html_attr 'Delete Property' %}"
-                          data-bind="click: confirmDeleteProperty, visible: isSafeToDelete"
-                          class="btn btn-danger">
-                    <i class="fa fa-trash"></i>
-                    {% trans 'Delete' %}
-                  </button>
-                </div>
-                <div class="row-item-small m-auto">
-                  <!-- ko if: !deprecated() -->
-                  <button id="gtm-deprecate-case-property" title="{% trans_html_attr 'Deprecate Property' %}"  data-bind="click: deprecateProperty" class="btn btn-default">
-                    <i class="fa fa-archive"></i>
-                    {% trans 'Deprecate' %}
-                  </button>
-                  <!-- /ko -->
-                  <!-- ko if: deprecated() -->
-                  <button title="{% trans_html_attr 'Restore Property' %}" data-bind="click: restoreProperty" class="btn btn-default">
-                    <i class="fa fa-undo"></i>
-                    {% trans 'Restore' %}
-                  </button>
-                  <!-- /ko -->
-                </div>
-              {% endif %}
-              </div>
-            </div>
-
-            {% if not request.is_view_only %}
-              <div class="table-row"
-                  data-bind="visible: !deprecated">
-                <div class="row-item">
-                  <form class="form-inline"
-                        data-bind="css: {
-                                    'has-error': !$root.newPropertyNameUnique(newPropertyName())
-                                                  || !$root.newPropertyNameValid(newPropertyName())
-                                  }">
-                    <input class="form-control"
-                          placeholder="Case Property"
-                          data-bind="value: newPropertyName">
-                    <button class="btn btn-default"
-                            id="gtm-add-case-property"
-                            data-bind="click: newCaseProperty,
-                                      enable: $root.newPropertyNameUnique(newPropertyName())
-                                              && $root.newPropertyNameValid(newPropertyName())">
-                      <i class="fa fa-plus"></i>
-                      {% trans "Add Case Property" %}
-                    </button>
-                    <div class="help-block">
-                      <span class="text-danger"
-                            data-bind="visible: !$root.newPropertyNameUnique(newPropertyName())">
-                        {% blocktrans %}
-                          A case property with this name already exists.
-                          If you don’t see it on the page, please click ‘Show Deprecated’ button to reveal deprecated
-                          properties.
-                        {% endblocktrans %}
-                      </span>
-                      <span class="text-danger" data-bind="visible: !$root.newPropertyNameValid(newPropertyName())">
-                        {% trans "Invalid case property name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
-                      </span>
+                              trigger: 'hover'
+                            },
+                            visible: isGeoCaseProp"
+                        >
+                          <i class="fa fa-question-circle icon-question-sign"></i>
+                        </span>
+                      </div>
+                    {% endif %}
+                    <div class="row-item-big main-form">
+                      <textarea
+                        class="form-control std-height vertical-resize"
+                        placeholder="{% trans 'Click here to add a description' %}"
+                        data-bind=" value: $data.description, rows: 1"
+                      ></textarea>
                     </div>
-
-                  </form>
+                  {% if fhir_integration_enabled %}
+                    <div class="row-item fhir-path">
+                      <input
+                        class="form-control"
+                        data-bind="
+                          value: $data.fhirResourcePropPath,
+                          disable: removeFHIRResourcePropertyPath"
+                      >
+                      <!-- ko if: fhirResourcePropPath() && !removeFHIRResourcePropertyPath() -->
+                      <button
+                        title="{% trans_html_attr 'Remove Path' %}"
+                        data-bind="click: removePath"
+                        class="fa-solid fa-xmark"
+                      ></button>
+                      <!-- /ko -->
+                      <!-- ko if: removeFHIRResourcePropertyPath() -->
+                      <button
+                        title="{% trans_html_attr 'Restore Path' %}"
+                        data-bind="click: restorePath"
+                        class="fa fa-undo"
+                      ></button>
+                      <!-- /ko -->
+                    </div>
+                  {% endif %}
+                  {% if request|toggle_enabled:"CASE_IMPORT_DATA_DICTIONARY_VALIDATION" %}
+                    <div class="row-item">
+                      <div data-bind="visible: canHaveAllowedValues()">
+                        <div data-bind="jqueryElement: $allowedValues"></div>
+                      </div>
+                      <div
+                        data-bind="visible: dataType() === 'date'"
+                        class="help-block"
+                      >
+                        {% trans "YYYY-MM-DD" %}
+                      </div>
+                    </div>
+                  {% endif %}
+                  {% if not request.is_view_only %}
+                    <div class="row-item-small m-auto">
+                      <button
+                        title="{% trans_html_attr 'Delete Property' %}"
+                        data-bind="click: confirmDeleteProperty, visible: isSafeToDelete"
+                        class="btn btn-danger"
+                      ><i class="fa fa-trash"></i>
+                        {% trans 'Delete' %}
+                      </button>
+                    </div>
+                    <div class="row-item-small m-auto">
+                      <!-- ko if: !deprecated() -->
+                      <button
+                        id="gtm-deprecate-case-property"
+                        title="{% trans_html_attr 'Deprecate Property' %}"
+                        data-bind="click: deprecateProperty" class="btn btn-default"
+                      ><i class="fa fa-archive"></i>
+                        {% trans 'Deprecate' %}
+                      </button>
+                      <!-- /ko -->
+                      <!-- ko if: deprecated() -->
+                      <button
+                        title="{% trans_html_attr 'Restore Property' %}"
+                        data-bind="click: restoreProperty"
+                        class="btn btn-default"
+                      ><i class="fa fa-undo"></i>
+                        {% trans 'Restore' %}
+                      </button>
+                      <!-- /ko -->
+                    </div>
+                  {% endif %}
                 </div>
               </div>
-            {% endif %}
 
-            </div>
+              {% if not request.is_view_only %}
+                <div class="table-row" data-bind="visible: !deprecated">
+                  <div class="row-item">
+                    <form
+                      class="form-inline"
+                      data-bind="
+                        css: {
+                          'has-error': !$root.newPropertyNameUnique(newPropertyName())
+                                       || !$root.newPropertyNameValid(newPropertyName())
+                        }"
+                    >
+                      <input
+                        class="form-control"
+                        placeholder="Case Property"
+                        data-bind="value: newPropertyName"
+                      />
+                      <button
+                        class="btn btn-default"
+                        id="gtm-add-case-property"
+                        data-bind="
+                          click: newCaseProperty,
+                          enable: $root.newPropertyNameUnique(newPropertyName())
+                                  && $root.newPropertyNameValid(newPropertyName())"
+                      >
+                        <i class="fa fa-plus"></i>
+                        {% trans "Add Case Property" %}
+                      </button>
+                      <div class="help-block">
+                        <span
+                          class="text-danger"
+                          data-bind="visible: !$root.newPropertyNameUnique(newPropertyName())"
+                        >
+                          {% blocktrans %}
+                            A case property with this name already exists.
+                            If you don’t see it on the page, please click ‘Show Deprecated’ button to reveal deprecated
+                            properties.
+                          {% endblocktrans %}
+                        </span>
+                        <span
+                          class="text-danger"
+                          data-bind="visible: !$root.newPropertyNameValid(newPropertyName())"
+                        >
+                          {% trans "Invalid case property name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
+                        </span>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              {% endif %}
             </div>
           </div>
 
           {% if not request.is_view_only %}
-            <form class="form-inline" data-bind="css: {'has-error': !newGroupNameUnique() || !newGroupNameValid()}">
-              <input class="form-control" placeholder="Group Name" data-bind="value: newGroupName">
-              <button class="btn btn-default" id="gtm-add-case-property-group" data-bind="click: $root.newGroup, enable: newGroupNameUnique() && newGroupNameValid()">
-                <i class="fa fa-plus"></i>
+            <form
+              class="form-inline"
+              data-bind="
+                css: {'has-error': !newGroupNameUnique() || !newGroupNameValid()}"
+            >
+              <input
+                class="form-control"
+                placeholder="Group Name"
+                data-bind="value: newGroupName">
+              <button
+                class="btn btn-default"
+                id="gtm-add-case-property-group"
+                data-bind="click: $root.newGroup, enable: newGroupNameUnique() && newGroupNameValid()"
+              ><i class="fa fa-plus"></i>
                 {% trans "Add Case Property Group" %}
               </button>
               <div class="help-block">
-                <span class="text-danger" data-bind="visible: !newGroupNameUnique()">
+                <span
+                  class="text-danger"
+                  data-bind="visible: !newGroupNameUnique()"
+                >
                   {% blocktrans %}
                     A case property group with this name already exists.
-                    If you don’t see it on the page, please click ‘Show Deprecated’ button to reveal deprecated
-                    groups.
+                    If you don’t see it on the page, please click ‘Show
+                    Deprecated’ button to reveal deprecated groups.
                   {% endblocktrans %}
                 </span>
-                <span class="text-danger" data-bind="visible: !newGroupNameValid()">
+                <span
+                  class="text-danger"
+                  data-bind="visible: !newGroupNameValid()"
+                >
                   {% trans "Invalid case group name. It should start with a letter, and only contain letters, numbers, '-', and '_'" %}
                 </span>
               </div>
             </form>
           {% endif %}
         </div>
+
         {% if not request.is_view_only %}
           <div data-bind="hidden: $root.caseTypes().length > 0">
-            <button class="btn btn-primary" data-bind="openModal: 'create-case-type'">
+            <button
+              class="btn btn-primary"
+              data-bind="openModal: 'create-case-type'"
+            >
               <i class="fa fa-plus"></i>
               {% trans "Add a new Case Type" %}
             </button>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -322,7 +322,7 @@
             <div
               data-bind="
                 sortable: {
-                    data: activeCaseTypeData(),
+                    data: getCaseTypeGroupsObservable(),
                     connectClass: 'groups',
                     options: { handle: 'i.sortable-handle' }
                 }"

--- a/corehq/apps/data_dictionary/tests/test_views.py
+++ b/corehq/apps/data_dictionary/tests/test_views.py
@@ -523,7 +523,8 @@ class DataDictionaryJsonTest(DataDictionaryViewTestBase):
                     group_data.update({
                         "id": group.id,
                         "description": "",
-                        "deprecated": False
+                        "deprecated": False,
+                        "index": group.index,
                     })
                 expected_output["groups"].append(group_data)
         return expected_output

--- a/corehq/apps/data_dictionary/views.py
+++ b/corehq/apps/data_dictionary/views.py
@@ -163,7 +163,7 @@ def data_dictionary_json_case_properties(request, domain, case_type_name):
 
         group_data = {
             "name": "",
-            "properties": grouped_properties
+            "properties": grouped_properties,
         }
         # Note that properties can be without group
         if group_id:
@@ -173,12 +173,14 @@ def data_dictionary_json_case_properties(request, domain, case_type_name):
                 "name": group.name,
                 "description": group.description,
                 "deprecated": group.deprecated,
+                "index": group.index,
             })
         case_type_data["groups"].append(group_data)
+
     if not properties_queryset:
         case_type_data["groups"].append({
             "name": "",
-            "properties": []
+            "properties": [],
         })
 
     # properties_queryset skips groups with no properties. Add them here
@@ -194,7 +196,8 @@ def data_dictionary_json_case_properties(request, domain, case_type_name):
             "name": group.name,
             "description": group.description,
             "deprecated": group.deprecated,
-            "properties": []
+            "index": group.index,
+            "properties": [],
         })
 
     return JsonResponse(case_type_data)


### PR DESCRIPTION
## Product Description
Sorting case property groups in the Data Dictionary UI did not work right - changes to ordering were neither reflected immediately in the UI nor applied correctly on page load. This aims to fix that.
Before:

https://github.com/user-attachments/assets/75b74faf-0794-4694-bc26-b0c39c8b75af

After:

https://github.com/user-attachments/assets/db8fc36a-97c9-44ff-bab7-a53a11865d3a

Case properties belonging to no group are sorted to the end of the page on load, which matches previous behavior.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-16085
There are two main fixes here -- the ability to sort case property groups in the UI, and applying that sorting when loading or reloading the page.

For the first, `sortable` was getting a plain array for its groups data (from `activeCaseTypeData()`), where it really wanted an observable array. Now it uses `getCaseTypeGroupsObservable()` as the sortable data instead, while updating the function to always return something so it doesn't error if there is no return value. `activeCaseTypeData()` is still useful to get the current, unwrapped version of the groups observable in other JS code in this file.

For the latter issue, `index` was already a field on a `CasePropertyGroup` and was already saved when updating the group's details. `index` is now added to the JSON returned for case property groups and used to sort the groups after all properties have been loaded. This sorting is done in the frontend because the case property query is limited to 500 properties per request on the backend, after which the frontend makes additional requests if needed and combines the results.

A good chunk of manual formatting was also applied to clean up the data dictionary html template, since auto-formatting tends to choke on heavily mixed django/knockout templates like this. While also working with code style, updated variables in `data_dictionary.js` to use `const` where `let` was unneeded. These style changes contribute to the bulk of lines changed in this PR.

## Safety Assurance

### Safety story
Tested locally and on staging that reordering and saving case property groups retains the order of those groups and no Javascript errors are seen. Tested with case types having various combinations of:
 - case properties with and without groups
 - groups with and without case properties
 - more than 500 case properties, which while very slow to load is technically supported

Also confirmed that reordering case properties within a group or moving properties from one group to another still works correctly.

### Automated test coverage
Not for this frontend code, but there is testing for the Data Dictionary view and JSON responses, which helps protect against regression.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
