### PR TITLE
Add language selector to support pre-login translations in HQ

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
@@ -6,7 +6,6 @@
 {% load compress %}
 {% load statici18n %}
 
-
 {% block pre_navigation_content %}
   {% include "hqwebapp/partials/bootstrap3/maintenance_alerts.html" %}
   {% if show_trial_banner %}
@@ -17,14 +16,18 @@
   {% endif %}
 {% endblock pre_navigation_content %}
 
-
 {% block navigation %}
-  <div id="hq-navigation"
-       class="navbar navbar-default navbar-static-top navbar-hq-main-menu">
+  <div
+    id="hq-navigation"
+    class="navbar navbar-default navbar-static-top navbar-hq-main-menu"
+  >
     <div class="container-fluid">
-
-      {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated  %}
-        <ul class="nav navbar-nav collapse-fullmenu-toggle" id="hq-fullmenu-responsive" role="menu">
+      {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated %}
+        <ul
+          class="nav navbar-nav collapse-fullmenu-toggle"
+          id="hq-fullmenu-responsive"
+          role="menu"
+        >
           <li>
             <a href="#hq-full-menu" data-toggle="collapse">
               <i class="fa fa-bars"></i>
@@ -44,7 +47,8 @@
                 aria-haspopup="true"
                 aria-expanded="false"
               >
-                {{ LANGUAGE_CODE|language_name_local|title }} <span class="caret"></span>
+                {{ LANGUAGE_CODE|language_name_local|title }}
+                <span class="caret"></span>
               </button>
               <ul class="dropdown-menu">
                 {% for lang_code, name in LANGUAGES %}
@@ -55,18 +59,24 @@
                         type="submit"
                         name="language"
                         value="{{ lang_code }}"
-                      >{{ lang_code|language_name_local|title }}</button>
+                      >
+                        {{ lang_code|language_name_local|title }}
+                      </button>
                     </form>
                   </li>
                 {% endfor %}
               </ul>
             </div>
-            <a href="{% url "login" %}" class="btn btn-primary navbar-btn">{% trans 'Sign In' %}</a>
+            <a href="{% url "login" %}" class="btn btn-primary navbar-btn"
+              >{% trans 'Sign In' %}</a
+            >
             {% if ANALYTICS_IDS.HUBSPOT_API_ID %}
-              <a href="#cta-form-get-demo"
-                 data-toggle="modal"
-                 id="cta-form-get-demo-button-header"
-                 class="btn btn-purple navbar-btn">
+              <a
+                href="#cta-form-get-demo"
+                data-toggle="modal"
+                id="cta-form-get-demo-button-header"
+                class="btn btn-purple navbar-btn"
+              >
                 {% trans 'Schedule a Demo' %}
               </a>
             {% endif %}
@@ -75,7 +85,10 @@
       {% endif %}
 
       <div class="navbar-header hq-header">
-        <a href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}" class="navbar-brand">
+        <a
+          href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}"
+          class="navbar-brand"
+        >
           {% if CUSTOM_LOGO_URL %}
             <img src="{{ CUSTOM_LOGO_URL }}" alt="CommCare HQ Logo" />
           {% else %}
@@ -86,7 +99,11 @@
       </div>
 
       {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated %}
-        <ul class="nav navbar-nav collapse-mainmenu-toggle" id="hq-mainmenu-responsive" role="menu">
+        <ul
+          class="nav navbar-nav collapse-mainmenu-toggle"
+          id="hq-mainmenu-responsive"
+          role="menu"
+        >
           <li>
             <a href="#hq-main-tabs" data-toggle="collapse">
               <i class="fa fa-bars"></i>
@@ -95,7 +112,11 @@
           </li>
         </ul>
 
-        <nav class="navbar-menus fullmenu collapse" id="hq-full-menu" role="navigation">
+        <nav
+          class="navbar-menus fullmenu collapse"
+          id="hq-full-menu"
+          role="navigation"
+        >
           <div class="nav-settings-bar pull-right">
             {% include 'hqwebapp/includes/bootstrap3/global_navigation_bar.html' %}
           </div>
@@ -104,11 +125,9 @@
           {% endblock %}
         </nav>
       {% endif %}
-
     </div>
   </div>
 {% endblock navigation %}
-
 
 {% block post_navigation_content %}
   {% if request.project.is_snapshot %}
@@ -119,26 +138,27 @@
   {% include "hqwebapp/partials/bootstrap3/unsupported_browser.html" %}
 {% endblock post_navigation_content %}
 
