### PR TITLE
Build test docker image with Github Actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,35 @@
+name: Build Test Docker Image
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get Python version
+        id: vars
+        # produces a variable like python=py3.13
+        run: echo "python=py$(cat .python-version)" >> $GITHUB_OUTPUT
+
+      - name: Docker login
+        if: secrets.DOCKERHUB_TOKEN != ''
+        uses: docker/login-action@v3
+        with:
+          username: dimagi
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image to Docker Hub
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: dimagi/commcarehq-${{ steps.vars.outputs.python }}
+          push: true


### PR DESCRIPTION
A Github Action provides more control over the image than is available with Docker Hub build automation. Specifically, it allows the Python version to be embedded in the image name.

As of this writing, the dimagi/commcare-hq repository cannot be selected in the Docker Hub build settings, likely due to Github access control changes since the build was originally configured. This means the commcarehq_base image cannot currently be reconfigured or updated on Docker Hub. The plan is to abandon that image with Python 3.9 and begin using images generated by this Action for Python 3.13 and onward.

Encoding the build configuration as a source code artifact and Github Action allows us to more reliably maintain it over time and more easily monitor build status in association with a hypothetical PR that breaks the build.

## Safety Assurance

### Safety story

Adds a new Github Action to build a docker image for testing. Not used by production code.

### Automated test coverage

No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations