### PR TITLE
add tests for `corehq.apps.data_cleaning.utils.cases`

### DIFF
--- a/corehq/apps/data_cleaning/tests/test_utils_cases.py
+++ b/corehq/apps/data_cleaning/tests/test_utils_cases.py
@@ -1,0 +1,500 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from corehq import privileges
+from corehq.apps.data_cleaning.utils.cases import clear_caches_case_data_cleaning, get_case_property_details
+from corehq.apps.data_dictionary.models import CaseProperty, CasePropertyAllowedValue
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.linked_domain.local_accessors import CaseType
+from corehq.apps.users.models import WebUser
+from corehq.util.quickcache import quickcache
+from corehq.util.test_utils import privilege_enabled
+
+
+@quickcache(vary_on=['domain', 'include_parent_properties', 'exclude_deprecated_properties'])
+def _mock_all_case_properties_by_domain(
+    domain,
+    include_parent_properties=True,
+    exclude_deprecated_properties=True,
+):
+    return SAMPLE_PROPERTIES
+
+
+class GetCasePropertyDetailsTest(TestCase):
+    domain = 'test-dc-case-prop-details'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+
+        cls.web_user = WebUser.create(cls.domain, 'tester@datacleaning.org', 'testpwd', None, None)
+        cls.addClassCleanup(cls.web_user.delete, cls.domain, deleted_by=None)
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        _mock_all_case_properties_by_domain,
+    )
+    @privilege_enabled(privileges.DATA_DICTIONARY)
+    def test_expected_format_no_dd_entries(self):
+        clear_caches_case_data_cleaning(self.domain, 'plant')
+        details = get_case_property_details(
+            self.domain,
+            'plant',
+        )
+        assert details == PLANT_DETAILS_NO_DD
+
+    def _generate_data_dictionary_entries(self):
+        case_type = CaseType.objects.create(
+            domain=self.domain,
+            name='plant',
+            description='Plant case type',
+        )
+        property_defs = [
+            ('height', 'Height (cm)', CaseProperty.DataType.NUMBER),
+            ('pot_type', 'Pot Type', CaseProperty.DataType.SELECT),
+            ('last_watered_on', 'Watered On', CaseProperty.DataType.DATE),
+            ('plant_id', 'Plant Barcode', CaseProperty.DataType.BARCODE),
+            ('contact_details', 'Contact Deets', CaseProperty.DataType.PHONE_NUMBER),
+            ('plant_secret', 'Plant Pass', CaseProperty.DataType.PASSWORD),
+        ]
+        for index, (name, label, data_type) in enumerate(property_defs):
+            CaseProperty.objects.create(
+                case_type=case_type,
+                name=name,
+                label=label,
+                data_type=data_type,
+                index=index,
+            )
+        pot_type = case_type.properties.get(name='pot_type')
+        options = ['plastic', 'ceramic', 'terracotta', 'concrete']
+        for option in options:
+            CasePropertyAllowedValue.objects.create(
+                allowed_value=option,
+                description=f'{option} pot',
+                case_property=pot_type,
+            )
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        _mock_all_case_properties_by_domain,
+    )
+    @privilege_enabled(privileges.DATA_DICTIONARY)
+    def test_expected_format_with_dd_entries(self):
+        clear_caches_case_data_cleaning(self.domain, 'plant')
+        self._generate_data_dictionary_entries()
+        details = get_case_property_details(
+            self.domain,
+            'plant',
+        )
+        assert details == PLANT_DETAILS_WITH_DD
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        _mock_all_case_properties_by_domain,
+    )
+    def test_expected_format_without_dd_access(self):
+        clear_caches_case_data_cleaning(self.domain, 'plant')
+        self._generate_data_dictionary_entries()
+        details = get_case_property_details(
+            self.domain,
+            'plant',
+        )
+        assert details == PLANT_DETAILS_NO_DD
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        _mock_all_case_properties_by_domain,
+    )
+    @privilege_enabled(privileges.DATA_DICTIONARY)
+    def test_expected_value_with_caches(self):
+        clear_caches_case_data_cleaning(self.domain, 'plant')
+        details = get_case_property_details(
+            self.domain,
+            'plant',
+        )
+        assert details == PLANT_DETAILS_NO_DD
+        self._generate_data_dictionary_entries()
+        details = get_case_property_details(
+            self.domain,
+            'plant',
+        )
+        assert details == PLANT_DETAILS_NO_DD
+        clear_caches_case_data_cleaning(self.domain, 'plant')
+        details = get_case_property_details(
+            self.domain,
+            'plant',
+        )
+        assert details == PLANT_DETAILS_WITH_DD
+
+
+SAMPLE_PROPERTIES = {
+    'plant': [
+        'height',
+        'last_watered_on',
+        'name',
+        'nickname',
+        'pot_type',
+        'plant_id',
+        'plant_location',
+        'contact_details',
+        'plant_secret',
+    ],
+    'plant_room': [
+        'description',
+        'distance_from_window_cm',
+        'light_level',
+        'min_water_required',
+        'name',
+        'plant_surfaces',
+        'room_barcode',
+        'room_id',
+        'room_location',
+        'water_ratio',
+    ],
+    'commcare-user': ['name'],
+}
+
+PLANT_DETAILS_NO_DD = {
+    'name': {
+        'label': 'Name',
+        'data_type': 'text',
+        'prop_id': 'name',
+        'is_editable': False,
+        'options': None,
+    },
+    'contact_details': {
+        'label': 'Contact Details',
+        'data_type': 'text',
+        'prop_id': 'contact_details',
+        'is_editable': True,
+        'options': None,
+    },
+    'nickname': {
+        'label': 'Nickname',
+        'data_type': 'text',
+        'prop_id': 'nickname',
+        'is_editable': True,
+        'options': None,
+    },
+    'plant_location': {
+        'label': 'Plant Location',
+        'data_type': 'text',
+        'prop_id': 'plant_location',
+        'is_editable': True,
+        'options': None,
+    },
+    'last_watered_on': {
+        'label': 'Last Watered On',
+        'data_type': 'text',
+        'prop_id': 'last_watered_on',
+        'is_editable': True,
+        'options': None,
+    },
+    'pot_type': {
+        'label': 'Pot Type',
+        'data_type': 'text',
+        'prop_id': 'pot_type',
+        'is_editable': True,
+        'options': None,
+    },
+    'height': {
+        'label': 'Height',
+        'data_type': 'text',
+        'prop_id': 'height',
+        'is_editable': True,
+        'options': None,
+    },
+    'plant_id': {
+        'label': 'Plant Id',
+        'data_type': 'text',
+        'prop_id': 'plant_id',
+        'is_editable': True,
+        'options': None,
+    },
+    'plant_secret': {
+        'label': 'Plant Secret',
+        'data_type': 'text',
+        'prop_id': 'plant_secret',
+        'is_editable': True,
+        'options': None,
+    },
+    '@case_id': {
+        'label': 'Case ID',
+        'data_type': 'text',
+        'prop_id': '@case_id',
+        'is_editable': False,
+        'options': None,
+    },
+    '@case_type': {
+        'label': 'Case Type',
+        'data_type': 'text',
+        'prop_id': '@case_type',
+        'is_editable': False,
+        'options': None,
+    },
+    '@owner_id': {
+        'label': 'Owner ID',
+        'data_type': 'text',
+        'prop_id': '@owner_id',
+        'is_editable': False,
+        'options': None,
+    },
+    '@status': {
+        'label': 'Open/Closed Status',
+        'data_type': 'text',
+        'prop_id': '@status',
+        'is_editable': False,
+        'options': None,
+    },
+    'external_id': {
+        'label': 'External ID',
+        'data_type': 'text',
+        'prop_id': 'external_id',
+        'is_editable': True,
+        'options': None,
+    },
+    'date_opened': {
+        'label': 'Date Opened',
+        'data_type': 'datetime',
+        'prop_id': 'date_opened',
+        'is_editable': False,
+        'options': None,
+    },
+    'closed_on': {
+        'label': 'Closed On',
+        'data_type': 'datetime',
+        'prop_id': 'closed_on',
+        'is_editable': False,
+        'options': None,
+    },
+    'last_modified': {
+        'label': 'Last Modified On',
+        'data_type': 'datetime',
+        'prop_id': 'last_modified',
+        'is_editable': False,
+        'options': None,
+    },
+    'closed_by_username': {
+        'label': 'Closed By',
+        'data_type': 'text',
+        'prop_id': 'closed_by_username',
+        'is_editable': False,
+        'options': None,
+    },
+    'last_modified_by_user_username': {
+        'label': 'Last Modified By',
+        'data_type': 'text',
+        'prop_id': 'last_modified_by_user_username',
+        'is_editable': False,
+        'options': None,
+    },
+    'opened_by_username': {
+        'label': 'Opened By',
+        'data_type': 'text',
+        'prop_id': 'opened_by_username',
+        'is_editable': False,
+        'options': None,
+    },
+    'owner_name': {
+        'label': 'Owner',
+        'data_type': 'text',
+        'prop_id': 'owner_name',
+        'is_editable': False,
+        'options': None,
+    },
+    'closed_by_user_id': {
+        'label': 'Closed By User ID',
+        'data_type': 'text',
+        'prop_id': 'closed_by_user_id',
+        'is_editable': False,
+        'options': None,
+    },
+    'opened_by_user_id': {
+        'label': 'Opened By User ID',
+        'data_type': 'text',
+        'prop_id': 'opened_by_user_id',
+        'is_editable': False,
+        'options': None,
+    },
+    'server_last_modified_date': {
+        'label': 'Last Modified (UTC)',
+        'data_type': 'datetime',
+        'prop_id': 'server_last_modified_date',
+        'is_editable': False,
+        'options': None,
+    },
+}
+
+PLANT_DETAILS_WITH_DD = {
+    'pot_type': {
+        'label': 'Pot Type',
+        'data_type': 'multiple_option',
+        'prop_id': 'pot_type',
+        'is_editable': True,
+        'options': ['plastic', 'ceramic', 'terracotta', 'concrete'],
+    },
+    'plant_secret': {
+        'label': 'Plant Pass',
+        'data_type': 'password',
+        'prop_id': 'plant_secret',
+        'is_editable': True,
+        'options': [],
+    },
+    'plant_location': {
+        'label': 'Plant Location',
+        'data_type': 'text',
+        'prop_id': 'plant_location',
+        'is_editable': True,
+        'options': None,
+    },
+    'nickname': {
+        'label': 'Nickname',
+        'data_type': 'text',
+        'prop_id': 'nickname',
+        'is_editable': True,
+        'options': None,
+    },
+    'height': {
+        'label': 'Height (cm)',
+        'data_type': 'integer',
+        'prop_id': 'height',
+        'is_editable': True,
+        'options': [],
+    },
+    'plant_id': {
+        'label': 'Plant Barcode',
+        'data_type': 'barcode',
+        'prop_id': 'plant_id',
+        'is_editable': True,
+        'options': [],
+    },
+    'name': {
+        'label': 'Name',
+        'data_type': 'text',
+        'prop_id': 'name',
+        'is_editable': False,
+        'options': None,
+    },
+    'last_watered_on': {
+        'label': 'Watered On',
+        'data_type': 'date',
+        'prop_id': 'last_watered_on',
+        'is_editable': True,
+        'options': [],
+    },
+    'contact_details': {
+        'label': 'Contact Deets',
+        'data_type': 'phone_number',
+        'prop_id': 'contact_details',
+        'is_editable': True,
+        'options': [],
+    },
+    '@case_id': {
+        'label': 'Case ID',
+        'data_type': 'text',
+        'prop_id': '@case_id',
+        'is_editable': False,
+        'options': None,
+    },
+    '@case_type': {
+        'label': 'Case Type',
+        'data_type': 'text',
+        'prop_id': '@case_type',
+        'is_editable': False,
+        'options': None,
+    },
+    '@owner_id': {
+        'label': 'Owner ID',
+        'data_type': 'text',
+        'prop_id': '@owner_id',
+        'is_editable': False,
+        'options': None,
+    },
+    '@status': {
+        'label': 'Open/Closed Status',
+        'data_type': 'text',
+        'prop_id': '@status',
+        'is_editable': False,
+        'options': None,
+    },
+    'external_id': {
+        'label': 'External ID',
+        'data_type': 'text',
+        'prop_id': 'external_id',
+        'is_editable': True,
+        'options': None,
+    },
+    'date_opened': {
+        'label': 'Date Opened',
+        'data_type': 'datetime',
+        'prop_id': 'date_opened',
+        'is_editable': False,
+        'options': None,
+    },
+    'closed_on': {
+        'label': 'Closed On',
+        'data_type': 'datetime',
+        'prop_id': 'closed_on',
+        'is_editable': False,
+        'options': None,
+    },
+    'last_modified': {
+        'label': 'Last Modified On',
+        'data_type': 'datetime',
+        'prop_id': 'last_modified',
+        'is_editable': False,
+        'options': None,
+    },
+    'closed_by_username': {
+        'label': 'Closed By',
+        'data_type': 'text',
+        'prop_id': 'closed_by_username',
+        'is_editable': False,
+        'options': None,
+    },
+    'last_modified_by_user_username': {
+        'label': 'Last Modified By',
+        'data_type': 'text',
+        'prop_id': 'last_modified_by_user_username',
+        'is_editable': False,
+        'options': None,
+    },
+    'opened_by_username': {
+        'label': 'Opened By',
+        'data_type': 'text',
+        'prop_id': 'opened_by_username',
+        'is_editable': False,
+        'options': None,
+    },
+    'owner_name': {
+        'label': 'Owner',
+        'data_type': 'text',
+        'prop_id': 'owner_name',
+        'is_editable': False,
+        'options': None,
+    },
+    'closed_by_user_id': {
+        'label': 'Closed By User ID',
+        'data_type': 'text',
+        'prop_id': 'closed_by_user_id',
+        'is_editable': False,
+        'options': None,
+    },
+    'opened_by_user_id': {
+        'label': 'Opened By User ID',
+        'data_type': 'text',
+        'prop_id': 'opened_by_user_id',
+        'is_editable': False,
+        'options': None,
+    },
+    'server_last_modified_date': {
+        'label': 'Last Modified (UTC)',
+        'data_type': 'datetime',
+        'prop_id': 'server_last_modified_date',
+        'is_editable': False,
+        'options': None,
+    },
+}

