### PR TITLE
Mjr/show multi updates

### DIFF
--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -221,21 +221,26 @@ class InvalidPropertyException(Exception):
         super().__init__(message)
 
 
-class MissingPropertyException(Exception):
-    def __init__(self, *missing_properties):
-        self.missing_properties = missing_properties
-        if self.missing_properties:
-            message = f"The following properties were not found: {', '.join(self.missing_properties)}"
+class MissingPropertyMapException(Exception):
+    def __init__(self, *missing_mappings):
+        self.missing_mappings = missing_mappings
+        if self.missing_mappings:
+            mappings = [
+                f"{mapping['case_property']}->{mapping['question_path']}"
+                for mapping in self.missing_mappings
+            ]
+            message = f"The following mappings were not found: {', '.join(mappings)}"
         else:
-            message = "No missing properties specified"
+            message = "Missing properties were not found"
         super().__init__(message)
 
 
 class DiffConflictException(Exception):
-    def __init__(self, *conflicting_keys):
-        self.conflicting_keys = conflicting_keys
-        if self.conflicting_keys:
-            message = f"The following keys were affected by multiple actions: {', '.join(self.conflicting_keys)}"
+    def __init__(self, *conflicting_mappings):
+        self.conflicting_mappings = conflicting_mappings
+        if self.conflicting_mappings:
+            mappings = ', '.join(self.conflicting_mappings)
+            message = f"The following mappings were affected by multiple actions: {mappings}"
         else:
-            message = "No conflicting keys specified"
+            message = "No conflicting mappings specified"
         super().__init__(message)

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -1146,7 +1146,7 @@ class FormValidator(IndexedFormBaseValidator):
             subcase_names.update(subcase_action.case_properties)
 
         if self.form.requires == 'none' and self.form.actions.open_case.is_active() \
