### PR TITLE
Add the domain subscription to output

### DIFF
--- a/corehq/toggles/management/commands/list_ff_domains.py
+++ b/corehq/toggles/management/commands/list_ff_domains.py
@@ -44,4 +44,4 @@ def get_enabled_domains(toggle_slug):
 
 def get_domain_subscription(domain):
     subs = Subscription.get_active_subscription_by_domain(domain)
-    return subs.plan_version.plan.name
+    return subs.plan_version.plan.name if subs else None


### PR DESCRIPTION
## Technical Summary

Follows up PR https://github.com/dimagi/commcare-hq/pull/36680

Adds each domain's subscription to the list of domains that have a given feature flag enabled.

e.g.
```bash
$ cchq production django-manage list_ff_domains SESSION_ENDPOINTS   
1 domain(s) enabled:
demo    (Dimagi Only CommCare Enterprise)
```

## Safety Assurance

### Safety story

Small change to a management command for internal use only.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
