### PR TITLE
Add url and project description to bug report emails

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/modal_report_issue.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/modal_report_issue.html
@@ -9,7 +9,7 @@
                   enctype="multipart/form-data"
                   role="form">
                 {% csrf_token %}
-                <input type="hidden" id="bug-report-url" name="url"/>
+                <input type="hidden" id="bug-report-url" name="url" value="{{ request.build_absolute_uri }}"/>
                 <input type="hidden" id="bug-report-username" name="username" value="{{ user.username }}"/>
                 <input type="hidden" id="bug-report-domain" name="domain" value="{{ domain }}"/>
                 <input type="hidden" id="bug-report-app_id" name="app_id" value="{{ app.id }}"/>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/modal_report_issue.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/modal_report_issue.html
@@ -14,7 +14,7 @@
             enctype="multipart/form-data"
             role="form">
         {% csrf_token %}
-        <input type="hidden" id="bug-report-url" name="url"/>
+        <input type="hidden" id="bug-report-url" name="url" value="{{ request.build_absolute_uri }}"/>
         <input type="hidden" id="bug-report-username" name="username" value="{{ user.username }}"/>
         <input type="hidden" id="bug-report-domain" name="domain" value="{{ domain }}"/>
         <input type="hidden" id="bug-report-app_id" name="app_id" value="{{ app.id }}"/>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/modal_report_issue.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/modal_report_issue.html.diff.txt
@@ -12,7 +12,7 @@
 -                  enctype="multipart/form-data"
 -                  role="form">
 -                {% csrf_token %}
--                <input type="hidden" id="bug-report-url" name="url"/>
+-                <input type="hidden" id="bug-report-url" name="url" value="{{ request.build_absolute_uri }}"/>
 -                <input type="hidden" id="bug-report-username" name="username" value="{{ user.username }}"/>
 -                <input type="hidden" id="bug-report-domain" name="domain" value="{{ domain }}"/>
 -                <input type="hidden" id="bug-report-app_id" name="app_id" value="{{ app.id }}"/>
@@ -36,7 +36,7 @@
 +            enctype="multipart/form-data"
 +            role="form">
 +        {% csrf_token %}
-+        <input type="hidden" id="bug-report-url" name="url"/>
++        <input type="hidden" id="bug-report-url" name="url" value="{{ request.build_absolute_uri }}"/>
 +        <input type="hidden" id="bug-report-username" name="username" value="{{ user.username }}"/>
 +        <input type="hidden" id="bug-report-domain" name="domain" value="{{ domain }}"/>
 +        <input type="hidden" id="bug-report-app_id" name="app_id" value="{{ app.id }}"/>

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -805,7 +805,6 @@ def _get_email_message_base(post_params, couch_user, uploaded_file, to_email):
         debug_context.update({
             'self_started': domain_object.internal.self_started,
             'has_handoff_info': bool(domain_object.internal.partner_contact),
-            'project_description': domain_object.project_description,
         })
 
     subject = '{subject} ({domain})'.format(subject=report['subject'], domain=domain)
@@ -821,6 +820,8 @@ def _get_email_message_base(post_params, couch_user, uploaded_file, to_email):
         reply_to = settings.SERVER_EMAIL
 
     message_parts.append("Message:\n\n{message}\n".format(message=report['message']))
+    message_parts.append(f"Project description: {domain_object.project_description}\n" if domain_object else "")
+
     if post_params.get('five-hundred-report'):
         extra_message = ("This message was reported from a 500 error page! "
                          "Please fix this ASAP (as if you wouldn't anyway)...")
@@ -828,7 +829,6 @@ def _get_email_message_base(post_params, couch_user, uploaded_file, to_email):
             "datetime: {datetime}\n"
             "Is self start: {self_started}\n"
             "Has Support Hand-off Info: {has_handoff_info}\n"
-            "Project description: {project_description}\n"
             "Sentry Error: {sentry_error}\n"
         ).format(**debug_context)
         traceback_info = cache.cache.get(report['500traceback']) or 'No traceback info available'

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -820,7 +820,8 @@ def _get_email_message_base(post_params, couch_user, uploaded_file, to_email):
         reply_to = settings.SERVER_EMAIL
 
     message_parts.append("Message:\n\n{message}\n".format(message=report['message']))
-    message_parts.append(f"Project description: {domain_object.project_description}\n" if domain_object else "")
+    if domain_object and domain_object.project_description:
+        message_parts.append(f"Project description: {domain_object.project_description}\n")
 
     if post_params.get('five-hundred-report'):
         extra_message = ("This message was reported from a 500 error page! "


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17591
"Project description" is part of the bug report form but was not included in the generated email unless it came from a 500 error page. It is now included whenever a `domain_object` is accessible and the `project_description` says anything, directly following the main "Message" because that is how it is ordered in the bug report form.

"url" exists as a hidden input in the html template and is used in generating the email but had no value assigned in the template, nor was any value given to it later. It now has the value of the current full url (what the user would see in their browser) assigned in the template.

## Safety Assurance

### Safety story
Tested locally to see that the email is constructed correctly. These are pretty straightforward changes, mostly to string formatting. I could see an argument for concern with sending the full url including any query params via email, but sensitive information shouldn't be included in a query string in the first place.

### Automated test coverage
Some testing for the bug report and solutions feature request views, which both use this email context.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
