### PR TITLE
Add user history logging for password resets + account confirmation

### DIFF
--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -61,8 +61,11 @@ from corehq.apps.hqwebapp.signals import clear_login_attempts
 from corehq.apps.ip_access.models import IPAccessConfig, get_ip_country
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.ota.models import MobileRecoveryMeasure
+from corehq.apps.users.audit.change_messages import UserChangeMessage
 from corehq.apps.users.decorators import require_can_manage_domain_alerts
 from corehq.apps.users.models import CouchUser
+from corehq.apps.users.util import log_user_change
+from corehq.const import USER_CHANGE_VIA_WEB
 from corehq.toggles import NAMESPACE_DOMAIN
 from corehq.toggles.models import Toggle
 from corehq.util.timezones.conversions import UserTime, ServerTime
@@ -584,6 +587,9 @@ class CustomPasswordResetView(PasswordResetConfirmView):
         user = User.objects.get(pk=uid)
         couch_user = CouchUser.from_django_user(user)
         clear_login_attempts(couch_user)
+        log_user_change(by_domain=couch_user.domain, for_domain=couch_user.domain, couch_user=couch_user,
+                        changed_by_user=couch_user, changed_via=USER_CHANGE_VIA_WEB,
+                        change_messages=UserChangeMessage.password_reset())
         return response
 
 

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -587,9 +587,7 @@ class CustomPasswordResetView(PasswordResetConfirmView):
         user = User.objects.get(pk=uid)
         couch_user = CouchUser.from_django_user(user)
         clear_login_attempts(couch_user)
-        domain = None
-        if couch_user.is_commcare_user():
-            domain = couch_user.domain
+        domain = couch_user.domain if couch_user.is_commcare_user() else None
         log_user_change(by_domain=None, for_domain=domain, couch_user=couch_user, changed_by_user=couch_user,
                         changed_via=USER_CHANGE_VIA_WEB, change_messages=UserChangeMessage.password_reset(),
                         by_domain_required_for_log=False, for_domain_required_for_log=False)

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -587,9 +587,9 @@ class CustomPasswordResetView(PasswordResetConfirmView):
         user = User.objects.get(pk=uid)
         couch_user = CouchUser.from_django_user(user)
         clear_login_attempts(couch_user)
-        log_user_change(by_domain=couch_user.domain, for_domain=couch_user.domain, couch_user=couch_user,
-                        changed_by_user=couch_user, changed_via=USER_CHANGE_VIA_WEB,
-                        change_messages=UserChangeMessage.password_reset())
+        log_user_change(by_domain=None, for_domain=None, couch_user=couch_user, changed_by_user=couch_user,
+                        changed_via=USER_CHANGE_VIA_WEB, change_messages=UserChangeMessage.password_reset(),
+                        by_domain_required_for_log=False, for_domain_required_for_log=False)
         return response
 
 

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -587,7 +587,10 @@ class CustomPasswordResetView(PasswordResetConfirmView):
         user = User.objects.get(pk=uid)
         couch_user = CouchUser.from_django_user(user)
         clear_login_attempts(couch_user)
-        log_user_change(by_domain=None, for_domain=None, couch_user=couch_user, changed_by_user=couch_user,
+        domain = None
+        if couch_user.is_commcare_user():
+            domain = couch_user.domain
+        log_user_change(by_domain=None, for_domain=domain, couch_user=couch_user, changed_by_user=couch_user,
                         changed_via=USER_CHANGE_VIA_WEB, change_messages=UserChangeMessage.password_reset(),
                         by_domain_required_for_log=False, for_domain_required_for_log=False)
         return response

--- a/corehq/apps/users/audit/change_messages.py
+++ b/corehq/apps/users/audit/change_messages.py
@@ -233,6 +233,14 @@ class UserChangeMessage(object):
             DEACTIVATE_AFTER_FIELD: message,
         }
 
+    @staticmethod
+    def mobile_account_confirmed_for_domain(domain):
+        return {
+            ACCOUNT_FIELD: {
+                CONFIRM_MOBILE_ACCOUNT: {"domain": domain}
+            }
+        }
+
 
 class UserChangeFormatter(object):
     @staticmethod
@@ -284,6 +292,7 @@ DOMAIN_INVITATION_FIELD = "domain_invitation"
 DEACTIVATE_AFTER_FIELD = "deactivate_after"
 DEACTIVATE_AFTER_DATE = "deactivate_after_date"
 DEACTIVATE_AFTER_DATE_DELETED = 'deactivate_after_date_deleted'
+ACCOUNT_FIELD = "account"
 
 CHANGE_MESSAGES_FIELDS = [
     PROGRAM_FIELD,
@@ -299,6 +308,7 @@ CHANGE_MESSAGES_FIELDS = [
     GROUPS_FIELD,
     DOMAIN_INVITATION_FIELD,
     DEACTIVATE_AFTER_FIELD,
+    ACCOUNT_FIELD
 ]
 
 # message slugs
@@ -326,6 +336,7 @@ SET_GROUPS = 'set_groups'
 CLEAR_GROUPS = 'clear_groups'
 ADD_DOMAIN_INVITATION = 'add_domain_invitation'
 REMOVE_DOMAIN_INVITATION = 'remove_domain_invitation'
+CONFIRM_MOBILE_ACCOUNT = 'confirm_mobile_account'
 
 MESSAGES = {
     SET_PROGRAM: UserChangeFormatter.simple_formatter(noop("Program: {name}[{id}]")),
@@ -367,6 +378,9 @@ MESSAGES = {
     ),
     DEACTIVATE_AFTER_DATE_DELETED: UserChangeFormatter.simple_formatter(
         noop("Deactivation After date has been deleted")
+    ),
+    CONFIRM_MOBILE_ACCOUNT: UserChangeFormatter.simple_formatter(
+        noop("Mobile Worker account confirmed for domain '{domain}'")
     ),
 }
 

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1558,6 +1558,9 @@ class CommCareUserConfirmAccountView(TemplateView, DomainViewMixin):
                 f'You have successfully confirmed the {user.raw_username} account. '
                 'You can now login'
             ))
+            log_user_change(by_domain=self.domain, for_domain=self.domain, couch_user=self.user,
+                            changed_by_user=self.user, changed_via=USER_CHANGE_VIA_WEB,
+                            change_messages=UserChangeMessage.mobile_account_confirmed_for_domain(self.domain))
             if hasattr(self, 'send_success_sms'):
                 self.send_success_sms()
             return HttpResponseRedirect('{}?username={}'.format(


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Users will now be able to see 2 new events in the User History Report:

- Successful password resets
- Mobile worker account confirmation 

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/USH-6024)
[Tech Spec](https://docs.google.com/document/d/1mXFquOF68-AhBHHkAmldyfNVViEEEUdBNfTFh-E9T98/edit?tab=t.0#heading=h.cz049gatooyt)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

No data will be impacted - only creating logs. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
