### PR TITLE
Set the domain_membership's is_active to True along with the user lev…

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2004,6 +2004,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             raise IllegalAccountConfirmation('Account is already confirmed')
         assert not self.is_active, 'Active account should not be unconfirmed!'
         self.is_active = True
+        self.get_domain_membership(self.domain).is_active = True
         self.is_account_confirmed = True
         self.set_password(password)
         self.self_set_password = True


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

This PR follows the discovery recently that mobile workers have been setting their `domain_membership.is_active` value to False if they are initially created with their `is_account_confirmed` value as False. This caused a host of issues to surface after refactoring the is_active and is_inactive UserES filters, including this issue where newly confirmed mobile workers couldn't login to commcare because they're now considered inactive. This PR fixes that value on account confirmation.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

I can't think of another instance outside of two stage user provisioning workflows where we'd create mobile workers as in_active from the start so I think this fix should cover that. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

[TWO_STAGE_USER_PROVISIONING](https://staging.commcarehq.org/hq/flags/edit/two_stage_user_provisioning/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging - fix verified by QA 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

[QA ticket](https://dimagi.atlassian.net/browse/QA-7946)

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
