### PR TITLE
Send success messages on password reset and mobile worker account confirmation

### DIFF
--- a/corehq/apps/domain/templates/domain/email/password_reset_confirmation.html
+++ b/corehq/apps/domain/templates/domain/email/password_reset_confirmation.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+{% blocktrans %}
+  <p>
+    You have successfully reset your password for the account {{ username }}.
+  </p>
+  <p>
+    Thank you,<br />
+    The CommCare HQ Team
+  </p>
+{% endblocktrans %}

--- a/corehq/apps/domain/templates/domain/email/password_reset_confirmation.txt
+++ b/corehq/apps/domain/templates/domain/email/password_reset_confirmation.txt
@@ -1,0 +1,4 @@
+You have successfully reset your password for the account {{ username }}.
+
+Thank you,
+The CommCare HQ Team

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -584,11 +584,7 @@ class CustomPasswordResetView(PasswordResetConfirmView):
                 messages.error(request, _(e.message))
                 return HttpResponseRedirect(request.path_info)
 
-        response = super().post(request, *args, **kwargs)
-        try:
-            # the response will only have context_data is the submitted form was invalid (mismatched passwords)
-            context = response.context_data
-        except AttributeError:
+        if self.get_context_data().get('form').is_valid():
             uidb64 = kwargs.get('uidb64')
             uid = urlsafe_base64_decode(uidb64)
             user = User.objects.get(pk=uid)
@@ -609,6 +605,7 @@ class CustomPasswordResetView(PasswordResetConfirmView):
                 domain=domain,
                 use_domain_gateway=True
             )
+        response = super().post(request, *args, **kwargs)
         return response
 
 

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -583,6 +583,7 @@ class CustomPasswordResetView(PasswordResetConfirmView):
             except ValidationError as e:
                 messages.error(request, _(e.message))
                 return HttpResponseRedirect(request.path_info)
+        response = super().post(request, *args, **kwargs)
 
         if self.get_context_data().get('form').is_valid():
             uidb64 = kwargs.get('uidb64')
@@ -605,7 +606,6 @@ class CustomPasswordResetView(PasswordResetConfirmView):
                 domain=domain,
                 use_domain_gateway=True
             )
-        response = super().post(request, *args, **kwargs)
         return response
 
 

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -10,6 +10,7 @@ from django.contrib.auth.views import PasswordResetConfirmView, PasswordResetVie
 from django.core.exceptions import ValidationError
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.http import urlsafe_base64_decode
@@ -58,6 +59,7 @@ from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.models import Alert
 from corehq.apps.hqwebapp.signals import clear_login_attempts
+from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.ip_access.models import IPAccessConfig, get_ip_country
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.ota.models import MobileRecoveryMeasure
@@ -581,16 +583,32 @@ class CustomPasswordResetView(PasswordResetConfirmView):
             except ValidationError as e:
                 messages.error(request, _(e.message))
                 return HttpResponseRedirect(request.path_info)
+            uidb64 = kwargs.get('uidb64')
+            uid = urlsafe_base64_decode(uidb64)
+            user = User.objects.get(pk=uid)
+            couch_user = CouchUser.from_django_user(user)
+            clear_login_attempts(couch_user)
+
+            domain = couch_user.domain if couch_user.is_commcare_user() else None
+            log_user_change(by_domain=None, for_domain=domain, couch_user=couch_user, changed_by_user=couch_user,
+                            changed_via=USER_CHANGE_VIA_WEB, change_messages=UserChangeMessage.password_reset(),
+                            by_domain_required_for_log=False, for_domain_required_for_log=False)
+
+            context = {
+                'username': couch_user.raw_username,
+            }
+            email = couch_user.get_email()
+            if not email:
+                email = couch_user.username
+            send_html_email_async.delay(
+                subject=_('Successful password reset for {}').format(couch_user.raw_username),
+                recipient=email,
+                html_content=render_to_string('domain/email/password_reset_confirmation.html', context),
+                text_content=render_to_string('domain/email/password_reset_confirmation.txt', context),
+                domain=domain,
+                use_domain_gateway=True
+            )
         response = super().post(request, *args, **kwargs)
-        uidb64 = kwargs.get('uidb64')
-        uid = urlsafe_base64_decode(uidb64)
-        user = User.objects.get(pk=uid)
-        couch_user = CouchUser.from_django_user(user)
-        clear_login_attempts(couch_user)
-        domain = couch_user.domain if couch_user.is_commcare_user() else None
-        log_user_change(by_domain=None, for_domain=domain, couch_user=couch_user, changed_by_user=couch_user,
-                        changed_via=USER_CHANGE_VIA_WEB, change_messages=UserChangeMessage.password_reset(),
-                        by_domain_required_for_log=False, for_domain_required_for_log=False)
         return response
 
 

