### PR TITLE
GA Split Screen Case Search

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -27,13 +27,17 @@ from django.utils.functional import cached_property
 
 from corehq import toggles
 from corehq.apps.app_manager import id_strings
-from corehq.apps.app_manager.suite_xml.contributors import (
-    PostProcessor,
+from corehq.apps.app_manager.suite_xml.contributors import PostProcessor
+from corehq.apps.app_manager.suite_xml.post_process.endpoints import (
+    EndpointsHelper,
 )
-from corehq.apps.app_manager.suite_xml.post_process.endpoints import EndpointsHelper
-from corehq.apps.app_manager.suite_xml.post_process.workflow import WorkflowDatumMeta
+from corehq.apps.app_manager.suite_xml.post_process.workflow import (
+    WorkflowDatumMeta,
+)
 from corehq.apps.app_manager.suite_xml.sections.details import DetailsHelper
-from corehq.apps.app_manager.suite_xml.utils import get_ordered_case_types_for_module
+from corehq.apps.app_manager.suite_xml.utils import (
+    get_ordered_case_types_for_module,
+)
 from corehq.apps.app_manager.suite_xml.xml_models import (
     CalculatedPropertyXPath,
     Command,
@@ -60,29 +64,32 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
 )
 from corehq.apps.app_manager.util import (
     is_linked_app,
-    module_offers_search,
-    module_uses_smart_links,
     module_offers_registry_search,
-    module_uses_inline_search,
+    module_offers_search,
     module_uses_include_all_related_cases,
+    module_uses_inline_search,
     module_uses_inline_search_with_parent_relationship_parent_select,
+    module_uses_smart_links,
 )
 from corehq.apps.app_manager.xpath import (
     CaseClaimXpath,
     CaseIDXPath,
-    SearchSelectedCasesInstanceXpath,
     CaseTypeXpath,
     InstanceXpath,
+    SearchSelectedCasesInstanceXpath,
+    XPath,
     interpolate_xpath,
     session_var,
-    XPath,
 )
-from corehq.apps.case_search.const import COMMCARE_PROJECT, EXCLUDE_RELATED_CASES_FILTER
+from corehq.apps.case_search.const import (
+    COMMCARE_PROJECT,
+    EXCLUDE_RELATED_CASES_FILTER,
+)
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY,
-    CASE_SEARCH_REGISTRY_ID_KEY,
     CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY,
+    CASE_SEARCH_REGISTRY_ID_KEY,
     CASE_SEARCH_SORT_KEY,
     CASE_SEARCH_XPATH_QUERY_KEY,
 )

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -92,6 +92,7 @@ from corehq.apps.case_search.models import (
     CASE_SEARCH_REGISTRY_ID_KEY,
     CASE_SEARCH_SORT_KEY,
     CASE_SEARCH_XPATH_QUERY_KEY,
+    split_screen_ui_enabled_for_domain,
 )
 from corehq.util.timer import time_method
 from corehq.util.view_utils import absolute_reverse
@@ -226,9 +227,15 @@ class RemoteRequestFactory(object):
             "default_search": self.module.search_config.default_search,
             "dynamic_search": self.app.split_screen_dynamic_search and not self.module.is_auto_select()
         }
-        if self.module.search_config.search_on_clear and toggles.SPLIT_SCREEN_CASE_SEARCH.enabled(self.app.domain):
-            kwargs["search_on_clear"] = (self.module.search_config.search_on_clear
-                and not self.module.is_auto_select())
+
+        if (
+            self.module.search_config.search_on_clear
+            and split_screen_ui_enabled_for_domain(self.app.domain)
+        ):
+            kwargs["search_on_clear"] = (
+                self.module.search_config.search_on_clear
+                and not self.module.is_auto_select()
+            )
         return [
             RemoteRequestQuery(**kwargs)
         ]

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -41,14 +41,28 @@ from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.const import RETURN_TO
 from corehq.apps.app_manager.exceptions import SuiteValidationError
 from corehq.apps.app_manager.id_strings import callout_header_locale
