### PR TITLE
Two stage mobile worker workflow API

### DIFF
--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -202,6 +202,7 @@ class TestCommCareUserResource(APIResourceTest):
                          [self.loc1.location_id, self.loc2.location_id])
         self.assertEqual(user_back.get_location_id(self.domain.name), self.loc1.location_id)
 
+    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
     @patch('corehq.apps.users.account_confirmation.send_account_confirmation')
     def test_create_and_send_confirmation_email(self, mock_send_account_confirmation):
         self.assertEqual(0, len(CommCareUser.by_domain(self.domain.name)))
@@ -222,6 +223,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertNotEqual(mobile_user, None)
         self.assertEqual(mock_send_account_confirmation.call_count, 1)
 
+    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
     def test_create_and_send_confirmation_email_no_email(self):
         user_json = {
             "username": "no_email",
@@ -414,6 +416,7 @@ class TestCommCareUserResource(APIResourceTest):
             "non-editable field 'username', 'default_phone_number' must be a string\"}"
         )
 
+    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
     @patch('corehq.apps.users.account_confirmation.send_account_confirmation')
     def test_update_and_send_confirmation_email(self, mock_send_account_confirmation):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234", created_by=None,
@@ -430,6 +433,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(mock_send_account_confirmation.call_count, 1)
 
+    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
     @patch('corehq.apps.users.account_confirmation.send_account_confirmation')
     def test_update_and_send_confirmation_already_confirmed(self, mock_send_account_confirmation):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
@@ -446,6 +450,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(mock_send_account_confirmation.call_count, 0)
 
+    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
     @patch('corehq.apps.users.account_confirmation.send_account_confirmation')
     def test_update_and_send_confirmation_no_email(self, mock_send_account_confirmation):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234", created_by=None,
@@ -463,6 +468,7 @@ class TestCommCareUserResource(APIResourceTest):
                          "This user has no email. You must provide the user's email to send a confirmation email.")
         self.assertEqual(mock_send_account_confirmation.call_count, 0)
 
+    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
     def test_update_cant_change_account_confirmation(self):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
                                    created_by=None, created_via=None, phone_number="50253311398")

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -109,9 +109,7 @@ class TestCommCareUserResource(APIResourceTest):
             'id': backend_id,
             'last_name': '',
             'phone_numbers': [],
-            'require_account_confirmation': False,
             'resource_uri': '/a/qwerty/api/v0.5/user/{}/'.format(backend_id),
-            'send_confirmation_email': False,
             'user_data': {'commcare_project': 'qwerty', PROFILE_SLUG: '', 'imaginary': '',
                           'commcare_location_id': self.loc2.location_id,
                           'commcare_primary_case_sharing_id': self.loc2.location_id,
@@ -144,9 +142,7 @@ class TestCommCareUserResource(APIResourceTest):
             'id': backend_id,
             'last_name': '',
             'phone_numbers': [],
-            'require_account_confirmation': False,
             'resource_uri': '/a/qwerty/api/v0.5/user/{}/'.format(backend_id),
-            'send_confirmation_email': False,
             'user_data': {'commcare_project': 'qwerty',
                           PROFILE_SLUG: '',
                           'imaginary': '',
@@ -480,7 +476,10 @@ class TestCommCareUserResource(APIResourceTest):
                                                    json.dumps(user_json),
                                                    content_type='application/json',
                                                    method='PUT')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.content).get('error'),
+                         "The confirmation email can not be sent because "
+                         "this user's account is already confirmed.")
         self.assertEqual(mock_send_account_confirmation.call_count, 0)
 
     @flag_enabled('TWO_STAGE_USER_PROVISIONING')


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Users will now be able to specify new mobile workers must confirm their accounts and immediately send a confirmation email from the user create API call. A confirmation email can be triggered via a user update call as well (if the user hasn't been confirmed yet)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/USH-6023)
[Tech Spec](https://docs.google.com/document/d/1mXFquOF68-AhBHHkAmldyfNVViEEEUdBNfTFh-E9T98/edit?tab=t.0#heading=h.13x6r5ivfsvg) 

Pretty simple - if `require_account_confirmation` is True, the user will be created with `is_account_confirmed` set to False, (default is True) and if `send_confirmation_email` is True as well, the confirmation email will be sent. Will return an error message if no email is provided/user doesn't have an email and it won't create the user so they can just add the email field to the JSON and call again using the same info. 

You will not be able to call the update function with `require_account_confirmation` since a user can't be changed to be unconfirmed. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[TWO_STAGE_USER_PROVISIONING](https://staging.commcarehq.org/hq/flags/edit/two_stage_user_provisioning/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging 
Only the `is_account_confirmed` field for new mobile users will be impacted. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added new tests. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
