### PR TITLE
Use `--active` to support other virtual environments

### DIFF
--- a/scripts/hammer.sh
+++ b/scripts/hammer.sh
@@ -1,7 +1,7 @@
 git checkout master &&
 git pull origin master &&
 git submodule update --init --recursive &&
-uv sync --compile-bytecode &&
+uv sync --compile-bytecode --active &&
 ( [ -f requirements/local.txt ] && uv pip install -r requirements/local.txt || true ) &&
 find . -name '*.pyc' -not -path './.venv/*' -delete &&
 ./manage.py sync_couch_views &&


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Update `hammer.sh` to use the `--active` flag when calling `uv`, so that it respects the currently activated virtual environment instead of defaulting to `.venv`. This change improves compatibility with developers who use `pyenv` or other virtualenv managers.

Previously, running `hammer.sh` while using a `pyenv`-managed environment caused the following warning:
```
warning: VIRTUAL_ENV=.........../.pyenv/versions/3.9.11/envs/hq does not match the project environment path .venv and will be ignored; use --active to target the active environment instead
```
This could lead to `uv` attempting to install packages in a non-active `.venv` directory or failing due to conflicting environments.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