-from corehq.apps.app_manager.suite_xml.const import FIELD_TYPE_LEDGER
-from corehq.apps.app_manager.suite_xml.contributors import SectionContributor
-from corehq.apps.app_manager.suite_xml.features.case_tiles import CaseTileHelper
-from corehq.apps.app_manager.suite_xml.features.scheduler import (
-    schedule_detail_variables,
+from corehq.apps.app_manager.util import (
+    create_temp_sort_column,
+    get_sort_and_sort_only_columns,
+    module_loads_registry_case,
+    module_offers_search,
+    module_uses_inline_search,
 )
-from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
-from corehq.apps.app_manager.suite_xml.xml_models import (
+from corehq.apps.app_manager.xpath import (
+    CaseTypeXpath,
+    CaseXPath,
+    XPath,
+    interpolate_xpath,
+    session_var,
+)
+from corehq.util.timer import time_method
+
+from ..const import FIELD_TYPE_LEDGER
+from ..contributors import SectionContributor
+from ..features.case_tiles import CaseTileHelper
+from ..features.scheduler import schedule_detail_variables
+from ..sections.entries import EntriesHelper
+from ..xml_models import (
     Action,
     Detail,
     DetailVariable,
@@ -70,15 +84,6 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     TextXPath,
     XPathVariable,
 )
-from corehq.apps.app_manager.util import (
-    create_temp_sort_column,
-    get_sort_and_sort_only_columns,
-    module_loads_registry_case,
-    module_offers_search,
-    module_uses_inline_search,
-)
-from corehq.apps.app_manager.xpath import CaseXPath, CaseTypeXpath, XPath, interpolate_xpath, session_var
-from corehq.util.timer import time_method
 
 AUTO_LAUNCH_EXPRESSIONS = {
     "single-select": "$next_input = '' or count(instance('casedb')/casedb/case[@case_id=$next_input]) = 0",
@@ -319,7 +324,10 @@ class DetailContributor(SectionContributor):
 
     @staticmethod
     def add_register_action(app, module, actions, build_profile_id, entries_helper):
-        from corehq.apps.app_manager.views.modules import get_parent_select_followup_forms
+        from corehq.apps.app_manager.views.modules import (
+            get_parent_select_followup_forms,
+        )
+
         form = app.get_form(module.case_list_form.form_id)
         if toggles.FOLLOWUP_FORMS_AS_CASE_LIST_FORM.enabled(app.domain):
             valid_forms = [f.unique_id for f in get_parent_select_followup_forms(app, module)]
@@ -513,9 +521,8 @@ class DetailContributor(SectionContributor):
 
     @staticmethod
     def _get_report_context_tile_detail():
-        from corehq.apps.app_manager.suite_xml.features.mobile_ucr import (
-            MOBILE_UCR_TILE_DETAIL_ID,
-        )
+        from ..features.mobile_ucr import MOBILE_UCR_TILE_DETAIL_ID
+
         return Detail(
             id=MOBILE_UCR_TILE_DETAIL_ID,
             title=Text(),

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -55,6 +55,7 @@ from corehq.apps.app_manager.xpath import (
     interpolate_xpath,
     session_var,
 )
+from corehq.apps.case_search.models import split_screen_ui_enabled_for_domain
 from corehq.util.timer import time_method
 
 from ..const import FIELD_TYPE_LEDGER
@@ -407,7 +408,7 @@ class DetailContributor(SectionContributor):
         in_search = module_loads_registry_case(module) or "search" in detail_id
 
         # don't add search again action in split screen
-        if in_search and toggles.SPLIT_SCREEN_CASE_SEARCH.enabled(module.get_app().domain):
+        if in_search and split_screen_ui_enabled_for_domain(module.get_app().domain):
             return None
 
         action_kwargs = DetailContributor._get_action_kwargs(module, in_search)

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -242,7 +242,7 @@
               {% include "app_manager/partials/nav_menu_media.html" with qualifier='case_search-search_label_media_' ICON_LABEL="Search Icon" AUDIO_LABEL="Search Audio" %}
             <!-- /ko -->
           </div>
-            {% if not request|toggle_enabled:'SPLIT_SCREEN_CASE_SEARCH' %}
+            {% if not split_screen_case_search %}
             <div class="form-group" data-bind="hidden: inlineSearchActive">
               <label for="search_again_label" class="{% css_label_class %} control-label">
                 {% trans "Label for Searching Again" %}
@@ -489,7 +489,7 @@
             </div>
           </div>
           {% endif %}
-          {% if request|toggle_enabled:'SPLIT_SCREEN_CASE_SEARCH' and not app.split_screen_dynamic_search%}
+          {% if split_screen_case_search and not app.split_screen_dynamic_search %}
           <div class="form-group">
             <label class="control-label {% css_label_class %}">
               {% trans "Clearing search terms resets search results" %}

--- a/corehq/apps/app_manager/tests/test_advanced_suite.py
+++ b/corehq/apps/app_manager/tests/test_advanced_suite.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import SimpleTestCase
 
 from corehq.apps.app_manager.const import (
@@ -363,6 +365,7 @@ class AdvancedSuiteTest(SimpleTestCase, SuiteMixin):
             "./entry[2]"
         )
 
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
     def test_advanced_module_remote_request(self, *args):
         factory = AppFactory(domain='domain', build_version='2.53.0')
         factory.app._id = "123"

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import SimpleTestCase
 
 from corehq import privileges
@@ -39,7 +41,11 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
     def test_3_tiered_select(self, *args):
         self._test_generic_suite('tiered-select-3', 'tiered-select-3')
 
-    def test_case_search_action(self):
+    @patch(
+        'corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain',
+        return_value=False,
+    )
+    def test_case_search_action(self, *args):
         app = Application.wrap(self.get_json('suite-advanced'))
         app.modules[0].search_config = CaseSearch(
             search_label=CaseSearchLabel(
@@ -278,6 +284,7 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
             "entry[1]/instance"
         )
 
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
     def test_sync_cases_on_form_entry_disabled(self, *args):
         factory = AppFactory()
         module, form = factory.new_basic_module('m0', 'case1')
@@ -292,6 +299,7 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
         self.assertXmlDoesNotHaveXpath(factory.app.create_suite(), "./entry/post")
 
     @case_search_sync_cases_on_form_entry_enabled_for_domain()
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
     def test_sync_cases_on_form_entry_enabled(self, *args):
         factory = AppFactory()
         module, form = factory.new_basic_module('m0', 'case1')

--- a/corehq/apps/app_manager/tests/test_suite_case_tiles.py
+++ b/corehq/apps/app_manager/tests/test_suite_case_tiles.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import SimpleTestCase
 
 from corehq.apps.app_manager.exceptions import SuiteValidationError
@@ -468,6 +470,10 @@ class SuiteCaseTilesTest(SimpleTestCase, SuiteMixin):
         )
 
     @flag_enabled("USH_CASE_CLAIM_UPDATES")
+    @patch(
+        'corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain',
+        return_value=False,
+    )
     def test_case_tile_with_case_search(self, *args):
         app = Application.new_app('domain', 'Untitled Application')
 

--- a/corehq/apps/app_manager/tests/test_suite_instances.py
+++ b/corehq/apps/app_manager/tests/test_suite_instances.py
@@ -176,7 +176,8 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
             "entry/instance"
         )
 
-    def test_search_input_instance_remote_request(self):
+    @mock.patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    def test_search_input_instance_remote_request(self, *args):
         self.form.requires = 'case'
         self.module.case_type = 'case'
 
@@ -221,10 +222,12 @@ class SuiteInstanceTests(SimpleTestCase, SuiteMixin):
             "entry[2]/instance"
         )
 
-    def test_search_prompt_itemset_instance(self):
+    @mock.patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    def test_search_prompt_itemset_instance(self, *args):
         self._test_search_prompt_itemset_instance(self.module)
 
-    def test_shadow_module_search_prompt_itemset_instance(self):
+    @mock.patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    def test_shadow_module_search_prompt_itemset_instance(self, *args):
         shadow_module = self.factory.app.add_module(ShadowModule.new_module("shadow", "en"))
         shadow_module.source_module_id = self.module.get_or_create_unique_id()
         self._test_search_prompt_itemset_instance(shadow_module)

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -61,7 +61,8 @@ class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
         )
         self.module.assign_references()
 
-    def test_multi_select_case_list(self):
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    def test_multi_select_case_list(self, *args):
         suite = self.factory.app.create_suite()
         self.assertXmlPartialEqual(
             """
@@ -94,7 +95,8 @@ class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
             "./remote-request",
         )
 
-    def test_multi_select_case_list_auto_select_true(self):
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    def test_multi_select_case_list_auto_select_true(self, *args):
         self.module.case_details.short.auto_select = True
         suite = self.factory.app.create_suite()
         self.assertXmlPartialEqual(
@@ -124,7 +126,8 @@ class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
             "./entry",
         )
 
-    def test_multi_select_case_list_modified_max_select_value(self):
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    def test_multi_select_case_list_modified_max_select_value(self, *args):
         self.module.case_details.short.max_select_value = 15
         print(self.module.case_details.short)
         suite = self.factory.app.create_suite()
@@ -171,7 +174,11 @@ class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
         del self.factory.app.modules[shadow_module.id]
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
-    def test_multi_select_case_list_auto_launch(self):
+    @patch(
+        'corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain',
+        return_value=False,
+    )
+    def test_multi_select_case_list_auto_launch(self, *args):
         self.module.search_config.auto_launch = True
         suite = self.factory.app.create_suite()
 
@@ -517,7 +524,11 @@ class MultiSelectChildModuleDatumIDTests(SimpleTestCase, SuiteMixin):
     @patch(
         "corehq.apps.app_manager.suite_xml.sections.entries."
         "case_search_sync_cases_on_form_entry_enabled_for_domain")
-    def test_multi_select_as_child_with_parent_select_case_search(self, mock1):
+    @patch(
+        'corehq.apps.app_manager.suite_xml.sections.details.'
+        'split_screen_ui_enabled_for_domain'
+    )
+    def test_multi_select_as_child_with_parent_select_case_search(self, *args):
         # parent select from parent module to child (seems weird)
         self.set_parent_select(self.m2, self.m4)
 

--- a/corehq/apps/app_manager/tests/test_suite_registry_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_registry_search.py
@@ -42,6 +42,10 @@ DOMAIN = 'test_domain'
 
 @patch_get_xform_resource_overrides()
 @patch.object(Application, 'supports_data_registry', lambda: True)
+@patch(
+    'corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain',
+    return_value=False,
+)
 class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
     file_path = ('data', 'suite_registry')
 
@@ -208,7 +212,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             self.app.create_suite(),
             './detail[@id="m0_case_long"]')
 
-    def test_form_linking_to_registry_module_from_registration_form(self):
+    def test_form_linking_to_registry_module_from_registration_form(self, *args):
         self.module.search_config.additional_case_types = ["other_case"]
         suite = self.app.create_suite()
         expected = f"""
@@ -238,7 +242,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             "./entry[2]/stack/create"
         )
 
-    def test_workflow_registry_module_previous_screen_after_case_list_form(self):
+    def test_workflow_registry_module_previous_screen_after_case_list_form(self, *args):
         factory = AppFactory(DOMAIN, "App with DR", build_version='2.53.0')
         m0, f0 = factory.new_basic_module("new case", "case")
         factory.form_opens_case(f0, "case")
@@ -294,7 +298,7 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         )
 
     @flag_enabled('MOBILE_UCR')
