### PR TITLE
Fix edge case in conflicting dates

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1343,7 +1343,7 @@ class Subscription(models.Model):
         ):
             if is_date_range_overlapping(date_start, date_end, sub.date_start, sub.date_end):
                 raise SubscriptionAdjustmentError(
-                    "The start date and end date of the new subscription "
+                    "The start date and/or end date of the new subscription "
                     f"conflicts with the subscription dates to {sub}."
                 )
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -65,6 +65,7 @@ from corehq.apps.accounting.utils import (
     get_dimagi_from_email,
     get_privileges,
     is_active_subscription,
+    is_date_range_overlapping,
     log_accounting_error,
     log_accounting_info,
     quantize_accounting_decimal,
@@ -1340,30 +1341,7 @@ class Subscription(models.Model):
         ).exclude(
             id=self.id,
         ):
-            related_has_no_end = sub.date_end is None
-            current_has_no_end = date_end is None
-            start_before_related_end = sub.date_end is not None and date_start < sub.date_end
-            start_before_related_start = date_start < sub.date_start
-            start_after_related_start = date_start > sub.date_start
-            end_before_related_end = (
-                date_end is not None and sub.date_end is not None
-                and date_end < sub.date_end
-            )
-            end_after_related_end = (
-                date_end is not None and sub.date_end is not None
-                and date_end > sub.date_end
-            )
-            end_after_related_start = date_end is not None and date_end > sub.date_start
-
-            if (
-                (start_before_related_end and start_after_related_start)
-                or (start_after_related_start and related_has_no_end)
-                or (end_after_related_start and end_before_related_end)
-                or (end_after_related_start and related_has_no_end)
-                or (start_before_related_start and end_after_related_end)
-                or (start_before_related_end and current_has_no_end)
-                or (current_has_no_end and related_has_no_end)
-            ):
+            if is_date_range_overlapping(date_start, date_end, sub.date_start, sub.date_end):
                 raise SubscriptionAdjustmentError(
                     "The start date of %(start_date)s conflicts with the "
                     "subscription dates to %(related_sub)s." % {

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1343,11 +1343,8 @@ class Subscription(models.Model):
         ):
             if is_date_range_overlapping(date_start, date_end, sub.date_start, sub.date_end):
                 raise SubscriptionAdjustmentError(
-                    "The start date of %(start_date)s conflicts with the "
-                    "subscription dates to %(related_sub)s." % {
-                        'start_date': self.date_start.strftime(USER_DATE_FORMAT),
-                        'related_sub': sub,
-                    }
+                    "The start date and end date of the new subscription "
+                    f"conflicts with the subscription dates to {sub}."
                 )
 
     def update_subscription(self, date_start, date_end,

--- a/corehq/apps/accounting/tests/test_utils.py
+++ b/corehq/apps/accounting/tests/test_utils.py
@@ -7,66 +7,66 @@ from corehq.apps.accounting.utils import is_date_range_overlapping
 
 class TestIsDateRangeOverlapping(SimpleTestCase):
     def test_first_range_is_contained_in_second_range(self):
-        self.assertTrue(is_date_range_overlapping(date(2025, 1, 3), date(2025, 1, 6),
-                                                  date(2025, 1, 1), date(2025, 1, 10)))
+        assert is_date_range_overlapping(date(2025, 1, 3), date(2025, 1, 6),
+                                         date(2025, 1, 1), date(2025, 1, 10))
 
     def test_second_range_is_contained_in_first_range(self):
-        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
-                                                  date(2025, 1, 5), date(2025, 1, 7)))
+        assert is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                         date(2025, 1, 5), date(2025, 1, 7))
 
     def test_partial_overlap_start(self):
-        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
-                                                  date(2024, 12, 20), date(2025, 1, 2)))
+        assert is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                         date(2024, 12, 20), date(2025, 1, 2))
 
     def test_partial_overlap_end(self):
-        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
-                                                  date(2025, 1, 9), date(2025, 1, 20)))
+        assert is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                         date(2025, 1, 9), date(2025, 1, 20))
 
     def test_exact_overlap(self):
-        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
-                                                  date(2025, 1, 1), date(2025, 1, 10)))
+        assert is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                         date(2025, 1, 1), date(2025, 1, 10))
 
     def test_no_overlap_before(self):
-        self.assertFalse(is_date_range_overlapping(date(2025, 1, 10), date(2025, 1, 20),
-                                                   date(2025, 1, 1), date(2025, 1, 9)))
+        assert not is_date_range_overlapping(date(2025, 1, 10), date(2025, 1, 20),
+                                             date(2025, 1, 1), date(2025, 1, 9))
 
     def test_no_overlap_after(self):
-        self.assertFalse(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 9),
-                                                   date(2025, 1, 10), date(2025, 1, 20)))
+        assert not is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 9),
+                                             date(2025, 1, 10), date(2025, 1, 20))
 
     def test_adjacent_ranges_do_not_overlap(self):
         # Two ranges that touch at a boundary is not considered an overlap.
         # This is a special case for our accounting system
