### PR TITLE
Disallow admin driven password changes after self setting passwords

### DIFF
--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -593,6 +593,9 @@ class CustomPasswordResetView(PasswordResetConfirmView):
             user = User.objects.get(pk=uid)
             couch_user = CouchUser.from_django_user(user)
             clear_login_attempts(couch_user)
+            if couch_user.is_commcare_user():
+                couch_user.self_set_password = True
+                couch_user.save()
 
             domain = couch_user.domain if couch_user.is_commcare_user() else None
             log_user_change(by_domain=None, for_domain=domain, couch_user=couch_user, changed_by_user=couch_user,

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1764,6 +1764,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
     # used by user provisioning workflow. defaults to true unless explicitly overridden during
     # user creation
     is_account_confirmed = BooleanProperty(default=True)
+    self_set_password = BooleanProperty(default=False)
 
     # This means that this user represents a location, and has a 1-1 relationship
     # with a location where location.location_type.has_user == True
@@ -2005,6 +2006,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         self.is_active = True
         self.is_account_confirmed = True
         self.set_password(password)
+        self.self_set_password = True
         self.save()
 
     def get_case_sharing_groups(self, domain=None):

--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -101,15 +101,17 @@
     <div class="tab-pane" id="user-password">
       <div class="panel-body">
         {% if not request.is_view_only %}
-          <form
-            id="reset-password-form"
-            class="form-horizontal"
-            action="{% url "change_password" domain couch_user.user_id %}"
-            method="POST"
-          >
-            {% crispy reset_password_form %}
-          </form>
-          <hr />
+          {% if reset_password_form %}
+            <form
+              id="reset-password-form"
+              class="form-horizontal"
+              action="{% url "change_password" domain couch_user.user_id %}"
+              method="POST"
+            >
+              {% crispy reset_password_form %}
+            </form>
+            <hr />
+          {% endif %}
           {% if send_password_reset_email_form %}
             <form
               action="{% url "send_password_reset_email" domain couch_user.user_id %}"

--- a/corehq/apps/users/tests/test_log_user_change.py
+++ b/corehq/apps/users/tests/test_log_user_change.py
@@ -185,6 +185,7 @@ def _get_expected_changes_json(user):
         'login_attempts': 0,
         'phone_numbers': [],
         'registering_device_id': '',
+        'self_set_password': False,
         'status': None,
         'subscribed_to_commcare_users': False,
         'two_factor_auth_disabled_until': None,

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1722,7 +1722,8 @@ def change_password(request, domain, login_id):
 
     commcare_user = CommCareUser.get_by_user_id(login_id, domain)
     json_dump = {}
-    if not commcare_user or not user_can_access_other_user(domain, request.couch_user, commcare_user):
+    if (not commcare_user or not user_can_access_other_user(domain, request.couch_user, commcare_user)
+            or (toggles.TWO_STAGE_USER_PROVISIONING.enabled(domain) and commcare_user.self_set_password)):
         raise Http404()
     django_user = commcare_user.get_django_user()
     if request.method == "POST":

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -332,6 +332,8 @@ class EditCommCareUserView(BaseEditUserView):
             messages.error(self.request, _(
                 "There were some errors while saving user's locations. Please check the 'Locations' tab"
             ))
+        if toggles.TWO_STAGE_USER_PROVISIONING.enabled(self.domain) and self.editable_user.self_set_password:
+            context['reset_password_form'] = ''
         if self.editable_user.is_active and toggles.TWO_STAGE_USER_PROVISIONING.enabled(self.domain):
             context.update({
                 'send_password_reset_email_form': SendCommCareUserPasswordResetEmailForm()


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

This is currently behind the [TWO_STAGE_USER_PROVISIONING](https://www.commcarehq.org/hq/flags/edit/two_stage_user_provisioning/) FF

When a mobile worker confirms their account or resets their password via the Forgot password or the admin driven Send password reset email workflows, the mobile workers choose their own passwords. This PR makes it so that afterwards, a project admin won't be able to manually change the password for these mobile workers. The only way to reset the password is to have the mobile workers themselves reset it. 

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/USH-6021)
[Jira Epic](https://dimagi.atlassian.net/browse/USH-5949)
[Tech Spec](https://docs.google.com/document/d/1mXFquOF68-AhBHHkAmldyfNVViEEEUdBNfTFh-E9T98/edit?tab=t.0#heading=h.oz1avc8pfw4q)

Adds a new `self_set_password` bool field to `CommCareUser` that'll keep track of mobile workers who chose their own passwords. It'll be used (along with a FF enabled check) to determine whether to show the password reset form in User Edit view + block passwords from being saved through the user edit view as an extra cautionary measure.  

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[TWO_STAGE_USER_PROVISIONING](https://www.commcarehq.org/hq/flags/edit/two_stage_user_provisioning/) 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally, will test on staging. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
