### PR TITLE
Support blank username in user audit report, with domain required to limit scope

### DIFF
--- a/corehq/apps/auditcare/tests/test_export.py
+++ b/corehq/apps/auditcare/tests/test_export.py
@@ -60,7 +60,7 @@ class TestNavigationEventsQueries(AuditcareTest):
     def test_navigation_events_date_range_query(self):
         start = datetime(2021, 2, 5)
         end = datetime(2021, 2, 15)
-        events = list(navigation_events_by_user(self.username, start, end))
+        events = list(navigation_events_by_user(self.username, start_date=start, end_date=end))
         self.assertEqual({e.user for e in events}, {self.username})
         self.assertEqual({e.event_date for e in events}, set(self.event_dates[4:15]))
         self.assertEqual(len(events), 11)

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -15,9 +15,13 @@ from corehq.util.models import ForeignValue
 from ..models import AccessAudit, NavigationEventAudit
 
 
-def navigation_events_by_user(user, start_date=None, end_date=None):
+def navigation_events_by_user(user, domain=None, start_date=None, end_date=None):
     where = get_date_range_where(start_date, end_date)
-    query = NavigationEventAudit.objects.filter(user=user, **where)
+    if user:
+        where['user'] = user
+    if domain:
+        where['domain'] = domain
+    query = NavigationEventAudit.objects.filter(**where)
     return AuditWindowQuery(query)
 
 

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -26,7 +26,7 @@ def navigation_events_by_user(user, domain=None, start_date=None, end_date=None)
 
 
 def write_log_events(writer, user, domain=None, override_user=None, start_date=None, end_date=None):
-    for event in navigation_events_by_user(user, start_date, end_date):
+    for event in navigation_events_by_user(user, domain, start_date, end_date):
         if not domain or domain == event.domain:
             write_log_event(writer, event, override_user)
 

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -15,12 +15,17 @@ from corehq.util.models import ForeignValue
 from ..models import AccessAudit, NavigationEventAudit
 
 
-def navigation_events_by_user(user, domain=None, start_date=None, end_date=None):
+def filters_for_navigation_event_query(user, domain=None, start_date=None, end_date=None):
     where = get_date_range_where(start_date, end_date)
     if user:
         where['user'] = user
     if domain:
         where['domain'] = domain
+    return where
+
+
+def navigation_events_by_user(user, domain=None, start_date=None, end_date=None):
+    where = filters_for_navigation_event_query(user, domain, start_date, end_date)
     query = NavigationEventAudit.objects.filter(**where)
     return AuditWindowQuery(query)
 

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -27,8 +27,7 @@ def navigation_events_by_user(user, domain=None, start_date=None, end_date=None)
 
 def write_log_events(writer, user, domain=None, override_user=None, start_date=None, end_date=None):
     for event in navigation_events_by_user(user, domain, start_date, end_date):
-        if not domain or domain == event.domain:
-            write_log_event(writer, event, override_user)
+        write_log_event(writer, event, override_user)
 
 
 def write_log_event(writer, event, override_user=None):

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -175,7 +175,7 @@ class UserAuditReport(AdminReport, DatespanMixin):
         context = super().report_context
 
         if not (self.selected_domain or self.selected_user):
-            context['warning_message'] = gettext_lazy("You must specify either a username or a domain. "
+            context['warning_message'] = _("You must specify either a username or a domain. "
                     "Requesting all audit events across all users and domains would exceed system limits.")
         elif self._is_limit_exceeded():
             context['warning_message'] = self._get_limit_exceeded_message()
@@ -183,10 +183,9 @@ class UserAuditReport(AdminReport, DatespanMixin):
         return context
 
     def _get_limit_exceeded_message(self):
-        return gettext_lazy(
-            f"Your search returned more than {self.MAX_RECORDS} records. "
-            "Please narrow down your search by selecting a specific user, domain, or a shorter date range."
-        )
+        return _("Your search returned more than {max_records} records. "
+                 "Please narrow down your search by selecting a specific user, domain, or a shorter date range."
+                 ).format(max_records=self.MAX_RECORDS)
 
 
 class UserListReport(GetParamsMixin, AdminReport):

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -133,7 +133,7 @@ class UserAuditReport(AdminReport, DatespanMixin):
 
     @property
     def rows(self):
-        # Either domain or user must be has a value
+        # Either domain or user must have a value
         if not (self.selected_domain or self.selected_user):
             return []
 

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -130,20 +130,23 @@ class UserAuditReport(AdminReport, DatespanMixin):
 
     @property
     def rows(self):
+        # Either domain or user must be has a value
+        if not (self.selected_domain or self.selected_user):
+            return []
+
         rows = []
         events = navigation_events_by_user(
-            self.selected_user, self.datespan.startdate, self.datespan.enddate
+            self.selected_user, self.selected_domain, self.datespan.startdate, self.datespan.enddate
         )
         for event in events:
-            if not self.selected_domain or self.selected_domain == event.domain:
-                rows.append([
-                    event.event_date,
-                    event.user,
-                    event.domain or '',
-                    event.ip_address,
-                    event.request_method,
-                    event.request_path
-                ])
+            rows.append([
+                event.event_date,
+                event.user,
+                event.domain or '',
+                event.ip_address,
+                event.request_method,
+                event.request_path
+            ])
         return rows
 
 

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -101,7 +101,7 @@ class UserAuditReport(AdminReport, DatespanMixin):
 
     fields = [
         'corehq.apps.reports.filters.dates.DatespanFilter',
-        'corehq.apps.reports.filters.simple.SimpleUsername',
+        'corehq.apps.reports.filters.simple.SingleUserNameOrAllUsers',
         'corehq.apps.reports.filters.simple.SimpleDomain',
     ]
     emailable = False

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -104,7 +104,7 @@ class UserAuditReport(AdminReport, DatespanMixin):
 
     fields = [
         'corehq.apps.reports.filters.dates.DatespanFilter',
-        'corehq.apps.reports.filters.simple.SingleUserNameOrAllUsers',
+        'corehq.apps.reports.filters.simple.SimpleUsername',
         'corehq.apps.reports.filters.simple.SimpleDomain',
     ]
     emailable = False

--- a/corehq/apps/hqadmin/templates/hqadmin/user_audit_report.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/user_audit_report.html
@@ -1,0 +1,14 @@
+{% extends "reports/bootstrap3/tabular.html" %}
+{% load i18n %}
+{% load hq_shared_tags %}
+
+{% block reportcontent %}
+  {% if warning_message %}
+    <div class="alert alert-warning">
+      <h4><i class="fa fa-exclamation-triangle"></i> {% trans "Warning" %}</h4>
+      <p>{{ warning_message }}</p>
+    </div>
+  {% else %}
+    {{ block.super }}
+  {% endif %}
+{% endblock reportcontent %}

--- a/corehq/apps/hqadmin/templates/hqadmin/user_audit_report.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/user_audit_report.html
@@ -5,7 +5,9 @@
 {% block reportcontent %}
   {% if warning_message %}
     <div class="alert alert-warning">
-      <h4><i class="fa fa-exclamation-triangle"></i> {% trans "Warning" %}</h4>
+      <h4>
+        <i class="fa-solid fa-triangle-exclamation"></i> {% trans "Warning" %}
+      </h4>
       <p>{{ warning_message }}</p>
     </div>
   {% else %}

--- a/corehq/apps/reports/filters/simple.py
+++ b/corehq/apps/reports/filters/simple.py
@@ -11,9 +11,6 @@ class RepeaterPayloadIdFilter(BaseSimpleFilter):
 class SimpleUsername(BaseSimpleFilter):
     slug = 'username'
     label = gettext_lazy("Username")
-
-
-class SingleUserNameOrAllUsers(SimpleUsername):
     help_inline = gettext_lazy("Leave this blank to include all users. "
                                "In that case, domain is required to limit the scope.")
 

--- a/corehq/apps/reports/filters/simple.py
+++ b/corehq/apps/reports/filters/simple.py
@@ -13,6 +13,11 @@ class SimpleUsername(BaseSimpleFilter):
     label = gettext_lazy("Username")
 
 
+class SingleUserNameOrAllUsers(SimpleUsername):
+    help_inline = gettext_lazy("Leave this blank to include all users. "
+                               "In that case, domain is required to limit the scope.")
+
+
 class SimpleDomain(BaseSimpleFilter):
     slug = 'domain_name'
     label = gettext_lazy('Domain')


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This change improves the support team’s ability to investigate user actions.
Previously, audit events could only be filtered by a specific username, which made it difficult to identify who performed a particular action (e.g., deleting data).
Support had to check one user at a time.
Now, by allowing the username field to be left blank (while still requiring a domain), they can view actions across all users in a domain, significantly streamlining investigations.

- Add helper text to username filter
<img width="723" alt="image" src="https://github.com/user-attachments/assets/ee8e7ccd-10f8-4925-8965-ed9b8166aec8" />

- Add warning message when returned records exceeds system limit
<img width="812" alt="image" src="https://github.com/user-attachments/assets/8da8d974-82d0-42c1-ae57-8d4039deb823" />

- Add warning message when neither username nor domain is specified
<img width="799" alt="image" src="https://github.com/user-attachments/assets/e0fe88f2-03df-4a17-8596-6b452803b5de" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17539

- Allowed username filter to be `None` to include all users
- Created new template that conditionally displays warnings or normal report
- Implemented limit checking to avoid pulling a lot of data into memory
- Optimized database queries using `[:MAX_RECORDS + 1].count()` to avoid expensive full table scans

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is an admin only feature. I've implement limit checking to avoid performance issue that this can bring to our server. I've tested it locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