--- a/corehq/apps/data_cleaning/tests/test_utils_cases.py
+++ b/corehq/apps/data_cleaning/tests/test_utils_cases.py
@@ -3,26 +3,22 @@ from unittest import mock
 from django.test import TestCase
 
 from corehq import privileges
-from corehq.apps.data_cleaning.utils.cases import clear_caches_case_data_cleaning, get_case_property_details
+from corehq.apps.data_cleaning.models.types import DataType
+from corehq.apps.data_cleaning.utils.cases import (
+    clear_caches_case_data_cleaning,
+    get_case_property_details,
+    get_property_details_from_data_dictionary,
+)
 from corehq.apps.data_dictionary.models import CaseProperty, CasePropertyAllowedValue
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.linked_domain.local_accessors import CaseType
-from corehq.apps.users.models import WebUser
 from corehq.util.quickcache import quickcache
-from corehq.util.test_utils import privilege_enabled
+from corehq.util.test_utils import disable_quickcache, privilege_enabled
 
 
-@quickcache(vary_on=['domain', 'include_parent_properties', 'exclude_deprecated_properties'])
-def _mock_all_case_properties_by_domain(
-    domain,
-    include_parent_properties=True,
-    exclude_deprecated_properties=True,
-):
-    return SAMPLE_PROPERTIES
-
-
-class GetCasePropertyDetailsTest(TestCase):
-    domain = 'test-dc-case-prop-details'
+class BaseCaseUtilsTest(TestCase):
+    domain = 'test-dc-case-utils'
+    case_type = 'plant'
 
     @classmethod
     def setUpClass(cls):
