### PR TITLE
patch getaddrinfo to simulate rebinding attack

### DIFF
--- a/corehq/util/urlvalidate/test/test_urlsanitize.py
+++ b/corehq/util/urlvalidate/test/test_urlsanitize.py
@@ -1,6 +1,10 @@
 from django.test import SimpleTestCase
 
 import pytest
+import socket
+
+from unittest.mock import patch
+
 from testil import assert_raises, eq
 
 from ..ip_resolver import CannotResolveHost
@@ -43,16 +47,24 @@ def test_example_urls(input_url, expected):
                 validate_user_input_url(input_url)
 
 
-def test_rebinding():
+# patch because the public service rebind.network cannot be resolved and might be taken down
+@patch('socket.getaddrinfo', side_effect=[
+    [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('8.8.8.8', 80))],
+    [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('169.254.169.254', 80))]
+])
+def test_rebinding(mock_gethostbyname):
     """
     this test doesn't do much, it just checks that a known rebinding endpoint
     is either valid, or pointing to a link local address
     """
     url = 'http://A.8.8.8.8.1time.169.254.169.254.1time.repeat.rebind.network/'
+    validate_user_input_url(url)
     try:
         validate_user_input_url(url)
     except PossibleSSRFAttempt as e:
-        eq(e.reason, 'is_link_local')
+        assert e.reason == 'is_link_local'
+    else:
+        assert False, "Expected PossibleSSRFAttempt to be raised"
 
 
 class SanitizeIPv6Tests(SimpleTestCase):

--- a/corehq/util/urlvalidate/test/test_urlsanitize.py
+++ b/corehq/util/urlvalidate/test/test_urlsanitize.py
@@ -52,14 +52,16 @@ def test_example_urls(input_url, expected):
     [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('8.8.8.8', 80))],
     [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('169.254.169.254', 80))]
 ])
-def test_rebinding(mock_gethostbyname):
+def test_dns_resolution_to_bad_address(mock_gethostbyname):
     """
     this test doesn't do much, it just checks that a known rebinding endpoint
     is either valid, or pointing to a link local address
     """
     url = 'http://A.8.8.8.8.1time.169.254.169.254.1time.repeat.rebind.network/'
+    # resolves to a good address
     validate_user_input_url(url)
     try:
+        # resolves to a bad address
         validate_user_input_url(url)
     except PossibleSSRFAttempt as e:
         assert e.reason == 'is_link_local'


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This PR updates the `test_rebinding` test to remove its dependency on the public service `rebind.network`, which is no longer reliably resolvable and may be permanently unavailable.

Previously, the test relied on the domain `A.8.8.8.8.1time.169.254.169.254.1time.repeat.rebind.network` to simulate DNS rebinding behavior — specifically, a domain that resolves first to a public IP (8.8.8.8) and then to a link-local IP (169.254.169.254). 

We now patch `socket.getaddrinfo` using side_effect to simulate the rebinding behavior:
- The first call to `getaddrinfo()` returns a safe public IP.
- The second call returns a link-local IP, triggering the expected SSRF protection logic.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Only update test.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
