### PR TITLE
Two stage user provisioning UI improvement

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -493,7 +493,9 @@ class MobileWorkerAccountConfirmationForm(BaseUserInvitationForm):
     """
     For Mobile Workers to confirm their accounts using Email.
     """
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['email'].widget.attrs['readonly'] = 'readonly'
 
 
 class MobileWorkerAccountConfirmationBySMSForm(BaseUserInvitationForm):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -888,7 +888,7 @@ class NewMobileWorkerForm(forms.Form):
                         _("Password"),
                         InlineField(
                             'new_password',
-                            data_bind="value: password, valueUpdate: 'input', enable: passwordEnabled",
+                            data_bind="value: password, valueUpdate: 'input'",
                         ),
                         crispy.HTML('''
                             <p class="help-block" data-bind="if: $root.isSuggestedPassword">
@@ -915,15 +915,6 @@ class NewMobileWorkerForm(forms.Form):
                                 <!-- ko if: $root.skipStandardValidations() -->
                                     <i class="fa fa-info-circle"></i> {custom_warning}
                                 <!-- /ko -->
-                                <!-- ko if: $root.passwordStatus() === $root.STATUS.DISABLED -->
-                                    <!-- ko if: $root.stagedUser().force_account_confirmation() -->
-                                        <i class="fa fa-warning"></i> {disabled_email}
-                                    <!-- /ko -->
-                                    <!-- ko if: !($root.stagedUser().force_account_confirmation())
-                                    && $root.stagedUser().force_account_confirmation_by_sms() -->
-                                        <i class="fa fa-warning"></i> {disabled_phone}
-                                    <!-- /ko -->
-                                <!-- /ko -->
                             </p>
                         '''.format(
                             suggested=_(
@@ -935,28 +926,22 @@ class NewMobileWorkerForm(forms.Form):
                             almost=_("Your password is almost strong enough! Try adding numbers or symbols!"),
                             weak=_("Your password is too weak! Try adding numbers or symbols!"),
                             custom_warning=_(settings.CUSTOM_PASSWORD_STRENGTH_MESSAGE),
-                            disabled_email=_(
-                                "Setting a password is disabled. The user "
-                                "will set their own password on confirming "
-                                "their account email."
-                            ),
-                            disabled_phone=_(
-                                "Setting a password is disabled. The user "
-                                "will set their own password on confirming "
-                                "their account phone number."
-                            ),
                             short=_("Password must have at least {password_length} characters."
                                     ).format(password_length=settings.MINIMUM_PASSWORD_LENGTH)
                         )),
                         required=True,
                     ),
-                    data_bind='''
-                        css: {
-                            'has-success': $root.passwordStatus() === $root.STATUS.SUCCESS,
-                            'has-warning': $root.passwordStatus() === $root.STATUS.WARNING,
-                            'has-error': $root.passwordStatus() === $root.STATUS.ERROR,
-                        }
-                    ''' if not has_custom_clean_password() else ''
+                    data_bind=(
+                        "visible: passwordVisible"
+                        + (
+                            ", css: {"
+                            "'has-success': $root.passwordStatus() === $root.STATUS.SUCCESS, "
+                            "'has-warning': $root.passwordStatus() === $root.STATUS.WARNING, "
+                            "'has-error': $root.passwordStatus() === $root.STATUS.ERROR"
+                            "}"
+                            if not has_custom_clean_password() else ""
+                        )
+                    )
                 ),
             )
         )

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -880,9 +880,9 @@ class NewMobileWorkerForm(forms.Form):
                 location_field,
                 confirm_account_field,
                 email_field,
-                send_email_field,
                 confirm_account_by_sms_field,
                 phone_number_field,
