### PR TITLE
scroll to top on pagination

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -890,6 +890,7 @@ define("cloudcare/js/formplayer/menus/views", [
             });
             self.smallScreenListener.listen();
             self.scrollContainer = $(constants.SCROLLABLE_CONTENT_CONTAINER);
+            self.scrollContainer.scrollTop(0);
         },
 
         ui: CaseListViewUI(),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -186,6 +186,12 @@ define("cloudcare/js/formplayer/router", [
         urlObject.setRequestInitiatedByTag(formplayerConstants.requestInitiatedByTagsMapping.PAGINATION);
         let encodedUrl = utils.objectToEncodedUrl(urlObject.toJson());
         API.listMenus(encodedUrl);
+
+        const contentContainer = document.getElementById(formplayerConstants.SCROLLABLE_CONTENT_CONTAINER.slice(1));
+        contentContainer.scroll({
+            top: 0,
+            left: 0,
+        });
     });
 
     FormplayerFrontend.on("menu:perPageLimit", function (casesPerPage, selections) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/router.js
@@ -187,11 +187,6 @@ define("cloudcare/js/formplayer/router", [
         let encodedUrl = utils.objectToEncodedUrl(urlObject.toJson());
         API.listMenus(encodedUrl);
 
-        const contentContainer = document.getElementById(formplayerConstants.SCROLLABLE_CONTENT_CONTAINER.slice(1));
-        contentContainer.scroll({
-            top: 0,
-            left: 0,
-        });
     });
 
     FormplayerFrontend.on("menu:perPageLimit", function (casesPerPage, selections) {

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/pagination.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/pagination.html
@@ -25,7 +25,7 @@
                   <span><i class="fa fa-fast-backward"></i></span>
                 </a>
               </li>
-              <li>
+              <li class="page-item">
                 <a class="page-link js-page" aria-label='{% trans_html_attr "Previous" %}' tabindex="0" data-id="<%- currentPage - 1 %>">
                   <span><i class="fa fa-caret-left"></i></span>
                 </a>
@@ -36,8 +36,8 @@
                   <span><i class="fa fa-fast-backward"></i></span>
                 </a>
               </li>
-              <li>
-                <a class="page-link js-page" data-id="<%- currentPage - 1 %>">
+              <li class="page-item">
+                <a class="page-link paginate-disabled" data-id="<%- currentPage - 1 %>">
                   <span><i class="fa fa-caret-left"></i></span>
                 </a>
               </li>
@@ -80,7 +80,7 @@
                   <a class="page-link paginate-disabled">{% trans "..." %}</a>
                 </li>
                 <li class="page-item js-page" data-id="<%- pageCount - 1 %>">
-                  <a class="page-link" aria-label="<%- pageNumLabel({num: pageCount}) %>" tabindex="0"><%- pageCount %></a>
+                  <a class="page-link paginate-disabled" aria-label="<%- pageNumLabel({num: pageCount}) %>" tabindex="0"><%- pageCount %></a>
                 </li>
               <% } %>
             <% } %>
@@ -91,7 +91,7 @@
                   <span><i class="fa fa-caret-right"></i></span>
                 </a>
               </li>
-              <li>
+              <li class="page-item paginate-disabled">
                 <a class="page-link js-page" data-id="<%- pageCount - 1 %>">
                   <span><i class="fa fa-fast-forward"></i></span>
                 </a>


### PR DESCRIPTION
## Product Description

Scroll to the top after changing a page on a case list.

Also, disable first and last page buttons when on respective pages.

![2025-07-29_13-24-17 (1)](https://github.com/user-attachments/assets/e8deeac3-ae4a-4e63-9ece-c3b3b0176656)

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6087

## Feature Flag

No

## Safety Assurance

### Safety story

Tested locally and on staging

### Automated test coverage

No

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change