-                and not self.form.actions.open_case.name_update.question_path:
+                and not self.form.actions.open_case.has_name_update():
             errors.append({'type': 'case_name required'})
 
         errors.extend(self.check_case_properties(

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -1182,7 +1182,7 @@ class FormValidator(IndexedFormBaseValidator):
 
         if update_case.update_multi:
             for (key, value) in update_case.update_multi.items():
-                if len(value) > 0:
+                if len(value) > 1:
                     errors.append(self._get_property_conflict_error(key))
 
         return errors

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -520,6 +520,15 @@ class UpdateCaseAction(FormAction):
         else:
             self.make_single()
 
+    def get_property_names(self):
+        all_names = set()
+        if self.update:
+            all_names.update(list(self.update.keys()))
+        elif self.update_multi:
+            all_names.update(list(self.update_multi.keys()))
+
+        return all_names
+
 
 class PreloadAction(FormAction):
 
@@ -680,7 +689,7 @@ class FormActions(UpdateableDocument):
 
     def all_property_names(self):
         names = set()
-        names.update(list(self.update_case.update.keys()))
+        names.update(self.update_case.get_property_names())
         names.update(list(self.case_preload.preload.values()))
         for subcase in self.subcases:
             names.update(list(subcase.case_properties.keys()))

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -352,11 +352,11 @@ class FormAction(UpdateableDocument):
         action_properties = action.properties()
         if 'name_path' in action_properties and action.name_path:
             yield 'name', action.name_path
-        if action_properties.get('name_update') and action.name_update.question_path:
+        if action_properties.get('name_update') and action.name_update and action.name_update.question_path:
             yield 'name', action.name_update.question_path
         if 'external_id' in action_properties and action.external_id:
             yield 'external_id', action.external_id
-        if 'update' in action_properties:
+        if 'update' in action_properties and action.update:
             for name, conditional_case_update in action.update.items():
                 yield name, conditional_case_update.question_path
         if 'case_properties' in action_properties:
@@ -606,6 +606,15 @@ class OpenCaseAction(FormAction):
 
         self.name_update = self.name_update_multi[0]
         self.name_update_multi = None
+
+    def has_name_update(self):
+        if self.name_update_multi:
+            return any([self._update_has_name(update) for update in self.name_update_multi])
+
+        return self.name_update and self._update_has_name(self.name_update)
+
+    def _update_has_name(self, update):
+        return bool(update.question_path)
 
 
 class OpenSubCaseAction(FormAction, IndexedSchema):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -485,7 +485,7 @@ class OpenReferralAction(UpdateReferralAction):
 
 class OpenCaseAction(FormAction):
 
-    # `name_update` is the "official" version, while `name_update_multi` is intended as a temporary option
+    # `name_update` is the "official" version, while `name_update_multi` is intended as a way
     # to allow the user to resolve conflicts. They should not be used together. Either the action is in a
     # buildable state, where `name_update` is specified, or conflicts are waiting to be resolved, where
     # `name_updatd_multi` will hold the updates.

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -382,27 +382,33 @@ class UpdateCaseAction(FormAction):
     def make_multi(self):
         '''
         Moves any updates from `update` into `update_multi`
+        Returns true when anything was moved
         '''
         if not (self.update and len(self.update)):
             # update contains no items, so no changes are necessary
-            return
+            return False
 
         self.update_multi = {k: [v] for (k, v) in self.update.items()}
         self.update = {}
+
+        return True
 
     def normalize_update(self):
         '''
         Attempt to move `update_multi` to `update`
         If `update_multi` contains multiple updates mapped to the same case property, no changes will occur
+        Returns true when updates are normalized, or false if nothing is done
         '''
         multi_question_cases = ((k, v) for (k, v) in self.update_multi.items() if len(v) > 1)
         if any(multi_question_cases):
             # must continue to use `update_multi`, as there are multiple questions saving to the same case property
-            return
+            return False
 
         normalized_update = {k: v[0] for (k, v) in self.update_multi.items()}
         self.update = normalized_update
         self.update_multi = None
+
+        return True
 
     DIFF_ACTION_ADD = 'add'
     DIFF_ACTION_DELETE = 'del'

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -410,7 +410,7 @@ class UpdateCaseAction(FormAction):
 
         normalized_update = {k: v[0] for (k, v) in self.update_multi.items() if v}
         self.update = normalized_update
-        self.update_multi = None
+        self.update_multi = {}
 
         return True
 
@@ -426,7 +426,7 @@ class UpdateCaseAction(FormAction):
             if updates:
                 self.update[case_property] = updates[-1]
 
-        self.update_multi = None
+        self.update_multi = {}
 
         return True
 
@@ -615,7 +615,7 @@ class OpenCaseAction(FormAction):
         if self.name_update_multi:
             self.name_update = self.name_update_multi[-1]
 
-        self.name_update_multi = None
+        self.name_update_multi = []
 
         return True
 
@@ -628,7 +628,7 @@ class OpenCaseAction(FormAction):
             return
 
         self.name_update = self.name_update_multi[0]
-        self.name_update_multi = None
+        self.name_update_multi = []
 
     def has_name_update(self):
         if self.name_update_multi:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -576,15 +576,18 @@ class OpenCaseAction(FormAction):
         self.update_object(updates)
         self.make_multi()
 
-        mappings = {self._NAME_UPDATE_MULTI_FIELD_NAME: self.name_update_multi}
-        normalized_diffs = diffs.convert_to_update_diff()
-        apply_diffs(mappings, normalized_diffs)
-        self.name_update_multi = mappings[self._NAME_UPDATE_MULTI_FIELD_NAME]
+        self.apply_name_update(diffs)
 
         if allow_conflicts:
             self.normalize_name_update()
         else:
             self.make_single()
+
+    def apply_name_update(self, diffs):
+        mappings = {self._NAME_UPDATE_MULTI_FIELD_NAME: self.name_update_multi}
+        update_diff = diffs.convert_to_update_diff()
+        apply_diffs(mappings, update_diff)
+        self.name_update_multi = mappings[self._NAME_UPDATE_MULTI_FIELD_NAME]
 
     def make_multi(self):
         '''

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -461,6 +461,10 @@ def _apply_updates(current_mappings, updates):
 
 
 class UpdateCaseAction(FormAction):
+    # `update` is the "official" version, while `update_multi` is intended as a way
+    # to allow the user to resolve conflicts. They should not be used together. Either the action is in a
+    # buildable state, where `update` is specified, or conflicts are waiting to be resolved, where
+    # `update_multi` will hold the updates.
     update = SchemaDictProperty(ConditionalCaseUpdate)
     update_multi = SchemaDictProperty(SchemaListProperty(ConditionalCaseUpdate))
 
@@ -560,7 +564,7 @@ class OpenCaseAction(FormAction):
     # `name_update` is the "official" version, while `name_update_multi` is intended as a way
     # to allow the user to resolve conflicts. They should not be used together. Either the action is in a
     # buildable state, where `name_update` is specified, or conflicts are waiting to be resolved, where
-    # `name_updatd_multi` will hold the updates.
+    # `name_update_multi` will hold the updates.
     name_update = SchemaProperty(ConditionalCaseUpdate)
     name_update_multi = SchemaListProperty(ConditionalCaseUpdate)
     external_id = StringProperty()

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -431,14 +431,22 @@ class UpdateCaseAction(FormAction):
         return True
 
     def apply_updates(self, updates, diffs, allow_conflicts=True):
+        # Remove the 'update' properties. Update/update_multi
+        # are intended to be updated via diffs
+        updates = self._get_non_update_properties(updates)
         self.update_object(updates)
         self.make_multi()
+
         self.apply_diffs_to_mappings(self.update_multi, diffs)
 
         if allow_conflicts:
             self.normalize_update()
         else:
             self.make_single()
+
+    @staticmethod
+    def _get_non_update_properties(updates):
+        return {key: updates[key] for key in updates if key not in ['update', 'update_multi']}
 
     def get_property_names(self):
         all_names = set()
@@ -576,6 +584,9 @@ class OpenCaseAction(FormAction):
     _NAME_UPDATE_MULTI_FIELD_NAME = 'name_update_multi'
 
     def apply_updates(self, updates, diffs, allow_conflicts=True):
+        # Remove the 'update' properties. name_update/name_update_multi
+        # are intended to be updated via diffs
+        updates = self._get_non_update_properties(updates)
         self.update_object(updates)
         self.make_multi()
 
@@ -585,6 +596,10 @@ class OpenCaseAction(FormAction):
             self.normalize_name_update()
         else:
             self.make_single()
+
+    @staticmethod
+    def _get_non_update_properties(updates):
+        return {key: updates[key] for key in updates if key not in ['name_update', 'name_update_multi']}
 
     def apply_name_update(self, diffs):
         # UpdateCaseAction's 'update' dictionary is a representation of any generic updates.

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -454,6 +454,7 @@ class UpdateCaseAction(FormAction):
         '''
         Expects `current_mappings` to be a dictionary of `ConditionalCaseUpdate` lists.
         Expects `diffs` to be an `UpdateCaseDiff`
+        Uses 'diffs' to modify 'current_mappings' in-place.
         '''
         cls._check_for_duplicate_keys(diffs)
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -473,8 +473,8 @@ class UpdateCaseAction(FormAction):
         Moves any updates from `update` into `update_multi`
         Returns true when anything was moved
         '''
-        if not (self.update and len(self.update)):
-            # update contains no items, so no changes are necessary
+        if self.update_multi:
+            # because update_multi is meant to be exclusive with update, no items need to be moved
             return False
 
         self.update_multi = {k: [v] for (k, v) in self.update.items()}
@@ -502,6 +502,7 @@ class UpdateCaseAction(FormAction):
     def make_single(self):
         '''
         Force `update_multi` into `update`, even if it means losing values
+        Returns true when anything was moved
         '''
         if not self.update_multi:
             return False

--- a/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
@@ -124,7 +124,7 @@ export default {
             const path = caseProperty.path;
             const updateMode = caseProperty.save_only_if_edited ? 'edit' : 'always';
             if (key || path) {
-                if (_(required).contains(key) && caseProperty.isOpenCase) {
+                if (_(required).contains(key)) {
                     extraDict[key] = extraDict[key] || [];
                     extraDict[key].push({question_path: path, update_mode: updateMode});
                 } else {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -75,8 +75,9 @@ $(function () {
             save: function () {
                 var requires = self.caseConfigViewModel.actionType() === 'update' ? 'case' : 'none';
                 var subcases = _(self.caseConfigViewModel.subcases()).map(HQOpenSubCaseAction.from_case_transaction);
+                const opensCase = self.caseType && (requires === 'none');
                 const updatedActions = Object.assign(
-                    HQFormActions.from_case_transaction(self.caseConfigViewModel.case_transaction),
+                    HQFormActions.from_case_transaction(self.caseConfigViewModel.case_transaction, opensCase),
                     {subcases: subcases},
                 );
                 const diff = getDiff(self.baseline, updatedActions);
@@ -678,7 +679,6 @@ $(function () {
                 key: 'name',
                 path: update.question_path,
                 required: false,
-                isOpenCase: true,
                 save_only_if_edited: update.update_mode === 'edit',
             }));
 
@@ -727,9 +727,10 @@ $(function () {
             });
             return x;
         },
-        from_case_transaction: function (caseTransaction) {
+        from_case_transaction: function (caseTransaction, opensCase) {
             var o = ko.mapping.toJS(caseTransaction, caseTransactionMapping(caseTransaction));
-            var x = caseConfigUtils.propertyArrayToMultiDict(['name'], o.case_properties);
+            const openCasePropertyNames = opensCase ? ['name'] : [];
+            var x = caseConfigUtils.propertyArrayToMultiDict(openCasePropertyNames, o.case_properties);
             var caseProperties = x[0],
                 openNameUpdate = x[1].name;
             var casePreload = caseConfigUtils.preloadArrayToDict(o.case_preload);

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -665,7 +665,6 @@ $(function () {
             const usercaseUpdate  = o.usercase_update || {};
             self.usercase_update = {
                 update: usercaseUpdate.update || {},
-                update_multi: usercaseUpdate.update_multi || {},
             };
             self.usercase_preload = {
                 preload: (o.usercase_preload || {}).preload || {},

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_action_diffs.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_action_diffs.js
@@ -17,7 +17,7 @@ export function getDiff(baseline, incoming) {
 
     if (incoming.open_case.name_update_multi) {
         const nameDiff = getNameDiff(baseline.open_case.name_update_multi, incoming.open_case.name_update_multi);
-        if (nameDiff) {
+        if (Object.keys(nameDiff).length) {
             diff['open_case'] = nameDiff;
         }
     }
@@ -96,23 +96,19 @@ function getNameDiff(original, updated) {
     const rawDiff = getUpdateMultiDiff(normalizedOriginal, normalizedUpdated);
 
     const result = {};
-    let hasResult = false;
     if ('add' in rawDiff) {
         result['add'] = rawDiff['add']['name'];
-        hasResult = true;
     }
 
     if ('delete' in rawDiff) {
         result['delete'] = rawDiff['delete']['name'];
-        hasResult = true;
     }
 
     if ('update' in rawDiff) {
         result['update'] = rawDiff['update']['name'];
-        hasResult = true;
     }
 
-    return hasResult ? result : null;
+    return result;
 }
 
 function normalizeUpdateObject(updateObject) {

--- a/corehq/apps/app_manager/tests/test_exceptions.py
+++ b/corehq/apps/app_manager/tests/test_exceptions.py
@@ -1,7 +1,7 @@
 from django.test import SimpleTestCase
 from corehq.apps.app_manager.exceptions import (
     DiffConflictException,
-    MissingPropertyException,
+    MissingPropertyMapException,
     InvalidPropertyException
 )
 
@@ -16,22 +16,32 @@ class InvalidPropertyExceptionTests(SimpleTestCase):
 class DiffConflictExceptionTests(SimpleTestCase):
     def test_with_specified_conflicts(self):
         exception = DiffConflictException('a', 'b', 'c')
-        self.assertEqual(list(exception.conflicting_keys), ['a', 'b', 'c'])
-        self.assertEqual(str(exception), 'The following keys were affected by multiple actions: a, b, c')
+        self.assertEqual(list(exception.conflicting_mappings), ['a', 'b', 'c'])
+        self.assertEqual(str(exception), 'The following mappings were affected by multiple actions: a, b, c')
 
     def test_with_nothing_specified(self):
         exception = DiffConflictException()
-        self.assertEqual(list(exception.conflicting_keys), [])
-        self.assertEqual(str(exception), "No conflicting keys specified")
+        self.assertEqual(list(exception.conflicting_mappings), [])
+        self.assertEqual(str(exception), "No conflicting mappings specified")
 
 
-class MissingPropertyExceptionTests(SimpleTestCase):
+class MissingPropertyMapExceptionTests(SimpleTestCase):
     def test_with_specified_properties(self):
-        exception = MissingPropertyException('a', 'b', 'c')
-        self.assertEqual(list(exception.missing_properties), ['a', 'b', 'c'])
-        self.assertEqual(str(exception), 'The following properties were not found: a, b, c')
+        exception = MissingPropertyMapException(
+            {'case_property': 'one', 'question_path': 'question_one'},
+            {'case_property': 'one', 'question_path': 'question_two'},
+            {'case_property': 'two', 'question_path': 'question_three'}
+        )
+        self.assertEqual(list(exception.missing_mappings), [
+            {'case_property': 'one', 'question_path': 'question_one'},
+            {'case_property': 'one', 'question_path': 'question_two'},
+            {'case_property': 'two', 'question_path': 'question_three'}
+        ])
+        self.assertEqual(str(exception),
+                         "The following mappings were not found: "
+                         "one->question_one, one->question_two, two->question_three")
 
     def test_with_nothing_specified(self):
-        exception = MissingPropertyException()
-        self.assertEqual(list(exception.missing_properties), [])
-        self.assertEqual(str(exception), "No missing properties specified")
+        exception = MissingPropertyMapException()
+        self.assertEqual(list(exception.missing_mappings), [])
+        self.assertEqual(str(exception), "Missing properties were not found")

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -177,8 +177,9 @@ class UpdateCaseActionTests(SimpleTestCase):
             }
         })
 
-        action.make_multi()
+        changed = action.make_multi()
 
+        self.assertFalse(changed)
         multi_paths = {k: [action.question_path for action in v] for (k, v) in action.update_multi.items()}
         self.assertEqual(multi_paths, {'two': ['/one/', '/two/']})
 
@@ -193,8 +194,9 @@ class UpdateCaseActionTests(SimpleTestCase):
             }
         })
 
-        action.make_multi()
+        changed = action.make_multi()
 
+        self.assertFalse(changed)
         multi_paths = {k: [action.question_path for action in v] for (k, v) in action.update_multi.items()}
         self.assertEqual(multi_paths, {'two': ['/one/', '/two/']})
 
@@ -206,8 +208,9 @@ class UpdateCaseActionTests(SimpleTestCase):
             }
         })
 
-        action.make_multi()
+        changed = action.make_multi()
 
+        self.assertTrue(changed)
         multi_paths = {k: [action.question_path for action in v] for (k, v) in action.update_multi.items()}
         self.assertEqual(multi_paths, {'one': ['/one/'], 'two': ['/two/']})
         self.assertEqual(action.update, {})
@@ -222,8 +225,9 @@ class UpdateCaseActionTests(SimpleTestCase):
             }
         })
 
-        action.normalize_update()
+        applied = action.normalize_update()
 
+        self.assertFalse(applied)
         self.assertEqual(action.update, {})
 
     def test_normalize_update_moves_update_multi_to_update(self):
@@ -234,10 +238,11 @@ class UpdateCaseActionTests(SimpleTestCase):
             }
         })
 
