### PR TITLE
Fix bug in get_flagged_pay_annually_prepay_invoice

### DIFF
--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -449,15 +449,28 @@ class TestFlaggedPayAnnuallyPrepayInvoice(BaseInvoiceTestCase):
         self.create_invoices(self.invoice_date)
         self.invoice = self.subscription.invoice_set.first()
 
+    def create_prepayment_invoice(self, date_due):
+        yearly_subscription_cost = self.plan_version.product_rate.monthly_fee * PAY_ANNUALLY_SUBSCRIPTION_MONTHS
+        return WirePrepaymentInvoice.objects.create(
+            domain=self.subscription.subscriber.domain,
+            date_start=self.subscription.date_start,
+            date_end=self.subscription.date_end,
+            date_due=date_due,
+            balance=yearly_subscription_cost,
+        )
+
+    def create_product_credit(self, amount):
+        return CreditLine.objects.create(
+            account=self.subscription.account,
+            subscription=self.subscription,
+            balance=amount,
+            is_product=True,
+        )
+
     def test_monthly_invoice_product_fully_paid(self):
         product_line_item = self.invoice.lineitem_set.get_products().first()
         # create a CreditLine the product_line_item will be paid with
-        CreditLine.objects.create(
-            account=self.invoice.subscription.account,
-            subscription=self.invoice.subscription,
-            balance=product_line_item.subtotal,
-            is_active=True,
-        )
+        self.create_product_credit(product_line_item.subtotal)
         product_line_item.calculate_credit_adjustments()
         product_line_item.save()
         flagged_invoice = get_flagged_pay_annually_prepay_invoice(self.invoice)
@@ -468,26 +481,12 @@ class TestFlaggedPayAnnuallyPrepayInvoice(BaseInvoiceTestCase):
         self.assertIsNone(flagged_invoice)
 
     def test_prepayment_invoice_not_due_yet(self):
-        yearly_subscription_cost = self.plan_version.product_rate.monthly_fee * PAY_ANNUALLY_SUBSCRIPTION_MONTHS
-        WirePrepaymentInvoice.objects.create(
-            domain=self.subscription.subscriber.domain,
-            date_start=self.subscription.date_start,
-            date_end=self.subscription.date_end,
-            date_due=datetime.date.today() + relativedelta(days=1),
-            balance=yearly_subscription_cost,
-        )
+        self.create_prepayment_invoice(datetime.date.today() + relativedelta(days=1))
         result = get_flagged_pay_annually_prepay_invoice(self.invoice)
         self.assertIsNone(result)
 
     def test_matching_prepayment_invoice_exists(self):
-        yearly_subscription_cost = self.plan_version.product_rate.monthly_fee * PAY_ANNUALLY_SUBSCRIPTION_MONTHS
-        prepay_invoice = WirePrepaymentInvoice.objects.create(
-            domain=self.subscription.subscriber.domain,
-            date_start=self.subscription.date_start,
-            date_end=self.subscription.date_end,
-            date_due=self.subscription.date_start,
-            balance=yearly_subscription_cost,
-        )
+        prepay_invoice = self.create_prepayment_invoice(self.subscription.date_start)
         result = get_flagged_pay_annually_prepay_invoice(self.invoice)
         self.assertEqual(result, prepay_invoice)
 

--- a/corehq/apps/accounting/utils/invoicing.py
+++ b/corehq/apps/accounting/utils/invoicing.py
@@ -135,7 +135,7 @@ def get_flagged_pay_annually_prepay_invoice(invoice):
     product_line_item = invoice.lineitem_set.get_products().first()
     if (
         product_line_item is None
-        or product_line_item.applied_credit >= product_line_item.subtotal
+        or product_line_item.total <= 0
     ):
         return None
 


### PR DESCRIPTION
## Technical Summary
Raised by ops - the logic to fetch applicable monthly invoices where the product credit was not automatically applied was flawed, resulting in too many emails being sent to them. The issue is that looking at `product_line_item.applied_credit` (a negative number) would never have been greater than `product_line_item.subtotal` (a positive number).

The test case to check whether the product was fully credited was still passing, because we weren't generating the prepayment invoice first and thus, even though `get_flagged_pay_annually_prepay_invoice` was not returning early as intended, there was no prepayment invoice for it to return, so we'd still get `None`.

The first two commits are to clean up and fix tests, the third is the fix to live code.

## Safety Assurance

### Safety story
This corrects logic that was essentially inverted, which becomes apparent once realizing that `applied_credit` is always a negative number when present. The logic is used only to send an email to an internal email address, so at worst they might receive too many or too few emails. Updated automated testing, specifically `test_monthly_invoice_product_fully_paid` correctly fails when using the function with its previous logic, and passes with the update to check `.total`.

### Automated test coverage
`TestFlaggedPayAnnuallyPrepayInvoice`

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