@@ -30,45 +26,88 @@ class GetCasePropertyDetailsTest(TestCase):
         cls.domain_obj = create_domain(cls.domain)
         cls.addClassCleanup(cls.domain_obj.delete)
 
-        cls.web_user = WebUser.create(cls.domain, 'tester@datacleaning.org', 'testpwd', None, None)
-        cls.addClassCleanup(cls.web_user.delete, cls.domain, deleted_by=None)
-
-    @mock.patch(
-        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
-        _mock_all_case_properties_by_domain,
-    )
-    @privilege_enabled(privileges.DATA_DICTIONARY)
-    def test_expected_format_no_dd_entries(self):
-        clear_caches_case_data_cleaning(self.domain, 'plant')
-        details = get_case_property_details(
-            self.domain,
-            'plant',
-        )
-        assert details == PLANT_DETAILS_NO_DD
-
-    def _generate_data_dictionary_entries(self):
-        case_type = CaseType.objects.create(
+    def setUp(self):
+        super().setUp()
+        self.case_type_dd = CaseType.objects.create(
             domain=self.domain,
-            name='plant',
+            name=self.case_type,
             description='Plant case type',
         )
-        property_defs = [
-            ('height', 'Height (cm)', CaseProperty.DataType.NUMBER),
-            ('pot_type', 'Pot Type', CaseProperty.DataType.SELECT),
-            ('last_watered_on', 'Watered On', CaseProperty.DataType.DATE),
-            ('plant_id', 'Plant Barcode', CaseProperty.DataType.BARCODE),
-            ('contact_details', 'Contact Deets', CaseProperty.DataType.PHONE_NUMBER),
-            ('plant_secret', 'Plant Pass', CaseProperty.DataType.PASSWORD),
-        ]
-        for index, (name, label, data_type) in enumerate(property_defs):
-            CaseProperty.objects.create(
-                case_type=case_type,
-                name=name,
-                label=label,
-                data_type=data_type,
-                index=index,
-            )
-        pot_type = case_type.properties.get(name='pot_type')
+
+
+class GetCasePropertyDetailsForDataDictionaryTest(BaseCaseUtilsTest):
+    @privilege_enabled(privileges.DATA_DICTIONARY)
+    def test_text_property(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='nickname',
+            label='Nickname',
+            data_type=CaseProperty.DataType.PLAIN,
+            index=1,
+        )
+        details = get_property_details_from_data_dictionary(self.domain, self.case_type)
+        expected_result = {
+            'nickname': {
+                'label': 'Nickname',
+                'data_type': DataType.TEXT,
+                'prop_id': 'nickname',
+                'is_editable': True,
+                'options': [],
+            },
+        }
+        assert details == expected_result
+
+    @privilege_enabled(privileges.DATA_DICTIONARY)
+    def test_date_property(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='watered_on',
+            label='Last Watered On',
+            data_type=CaseProperty.DataType.DATE,
+            index=1,
+        )
+        details = get_property_details_from_data_dictionary(self.domain, self.case_type)
+        expected_result = {
+            'watered_on': {
+                'label': 'Last Watered On',
+                'data_type': DataType.DATE,
+                'prop_id': 'watered_on',
+                'is_editable': True,
+                'options': [],
+            },
+        }
+        assert details == expected_result
+
+    @privilege_enabled(privileges.DATA_DICTIONARY)
+    def test_number_property(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='height',
+            label='Height (cm)',
+            data_type=CaseProperty.DataType.NUMBER,
+            index=1,
+        )
+        details = get_property_details_from_data_dictionary(self.domain, self.case_type)
+        expected_result = {
+            'height': {
+                'label': 'Height (cm)',
+                'data_type': DataType.INTEGER,
+                'prop_id': 'height',
+                'is_editable': True,
+                'options': [],
+            },
+        }
+        assert details == expected_result
+
+    @privilege_enabled(privileges.DATA_DICTIONARY)
+    def test_select_property(self):
+        pot_type = CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='pot_type',
+            label='Pot Type',
+            data_type=CaseProperty.DataType.SELECT,
+            index=1,
+        )
         options = ['plastic', 'ceramic', 'terracotta', 'concrete']
         for option in options:
             CasePropertyAllowedValue.objects.create(
@@ -76,425 +115,590 @@ class GetCasePropertyDetailsTest(TestCase):
                 description=f'{option} pot',
                 case_property=pot_type,
             )