-
 {% block messages %}
-  <div id="hq-messages-container"
-       class="container-fluid messages-container">
+  <div id="hq-messages-container" class="container-fluid messages-container">
     <div class="row">
       <div class="col-sm-12">
         {% if messages %}
           {% for message in messages %}
-            <div class="alert alert-margin-top fade in{% if message.tags %} {{ message.tags }}{% endif %}">
+            <div
+              class="alert alert-margin-top fade in{% if message.tags %}{{ message.tags }}{% endif %}"
+            >
               <a class="close" data-dismiss="alert" href="#">&times;</a>
               {% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}
             </div>
           {% endfor %}
         {% endif %}
-        <div id="message-alerts"
-             class="ko-template"
-             data-bind="foreach: {data: alerts, beforeRemove: fadeOut}">
+        <div
+          id="message-alerts"
+          class="ko-template"
+          data-bind="foreach: {data: alerts, beforeRemove: fadeOut}"
+        >
           <div data-bind="attr: {'class': alert_class}">
-            <a class="close"
-               data-dismiss="alert" href="#">&times;</a>
+            <a class="close" data-dismiss="alert" href="#">&times;</a>
             <span data-bind="html: message"></span>
           </div>
         </div>
@@ -147,13 +167,11 @@
   </div>
 {% endblock messages %}
 
-
 {% block footer %}
   {% if not enterprise_mode %}
     {% include 'hqwebapp/partials/bootstrap3/footer.html' %}
   {% endif %}
 {% endblock footer %}
