### PR TITLE
Collect high usages of case owners

### DIFF
--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from dimagi.utils.logging import notify_error
+from dimagi.utils.logging import notify_exception
 
 from corehq.apps.es import cases as case_es
 from corehq.apps.es import filters
@@ -181,7 +181,7 @@ def get_case_owners(can_access_all_locations, domain, mobile_user_and_group_slug
         # temporary code to understand usages of this function that result in a lot of owner_ids
         limit = SystemLimit.get_limit_for_key("owner_id_limit", 1000, domain=domain)
         if len(owner_ids) > limit:
-            notify_error("Exceeded recommended owner id count", details={"count": len(owner_ids)})
+            notify_exception(None, "Exceeded recommended owner id count", details={"count": len(owner_ids)})
     return owner_ids
 
 

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -179,7 +179,7 @@ def get_case_owners(can_access_all_locations, domain, mobile_user_and_group_slug
     ))
     if settings.IS_SAAS_ENVIRONMENT:
         # temporary code to understand usages of this function that result in a lot of owner_ids
-        limit = SystemLimit.get_limit_for_key("owner_id_limit", 1000, domain)
+        limit = SystemLimit.get_limit_for_key("owner_id_limit", 1000, domain=domain)
         if len(owner_ids) > limit:
             notify_error("Exceeded recommended owner id count", details={"count": len(owner_ids)})
     return owner_ids


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18003

I massacred https://github.com/dimagi/commcare-hq/pull/36725 by accident, and decided to just move to a new PR. Originally tried to do this in the OR and AND elasticsearch helpers we have setup, but given what I'm actually interested in understanding, it isn't worth it.

This targets the `get_case_owners` function directly, reporting any usages above 1000 owner_ids to sentry. I can configure this value via a SystemLimit in the django admin if that is too noisy (or not noisy enough).

I scoped this to saas envs specifically since it is only temporary, and the SystemLimit does result in a db entry that I'd rather not pollute self hoster's envs with.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Isolated to SaaS envs, and is a straightforward check/sentry notification, so with a test on staging this doesn't seem risky.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
corehq.apps.reports.tests.standard.cases.test_utils.CaseOwnersTest exercises this function. Given this is temporary code that is straightforward, I don't feel a need to add a test.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
