### PR TITLE
Remove internal ff "RATE_LIMIT_REPEATERS"

### DIFF
--- a/corehq/motech/rate_limiter.py
+++ b/corehq/motech/rate_limiter.py
@@ -6,7 +6,7 @@ from corehq.project_limits.rate_limiter import (
     PerUserRateDefinition,
     RateLimiter,
 )
-from corehq.toggles import RATE_LIMIT_REPEATERS, RATE_LIMIT_REPEATER_ATTEMPTS, NAMESPACE_DOMAIN
+from corehq.toggles import RATE_LIMIT_REPEATER_ATTEMPTS, NAMESPACE_DOMAIN
 from corehq.util.decorators import silence_and_report_error, run_only_when
 from corehq.util.metrics import metrics_gauge, metrics_counter
 from corehq.util.quickcache import quickcache
@@ -84,11 +84,6 @@ def rate_limit_repeater(domain, repeater_id):
         allow_usage = True
     elif repeater_rate_limiter.allow_usage(domain):
         allow_usage = True
-    elif not RATE_LIMIT_REPEATERS.enabled(domain, namespace=NAMESPACE_DOMAIN):
-        allow_usage = True
-        metrics_counter('commcare.repeaters.rate_limited.test', tags={
-            'domain': domain,
-        })
     else:
         allow_usage = False
         metrics_counter('commcare.repeaters.rate_limited', tags={

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1996,20 +1996,6 @@ DO_NOT_RATE_LIMIT_SUBMISSIONS = StaticToggle(
     """
 )
 
-RATE_LIMIT_REPEATERS = DynamicallyPredictablyRandomToggle(
-    'rate_limit_repeaters',
-    'Apply rate limiting to data forwarding (repeaters)',
-    TAG_INTERNAL,
-    [NAMESPACE_DOMAIN],
-    description="""
-    Rate limits are based on aggregate time spent waiting on data forwarding responses
-    within tasks for each project within the last second, minute, hour, day, and week windows.
-    Project allowances are based on the number of mobile workers in the project or subscription.
-    Rate limits are only applied (to any project) when global thresholds are surpassed.
-    The specific per-domain and global thresholds can be dynamically updated within the Django Admin.
-    """
-)
-
 RATE_LIMIT_REPEATER_ATTEMPTS = DynamicallyPredictablyRandomToggle(
     'rate_limit_repeater_attempts',
     'Apply rate limiting to attempts for data forwarding (repeaters)',


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This just removes the internal feature flag `RATE_LIMIT_REPEATERS`, originally added in https://github.com/dimagi/commcare-hq/pull/34870
This feature flag was specifically used to rate limit repeaters on specific project spaces when global thresholds were surpassed and is not needed anymore since the limits now can be set via Django Admin.
Confirmed with Danny [here](https://dimagi.atlassian.net/browse/SAAS-17831?focusedCommentId=387159) who originally added that FF.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
We have been asked to GA the feature flag, which means it's true for all domains, which effectively resulted in the feature flag removal due to how its used.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Does not add any new code and just removes code that would have run for domains that didn't have the feature flag enabled, when the global thresholds were breached.
In case the data forwarders global thresholds are breached, the rate limiting will now apply to all domains and we can manage per-domain thresholds within the Django Admin which makes this feature flag redundant.
More context in Danny's response [here](https://dimagi.atlassian.net/browse/SAAS-17831?focusedCommentId=387159)

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
