### PR TITLE
Admin Triggered Mobile Worker Password Reset Email Validation

### DIFF
--- a/corehq/apps/users/tests/test_views.py
+++ b/corehq/apps/users/tests/test_views.py
@@ -696,6 +696,7 @@ class TestCommCareUserPasswordResetView(TestCase):
     def _mock_commcare_user(self, is_active=True, has_usable_password=True):
         mock_user = Mock()
         mock_user._id = "mock-user-id"
+        mock_user.get_email.return_value = "test@example.com"
         mock_django_user = Mock()
         mock_django_user.is_active = is_active
         mock_django_user.has_usable_password.return_value = has_usable_password
@@ -741,7 +742,6 @@ class TestCommCareUserPasswordResetView(TestCase):
         view.setup(request, domain=self.domain, couch_user_id=self.editable_user_id)
 
         response = view.post(request)
-        # response = view.post(request, domain=self.domain, couch_user_id=self.editable_user_id)
 
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertEqual(response.url, '/edit/user/url#user-password')

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1695,8 +1695,12 @@ class CommCareUserPasswordResetView(BaseManageCommCareUserView, FormView):
         error_messages = {
             'inactive': gettext_lazy("This user is inactive and cannot reset their password."),
             'unusable': gettext_lazy("This user account cannot reset the password."),
+            'no_email': gettext_lazy("This user does not have an email address set."),
         }
 
+        if not self.editable_user.get_email():
+            messages.error(self.request, _("Password reset email failed to send - ") + error_messages['no_email'])
+            return HttpResponseRedirect(f"{base_url}#user-password")
         if not django_user.has_usable_password():
             messages.error(self.request, _("Password reset email failed to send - ") + error_messages['unusable'])
             return HttpResponseRedirect(f"{base_url}#user-password")
@@ -1744,7 +1748,7 @@ class CommCareUserPasswordResetView(BaseManageCommCareUserView, FormView):
         return kwargs
 
     def get_success_url(self):
-        messages.success(self.request, _("Password reset email sent."))
+        messages.success(self.request, _("Password reset email sent to {}").format(self.editable_user.get_email()))
         base_url = reverse(
             EditCommCareUserView.urlname,
             args=[self.request.domain, self.editable_user_id],


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This change affects only [TWO_STAGE_USER_PROVISIONING](https://staging.commcarehq.org/hq/flags/edit/two_stage_user_provisioning/)

When sending a password reset via the "Send Password Reset Link" button, it checks that the editable user has an email configured and errors if it does not.
![Screenshot 2025-07-09 at 11 18 28 AM](https://github.com/user-attachments/assets/9933d3f9-a915-464e-a703-56c3bb8408d6)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
small followup to https://github.com/dimagi/commcare-hq/pull/36689

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[TWO_STAGE_USER_PROVISIONING](https://staging.commcarehq.org/hq/flags/edit/two_stage_user_provisioning/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test for this validation

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