--- a/corehq/apps/users/templates/users/email/mobile_worker_account_confirmation.html
+++ b/corehq/apps/users/templates/users/email/mobile_worker_account_confirmation.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+{% blocktrans %}
+  <p>
+    You have successfully confirmed the account {{ new_mobile_worker }} for the
+    project space {{ domain }}.
+  </p>
+  <p>
+    If you think you have received this by mistake, you can go ahead and ignore
+    this email.
+  </p>
+  <p>
+    Thank you,<br />
+    The CommCare HQ Team
+  </p>
+{% endblocktrans %}

--- a/corehq/apps/users/templates/users/email/mobile_worker_account_confirmation.txt
+++ b/corehq/apps/users/templates/users/email/mobile_worker_account_confirmation.txt
@@ -1,0 +1,6 @@
+You have successfully confirmed the account {{ new_mobile_worker }} for the project space {{ domain }}.
+
+If you think you have received this by mistake, you can go ahead and ignore this email.
+
+Thank you,
+The CommCare HQ Team

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -75,6 +75,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.crispy import make_form_readonly
 from corehq.apps.hqwebapp.decorators import waf_allow
+from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.locations.models import SQLLocation
@@ -1583,6 +1584,19 @@ class CommCareUserConfirmAccountView(TemplateView, DomainViewMixin):
                             change_messages=UserChangeMessage.mobile_account_confirmed_for_domain(self.domain))
             if hasattr(self, 'send_success_sms'):
                 self.send_success_sms()
+            else:
+                context = {
+                    "new_mobile_worker": self.user.raw_username,
+                    "domain": self.domain
+                }
+                send_html_email_async.delay(
+                    subject=_('Successful account confirmation for {}').format(self.user.raw_username),
+                    recipient=self.user.email,
+                    html_content=render_to_string('users/email/mobile_worker_account_confirmation.html', context),
+                    text_content=render_to_string('users/email/mobile_worker_account_confirmation.txt', context),
+                    domain=self.domain,
+                    use_domain_gateway=True
+                )
             return HttpResponseRedirect('{}?username={}'.format(
                 reverse('domain_login', args=[self.domain]),
                 user.raw_username,

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1579,19 +1579,19 @@ class CommCareUserConfirmAccountView(TemplateView, DomainViewMixin):
                 f'You have successfully confirmed the {user.raw_username} account. '
                 'You can now login'
             ))
-            log_user_change(by_domain=self.domain, for_domain=self.domain, couch_user=self.user,
-                            changed_by_user=self.user, changed_via=USER_CHANGE_VIA_WEB,
+            log_user_change(by_domain=self.domain, for_domain=self.domain, couch_user=user,
+                            changed_by_user=user, changed_via=USER_CHANGE_VIA_WEB,
                             change_messages=UserChangeMessage.mobile_account_confirmed_for_domain(self.domain))
             if hasattr(self, 'send_success_sms'):
                 self.send_success_sms()
             else:
                 context = {
-                    "new_mobile_worker": self.user.raw_username,
+                    "new_mobile_worker": user.raw_username,
                     "domain": self.domain
                 }
                 send_html_email_async.delay(
-                    subject=_('Successful account confirmation for {}').format(self.user.raw_username),
-                    recipient=self.user.email,
+                    subject=_('Successful account confirmation for {}').format(user.raw_username),
+                    recipient=user.email,
                     html_content=render_to_string('users/email/mobile_worker_account_confirmation.html', context),
                     text_content=render_to_string('users/email/mobile_worker_account_confirmation.txt', context),
                     domain=self.domain,


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Mobile workers (belonging to domains that use [TWO_STAGE_USER_PROVISIONING](https://www.commcarehq.org/hq/flags/edit/two_stage_user_provisioning/)) will get a confirmation email after successfully confirming their new accounts in the domain.

Mobile workers and web users alike will get a confirmation email following a successful password reset through the "Forgot Password" workflow. 

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi.atlassian.net/browse/USH-6025)
[Jira Epic](https://dimagi.atlassian.net/browse/USH-5949)
[Tech spec](https://docs.google.com/document/d/1mXFquOF68-AhBHHkAmldyfNVViEEEUdBNfTFh-E9T98/edit?tab=t.0#heading=h.ulf1szacfumo)


Just a small addition to send emails to the appropriate user with the appropriate content. 

Fixed a small bug where login attempts were being cleared even if the password reset wasn't successful (entered the wrong password the second time) too. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[TWO_STAGE_USER_PROVISIONING](https://www.commcarehq.org/hq/flags/edit/two_stage_user_provisioning/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging

Only data impact is the bug I fixed (will only clear login attempts on successful form submission) - the rest is only emails getting sent out. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
