### PR TITLE
Ability to withdraw payment cases that are yet to be submitted to service provider 

### DIFF
--- a/corehq/apps/integration/payments/const.py
+++ b/corehq/apps/integration/payments/const.py
@@ -1,4 +1,5 @@
 from enum import Enum
+
 from django.db import models
 from django.utils.translation import gettext as _
 

--- a/corehq/apps/integration/payments/filters.py
+++ b/corehq/apps/integration/payments/filters.py
@@ -1,10 +1,12 @@
 from django.utils.translation import gettext as _
 
+from corehq.apps.integration.payments.const import PaymentStatus
+from corehq.apps.integration.payments.services import (
+    get_payment_batch_numbers_for_domain,
+)
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter
-from corehq.apps.integration.payments.services import get_payment_batch_numbers_for_domain
 from corehq.apps.reports.filters.case_list import CaseListFilter
 from corehq.apps.reports.filters.users import WebUserFilter
-from corehq.apps.integration.payments.const import PaymentStatus
 
 
 class BatchNumberFilter(BaseSingleOptionFilter):

--- a/corehq/apps/integration/payments/forms.py
+++ b/corehq/apps/integration/payments/forms.py
@@ -4,9 +4,12 @@ from django.utils.translation import gettext_lazy as _
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
-from corehq.apps.hqwebapp import crispy as hqcrispy
 
-from corehq.apps.integration.payments.models import MoMoConfig, MoMoEnvironments
+from corehq.apps.hqwebapp import crispy as hqcrispy
+from corehq.apps.integration.payments.models import (
+    MoMoConfig,
+    MoMoEnvironments,
+)
 from corehq.motech.models import ConnectionSettings
 
 

--- a/corehq/apps/integration/payments/models.py
+++ b/corehq/apps/integration/payments/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils.translation import gettext as _
+
 from corehq.motech.models import ConnectionSettings
 
 

--- a/corehq/apps/integration/payments/services.py
+++ b/corehq/apps/integration/payments/services.py
@@ -11,8 +11,8 @@ from corehq.apps.es.case_search import CaseSearchES
 from corehq.apps.hqcase.api.updates import handle_case_update
 from corehq.apps.hqcase.utils import bulk_update_cases
 from corehq.apps.integration.payments.const import (
-    PAYMENT_SUCCESS_STATUS_CODE,
     PAYMENT_SUBMITTED_DEVICE_ID,
+    PAYMENT_SUCCESS_STATUS_CODE,
     PaymentProperties,
     PaymentStatus,
 )

--- a/corehq/apps/integration/payments/services.py
+++ b/corehq/apps/integration/payments/services.py
@@ -107,14 +107,7 @@ def verify_payment_cases(domain, case_ids: list, verifying_user: WebUser):
     if not case_ids:
         return []
 
