### PR TITLE
Update Mobile Worker creation and edit API docs

### DIFF
--- a/docs/api/mobile-worker.rst
+++ b/docs/api/mobile-worker.rst
@@ -72,11 +72,11 @@ Request & Response Details
      - A list of location_ids that the mobile worker will be assigned to.
      - ["26fc44e2792b4f2fa8ef86178f0a958e", "c1b029932ed442a6a846a4ea10e46a78"]
    * - require_account_confirmation
-     - If True, creates an unconfirmed account (similar to a deactivated account).
-     - True or False
+     - If True, creates an unconfirmed account (similar to a deactivated account). False by default.
+     - True
    * - send_confirmation_email_now
-     - If True, immediately sends an account confirmation email*.
-     - True or False
+     - If True, immediately sends an account confirmation email*. False by default.
+     - True
 
 \* To send a confirmation email, the following must be true:
     - 'password' should be excluded from the input
@@ -219,8 +219,8 @@ Request & Response Details
      - A list of location_ids that the mobile worker will be assigned to. To remove all assigned locations, pass an empty array.
      - ["26fc44e2792b4f2fa8ef86178f0a958e", "c1b029932ed442a6a846a4ea10e46a78"]
    * - send_confirmation_email_now
-     - If True and the user is an unconfirmed account, immediately sends an account confirmation email.
-     - True or False
+     - If True and the user is an unconfirmed account, immediately sends an account confirmation email. False by default.
+     - True
 
 **Sample Input**
 

--- a/docs/api/mobile-worker.rst
+++ b/docs/api/mobile-worker.rst
@@ -71,7 +71,17 @@ Request & Response Details
    * - locations
      - A list of location_ids that the mobile worker will be assigned to.
      - ["26fc44e2792b4f2fa8ef86178f0a958e", "c1b029932ed442a6a846a4ea10e46a78"]
+   * - require_account_confirmation
+     - If True, creates an unconfirmed account (similar to a deactivated account).
+     - True or False
+   * - send_confirmation_email_now
+     - If True, immediately sends an account confirmation email*.
+     - True or False
 
+\* To send a confirmation email, the following must be true:
+    - 'password' should be excluded from the input
+    - 'email' should be included in the input
+    - 'require_account_confirmation' must be True
 
 **Output Parameters**
 
@@ -107,6 +117,24 @@ Request & Response Details
        ],
        "primary_location": "26fc44e2792b4f2fa8ef86178f0a958e", 
        "locations": ["26fc44e2792b4f2fa8ef86178f0a958e", "c1b029932ed442a6a846a4ea10e46a78"],
+       "user_data": {
+          "chw_id": "13/43/DFA"
+       }
+    }
+
+**Sample Input - Unconfirmed User (JSON Format)**
+
+.. code-block:: json
+
+    {
+       "username": "jdoe",
+       "first_name": "John",
+       "last_name": "Doe",
+       "email": "jdoe@example.org",
+       "primary_location": "26fc44e2792b4f2fa8ef86178f0a958e",
+       "locations": ["26fc44e2792b4f2fa8ef86178f0a958e", "c1b029932ed442a6a846a4ea10e46a78"],
+       "require_account_confirmation": "True",
+       "send_confirmation_email_now": "True",
        "user_data": {
           "chw_id": "13/43/DFA"
        }
@@ -190,6 +218,9 @@ Request & Response Details
    * - locations
      - A list of location_ids that the mobile worker will be assigned to. To remove all assigned locations, pass an empty array.
      - ["26fc44e2792b4f2fa8ef86178f0a958e", "c1b029932ed442a6a846a4ea10e46a78"]
+   * - send_confirmation_email_now
+     - If True and the user is an unconfirmed account, immediately sends an account confirmation email.
+     - True or False
 
 **Sample Input**
 
@@ -211,6 +242,7 @@ Request & Response Details
        ],
        "primary_location": "26fc44e2792b4f2fa8ef86178f0a958e", 
        "locations": ["26fc44e2792b4f2fa8ef86178f0a958e", "c1b029932ed442a6a846a4ea10e46a78"],
+       "send_confirmation_email_now": "True",
        "user_data": {
           "chw_id": "13/43/DFA"
        }


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

Updating [Mobile Worker API docs](https://commcare-hq.readthedocs.io/api/mobile-worker.html#user-edit-mobile-worker) as a result of [this PR](https://github.com/dimagi/commcare-hq/pull/36675).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
Technically currently [TWO_STAGE_USER_PROVISIONING](https://staging.commcarehq.org/hq/flags/edit/two_stage_user_provisioning/) but these docs are meant to go out after this feature has been GA'd (very soon) - DO NOT MERGE UNTIL THEN. 

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

This is only a docs update

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
