### PR TITLE
Gracefully handle saved reports associated with deleted users

### DIFF
--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -881,7 +881,7 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
         for report_config in self.configs:
             mock_request = HttpRequest()
             mock_request.couch_user = self.owner
-            mock_request.user = self.owner.get_django_user() if self.owner else None
+            mock_request.user = self.owner.get_django_user()
             mock_request.domain = self.domain
             mock_request.couch_user.current_domain = self.domain
             mock_request.couch_user.language = self.language


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18099

This came up during the dump and restore test, which in reality might be the only way to end up with a deleted user like this.

Saved reports (a configuration of filters for a specific report) are created by users in a domain. These saved reports are shared once they are used in a scheduled report, meaning other users in that domain could create scheduled reports referencing the saved report.

So in this scenario, user A created a saved report, then a scheduled report.  User B created a scheduled report that referenced this saved report as well. User A was removed from the domain. The domain was dumped, only including users in that domain. The scheduled report created by user B still existed, and is included in the dump. In the new environment, when attempting to render this saved report, the page 500s because it assumes the owner of the saved report will be found in the db and attempts to access attributes on it.

This felt like the easiest way to support this edge case without making any larger changes. It has the added bonus of just handling this unlikely scenario more gracefully if it were to happen in other unexpected ways.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I've tested this locally and deployed it on my test monolith where I first experienced the issue. Both display "Unknown User" for the saved report as expected.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None that I am aware of.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