-        action.normalize_update()
+        applied = action.normalize_update()
 
         update_paths = {k: v.question_path for (k, v) in action.update.items()}
 
+        self.assertTrue(applied)
         self.assertEqual(update_paths, {'one': '/one/', 'two': '/two/'})
         self.assertIsNone(action.update_multi)
 

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -375,6 +375,24 @@ class UpdateCaseActionTests(SimpleTestCase):
         self.assertEqual(action.update['one'].question_path, '/two/')
         self.assertEqual(action.update_multi, None)
 
+    def test_get_property_names_returns_keys_from_update(self):
+        action = UpdateCaseAction({
+            'update': {
+                'one': {'question_path': '/two/'}
+            }
+        })
+
+        self.assertEqual(action.get_property_names(), {'one'})
+
+    def test_get_property_names_returns_keys_from_update_multi(self):
+        action = UpdateCaseAction({
+            'update_multi': {
+                'one': [{'question_path': '/two/'}]
+            }
+        })
+
+        self.assertEqual(action.get_property_names(), {'one'})
+
 
 class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
     def test_no_changes(self):
@@ -584,6 +602,15 @@ class FormActionsTests(SimpleTestCase):
     def test_constructor_creates_empty_values(self):
         actions = FormActions()
         self.assertEqual(actions.update_case.update, {})
