### PR TITLE
Fix Mobile Workers incorrectly marked as inactive

### DIFF
--- a/corehq/apps/users/migrations/0083_reset_ccu_dm_is_active.py
+++ b/corehq/apps/users/migrations/0083_reset_ccu_dm_is_active.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+
+from corehq.apps.es import UserES, filters
+from corehq.apps.users.models import CommCareUser
+from corehq.util.couch import DocUpdate, iter_update
+from corehq.util.log import with_progress_bar
+
+
+def affected_ids():
+    return UserES().mobile_users().nested(
+        'user_domain_memberships',
+        filters.term('user_domain_memberships.is_active', False),
+    ).scroll_ids()
+
+
+def fix_user(user_doc):
+    if user_doc['domain_membership'].get('is_active', True) is False:
+        user_doc['domain_membership']['is_active'] = True
+        return DocUpdate(user_doc)
+
+
+def reset_is_active(apps, schema_editor):
+    iter_update(
+        CommCareUser.get_db(),
+        fix_user,
+        with_progress_bar(list(affected_ids())),
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0082_connectidmessagingkey_unique_active_messaging_key_per_user_and_domain'),
+    ]
+
+    operations = [
+        migrations.RunPython(reset_is_active),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -1331,6 +1331,7 @@ users
  0080_connectiduserlink_is_active
  0081_rm_orphaned_user_data
  0082_connectidmessagingkey_unique_active_messaging_key_per_user_and_domain
+ 0083_reset_ccu_dm_is_active
 util
  0001_initial
  0002_complaintbouncemeta_permanentbouncemeta_transientbounceemail


### PR DESCRIPTION
## Product Description
Fix Mobile Workers incorrectly marked as inactive

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18002

Check out [this comment](https://dimagi.atlassian.net/browse/SAAS-18002?focusedCommentId=388653) for an explanation.  Essentially, the permissiveness in couch and couchdbkit combined with some implicit programming to set `is_active` on `CommCareUser` object's `domain_membership` objects, going back to the start of the `TWO_STAGE_USER_PROVISIONING` feature flag (when no such field was defined on the model).  Now that we've added a field with that name, we're incorrectly interpreting superfluous old data as invalid new data.  This migration sets it to the value we expect to find.  It's no longer possible to get users in that state in-product, so correcting existing users should be sufficient.

## Feature Flag
TWO_STAGE_USER_PROVISIONING
TWO_STAGE_USER_PROVISIONING_BY_SMS

## Safety Assurance
Testing locally and on staging

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
