### PR TITLE
Fix DD save button not being clickable on small windows

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -200,7 +200,7 @@
       ></div>
     {% endif %}
     <div class="row">
-      <div class="col-md-12">
+      <div class="col-xs-12">
         <div>
           <h3
             data-bind="text: $root.activeCaseType()"


### PR DESCRIPTION
## Product Description
Before:

https://github.com/user-attachments/assets/9ccd9e37-7a36-40c9-b4f1-cb8da799be35


After:

https://github.com/user-attachments/assets/d7cb34c0-3622-43bc-bfa3-3a9d5912ebd3



## Technical Summary
The `md` column style meant that at smaller window sizes, this `<div>` would expand to effectively cover the save button, making it unclickable.

## Safety Assurance

### Safety story
Very small, safe sort of change to a single styling class.

### Automated test coverage
nope

### QA Plan
nada

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