+
+    def test_all_property_names(self):
+        actions = FormActions()
+        self.assertEqual(actions.all_property_names(), set())
+
+    def test_all_property_names_adds_update_case_names(self):
+        update_case = UpdateCaseAction({'update': {'one': {'question_path': 'two'}}})
+        actions = FormActions(update_case=update_case)
+        self.assertEqual(actions.all_property_names(), {'one'})
 
 
 class FormActions_WithUpdatesTests(SimpleTestCase):

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -4,7 +4,9 @@ from corehq.apps.app_manager.exceptions import (
     DiffConflictException,
     InvalidPropertyException
 )
-from corehq.apps.app_manager.models import FormActions, UpdateCaseAction, OpenCaseAction
+from corehq.apps.app_manager.models import (
+    FormActions, UpdateCaseAction, OpenCaseAction, OpenCaseDiff, UpdateCaseDiff, FormActionsDiff
+)
 
 
 class UpdateableDocumentTests(SimpleTestCase):
@@ -69,7 +71,6 @@ class OpenCaseActionTests(SimpleTestCase):
         multi_paths = [update.question_path for update in action.name_update_multi]
         self.assertEqual(multi_paths, ['name1', 'name2'])
 
-
     def test_make_multi_populates_multi(self):
         action = OpenCaseAction({
             'name_update': {'question_path': 'name'}
@@ -111,7 +112,7 @@ class OpenCaseActionTests(SimpleTestCase):
         action.normalize_name_update()
 
         self.assertEqual(action.name_update.question_path, 'name')
-        self.assertEqual(len(action.name_update_multi), 0)
+        self.assertIsNone(action.name_update_multi)
 
     def test_make_single_does_nothing_when_name_update_multi_is_empty(self):
         action = OpenCaseAction({
@@ -136,14 +137,14 @@ class OpenCaseAction_ApplyUpdates_Tests(SimpleTestCase):
     def test_no_changes(self):
         action = OpenCaseAction({'name_update': {'question_path': 'name'}})
 
-        action.apply_updates({}, {})
+        action.apply_updates({}, OpenCaseDiff({}))
 
         self.assertEqual(action.name_update.question_path, 'name')
 
     def test_name_update(self):
         action = OpenCaseAction({'name_update': {'question_path': 'name'}})
 
-        action.apply_updates({}, {'add': [{'question_path': 'new_name'}]})
+        action.apply_updates({}, OpenCaseDiff({'add': [{'question_path': 'new_name'}]}))
 
         multi_paths = [update.question_path for update in action.name_update_multi]
         self.assertEqual(multi_paths, ['name', 'new_name'])
@@ -152,7 +153,7 @@ class OpenCaseAction_ApplyUpdates_Tests(SimpleTestCase):
         action = OpenCaseAction({'name_update': {'question_path': 'name'}})
 
         update_condition_dict = {'condition': {'type': 'if', 'question': 'name', 'answer': 'bob', 'operator': '='}}
-        action.apply_updates(update_condition_dict, {})
+        action.apply_updates(update_condition_dict, OpenCaseDiff({}))
 
         self.assertEqual(action.condition.type, 'if')
         self.assertEqual(action.condition.question, 'name')
@@ -162,7 +163,7 @@ class OpenCaseAction_ApplyUpdates_Tests(SimpleTestCase):
     def test_can_assign_with_update(self):
         action = OpenCaseAction({'name_update': {'question_path': 'name'}})
 
-        action.apply_updates({'name_update': {'question_path': 'name2'}}, {})
+        action.apply_updates({'name_update': {'question_path': 'name2'}}, OpenCaseDiff({}))
 
         self.assertEqual(action.name_update.question_path, 'name2')
 
@@ -171,19 +172,19 @@ class OpenCaseAction_ApplyUpdates_Tests(SimpleTestCase):
 
         update = {'name_update': {'question_path': 'name2', 'update_mode': 'always'}}
         diff = {'update': [{'question_path': 'name2', 'update_mode': 'edit'}]}
-        action.apply_updates(update, diff)
+        action.apply_updates(update, OpenCaseDiff(diff))
 
         self.assertEqual(action.name_update.update_mode, 'edit')
 
     def test_with_invalid_key_raises_exception(self):
         action = OpenCaseAction({'name_update': {'question_path': 'name'}})
         with self.assertRaises(InvalidPropertyException):
-            action.apply_updates({'invalid_property': {}}, {})
+            action.apply_updates({'invalid_property': {}}, OpenCaseDiff({}))
 
     def test_conflicting_name_addition_is_overwritten(self):
         action = OpenCaseAction({'name_update': {'question_path': 'name', 'update_mode': 'always'}})
 
-        action.apply_updates({}, {'add': [{'question_path': 'name', 'update_mode': 'edit'}]})
+        action.apply_updates({}, OpenCaseDiff({'add': [{'question_path': 'name', 'update_mode': 'edit'}]}))
 
         self.assertEqual(action.name_update.question_path, 'name')
         self.assertEqual(action.name_update.update_mode, 'edit')
@@ -191,21 +192,21 @@ class OpenCaseAction_ApplyUpdates_Tests(SimpleTestCase):
     def test_apply_updates_remove_name(self):
         action = OpenCaseAction({'name_update_multi': [{'question_path': 'name1'}, {'question_path': 'name2'}]})
 
-        action.apply_updates({}, {'del': [{'question_path': 'name1'}]})
+        action.apply_updates({}, OpenCaseDiff({'delete': [{'question_path': 'name1'}]}))
 
         self.assertEqual(action.name_update.question_path, 'name2')
 
     def test_apply_updates_remove_name_does_nothing_when_name_is_absent(self):
         action = OpenCaseAction({'name_update': {'question_path': 'name2'}})
 
-        action.apply_updates({}, {'del': [{'question_path': 'name1'}]})
+        action.apply_updates({}, OpenCaseDiff({'delete': [{'question_path': 'name1'}]}))
 
         self.assertEqual(action.name_update.question_path, 'name2')
 
     def test_apply_updates_update_name(self):
         action = OpenCaseAction({'name_update': {'question_path': 'name'}})
 
-        action.apply_updates({}, {'update': [{'question_path': 'name', 'update_mode': 'edit'}]})
+        action.apply_updates({}, OpenCaseDiff({'update': [{'question_path': 'name', 'update_mode': 'edit'}]}))
 
         self.assertEqual(action.name_update.update_mode, 'edit')
 
@@ -213,7 +214,8 @@ class OpenCaseAction_ApplyUpdates_Tests(SimpleTestCase):
         action = OpenCaseAction({'name_update': {'question_path': 'name'}})
 
         with self.assertRaises(MissingPropertyMapException):
-            action.apply_updates({}, {'update': [{'question_path': 'missing_name', 'update_mode': 'edit'}]})
+            diff = OpenCaseDiff({'update': [{'question_path': 'missing_name', 'update_mode': 'edit'}]})
+            action.apply_updates({}, diff)
 
 
 class UpdateCaseActionTests(SimpleTestCase):
@@ -334,7 +336,7 @@ class UpdateCaseActionTests(SimpleTestCase):
         self.assertEqual(action.update['one'].question_path, '/one/')
         self.assertEqual(action.update_multi, {})
 
-    def test_make_single_takes_the_first_entry_for_conflicting_case_properties(self):
+    def test_make_single_takes_the_last_entry_for_conflicting_case_properties(self):
         action = UpdateCaseAction({
             'update_multi': {
                 'one': [{'question_path': '/one/'}, {'question_path': '/two/'}]
@@ -342,7 +344,7 @@ class UpdateCaseActionTests(SimpleTestCase):
         })
 
         action.make_single()
-        self.assertEqual(action.update['one'].question_path, '/one/')
+        self.assertEqual(action.update['one'].question_path, '/two/')
         self.assertEqual(action.update_multi, None)
 
 
@@ -352,7 +354,7 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
             'one': {'question_path': 'one'}
         }})
 
-        actions.apply_updates({}, {})
+        actions.apply_updates({}, UpdateCaseDiff({}))
 
         self.assertEqual(actions.update['one'].question_path, 'one')
 
@@ -362,9 +364,9 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
             'two': {'question_path': 'two'},
         }})
 
-        actions.apply_updates({}, {
+        actions.apply_updates({}, UpdateCaseDiff({
             'add': {'three': [{'question_path': 'some_path'}]},
-        })
+        }))
 
         self.assertEqual(set(actions.update.keys()), {'one', 'two', 'three'})
 
@@ -373,9 +375,9 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
             'one': {'question_path': 'question1'}
         }})
 
-        actions.apply_updates({}, {
+        actions.apply_updates({}, UpdateCaseDiff({
             'add': {'one': [{'question_path': 'question2'}]}
-        })
+        }))
 
         self.assertEqual(actions.update, {})
         self.assertEqual(set(actions.update_multi.keys()), {'one'})
@@ -387,9 +389,9 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
             'one': {'question_path': 'question1'}
         }})
 
-        actions.apply_updates({}, {
+        actions.apply_updates({}, UpdateCaseDiff({
             'add': {'one': [{'question_path': 'question2'}]}
-        }, allow_conflicts=False)
+        }), allow_conflicts=False)
 
         self.assertEqual(actions.update['one'].question_path, 'question2')
         self.assertIsNone(actions.update_multi)
@@ -399,9 +401,9 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
             'one': [{'question_path': 'question1'}, {'question_path': 'question2'}]
         }})
 
-        actions.apply_updates({}, {
+        actions.apply_updates({}, UpdateCaseDiff({
             'add': {'one': [{'question_path': 'question3'}]}
-        })
+        }))
 
         self.assertEqual(set(actions.update_multi.keys()), {'one'})
         paths = [update.question_path for update in actions.update_multi['one']]
@@ -412,9 +414,9 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
             'one': {'question_path': 'question1'}
         }})
 
-        actions.apply_updates({}, {
+        actions.apply_updates({}, UpdateCaseDiff({
             'add': {'one': [{'question_path': 'question1'}]}
-        })
+        }))
 
         self.assertEqual(set(actions.update.keys()), {'one'})
         self.assertEqual(actions.update['one'].question_path, 'question1')
@@ -424,9 +426,9 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
             'one': {'question_path': 'one', 'update_mode': 'always'},
         }})
 
-        actions.apply_updates({}, {
+        actions.apply_updates({}, UpdateCaseDiff({
             'add': {'one': [{'question_path': 'one', 'update_mode': 'edit'}]},
-        })
+        }))
 
         self.assertEqual(actions.update['one'].update_mode, 'edit')
 
@@ -436,9 +438,9 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
             'two': {'question_path': 'two'},
         }})
 
-        actions.apply_updates({}, {
-            'del': {'one': [{'question_path': 'one'}]},
-        })
+        actions.apply_updates({}, UpdateCaseDiff({
+            'delete': {'one': [{'question_path': 'one'}]},
+        }))
 
         self.assertEqual(set(actions.update.keys()), {'two'})
 
