### PR TITLE
Add multimedia import instruction

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -3252,10 +3252,6 @@ class ImportAppForm(forms.Form):
         return app_file
 
     def construct_download_url(self, source_server, source_domain, app_id):
-        server_mapping = {
-            'production': 'www',
-            'india': 'india',
-            'eu': 'eu',
-        }
-        server_address = server_mapping[source_server]
+        from corehq.apps.domain.views.import_apps import SERVER_SUBDOMAIN_MAPPING
+        server_address = SERVER_SUBDOMAIN_MAPPING[source_server]
         return f"https://{server_address}.commcarehq.org/a/{source_domain}/apps/source/{app_id}/"

--- a/corehq/apps/domain/templates/domain/import_app_from_another_server_main.html
+++ b/corehq/apps/domain/templates/domain/import_app_from_another_server_main.html
@@ -9,6 +9,9 @@
     <div
       class="mt-3"
       hx-get="{{ htmx_import_app_steps_view_url }}"
+      {% if import_details %}
+        hq-hx-action="recent_import_details" hx-vals="{{ import_details }}"
+      {% endif %}
       hx-trigger="load"
     ></div>
   </div>

--- a/corehq/apps/domain/templates/domain/import_app_step_3_instruction.html
+++ b/corehq/apps/domain/templates/domain/import_app_step_3_instruction.html
@@ -1,0 +1,50 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+
+<div>
+  <div class="alert alert-success">
+    <h4>{% trans "Your application has been successfully imported!" %}</h4>
+    <p class="lead mb-1">
+      {% trans "You’re almost done — if your application contains multimedia files, follow these steps to copy them to your new application." %}
+    </p>
+  </div>
+
+  <div class="card mb-3">
+    <div class="card-header">
+      {% trans "Step 1: Download Multimedia from Source App" %}
+    </div>
+    <div class="card-body">
+      <p class="mb-2">
+        {% trans "Go to the source application's multimedia page and download the multimedia files as a ZIP:" %}
+      </p>
+      <a href="{{ source_multimedia_url }}" target="_blank">
+        <i class="fa fa-external-link"></i>
+        {% trans "Go to Source App Multimedia Download Page" %}
+      </a>
+      <p class="mb-1">{% trans 'Click "Download ZIP".' %}</p>
+    </div>
+  </div>
+
+  <div class="card mb-3">
+    <div class="card-header">
+      {% trans "Step 2: Upload Multimedia to New App" %}
+    </div>
+    <div class="card-body">
+      <p class="mb-2">
+        {% trans "Go to your new application's multimedia page and upload the downloaded files:" %}
+      </p>
+      <a href="{{ current_multimedia_url }}" target="_blank">
+        <i class="fa fa-external-link"></i>
+        {% trans "Go to New App Multimedia Upload Page" %}
+      </a>
+      <p class="mb-1">{% trans 'Upload Multimedia Files under Step 3.' %}</p>
+    </div>
+  </div>
+
+  <p class="lead">
+    {% trans "All done? Click below to go to your new application." %}
+  </p>
+  <button type="submit" class="btn btn-primary">
+    {% trans "Go to Application" %}
+  </button>
+</div>

--- a/corehq/apps/domain/templates/domain/import_app_step_3_instruction.html
+++ b/corehq/apps/domain/templates/domain/import_app_step_3_instruction.html
@@ -3,46 +3,77 @@
 
 <div>
   <div class="alert alert-success">
-    <h4>{% trans "Your application has been successfully imported!" %}</h4>
+    <h4>
+      {% blocktrans %}
+        Your application has been successfully imported!
+      {% endblocktrans %}
+    </h4>
     <p class="lead mb-1">
-      {% trans "You’re almost done — if your application contains multimedia files, follow these steps to copy them to your new application." %}
+      {% blocktrans %}
+        You're almost done — if your application contains multimedia files,
+        follow these steps to copy them to your new application.
+      {% endblocktrans %}
     </p>
   </div>
 
   <div class="card mb-3">
     <div class="card-header">