+        details = get_property_details_from_data_dictionary(self.domain, self.case_type)
+        expected_result = {
+            'pot_type': {
+                'label': 'Pot Type',
+                'data_type': DataType.MULTIPLE_OPTION,
+                'prop_id': 'pot_type',
+                'is_editable': True,
+                'options': options,
+            },
+        }
+        assert details == expected_result
 
-    @mock.patch(
-        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
-        _mock_all_case_properties_by_domain,
-    )
     @privilege_enabled(privileges.DATA_DICTIONARY)
-    def test_expected_format_with_dd_entries(self):
-        clear_caches_case_data_cleaning(self.domain, 'plant')
-        self._generate_data_dictionary_entries()
-        details = get_case_property_details(
-            self.domain,
-            'plant',
+    def test_barcode_property(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='plant_id',
+            label='Plant Barcode',
+            data_type=CaseProperty.DataType.BARCODE,
+            index=1,
         )
-        assert details == PLANT_DETAILS_WITH_DD
+        details = get_property_details_from_data_dictionary(self.domain, self.case_type)
+        expected_result = {
+            'plant_id': {
+                'label': 'Plant Barcode',
+                'data_type': DataType.BARCODE,
+                'prop_id': 'plant_id',
+                'is_editable': True,
+                'options': [],
+            },
+        }
+        assert details == expected_result
 
-    @mock.patch(
-        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
-        _mock_all_case_properties_by_domain,
-    )
-    def test_expected_format_without_dd_access(self):
-        clear_caches_case_data_cleaning(self.domain, 'plant')
-        self._generate_data_dictionary_entries()
-        details = get_case_property_details(
-            self.domain,
-            'plant',
-        )
-        assert details == PLANT_DETAILS_NO_DD
-
-    @mock.patch(
-        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
-        _mock_all_case_properties_by_domain,
-    )
     @privilege_enabled(privileges.DATA_DICTIONARY)
-    def test_expected_value_with_caches(self):
-        clear_caches_case_data_cleaning(self.domain, 'plant')
-        details = get_case_property_details(
-            self.domain,
-            'plant',
+    def test_phone_number_property(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='contact_details',
+            label='Contact Deets',
+            data_type=CaseProperty.DataType.PHONE_NUMBER,
+            index=1,
         )
-        assert details == PLANT_DETAILS_NO_DD
-        self._generate_data_dictionary_entries()
-        details = get_case_property_details(
-            self.domain,
-            'plant',
+        details = get_property_details_from_data_dictionary(self.domain, self.case_type)
+        expected_result = {
+            'contact_details': {
+                'label': 'Contact Deets',
+                'data_type': DataType.PHONE_NUMBER,
+                'prop_id': 'contact_details',
+                'is_editable': True,
+                'options': [],
+            },
+        }
+        assert details == expected_result
+
+    @privilege_enabled(privileges.DATA_DICTIONARY)
+    def test_password_property(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='plant_secret',
+            label='Plant Pass',
+            data_type=CaseProperty.DataType.PASSWORD,
+            index=1,
         )
-        assert details == PLANT_DETAILS_NO_DD
-        clear_caches_case_data_cleaning(self.domain, 'plant')
-        details = get_case_property_details(
-            self.domain,
-            'plant',
+        details = get_property_details_from_data_dictionary(self.domain, self.case_type)
+        expected_result = {
+            'plant_secret': {
+                'label': 'Plant Pass',
+                'data_type': DataType.PASSWORD,
+                'prop_id': 'plant_secret',
+                'is_editable': True,
+                'options': [],
+            },
+        }
+        assert details == expected_result
+
+    @privilege_enabled(privileges.DATA_DICTIONARY)
+    def test_undefined_property(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='undefined_property',
+            label='Undefined Property',
+            data_type=CaseProperty.DataType.UNDEFINED,
+            index=1,
         )
-        assert details == PLANT_DETAILS_WITH_DD
+        details = get_property_details_from_data_dictionary(self.domain, self.case_type)
+        expected_result = {
+            'undefined_property': {
+                'label': 'Undefined Property',
+                'data_type': DataType.TEXT,
+                'prop_id': 'undefined_property',
+                'is_editable': True,
+                'options': [],
+            },
+        }
+        assert details == expected_result
+
+    @privilege_enabled(privileges.DATA_DICTIONARY)
+    def test_gps_property(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='plant_location',
+            label='Plant Location',
+            data_type=CaseProperty.DataType.GPS,
+            index=1,
+        )
+        details = get_property_details_from_data_dictionary(self.domain, self.case_type)
+        expected_result = {
+            'plant_location': {
+                'label': 'Plant Location',
+                'data_type': DataType.GPS,
+                'prop_id': 'plant_location',
+                'is_editable': True,
+                'options': [],
+            },
+        }
+        assert details == expected_result
+
+    @privilege_enabled(privileges.DATA_DICTIONARY)
+    def test_no_properties(self):
+        details = get_property_details_from_data_dictionary(self.domain, self.case_type)
+        expected_result = {}
+        assert details == expected_result
+
+    def test_no_privilege(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='plant_location',
+            label='Plant Location',
+            data_type=CaseProperty.DataType.GPS,
+            index=1,
+        )
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='undefined_property',
+            label='Undefined Property',
+            data_type=CaseProperty.DataType.UNDEFINED,
+            index=2,
+        )
+        details = get_property_details_from_data_dictionary(self.domain, self.case_type)
+        expected_result = {}
+        assert details == expected_result
 
 
-SAMPLE_PROPERTIES = {
-    'plant': [
-        'height',
-        'last_watered_on',
-        'name',
-        'nickname',
-        'pot_type',
-        'plant_id',
-        'plant_location',
-        'contact_details',
-        'plant_secret',
-    ],
-    'plant_room': [
-        'description',
-        'distance_from_window_cm',
-        'light_level',
-        'min_water_required',
-        'name',
-        'plant_surfaces',
-        'room_barcode',
-        'room_id',
-        'room_location',
-        'water_ratio',
-    ],
-    'commcare-user': ['name'],
-}
+def get_mock_all_case_properties_by_domain(result_properties):
+    @quickcache(vary_on=['domain', 'include_parent_properties', 'exclude_deprecated_properties'])
+    def _mock_all_case_properties_by_domain(
+        domain, include_parent_properties=True, exclude_deprecated_properties=True
+    ):
+        return result_properties
 
-PLANT_DETAILS_NO_DD = {
-    'name': {
-        'label': 'Name',
-        'data_type': 'text',
-        'prop_id': 'name',
-        'is_editable': False,
-        'options': None,
-    },
-    'contact_details': {
-        'label': 'Contact Details',
-        'data_type': 'text',
-        'prop_id': 'contact_details',
-        'is_editable': True,
-        'options': None,
-    },
-    'nickname': {
-        'label': 'Nickname',
-        'data_type': 'text',
-        'prop_id': 'nickname',
-        'is_editable': True,
-        'options': None,
-    },
-    'plant_location': {
-        'label': 'Plant Location',
-        'data_type': 'text',
-        'prop_id': 'plant_location',
-        'is_editable': True,
-        'options': None,
-    },
-    'last_watered_on': {
-        'label': 'Last Watered On',
-        'data_type': 'text',
-        'prop_id': 'last_watered_on',
-        'is_editable': True,
-        'options': None,
-    },
-    'pot_type': {
-        'label': 'Pot Type',
-        'data_type': 'text',
-        'prop_id': 'pot_type',
-        'is_editable': True,
-        'options': None,
-    },
-    'height': {
-        'label': 'Height',
-        'data_type': 'text',
-        'prop_id': 'height',
-        'is_editable': True,
-        'options': None,
-    },
-    'plant_id': {
-        'label': 'Plant Id',
-        'data_type': 'text',
-        'prop_id': 'plant_id',
-        'is_editable': True,
-        'options': None,
-    },
-    'plant_secret': {
-        'label': 'Plant Secret',
-        'data_type': 'text',
-        'prop_id': 'plant_secret',
-        'is_editable': True,
-        'options': None,
-    },
-    '@case_id': {
-        'label': 'Case ID',
-        'data_type': 'text',
-        'prop_id': '@case_id',
-        'is_editable': False,
-        'options': None,
-    },
-    '@case_type': {
-        'label': 'Case Type',
-        'data_type': 'text',
-        'prop_id': '@case_type',
-        'is_editable': False,
-        'options': None,
-    },
-    '@owner_id': {
-        'label': 'Owner ID',
-        'data_type': 'text',
-        'prop_id': '@owner_id',
-        'is_editable': False,
-        'options': None,
-    },
-    '@status': {
-        'label': 'Open/Closed Status',
-        'data_type': 'text',
-        'prop_id': '@status',
-        'is_editable': False,
-        'options': None,
-    },
-    'external_id': {
-        'label': 'External ID',
-        'data_type': 'text',
-        'prop_id': 'external_id',
-        'is_editable': True,
-        'options': None,
-    },
-    'date_opened': {
-        'label': 'Date Opened',
-        'data_type': 'datetime',
-        'prop_id': 'date_opened',
-        'is_editable': False,
-        'options': None,
-    },
-    'closed_on': {
-        'label': 'Closed On',
-        'data_type': 'datetime',
-        'prop_id': 'closed_on',
-        'is_editable': False,
-        'options': None,
-    },
-    'last_modified': {
-        'label': 'Last Modified On',
-        'data_type': 'datetime',
-        'prop_id': 'last_modified',
-        'is_editable': False,
-        'options': None,
-    },
-    'closed_by_username': {
-        'label': 'Closed By',
-        'data_type': 'text',
-        'prop_id': 'closed_by_username',
-        'is_editable': False,
-        'options': None,
-    },
-    'last_modified_by_user_username': {
-        'label': 'Last Modified By',
-        'data_type': 'text',
-        'prop_id': 'last_modified_by_user_username',
-        'is_editable': False,
-        'options': None,
-    },
-    'opened_by_username': {
-        'label': 'Opened By',
-        'data_type': 'text',
-        'prop_id': 'opened_by_username',
-        'is_editable': False,
-        'options': None,
-    },
-    'owner_name': {
-        'label': 'Owner',
-        'data_type': 'text',
-        'prop_id': 'owner_name',
-        'is_editable': False,
-        'options': None,
-    },
-    'closed_by_user_id': {
-        'label': 'Closed By User ID',
-        'data_type': 'text',
-        'prop_id': 'closed_by_user_id',
-        'is_editable': False,
-        'options': None,
-    },
-    'opened_by_user_id': {
-        'label': 'Opened By User ID',
-        'data_type': 'text',
-        'prop_id': 'opened_by_user_id',
-        'is_editable': False,
-        'options': None,
-    },
-    'server_last_modified_date': {
-        'label': 'Last Modified (UTC)',
-        'data_type': 'datetime',
-        'prop_id': 'server_last_modified_date',
-        'is_editable': False,
-        'options': None,
-    },
-}
+    return _mock_all_case_properties_by_domain
 
-PLANT_DETAILS_WITH_DD = {
-    'pot_type': {
-        'label': 'Pot Type',
-        'data_type': 'multiple_option',
-        'prop_id': 'pot_type',
-        'is_editable': True,
-        'options': ['plastic', 'ceramic', 'terracotta', 'concrete'],
-    },
-    'plant_secret': {
-        'label': 'Plant Pass',
-        'data_type': 'password',
-        'prop_id': 'plant_secret',
-        'is_editable': True,
-        'options': [],
-    },
-    'plant_location': {
-        'label': 'Plant Location',
-        'data_type': 'text',
-        'prop_id': 'plant_location',
-        'is_editable': True,
-        'options': None,
-    },
-    'nickname': {
-        'label': 'Nickname',
-        'data_type': 'text',
-        'prop_id': 'nickname',
-        'is_editable': True,
-        'options': None,
-    },
-    'height': {
-        'label': 'Height (cm)',
-        'data_type': 'integer',
-        'prop_id': 'height',
-        'is_editable': True,
-        'options': [],
-    },
-    'plant_id': {
-        'label': 'Plant Barcode',
-        'data_type': 'barcode',
-        'prop_id': 'plant_id',
-        'is_editable': True,
-        'options': [],
-    },
-    'name': {
-        'label': 'Name',
-        'data_type': 'text',
-        'prop_id': 'name',
-        'is_editable': False,
-        'options': None,
-    },
-    'last_watered_on': {
-        'label': 'Watered On',
-        'data_type': 'date',
-        'prop_id': 'last_watered_on',
-        'is_editable': True,
-        'options': [],
-    },
-    'contact_details': {
-        'label': 'Contact Deets',
-        'data_type': 'phone_number',
-        'prop_id': 'contact_details',
-        'is_editable': True,
-        'options': [],
-    },
-    '@case_id': {
-        'label': 'Case ID',
-        'data_type': 'text',
-        'prop_id': '@case_id',
-        'is_editable': False,
-        'options': None,
-    },
-    '@case_type': {
-        'label': 'Case Type',
-        'data_type': 'text',
-        'prop_id': '@case_type',
-        'is_editable': False,
-        'options': None,
-    },
-    '@owner_id': {
-        'label': 'Owner ID',
-        'data_type': 'text',
-        'prop_id': '@owner_id',
-        'is_editable': False,
-        'options': None,
-    },
-    '@status': {
-        'label': 'Open/Closed Status',
-        'data_type': 'text',
-        'prop_id': '@status',
-        'is_editable': False,
-        'options': None,
-    },
-    'external_id': {
-        'label': 'External ID',
-        'data_type': 'text',
-        'prop_id': 'external_id',
-        'is_editable': True,
-        'options': None,
-    },
-    'date_opened': {
-        'label': 'Date Opened',
-        'data_type': 'datetime',
-        'prop_id': 'date_opened',
-        'is_editable': False,
-        'options': None,
-    },
-    'closed_on': {
-        'label': 'Closed On',
-        'data_type': 'datetime',
-        'prop_id': 'closed_on',
-        'is_editable': False,
-        'options': None,
-    },
-    'last_modified': {
-        'label': 'Last Modified On',
-        'data_type': 'datetime',
-        'prop_id': 'last_modified',
-        'is_editable': False,
-        'options': None,
-    },
-    'closed_by_username': {
-        'label': 'Closed By',
-        'data_type': 'text',
-        'prop_id': 'closed_by_username',
-        'is_editable': False,
-        'options': None,
-    },
-    'last_modified_by_user_username': {
-        'label': 'Last Modified By',
-        'data_type': 'text',
-        'prop_id': 'last_modified_by_user_username',
-        'is_editable': False,
-        'options': None,
-    },
-    'opened_by_username': {
-        'label': 'Opened By',
-        'data_type': 'text',
-        'prop_id': 'opened_by_username',
-        'is_editable': False,
-        'options': None,
-    },
-    'owner_name': {
-        'label': 'Owner',
-        'data_type': 'text',
-        'prop_id': 'owner_name',
-        'is_editable': False,
-        'options': None,
-    },
-    'closed_by_user_id': {
-        'label': 'Closed By User ID',
-        'data_type': 'text',
-        'prop_id': 'closed_by_user_id',
-        'is_editable': False,
-        'options': None,
-    },
-    'opened_by_user_id': {
-        'label': 'Opened By User ID',
-        'data_type': 'text',
-        'prop_id': 'opened_by_user_id',
-        'is_editable': False,
-        'options': None,
-    },
-    'server_last_modified_date': {
-        'label': 'Last Modified (UTC)',
-        'data_type': 'datetime',
-        'prop_id': 'server_last_modified_date',
-        'is_editable': False,
-        'options': None,
-    },
-}
+
+@privilege_enabled(privileges.DATA_DICTIONARY)
+@disable_quickcache
+class GetCasePropertyDetailsTest(BaseCaseUtilsTest):
+    case_type = 'plant'
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [],
+                'other': [],
+            }
+        ),
+    )
+    def test_text_system_property(self):
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Owner',
+            'data_type': DataType.TEXT,
+            'prop_id': 'owner_name',
+            'is_editable': False,
+            'options': None,
+        }
+        assert details['owner_name'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [],
+                'other': [],
+            }
+        ),
+    )
+    def test_date_system_property(self):
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Date Opened',
+            'data_type': DataType.DATETIME,
+            'prop_id': 'date_opened',
+            'is_editable': False,
+            'options': None,
+        }
+        assert details['date_opened'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [],
+                'other': [],
+            }
+        ),
+    )
+    def test_editable_system_property(self):
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'External ID',
+            'data_type': DataType.TEXT,
+            'prop_id': 'external_id',
+            'is_editable': True,
+            'options': None,
+        }
+        assert details['external_id'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [],
+                'other': [],
+            }
+        ),
+    )
+    def test_skipped_system_property(self):
+        details = get_case_property_details(self.domain, self.case_type)
+        assert details.get('case_name') is None
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [
+                    'not_in_dd',
+                ],
+                'other': [],
+            }
+        ),
+    )
+    def test_default_property_format(self):
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Not In Dd',
+            'data_type': 'text',
+            'prop_id': 'not_in_dd',
+            'is_editable': True,
+            'options': [],
+        }
+        assert details['not_in_dd'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [
+                    'a_plant_property',
+                ],
+                'other': [],
+            }
+        ),
+    )
+    def test_dd_override(self):
+        details = get_case_property_details(self.domain, self.case_type)
+        assert details['a_plant_property']['label'] == 'A Plant Property'
+        assert details['a_plant_property']['data_type'] == DataType.TEXT
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='a_plant_property',
+            label='Overridden Plant Property',
+            data_type=CaseProperty.DataType.NUMBER,
+            index=1,
+        )
+        details = get_case_property_details(self.domain, self.case_type)
+        assert details['a_plant_property']['label'] == 'Overridden Plant Property'
+        assert details['a_plant_property']['data_type'] == DataType.INTEGER
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [],
+                'other': [],
+            }
+        ),
+    )
+    def test_dd_only_property(self):
+        details = get_case_property_details(self.domain, self.case_type)
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='height',
+            label='Height (cm)',
+            data_type=CaseProperty.DataType.NUMBER,
+            index=1,
+        )
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Height (cm)',
+            'data_type': DataType.INTEGER,
+            'prop_id': 'height',
+            'is_editable': True,
+            'options': [],
+        }
+        assert details['height'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [
+                    'nickname',
+                ],
+                'other': [],
+            }
+        ),
+    )
+    def test_undefined_property_format(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='nickname',
+            label='Plant Nickname',
+            data_type=CaseProperty.DataType.UNDEFINED,
+            index=1,
+        )
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Plant Nickname',
+            'data_type': DataType.TEXT,
+            'prop_id': 'nickname',
+            'is_editable': True,
+            'options': [],
+        }
+        assert details['nickname'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [
+                    'description',
+                ],
+                'other': [],
+            }
+        ),
+    )
+    def test_text_property_format(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='description',
+            label='Plant Description',
+            data_type=CaseProperty.DataType.PLAIN,
+            index=1,
+        )
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Plant Description',
+            'data_type': DataType.TEXT,
+            'prop_id': 'description',
+            'is_editable': True,
+            'options': [],
+        }
+        assert details['description'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [
+                    'height',
+                ],
+                'other': [],
+            }
+        ),
+    )
+    def test_integer_property_format(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='height',
+            label='Height (cm)',
+            data_type=CaseProperty.DataType.NUMBER,
+            index=1,
+        )
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Height (cm)',
+            'data_type': DataType.INTEGER,
+            'prop_id': 'height',
+            'is_editable': True,
+            'options': [],
+        }
+        assert details['height'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [
+                    'plant_location',
+                ],
+                'other': [],
+            }
+        ),
+    )
+    def test_gps_property_format(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='plant_location',
+            label='Plant Location',
+            data_type=CaseProperty.DataType.GPS,
+            index=1,
+        )
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Plant Location',
+            'data_type': DataType.GPS,
+            'prop_id': 'plant_location',
+            'is_editable': True,
+            'options': [],
+        }
+        assert details['plant_location'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [
+                    'plant_barcode',
+                ],
+                'other': [],
+            }
+        ),
+    )
+    def test_barcode_property_format(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='plant_barcode',
+            label='Plant Barcode',
+            data_type=CaseProperty.DataType.BARCODE,
+            index=1,
+        )
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Plant Barcode',
+            'data_type': DataType.BARCODE,
+            'prop_id': 'plant_barcode',
+            'is_editable': True,
+            'options': [],
+        }
+        assert details['plant_barcode'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [
+                    'contact_number',
+                ],
+                'other': [],
+            }
+        ),
+    )
+    def test_phone_number_property_format(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='contact_number',
+            label='Contact Number',
+            data_type=CaseProperty.DataType.PHONE_NUMBER,
+            index=1,
+        )
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Contact Number',
+            'data_type': DataType.PHONE_NUMBER,
+            'prop_id': 'contact_number',
+            'is_editable': True,
+            'options': [],
+        }
+        assert details['contact_number'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [
+                    'plant_secret',
+                ],
+                'other': [],
+            }
+        ),
+    )
+    def test_password_property_format(self):
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='plant_secret',
+            label='Plant Secret',
+            data_type=CaseProperty.DataType.PASSWORD,
+            index=1,
+        )
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Plant Secret',
+            'data_type': DataType.PASSWORD,
+            'prop_id': 'plant_secret',
+            'is_editable': True,
+            'options': [],
+        }
+        assert details['plant_secret'] == expected_result
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [
+                    'pot_type',
+                ],
+                'other': [],
+            }
+        ),
+    )
+    def test_multiple_option_property_format(self):
+        pot_type = CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='pot_type',
+            label='Pot Type',
+            data_type=CaseProperty.DataType.SELECT,
+            index=1,
+        )
+        options = ['plastic', 'ceramic', 'terracotta', 'concrete']
+        for option in options:
+            CasePropertyAllowedValue.objects.create(
+                allowed_value=option,
+                description=f'{option} pot',
+                case_property=pot_type,
+            )
+        details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Pot Type',
+            'data_type': DataType.MULTIPLE_OPTION,
+            'prop_id': 'pot_type',
+            'is_editable': True,
+            'options': options,
+        }
+        assert details['pot_type'] == expected_result
+
+
+@privilege_enabled(privileges.DATA_DICTIONARY)
+class ClearCachesTest(BaseCaseUtilsTest):
+    case_type = 'plant'
+
+    @mock.patch(
+        'corehq.apps.data_cleaning.utils.cases.all_case_properties_by_domain',
+        get_mock_all_case_properties_by_domain(
+            {
+                case_type: [
+                    'height',
+                ],
+                'other': [],
+            }
+        ),
+    )
+    def test_clear_caches(self):
+        clear_caches_case_data_cleaning(self.domain, self.case_type)
+        first_details = get_case_property_details(self.domain, self.case_type)
+        expected_result = {
+            'label': 'Height',
+            'data_type': DataType.TEXT,
+            'prop_id': 'height',
+            'is_editable': True,
+            'options': [],
+        }
+        assert first_details['height'] == expected_result
+        CaseProperty.objects.create(
+            case_type=self.case_type_dd,
+            name='height',
+            label='Height (cm)',
+            data_type=CaseProperty.DataType.NUMBER,
+            index=1,
+        )
+        details = get_case_property_details(self.domain, self.case_type)
+        assert details == first_details
+        clear_caches_case_data_cleaning(self.domain, self.case_type)
+        details = get_case_property_details(self.domain, self.case_type)
+        assert details != first_details
+        assert details['height']['label'] == 'Height (cm)'
+        assert details['height']['data_type'] == DataType.INTEGER

