### PR TITLE
fa-triangle-exclamation

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -28,7 +28,7 @@
 {% if build_errors %}
   <div class="alert alert-warning alert-build">
     <h4 class="alert-heading">
-      <i class="fa fa-exclamation-triangle"></i>
+      <i class="fa fa-triangle-exclamation"></i>
       {% trans "Cannot make new version" %}
     </h4>
     <ul class="list-unstyled" id="build-errors">

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_ucr_v1_warning.html
@@ -4,7 +4,7 @@
 
 <div class="alert alert-warning alert-build">
   <h4 class="alert-heading">
-    <i class="fa fa-exclamation-triangle"></i>
+    <i class="fa fa-triangle-exclamation"></i>
     {% trans "Warning" %}
   </h4>
   <span> {{ warning_message }} </span>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/case_property_warning.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/case_property_warning.html
@@ -7,7 +7,7 @@
   class="alert alert-warning"
   data-bind="visible: showWarning()"
 >
-  <i class="fa fa-exclamation-triangle"></i>
+  <i class="fa fa-triangle-exclamation"></i>
   {% trans "Performance warning" %}
   <button
     id="performance-warning-toggle"

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap3/case_rule_actions.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap3/case_rule_actions.html
@@ -68,7 +68,7 @@
     <div data-bind="template: {name: 'remove-action'}"></div>
     <label class="control-label col-xs-2">{% trans "Close the case" %}</label>
     <span class="help-block col-xs-8">
-      <i class="fa fa-exclamation-triangle"></i>
+      <i class="fa fa-triangle-exclamation"></i>
       {% trans "All cases matching the above criteria will be closed" %}
     </span>
   </div>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap5/case_rule_actions.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/bootstrap5/case_rule_actions.html
@@ -79,7 +79,7 @@
     <div data-bind="template: {name: 'remove-action'}"></div>
     <label class="form-label col-sm-2">{% trans "Close the case" %}</label>
     <span class="help-block col-sm-8">
-      <i class="fa fa-exclamation-triangle"></i>
+      <i class="fa fa-triangle-exclamation"></i>
       {% trans "All cases matching the above criteria will be closed" %}
     </span>
   </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/data_interfaces/partials/case_rule_actions.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/data_interfaces/partials/case_rule_actions.html.diff.txt
@@ -56,7 +56,7 @@
 -    <span class="help-block col-xs-8">
 +    <label class="form-label col-sm-2">{% trans "Close the case" %}</label>
 +    <span class="help-block col-sm-8">
-       <i class="fa fa-exclamation-triangle"></i>
+       <i class="fa fa-triangle-exclamation"></i>
        {% trans "All cases matching the above criteria will be closed" %}
      </span>
 @@ -79,11 +90,10 @@

--- a/corehq/apps/notifications/templates/notifications/partials/bootstrap3/global_notifications.html
+++ b/corehq/apps/notifications/templates/notifications/partials/bootstrap3/global_notifications.html
@@ -23,7 +23,7 @@
         <span class="notifications-icon">
           <i class="notifications-type fa"
              data-bind="css: {
-                  'fa-exclamation-triangle icon-warning-sign': isAlert(),
+                  'fa-triangle-exclamation icon-warning-sign': isAlert(),
                   'fa-info-circle icon-info-sign': isInfo() || isFeature(),
               }"></i>
         </span>

--- a/corehq/apps/notifications/templates/notifications/partials/bootstrap5/global_notifications.html
+++ b/corehq/apps/notifications/templates/notifications/partials/bootstrap5/global_notifications.html
@@ -28,7 +28,7 @@
         <span class="notifications-icon">
           <i class="notifications-type fa"
              data-bind="css: {
-                  'fa-exclamation-triangle icon-warning-sign': isAlert(),
+                  'fa-triangle-exclamation icon-warning-sign': isAlert(),
                   'fa-info-circle icon-info-sign': isInfo() || isFeature(),
               }"></i>
         </span>

--- a/corehq/apps/registration/templates/registration/partials/register_new_user/submit_errors.html
+++ b/corehq/apps/registration/templates/registration/partials/register_new_user/submit_errors.html
@@ -2,7 +2,7 @@
 
 <fieldset class="submit-errors" data-bind="visible: hasSubmitErrors">
   <legend>
-    <i class="fa fa-exclamation-triangle"></i>
+    <i class="fa fa-triangle-exclamation"></i>
     {% trans "Issue with registration" %}
   </legend>
   <p>

--- a/corehq/apps/styleguide/context.py
+++ b/corehq/apps/styleguide/context.py
@@ -236,7 +236,7 @@ def get_common_icons():
         {
             'name': 'Common FontAwesome secondary icons',
             'icons': _add_prefix_to_icons('fa-solid', [
-                'fa-cloud-arrow-down', 'fa-cloud-arrow-up', 'fa-exclamation-triangle', 'fa-info-circle',
+                'fa-cloud-arrow-down', 'fa-cloud-arrow-up', 'fa-triangle-exclamation', 'fa-info-circle',
                 'fa-question-circle', 'fa-check', 'fa-external-link',
             ]),
         }


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Correcting my mistake in https://github.com/dimagi/commcare-hq/pull/36580. I thought `fa-exclamation-triangle` was the standard, but turns out it is `fa-triangle-exclamation`.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
These icons are both valid, but just switching the the more conventional name and what is more prevalent in our codebase.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