-
 
 {% block modals %}
   {% if domain and not enterprise_mode %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
@@ -37,6 +37,30 @@
       {% if not request.user.is_authenticated %}
         <nav class="navbar-menus navbar-signin" role="navigation">
           <div class="nav-settings-bar pull-right">
+            <div class="navbar-nav dropdown">
+              <button
+                class="dropdown-toggle btn btn-default navbar-btn"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+              >
+                {{ LANGUAGE_CODE }} <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">
+                {% for lang in LANGUAGES %}
+                  <li>
+                    <form action="{% url 'set_language' %}" method="post">
+                      {% csrf_token %}
+                      <button
+                        type="submit"
+                        name="language"
+                        value="{{ lang.0 }}"
+                      >{{ lang.1 }}</button>
+                    </form>
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
             <a href="{% url "login" %}" class="btn btn-primary navbar-btn">{% trans 'Sign In' %}</a>
             {% if ANALYTICS_IDS.HUBSPOT_API_ID %}
               <a href="#cta-form-get-demo"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
@@ -47,7 +47,7 @@
                 aria-haspopup="true"
                 aria-expanded="false"
               >
-                {{ LANGUAGE_CODE|language_name_local|title }}
+                {{ LANGUAGE_CODE|language_name_local }}
                 <span class="caret"></span>
               </button>
               <ul class="dropdown-menu">
@@ -60,7 +60,7 @@
                         name="language"
                         value="{{ lang_code }}"
                       >
-                        {{ lang_code|language_name_local|title }}
+                        {{ lang_code|language_name_local }}
                       </button>
                     </form>
                   </li>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
@@ -44,18 +44,18 @@
                 aria-haspopup="true"
                 aria-expanded="false"
               >
-                {{ LANGUAGE_CODE }} <span class="caret"></span>
+                {{ LANGUAGE_CODE|language_name_local|title }} <span class="caret"></span>
               </button>
               <ul class="dropdown-menu">
-                {% for lang in LANGUAGES %}
+                {% for lang_code, name in LANGUAGES %}
                   <li>
                     <form action="{% url 'set_language' %}" method="post">
                       {% csrf_token %}
                       <button
                         type="submit"
                         name="language"
-                        value="{{ lang.0 }}"
-                      >{{ lang.1 }}</button>
+                        value="{{ lang_code }}"
+                      >{{ lang_code|language_name_local|title }}</button>
                     </form>
                   </li>
                 {% endfor %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
@@ -68,18 +68,18 @@
                 aria-haspopup="true"
                 aria-expanded="false"
               >
-                {{ LANGUAGE_CODE }} <span class="caret"></span>
+                {{ LANGUAGE_CODE|language_name_local|title }} <span class="caret"></span>
               </button>
               <ul class="dropdown-menu">
-                {% for lang in LANGUAGES %}
+                {% for lang_code, name in LANGUAGES %}
                   <li>
                     <form action="{% url 'set_language' %}" method="post">
                       {% csrf_token %}
                       <button
                         type="submit"
                         name="language"
-                        value="{{ lang.0 }}"
-                      >{{ lang.1 }}</button>
+                        value="{{ lang_code }}"
+                      >{{ lang_code|language_name_local|title }}</button>
                     </form>
                   </li>
                 {% endfor %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
@@ -6,7 +6,6 @@
 {% load compress %}
 {% load statici18n %}
 
-
 {% block pre_navigation_content %}
   {% include "hqwebapp/partials/bootstrap5/maintenance_alerts.html" %}
   {% if show_trial_banner %}
@@ -17,14 +16,17 @@
   {% endif %}
 {% endblock pre_navigation_content %}
 
-
 {% block navigation %}
-  <nav id="hq-navigation"
-       class="navbar navbar-expand-lg bg-light border-bottom-1 navbar-hq-main-menu">
+  <nav
+    id="hq-navigation"
+    class="navbar navbar-expand-lg bg-light border-bottom-1 navbar-hq-main-menu"
+  >
     <div class="container-fluid">
-
       <div class="navbar-header hq-header">
-        <a href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}" class="navbar-brand">
+        <a
+          href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}"
+          class="navbar-brand"
+        >
           {% if CUSTOM_LOGO_URL %}
             <img src="{{ CUSTOM_LOGO_URL }}" alt="CommCare HQ Logo" />
           {% else %}
@@ -34,14 +36,16 @@
         </a>
       </div>
 
-      {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated  %}
-        <button class="navbar-toggler"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#hq-full-menu"
-                aria-controls="hq-full-menu"
-                aria-expanded="false"
-                aria-label="toggle menu">
+      {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated %}
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#hq-full-menu"
+          aria-controls="hq-full-menu"
+          aria-expanded="false"
+          aria-label="toggle menu"
+        >
           <i class="fa fa-bars"></i>
           {% trans "Menu" %}
         </button>
@@ -68,7 +72,8 @@
                 aria-haspopup="true"
                 aria-expanded="false"
               >
-                {{ LANGUAGE_CODE|language_name_local|title }} <span class="caret"></span>
+                {{ LANGUAGE_CODE|language_name_local|title }}
+                <span class="caret"></span>
               </button>
               <ul class="dropdown-menu">
                 {% for lang_code, name in LANGUAGES %}
@@ -79,29 +84,33 @@
                         type="submit"
                         name="language"
                         value="{{ lang_code }}"
-                      >{{ lang_code|language_name_local|title }}</button>
+                      >
+                        {{ lang_code|language_name_local|title }}
+                      </button>
                     </form>
                   </li>
                 {% endfor %}
               </ul>
             </div>
-            <a href="{% url "login" %}" class="btn btn-primary navbar-btn">{% trans 'Sign In' %}</a>
+            <a href="{% url "login" %}" class="btn btn-primary navbar-btn"
+              >{% trans 'Sign In' %}</a
+            >
             {% if ANALYTICS_IDS.HUBSPOT_API_ID %}
-              <a href="#cta-form-get-demo"
-                 data-bs-toggle="modal"
-                 id="cta-form-get-demo-button-header"
-                 class="btn btn-purple navbar-btn">
+              <a
+                href="#cta-form-get-demo"
+                data-bs-toggle="modal"
+                id="cta-form-get-demo-button-header"
+                class="btn btn-purple navbar-btn"
+              >
                 {% trans 'Schedule a Demo' %}
               </a>
             {% endif %}
           </div>
         </nav>
       {% endif %}
-
     </div>
   </nav>
 {% endblock navigation %}
-
 
 {% block post_navigation_content %}
   {% if request.project.is_snapshot %}
@@ -112,26 +121,41 @@
   {% include "hqwebapp/partials/bootstrap5/unsupported_browser.html" %}
 {% endblock post_navigation_content %}
 
-
 {% block messages %}
-  <div id="hq-messages-container"
-       class="container-fluid messages-container">
+  <div id="hq-messages-container" class="container-fluid messages-container">
     <div class="row">
       <div class="col-sm-12">
         {% if messages %}
           {% for message in messages %}
-            <div class="alert alert-dismissible alert-margin-top fade show{% if message.tags %} {{ message.tags }}{% endif %}">
+            <div
+              class="alert alert-dismissible alert-margin-top fade show{% if message.tags %}{{ message.tags }}{% endif %}"
+            >
               {% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}
-              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{% trans_html_attr "Close" %}"></button>
+              <button
+                type="button"
+                class="btn-close"
+                data-bs-dismiss="alert"
+                aria-label="{% trans_html_attr "Close" %}"
+              ></button>
             </div>
           {% endfor %}
         {% endif %}
-        <div id="message-alerts"
-             class="ko-template"
-             data-bind="foreach: {data: alerts, beforeRemove: fadeOut}">
-          <div class="alert alert-dismissible fade show" data-bind="attr: {class: alert_class}">
+        <div
+          id="message-alerts"
+          class="ko-template"
+          data-bind="foreach: {data: alerts, beforeRemove: fadeOut}"
+        >
+          <div
+            class="alert alert-dismissible fade show"
+            data-bind="attr: {class: alert_class}"
+          >
             <span data-bind="html: message"></span>
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{% trans_html_attr "Close" %}"></button>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="alert"
+              aria-label="{% trans_html_attr "Close" %}"
+            ></button>
           </div>
         </div>
       </div>
@@ -139,13 +163,11 @@
   </div>
 {% endblock messages %}
 
-
 {% block footer %}
   {% if not enterprise_mode %}
     {% include 'hqwebapp/partials/bootstrap5/footer.html' %}
   {% endif %}
 {% endblock footer %}
-
 
 {% block modals %}
   {% if domain and not enterprise_mode %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
@@ -67,13 +67,12 @@
           <div class="nav-settings-bar">
             <div class="navbar-nav dropdown">
               <button
-                class="dropdown-toggle btn btn-default navbar-btn"
+                class="dropdown-toggle btn btn-outline-primary navbar-btn"
                 data-bs-toggle="dropdown"
                 aria-haspopup="true"
                 aria-expanded="false"
               >
                 {{ LANGUAGE_CODE|language_name_local }}
-                <span class="caret"></span>
               </button>
               <ul class="dropdown-menu">
                 {% for lang_code, name in LANGUAGES %}
@@ -81,6 +80,7 @@
                     <form action="{% url 'set_language' %}" method="post">
                       {% csrf_token %}
                       <button
+                        class="dropdown-item"
                         type="submit"
                         name="language"
                         value="{{ lang_code }}"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
@@ -61,6 +61,30 @@
       {% if not request.user.is_authenticated %}
         <nav class="navbar-signin ms-2" role="navigation">
           <div class="nav-settings-bar">
+            <div class="navbar-nav dropdown">
+              <button
+                class="dropdown-toggle btn btn-default navbar-btn"
+                data-bs-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+              >
+                {{ LANGUAGE_CODE }} <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">
+                {% for lang in LANGUAGES %}
+                  <li>
+                    <form action="{% url 'set_language' %}" method="post">
+                      {% csrf_token %}
+                      <button
+                        type="submit"
+                        name="language"
+                        value="{{ lang.0 }}"
+                      >{{ lang.1 }}</button>
+                    </form>
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
             <a href="{% url "login" %}" class="btn btn-primary navbar-btn">{% trans 'Sign In' %}</a>
             {% if ANALYTICS_IDS.HUBSPOT_API_ID %}
               <a href="#cta-form-get-demo"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
@@ -72,7 +72,7 @@
                 aria-haspopup="true"
                 aria-expanded="false"
               >
-                {{ LANGUAGE_CODE|language_name_local|title }}
+                {{ LANGUAGE_CODE|language_name_local }}
                 <span class="caret"></span>
               </button>
               <ul class="dropdown-menu">
@@ -85,7 +85,7 @@
                         name="language"
                         value="{{ lang_code }}"
                       >
-                        {{ lang_code|language_name_local|title }}
+                        {{ lang_code|language_name_local }}
                       </button>
                     </form>
                   </li>

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -15,10 +15,12 @@ from django.urls import reverse
 from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
+from django.templatetags import i18n
 
 from django_prbac.utils import has_privilege
 
 from dimagi.utils.web import json_handler
+from langcodes import langs_by_code
 
 from corehq import privileges
 from corehq.apps.hqwebapp.exceptions import (
@@ -598,6 +600,14 @@ def html_attr(value):
     if not isinstance(value, str):
         value = JSON(value)
     return conditional_escape(value)
+
+
+@register.filter
+def language_name_local(lang_code):
+    #override built-in template filter to be usable with our custom langcodes
+    lang = langs_by_code.get(lang_code)
+    lang_code = lang['two'] if lang else ''
+    return i18n.language_name_local(lang_code)
 
 
 def _create_page_data(parser, original_token, node_slug):

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -612,8 +612,16 @@ def language_name_local(lang_code):
     in langcodes and always title case its output.
     """
     lang = langs_by_code.get(lang_code)
-    lang_code = lang['two'] if lang else ''
-    return i18n.language_name_local(lang_code).title()
+    if lang:
+        lang_code = lang.get('two', lang_code)
+        try:
+            lang_name = i18n.language_name_local(lang_code)
+        except KeyError:
+            # fall back to English name from langcodes
+            lang_name = lang['names'][0]
+    else:
+        lang_name = ''
+    return lang_name.title()
 
 
 def _create_page_data(parser, original_token, node_slug):

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -608,19 +608,13 @@ def html_attr(value):
 @register.filter
 def language_name_local(lang_code):
     """
-    Override built-in language_name_local filter to work with languages defined
-    in langcodes and always title case its output.
+    Override built-in language_name_local filter to work with 3-letter lang
+    codes and always title case its output. KeyError will be raised if language
+    is missing from either langs_by_code or django.conf.locale.LANG_INFO.
     """
-    lang = langs_by_code.get(lang_code)
-    if lang:
-        lang_code = lang.get('two', lang_code)
-        try:
-            lang_name = i18n.language_name_local(lang_code)
-        except KeyError:
-            # fall back to English name from langcodes
-            lang_name = lang['names'][0]
-    else:
-        lang_name = ''
+    lang = langs_by_code[lang_code]
+    lang_code = lang.get('two', lang_code)
+    lang_name = i18n.language_name_local(lang_code)
     return lang_name.title()
 
 

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -607,10 +607,13 @@ def html_attr(value):
 
 @register.filter
 def language_name_local(lang_code):
-    #override built-in template filter to be usable with our custom langcodes
+    """
+    Override built-in language_name_local filter to work with languages defined
+    in langcodes and always title case its output.
+    """
     lang = langs_by_code.get(lang_code)
     lang_code = lang['two'] if lang else ''
-    return i18n.language_name_local(lang_code)
+    return i18n.language_name_local(lang_code).title()
 
 
 def _create_page_data(parser, original_token, node_slug):

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -6,21 +6,18 @@ from django import template
 from django.conf import settings
 from django.http import QueryDict
 from django.template import NodeList, TemplateSyntaxError, loader_tags
-from django.template.base import (
-    Variable,
-    VariableDoesNotExist,
-)
+from django.template.base import Variable, VariableDoesNotExist
 from django.template.loader import render_to_string
+from django.templatetags import i18n
 from django.urls import reverse
 from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
-from django.templatetags import i18n
 
 from django_prbac.utils import has_privilege
+from langcodes import langs_by_code
 
 from dimagi.utils.web import json_handler
-from langcodes import langs_by_code
 
 from corehq import privileges
 from corehq.apps.hqwebapp.exceptions import (
@@ -257,8 +254,14 @@ def css_field_class():
 
 @register.simple_tag
 def css_action_class():
-    from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS, get_form_action_class
-    from corehq.apps.hqwebapp.utils.bootstrap import get_bootstrap_version, BOOTSTRAP_5
+    from corehq.apps.hqwebapp.crispy import (
+        CSS_ACTION_CLASS,
+        get_form_action_class,
+    )
+    from corehq.apps.hqwebapp.utils.bootstrap import (
+        BOOTSTRAP_5,
+        get_bootstrap_version,
+    )
     if get_bootstrap_version() == BOOTSTRAP_5:
         return get_form_action_class()
     return CSS_ACTION_CLASS
@@ -721,8 +724,15 @@ class WebpackMainNode(template.Node):
 
 @register.filter
 def webpack_bundles(entry_name):
-    from corehq.apps.hqwebapp.utils.webpack import get_webpack_manifest, WebpackManifestNotFoundError
-    from corehq.apps.hqwebapp.utils.bootstrap import get_bootstrap_version, BOOTSTRAP_5, BOOTSTRAP_3
+    from corehq.apps.hqwebapp.utils.bootstrap import (
+        BOOTSTRAP_3,
+        BOOTSTRAP_5,
+        get_bootstrap_version,
+    )
+    from corehq.apps.hqwebapp.utils.webpack import (
+        WebpackManifestNotFoundError,
+        get_webpack_manifest,
+    )
     bootstrap_version = get_bootstrap_version()
 
     try:
@@ -793,8 +803,8 @@ def breadcrumbs(page, section, parents=None):
 
 @register.filter
 def request_has_privilege(request, privilege_name):
-    from corehq.apps.accounting.utils import domain_has_privilege
     from corehq import privileges
+    from corehq.apps.accounting.utils import domain_has_privilege
     privilege = _get_obj_from_name_or_instance(privileges, privilege_name)
     return domain_has_privilege(request.domain, privilege)
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
@@ -1,7 +1,7 @@
 --- 
 +++ 
-@@ -8,7 +8,7 @@
- 
+@@ -7,7 +7,7 @@
+ {% load statici18n %}
  
  {% block pre_navigation_content %}
 -  {% include "hqwebapp/partials/bootstrap3/maintenance_alerts.html" %}
@@ -9,18 +9,22 @@
    {% if show_trial_banner %}
      {% include "hqwebapp/partials/trial_banner.html" %}
    {% endif %}
-@@ -19,28 +19,52 @@
- 
+@@ -17,33 +17,58 @@
+ {% endblock pre_navigation_content %}
  
  {% block navigation %}
--  <div id="hq-navigation"
--       class="navbar navbar-default navbar-static-top navbar-hq-main-menu">
-+  <nav id="hq-navigation"
-+       class="navbar navbar-expand-lg bg-light border-bottom-1 navbar-hq-main-menu">
+-  <div
++  <nav
+     id="hq-navigation"
+-    class="navbar navbar-default navbar-static-top navbar-hq-main-menu"
++    class="navbar navbar-expand-lg bg-light border-bottom-1 navbar-hq-main-menu"
+   >
      <div class="container-fluid">
- 
 +      <div class="navbar-header hq-header">
-+        <a href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}" class="navbar-brand">
++        <a
++          href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}"
++          class="navbar-brand"
++        >
 +          {% if CUSTOM_LOGO_URL %}
 +            <img src="{{ CUSTOM_LOGO_URL }}" alt="CommCare HQ Logo" />
 +          {% else %}
@@ -30,8 +34,20 @@
 +        </a>
 +      </div>
 +
-       {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated  %}
--        <ul class="nav navbar-nav collapse-fullmenu-toggle" id="hq-fullmenu-responsive" role="menu">
+       {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated %}
+-        <ul
+-          class="nav navbar-nav collapse-fullmenu-toggle"
+-          id="hq-fullmenu-responsive"
+-          role="menu"
++        <button
++          class="navbar-toggler"
++          type="button"
++          data-bs-toggle="collapse"
++          data-bs-target="#hq-full-menu"
++          aria-controls="hq-full-menu"
++          aria-expanded="false"
++          aria-label="toggle menu"
+         >
 -          <li>
 -            <a href="#hq-full-menu" data-toggle="collapse">
 -              <i class="fa fa-bars"></i>
@@ -39,13 +55,6 @@
 -            </a>
 -          </li>
 -        </ul>
-+        <button class="navbar-toggler"
-+                type="button"
-+                data-bs-toggle="collapse"
-+                data-bs-target="#hq-full-menu"
-+                aria-controls="hq-full-menu"
-+                aria-expanded="false"
-+                aria-label="toggle menu">
 +          <i class="fa fa-bars"></i>
 +          {% trans "Menu" %}
 +        </button>
@@ -67,20 +76,33 @@
 -          <div class="nav-settings-bar pull-right">
 +        <nav class="navbar-signin ms-2" role="navigation">
 +          <div class="nav-settings-bar">
-             <a href="{% url "login" %}" class="btn btn-primary navbar-btn">{% trans 'Sign In' %}</a>
+             <div class="navbar-nav dropdown">
+               <button
+                 class="dropdown-toggle btn btn-default navbar-btn"
+-                data-toggle="dropdown"
++                data-bs-toggle="dropdown"
+                 aria-haspopup="true"
+                 aria-expanded="false"
+               >
+@@ -73,7 +98,7 @@
              {% if ANALYTICS_IDS.HUBSPOT_API_ID %}
-               <a href="#cta-form-get-demo"
--                 data-toggle="modal"
-+                 data-bs-toggle="modal"
-                  id="cta-form-get-demo-button-header"
-                  class="btn btn-purple navbar-btn">
-                 {% trans 'Schedule a Demo' %}
-@@ -50,49 +74,18 @@
+               <a
+                 href="#cta-form-get-demo"
+-                data-toggle="modal"
++                data-bs-toggle="modal"
+                 id="cta-form-get-demo-button-header"
+                 class="btn btn-purple navbar-btn"
+               >
+@@ -83,59 +108,17 @@
+           </div>
          </nav>
        {% endif %}
- 
+-
 -      <div class="navbar-header hq-header">
--        <a href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}" class="navbar-brand">
+-        <a
+-          href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}"
+-          class="navbar-brand"
+-        >
 -          {% if CUSTOM_LOGO_URL %}
 -            <img src="{{ CUSTOM_LOGO_URL }}" alt="CommCare HQ Logo" />
 -          {% else %}
@@ -91,7 +113,11 @@
 -      </div>
 -
 -      {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated %}
--        <ul class="nav navbar-nav collapse-mainmenu-toggle" id="hq-mainmenu-responsive" role="menu">
+-        <ul
+-          class="nav navbar-nav collapse-mainmenu-toggle"
+-          id="hq-mainmenu-responsive"
+-          role="menu"
+-        >
 -          <li>
 -            <a href="#hq-main-tabs" data-toggle="collapse">
 -              <i class="fa fa-bars"></i>
@@ -100,7 +126,11 @@
 -          </li>
 -        </ul>
 -
--        <nav class="navbar-menus fullmenu collapse" id="hq-full-menu" role="navigation">
+-        <nav
+-          class="navbar-menus fullmenu collapse"
+-          id="hq-full-menu"
+-          role="navigation"
+-        >
 -          <div class="nav-settings-bar pull-right">
 -            {% include 'hqwebapp/includes/bootstrap3/global_navigation_bar.html' %}
 -          </div>
@@ -109,12 +139,10 @@
 -          {% endblock %}
 -        </nav>
 -      {% endif %}
--
      </div>
 -  </div>
 +  </nav>
  {% endblock navigation %}
- 
  
  {% block post_navigation_content %}
    {% if request.project.is_snapshot %}
@@ -127,32 +155,46 @@
 +  {% include "hqwebapp/partials/bootstrap5/unsupported_browser.html" %}
  {% endblock post_navigation_content %}
  
- 
-@@ -103,19 +96,18 @@
-       <div class="col-sm-12">
+ {% block messages %}
+@@ -145,10 +128,15 @@
          {% if messages %}
            {% for message in messages %}
--            <div class="alert alert-margin-top fade in{% if message.tags %} {{ message.tags }}{% endif %}">
+             <div
+-              class="alert alert-margin-top fade in{% if message.tags %}{{ message.tags }}{% endif %}"
++              class="alert alert-dismissible alert-margin-top fade show{% if message.tags %}{{ message.tags }}{% endif %}"
+             >
 -              <a class="close" data-dismiss="alert" href="#">&times;</a>
-+            <div class="alert alert-dismissible alert-margin-top fade show{% if message.tags %} {{ message.tags }}{% endif %}">
                {% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}
-+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{% trans_html_attr "Close" %}"></button>
++              <button
++                type="button"
++                class="btn-close"
++                data-bs-dismiss="alert"
++                aria-label="{% trans_html_attr "Close" %}"
++              ></button>
              </div>
            {% endfor %}
          {% endif %}
-         <div id="message-alerts"
-              class="ko-template"
-              data-bind="foreach: {data: alerts, beforeRemove: fadeOut}">
+@@ -157,9 +145,17 @@
+           class="ko-template"
+           data-bind="foreach: {data: alerts, beforeRemove: fadeOut}"
+         >
 -          <div data-bind="attr: {'class': alert_class}">
--            <a class="close"
--               data-dismiss="alert" href="#">&times;</a>
-+          <div class="alert alert-dismissible fade show" data-bind="attr: {class: alert_class}">
+-            <a class="close" data-dismiss="alert" href="#">&times;</a>
++          <div
++            class="alert alert-dismissible fade show"
++            data-bind="attr: {class: alert_class}"
++          >
              <span data-bind="html: message"></span>
-+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{% trans_html_attr "Close" %}"></button>
++            <button
++              type="button"
++              class="btn-close"
++              data-bs-dismiss="alert"
++              aria-label="{% trans_html_attr "Close" %}"
++            ></button>
            </div>
          </div>
        </div>
-@@ -126,7 +118,7 @@
+@@ -169,16 +165,16 @@
  
  {% block footer %}
    {% if not enterprise_mode %}
@@ -161,7 +203,6 @@
    {% endif %}
  {% endblock footer %}
  
-@@ -134,9 +126,9 @@
  {% block modals %}
    {% if domain and not enterprise_mode %}
      {% if show_overdue_invoice_modal %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
@@ -9,7 +9,7 @@
    {% if show_trial_banner %}
      {% include "hqwebapp/partials/trial_banner.html" %}
    {% endif %}
-@@ -17,33 +17,58 @@
+@@ -17,38 +17,62 @@
  {% endblock pre_navigation_content %}
  
  {% block navigation %}
@@ -78,12 +78,26 @@
 +          <div class="nav-settings-bar">
              <div class="navbar-nav dropdown">
                <button
-                 class="dropdown-toggle btn btn-default navbar-btn"
+-                class="dropdown-toggle btn btn-default navbar-btn"
 -                data-toggle="dropdown"
++                class="dropdown-toggle btn btn-outline-primary navbar-btn"
 +                data-bs-toggle="dropdown"
                  aria-haspopup="true"
                  aria-expanded="false"
                >
+                 {{ LANGUAGE_CODE|language_name_local }}
+-                <span class="caret"></span>
+               </button>
+               <ul class="dropdown-menu">
+                 {% for lang_code, name in LANGUAGES %}
+@@ -56,6 +80,7 @@
+                     <form action="{% url 'set_language' %}" method="post">
+                       {% csrf_token %}
+                       <button
++                        class="dropdown-item"
+                         type="submit"
+                         name="language"
+                         value="{{ lang_code }}"
 @@ -73,7 +98,7 @@
              {% if ANALYTICS_IDS.HUBSPOT_API_ID %}
                <a

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, re_path as url
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
+from django.views.i18n import set_language
 
 from two_factor.gateways.twilio.urls import urlpatterns as tf_twilio_urls
 from two_factor.urls import urlpatterns as tf_urls
@@ -69,6 +70,7 @@ urlpatterns = [
 
     url(r'^no_permissions/$', no_permissions, name='no_permissions'),
 
+    url(r'^set_language/$', set_language, name='set_language'),
     url(r'^accounts/login/$', login, name="login"),
     url(r'^accounts/logout/$', logout, name="logout"),
     url(r'^reports/$', redirect_to_default),

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -1,7 +1,6 @@
 from django.urls import include, re_path as url
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
-from django.views.i18n import set_language
 
 from two_factor.gateways.twilio.urls import urlpatterns as tf_twilio_urls
 from two_factor.urls import urlpatterns as tf_urls
@@ -39,6 +38,7 @@ from corehq.apps.hqwebapp.views import (
     OauthApplicationRegistration,
     retrieve_download,
     server_up,
+    set_language,
     temporary_google_verify,
     check_sso_login_status,
 )

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -48,7 +48,6 @@ from django.views.decorators.http import require_GET, require_POST
 from django.views.generic import TemplateView
 from django.views.generic.base import View
 
-from langcodes import langs_by_code
 from memoized import memoized
 from sentry_sdk import last_event_id
 from two_factor.utils import default_device
@@ -1566,7 +1565,8 @@ def set_language(request):
         response = HttpResponse(status=204)
 
     lang_code = request.POST.get("language")
-    if lang_code and lang_code in langs_by_code.keys():
+    valid_lang_codes = [lang_code for lang_code, __ in settings.LANGUAGES]
+    if lang_code and lang_code in valid_lang_codes:
         response.set_cookie(
             settings.LANGUAGE_COOKIE_NAME,
             lang_code,


### PR DESCRIPTION
## Product Description
Adds this dropdown to the navbar pre-login to let a user select their language.
<img width="170" height="282" alt="image" src="https://github.com/user-attachments/assets/0d725e5c-ddee-4ffe-877a-b54ef0b845fa" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18015
Adds a menu dropdown to the navbar when a user is not logged in, which lists the languages we currently have available in HQ as single-button forms that post a langcode to the `set_language` url.

Makes a built-in django i18n view `set_language` accessible in hqwebapp urls at ... `/set_language/`. If `update_django_locales` has never been run, as in my local environment prior to working on this feature, setting the language using one of our 3-letter langcodes (every language except English, Spanish, Swahili, and Afrikaans) will not have any effect on the page.

Also lets us use the `language_name_local` template filter with our custom langcodes by converting to 2-letter codes first.

Review by commit.

## Safety Assurance

### Safety story
Adds a new view based on `django.views.i18n.set_language` that sets the language and redirects based on form input. Uses a similar level of validation as that built-in view to ensure that: the referer we are redirecting to is safe to do so (if not, don't navigate anywhere), and that the langcode exists in `langcodes.langs_by_code` (otherwise, don't set it).

Tested locally and on staging. Also confirmed that if a user sets a language, then logs into an account that has a different language set, the account language takes precedence (by overwriting the `django_language` cookie).

### Automated test coverage
Added TestSetLanguage for the custom `set_language` view.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
