### PR TITLE
Update dropdown styling on signup page

### DIFF
--- a/corehq/apps/hqwebapp/static/registration/less/registration-main.less
+++ b/corehq/apps/hqwebapp/static/registration/less/registration-main.less
@@ -139,29 +139,21 @@ p.sso-message-block {
   border-radius: @input-border-radius-large;
   border: 2px solid #cccccc;
   font-size: 1em;
-}
 
-.radio-select_options {
-  border-radius: @input-border-radius-large;
-}
-
-.radio-select {
+  &_options {
+    border-radius: @input-border-radius-large;
+  }
   &_expand {
     &::after {
       line-height: @input-height-large;
     }
   }
-}
-.radio-select {
   &_items {
     padding-top: @input-height-large;
   }
   &_label {
     line-height: @input-height-large - 2px;
   }
-}
-
-.radio-select {
   &_expand:checked {
     + .radio-select_closeLabel {
       + .radio-select_options {

--- a/corehq/apps/hqwebapp/static/registration/less/registration-main.less
+++ b/corehq/apps/hqwebapp/static/registration/less/registration-main.less
@@ -189,21 +189,6 @@ p.sso-message-block {
   margin: 10px 0;
 }
 
-.check-list {
-  @_text-indent: 8px;
-  padding: 0;
-  padding-top: 10px;
-  padding-left: @_text-indent;
-  margin: 0;
-  list-style: none;
-
-  li {
-    text-indent: -@_text-indent;
-    margin-left: @_text-indent;
-    font-size: 12px;
-  }
-}
-
 ._make-btn-primary-choice (@color) {
   .btn-primary {
     background-color: @color;

--- a/corehq/apps/hqwebapp/static/registration/less/registration-main.less
+++ b/corehq/apps/hqwebapp/static/registration/less/registration-main.less
@@ -138,7 +138,7 @@ p.sso-message-block {
   box-sizing: border-box;
   border-radius: @input-border-radius-large;
   border: 2px solid #cccccc;
-  font-size: 1em;
+  font-size: @font-size-large;
 
   &_options {
     border-radius: @input-border-radius-large;
@@ -153,6 +153,7 @@ p.sso-message-block {
   }
   &_label {
     line-height: @input-height-large - 2px;
+    padding-left: @padding-large-horizontal;
   }
   &_expand:checked {
     + .radio-select_closeLabel {


### PR DESCRIPTION
## Product Description
Before:
![image](https://github.com/user-attachments/assets/87e8cf36-7fe6-4692-8968-f6f449ccb4fe)

After:
![image](https://github.com/user-attachments/assets/5e1ebe45-29b1-416d-aebf-888e2d4f987d)


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-16797
Cleans up a stylesheet file a little and updates the text size and left padding for `.radio-select` elements on the registration page (just the "persona" dropdown at present).

## Safety Assurance

### Safety story
These are just styling changes and have been tested locally and on staging to see the desired effect.

### Automated test coverage
Not for stylesheets.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
