### PR TITLE
Fix sentry-sdk on Python 3.13

### DIFF
--- a/corehq/util/htmx_action.py
+++ b/corehq/util/htmx_action.py
@@ -3,7 +3,7 @@ import logging
 
 from django.http import HttpResponse, HttpResponseForbidden
 from django.utils.encoding import force_str
-from sentry_sdk import capture_exception, configure_scope
+from sentry_sdk import capture_exception, get_current_scope
 
 from corehq.util.htmx_gtm import get_htmx_gtm_event
 
@@ -146,17 +146,17 @@ class HqHtmxActionMixin:
         except HtmxResponseException as err:
             return self._return_error_response(err, action=action)
         except Exception as err:
-            with configure_scope() as scope:
-                scope.set_tag('hq_hx_action', action)
-                scope.set_extra(
-                    'request_details',
-                    {
-                        'method': request.method,
-                        'path': request.path,
-                        'domain': request.domain if hasattr(request, 'domain') else None,
-                    },
-                )
-                capture_exception(err)
+            scope = get_current_scope()
+            scope.set_tag('hq_hx_action', action)
+            scope.set_extra(
+                'request_details',
+                {
+                    'method': request.method,
+                    'path': request.path,
+                    'domain': request.domain if hasattr(request, 'domain') else None,
+                },
+            )
+            capture_exception(err)
             raise
         return response
 

--- a/uv.lock
+++ b/uv.lock
@@ -4020,15 +4020,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.8.0"
+version = "2.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/9d/d61d64819ecb0481647229c3ee8ddc00887552acc23745fd65d0d4d066f3/sentry_sdk-2.8.0.tar.gz", hash = "sha256:aa4314f877d9cd9add5a0c9ba18e3f27f99f7de835ce36bd150e48a41c7c646f", size = 273663, upload-time = "2024-07-08T08:11:38.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/59/eb90c45cb836cf8bec973bba10230ddad1c55e2b2e9ffa9d7d7368948358/sentry_sdk-2.32.0.tar.gz", hash = "sha256:9016c75d9316b0f6921ac14c8cd4fb938f26002430ac5be9945ab280f78bec6b", size = 334932, upload-time = "2025-06-27T08:10:02.89Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/f4/8e1be145ce63c4ef4e126ee362992ae1ada5e716723883912b74829583e7/sentry_sdk-2.8.0-py2.py3-none-any.whl", hash = "sha256:6051562d2cfa8087bb8b4b8b79dc44690f8a054762a29c07e22588b1f619bfb5", size = 300617, upload-time = "2024-07-08T08:11:33.904Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a1/fc4856bd02d2097324fb7ce05b3021fb850f864b83ca765f6e37e92ff8ca/sentry_sdk-2.32.0-py2.py3-none-any.whl", hash = "sha256:6cf51521b099562d7ce3606da928c473643abe99b00ce4cb5626ea735f4ec345", size = 356122, upload-time = "2025-06-27T08:10:01.424Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes failing test on Python 3.13:
```sh
pytest corehq/apps/campaign/tests/test_views.py::TestDeleteWidget::test_delete_nonexistent_widget
```
Which caused `TypeError: cannot pickle 'FrameLocalsProxy' object` on sentry-sdk==2.8.0

## Safety Assurance

### Safety story

Upgrades an error handling library and updates deprecated API usage. Reviewed [change log](https://github.com/getsentry/sentry-python/blob/master/CHANGELOG.md), no breaking changes observed.

### Automated test coverage

Yes.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations