### PR TITLE
Set language based on request.LANGUAGE_CODE when activating a new web user

### DIFF
--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -52,7 +52,7 @@ _soft_assert_registration_issues = soft_assert(
 
 
 def activate_new_user_via_reg_form(form, created_by, created_via, is_domain_admin=False, domain=None, ip=None,
-                                   commit=True):
+                                   language=None, commit=True):
     full_name = form.cleaned_data['full_name']
     new_user = activate_new_user(
         username=form.cleaned_data['email'],
@@ -65,14 +65,15 @@ def activate_new_user_via_reg_form(form, created_by, created_via, is_domain_admi
         domain=domain,
         ip=ip,
         atypical_user=form.cleaned_data.get('atypical_user', False),
+        language=language,
         commit=commit
     )
     return new_user
 
 
 def activate_new_user(
-    username, password, created_by, created_via, first_name=None, last_name=None,
-    is_domain_admin=False, domain=None, ip=None, atypical_user=False, commit=True
+    username, password, created_by, created_via, first_name=None, last_name=None, is_domain_admin=False,
+    domain=None, ip=None, atypical_user=False, language=None, commit=True
 ):
     from corehq.apps.analytics.tasks import record_event
     now = datetime.utcnow()
@@ -105,6 +106,7 @@ def activate_new_user(
     new_user.date_joined = now
     new_user.last_password_set = now
     new_user.atypical_user = atypical_user
+    new_user.language = language
     if commit:
         new_user.save()
 

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -95,7 +95,8 @@ class ProcessRegistrationView(JSONResponseMixin, View):
             reg_form,
             created_by=None,
             created_via=USER_CHANGE_VIA_WEB,
-            ip=get_ip(self.request)
+            ip=get_ip(self.request),
+            language=getattr(self.request, 'LANGUAGE_CODE', None),
         )
         new_user = authenticate(
             username=reg_form.cleaned_data['email'],

--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -126,6 +126,7 @@ class SsoBackend(ModelBackend):
             last_name=get_sso_user_last_name_from_session(request),
             domain=domain,
             ip=get_ip(request),
+            language=getattr(request, 'LANGUAGE_CODE', None),
         )
         request.sso_new_user_messages['success'].append(
             _("User account for {} created.").format(new_web_user.username)

--- a/corehq/apps/users/views/web.py
+++ b/corehq/apps/users/views/web.py
@@ -181,6 +181,7 @@ class UserInvitationView(object):
                         created_via=USER_CHANGE_VIA_INVITATION,
                         domain=invitation.domain,
                         is_domain_admin=False,
+                        language=getattr(request, 'LANGUAGE_CODE', None),
                         commit=False
                     )
                     invitation.accept_invitation_and_join_domain(user)


### PR DESCRIPTION
## Product Description
Sets a new web user's language in HQ upon creating their account, which will be able to be changed prior to login with  #36733

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18016
Safely gets `request.LANGUAGE_CODE`, which exists whenever `LocaleMiddleware` is active for the request, and assigns to the new web user's `language`. This value is fine set to `None` -- this is the effectively the current state, where a web user's language is not pre-set to anything.

## Safety Assurance

### Safety story
Tested locally and on staging to see that the web user's language gets set correctly, and that explicitly setting `language` to `None` has the same effect when navigating HQ as leaving it unset.

### Automated test coverage
Added some very basic tests for `activate_new_user` that include the `language` property. They might be redundant, because the file is already reported as having near 100% test coverage, but I didn't see anything preexisting that looked directly at the functionality of creating the new user. The new test cases don't look at the action of getting the language code from the request, because I think that would be more a test of django's `LocaleMiddleware` itself, which we tend to assume as a django built-in already works correctly.

### QA Plan
Not Planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
