### PR TITLE
The error message is in body.error, not body

### DIFF
--- a/corehq/apps/sso/utils/entra.py
+++ b/corehq/apps/sso/utils/entra.py
@@ -101,7 +101,7 @@ def _get_user_principal_names(user_ids, token):
         batch_result = batch_response.json()
         for resp in batch_result['responses']:
             if 'body' in resp and 'error' in resp['body']:
-                raise EntraVerificationFailed(resp['body']['error']['code'], resp['body']['message'])
+                raise EntraVerificationFailed(resp['body']['error']['code'], resp['body']['error']['message'])
 
         # Extract userPrincipalName from batch response
         for resp in batch_result['responses']:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Followup to https://github.com/dimagi/commcare-hq/commit/4069f8802d3364f3241e272871726fb818a8c4ff

The commit message in that commit ^ shows a typical error response and confirms that the message is part of the 'error' dictionary within the body.

Is there any reason we would want to both create a sentry error and also still send an email to the customer letting them auto deactivation failed for an unknown reason? That is a question for @jingcheng16.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Observed this response on staging today with the same structure as specified in the linked commit. This currently results in a key error so this change can't make it any worse, and will make it better.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
