### PR TITLE
Remove dead code in import app feature

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/import_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/import_app.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load compress %}
-
 {% js_entry_b3 'app_manager/js/import_app' %}
 
 {% block page_navigation %}
@@ -15,25 +14,41 @@
   {% registerurl 'import_app' domain %}
   <div class="appmanager-content-single-page">
     <h1>{% trans "Import Application" %}</h1>
-    <form action="{% url "import_app" domain %}" id="app-import-form" method="post" enctype="multipart/form-data">
+    <form
+      action="{% url "import_app" domain %}"
+      id="app-import-form"
+      method="post"
+      enctype="multipart/form-data"
+    >
       {% csrf_token %}
       <div class="form-horizontal">
         <div class="form-group">
           <label class="{% css_label_class %} control-label">Name</label>
           <div class="{% css_field_class %}">
-            <input class="form-control" type="text" name="name"/>
+            <input class="form-control" type="text" name="name" />
           </div>
         </div>
         <div class="form-group">
-          <label for="source_file" class="{% css_label_class %} control-label">{% trans "Application Source File" %}</label>
+          <label for="source_file" class="{% css_label_class %} control-label"
+            >{% trans "Application Source File" %}</label
+          >
           <div class="{% css_field_class %}">
-            <input id="source_file" type="file" name="source_file" data-bind="value: file"/>
+            <input
+              id="source_file"
+              type="file"
+              name="source_file"
+              data-bind="value: file"
+            />
           </div>
         </div>
         <div class="form-actions">
           <div class="{% css_action_class %}">
-            <a href="#" class="btn btn-default historyBack">{% trans "No, take me back." %}</a>
-            <button class="btn btn-primary" type="submit">{% trans 'Yes, import application' %}</button>
+            <a href="#" class="btn btn-default historyBack"
+              >{% trans "No, take me back." %}</a
+            >
+            <button class="btn btn-primary" type="submit">
+              {% trans 'Yes, import application' %}
+            </button>
           </div>
         </div>
       </div>

--- a/corehq/apps/app_manager/templates/app_manager/import_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/import_app.html
@@ -15,14 +15,8 @@
   {% registerurl 'import_app' domain %}
   <div class="appmanager-content-single-page">
     <h1>{% trans "Import Application" %}</h1>
-    {% initial_page_data 'export_json' app.export_json %}
     <form action="{% url "import_app" domain %}" id="app-import-form" method="post" enctype="multipart/form-data">
       {% csrf_token %}
-      {% if app %}
-        {% blocktrans with app_name=app.name app_domain=app.domain %}
-          <p>Import application <strong>{{ app_name }}</strong> from domain <strong>{{ app_domain }}</strong>?</p>
-        {% endblocktrans %}
-      {% endif %}
       <div class="form-horizontal">
         <div class="form-group">
           <label class="{% css_label_class %} control-label">Name</label>

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -91,7 +91,6 @@ from corehq.apps.domain.decorators import (
     login_or_digest,
     track_domain_request,
 )
-from corehq.apps.domain.models import Domain
 from corehq.apps.hqmedia.models import MULTIMEDIA_PREFIX, CommCareMultimedia
 from corehq.apps.hqwebapp.forms import AppTranslationsBulkUploadForm
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
@@ -651,32 +650,8 @@ def import_app(request, domain):
 
         return back_to_main(request, domain, app_id=app._id)
     else:
-        app_id = request.GET.get('app')
-        redirect_domain = request.GET.get('domain') or None
-        if redirect_domain is not None:
-            redirect_domain = redirect_domain.lower()
-            if Domain.get_by_name(redirect_domain):
-                return HttpResponseRedirect(
-                    reverse('import_app', args=[redirect_domain])
-                    + "?app={app_id}".format(app_id=app_id)
-                )
-            else:
-                if redirect_domain:
-                    messages.error(request, "We can't find a project called \"%s\"." % redirect_domain)
-                else:
-                    messages.error(request, "You left the project name blank.")
-                return HttpResponseRedirect(request.META.get('HTTP_REFERER', request.path))
-
-        if app_id:
-            app = get_app(None, app_id)
-            assert (app.get_doc_type() in ('Application', 'RemoteApp'))
-            assert (request.couch_user.is_member_of(app.domain))
-        else:
-            app = None
-
         return render(request, template, {
             'domain': domain,
-            'app': app,
         })
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
🐠 Review by commit because there is one prettify html commit.

<img width="937" alt="image" src="https://github.com/user-attachments/assets/1fc77b40-dc23-4b76-a94f-c850a6f2bc0b" />


Previously, there are two ways to import apps:
- Upload app source file
- Provide an existing app id via URL parameter

In the second way, template would show: "Import application `app.name` from domain `app.domain`"
`{% initial_page_data 'export_json' app.export_json %}` would pass the app's json file to javascript
User could just click "Yes, import application" without uploading any file. The form submission would use the pre-loaded app data instead of requiring a file upload.

But now we only support one way — user must upload a json file, and we have moved app copy in the same server feature to the source app's setting page with a better UI.

Thus the dead code can be removed. Now the GET request will simple displays form for importing applications from JSON files.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe, I have tested locally, the importing app with uploading a file function is not impacted.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