-        self.assertFalse(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
-                                                   date(2025, 1, 10), date(2025, 1, 20)))
+        assert not is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                             date(2025, 1, 10), date(2025, 1, 20))
 
-        self.assertFalse(is_date_range_overlapping(date(2025, 1, 10), date(2025, 1, 20),
-                                                   date(2025, 1, 1), date(2025, 1, 10)))
+        assert not is_date_range_overlapping(date(2025, 1, 10), date(2025, 1, 20),
+                                             date(2025, 1, 1), date(2025, 1, 10))
 
     def test_same_start_date_is_overlap(self):
-        self.assertTrue(is_date_range_overlapping(date(2025, 1, 5), date(2025, 1, 10),
-                                                  date(2025, 1, 5), date(2025, 1, 15)))
+        assert is_date_range_overlapping(date(2025, 1, 5), date(2025, 1, 10),
+                                         date(2025, 1, 5), date(2025, 1, 15))
 
     def test_same_end_date_is_overlap(self):
-        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
-                                                  date(2025, 1, 5), date(2025, 1, 10)))
+        assert is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                         date(2025, 1, 5), date(2025, 1, 10))
 
     def test_first_range_infinite_end(self):
-        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), None,
-                                                  date(2025, 1, 10), date(2025, 1, 20)))
+        assert is_date_range_overlapping(date(2025, 1, 1), None,
+                                         date(2025, 1, 10), date(2025, 1, 20))
 
     def test_second_range_infinite_end(self):
-        self.assertTrue(is_date_range_overlapping(date(2025, 1, 10), date(2025, 1, 20),
-                                                  date(2025, 1, 1), None))
+        assert is_date_range_overlapping(date(2025, 1, 10), date(2025, 1, 20),
+                                         date(2025, 1, 1), None)
 
     def test_both_ranges_infinite_end(self):
-        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), None,
-                                                  date(2025, 2, 1), None))
+        assert is_date_range_overlapping(date(2025, 1, 1), None,
+                                         date(2025, 2, 1), None)
 
     def test_first_range_infinite_end_but_start_after_second_range_end(self):
-        self.assertFalse(is_date_range_overlapping(date(2025, 1, 1), None,
-                                                   date(2024, 1, 1), date(2024, 12, 31)))
+        assert not is_date_range_overlapping(date(2025, 1, 1), None,
+                                             date(2024, 1, 1), date(2024, 12, 31))
 
     def test_second_range_infinite_end_but_start_after_first_range_end(self):
-        self.assertFalse(is_date_range_overlapping(date(2024, 1, 1), date(2024, 12, 31),
-                                                   date(2025, 1, 1), None))
+        assert not is_date_range_overlapping(date(2024, 1, 1), date(2024, 12, 31),
+                                             date(2025, 1, 1), None)

--- a/corehq/apps/accounting/tests/test_utils.py
+++ b/corehq/apps/accounting/tests/test_utils.py
@@ -1,0 +1,72 @@
+from datetime import date
+
+from django.test import SimpleTestCase
+
+from corehq.apps.accounting.utils import is_date_range_overlapping
+
+
+class TestIsDateRangeOverlapping(SimpleTestCase):
+    def test_first_range_is_contained_in_second_range(self):
+        self.assertTrue(is_date_range_overlapping(date(2025, 1, 3), date(2025, 1, 6),
+                                                  date(2025, 1, 1), date(2025, 1, 10)))
+
+    def test_second_range_is_contained_in_first_range(self):
+        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                                  date(2025, 1, 5), date(2025, 1, 7)))
+
+    def test_partial_overlap_start(self):
+        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                                  date(2024, 12, 20), date(2025, 1, 2)))
+
+    def test_partial_overlap_end(self):
+        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                                  date(2025, 1, 9), date(2025, 1, 20)))
+
+    def test_exact_overlap(self):
+        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                                  date(2025, 1, 1), date(2025, 1, 10)))
+
+    def test_no_overlap_before(self):
+        self.assertFalse(is_date_range_overlapping(date(2025, 1, 10), date(2025, 1, 20),
+                                                   date(2025, 1, 1), date(2025, 1, 9)))
+
+    def test_no_overlap_after(self):
+        self.assertFalse(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 9),
+                                                   date(2025, 1, 10), date(2025, 1, 20)))
+
+    def test_adjacent_ranges_do_not_overlap(self):
+        # Two ranges that touch at a boundary is not considered an overlap.
+        # This is a special case for our accounting system
+        self.assertFalse(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                                   date(2025, 1, 10), date(2025, 1, 20)))
+
+        self.assertFalse(is_date_range_overlapping(date(2025, 1, 10), date(2025, 1, 20),
+                                                   date(2025, 1, 1), date(2025, 1, 10)))
+
+    def test_same_start_date_is_overlap(self):
+        self.assertTrue(is_date_range_overlapping(date(2025, 1, 5), date(2025, 1, 10),
+                                                  date(2025, 1, 5), date(2025, 1, 15)))
+
+    def test_same_end_date_is_overlap(self):
+        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), date(2025, 1, 10),
+                                                  date(2025, 1, 5), date(2025, 1, 10)))
+
+    def test_first_range_infinite_end(self):
+        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), None,
+                                                  date(2025, 1, 10), date(2025, 1, 20)))
+
+    def test_second_range_infinite_end(self):
+        self.assertTrue(is_date_range_overlapping(date(2025, 1, 10), date(2025, 1, 20),
+                                                  date(2025, 1, 1), None))
+
+    def test_both_ranges_infinite_end(self):
+        self.assertTrue(is_date_range_overlapping(date(2025, 1, 1), None,
+                                                  date(2025, 2, 1), None))
+
+    def test_first_range_infinite_end_but_start_after_second_range_end(self):
+        self.assertFalse(is_date_range_overlapping(date(2025, 1, 1), None,
+                                                   date(2024, 1, 1), date(2024, 12, 31)))
+
+    def test_second_range_infinite_end_but_start_after_first_range_end(self):
+        self.assertFalse(is_date_range_overlapping(date(2024, 1, 1), date(2024, 12, 31),
+                                                   date(2025, 1, 1), None))

