### PR TITLE
Fixes "Domain Temporarily Unavailable"

### DIFF
--- a/corehq/apps/domain/templates/domain/bootstrap3/data_migration_in_progress.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/data_migration_in_progress.html
@@ -2,9 +2,14 @@
 {% load i18n %}
 
 {% block page_content %}
-  <h1>{% block title %}{% trans "Project Space Unavailable" %}{% endblock %}</h1>
+  <h1>
+    {% block title %}{% trans "Project Space Unavailable" %}{% endblock %}
+  </h1>
 
-  <p>{% blocktrans %}The page you requested is unavailable because the project
-    space is being or has been migrated to a different hosting environment.
-  {% endblocktrans %}</p>
+  <p>
+    {% blocktrans %}
+      The page you requested is unavailable because the project space is being
+      or has been migrated to a different hosting environment.
+    {% endblocktrans %}
+  </p>
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/data_migration_in_progress.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/data_migration_in_progress.html
@@ -2,8 +2,9 @@
 {% load i18n %}
 
 {% block page_content %}
-  <h1>{% block title %}{% trans "Domain Temporarily Unavailable" %}{% endblock %}</h1>
+  <h1>{% block title %}{% trans "Project Space Unavailable" %}{% endblock %}</h1>
 
-  <p>{% blocktrans %}The page you requested is currently unavailable due to a
-    data migration. Please check back later.{% endblocktrans %}</p>
+  <p>{% blocktrans %}The page you requested is unavailable because the project
+    space is being or has been migrated to a different hosting environment.
+  {% endblocktrans %}</p>
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/data_migration_in_progress.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/data_migration_in_progress.html
@@ -2,9 +2,14 @@
 {% load i18n %}
 
 {% block page_content %}
-  <h1>{% block title %}{% trans "Project Space Unavailable" %}{% endblock %}</h1>
+  <h1>
+    {% block title %}{% trans "Project Space Unavailable" %}{% endblock %}
+  </h1>
 
-  <p>{% blocktrans %}The page you requested is unavailable because the project
-    space is being or has been migrated to a different hosting environment.
-  {% endblocktrans %}</p>
+  <p>
+    {% blocktrans %}
+      The page you requested is unavailable because the project space is being
+      or has been migrated to a different hosting environment.
+    {% endblocktrans %}
+  </p>
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/data_migration_in_progress.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/data_migration_in_progress.html
@@ -2,8 +2,9 @@
 {% load i18n %}
 
 {% block page_content %}
-  <h1>{% block title %}{% trans "Domain Temporarily Unavailable" %}{% endblock %}</h1>
+  <h1>{% block title %}{% trans "Project Space Unavailable" %}{% endblock %}</h1>
 
-  <p>{% blocktrans %}The page you requested is currently unavailable due to a
-    data migration. Please check back later.{% endblocktrans %}</p>
+  <p>{% blocktrans %}The page you requested is unavailable because the project
+    space is being or has been migrated to a different hosting environment.
+  {% endblocktrans %}</p>
 {% endblock %}


### PR DESCRIPTION
## Technical Summary

Fixes misleading messaging about domains that have been migrated to third-party-hosted environments.

This change was prompted by multiple confused customers, including:
* [SUPPORT-22620](https://dimagi.atlassian.net/browse/SUPPORT-22620)
* [SUPPORT-24275](https://dimagi.atlassian.net/browse/SUPPORT-24275)
* [SUPPORT-24275](https://dimagi.atlassian.net/browse/SUPPORT-24275)

## Safety Assurance

### Safety story

Text-only change.

### Automated test coverage

Not applicable

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SUPPORT-22620]: https://dimagi.atlassian.net/browse/SUPPORT-22620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUPPORT-24275]: https://dimagi.atlassian.net/browse/SUPPORT-24275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUPPORT-24275]: https://dimagi.atlassian.net/browse/SUPPORT-24275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