+                send_email_field,
                 crispy.Div(
                     hqcrispy.B3MultiField(
                         _("Password"),

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -800,9 +800,9 @@ class NewMobileWorkerForm(forms.Form):
             send_email_field = crispy.Div(
                 crispy.Field(
                     'send_account_confirmation_email',
-                    data_bind='checked: send_account_confirmation_email, enable: sendConfirmationEmailEnabled',
+                    data_bind='checked: send_account_confirmation_email, enable: requireAccountConfirmation',
                 ),
-                data_bind='visible: sendConfirmationEmailEnabled'
+                data_bind='visible: requireAccountConfirmation'
             )
         else:
             confirm_account_field = crispy.Hidden(

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -681,7 +681,10 @@ class NewMobileWorkerForm(forms.Form):
         required=False,
     )
     email = forms.EmailField(
-        label=gettext_noop("Email"),
+        label=format_html_lazy(
+            '{} <span data-bind="visible: $root.stagedUser().emailRequired">*</span>',
+            gettext_noop("Email"),
+        ),
         required=False,
         help_text="""
             <span data-bind="visible: $root.emailStatus() !== $root.STATUS.NONE">

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -797,9 +797,12 @@ class NewMobileWorkerForm(forms.Form):
                     },
                 '''
             )
-            send_email_field = crispy.Field(
-                'send_account_confirmation_email',
-                data_bind='checked: send_account_confirmation_email, enable: sendConfirmationEmailEnabled',
+            send_email_field = crispy.Div(
+                crispy.Field(
+                    'send_account_confirmation_email',
+                    data_bind='checked: send_account_confirmation_email, enable: sendConfirmationEmailEnabled',
+                ),
+                data_bind='visible: sendConfirmationEmailEnabled'
             )
         else:
             confirm_account_field = crispy.Hidden(

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -346,16 +346,14 @@ var newUserCreationModel = function (options) {
             return self.STATUS.NONE;
         }
 
-        if (self.requiredEmailMissing() || self.emailIsInvalid()) {
+        if (self.emailIsInvalid()) {
             return self.STATUS.ERROR;
         }
     });
 
     self.emailStatusMessage = ko.computed(function () {
 
-        if (self.requiredEmailMissing()) {
-            return gettext('Email address is required when users confirm their own accounts.');
-        } else if (self.emailIsInvalid()) {
+        if (self.emailIsInvalid()) {
             return gettext('Please enter a valid email address.');
         }
         return "";

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -77,7 +77,7 @@ var userModel = function (options) {
 
     // used by two-stage provisioning
     self.emailRequired = ko.observable(self.force_account_confirmation());
-    self.sendConfirmationEmailEnabled = ko.observable(self.force_account_confirmation());
+    self.requireAccountConfirmation = ko.observable(self.force_account_confirmation());
 
     // used by two-stage sms provisioning
     self.phoneRequired = ko.observable(self.force_account_confirmation_by_sms());
@@ -488,13 +488,13 @@ var newUserCreationModel = function (options) {
                 // clear and disable password input
                 user.password('');
                 user.passwordVisible(false);
-                user.sendConfirmationEmailEnabled(true);
+                user.requireAccountConfirmation(true);
             } else {
                 // make email optional
                 user.emailRequired(false);
                 // enable password input
                 user.passwordVisible(true);
-                user.sendConfirmationEmailEnabled(false);
+                user.requireAccountConfirmation(false);
                 // uncheck email confirmation box if it was checked
                 user.send_account_confirmation_email(false);
             }
@@ -506,13 +506,13 @@ var newUserCreationModel = function (options) {
                 // clear and disable password input
                 user.password('');
                 user.passwordVisible(false);
-                user.sendConfirmationEmailEnabled(true);
+                user.requireAccountConfirmation(true);
             } else {
                 // make phone number optional
                 user.phoneRequired(false);
                 // enable password input
                 user.passwordVisible(true);
-                user.sendConfirmationEmailEnabled(false);
+                user.requireAccountConfirmation(false);
                 user.send_account_confirmation_email(false);
             }
         });

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -38,7 +38,6 @@ var STATUS = {
     SUCCESS: 'success',
     WARNING: 'warning',
     ERROR: 'danger',
-    DISABLED: 'disabled',
 };
 
 var rmi = function () {};
@@ -83,7 +82,7 @@ var userModel = function (options) {
     // used by two-stage sms provisioning
     self.phoneRequired = ko.observable(self.force_account_confirmation_by_sms());
 
-    self.passwordEnabled = ko.observable(!(self.force_account_confirmation_by_sms() || self.force_account_confirmation()));
+    self.passwordVisible = ko.observable(!(self.force_account_confirmation_by_sms() || self.force_account_confirmation()));
 
     self.action_error = ko.observable('');  // error when activating/deactivating a user
 
@@ -287,14 +286,6 @@ var newUserCreationModel = function (options) {
             return self.STATUS.NONE;
         }
 
-        if (self.stagedUser().force_account_confirmation()) {
-            return self.STATUS.DISABLED;
-        }
-
-        if (self.stagedUser().force_account_confirmation_by_sms()) {
-            return self.STATUS.DISABLED;
-        }
-
         if (!self.useStrongPasswords()) {
             // No validation
             return self.STATUS.NONE;
@@ -496,13 +487,13 @@ var newUserCreationModel = function (options) {
                 user.emailRequired(true);
                 // clear and disable password input
                 user.password('');
-                user.passwordEnabled(false);
+                user.passwordVisible(false);
                 user.sendConfirmationEmailEnabled(true);
             } else {
                 // make email optional
                 user.emailRequired(false);
                 // enable password input
-                user.passwordEnabled(true);
+                user.passwordVisible(true);
                 user.sendConfirmationEmailEnabled(false);
                 // uncheck email confirmation box if it was checked
                 user.send_account_confirmation_email(false);
@@ -514,13 +505,13 @@ var newUserCreationModel = function (options) {
                 user.phoneRequired(true);
                 // clear and disable password input
                 user.password('');
-                user.passwordEnabled(false);
+                user.passwordVisible(false);
                 user.sendConfirmationEmailEnabled(true);
             } else {
                 // make phone number optional
                 user.phoneRequired(false);
                 // enable password input
-                user.passwordEnabled(true);
+                user.passwordVisible(true);
                 user.sendConfirmationEmailEnabled(false);
                 user.send_account_confirmation_email(false);
             }
@@ -564,7 +555,7 @@ var newUserCreationModel = function (options) {
         if (!self.stagedUser().username()) {
             return false;
         }
-        if (self.stagedUser().passwordEnabled()) {
+        if (self.stagedUser().passwordVisible()) {
             if  (!self.stagedUser().password()) {
                 return false;
             }
@@ -600,7 +591,7 @@ var newUserCreationModel = function (options) {
         self.newUsers.push(newUser);
         newUser.creation_status(STATUS.PENDING);
         // if we disabled the password, set it just in time before going to the server
-        if (!newUser.passwordEnabled()) {
+        if (!newUser.passwordVisible()) {
             newUser.password(self.generateStrongPassword());
         }
         rmi('create_mobile_worker', {

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -521,6 +521,8 @@ var newUserCreationModel = function (options) {
                 user.phoneRequired(false);
                 // enable password input
                 user.passwordEnabled(true);
+                user.sendConfirmationEmailEnabled(false);
+                user.send_account_confirmation_email(false);
             }
         });
     });


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This PR has three UI changes:

This change affects two stage user provisioning:
1. When confirming an account, the email field is now disabled. It is already prepopulated with the email set by the admin who created the user so it should not be editable.
![Screenshot 2025-07-09 at 3 32 47 PM](https://github.com/user-attachments/assets/2e6d535e-06c5-473a-b545-54f54d11bcfb)


These changes affect both two stage user provisioning and two stage user provisioning by SMS FF:
2. When "Require account confirmation" is checked, the "password" field is hidden and "send account confirmation" field is shown.
3. When "Require account confirmation" is not checked, the "password" field is shown and "send account confirmation" field is hidden.
4. There is no longer "email is required" error. It just toggles an asterisk next to the email field to denote that it's required.

**Before:**

https://github.com/user-attachments/assets/e187d2d1-bc05-423b-845e-42d8c9fc0ece

**After:**

https://github.com/user-attachments/assets/4b884256-857c-4a1d-a748-f46f08b7fdb4


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-6027](https://dimagi.atlassian.net/browse/USH-6027)
[Tech Spec](https://docs.google.com/document/d/1mXFquOF68-AhBHHkAmldyfNVViEEEUdBNfTFh-E9T98/edit?tab=t.0#heading=h.ulf1szacfumo)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[TWO_STAGE_USER_PROVISIONING](https://www.commcarehq.org/hq/flags/edit/two_stage_user_provisioning/)
[two_stage_user_provisioning_by_sms](https://www.commcarehq.org/hq/flags/edit/two_stage_user_provisioning_by_sms/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change is purely a UI change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[QA-7908](https://dimagi.atlassian.net/browse/QA-7908)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-5949]: https://dimagi.atlassian.net/browse/USH-5949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[USH-6027]: https://dimagi.atlassian.net/browse/USH-6027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