@@ -447,7 +449,7 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
             'one': {'question_path': 'one'},
         }})
 
-        actions.apply_updates({}, {'del': {'one': [{'question_path': 'two'}]}})
+        actions.apply_updates({}, UpdateCaseDiff({'delete': {'one': [{'question_path': 'two'}]}}))
 
         self.assertEqual(actions.update.keys(), {'one'})
         self.assertEqual(actions.update['one'].question_path, 'one')
@@ -457,11 +459,11 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
             'one': {'question_path': 'question_one', 'update_mode': 'always'},
         }})
 
-        actions.apply_updates({}, {
+        actions.apply_updates({}, UpdateCaseDiff({
             'update': {
                 'one': [{'question_path': 'question_one', 'update_mode': 'edit'}],
             }
-        })
+        }))
 
         self.assertEqual(actions.update['one'].update_mode, 'edit')
 
@@ -472,9 +474,9 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
         }})
 
         with self.assertRaises(MissingPropertyMapException):
-            actions.apply_updates({}, {
+            actions.apply_updates({}, UpdateCaseDiff({
                 'update': {'two': [{'question_path': 'question_two', 'update_mode': 'edit'}]}
-            })
+            }))
 
     def test_updating_a_missing_question_raises_error(self):
         # If the specific mapping was deleted by a different session, updating it shouldn't restore it
@@ -483,22 +485,22 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
         }})
 
         with self.assertRaises(MissingPropertyMapException):
-            actions.apply_updates({}, {
+            actions.apply_updates({}, UpdateCaseDiff({
                 'update': {
                     'one': [{'question_path': 'question_two', 'update_mode': 'edit'}]
                 }
-            })
+            }))
 
     def test_missing_property_exception_contains_all_missing_properties(self):
         actions = UpdateCaseAction({'update': {}})
 
         with self.assertRaises(MissingPropertyMapException) as context:
-            actions.apply_updates({}, {
+            actions.apply_updates({}, UpdateCaseDiff({
                 'update': {
                     'one': [{'question_path': 'question_one', 'update_mode': 'always'}],
                     'two': [{'question_path': 'question_two', 'update_mode': 'edit'}],
                 }
-            })
+            }))
 
         self.assertEqual(list(context.exception.missing_mappings), [
             {'case_property': 'one', 'question_path': 'question_one'},
@@ -512,24 +514,24 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
         }})
 
         with self.assertRaises(DiffConflictException):
-            actions.apply_updates({}, {
+            actions.apply_updates({}, UpdateCaseDiff({
                 'update': {'two': [{'question_path': 'question_two', 'update_mode': 'always'}]},
-                'del': {'two': [{'question_path': 'question_two'}]}
-            })
+                'delete': {'two': [{'question_path': 'question_two'}]}
+            }))
 
     def test_updates_no_diffs(self):
         actions = UpdateCaseAction({'update': {
             'one': {'question_path': 'one'}
         }})
 
-        actions.apply_updates({'update': {'one': {'question_path': 'two'}}}, {})
+        actions.apply_updates({'update': {'one': {'question_path': 'two'}}}, UpdateCaseDiff({}))
 
         self.assertEqual(actions.update['one'].question_path, 'two')
 
     def test_updates_condition(self):
         actions = UpdateCaseAction()
 
-        actions.apply_updates({'condition': {'type': 'never'}}, {})
+        actions.apply_updates({'condition': {'type': 'never'}}, UpdateCaseDiff({}))
         self.assertEqual(actions.condition.type, 'never')
 
     def test_diffs_override_updates(self):
@@ -540,11 +542,11 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
         updates = {
             'update': {'one': {'question_path': 'one', 'update_mode': 'always'}}
         }
-        diffs = {
+        diffs = UpdateCaseDiff({
             'update': {
                 'one': [{'question_path': 'one', 'update_mode': 'edit'}]
             }
-        }
+        })
         actions.apply_updates(updates, diffs)
 
         self.assertEqual(actions.update['one'].update_mode, 'edit')
@@ -570,7 +572,7 @@ class FormActions_WithUpdatesTests(SimpleTestCase):
             }
         })
 
-        result = actions.with_updates({}, {})
+        result = actions.with_updates({}, FormActionsDiff({}))
 
         self.assertEqual(result['open_case']['name_update']['question_path'], 'name')
         self.assertEqual(list(result['update_case']['update'].keys()), ['one', 'two'])
@@ -581,7 +583,7 @@ class FormActions_WithUpdatesTests(SimpleTestCase):
 
         close_case_update = {'close_case': {'condition': {'type': 'never'}}}
 
-        result = actions.with_updates(close_case_update, {})
+        result = actions.with_updates(close_case_update, FormActionsDiff({}))
 
         self.assertEqual(result.close_case.condition.type, 'never')
 
@@ -598,20 +600,99 @@ class FormActions_WithUpdatesTests(SimpleTestCase):
             }
         })
 
-        result = actions.with_updates({}, {
+        result = actions.with_updates({}, FormActionsDiff({
             'open_case': {
                 'add': [{'question_path': 'new_name'}],
-                'del': [{'question_path': 'form_name'}],
+                'delete': [{'question_path': 'form_name'}],
             },
             'update_case': {
                 'add': {'three': [{'question_path': 'three'}]},
-                'del': {'one': [{'question_path': 'one'}]},
+                'delete': {'one': [{'question_path': 'one'}]},
                 'update': {
                     'two': [{'question_path': 'two', 'update_mode': 'edit'}]
                 }
             }
-        })
+        }))
 
         self.assertEqual(result.open_case.name_update.question_path, 'new_name')
         self.assertEqual(set(result.update_case.update.keys()), {'two', 'three'})
         self.assertEqual(result.update_case.update['two'].update_mode, 'edit')