-    def test_prompt_itemset_mobile_report(self):
+    def test_prompt_itemset_mobile_report(self, *args):
         self.module.search_config.properties[0].input_ = 'select1'
         instance_id = "commcare-reports:123abc"
         self.module.search_config.properties[0].itemset = Itemset(
@@ -407,6 +411,7 @@ class RegistrySuiteShadowModuleTest(SimpleTestCase, SuiteMixin):
         self.shadow_module = self.app.modules[1]
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
     def test_suite(self, *args):
         suite = self.app.create_suite()
         self.assertXmlPartialEqual(
@@ -421,6 +426,7 @@ class RegistrySuiteShadowModuleTest(SimpleTestCase, SuiteMixin):
         )
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
     def test_additional_types(self, *args):
         another_case_type = "another_case_type"
         self.module.search_config.additional_case_types = [another_case_type]
@@ -480,7 +486,8 @@ class RemoteRequestSuiteFormLinkChildModuleTest(SimpleTestCase, SuiteMixin):
         # wrap to have assign_references called
         self.app = Application.wrap(factory.app.to_json())
 
-    def test_form_link_in_child_module_with_registry_search(self):
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    def test_form_link_in_child_module_with_registry_search(self, *args):
         suite = self.app.create_suite()
 
         expected = f"""

--- a/corehq/apps/app_manager/tests/test_suite_sorting.py
+++ b/corehq/apps/app_manager/tests/test_suite_sorting.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import SimpleTestCase
 
 from corehq import privileges
@@ -47,6 +49,10 @@ class SuiteSortingTest(SimpleTestCase, SuiteMixin):
             "./detail[@id='m0_case_short']"
         )
 
+    @patch(
+        'corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain',
+        return_value=False,
+    )
     def test_sort_cache_search(self, *args):
         app = Application.wrap(self.get_json('suite-advanced'))
         app.modules[0].search_config = CaseSearch(

--- a/corehq/apps/app_manager/tests/test_suite_split_screen_case_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_split_screen_case_search.py
@@ -17,7 +17,7 @@ from corehq.util.test_utils import flag_enabled
 class SplitScreenCaseSearchTest(SimpleTestCase, SuiteMixin):
 
     @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
-    def test_split_screen_case_search_removes_search_again(self, __):
+    def test_split_screen_case_search_removes_search_again(self, *args):
         factory = AppFactory.case_claim_app_factory()
         suite = factory.app.create_suite()
         # case list actions unaffected

--- a/corehq/apps/app_manager/tests/test_suite_split_screen_case_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_split_screen_case_search.py
@@ -16,8 +16,8 @@ from corehq.util.test_utils import flag_enabled
 @patch_get_xform_resource_overrides()
 class SplitScreenCaseSearchTest(SimpleTestCase, SuiteMixin):
 
-    @flag_enabled('SPLIT_SCREEN_CASE_SEARCH')
-    def test_split_screen_case_search_removes_search_again(self):
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    def test_split_screen_case_search_removes_search_again(self, __):
         factory = AppFactory.case_claim_app_factory()
         suite = factory.app.create_suite()
         # case list actions unaffected
@@ -65,31 +65,35 @@ class DynamicSearchSuiteTest(SimpleTestCase, SuiteMixin):
         self.app = Application.wrap(self.app.to_json())
         self.module = self.app.modules[0]
 
-    @flag_enabled('SPLIT_SCREEN_CASE_SEARCH')
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    @patch('corehq.apps.app_manager.suite_xml.post_process.remote_requests.split_screen_ui_enabled_for_domain')
     @flag_enabled('DYNAMICALLY_UPDATE_SEARCH_RESULTS')
-    def test_dynamic_search_suite(self):
+    def test_dynamic_search_suite(self, *args):
         suite = self.app.create_suite()
         suite = parse_normalize(suite, to_string=False)
         self.assertEqual("true", suite.xpath("./remote-request[1]/session/query/@dynamic_search")[0])
 
     @patch('corehq.apps.app_manager.models.ModuleBase.is_auto_select', return_value=True)
-    @flag_enabled('SPLIT_SCREEN_CASE_SEARCH')
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    @patch('corehq.apps.app_manager.suite_xml.post_process.remote_requests.split_screen_ui_enabled_for_domain')
     @flag_enabled('DYNAMICALLY_UPDATE_SEARCH_RESULTS')
-    def test_dynamic_search_suite_disable_with_auto_select(self, mock):
+    def test_dynamic_search_suite_disable_with_auto_select(self, *args):
         suite = self.app.create_suite()
         suite = parse_normalize(suite, to_string=False)
         self.assertEqual(True, self.module.is_auto_select())
         self.assertEqual("false", suite.xpath("./remote-request[1]/session/query/@dynamic_search")[0])
 
-    @flag_enabled('SPLIT_SCREEN_CASE_SEARCH')
-    def test_search_on_clear(self):
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    @patch('corehq.apps.app_manager.suite_xml.post_process.remote_requests.split_screen_ui_enabled_for_domain')
+    def test_search_on_clear(self, *args):
         suite = self.app.create_suite()
         suite = parse_normalize(suite, to_string=False)
         self.assertEqual("true", suite.xpath("./remote-request[1]/session/query/@search_on_clear")[0])
 
     @patch('corehq.apps.app_manager.models.ModuleBase.is_auto_select', return_value=True)
-    @flag_enabled('SPLIT_SCREEN_CASE_SEARCH')
-    def test_search_on_clear_disable_with_auto_select(self, mock):
+    @patch('corehq.apps.app_manager.suite_xml.sections.details.split_screen_ui_enabled_for_domain')
+    @patch('corehq.apps.app_manager.suite_xml.post_process.remote_requests.split_screen_ui_enabled_for_domain')
+    def test_search_on_clear_disable_with_auto_select(self, *args):
         suite = self.app.create_suite()
         suite = parse_normalize(suite, to_string=False)
         self.assertEqual(True, self.module.is_auto_select())

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -716,7 +716,7 @@ class TestViewGeneric(ViewsBase):
         'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'EULA_COMPLIANCE', 'sentry',
         'case_list_form_not_allowed_reasons', 'child_module_enabled', 'block', 'IS_ANALYTICS_ENVIRONMENT',
         'formats_supporting_case_list_optimizations', 'module_type', 'icon_class', 'form_submit_history_url',
-        'btn_style',
+        'btn_style', 'split_screen_case_search',
     }
 
     expected_keys_form = {

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -106,7 +106,10 @@ from corehq.apps.app_manager.views.utils import (
 )
 from corehq.apps.app_manager.xform import CaseError
 from corehq.apps.app_manager.xpath_validator import validate_xpath
-from corehq.apps.case_search.models import case_search_enabled_for_domain
+from corehq.apps.case_search.models import (
+    case_search_enabled_for_domain,
+    split_screen_ui_enabled_for_domain,
+)
 from corehq.apps.domain.decorators import (
     LoginAndDomainMixin,
     track_domain_request,
@@ -159,6 +162,7 @@ def get_module_view_context(request, app, module, lang=None):
             and has_privilege(request, privileges.CLOUDCARE)
             and toggles.USH_CASE_CLAIM_UPDATES.enabled(app.domain)
         ),
+        'split_screen_case_search': split_screen_ui_enabled_for_domain(app.domain),
         'custom_assertions': [
             {'test': assertion.test, 'text': assertion.text.get(lang)}
             for assertion in module.custom_assertions

--- a/corehq/apps/case_search/migrations/0017_casesearchconfig_split_screen_ui.py
+++ b/corehq/apps/case_search/migrations/0017_casesearchconfig_split_screen_ui.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+from corehq.toggles import StaticToggle
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def populate_split_screen_ui(apps, schema_editor):
+    CaseSearchConfig = apps.get_model('case_search', 'CaseSearchConfig')
+
+    for domain in get_enabled_domains('split_screen_case_search'):
+        CaseSearchConfig.objects.update_or_create(
+            pk=domain,
+            defaults={'split_screen_ui': True},
+        )
+
+
+def get_enabled_domains(toggle_slug):
+    toggle = StaticToggle(toggle_slug, '', '')
+    return toggle.get_enabled_domains()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('case_search', '0016_csqlfixtureexpression_user_data_criteria'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='casesearchconfig',
+            name='split_screen_ui',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(
+            populate_split_screen_ui,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/corehq/apps/case_search/migrations/0017_casesearchconfig_split_screen_ui.py
+++ b/corehq/apps/case_search/migrations/0017_casesearchconfig_split_screen_ui.py
@@ -1,5 +1,5 @@
 from django.db import migrations, models
-from corehq.toggles import StaticToggle
+from corehq.toggles import get_enabled_domains
 from corehq.util.django_migrations import skip_on_fresh_install
 
 
@@ -12,11 +12,6 @@ def populate_split_screen_ui(apps, schema_editor):
             pk=domain,
             defaults={'split_screen_ui': True},
         )
-
-
-def get_enabled_domains(toggle_slug):
-    toggle = StaticToggle(toggle_slug, '', '')
-    return toggle.get_enabled_domains()
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -392,6 +392,24 @@ def case_search_sync_cases_on_form_entry_enabled_for_domain(domain):
     return config.sync_cases_on_form_entry if config else False
 
 
+@quickcache(['domain'], timeout=24 * 60 * 60, memoize_timeout=60)
+def split_screen_ui_enabled_for_domain(domain):
+    from corehq.apps.accounting.models import SoftwarePlanEdition, Subscription
+
+    config = CaseSearchConfig.objects.get_or_none(pk=domain)
+    if not config:
+        return False
+    if not config.split_screen_ui:
+        return False
+    subs = Subscription.get_active_subscription_by_domain(domain)
+    if not subs:
+        return False
+    return subs.plan_version.plan.edition in (
+        SoftwarePlanEdition.ADVANCED,
+        SoftwarePlanEdition.ENTERPRISE,
+    )
+
+
 def enable_case_search(domain):
     from corehq.apps.case_search.tasks import reindex_case_search_for_domain
 

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -304,7 +304,7 @@ class CaseSearchConfig(models.Model):
     index_name = models.CharField(max_length=256, blank=True, default='', help_text=(
         "Name or alias of alternative index to use for case search"))
     # Show the search filters in a sidebar on the left and the results
-    # on the right. Available in Advanced Plan and up.
+    # on the right.
     split_screen_ui = models.BooleanField(blank=False, null=False, default=False)
     # TODO: GA or Bust:
     #   # When split_screen_ui is True, search results update when a search

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -303,6 +303,14 @@ class CaseSearchConfig(models.Model):
     # See case_search_sub.py docstring for context
     index_name = models.CharField(max_length=256, blank=True, default='', help_text=(
         "Name or alias of alternative index to use for case search"))
+    # Show the search filters in a sidebar on the left and the results
+    # on the right. Available in Advanced Plan and up.
+    split_screen_ui = models.BooleanField(blank=False, null=False, default=False)
+    # TODO: GA or Bust:
+    #   # When split_screen_ui is True, search results update when a search
+    #   # field is updated without requiring the user to manually press a
+    #   # button to search
+    #   dynamically_update_results = models.BooleanField(blank=False, null=False, default=False)
 
     objects = GetOrNoneManager()
 

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -420,6 +420,7 @@ def enable_case_search(domain):
         case_search_enabled_for_domain.clear(domain)
         reindex_case_search_for_domain.delay(domain)
         case_search_sync_cases_on_form_entry_enabled_for_domain.clear(domain)
+        split_screen_ui_enabled_for_domain.clear(domain)
     return config
 
 
@@ -439,6 +440,7 @@ def disable_case_search(domain):
         case_search_enabled_for_domain.clear(domain)
         delete_case_search_cases_for_domain.delay(domain)
         case_search_sync_cases_on_form_entry_enabled_for_domain.clear(domain)
+        split_screen_ui_enabled_for_domain.clear(domain)
     return config
 
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/utils.js
@@ -1,7 +1,7 @@
 define("cloudcare/js/formplayer/menus/utils", [
     'underscore',
     'backbone',
-    'hqwebapp/js/toggles',
+    'hqwebapp/js/initial_page_data',
     'analytix/js/noopMetrics',
     'cloudcare/js/formplayer/app',
     'cloudcare/js/formplayer/constants',
@@ -14,7 +14,7 @@ define("cloudcare/js/formplayer/menus/utils", [
 ], function (
     _,
     Backbone,
-    toggles,
+    initialPageData,
     noopMetrics,
     FormplayerFrontend,
     constants,
@@ -176,7 +176,7 @@ define("cloudcare/js/formplayer/menus/utils", [
     };
 
     var isSidebarEnabled = function (menuResponse) {
-        const splitScreenCaseSearchEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH');
+        const splitScreenCaseSearchEnabled = initialPageData.get('split_screen_case_search');
         if (menuResponse.type === constants.QUERY) {
             return splitScreenCaseSearchEnabled && menuResponse.models && menuResponse.models.length > 0;
         } else if (menuResponse.type === constants.ENTITIES) {
@@ -226,7 +226,7 @@ define("cloudcare/js/formplayer/menus/utils", [
 
             if (/search_command\.m\d+/.test(menuResponse.queryKey) && menuResponse.currentPage === 0) {
                 noopMetrics.track.event('Started Case Search', {
-                    'Split Screen Case Search': toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
+                    'Split Screen Case Search': initialPageData.get('split_screen_case_search'),
                 });
             }
             var caseListView = getCaseListView(menuResponse);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1029,7 +1029,7 @@ define("cloudcare/js/formplayer/menus/views", [
             FormplayerFrontend.trigger("menu:select", this.selectedCaseIds);
             if (/search_command\.m\d+/.test(sessionStorage.queryKey)) {
                 noopMetrics.track.event('Completed Case Search', {
-                    'Split Screen Case Search': toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
+                    'Split Screen Case Search': initialPageData.get('split_screen_case_search'),
                 });
             }
         },
@@ -1285,7 +1285,7 @@ define("cloudcare/js/formplayer/menus/views", [
                 isMultiSelect: false,
                 showMap: this.showMap,
                 sidebarEnabled: this.options.sidebarEnabled,
-                splitScreenToggleEnabled: toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
+                splitScreenCaseSearchEnabled: initialPageData.get('split_screen_case_search'),
                 smallScreenEnabled: this.smallScreenEnabled,
                 triggerEmptyCaseList: this.options.triggerEmptyCaseList,
 
@@ -1715,7 +1715,7 @@ define("cloudcare/js/formplayer/menus/views", [
                 FormplayerFrontend.trigger("menu:select", this.caseId);
                 if (/search_command\.m\d+/.test(sessionStorage.queryKey)) {
                     noopMetrics.track.event('Completed Case Search', {
-                        'Split Screen Case Search': toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
+                        'Split Screen Case Search': initialPageData.get('split_screen_case_search'),
                     });
                 }
             }
@@ -1801,7 +1801,7 @@ define("cloudcare/js/formplayer/menus/views", [
             $('#persistent-menu-region').removeClass('d-none');
             this.sidebarEnabled = options.sidebarEnabled;
             this.menuExpanded;
-            this.splitScreenToggleEnabled = toggles.toggleEnabled('SPLIT_SCREEN_CASE_SEARCH'),
+            this.splitScreenCaseSearchEnabled = initialPageData.get('split_screen_case_search'),
             this.offcanvas = 'offcanvas';
             this.collapse = 'collapse';
             this.containerCollapseClasses = this.collapse + ' position-relative';
@@ -1928,7 +1928,7 @@ define("cloudcare/js/formplayer/menus/views", [
                 persistentMenuContainer.addClass('border-top');
             }
 
-            if (this.splitScreenToggleEnabled && !sessionStorage.getItem('handledDefaultClosed')) {
+            if (this.splitScreenCaseSearchEnabled && !sessionStorage.getItem('handledDefaultClosed')) {
                 self.hideMenu();
                 self.unlockMenu();
                 self.flipArrowRight();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/menu_list_spec.js
@@ -14,10 +14,11 @@ import UsersModels from "cloudcare/js/formplayer/users/models";
 
 describe('Render a case list', function () {
     before(function () {
+        this.sscsOrigValue = initialPageData.get('split_screen_case_search');
+        initialPageData.register('split_screen_case_search', false);
         initialPageData.register(
             "toggles_dict",
             {
-                SPLIT_SCREEN_CASE_SEARCH: false,
                 DYNAMICALLY_UPDATE_SEARCH_RESULTS: false,
                 USE_PROMINENT_PROGRESS_BAR: false,
                 ACTIVATE_DATADOG_APM_TRACES: false,
@@ -28,6 +29,11 @@ describe('Render a case list', function () {
 
     after(function () {
         initialPageData.unregister("toggles_dict");
+        if (this.sscsOrigValue !== undefined) {
+            initialPageData.register('split_screen_case_search', this.sscsOrigValue);
+        } else {
+            initialPageData.unregister('split_screen_case_search');
+        }
     });
 
     describe('#getMenuView', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -3,7 +3,7 @@ import _ from "underscore";
 import Backbone from "backbone";
 import Marionette from "backbone.marionette";
 import sinon from "sinon";
-import Toggles from "hqwebapp/js/toggles";
+import initialPageData from "hqwebapp/js/initial_page_data";
 import FormplayerFrontend from "cloudcare/js/formplayer/app";
 import API from "cloudcare/js/formplayer/menus/api";
 import Controller from "cloudcare/js/formplayer/menus/controller";
@@ -42,7 +42,7 @@ describe('Split Screen Case Search', function () {
             },
             addRegions: function () { return; },
         };
-        stubs.splitScreenToggleEnabled = sinon.stub(Toggles, 'toggleEnabled').withArgs('SPLIT_SCREEN_CASE_SEARCH');
+        stubs.splitScreenCaseSearchEnabled = sinon.stub(initialPageData, 'get').withArgs('split_screen_case_search');
     });
 
     beforeEach(function () {
@@ -50,7 +50,7 @@ describe('Split Screen Case Search', function () {
         user.displayOptions = {
             singleAppMode: false,
         };
-        stubs.splitScreenToggleEnabled.returns(true);
+        stubs.splitScreenCaseSearchEnabled.returns(true);
     });
 
     afterEach(function () {
@@ -141,7 +141,7 @@ describe('Split Screen Case Search', function () {
         });
 
         it('should empty sidebar if feature flag disabled', function () {
-            stubs.splitScreenToggleEnabled.returns(false);
+            stubs.splitScreenCaseSearchEnabled.returns(false);
             Controller.showMenu(splitScreenCaseListResponse);
 
             assert.isTrue(stubs.regions['sidebar'].empty.called);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/utils_spec.js
@@ -37,14 +37,20 @@ describe('Utils', function () {
         let stubs = {};
 
         before(function () {
+            this.sscsOrigValue = initialPageData.get('split_screen_case_search');
+            initialPageData.register('split_screen_case_search', false);
             initialPageData.register("toggles_dict", {
-                SPLIT_SCREEN_CASE_SEARCH: false,
                 DYNAMICALLY_UPDATE_SEARCH_RESULTS: false,
             });
         });
 
         after(function () {
             initialPageData.unregister("toggles_dict");
+            if (this.sscsOrigValue !== undefined) {
+                initialPageData.register('split_screen_case_search', this.sscsOrigValue);
+            } else {
+                initialPageData.unregister('split_screen_case_search');
+            }
         });
 
         beforeEach(function () {

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -56,6 +56,7 @@
   {% initial_page_data 'default_geocoder_location' default_geocoder_location %}
   {% initial_page_data 'username' username %}
   {% initial_page_data 'has_geocoder_privs' has_geocoder_privs %}
+  {% initial_page_data 'split_screen_case_search' split_screen_case_search %}
   {% initial_page_data 'dialer_enabled' integrations.dialer_enabled %}
   {% initial_page_data 'gaen_otp_enabled' integrations.gaen_otp_enabled %}
   {% initial_page_data 'hmac_root_url' integrations.hmac_root_url %}

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/list.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/list.html
@@ -19,7 +19,7 @@
     </div>
     <% } %>
 
-    <% if (!splitScreenToggleEnabled) { %>
+    <% if (!splitScreenCaseSearchEnabled) { %>
     <div class="module-search-container">
       <div class="input-group input-group-lg">
         <input type="text"

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -46,6 +46,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_current_app_doc,
     get_build_doc_by_build_id,
 )
+from corehq.apps.case_search.models import split_screen_ui_enabled_for_domain
 from corehq.apps.cloudcare.const import (
     PREVIEW_APP_ENVIRONMENT,
     WEB_APPS_ENVIRONMENT,
@@ -235,6 +236,7 @@ class FormplayerMain(View):
             "environment": WEB_APPS_ENVIRONMENT,
             "integrations": integration_contexts(domain),
             "has_geocoder_privs": has_geocoder_privs(domain),
+            "split_screen_case_search": split_screen_ui_enabled_for_domain(domain),
             "valid_multimedia_extensions_map": VALID_ATTACHMENT_FILE_EXTENSION_MAP,
             "lang_code_name_mapping": lang_code_name_mapping,
         }

--- a/corehq/apps/domain/static/domain/js/bootstrap3/case_search.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/case_search.js
@@ -50,6 +50,7 @@ module.caseSearchConfig = function (options) {
     self.toggleEnabled = ko.observable(initialValues.enabled);
     self.synchronousWebApps = ko.observable(initialValues.synchronous_web_apps);
     self.syncCaseOnFormEntry = ko.observable(initialValues.sync_cases_on_form_entry);
+    self.splitScreenUI = ko.observable(initialValues.split_screen_ui);
     self.fuzzyProperties = ko.observableArray();
     for (var caseType in initialValues.fuzzy_properties) {
         self.fuzzyProperties.push(caseTypeProps(
@@ -71,6 +72,7 @@ module.caseSearchConfig = function (options) {
     self.fuzzyProperties.subscribe(self.change);
     self.synchronousWebApps.subscribe(self.change);
     self.syncCaseOnFormEntry.subscribe(self.change);
+    self.splitScreenUI.subscribe(self.change);
 
     self.addCaseType = function () {
         self.fuzzyProperties.push(caseTypeProps('', ['']));
@@ -118,6 +120,7 @@ module.caseSearchConfig = function (options) {
             'enable': self.toggleEnabled(),
             'synchronous_web_apps': self.synchronousWebApps(),
             'sync_cases_on_form_entry': self.syncCaseOnFormEntry(),
+            'split_screen_ui': self.splitScreenUI(),
             'fuzzy_properties': fuzzyProperties,
             'ignore_patterns': _.map(self.ignorePatterns(), function (rc) {
                 return {

--- a/corehq/apps/domain/static/domain/js/bootstrap5/case_search.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap5/case_search.js
@@ -50,6 +50,7 @@ module.caseSearchConfig = function (options) {
     self.toggleEnabled = ko.observable(initialValues.enabled);
     self.synchronousWebApps = ko.observable(initialValues.synchronous_web_apps);
     self.syncCaseOnFormEntry = ko.observable(initialValues.sync_cases_on_form_entry);
+    self.splitScreenUI = ko.observable(initialValues.split_screen_ui);
     self.fuzzyProperties = ko.observableArray();
     for (var caseType in initialValues.fuzzy_properties) {
         self.fuzzyProperties.push(caseTypeProps(
@@ -71,6 +72,7 @@ module.caseSearchConfig = function (options) {
     self.fuzzyProperties.subscribe(self.change);
     self.synchronousWebApps.subscribe(self.change);
     self.syncCaseOnFormEntry.subscribe(self.change);
+    self.splitScreenUI.subscribe(self.change);
 
     self.addCaseType = function () {
         self.fuzzyProperties.push(caseTypeProps('', ['']));
@@ -118,6 +120,7 @@ module.caseSearchConfig = function (options) {
             'enable': self.toggleEnabled(),
             'synchronous_web_apps': self.synchronousWebApps(),
             'sync_cases_on_form_entry': self.syncCaseOnFormEntry(),
+            'split_screen_ui': self.splitScreenUI(),
             'fuzzy_properties': fuzzyProperties,
             'ignore_patterns': _.map(self.ignorePatterns(), function (rc) {
                 return {

--- a/corehq/apps/domain/templates/domain/admin/case_search.html
+++ b/corehq/apps/domain/templates/domain/admin/case_search.html
@@ -110,6 +110,25 @@
         </div>
 
         <div data-bind="visible: toggleEnabled" class="mb-3">
+          <h2>{% trans "Split Screen UI" %}</h2>
+          <p>
+            <div class="form-check">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                id="split-screen-ui"
+                data-bind="checked: splitScreenUI"
+              />
+              <label class="form-check-label" for="split-screen-ui">
+                {% blocktrans %}
+                  Show the search filters in a sidebar on the left and the results on the right.
+                {% endblocktrans %}
+              </label>
+            </div>
+          </p>
+        </div>
+
+        <div data-bind="visible: toggleEnabled" class="mb-3">
           <h2>{% trans "Remove Special Characters" %}</h2>
           <p>
             {% blocktrans %}
@@ -156,6 +175,7 @@
             <i class="fa fa-plus"></i> {% trans "Add case property" %}
           </button>
         </div>
+
       </form>
     </div>
   </div>

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -464,6 +464,7 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
             'enabled': request_json.get('enable'),
             'synchronous_web_apps': request_json.get('synchronous_web_apps'),
             'sync_cases_on_form_entry': request_json.get('sync_cases_on_form_entry'),
+            'split_screen_ui': request_json.get('split_screen_ui'),
         })
         case_search_synchronous_web_apps_for_domain.clear(self.domain)
         case_search_sync_cases_on_form_entry_enabled_for_domain.clear(self.domain)
@@ -483,6 +484,7 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
                 'enabled': config.enabled,
                 'synchronous_web_apps': config.synchronous_web_apps,
                 'sync_cases_on_form_entry': config.sync_cases_on_form_entry,
+                'split_screen_ui': config.split_screen_ui,
                 'fuzzy_properties': {
                     fp.case_type: fp.properties for fp in config.fuzzy_properties.all()
                 },

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -40,6 +40,7 @@ from corehq.apps.case_search.models import (
     case_search_synchronous_web_apps_for_domain,
     disable_case_search,
     enable_case_search,
+    split_screen_ui_enabled_for_domain,
 )
 from corehq.apps.domain.decorators import (
     LoginAndDomainMixin,
@@ -472,6 +473,7 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
         })
         case_search_synchronous_web_apps_for_domain.clear(self.domain)
         case_search_sync_cases_on_form_entry_enabled_for_domain.clear(self.domain)
+        split_screen_ui_enabled_for_domain.clear(self.domain)
         config.ignore_patterns.set(updated_ignore_patterns)
         config.fuzzy_properties.set(updated_fuzzies)
         return json_response(self.page_context)

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -1,4 +1,3 @@
-import pytz
 import json
 from collections import defaultdict
 from functools import cached_property
@@ -6,7 +5,10 @@ from functools import cached_property
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
-from django.contrib.auth.views import PasswordResetConfirmView, PasswordResetView
+from django.contrib.auth.views import (
+    PasswordResetConfirmView,
+    PasswordResetView,
+)
 from django.core.exceptions import ValidationError
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
@@ -18,30 +20,31 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 from django.views.decorators.http import require_POST
 
+import pytz
 from couchdbkit import ResourceNotFound
 from django_prbac.decorators import requires_privilege_raise404
 from django_prbac.utils import has_privilege
 from memoized import memoized
 
-from corehq.apps.accounting.decorators import always_allow_project_access
-from corehq.apps.enterprise.mixins import ManageMobileWorkersMixin
-from dimagi.utils.web import json_response, get_ip
+from dimagi.utils.web import get_ip, json_response
 
 from corehq import feature_previews, privileges, toggles
+from corehq.apps.accounting.decorators import always_allow_project_access
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 from corehq.apps.app_manager.decorators import require_can_edit_apps
 from corehq.apps.case_search.models import (
     CaseSearchConfig,
     FuzzyProperties,
     IgnorePatterns,
+    case_search_sync_cases_on_form_entry_enabled_for_domain,
     case_search_synchronous_web_apps_for_domain,
     disable_case_search,
-    enable_case_search, case_search_sync_cases_on_form_entry_enabled_for_domain,
+    enable_case_search,
 )
 from corehq.apps.domain.decorators import (
+    LoginAndDomainMixin,
     domain_admin_required,
     login_and_domain_required,
-    LoginAndDomainMixin,
 )
 from corehq.apps.domain.extension_points import has_custom_clean_password
 from corehq.apps.domain.forms import (
@@ -50,14 +53,15 @@ from corehq.apps.domain.forms import (
     DomainAlertForm,
     DomainGlobalSettingsForm,
     DomainMetadataForm,
+    IPAccessConfigForm,
     PrivacySecurityForm,
     ProjectSettingsForm,
-    IPAccessConfigForm,
-    clean_password
+    clean_password,
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.domain.views.import_apps import ImportAppStepsView
+from corehq.apps.enterprise.mixins import ManageMobileWorkersMixin
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.models import Alert
 from corehq.apps.hqwebapp.signals import clear_login_attempts
@@ -72,7 +76,7 @@ from corehq.apps.users.util import log_user_change
 from corehq.const import USER_CHANGE_VIA_WEB
 from corehq.toggles import NAMESPACE_DOMAIN
 from corehq.toggles.models import Toggle
-from corehq.util.timezones.conversions import UserTime, ServerTime
+from corehq.util.timezones.conversions import ServerTime, UserTime
 
 MAX_ACTIVE_ALERTS = 3
 

--- a/corehq/apps/translations/app_translations/download.py
+++ b/corehq/apps/translations/app_translations/download.py
@@ -8,6 +8,7 @@ from corehq.apps.app_manager.exceptions import XFormException
 from corehq.apps.app_manager.models import ReportModule
 from corehq.apps.app_manager.util import module_offers_search
 from corehq.apps.app_manager.xform import ItextOutput, ItextValue
+from corehq.apps.case_search.models import split_screen_ui_enabled_for_domain
 from corehq.apps.translations.app_translations.utils import (
     get_form_sheet_name,
     get_menu_row,
@@ -218,7 +219,7 @@ def get_module_search_command_rows(langs, module, domain):
         ('description', 'list')
         + tuple(module.search_config.description.get(lang, '') for lang in langs),
     ]
-    if not toggles.SPLIT_SCREEN_CASE_SEARCH.enabled(domain):
+    if not split_screen_ui_enabled_for_domain(domain):
         rows.append(
             ('search_again_label', 'list') + tuple(module.search_config.search_again_label.label.get(lang, '')
                                                    for lang in langs),

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -1140,7 +1140,11 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
                          [('case_list_menu_item_label', 'list', 'Steth List')])
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
-    def test_module_search_labels_rows(self):
+    @patch(
+        'corehq.apps.translations.app_translations.download.split_screen_ui_enabled_for_domain',
+        return_value=False,
+    )
+    def test_module_search_labels_rows(self, *args):
         app = AppFactory.case_claim_app_factory().app
         self.assertEqual(get_module_search_command_rows(app.langs, app.modules[0], app.domain),
                          [('search_label', 'list', 'Find a Mother'),
@@ -1149,8 +1153,11 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
                           ('search_again_label', 'list', 'Find Another Mother')])
 
     @flag_enabled('USH_CASE_CLAIM_UPDATES')
-    @flag_enabled('SPLIT_SCREEN_CASE_SEARCH')
-    def test_module_split_screen_case_search_rows(self):
+    @patch(
+        'corehq.apps.translations.app_translations.download.split_screen_ui_enabled_for_domain',
+        return_value=True,
+    )
+    def test_module_split_screen_case_search_rows(self, *args):
         app = AppFactory.case_claim_app_factory().app
         self.assertEqual(get_module_search_command_rows(app.langs, app.modules[0], app.domain),
                          [('search_label', 'list', 'Find a Mother'),

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -639,6 +639,11 @@ def toggle_values_by_name(username, domain):
     }
 
 
+def get_enabled_domains(toggle_slug):
+    toggle = StaticToggle(toggle_slug.lower(), '', '')
+    return toggle.get_enabled_domains()
+
+
 @quickcache(["domain"], timeout=24 * 60 * 60, skip_arg=lambda _: settings.UNIT_TESTING)
 def toggles_enabled_for_domain(domain):
     """Return set of toggle names that are enabled for the given domain"""

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1110,16 +1110,6 @@ USH_EMPTY_CASE_LIST_TEXT = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN]
 )
 
-SPLIT_SCREEN_CASE_SEARCH = StaticToggle(
-    'split_screen_case_search',
-    "Split screen case search: In case search, show the search filters in a sidebar on the left and the results"
-    " on the right.",
-    TAG_CUSTOM,
-    help_link='https://confluence.dimagi.com/display/USH/Split+Screen+Case+Search',
-    namespaces=[NAMESPACE_DOMAIN],
-    parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
-)
-
 # TODO: GA or Bust: See CaseSearchConfig.dynamically_update_results
 DYNAMICALLY_UPDATE_SEARCH_RESULTS = StaticToggle(
     'dynamically_update_search_results',
@@ -1128,7 +1118,7 @@ DYNAMICALLY_UPDATE_SEARCH_RESULTS = StaticToggle(
     TAG_CUSTOM,
     help_link='https://confluence.dimagi.com/display/USH/Split+Screen+Case+Search',
     namespaces=[NAMESPACE_DOMAIN],
-    parent_toggles=[SPLIT_SCREEN_CASE_SEARCH]
+    parent_toggles=[]
 )
 
 USH_USERCASES_FOR_WEB_USERS = StaticToggle(

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1115,6 +1115,7 @@ SPLIT_SCREEN_CASE_SEARCH = StaticToggle(
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
 )
 
+# TODO: GA or Bust: See CaseSearchConfig.dynamically_update_results
 DYNAMICALLY_UPDATE_SEARCH_RESULTS = StaticToggle(
     'dynamically_update_search_results',
     "In case search with split screen case search enabled, search results update when a search field is updated"

--- a/corehq/toggles/management/commands/list_ff_domains.py
+++ b/corehq/toggles/management/commands/list_ff_domains.py
@@ -4,7 +4,7 @@ from couchdbkit import ResourceNotFound
 from django.core.management.base import BaseCommand
 
 from corehq.apps.accounting.models import Subscription
-from corehq.toggles import StaticToggle, Toggle
+from corehq.toggles import Toggle, get_enabled_domains
 
 
 class Command(BaseCommand):
@@ -35,11 +35,6 @@ def toggle_exists(toggle_slug):
     except ResourceNotFound:
         return False
     return True
-
-
-def get_enabled_domains(toggle_slug):
-    toggle = StaticToggle(toggle_slug.lower(), '', '')
-    return toggle.get_enabled_domains()
 
 
 def get_domain_subscription(domain):

--- a/migrations.lock
+++ b/migrations.lock
@@ -251,6 +251,7 @@ case_search
  0014_casesearchconfig_index_name
  0015_csqlfixtureexpression_csqlfixtureexpressionlog
  0016_csqlfixtureexpression_user_data_criteria
+ 0017_casesearchconfig_split_screen_ui
 cleanup
  0001_convert_change_feed_checkpoint_to_sql
  0002_convert_mc_checkpoint_to_sql


### PR DESCRIPTION
## Product Description

This pull request makes "Split Screen Case Search" generally available for projects with Advanced or Enterprise subscriptions.

The current setting is migrated from the feature flag to case search settings for the domain. It is managed under Project Settings > Case Search, with other case search settings:

<img width="884" height="853" alt="image" src="https://github.com/user-attachments/assets/f83b2e18-d031-476c-9a40-22f1ff0a046e" />

## Technical Summary

Jira: [SAAS-18054](https://dimagi.atlassian.net/browse/SAAS-18054)

Like other `CaseSearchConfig` attributes, the new attribute is also available in Django Admin:

<img width="571" height="514" alt="image" src="https://github.com/user-attachments/assets/4ff59c07-f649-460b-8cb8-f3345f4efb94" />

Easier to :blowfish: review :fish: by :tropical_fish: commit.

## Feature Flag

`split_screen_case_search`

## Safety Assurance

### Safety story

Tested on Staging

### Automated test coverage

Formplayer tests included

### QA Plan

[QA-7953](https://dimagi.atlassian.net/browse/QA-7953)

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-18054]: https://dimagi.atlassian.net/browse/SAAS-18054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[QA-7953]: https://dimagi.atlassian.net/browse/QA-7953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