### PR TITLE
Default choice selection to empty when generating new api

### DIFF
--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -269,7 +269,8 @@ class HQPhoneNumberForm(PhoneNumberForm):
 
 
 class HQApiKeyForm(forms.Form):
-    ALL_DOMAINS = 'ALL_DOMAINS'  # This value is safe to use because we normalize all domain names
+    ALL_DOMAINS_UI = 'ALL_DOMAINS_UI'
+    ALL_DOMAINS = ''
     name = forms.CharField()
     ip_allowlist = SimpleArrayField(
         forms.GenericIPAddressField(
@@ -291,7 +292,7 @@ class HQApiKeyForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         user_domains = user_domains or []
-        all_domains = (self.ALL_DOMAINS, _('All Projects'))
+        all_domains = (self.ALL_DOMAINS_UI, _('All Projects'))
         default_empty_choice = ('', '')
         self.fields['domain'].choices = [default_empty_choice] + [(d, d) for d in user_domains] + [all_domains]
 
@@ -355,8 +356,8 @@ class HQApiKeyForm(forms.Form):
             return new_key
 
     def clean_domain(self):
-        if self.cleaned_data['domain'] == self.ALL_DOMAINS:
-            return ''
+        if self.cleaned_data['domain'] == self.ALL_DOMAINS_UI:
+            return self.ALL_DOMAINS
         return self.cleaned_data['domain']
 
     def clean_expiration_date(self):

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -345,18 +345,19 @@ class HQApiKeyForm(forms.Form):
             HQApiKey.all_objects.get(name=self.cleaned_data['name'], user=user)
             raise DuplicateApiKeyName
         except HQApiKey.DoesNotExist:
-            if self.cleaned_data['domain'] == self.ALL_DOMAINS:
-                domain = ''
-            else:
-                domain = self.cleaned_data['domain']
             new_key = HQApiKey.objects.create(
                 name=self.cleaned_data['name'],
                 ip_allowlist=self.cleaned_data['ip_allowlist'],
                 user=user,
-                domain=domain,
+                domain=self.cleaned_data['domain'],
                 expiration_date=self.cleaned_data['expiration_date'],
             )
             return new_key
+
+    def clean_domain(self):
+        if self.cleaned_data['domain'] == self.ALL_DOMAINS:
+            return ''
+        return self.cleaned_data['domain']
 
     def clean_expiration_date(self):
         if not self.cleaned_data['expiration_date']:

--- a/corehq/apps/settings/tests/test_forms.py
+++ b/corehq/apps/settings/tests/test_forms.py
@@ -69,7 +69,8 @@ class HQApiKeyTests(SimpleTestCase):
     def test_form_domain_list(self):
         form = HQApiKeyForm(user_domains=['domain1', 'domain2'])
         domain_choices = form.fields['domain'].choices
-        self.assertEqual(domain_choices, [('', 'All Projects'), ('domain1', 'domain1'), ('domain2', 'domain2')])
+        self.assertEqual(domain_choices, [('', ''), ('domain1', 'domain1'), ('domain2', 'domain2'),
+                                          (HQApiKeyForm.ALL_DOMAINS, 'All Projects')])
 
     def test_expiration_date_is_not_required_by_default(self):
         form = HQApiKeyForm()
@@ -161,6 +162,7 @@ class HQApiKeyTests(SimpleTestCase):
     def _form_data(self, expiration_date='2023-01-01'):
         data = {
             'name': 'TestKey',
+            'domain': HQApiKeyForm.ALL_DOMAINS,
         }
 
         if expiration_date:

--- a/corehq/apps/settings/tests/test_forms.py
+++ b/corehq/apps/settings/tests/test_forms.py
@@ -70,7 +70,7 @@ class HQApiKeyTests(SimpleTestCase):
         form = HQApiKeyForm(user_domains=['domain1', 'domain2'])
         domain_choices = form.fields['domain'].choices
         self.assertEqual(domain_choices, [('', ''), ('domain1', 'domain1'), ('domain2', 'domain2'),
-                                          (HQApiKeyForm.ALL_DOMAINS, 'All Projects')])
+                                          (HQApiKeyForm.ALL_DOMAINS_UI, 'All Projects')])
 
     def test_expiration_date_is_not_required_by_default(self):
         form = HQApiKeyForm()
@@ -162,7 +162,7 @@ class HQApiKeyTests(SimpleTestCase):
     def _form_data(self, expiration_date='2023-01-01'):
         data = {
             'name': 'TestKey',
-            'domain': HQApiKeyForm.ALL_DOMAINS,
+            'domain': HQApiKeyForm.ALL_DOMAINS_UI,
         }
 
         if expiration_date:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
**Before**
We used to default api key's scope to all projects this web user has access to
<img width="523" height="318" alt="image" src="https://github.com/user-attachments/assets/3064c239-6b12-4641-abf8-2745e5c52b23" />

**After**
We now will default to no selection, and move the option "All Projects" to the bottom of the list so we discourage user from creating unscoped key
<img width="846" height="620" alt="image" src="https://github.com/user-attachments/assets/d9519106-51d9-4ea5-832c-818dd9d54b3e" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-18096

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I've tested locally. This is just change what options we provided and the order of it.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

corehq.apps.settings.tests.test_forms::HQApiKeyTests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