--- a/corehq/apps/accounting/utils/__init__.py
+++ b/corehq/apps/accounting/utils/__init__.py
@@ -510,3 +510,32 @@ def count_form_submitting_mobile_workers(domain, start, end):
 def self_signup_workflow_in_progress(domain):
     from corehq.apps.registration.models import SelfSignupWorkflow
     return SelfSignupWorkflow.get_in_progress_for_domain(domain)
+
+
+def is_date_range_overlapping(start_1, end_1, start_2, end_2):
+    range_2_has_no_end = end_2 is None
+    range_1_has_no_end = end_1 is None
+    start_1_before_end_2 = end_2 is not None and start_1 < end_2
+    start_1_before_start_2 = start_1 < start_2
+    start_1_after_start_2 = start_1 > start_2
+    end_1_before_end_2 = (
+        end_1 is not None and end_2 is not None
+        and end_1 < end_2
+    )
+    end_1_after_end_2 = (
+        end_1 is not None and end_2 is not None
+        and end_1 > end_2
+    )
+    end_1_after_start_2 = end_1 is not None and end_1 > start_2
+
+    if (
+        (start_1_before_end_2 and start_1_after_start_2)
+        or (start_1_after_start_2 and range_2_has_no_end)
+        or (end_1_after_start_2 and end_1_before_end_2)
+        or (end_1_after_start_2 and range_2_has_no_end)
+        or (start_1_before_start_2 and end_1_after_end_2)
+        or (start_1_before_end_2 and range_1_has_no_end)
+        or (range_1_has_no_end and range_2_has_no_end)
+    ):
+        return True
+    return False

--- a/corehq/apps/accounting/utils/__init__.py
+++ b/corehq/apps/accounting/utils/__init__.py
@@ -513,29 +513,8 @@ def self_signup_workflow_in_progress(domain):
 
 
 def is_date_range_overlapping(start_1, end_1, start_2, end_2):
-    range_2_has_no_end = end_2 is None
-    range_1_has_no_end = end_1 is None
-    start_1_before_end_2 = end_2 is not None and start_1 < end_2
-    start_1_before_start_2 = start_1 < start_2
-    start_1_after_start_2 = start_1 > start_2
-    end_1_before_end_2 = (
-        end_1 is not None and end_2 is not None
-        and end_1 < end_2
-    )
-    end_1_after_end_2 = (
-        end_1 is not None and end_2 is not None
-        and end_1 > end_2
-    )
-    end_1_after_start_2 = end_1 is not None and end_1 > start_2
-
-    if (
-        (start_1_before_end_2 and start_1_after_start_2)
-        or (start_1_after_start_2 and range_2_has_no_end)
-        or (end_1_after_start_2 and end_1_before_end_2)
-        or (end_1_after_start_2 and range_2_has_no_end)
-        or (start_1_before_start_2 and end_1_after_end_2)
-        or (start_1_before_end_2 and range_1_has_no_end)
-        or (range_1_has_no_end and range_2_has_no_end)
-    ):
-        return True
-    return False
+    if end_1 is None:
+        end_1 = datetime.date.max
+    if end_2 is None:
+        end_2 = datetime.date.max
+    return start_1 < end_2 and start_2 < end_1


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
`raise_conflicting_dates` is missing one edge case: if the two date range sharing the same end date, which allows two subscription with same end date to be created. This PR will fix it.

Also updated the error message since both start date and end date can cause conflict:
<img width="1280" height="90" alt="image" src="https://github.com/user-attachments/assets/d4fb9700-baac-44ae-98a5-6a18e6db36f4" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-16847

Add a utility function `is_date_range_overlapping(start_1, end_1, start_2, end_2)` so it can be tested. Then simplify the existing logic, just treats each date range as a half-open interval [start, end), and do a interval overlap check.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Unit test added in corehq.apps.accounting.tests.test_utils

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
