### PR TITLE
`Repeater.register()` doesn't need a return value.

### DIFF
--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -644,7 +644,8 @@ class TestRepeaterModelMethods(RepeaterTestCase):
         payload, cases = _create_case(
             domain=DOMAIN, case_id=case_id, case_type='some_case', owner_id='abcd'
         )
-        repeat_record = self.repeater.register(payload, fire_synchronously=True)
+        self.repeater.register(payload, fire_synchronously=True)
+        repeat_record = self.repeater.repeat_records.last()
         self.assertEqual(repeat_record.payload_id, payload.get_id)
         all_records = list(RepeatRecord.objects.iterate(DOMAIN))
         self.assertEqual(len(all_records), 1)
@@ -655,7 +656,8 @@ class TestRepeaterModelMethods(RepeaterTestCase):
         payload, cases = _create_case(
             domain=DOMAIN, case_id=case_id, case_type='some_case', owner_id='abcd'
         )
-        repeat_record = self.repeater.register(payload, fire_synchronously=True)
+        self.repeater.register(payload, fire_synchronously=True)
+        repeat_record = self.repeater.repeat_records.last()
         resp = ResponseMock()
         resp.status_code = 200
         resp.reason = 'OK'


### PR DESCRIPTION
## Technical Summary

Follows up [this PR comment](https://github.com/dimagi/commcare-hq/pull/36105#discussion_r2172051619).

The return value of `Repeater.register()` is only used in tests. By dropping the return value, we can speed up a query.

## Safety Assurance

### Safety story

* Small change.
* Does not affect functionality.

### Automated test coverage

Yes

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
