### PR TITLE
Remove redundant feature flag for onse

### DIFF
--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -15,7 +15,6 @@ from corehq import privileges
 from dimagi.utils.dates import DateSpan
 
 from corehq.apps.export.filters import (
-    AND,
     NOT,
     OR,
     FormSubmittedByFilter,
@@ -51,7 +50,6 @@ from corehq.apps.reports.filters.users import (
 )
 from corehq.apps.reports.models import HQUserType
 from corehq.apps.reports.util import datespan_from_beginning
-from corehq.toggles import FILTER_ON_GROUPS_AND_LOCATIONS
 from corehq.util import flatten_non_iterable_list
 from corehq.apps.userreports.dbaccessors import get_datasources_for_domain
 
@@ -765,8 +763,6 @@ class FormExportFilterBuilder(AbstractExportFilterBuilder):
 
         if not location_filter and not group_filter:
             group_and_location_metafilter = None
-        elif FILTER_ON_GROUPS_AND_LOCATIONS.enabled(self.domain_object.name) and location_ids and group_ids:
-            group_and_location_metafilter = AND(group_filter, location_filter)
         else:
             group_and_location_metafilter = OR(*list(filter(None, [group_filter, location_filter])))
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -6,7 +6,6 @@ from django.utils.translation import gettext_lazy, gettext_noop
 
 from memoized import memoized
 
-from corehq import toggles
 from corehq.feature_previews import USE_LOCATION_DISPLAY_NAME
 from corehq.apps.domain.models import Domain
 from corehq.apps.enterprise.models import EnterprisePermissions
@@ -414,16 +413,10 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
 
         group_id_filter = filters.term("__group_ids", group_ids)
 
-        if toggles.FILTER_ON_GROUPS_AND_LOCATIONS.enabled(domain) and group_ids and location_ids:
-            group_and_location_filter = filters.AND(
-                group_id_filter,
-                user_es.location(location_ids),
-            )
-        else:
-            group_and_location_filter = filters.OR(
-                group_id_filter,
-                user_es.location(location_ids),
-            )
+        group_and_location_filter = filters.OR(
+            group_id_filter,
+            user_es.location(location_ids),
+        )
 
         id_filter = filters.OR(
             filters.term("_id", user_ids),

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1870,18 +1870,6 @@ ALLOW_BLANK_CASE_TAGS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-FILTER_ON_GROUPS_AND_LOCATIONS = StaticToggle(
-    'filter_on_groups_and_locations',
-    '[ONSE] Change filter from groups OR locations to groups AND locations in all reports and exports in the '
-    'ONSE domain with group and location filters',
-    TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN],
-    description='For reports filtered by groups and locations, change the OR logic to an AND, so that '
-                '(for example): "Groups or Users: [Salima District] AND [User group Healthworkers]" '
-                'returns 40 healthworkers who are also in salima. Changes this logic to all reports that '
-                'have group and location filters, such as the Submissions by Form report.',
-)
-
 DONT_INDEX_SAME_CASETYPE = StaticToggle(
     'dont_index_same_casetype',
     "Don't create a parent index if the child case has the same case type as the parent case",


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This removes the following feature flag that is currently not being used by any active real projects.
"[ONSE] Change filter from groups OR locations to groups AND locations in all reports and exports"

Waiting on approval before merging, but good for review.
Approved
https://dimagi.atlassian.net/browse/SAAS-17786?focusedCommentId=386589

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-17786

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just removes some code which was mainly a customization for existing code and didn't add any new code.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
