### PR TITLE
Enforce system limit for owner ids in reports

### DIFF
--- a/corehq/apps/reports/exceptions.py
+++ b/corehq/apps/reports/exceptions.py
@@ -1,11 +1,15 @@
-
-
 class BadRequestError(Exception):
     """
     For catching client-side errors.
     Views should catch and return HTTP400 or similar
     """
     pass
+
+
+class TooManyOwnerIDsError(Exception):
+    """
+    Raised if attempting to render a report that filters using too many owner ids
+    """
 
 
 class InvalidDaterangeException(Exception):

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -7,7 +7,7 @@ from corehq.apps.es import cases as case_es
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.api import ReportDataSource
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
-from corehq.apps.reports.exceptions import BadRequestError
+from corehq.apps.reports.exceptions import BadRequestError, TooManyOwnerIDsError
 from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
 from corehq.apps.reports.filters.select import SelectOpenCloseFilter
 from corehq.apps.reports.generic import ElasticProjectInspectionReport
@@ -92,6 +92,10 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
                     if original_exception.info.get('status') == 400:
                         raise BadRequestError()
             raise e
+        except TooManyOwnerIDsError:
+            raise BadRequestError(
+                _("Cannot filter by that many case owners. Choose a more specific group or location.")
+            )
 
     def _run_es_query(self):
         return self._build_query().run().raw

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -14,6 +14,7 @@ from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
 from corehq.apps.reports.models import HQUserType
 from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
 from corehq.apps.hqcase.utils import SYSTEM_FORM_XMLNS_MAP
+from corehq.project_limits.const import OWNER_ID_LIMIT_KEY, DEFAULT_OWNER_ID_LIMIT
 from corehq.project_limits.models import SystemLimit
 
 
@@ -174,7 +175,7 @@ def get_case_owners(can_access_all_locations, domain, mobile_user_and_group_slug
         location_owner_ids,
         assigned_user_ids_at_selected_locations,
     ))
-    limit = SystemLimit.get_limit_for_key("owner_id_limit", 1000, domain=domain)
+    limit = SystemLimit.get_limit_for_key(OWNER_ID_LIMIT_KEY, DEFAULT_OWNER_ID_LIMIT, domain=domain)
     if len(owner_ids) > limit:
         raise TooManyOwnerIDsError
     return owner_ids

--- a/corehq/project_limits/const.py
+++ b/corehq/project_limits/const.py
@@ -1,6 +1,8 @@
 # SystemLimit keys
 CASE_PROP_LIMIT_PER_CASE_TYPE_KEY = "case_prop_limit_per_case_type"
 DEVICE_LIMIT_PER_USER_KEY = "device_limit_per_user"
+OWNER_ID_LIMIT_KEY = "owner_id_limit"
 
 # SystemLimit defaults
 DEFAULT_CASE_PROPS_PER_CASE_TYPE = 250
+DEFAULT_OWNER_ID_LIMIT = 65_536  # max allowed term count in elasticsearch

--- a/corehq/project_limits/migrations/0005_systemlimit_owneriddefault.py
+++ b/corehq/project_limits/migrations/0005_systemlimit_owneriddefault.py
@@ -1,0 +1,35 @@
+from django.apps import apps
+from django.db import migrations
+
+from corehq.project_limits.const import DEFAULT_OWNER_ID_LIMIT, OWNER_ID_LIMIT_KEY
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _update_owner_id_system_limit(limit):
+    SystemLimit = apps.get_model('project_limits', 'SystemLimit')
+
+    try:
+        system_limit = SystemLimit.objects.get(key=OWNER_ID_LIMIT_KEY, domain="")
+    except SystemLimit.DoesNotExist:
+        SystemLimit.objects.create(key=OWNER_ID_LIMIT_KEY, limit=limit)
+    else:
+        system_limit.limit = limit
+        system_limit.save()
+
+
+def make_migration_fn(limit):
+    def migrate(apps, schema_editor):
+        _update_owner_id_system_limit(limit)
+
+    return migrate
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('project_limits', '0004_systemlimit'),
+    ]
+
+    operations = [
+        migrations.RunPython(make_migration_fn(DEFAULT_OWNER_ID_LIMIT), reverse_code=make_migration_fn(1000))
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -861,6 +861,7 @@ project_limits
  0002_ratelimitedtwofactorlog
  0003_pillowlaggaugedefinition
  0004_systemlimit
+ 0005_systemlimit_owneriddefault
 registration
  0001_initial
  0002_alter_request_ip


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18003

This is intended to be used in urgent situations only. This gives us a lever to pull if needed. See the ticket for more context on that.

The new default value is pulled from https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-terms-query.html#query-dsl-terms-lookup

This was previously collecting sentry errors any time we exceeded the defined limit, but now it will raise an exception. On the user's end, this will look like an error message that says "There was an error with your query, it has been logged, please try another query.". We are planning to look at a longer term fix to support these types of queries. For now, the default limit is set high enough that this won't actually disrupt anyone, but if needed we can quickly decrease it, and target specific domains if helpful.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No automated tests that I'm aware of.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
