### PR TITLE
Migration to sync couch and es CommCareUsers

### DIFF
--- a/corehq/ex-submodules/pillowtop/management/commands/sync_es_users.py
+++ b/corehq/ex-submodules/pillowtop/management/commands/sync_es_users.py
@@ -1,3 +1,5 @@
+import os
+
 from django.core.management.base import BaseCommand
 from elasticsearch6.exceptions import NotFoundError
 
@@ -13,6 +15,8 @@ from corehq.util.log import with_progress_bar
 class Command(BaseCommand):
     help = "Sync users in Elasticsearch with Couchdb (WebUser or CommCareUser)"
 
+    SYNC_ES_USERS_PROGRESS_FILENAME = 'sync_es_users_processed_doc_ids.txt'
+
     def add_arguments(self, parser):
         parser.add_argument(
             '--doc_types',
@@ -25,10 +29,30 @@ class Command(BaseCommand):
         doc_type = options['doc_types']
         user_docs = get_all_docs_with_doc_types(db=CouchUser.get_db(), doc_types=[doc_type])
         doc_count = get_doc_count_by_type(CouchUser.get_db(), doc_type)
-        for user_doc in with_progress_bar(user_docs, doc_count):
-            try:
-                update_user_in_es(None, CouchUser.wrap_correctly(user_doc))
-            except NotFoundError as e:
-                self.stdout.write(self.style.WARNING(
-                    f"User not found in Elasticsearch: {user_doc.get('_id')} - {str(e)}"
-                ))
+
+        processed_ids = set()
+        processed_count = 0
+        try:
+            with open(self.SYNC_ES_USERS_PROGRESS_FILENAME, 'r') as f:
+                for line in f:
+                    processed_ids.add(line.strip())
+        except FileNotFoundError:
+            pass
+
+        with open(self.SYNC_ES_USERS_PROGRESS_FILENAME, 'a') as f:
+            for user_doc in with_progress_bar(user_docs, doc_count):
+                user_id = user_doc.get('_id')
+                if user_id in processed_ids:
+                    continue
+                try:
+                    update_user_in_es(None, CouchUser.wrap_correctly(user_doc))
+                    f.write(user_id + '\n')
+                    processed_count += 1
+                    if processed_count % 100 == 0:
+                        f.flush()
+                except NotFoundError as e:
+                    self.stdout.write(self.style.WARNING(
+                        f"User not found in Elasticsearch: {user_doc.get('_id')} - {str(e)}"
+                    ))
+            f.flush()
+        os.remove(self.SYNC_ES_USERS_PROGRESS_FILENAME)

--- a/corehq/ex-submodules/pillowtop/management/commands/sync_es_users.py
+++ b/corehq/ex-submodules/pillowtop/management/commands/sync_es_users.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.signals import update_user_in_es
+from elasticsearch6.exceptions import NotFoundError
 
 
 class Command(BaseCommand):
@@ -20,4 +21,9 @@ class Command(BaseCommand):
         user_docs = get_all_docs_with_doc_types(db=CouchUser.get_db(), doc_types=[doc_type])
 
         for user_doc in user_docs:
-            update_user_in_es(None, CouchUser.wrap_correctly(user_doc))
+            try:
+                update_user_in_es(None, CouchUser.wrap_correctly(user_doc))
+            except NotFoundError as e:
+                self.stdout.write(self.style.WARNING(
+                    f"User not found in Elasticsearch: {user_doc.get('_id')} - {str(e)}"
+                ))

--- a/corehq/ex-submodules/pillowtop/migrations/0009_sync_es_with_couch_commcareusers.py
+++ b/corehq/ex-submodules/pillowtop/migrations/0009_sync_es_with_couch_commcareusers.py
@@ -5,7 +5,7 @@ from corehq.util.django_migrations import skip_on_fresh_install
 
 @skip_on_fresh_install
 def sync_couch_commcareusers_with_es(*args, **kwargs):
-    call_command('sync_es_users', doc_types='CommCareUser')
+    call_command('sync_es_users', doc_types='CommCareUser', progress_key='0009_commcareusers_migration')
 
 
 class Migration(migrations.Migration):

--- a/corehq/ex-submodules/pillowtop/migrations/0009_sync_es_with_couch_commcareusers.py
+++ b/corehq/ex-submodules/pillowtop/migrations/0009_sync_es_with_couch_commcareusers.py
@@ -4,16 +4,16 @@ from corehq.util.django_migrations import skip_on_fresh_install
 
 
 @skip_on_fresh_install
-def sync_couch_webusers_with_es(*args, **kwargs):
-    call_command('sync_es_users', doc_types='WebUser')
+def sync_couch_commcareusers_with_es(*args, **kwargs):
+    call_command('sync_es_users', doc_types='CommCareUser')
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('pillowtop', '0007_copy_xforms_checkpoint'),
+        ('pillowtop', '0008_sync_es_with_couch_webusers'),
     ]
 
     operations = [
-        migrations.RunPython(sync_couch_webusers_with_es)
+        migrations.RunPython(sync_couch_commcareusers_with_es)
     ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -847,6 +847,7 @@ pillowtop
  0006_add_geopoint_to_case_search_index
  0007_copy_xforms_checkpoint
  0008_sync_es_with_couch_webusers
+ 0009_sync_es_with_couch_commcareusers
 preindex
  0001_initial
  0002_initial


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user facing effects

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This is a followup to https://github.com/dimagi/commcare-hq/pull/36732. That PR added `is_account_confirmed` field to ES mapping. This field already previously existed in couch user docs. As such, this field will need to be synced and populated into ES.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This syncs couch data to ES and uses a management command that has historically been used.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [X] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
