### PR TITLE
Mjr/barcode hack

### DIFF
--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -17,7 +17,7 @@ from corehq.apps.receiverwrapper.exceptions import LocalSubmissionError
 from corehq.apps.receiverwrapper.rate_limiter import rate_limit_submission
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.submission_post import SubmissionPost
-from corehq.form_processor.utils import convert_xform_to_json
+from corehq.form_processor.utils.xform import convert_xform_to_json, sanitize_instance_xml
 from corehq.util.quickcache import quickcache
 from corehq.util.soft_assert import soft_assert
 
@@ -269,6 +269,7 @@ def should_ignore_submission(request):
     form_json = None
     if settings.IGNORE_ALL_DEMO_USER_SUBMISSIONS:
         instance, _ = couchforms.get_instance_and_attachment(request)
+        instance = sanitize_instance_xml(instance, request)
         try:
             form_json = convert_xform_to_json(instance)
         except couchforms.XMLSyntaxError:
@@ -285,6 +286,7 @@ def should_ignore_submission(request):
 
     if form_json is None:
         instance, _ = couchforms.get_instance_and_attachment(request)
+        instance = sanitize_instance_xml(instance, request)
         form_json = convert_xform_to_json(instance)
     return False if from_demo_user(form_json) else True
 

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -56,7 +56,7 @@ from corehq.apps.users.models import CouchUser
 from corehq.form_processor.exceptions import XFormLockError
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.submission_post import SubmissionPost
-from corehq.form_processor.utils import convert_xform_to_json
+from corehq.form_processor.utils.xform import convert_xform_to_json, sanitize_instance_xml
 from corehq.util.metrics import metrics_counter, metrics_histogram
 from corehq.util.timer import TimingContext, set_request_duration_reporting_threshold
 from couchdbkit import ResourceNotFound
@@ -103,9 +103,11 @@ def _process_form(request, domain, app_id, user_id, authenticated,
 
     try:
         instance, attachments = couchforms.get_instance_and_attachment(request)
+        instance = sanitize_instance_xml(instance, request)
     except MultimediaBug:
         try:
             instance = request.FILES[MAGIC_PROPERTY].read()
+            instance = sanitize_instance_xml(instance, request)
             xform = convert_xform_to_json(instance)
             meta = xform.get("meta", {})
         except Exception:
@@ -307,6 +309,7 @@ def _noauth_post(request, domain, app_id=None):
     except BadSubmissionRequest as e:
         return HttpResponseBadRequest(e.message)
 
+    instance = sanitize_instance_xml(instance, request)
     form_json = convert_xform_to_json(instance)
     case_updates = get_case_updates(form_json)
 

--- a/corehq/form_processor/tests/utils/test_xform.py
+++ b/corehq/form_processor/tests/utils/test_xform.py
@@ -1,0 +1,22 @@
+from django.test import SimpleTestCase, RequestFactory
+from corehq.util.test_utils import flag_enabled
+from corehq.form_processor.utils.xform import sanitize_instance_xml
+
+
+class TestSanitizeInstanceXML(SimpleTestCase):
+    def test_does_nothing_with_feature_flags_off(self):
+        initial_input = b'abc&#29;123'
+        request = RequestFactory().get('/')
+        self.assertEqual(sanitize_instance_xml(initial_input, request), initial_input)
+
+    @flag_enabled('CONVERT_XML_GROUP_SEPARATOR')
+    def test_replaces_group_separator_with_replacement_when_feature_flag_is_on(self):
+        initial_input = b'abc&#29;123'
+        request = RequestFactory().get('/')
+        self.assertEqual(sanitize_instance_xml(initial_input, request), b'abc&#xFFFD;123')
+
+    @flag_enabled('CONVERT_XML_GROUP_SEPARATOR')
+    def test_replaces_all_occurrences(self):
+        initial_input = b'abc&#29;123&#29;def'
+        request = RequestFactory().get('/')
+        self.assertEqual(sanitize_instance_xml(initial_input, request), b'abc&#xFFFD;123&#xFFFD;def')

--- a/corehq/form_processor/utils/xform.py
+++ b/corehq/form_processor/utils/xform.py
@@ -9,6 +9,7 @@ import xml2json
 from corehq.form_processor.interfaces.processor import XFormQuestionValueIterator
 from corehq.form_processor.models import Attachment, XFormInstance
 from corehq.form_processor.exceptions import XFormQuestionValueNotFound
+from corehq.toggles import CONVERT_XML_GROUP_SEPARATOR
 from dimagi.ext import jsonobject
 from dimagi.utils.parsing import json_format_datetime
 
@@ -178,6 +179,14 @@ def extract_meta_user_id(form):
     elif form.get('Meta'):
         user_id = form.get('Meta').get('user_id', None)
     return user_id
+
+
+def sanitize_instance_xml(xml_string, request):
+    GROUP_SEPARATOR = b'&#29;'
+    REPLACEMENT_CHARACTER = b'&#xFFFD;'
+    if CONVERT_XML_GROUP_SEPARATOR.enabled_for_request(request):
+        xml_string = xml_string.replace(GROUP_SEPARATOR, REPLACEMENT_CHARACTER)
+    return xml_string
 
 
 def convert_xform_to_json(xml_string):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -3002,3 +3002,10 @@ ACTIVATE_DATADOG_APM_TRACES = StaticToggle(
     tag=TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN]
 )
+
+CONVERT_XML_GROUP_SEPARATOR = StaticToggle(
+    slug='convert_xml_group_separator',
+    label='Convert the group separator to a symbol XML can support',
+    tag=TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
## Product Description
![image](https://github.com/user-attachments/assets/629cf7d8-fa89-477e-b5a3-8ed03bfc4c75)


## Technical Summary
Adds a feature flag and code to support converting the group separator character (`&#29;`) to the replacement character (`&#xFFFD;`). This is a temporary fix for dimagi.atlassian.net/browse/SAAS-17816, as the group separator character is not valid in the XML 1.0 spec. Long-term, we may move to an alternative solution, but this feels the most reversible. The replacement character, despite looking like an error, was chosen because it is very unlikely to be used by the user, which also makes it easily reversible. In the future, if we move to an alternative solution and need to migrate these forms, we won't have to figure out which forms were affected and which were not (which might have been the case with a more common character, like tab, for example).

## Feature Flag
Introduces the `CONVERT_XML_GROUP_SEPARATOR` feature flag, which is intended to be a one-off, temporary flag.

## Safety Assurance

### Safety story
Added unit tests for the `sanitize` method and verified that I could submit data with the group separator character locally. However, I did not test all the endpoints that added the sanitize method. I am making the assumption that the instance will always be binary XML data, and that converting this character for the purposes of fixing the barcode scanner won't have consequences if someone tries to use that character in other fields. I did trace through the code of the affected paths, but it's still a concern with form submission code.

All of this should be mitigated by this being behind a feature flag that only this domain should use. Without the feature flag enabled, the sanitize function just returns the initial string.

### Automated test coverage

Added a new test suite for the sanitize method

### QA Plan

No QA due to the urgency from the client.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