--- a/corehq/apps/data_cleaning/utils/cases.py
+++ b/corehq/apps/data_cleaning/utils/cases.py
@@ -139,7 +139,7 @@ def get_case_property_details(domain, case_type):
                 data_type=DataType.TEXT,
                 prop_id=prop_id,
                 is_editable=True,
-                options=None,
+                options=[],
             )._asdict(),
         )
     details.update(_get_system_property_details())

--- a/corehq/apps/data_cleaning/utils/cases.py
+++ b/corehq/apps/data_cleaning/utils/cases.py
@@ -100,7 +100,7 @@ def _get_default_label(prop_id):
     return prop_id.replace('_', ' ').title()
 
 
-def _get_property_details_from_data_dictionary(domain, case_type):
+def get_property_details_from_data_dictionary(domain, case_type):
     if not domain_has_privilege(domain, privileges.DATA_DICTIONARY):
         return {}
     from corehq.apps.data_dictionary.models import CaseType
@@ -129,7 +129,7 @@ def get_case_property_details(domain, case_type):
         include_parent_properties=False,
         exclude_deprecated_properties=False,
     ).get(case_type, [])
-    data_dictionary_details = _get_property_details_from_data_dictionary(domain, case_type)
+    data_dictionary_details = get_property_details_from_data_dictionary(domain, case_type)
     properties = set(properties).union(data_dictionary_details.keys())
     for prop_id in properties:
         details[prop_id] = data_dictionary_details.get(

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -221,6 +221,7 @@ class privilege_enabled:
         'corehq.apps.users.views.mobile.users.domain_has_privilege',
         'corehq.pillows.case_search.domain_has_privilege',
         'django_prbac.decorators.has_privilege',
+        'corehq.apps.data_cleaning.utils.cases.domain_has_privilege',
     )
 
     def __init__(self, privilege_slug):


### PR DESCRIPTION
## Technical Summary
While I was working on the bulk data editing feature, I postponed writing several tests to adhere to time constraints.

This is a followup to this feature, adding tests for `corehq.apps.data_cleaning.utils.cases`
https://dimagi.atlassian.net/browse/SAAS-16853

## Safety Assurance

### Safety story
just tests...putting a test on it

### Automated test coverage
yes

### QA Plan
not needed, it's a test

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
