### PR TITLE
Refactor and clean up pillows

### DIFF
--- a/corehq/ex-submodules/pillowtop/run_pillowtop.py
+++ b/corehq/ex-submodules/pillowtop/run_pillowtop.py
@@ -1,14 +1,7 @@
-import sys
-from pillowtop import get_all_pillow_instances
 import multiprocessing
+import sys
 
-
-def _do_run_pillow(pillow_class):
-    try:
-        print("running %s" % pillow_class)
-        pillow_class.run()
-    except Exception as ex:
-        print("Some pillow error: %s: %s" % (pillow_class.__class__.__name__, ex))
+from pillowtop import get_all_pillow_instances
 
 
 def start_pillows(pillows=None):

--- a/corehq/ex-submodules/pillowtop/tests/test_bulk.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_bulk.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from django.test import SimpleTestCase, TestCase
 
 from pillowtop.feed.interface import Change, ChangeMeta
-from pillowtop.pillow.interface import PillowBase
+from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import BulkElasticProcessor
 from pillowtop.utils import bulk_fetch_changes_docs, get_errors_with_ids
 
@@ -34,7 +34,7 @@ class BulkTest(SimpleTestCase):
             Change(4, 'a'),
             Change(1, 'b'),
         ]
-        deduped = PillowBase._deduplicate_changes(changes)
+        deduped = ConstructedPillow._deduplicate_changes(changes)
         self.assertEqual(
             [(change.id, change.sequence_id) for change in deduped],
             [(3, 'a'), (2, 'b'), (4, 'a'), (1, 'b')]

--- a/testapps/test_pillowtop/tests/test_domain_pillow.py
+++ b/testapps/test_pillowtop/tests/test_domain_pillow.py
@@ -96,7 +96,7 @@ class DomainPillowTest(TestCase):
         # confirm domain still exists
         self._verify_domain_in_es(domain_name)
 
-    @patch('pillowtop.pillow.interface.PillowBase._update_checkpoint')
+    @patch('pillowtop.pillow.interface.ConstructedPillow._update_checkpoint')
     @patch('corehq.pillows.domain.KafkaChangeFeed.iter_changes', return_value=[])
     def test_no_changes(self, mock_iter, mock_update):
         since = get_topic_offset(topics.DOMAIN)

--- a/testapps/test_pillowtop/utils.py
+++ b/testapps/test_pillowtop/utils.py
@@ -7,7 +7,7 @@ from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 from corehq.apps.change_feed.topics import get_multi_topic_offset
 from corehq.util.decorators import ContextDecorator
 from pillowtop import get_pillow_by_name
-from pillowtop.pillow.interface import PillowBase
+from pillowtop.pillow.interface import ConstructedPillow
 
 
 class process_pillow_changes(ContextDecorator):
@@ -28,7 +28,7 @@ class process_pillow_changes(ContextDecorator):
     def _populate(self):
         if not self._populated:
             for pillow_name_or_instance, pillow_kwargs in self.pillow_names_or_instances:
-                if isinstance(pillow_name_or_instance, PillowBase):
+                if isinstance(pillow_name_or_instance, ConstructedPillow):
                     self._pillows.append(pillow_name_or_instance)
                 else:
                     self._pillows.append(self._get_pillow(pillow_name_or_instance, pillow_kwargs or {}))


### PR DESCRIPTION
The first four commits are code simplifying refactors. The first three do not change behavior at all, while the fourth makes two minor changes to the `run_ptop` management command:
- Checkpoints are listed if `--list-checkpoints` and `--all` options are both specified. Previously this would have run all pillows and ignored `--list-checkpoints`. This establishes consistent behavior for `--list` and `--list-checkpoints` options.
- Process number and chunk size assertions are not done except when running with `--pillow-name`. In all other cases those options are ignored.

These changes are unlikely to impact production usage of `run_ptop`.

~The fifth commit fixes buggy code that never worked, and the final fixes a couple of memory leaks in `RegistryDataSourceTableManager`.~ Remaining commits removed because they simply create noise in the context of other work.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

New tests have been added for non-trivial changes.

### Automated test coverage

Yes.

### QA Plan

No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations