### PR TITLE
Show active filter for all MW downloads

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1670,13 +1670,13 @@ class UserFilterForm(forms.Form):
                 data_bind="slideVisible: !isCrossDomain() && location_id",
             ),
         ]
-        if DEACTIVATE_WEB_USERS.enabled(self.domain):
-            fields += ["user_active_status"]
+        if self.user_type == MOBILE_USER_TYPE or DEACTIVATE_WEB_USERS.enabled(self.domain):
+            fields.append("user_active_status")
 
         fieldset_label = _('Filter and Download Users')
         if self.user_type == MOBILE_USER_TYPE:
             fieldset_label = _('Filter and Download Mobile Workers')
-            fields += [crispy.Field("columns", data_bind="value: columns")]
+            fields.append(crispy.Field("columns", data_bind="value: columns"))
 
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Bring back the "Active / Deactivated" filter for mobile worker downloads:
<img width="900" height="447" alt="image" src="https://github.com/user-attachments/assets/95615e5e-9b8e-42f9-ab51-c65a63cd3b82" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18066

Introduced in
https://github.com/dimagi/commcare-hq/pull/36558/files#diff-8440ff6f063677238da8fc25000acb8bbfb4345c3b9d97a0cf81414d15702265L1650

This was moved twice, hence the error:

  1. Old way: only available for MWs
  2. Available for both user types
  3. Behind the feature flag (also for MWs - whoops)
  4. New way: Available for MWs _and_ both user types on FF'd domains


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.  The change seems small/simple enough that that is fine for me

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
