### PR TITLE
Missing message banners

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
@@ -145,7 +145,7 @@
         {% if messages %}
           {% for message in messages %}
             <div
-              class="alert alert-margin-top fade in{% if message.tags %}{{ message.tags }}{% endif %}"
+              class="alert alert-margin-top fade in {% if message.tags %}{{ message.tags }}{% endif %}"
             >
               <a class="close" data-dismiss="alert" href="#">&times;</a>
               {% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
@@ -128,7 +128,7 @@
         {% if messages %}
           {% for message in messages %}
             <div
-              class="alert alert-dismissible alert-margin-top fade show{% if message.tags %}{{ message.tags }}{% endif %}"
+              class="alert alert-dismissible alert-margin-top fade show {% if message.tags %}{{ message.tags }}{% endif %}"
             >
               {% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}
               <button

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
@@ -174,8 +174,8 @@
          {% if messages %}
            {% for message in messages %}
              <div
--              class="alert alert-margin-top fade in{% if message.tags %}{{ message.tags }}{% endif %}"
-+              class="alert alert-dismissible alert-margin-top fade show{% if message.tags %}{{ message.tags }}{% endif %}"
+-              class="alert alert-margin-top fade in {% if message.tags %}{{ message.tags }}{% endif %}"
++              class="alert alert-dismissible alert-margin-top fade show {% if message.tags %}{{ message.tags }}{% endif %}"
              >
 -              <a class="close" data-dismiss="alert" href="#">&times;</a>
                {% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Success/error banners have disappeared! This brings them back. 

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

Bug from [this PR](https://github.com/dimagi/commcare-hq/pull/36733) made while pretty-fying, which omitted an important space between the classes that made the success/error banners invisible (but still there and clickable). This just adds the space back in. 


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging. Just a small template fix. 

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