+
+
+class OpenCaseDiffTests(SimpleTestCase):
+    def test_construction_with_all_values(self):
+        diff = OpenCaseDiff({
+            'add': [{'question_path': 'one'}, {'question_path': 'two'}],
+            'delete': [{'question_path': 'three'}, {'question_path': 'four'}],
+            'update': [{'question_path': 'five', 'update_mode': 'edit'}]
+        })
+
+        add_questions = [question.question_path for question in diff.add]
+        delete_questions = [question.question_path for question in diff.delete]
+        assert add_questions == ['one', 'two']
+        assert delete_questions == ['three', 'four']
+        assert diff.update[0].update_mode == 'edit'
+
+    def test_convert_to_update_diff(self):
+        diff = OpenCaseDiff({
+            'add': [{'question_path': 'one'}],
+            'delete': [{'question_path': 'two'}],
+            'update': [{'question_path': 'three', 'update_mode': 'edit'}]
+        })
+
+        update_diff = diff.convert_to_update_diff()
+
+        assert [question.question_path for question in update_diff.add['name_update_multi']] == ['one']
+        assert [question.question_path for question in update_diff.delete['name_update_multi']] == ['two']
+        assert update_diff.update['name_update_multi'][0].update_mode == 'edit'
+
+    def test_convert_to_update_diff_only_includes_populated_values(self):
+        diff = OpenCaseDiff({
+            'delete': [{'question_path': 'one'}]
+        })
+
+        update_diff = diff.convert_to_update_diff()
+
+        assert [question.question_path for question in update_diff.delete['name_update_multi']] == ['one']
+        assert update_diff.add == {}
+        assert update_diff.update == {}
+
+
+class UpdateCaseDiffTests(SimpleTestCase):
+    def test_construction_with_all_values(self):
+        diff = UpdateCaseDiff({
+            'add': {
+                'case_one': [{'question_path': 'one'}],
+                'case_two': [{'question_path': 'two'}]
+            },
+            'delete': {
+                'case_three': [{'question_path': 'three'}, {'question_path': 'four'}]
+            },
+            'update': {
+                'case_four': [{'question_path': 'five', 'update_mode': 'edit'}]
+            }
+        })
+
+        assert diff.add['case_one'][0].question_path == 'one'
+        assert diff.add['case_two'][0].question_path == 'two'
+
+        assert [question.question_path for question in diff.delete['case_three']] == ['three', 'four']
+
+        assert diff.update['case_four'][0].update_mode == 'edit'
+
+
+class FormActionsDiffTests(SimpleTestCase):
+    def test_json_construction(self):
+        diff = FormActionsDiff({
+            'open_case': {
+                'add': [{'question_path': 'one'}]
+            },
+            'update_case': {
+                'delete': {
+                    'case_two': [{'question_path': 'two'}]
+                }
+            }
+        })
+
+        assert diff.open_case.add[0].question_path == 'one'
+        assert diff.update_case.delete['case_two'][0].question_path == 'two'

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -188,21 +188,19 @@ class OpenCaseAction_ApplyUpdates_Tests(SimpleTestCase):
         self.assertEqual(action.condition.answer, 'bob')
         self.assertEqual(action.condition.operator, '=')
 
-    def test_can_assign_with_update(self):
+    def test_ignores_direct_name_update(self):
         action = OpenCaseAction({'name_update': {'question_path': 'name'}})
 
         action.apply_updates({'name_update': {'question_path': 'name2'}}, OpenCaseDiff({}))
 
-        self.assertEqual(action.name_update.question_path, 'name2')
+        self.assertEqual(action.name_update.question_path, 'name')
 
-    def test_diffs_override_updates(self):
-        action = OpenCaseAction({'name_update': {'question_path': 'name'}})
+    def test_ignores_direct_name_update_multi(self):
+        action = OpenCaseAction({'name_update': {'question_name': 'name'}})
 
-        update = {'name_update': {'question_path': 'name2', 'update_mode': 'always'}}
-        diff = {'update': [{'question_path': 'name2', 'update_mode': 'edit'}]}
-        action.apply_updates(update, OpenCaseDiff(diff))
+        action.apply_updates({'name_update_multi': [{'question_path': 'name2'}]}, OpenCaseDiff({}))
 
-        self.assertEqual(action.name_update.update_mode, 'edit')
+        self.assertEqual(action.name_update_multi, [])
 
     def test_with_invalid_key_raises_exception(self):
         action = OpenCaseAction({'name_update': {'question_path': 'name'}})
@@ -565,14 +563,23 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
                 'delete': {'two': [{'question_path': 'question_two'}]}
             }))
 
-    def test_updates_no_diffs(self):
+    def test_ignores_direct_updates(self):
         actions = UpdateCaseAction({'update': {
             'one': {'question_path': 'one'}
         }})
 
         actions.apply_updates({'update': {'one': {'question_path': 'two'}}}, UpdateCaseDiff({}))
 
-        self.assertEqual(actions.update['one'].question_path, 'two')
+        self.assertEqual(actions.update['one'].question_path, 'one')
+
+    def test_ignores_direct_update_multi(self):
+        actions = UpdateCaseAction({'update': {
+            'one': {'question_path': 'one'}
+        }})
+
+        actions.apply_updates({'update_multi': {'one': {'question_path': 'two'}}}, UpdateCaseDiff({}))
+
+        self.assertEqual(actions.update_multi, {})
 
     def test_updates_condition(self):
         actions = UpdateCaseAction()

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -112,7 +112,7 @@ class OpenCaseActionTests(SimpleTestCase):
         action.normalize_name_update()
 
         self.assertEqual(action.name_update.question_path, 'name')
