### PR TITLE
Two Stage Confirmation by SMS - improve encryption method

### DIFF
--- a/corehq/apps/domain/tests/test_utils.py
+++ b/corehq/apps/domain/tests/test_utils.py
@@ -19,7 +19,7 @@ from corehq.apps.domain.utils import (
     is_domain_in_use,
 )
 from corehq.apps.users.models import CommCareUser
-from corehq.motech.utils import b64_aes_decrypt
+from corehq.motech.utils import b64_aes_cbc_decrypt
 from corehq.tests.tools import nottest
 from corehq.tests.util.context import testcontextmanager
 from corehq.util.test_utils import generate_cases, unit_testing_only
@@ -103,7 +103,7 @@ class UtilsTests(TestCase):
         commcare_user = CommCareUser.create("22", ''.join(str(randint(1, 100))
                                             for i in range(3)), "pass22", None, None)
         encrypted_string = encrypt_account_confirmation_info(commcare_user)
-        decrypted = json.loads(b64_aes_decrypt(encrypted_string))
+        decrypted = json.loads(b64_aes_cbc_decrypt(encrypted_string))
         self.assertIsInstance(decrypted, dict)
         self.assertIsNotNone(decrypted.get("user_id"))
         self.assertIsNotNone(decrypted.get("time"))

--- a/corehq/apps/domain/utils.py
+++ b/corehq/apps/domain/utils.py
@@ -14,7 +14,7 @@ from memoized import memoized
 
 from corehq.apps.domain.dbaccessors import iter_all_domains_and_deleted_domains_with_name
 from corehq.apps.domain.extension_points import custom_domain_module
-from corehq.motech.utils import b64_aes_encrypt
+from corehq.motech.utils import b64_aes_cbc_encrypt
 from corehq.util.test_utils import unit_testing_only
 
 from corehq.apps.domain.models import Domain
@@ -183,7 +183,7 @@ def log_domain_changes(user, domain, new_obj, old_obj):
 
 def encrypt_account_confirmation_info(commcare_user):
     data = {"user_id": commcare_user.get_id, "time": int(time.time())}
-    return b64_aes_encrypt(json.dumps(data))
+    return b64_aes_cbc_encrypt(json.dumps(data))
 
 
 def is_domain_in_use(domain_name):

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -155,7 +155,7 @@ from corehq.const import (
     USER_CHANGE_VIA_WEB,
     USER_DATE_FORMAT,
 )
-from corehq.motech.utils import b64_aes_decrypt
+from corehq.motech.utils import b64_aes_decrypt, b64_aes_cbc_decrypt
 from corehq.pillows.utils import MOBILE_USER_TYPE, WEB_USER_TYPE
 from corehq.util import get_document_or_404
 from corehq.util.dates import iso_string_to_datetime
@@ -1577,7 +1577,12 @@ class CommCareUserConfirmAccountBySMSView(CommCareUserConfirmAccountView):
     @property
     @memoized
     def user_invite_hash(self):
-        return json.loads(b64_aes_decrypt(self.kwargs.get('user_invite_hash')))
+        try:
+            return json.loads(b64_aes_cbc_decrypt(self.kwargs.get('user_invite_hash')))
+        except Exception:
+            # Temporarily fallback to b64_aes_decrypt if b64_aes_cbc_decrypt fails
+            # to handle existing invites
+            return json.loads(b64_aes_decrypt(self.kwargs.get('user_invite_hash')))
 
     @property
     @memoized


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user facing changes

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi.atlassian.net/browse/USH-5756)
This is a continuation of the work to transition to using the stronger CBC mode of encryption. 

[CodeQL recommends](https://codeql.github.com/codeql-query-help/swift/swift-ecb-encryption/) using CBC cipher mode instead of ECB. From the doc:

> ECB should not be used as a mode for encryption as it has dangerous weaknesses. Data is encrypted the same way every time, which means that the same plaintext input will always produce the same ciphertext. This behavior makes messages encrypted with ECB more vulnerable to replay attacks.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[two_stage_user_provisioning_by_sms](https://www.commcarehq.org/hq/flags/edit/two_stage_user_provisioning_by_sms/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change blast radius is limited to mobile worker confirmation via SMS. This change also as a backup uses the existing ebc decryption method.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
`test_user_info_encryption_decryption` checks the encryption util method

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
This encrypts expiry link timestamps with cbc. If this PR is reverted, those links will still contain the expiry link so those links will be broken. If we need to revert this, then when attempting to decrypt, we should attempt to decrypt using cbc as a backup.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