-    for case in CommCareCase.objects.iter_cases(case_ids, domain):
-        payment_status_value = case.get_case_property(PaymentProperties.PAYMENT_STATUS)
-        if PaymentStatus.from_value(payment_status_value) not in [
-            PaymentStatus.NOT_VERIFIED, PaymentStatus.REQUEST_FAILED
-        ]:
-            raise PaymentRequestError(
-                _("Only payments in 'Not Verified' or 'Request failed' state are eligible for verification.")
-            )
+    _validate_payment_status_for_verification(case_ids, domain)
 
     payment_properties_update = {
         PaymentProperties.PAYMENT_VERIFIED: str(True),
@@ -133,6 +126,17 @@ def verify_payment_cases(domain, case_ids: list, verifying_user: WebUser):
         updated_cases.extend(cases)
 
     return updated_cases
+
+
+def _validate_payment_status_for_verification(case_ids, domain):
+    for case in CommCareCase.objects.iter_cases(case_ids, domain):
+        payment_status_value = case.get_case_property(PaymentProperties.PAYMENT_STATUS)
+        if PaymentStatus.from_value(payment_status_value) not in [
+            PaymentStatus.NOT_VERIFIED, PaymentStatus.REQUEST_FAILED
+        ]:
+            raise PaymentRequestError(
+                _("Only payments in 'Not Verified' or 'Request failed' state are eligible for verification.")
+            )
 
 
 def _get_cases_updates(case_ids, updates):
@@ -212,12 +216,7 @@ def revert_payment_verification(domain, case_ids: list):
     if not case_ids:
         return []
 
-    for case in CommCareCase.objects.iter_cases(case_ids, domain):
-        payment_status_value = case.get_case_property(PaymentProperties.PAYMENT_STATUS)
-        if PaymentStatus.from_value(payment_status_value) != PaymentStatus.PENDING_SUBMISSION:
-            raise PaymentRequestError(
-                _("Only payments in the 'Pending Submission' state are eligible for verification reversal.")
-            )
+    _validate_payment_status_for_revert_verification(case_ids, domain)
 
     payment_properties_update = {
         PaymentProperties.PAYMENT_VERIFIED: str(False),
@@ -235,3 +234,12 @@ def revert_payment_verification(domain, case_ids: list):
         updated_cases.extend(cases)
 
     return updated_cases
+
+
+def _validate_payment_status_for_revert_verification(case_ids, domain):
+    for case in CommCareCase.objects.iter_cases(case_ids, domain):
+        payment_status_value = case.get_case_property(PaymentProperties.PAYMENT_STATUS)
+        if PaymentStatus.from_value(payment_status_value) != PaymentStatus.PENDING_SUBMISSION:
+            raise PaymentRequestError(
+                _("Only payments in the 'Pending Submission' state are eligible for verification reversal.")
+            )

--- a/corehq/apps/integration/payments/services.py
+++ b/corehq/apps/integration/payments/services.py
@@ -110,7 +110,7 @@ def verify_payment_cases(domain, case_ids: list, verifying_user: WebUser):
     _validate_payment_status_for_verification(case_ids, domain)
 
     payment_properties_update = {
-        PaymentProperties.PAYMENT_VERIFIED: str(True),
+        PaymentProperties.PAYMENT_VERIFIED: 'True',
         PaymentProperties.PAYMENT_VERIFIED_ON_UTC: str(datetime.now()),
         PaymentProperties.PAYMENT_VERIFIED_BY: verifying_user.username,
         PaymentProperties.PAYMENT_VERIFIED_BY_USER_ID: verifying_user.user_id,
@@ -219,7 +219,7 @@ def revert_payment_verification(domain, case_ids: list):
     _validate_payment_status_for_revert_verification(case_ids, domain)
 
     payment_properties_update = {
-        PaymentProperties.PAYMENT_VERIFIED: str(False),
+        PaymentProperties.PAYMENT_VERIFIED: 'False',
         PaymentProperties.PAYMENT_VERIFIED_ON_UTC: '',
         PaymentProperties.PAYMENT_VERIFIED_BY: '',
         PaymentProperties.PAYMENT_VERIFIED_BY_USER_ID: '',

--- a/corehq/apps/integration/payments/services.py
+++ b/corehq/apps/integration/payments/services.py
@@ -110,7 +110,9 @@ def verify_payment_cases(domain, case_ids: list, verifying_user: WebUser):
     valid_statuses_for_verification = [PaymentStatus.NOT_VERIFIED, PaymentStatus.REQUEST_FAILED]
     if _any_invalid_payment_status(case_ids, domain, valid_statuses_for_verification):
         raise PaymentRequestError(
-            _("Only payments in 'Not Verified' or 'Request failed' state are eligible for verification.")
+            _("Only payments in '{}' or '{}' state are eligible for verification.".format(
+                PaymentStatus.NOT_VERIFIED.label, PaymentStatus.REQUEST_FAILED.label
+            ))
         )
     payment_properties_update = {
         PaymentProperties.PAYMENT_VERIFIED: 'True',
@@ -218,7 +220,9 @@ def revert_payment_verification(domain, case_ids: list):
 
     if _any_invalid_payment_status(case_ids, domain, [PaymentStatus.PENDING_SUBMISSION]):
         raise PaymentRequestError(
-            _("Only payments in the 'Pending Submission' state are eligible for verification reversal.")
+            _("Only payments in the '{}' state are eligible for verification reversal.".format(
+                PaymentStatus.PENDING_SUBMISSION.label
+            ))
         )
 
     payment_properties_update = {

--- a/corehq/apps/integration/payments/services.py
+++ b/corehq/apps/integration/payments/services.py
@@ -225,14 +225,12 @@ def revert_payment_verification(domain, case_ids: list):
             ))
         )
 
-    payment_properties_update = {
-        PaymentProperties.PAYMENT_VERIFIED: 'False',
-        PaymentProperties.PAYMENT_VERIFIED_ON_UTC: '',
-        PaymentProperties.PAYMENT_VERIFIED_BY: '',
-        PaymentProperties.PAYMENT_VERIFIED_BY_USER_ID: '',
-        PaymentProperties.PAYMENT_STATUS: PaymentStatus.NOT_VERIFIED,
-    }
+    return _update_payment_properties_for_revert(domain, case_ids)
+
+
+def _update_payment_properties_for_revert(domain, case_ids: list):
     updated_cases = []
+    payment_properties_update = _properties_to_update_for_revert()
     for case_ids_chunk in chunked(case_ids, CHUNK_SIZE):
         case_changes = [(case_id, payment_properties_update, False) for case_id in case_ids_chunk]
         xform, cases = bulk_update_cases(
@@ -241,3 +239,13 @@ def revert_payment_verification(domain, case_ids: list):
         updated_cases.extend(cases)
 
     return updated_cases
+
+
+def _properties_to_update_for_revert():
+    return {
+        PaymentProperties.PAYMENT_VERIFIED: 'False',
+        PaymentProperties.PAYMENT_VERIFIED_ON_UTC: '',
+        PaymentProperties.PAYMENT_VERIFIED_BY: '',
+        PaymentProperties.PAYMENT_VERIFIED_BY_USER_ID: '',
+        PaymentProperties.PAYMENT_STATUS: PaymentStatus.NOT_VERIFIED,
+    }

--- a/corehq/apps/integration/payments/services.py
+++ b/corehq/apps/integration/payments/services.py
@@ -39,11 +39,12 @@ def request_payments_for_cases(case_ids, config):
 def _get_payment_cases_updates(case_ids_chunk, config):
     payment_updates = []
     for payment_case in CommCareCase.objects.get_cases(case_ids=list(case_ids_chunk)):
-        payment_update = request_payment(payment_case, config)
         # Additional safeguard to ensure we only process cases that are pending submission
         payment_status_value = payment_case.get_case_property(PaymentProperties.PAYMENT_STATUS)
         if PaymentStatus.from_value(payment_status_value) != PaymentStatus.PENDING_SUBMISSION:
             continue
+
+        payment_update = request_payment(payment_case, config)
 
         should_close = False
         payment_updates.append(

--- a/corehq/apps/integration/payments/services.py
+++ b/corehq/apps/integration/payments/services.py
@@ -40,6 +40,10 @@ def _get_payment_cases_updates(case_ids_chunk, config):
     payment_updates = []
     for payment_case in CommCareCase.objects.get_cases(case_ids=list(case_ids_chunk)):
         payment_update = request_payment(payment_case, config)
+        # Additional safeguard to ensure we only process cases that are pending submission
+        payment_status_value = payment_case.get_case_property(PaymentProperties.PAYMENT_STATUS)
+        if PaymentStatus.from_value(payment_status_value) != PaymentStatus.PENDING_SUBMISSION:
+            continue
 
         should_close = False
         payment_updates.append(

--- a/corehq/apps/integration/payments/tables.py
+++ b/corehq/apps/integration/payments/tables.py
@@ -5,7 +5,9 @@ from django.utils.translation import gettext as _
 from django_tables2 import columns
 
 from corehq.apps.hqwebapp.tables.columns import DateTimeStringColumn
-from corehq.apps.hqwebapp.tables.elasticsearch.records import CaseSearchElasticRecord
+from corehq.apps.hqwebapp.tables.elasticsearch.records import (
+    CaseSearchElasticRecord,
+)
 from corehq.apps.hqwebapp.tables.elasticsearch.tables import ElasticTable
 from corehq.apps.hqwebapp.tables.htmx import BaseHtmxTable
 from corehq.apps.integration.payments.const import PaymentStatus

--- a/corehq/apps/integration/payments/tests/test_services.py
+++ b/corehq/apps/integration/payments/tests/test_services.py
@@ -1,21 +1,28 @@
 import uuid
 from unittest.mock import patch
 
-import pytest
 from django.test import TestCase
 
-from casexml.apps.case.mock import CaseFactory
-from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.integration.payments.models import MoMoConfig
-from corehq.apps.users.models import WebUser
+import pytest
 
-from corehq.motech.models import ConnectionSettings
+from casexml.apps.case.mock import CaseFactory
+
 from corehq.apps.case_importer.const import MOMO_PAYMENT_CASE_TYPE
-from corehq.apps.integration.payments.services import verify_payment_cases, request_payments_for_cases, \
-    revert_payment_verification
-from corehq.apps.integration.payments.const import PaymentProperties, PaymentStatus
-from corehq.apps.integration.payments.services import _request_payment
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.integration.payments.const import (
+    PaymentProperties,
+    PaymentStatus,
+)
 from corehq.apps.integration.payments.exceptions import PaymentRequestError
+from corehq.apps.integration.payments.models import MoMoConfig
+from corehq.apps.integration.payments.services import (
+    _request_payment,
+    request_payments_for_cases,
+    revert_payment_verification,
+    verify_payment_cases,
+)
+from corehq.apps.users.models import WebUser
+from corehq.motech.models import ConnectionSettings
 
 
 class TestVerifyPaymentCases(TestCase):

--- a/corehq/apps/integration/payments/tests/test_services.py
+++ b/corehq/apps/integration/payments/tests/test_services.py
@@ -259,6 +259,7 @@ class TestRequestPaymentsForCases(TestCase):
             PaymentProperties.PAYEE_NOTE: 'Jan payment',
             PaymentProperties.PAYER_MESSAGE: 'Thanks',
             PaymentProperties.PAYMENT_VERIFIED: 'True',
+            PaymentProperties.PAYMENT_STATUS: PaymentStatus.PENDING_SUBMISSION,
         }
 
     @patch('corehq.apps.integration.payments.services._make_payment_request')
@@ -308,7 +309,6 @@ class TestRequestPaymentsForCases(TestCase):
         for payment_case in payment_cases:
             case_data = payment_case.case_json
             assert case_data.get('transaction_id') is None
-            assert PaymentProperties.PAYMENT_STATUS not in case_data
             assert PaymentProperties.PAYMENT_TIMESTAMP not in case_data
 
         request_payments_for_cases([_case.case_id for _case in payment_cases], self.config)

--- a/corehq/apps/integration/payments/tests/test_views.py
+++ b/corehq/apps/integration/payments/tests/test_views.py
@@ -4,28 +4,38 @@ from django.test import TestCase
 from django.urls import reverse
 
 from casexml.apps.case.mock import CaseFactory
-from corehq.apps.case_importer.const import MOMO_PAYMENT_CASE_TYPE
 
+from corehq.apps.case_importer.const import MOMO_PAYMENT_CASE_TYPE
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.es.groups import group_adapter
-from corehq.apps.es.users import user_adapter
 from corehq.apps.es.tests.utils import es_test
-from corehq.apps.integration.kyc.models import KycVerificationStatus, UserDataStore, KycConfig
-from corehq.apps.integration.payments.const import PaymentProperties, PaymentStatus
+from corehq.apps.es.users import user_adapter
+from corehq.apps.integration.kyc.models import (
+    KycConfig,
+    KycVerificationStatus,
+    UserDataStore,
+)
+from corehq.apps.integration.payments.const import (
+    PaymentProperties,
+    PaymentStatus,
+)
+from corehq.apps.integration.payments.filters import (
+    BatchNumberFilter,
+    PaymentVerifiedByFilter,
+)
 from corehq.apps.integration.payments.models import MoMoConfig
 from corehq.apps.integration.payments.views import (
+    PaymentConfigurationView,
     PaymentsVerificationReportView,
     PaymentsVerificationTableView,
-    PaymentConfigurationView,
 )
 from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
-from corehq.apps.users.models import WebUser, HqPermissions
+from corehq.apps.users.models import HqPermissions, WebUser
 from corehq.apps.users.models_role import UserRole
 from corehq.apps.users.permissions import PAYMENTS_REPORT_PERMISSION
 from corehq.motech.models import ConnectionSettings
 from corehq.util.test_utils import flag_enabled
-from corehq.apps.integration.payments.filters import BatchNumberFilter, PaymentVerifiedByFilter
 
 
 class BaseTestPaymentsView(TestCase):

--- a/corehq/apps/integration/payments/tests/test_views.py
+++ b/corehq/apps/integration/payments/tests/test_views.py
@@ -404,8 +404,12 @@ class TestPaymentsVerifyTableView(BaseTestPaymentsView):
         )
 
     @flag_enabled('MTN_MOBILE_WORKER_VERIFICATION')
+    @patch(
+        'corehq.apps.integration.payments.views.PaymentsVerificationTableView.'
+        '_check_for_active_revert_verification_request'
+    )
     @patch('corehq.apps.integration.payments.views.get_celery_task_tracker')
-    def test_revert_verification_payment_submissions_active(self, mock_task_tracker):
+    def test_revert_verification_payment_submissions_active(self, mock_task_tracker, *args):
         # Setup: mock the task tracker to simulate active submissions
         mock_task_tracker.return_value.is_active.return_value = True
 

--- a/corehq/apps/integration/payments/tests/test_views.py
+++ b/corehq/apps/integration/payments/tests/test_views.py
@@ -367,8 +367,12 @@ class TestPaymentsVerifyTableView(BaseTestPaymentsView):
         )
 
         assert response.status_code == 400
-        assert (b"Only payments in the 'Pending Submission' state are eligible for verification reversal."
-                in response.content)
+        assert (
+            "Only payments in the '{}' state are eligible for verification reversal.".format(
+                PaymentStatus.PENDING_SUBMISSION.label
+            )
+            in str(response.content)
+        )
 
     @flag_enabled('MTN_MOBILE_WORKER_VERIFICATION')
     def test_revert_verification_no_cases(self):

--- a/corehq/apps/integration/payments/urls.py
+++ b/corehq/apps/integration/payments/urls.py
@@ -1,11 +1,10 @@
 from django.urls import re_path as url
 
 from corehq.apps.integration.payments.views import (
+    PaymentConfigurationView,
     PaymentsVerificationReportView,
     PaymentsVerificationTableView,
-    PaymentConfigurationView,
 )
-
 
 urlpatterns = [
     url(r'^verify/$', PaymentsVerificationReportView.as_view(), name=PaymentsVerificationReportView.urlname),

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -18,20 +18,32 @@ from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.tables.pagination import SelectablePaginatedTableView
 from corehq.apps.integration.kyc.models import KycConfig
-from corehq.apps.integration.payments.const import PaymentProperties, PaymentStatus
-from corehq.apps.integration.payments.forms import PaymentConfigureForm
+from corehq.apps.integration.payments.const import (
+    PaymentProperties,
+    PaymentStatus,
+)
 from corehq.apps.integration.payments.exceptions import PaymentRequestError
+from corehq.apps.integration.payments.forms import PaymentConfigureForm
 from corehq.apps.integration.payments.models import MoMoConfig
-from corehq.apps.integration.payments.services import revert_payment_verification, verify_payment_cases
+from corehq.apps.integration.payments.services import (
+    revert_payment_verification,
+    verify_payment_cases,
+)
 from corehq.apps.integration.payments.tables import PaymentsVerifyTable
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
 from corehq.apps.reports.generic import get_filter_classes
-from corehq.apps.reports.standard.cases.utils import add_case_owners_and_location_access
+from corehq.apps.reports.standard.cases.utils import (
+    add_case_owners_and_location_access,
+)
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions, WebUser
 from corehq.apps.users.permissions import PAYMENTS_REPORT_PERMISSION
-from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action, HtmxResponseException
+from corehq.util.htmx_action import (
+    HqHtmxActionMixin,
+    HtmxResponseException,
+    hq_hx_action,
+)
 from corehq.util.timezones.utils import get_timezone
 
 

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -195,14 +195,14 @@ class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableV
 
         try:
             self._validate_verification_request(case_ids)
+            verified_cases = verify_payment_cases(
+                request.domain,
+                case_ids=case_ids,
+                verifying_user=web_user,
+            )
         except PaymentRequestError as e:
             raise HtmxResponseException(str(e), status_code=400)
 
-        verified_cases = verify_payment_cases(
-            request.domain,
-            case_ids=case_ids,
-            verifying_user=web_user,
-        )
         success_count = len(verified_cases)
         context = {
             'success_count': success_count,

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -228,24 +228,13 @@ class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableV
             context,
         )
 
-    def _validate_revert_verification_request(self, case_ids):
-        if not case_ids:
-            raise PaymentRequestError(_("One or more case IDs are required to revert verification."))
-
-        if len(case_ids) > self.REVERT_VERIFICATION_ROWS_LIMIT:
-            raise PaymentRequestError(
-                _("You can only revert verification for up to {} cases at a time.").format(
-                    self.REVERT_VERIFICATION_ROWS_LIMIT
-                ),
-            )
-
     @hq_hx_action('post')
     def revert_verification(self, request, *args, **kwargs):
         case_ids = request.POST.getlist('selected_ids')
 
         try:
-            self._validate_revert_verification_request(case_ids)
             self._check_for_active_payment_task()
+            self._validate_revert_verification_request(case_ids)
             revert_payment_verification(request.domain, case_ids=case_ids)
         except PaymentRequestError as e:
             raise HtmxResponseException(str(e), status_code=400)
@@ -262,6 +251,17 @@ class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableV
             raise PaymentRequestError(
                 _("Payment submissions are currently active for your project and should be completed shortly."
                   " Please try again later.")
+            )
+
+    def _validate_revert_verification_request(self, case_ids):
+        if not case_ids:
+            raise PaymentRequestError(_("One or more case IDs are required to revert verification."))
+
+        if len(case_ids) > self.REVERT_VERIFICATION_ROWS_LIMIT:
+            raise PaymentRequestError(
+                _("You can only revert verification for up to {} cases at a time.").format(
+                    self.REVERT_VERIFICATION_ROWS_LIMIT
+                ),
             )
 
 

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -257,8 +257,8 @@ class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableV
                 _("Revert verification request is in progress for your project. Please try again after some time.")
             )
 
-    @memoized
     @property
+    @memoized
     def revert_verification_request_tracker(self):
         return get_celery_task_tracker(self.request.domain, REVERT_VERIFICATION_REQUEST_SLUG)
 

--- a/corehq/apps/integration/static/integration/js/payments/payments_verify.js
+++ b/corehq/apps/integration/static/integration/js/payments/payments_verify.js
@@ -6,6 +6,11 @@ import { multiCheckboxSelectionHandler } from "integration/js/checkbox_selection
 import htmx from 'htmx.org';
 
 
+function updateVerifyAndRevertButton(selectedIds) {
+    updateVerifyButton(selectedIds);
+    updateRevertVerificationButton(selectedIds);
+}
+
 function updateVerifyButton(selectedIds) {
     const $verifySelectedBtn = $('#verify-selected-btn');
     const $verifyConfirmationBtn = $('#verify-confirmation-btn');
@@ -17,7 +22,18 @@ function updateVerifyButton(selectedIds) {
     $verifyConfirmationBtn.attr('hx-vals', JSON.stringify(verifyBtnVals));
 }
 
-const handler = new multiCheckboxSelectionHandler('selection', 'select_all', updateVerifyButton);
+function updateRevertVerificationButton(selectedIds) {
+    const $revertVerificationBtn = $('#revert-verification-selected-btn');
+    const $revertVerificationConfirmationBtn = $('#revert-verification-confirmation-btn');
+
+    let revertVerificationVals = JSON.parse($revertVerificationConfirmationBtn.attr('hx-vals'));
+
+    $revertVerificationBtn.prop('disabled', !(selectedIds.length));
+    revertVerificationVals['selected_ids'] = selectedIds;
+    $revertVerificationConfirmationBtn.attr('hx-vals', JSON.stringify(revertVerificationVals));
+}
+
+const handler = new multiCheckboxSelectionHandler('selection', 'select_all', updateVerifyAndRevertButton);
 $(function () {
     handler.init();
 });

--- a/corehq/apps/integration/static/integration/js/payments/payments_verify.js
+++ b/corehq/apps/integration/static/integration/js/payments/payments_verify.js
@@ -48,7 +48,7 @@ $(document).on('htmx:afterRequest', function (event) {
     const method = event.detail.requestConfig.verb;
     if (method === 'get') {
         handler.selectedIds = [];
-        updateVerifyButton([]);
+        updateVerifyAndRevertButton([]);
     } else if (method === 'post') {
         const endpoint = requestPath + window.location.search;
         // The timeout is to allow the verification request enough time to update the affected cases in ES before

--- a/corehq/apps/integration/templates/payments/partials/custom_error_modal.html
+++ b/corehq/apps/integration/templates/payments/partials/custom_error_modal.html
@@ -1,0 +1,9 @@
+{% extends 'hqwebapp/htmx/error_modal.html' %}
+
+{% block modal_title %}
+  Payment Request Error
+{% endblock modal_title %}
+
+{% block modal_content %}
+  <p x-text="errorText"></p>
+{% endblock modal_content %}

--- a/corehq/apps/integration/templates/payments/partials/payments_revert_verification_alert.html
+++ b/corehq/apps/integration/templates/payments/partials/payments_revert_verification_alert.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="alert alert-success alert-dismissable fade show" role="alert">
-  {% trans 'Successfully reverted verification for selected record(s). Status for these will be refreshed in a few seconds.' %}
+  {% trans 'Successfully reverted verification for selected record(s). Updated status will reflect shortly.' %}
   <button
     type="button"
     class="btn-close float-end"

--- a/corehq/apps/integration/templates/payments/partials/payments_revert_verification_alert.html
+++ b/corehq/apps/integration/templates/payments/partials/payments_revert_verification_alert.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+<div class="alert alert-success alert-dismissable fade show" role="alert">
+  {% trans 'Successfully reverted verification for selected record(s). Status for these will be refreshed in a few seconds.' %}
+  <button
+    type="button"
+    class="btn-close float-end"
+    data-bs-dismiss="alert"
+    aria-label="{% trans Close %}"
+  ></button>
+</div>

--- a/corehq/apps/integration/templates/payments/partials/payments_revert_verification_modal.html
+++ b/corehq/apps/integration/templates/payments/partials/payments_revert_verification_modal.html
@@ -1,0 +1,52 @@
+{% load i18n %}
+
+<div
+  class="modal fade"
+  id="revert-verification-confirmation-modal"
+  tabindex="-1"
+  role="dialog"
+>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">
+          {% trans "Revert Verification of Pending Payments" %}
+        </h5>
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="Close"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <p>
+          {% trans "Are you sure you want to proceed with the selected payments?" %}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button
+          type="button"
+          class="btn btn-outline-primary"
+          data-bs-dismiss="modal"
+        >
+          {% trans "Cancel" %}
+        </button>
+        <button
+          type="button"
+          class="btn btn-primary"
+          id="revert-verification-confirmation-btn"
+          data-bs-dismiss="modal"
+          hx-post="{% url 'payments_verify_table' domain %}"
+          hx-target="#revert-verification-alert"
+          hq-hx-action="revert_verification"
+          hx-vals='{
+                    "selected_ids": []
+            }'
+        >
+          {% trans "Confirm" %}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/corehq/apps/integration/templates/payments/partials/payments_verify_alert.html
+++ b/corehq/apps/integration/templates/payments/partials/payments_verify_alert.html
@@ -3,8 +3,8 @@
 {% if success_count %}
   <div class="alert alert-success alert-dismissable fade show" role="alert">
     {% blocktrans %}
-      Successfully verified {{ success_count }} records for payments!
-      Verification status for these will be refreshed in a few seconds.
+      Successfully verified {{ success_count }} records for payments! Updated
+      status will reflect shortly.
     {% endblocktrans %}
     <button
       type="button"

--- a/corehq/apps/integration/templates/payments/payments_verify_report.html
+++ b/corehq/apps/integration/templates/payments/payments_verify_report.html
@@ -36,6 +36,18 @@
       <span> {% trans "Verify Selected" %} </span>
     </button>
   </p>
+  <p>
+    <button
+      id="revert-verification-selected-btn"
+      class="btn btn-primary"
+      type="button"
+      disabled="true"
+      data-bs-toggle="modal"
+      data-bs-target="#revert-verification-confirmation-modal"
+    >
+      <span> {% trans "UnVerify Selected" %} </span>
+    </button>
+  </p>
   <div
     id="payment-verify-table"
     hx-trigger="load"
@@ -46,6 +58,7 @@
     </div>
   </div>
   {% include "payments/partials/payments_confirmation_modal.html" %}
+  {% include "payments/partials/payments_revert_verification_modal.html" %}
 {% endblock %}
 
 {% block modals %}

--- a/corehq/apps/integration/templates/payments/payments_verify_report.html
+++ b/corehq/apps/integration/templates/payments/payments_verify_report.html
@@ -23,6 +23,7 @@
   </div>
 
   <div id="verify-alert"></div>
+  <div id="revert-verification-alert"></div>
   <p>
     <button
       id="verify-selected-btn"

--- a/corehq/apps/integration/templates/payments/payments_verify_report.html
+++ b/corehq/apps/integration/templates/payments/payments_verify_report.html
@@ -66,6 +66,6 @@
 {% endblock %}
 
 {% block modals %}
-  {% include "hqwebapp/htmx/error_modal.html" %}
+  {% include "payments/partials/custom_error_modal.html" %}
   {{ block.super }}
 {% endblock modals %}

--- a/corehq/apps/integration/templates/payments/payments_verify_report.html
+++ b/corehq/apps/integration/templates/payments/payments_verify_report.html
@@ -47,7 +47,7 @@
           data-bs-toggle="modal"
           data-bs-target="#revert-verification-confirmation-modal"
         >
-          <span> {% trans "UnVerify Selected" %} </span>
+          <span> {% trans "Revert Verification" %} </span>
         </button>
       </div>
     </div>

--- a/corehq/apps/integration/templates/payments/payments_verify_report.html
+++ b/corehq/apps/integration/templates/payments/payments_verify_report.html
@@ -24,30 +24,34 @@
 
   <div id="verify-alert"></div>
   <div id="revert-verification-alert"></div>
-  <p>
-    <button
-      id="verify-selected-btn"
-      class="btn btn-primary"
-      type="button"
-      disabled="true"
-      data-bs-toggle="modal"
-      data-bs-target="#verify-confirmation-modal"
-    >
-      <span> {% trans "Verify Selected" %} </span>
-    </button>
-  </p>
-  <p>
-    <button
-      id="revert-verification-selected-btn"
-      class="btn btn-primary"
-      type="button"
-      disabled="true"
-      data-bs-toggle="modal"
-      data-bs-target="#revert-verification-confirmation-modal"
-    >
-      <span> {% trans "UnVerify Selected" %} </span>
-    </button>
-  </p>
+  <div class="col-5 mb-2 mt-4">
+    <div class="row">
+      <div class="col-3">
+        <button
+          id="verify-selected-btn"
+          class="btn btn-primary"
+          type="button"
+          disabled="true"
+          data-bs-toggle="modal"
+          data-bs-target="#verify-confirmation-modal"
+        >
+          <span> {% trans "Verify Selected" %} </span>
+        </button>
+      </div>
+      <div class="col-4">
+        <button
+          id="revert-verification-selected-btn"
+          class="btn btn-primary"
+          type="button"
+          disabled="true"
+          data-bs-toggle="modal"
+          data-bs-target="#revert-verification-confirmation-modal"
+        >
+          <span> {% trans "UnVerify Selected" %} </span>
+        </button>
+      </div>
+    </div>
+  </div>
   <div
     id="payment-verify-table"
     hx-trigger="load"


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Ability to withdraw payment cases that are yet to be submitted to service provider i.e. in the `Pending Submission` state.

Screenshots:
- Button with confirmation modal on click

<img width="2676" height="1060" alt="image" src="https://github.com/user-attachments/assets/e2c27cdc-f88c-4877-9df0-affc31bb0f73" />

- After revert verification
<img width="2619" height="865" alt="image" src="https://github.com/user-attachments/assets/2874c7d8-9cdf-4676-bafd-1feccc8d8354" />

- Reverting verification for non eligible statuses

<img width="2724" height="1110" alt="image" src="https://github.com/user-attachments/assets/78a72c21-e3b8-478a-8372-40b1af7a6a97" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-4547)

Additionally, 
- it also adds validation in the backend for max no. of cases that can be verified and reverted. The count is set to 100 which is same as the max value of rows that can be selected from the UI.
- Adds validation so that only cases that are `Not Verified` or `Request Failed` are eligible for verification. This avoids any accidental duplicate payments.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
MTN_MOBILE_WORKER_VERIFICATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
New test cases included.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