-      {% trans "Step 1: Download Multimedia from Source App" %}
+      {% blocktrans %}
+        Step 1: Download Multimedia from Source App
+      {% endblocktrans %}
     </div>
     <div class="card-body">
       <p class="mb-2">
-        {% trans "Go to the source application's multimedia page and download the multimedia files as a ZIP:" %}
+        {% blocktrans %}
+          Go to the source application's multimedia page and download the
+          multimedia files as a ZIP:
+        {% endblocktrans %}
       </p>
       <a href="{{ source_multimedia_url }}" target="_blank">
         <i class="fa fa-external-link"></i>
-        {% trans "Go to Source App Multimedia Download Page" %}
+        {% blocktrans %}
+          Go to Source App Multimedia Download Page
+        {% endblocktrans %}
       </a>
-      <p class="mb-1">{% trans 'Click "Download ZIP".' %}</p>
+      <p class="mb-1">
+        {% blocktrans %}
+          Click "Download ZIP".
+        {% endblocktrans %}
+      </p>
     </div>
   </div>
 
   <div class="card mb-3">
     <div class="card-header">
-      {% trans "Step 2: Upload Multimedia to New App" %}
+      {% blocktrans %}
+        Step 2: Upload Multimedia to New App
+      {% endblocktrans %}
     </div>
     <div class="card-body">
       <p class="mb-2">
-        {% trans "Go to your new application's multimedia page and upload the downloaded files:" %}
+        {% blocktrans %}
+          Go to your new application's multimedia page and upload the downloaded
+          files:
+        {% endblocktrans %}
       </p>
       <a href="{{ current_multimedia_url }}" target="_blank">
         <i class="fa fa-external-link"></i>
-        {% trans "Go to New App Multimedia Upload Page" %}
+        {% blocktrans %}
+          Go to New App Multimedia Upload Page
+        {% endblocktrans %}
       </a>
-      <p class="mb-1">{% trans 'Upload Multimedia Files under Step 3.' %}</p>
+      <p class="mb-1">
+        {% blocktrans %}
+          Upload Multimedia Files under Step 3.
+        {% endblocktrans %}
+      </p>
     </div>
   </div>
 
   <p class="lead">
-    {% trans "All done? Click below to go to your new application." %}
+    {% blocktrans %}
+      All done? Click below to go to your new application.
+    {% endblocktrans %}
   </p>
   <a href="{{ new_app_url }}" class="btn btn-primary">
     {% trans "Go to Application" %}

--- a/corehq/apps/domain/templates/domain/import_app_step_3_instruction.html
+++ b/corehq/apps/domain/templates/domain/import_app_step_3_instruction.html
@@ -44,7 +44,7 @@
   <p class="lead">
     {% trans "All done? Click below to go to your new application." %}
   </p>
-  <button type="submit" class="btn btn-primary">
+  <a href="{{ new_app_url }}" class="btn btn-primary">
     {% trans "Go to Application" %}
-  </button>
+  </a>
 </div>

--- a/corehq/apps/domain/views/import_apps.py
+++ b/corehq/apps/domain/views/import_apps.py
@@ -90,6 +90,7 @@ class ImportAppStepsView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin
         return self.get(request, form=form, next_action=next_action, *args, **kwargs)
 
     def import_app_step_3_response(self, request, source_server, source_domain, source_app_id, new_app_id):
+        from corehq.apps.app_manager.views.utils import back_to_main
         #TODO: make this a constant in later commit
         server_mapping = {
             'production': 'www',
@@ -99,9 +100,11 @@ class ImportAppStepsView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin
         source_multimedia_url = (f"https://{server_mapping[source_server]}.commcarehq.org/a/{source_domain}/apps/"
                                  f"view/{source_app_id}/settings/#multimedia-tab")
         current_multimedia_url = reverse(BulkUploadMultimediaView.urlname, args=[self.domain, new_app_id])
+        new_app_url = back_to_main(request, self.domain, new_app_id).url
         return self.render_htmx_partial_response(request, 'domain/import_app_step_3_instruction.html', {
             'source_multimedia_url': source_multimedia_url,
             'current_multimedia_url': current_multimedia_url,
+            'new_app_url': new_app_url,
         })
 
     @hq_hx_action('get')

--- a/corehq/apps/domain/views/import_apps.py
+++ b/corehq/apps/domain/views/import_apps.py
@@ -104,8 +104,10 @@ class ImportAppStepsView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin
 
     def import_app_step_3_response(self, request, source_server, source_domain, source_app_id, new_app_id):
         from corehq.apps.app_manager.views.utils import back_to_main
-        source_multimedia_url = (f"https://{SERVER_SUBDOMAIN_MAPPING[source_server]}.commcarehq.org/a/"
-                                 f"{source_domain}/apps/view/{source_app_id}/settings/#multimedia-tab")
+        source_multimedia_url = (
+            f"https://{SERVER_SUBDOMAIN_MAPPING[source_server]}.commcarehq.org/a/"
+            f"{source_domain}/apps/view/{source_app_id}/settings/#multimedia-tab"
+        )
         current_multimedia_url = reverse(BulkUploadMultimediaView.urlname, args=[self.domain, new_app_id])
         new_app_url = back_to_main(request, self.domain, new_app_id).url
         return self.render_htmx_partial_response(request, 'domain/import_app_step_3_instruction.html', {

--- a/corehq/apps/domain/views/import_apps.py
+++ b/corehq/apps/domain/views/import_apps.py
@@ -13,6 +13,12 @@ from corehq.apps.hqmedia.views import BulkUploadMultimediaView
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
+SERVER_SUBDOMAIN_MAPPING = {
+    'production': 'www',
+    'india': 'india',
+    'eu': 'eu',
+}
+
 
 @method_decorator(
     [
@@ -91,14 +97,8 @@ class ImportAppStepsView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin
 
     def import_app_step_3_response(self, request, source_server, source_domain, source_app_id, new_app_id):
         from corehq.apps.app_manager.views.utils import back_to_main
-        #TODO: make this a constant in later commit
-        server_mapping = {
-            'production': 'www',
-            'india': 'india',
-            'eu': 'eu',
-        }
-        source_multimedia_url = (f"https://{server_mapping[source_server]}.commcarehq.org/a/{source_domain}/apps/"
-                                 f"view/{source_app_id}/settings/#multimedia-tab")
+        source_multimedia_url = (f"https://{SERVER_SUBDOMAIN_MAPPING[source_server]}.commcarehq.org/a/"
+                                 f"{source_domain}/apps/view/{source_app_id}/settings/#multimedia-tab")
         current_multimedia_url = reverse(BulkUploadMultimediaView.urlname, args=[self.domain, new_app_id])
         new_app_url = back_to_main(request, self.domain, new_app_id).url
         return self.render_htmx_partial_response(request, 'domain/import_app_step_3_instruction.html', {

--- a/corehq/apps/domain/views/import_apps.py
+++ b/corehq/apps/domain/views/import_apps.py
@@ -1,5 +1,6 @@
 import json
 
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
@@ -8,6 +9,7 @@ from corehq.apps.app_manager.models import import_app as import_app_util
 from corehq.apps.domain.decorators import LoginAndDomainMixin
 from corehq.apps.domain.forms import ExtractAppInfoForm, ImportAppForm
 from corehq.apps.domain.views.base import DomainViewMixin
+from corehq.apps.hqmedia.views import BulkUploadMultimediaView
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
@@ -55,7 +57,6 @@ class ImportAppStepsView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin
     @hq_hx_action('post')
     def process_second_step(self, request, *args, **kwargs):
         from corehq.apps.app_manager.views.apps import clear_app_cache
-        from corehq.apps.app_manager.views.utils import back_to_main
 
         form = ImportAppForm(
             self.container_id,
@@ -67,12 +68,46 @@ class ImportAppStepsView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin
         next_action = 'process_second_step'
 
         if form.is_valid():
+            from corehq.apps.domain.views.settings import ImportAppFromAnotherServerView
             clear_app_cache(request, self.domain)
             name = form.cleaned_data.get('app_name')
             file = form.cleaned_data.get('app_file')
             file.seek(0)  # rewind to the beginning becaues the file has already been read once when validating
             source = json.load(file)
             app = import_app_util(source, self.domain, {'name': name}, request=request)
-            response = back_to_main(request, self.domain, app_id=app._id)
-            return self.render_htmx_redirect(response.url)
+            source_server = form.cleaned_data.get('source_server')
+            source_domain = form.cleaned_data.get('source_domain')
+            source_app_id = form.cleaned_data.get('app_id')
+            new_app_id = app._id
+            response = self.import_app_step_3_response(request, source_server, source_domain, source_app_id,
+                                                   new_app_id)
+            # Add query params to the url so user won't lost the instruction page if refresh the page accidentally
+            current_url = reverse(ImportAppFromAnotherServerView.urlname, args=[self.domain])
+            query_params = (f"?source_server={source_server}&source_domain={source_domain}&"
+                            f"source_app_id={source_app_id}&new_app_id={new_app_id}")
+            response["HX-Push-Url"] = current_url + query_params
+            return response
         return self.get(request, form=form, next_action=next_action, *args, **kwargs)
+
+    def import_app_step_3_response(self, request, source_server, source_domain, source_app_id, new_app_id):
+        #TODO: make this a constant in later commit
+        server_mapping = {
+            'production': 'www',
+            'india': 'india',
+            'eu': 'eu',
+        }
+        source_multimedia_url = (f"https://{server_mapping[source_server]}.commcarehq.org/a/{source_domain}/apps/"
+                                 f"view/{source_app_id}/settings/#multimedia-tab")
+        current_multimedia_url = reverse(BulkUploadMultimediaView.urlname, args=[self.domain, new_app_id])
+        return self.render_htmx_partial_response(request, 'domain/import_app_step_3_instruction.html', {
+            'source_multimedia_url': source_multimedia_url,
+            'current_multimedia_url': current_multimedia_url,
+        })
+
+    @hq_hx_action('get')
+    def recent_import_details(self, request, *args, **kwargs):
+        source_server = request.GET.get('source_server')
+        source_domain = request.GET.get('source_domain')
+        source_app_id = request.GET.get('source_app_id')
+        new_app_id = request.GET.get('new_app_id')
+        return self.import_app_step_3_response(request, source_server, source_domain, source_app_id, new_app_id)

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -798,14 +798,33 @@ class ImportAppFromAnotherServerView(BaseAdminProjectSettingsView):
     urlname = 'import_app_from_another_server_main'
     template_name = 'domain/import_app_from_another_server_main.html'
 
+    def get_recent_import_details(self):
+        """
+        Returns the details of the most recent import app steps.
+        """
+        if self.request.GET.get('source_domain'):
+            return {
+                'source_server': self.request.GET.get('source_server'),
+                'source_domain': self.request.GET.get('source_domain'),
+                'source_app_id': self.request.GET.get('source_app_id'),
+                'new_app_id': self.request.GET.get('new_app_id'),
+            }
+        return {}
+
     @property
     def page_context(self):
-        return {
+        context = {
             'htmx_import_app_steps_view_url': reverse(
                 ImportAppStepsView.urlname,
                 args=[self.domain,],
             ),
         }
+        recent_import_details = self.get_recent_import_details()
+        if recent_import_details:
+            context.update({
+                'import_details': json.dumps(recent_import_details),
+            })
+        return context
 
 
 @require_POST


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
<img width="1280" height="674" alt="image" src="https://github.com/user-attachments/assets/e2bb3cea-02cf-4757-87ec-aadbf34ec35c" />

This PR is to add the third step in the import app workflow — show user how to import multimedia from the source app to the new app.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17799

A new template for the third step is created. This is a simple template only shows some instruction texts and url, no form submissions.
The new template will be rendered when the form in the step 2 is valid.
New GET endpoint `recent_import_details` is added to ensure the response can be rendered again if user refresh the page accidentally.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This PR is just adding a third step to display some url, worst case is that the url we displayed is wrong. No safety concern.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