-        self.assertIsNone(action.name_update_multi)
+        self.assertEqual(action.name_update_multi, [])
 
     def test_make_single_does_nothing_when_name_update_multi_is_empty(self):
         action = OpenCaseAction({
@@ -130,7 +130,7 @@ class OpenCaseActionTests(SimpleTestCase):
 
         action.make_single()
         self.assertEqual(action.name_update.question_path, 'name2')
-        self.assertEqual(action.name_update_multi, None)
+        self.assertEqual(action.name_update_multi, [])
 
     def test_has_name_update_returns_true_with_name_update(self):
         action = OpenCaseAction({
@@ -339,7 +339,7 @@ class UpdateCaseActionTests(SimpleTestCase):
 
         self.assertTrue(applied)
         self.assertEqual(update_paths, {'one': '/one/', 'two': '/two/'})
-        self.assertIsNone(action.update_multi)
+        self.assertEqual(action.update_multi, {})
 
     def test_normalize_update_removes_empty_keys(self):
         action = UpdateCaseAction({
@@ -351,7 +351,7 @@ class UpdateCaseActionTests(SimpleTestCase):
         action.normalize_update()
 
         self.assertNotIn('one', action.update)
-        self.assertIsNone(action.update_multi)
+        self.assertEqual(action.update_multi, {})
 
     def test_make_single_does_nothing_when_update_multi_is_empty(self):
         action = UpdateCaseAction({
@@ -373,7 +373,7 @@ class UpdateCaseActionTests(SimpleTestCase):
 
         action.make_single()
         self.assertEqual(action.update['one'].question_path, '/two/')
-        self.assertEqual(action.update_multi, None)
+        self.assertEqual(action.update_multi, {})
 
     def test_get_property_names_returns_keys_from_update(self):
         action = UpdateCaseAction({
@@ -440,7 +440,7 @@ class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):
         }), allow_conflicts=False)
 
         self.assertEqual(actions.update['one'].question_path, 'question2')
-        self.assertIsNone(actions.update_multi)
+        self.assertEqual(actions.update_multi, {})
 
     def test_add_value_with_existing_conflict(self):
         actions = UpdateCaseAction({'update_multi': {

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -231,7 +231,8 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
     form = app.get_form(form_unique_id)
     old_load_from_form = form.actions.load_from_form
 
-    form.actions = _get_updates(form.actions, request.POST)
+    allow_conflicts = toggles.FORMBUILDER_SAVE_TO_CASE.enabled_for_request(request)
+    form.actions = _get_updates(form.actions, request.POST, allow_conflicts)
 
     if old_load_from_form:
         form.actions.load_from_form = old_load_from_form
@@ -251,10 +252,10 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
     return json_response(response_json)
 
 
-def _get_updates(existing_actions, data):
+def _get_updates(existing_actions, data, allow_conflicts):
     updates = json.loads(data['actions'])
     update_diff = json.loads(data['update_diff']) if 'update_diff' in data else {}
-    return existing_actions.with_updates(updates, update_diff)
+    return existing_actions.with_updates(updates, update_diff, allow_conflicts)
 
 
 @waf_allow('XSS_BODY')

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -72,6 +72,7 @@ from corehq.apps.app_manager.models import (
     IncompatibleFormTypeException,
     OpenCaseAction,
     UpdateCaseAction,
+    FormActionsDiff,
 )
 from corehq.apps.app_manager.templatetags.xforms_extras import (
     clean_trans,
@@ -254,7 +255,7 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
 
 def _get_updates(existing_actions, data, allow_conflicts):
     updates = json.loads(data['actions'])
-    update_diff = json.loads(data['update_diff']) if 'update_diff' in data else {}
+    update_diff = FormActionsDiff(json.loads(data['update_diff']) if 'update_diff' in data else {})
     return existing_actions.with_updates(updates, update_diff, allow_conflicts)
 
 
@@ -875,6 +876,8 @@ def get_form_view_context(
                 'schedule_options': schedule_options,
             })
     else:
+        # TODO: figure out a cleaner method
+        form.actions.make_multi()
         context.update({
             'show_custom_ref': toggles.APP_BUILDER_CUSTOM_PARENT_REF.enabled_for_request(request),
         })

--- a/corehq/apps/hqwebapp/tests/utils/test_translation.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_translation.py
@@ -1,36 +1,11 @@
-from contextlib import ContextDecorator
-from unittest.mock import patch
 from django.test import SimpleTestCase
+from corehq.apps.translations.tests.utils import custom_translations, CUSTOM_LANGUAGE
 
 from django.utils import translation
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext, gettext_lazy
-from django.utils.translation.trans_real import translation as get_translations
 
 from ...utils.translation import format_html_lazy
-
-CUSTOM_LANGUAGE = 'custom'
-
-
-class custom_translations(ContextDecorator):
-    """
-    A decorator/context manager to provide runtime translations for the 'custom' language
-    """
-    def __init__(self, translation_mapping):
-        self.translation_mapping = translation_mapping
-
-    def __enter__(self):
-        translations = get_translations(CUSTOM_LANGUAGE)
-        old_gettext = translations.gettext
-
-        def lookup(id):
-            return self.translation_mapping.get(id) or old_gettext(id)
-
-        self.patcher = patch.object(translations, 'gettext', lookup)
-        self.patcher.start()
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.patcher.stop()
 
 
 class TestCustomTranslationsDecorator(SimpleTestCase):

--- a/corehq/apps/translations/tests/utils.py
+++ b/corehq/apps/translations/tests/utils.py
@@ -1,0 +1,33 @@
+from contextlib import ContextDecorator
+from unittest.mock import patch
+
+from django.utils.translation.trans_real import translation as get_translations
+
+CUSTOM_LANGUAGE = 'custom'
+
+
+class custom_translations(ContextDecorator):
+    """
+    A decorator/context manager to provide runtime translations for the 'custom' language.
+    Decorate your method with something like:
+    @custom_translations({'original': 'translated'})
+
+    and then within the test you can use:
+    with translation.override(CUSTOM_LANGUAGE):
+       gettext('original')
+    """
+    def __init__(self, translation_mapping):
+        self.translation_mapping = translation_mapping
+
+    def __enter__(self):
+        translations = get_translations(CUSTOM_LANGUAGE)
+        old_gettext = translations.gettext
+
+        def lookup(id):
+            return self.translation_mapping.get(id) or old_gettext(id)
+
+        self.patcher = patch.object(translations, 'gettext', lookup)
+        self.patcher.start()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.patcher.stop()

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1183,7 +1183,7 @@ FORMBUILDER_SAVE_TO_CASE = StaticToggle(
     'saas_formbuilder_save_to_case',
     'Form Builder - Save Questions to Case Properties',
     TAG_PRODUCT,
-    namespaces=[NAMESPACE_USER],
+    namespaces=[NAMESPACE_DOMAIN],
     description='Allows users to save questions to case properties within the Form Builder'
 )
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
This modifies how our `FormActions` work so that, when the `FORMBUILDER_SAVE_TO_CASE` flag is enabled, multiple questions can be saved to the same case property. There are still some rough edges here, such as the case property page displaying these multiple questions sorted by the question name, rather than the case property name, making it difficult to find the conflicting questions. However, because the intention is that these conflicts should be rare, I believe this workflow is good enough to merge, and we can work on polishing these pain points later.

## Feature Flag
This does involve the `FORMBUILDER_SAVE_TO_CASE` flag

## Safety Assurance

### Safety story
Tested locally that I could still save case property mappings through the case management page. Also tested what would happen if I submitted changes after the case properties had already changed (and thus triggering a conflict). Tested with an without the feature flag. Did brief testing around UserCaseProperties, verified that I could still build an application, and verified that I could view the App Summary. It's difficult to know if this is comprehensive.

### Automated test coverage

Many new tests added/updated in app_manager/test_models

### QA Plan

I intend to schedule this to go through to QA, to give us better confidence that these changes aren't affecting areas I didn't anticipate

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
