### PR TITLE
Simple migration to assigns edit permissions for all toggle tags to superusers to maintain consistency with the current behavior.

### DIFF
--- a/corehq/toggles/migrations/0002_assign_permissions_superusers.py
+++ b/corehq/toggles/migrations/0002_assign_permissions_superusers.py
@@ -1,0 +1,41 @@
+from django.contrib.auth.models import User
+from django.db import migrations
+
+from corehq.toggles import ALL_TAGS
+from corehq.toggles.sql_models import ToggleEditPermission
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+# This migration assigns edit permissions for all toggle tags to superusers to maintain consistency
+# with the current behavior.
+
+@skip_on_fresh_install
+def _assign_all_toggle_edit_permissions_to_superusers(apps, schema_editor):
+    superusers = User.objects.filter(is_superuser=True).values_list('username', flat=True)
+    for tag in ALL_TAGS:
+        toggle_permission = ToggleEditPermission.get_by_tag_slug(tag.slug)
+        if not toggle_permission:
+            toggle_permission = ToggleEditPermission(tag_slug=tag.slug)
+        toggle_permission.add_users(list(superusers))
+
+
+def _reverse(apps, schema_editor):
+    superusers = User.objects.filter(is_superuser=True).values_list('username', flat=True)
+    for tag in ALL_TAGS:
+        toggle_permission = ToggleEditPermission.get_by_tag_slug(tag.slug)
+        if toggle_permission:
+            toggle_permission.remove_users(list(superusers))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('toggles', '0001_toggle_edit_permission'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _assign_all_toggle_edit_permissions_to_superusers,
+            reverse_code=_reverse,
+        ),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -1210,6 +1210,7 @@ toggle_ui
  0002_toggleaudit
 toggles
  0001_toggle_edit_permission
+ 0002_assign_permissions_superusers
 translations
  0001_initial
  0002_transifexblacklist


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Simple migration to assigns edit permissions for all toggle tags to superusers to maintain consistency with the current behavior.


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

Builts on top of this [PR](https://github.com/dimagi/commcare-hq/pull/36233)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local. To be tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
