### PR TITLE
Translate "copying" and "reassigning".

### DIFF
--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -635,9 +635,11 @@ class BulkCaseActionSatusView(DataInterfaceSection):
 
     def get(self, request, *args, **kwargs):
         if self.is_copy_action:
-            action_text = "Copying"
+            progress_text = _('Copying cases. This may take some time.')
+            error_text = _('Bulk case copying failed. We have logged this failure.')
         else:
-            action_text = "Reassigning"
+            progress_text = _('Reassigning cases. This may take some time.')
+            error_text = _('Bulk case reassigning failed. We have logged this failure.')
 
         context = super(BulkCaseActionSatusView, self).main_context
         context.update({
@@ -645,10 +647,8 @@ class BulkCaseActionSatusView(DataInterfaceSection):
             'download_id': kwargs['download_id'],
             'poll_url': self.poll_url(kwargs['download_id']),
             'title': _(self.page_title),
-            'progress_text': _("{action_text} Cases. This may take some time...").format(action_text=action_text),
-            'error_text': _(
-                "Bulk Case {action_text} failed for some reason and we have noted this failure."
-            ).format(action_text=action_text),
+            'progress_text': progress_text,
+            'error_text': error_text,
         })
         return render(request, 'hqwebapp/bootstrap3/soil_status_full.html', context)
 


### PR DESCRIPTION
## Technical Summary

Tiny change. Fixes a translation bug where the words "copying" and "reassigning" are not translated, but the rest of the sentence is.

## Safety Assurance

### Safety story

* Not a functional change
* Only affects two strings.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
