### PR TITLE
Only is_active for commcare users

### DIFF
--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -148,22 +148,42 @@ def domain(domain, *, include_active=True, include_inactive=False):
 
 
 def is_active(domain):
-    return filters.AND(
-        filters.term("is_active", True),
-        filters.nested('user_domain_memberships', filters.AND(
-            filters.term('user_domain_memberships.domain.exact', domain),
-            filters.NOT(filters.term('user_domain_memberships.is_active', False)),
-        ))
+    return filters.OR(
+        filters.AND(
+            filters.doc_type("CommCareUser"),
+            filters.term("is_active", True),
+            filters.nested('user_domain_memberships',
+                filters.term('user_domain_memberships.domain.exact', domain)),
+        ),
+        filters.AND(
+            filters.doc_type("WebUser"),
+            filters.term("is_active", True),
+            filters.nested('user_domain_memberships', filters.AND(
+                filters.term('user_domain_memberships.domain.exact', domain),
+                filters.NOT(filters.term('user_domain_memberships.is_active', False)),
+            ))
+        )
     )
 
 
 def is_inactive(domain):
     return filters.OR(
-        filters.term("is_active", False),
-        filters.nested('user_domain_memberships', filters.AND(
-            filters.term('user_domain_memberships.domain.exact', domain),
-            filters.term('user_domain_memberships.is_active', False),
-        ))
+        filters.AND(
+            filters.doc_type("CommCareUser"),
+            filters.term("is_active", False),
+            filters.nested('user_domain_memberships',
+                filters.term('user_domain_memberships.domain.exact', domain)),
+        ),
+        filters.AND(
+            filters.doc_type("WebUser"),
+            filters.OR(
+                filters.term("is_active", False),
+                filters.nested('user_domain_memberships', filters.AND(
+                    filters.term('user_domain_memberships.domain.exact', domain),
+                    filters.term('user_domain_memberships.is_active', False),
+                ))
+            )
+        )
     )
 
 


### PR DESCRIPTION
## Product Description

Only check the user level is_active for Commcare users. Build the check into the is active statement

## Technical Summary

https://dimagi.atlassian.net/browse/SAAS-18002

## Feature Flag

None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
