### PR TITLE
Remove obsolete dependabot runtime.txt

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,0 @@
-python-3.9
-# Specifies the python version that dependabot should use.
-# NOTE: the full "allowed syntax" of this file isn't well documented. If you
-# suspect problems with the contents of this file, try:
-# - removing all comments
-# - using a full version, including patch (e.g. 'python-3.9.14')


### PR DESCRIPTION
Some quick online searches (powered by [perplexity](https://www.perplexity.ai/search/how-and-under-what-circumstanc-JWysbJmZTNqh1Y_1ib1pLQ)), runtime.txt is apparently not used by dependabot. On the other hand, it does appear to be [known by dependabot](https://github.com/dimagi/commcare-hq/network/updates) in some capacity, but unclear how it is used. Hopefully dependabot will prioritize `.python-version` over this file.

![Screenshot From 2025-07-02 09-47-13](https://github.com/user-attachments/assets/d4b59b91-3c39-4086-b41b-c91158d529fb)

I wonder if it was more important previously before we switched to uv for dependency management?

## Safety Assurance

### Safety story

Does not affect production code. If it affects anything, it would be dependabot.

### Automated test coverage

No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations