### PR TITLE
Improve button spacing for pre-login language selector

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
@@ -40,9 +40,9 @@
       {% if not request.user.is_authenticated %}
         <nav class="navbar-menus navbar-signin" role="navigation">
           <div class="nav-settings-bar pull-right">
-            <div class="navbar-nav dropdown">
+            <div class="navbar-btn dropdown" style="display: inline-block;">
               <button
-                class="dropdown-toggle btn btn-default navbar-btn"
+                class="dropdown-toggle btn btn-default"
                 data-toggle="dropdown"
                 aria-haspopup="true"
                 aria-expanded="false"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
@@ -65,9 +65,9 @@
       {% if not request.user.is_authenticated %}
         <nav class="navbar-signin ms-2" role="navigation">
           <div class="nav-settings-bar">
-            <div class="navbar-nav dropdown">
+            <div class="navbar-btn dropdown d-inline-block">
               <button
-                class="dropdown-toggle btn btn-outline-primary navbar-btn"
+                class="dropdown-toggle btn btn-outline-primary"
                 data-bs-toggle="dropdown"
                 aria-haspopup="true"
                 aria-expanded="false"

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
@@ -74,13 +74,14 @@
        {% if not request.user.is_authenticated %}
 -        <nav class="navbar-menus navbar-signin" role="navigation">
 -          <div class="nav-settings-bar pull-right">
+-            <div class="navbar-btn dropdown" style="display: inline-block;">
 +        <nav class="navbar-signin ms-2" role="navigation">
 +          <div class="nav-settings-bar">
-             <div class="navbar-nav dropdown">
++            <div class="navbar-btn dropdown d-inline-block">
                <button
--                class="dropdown-toggle btn btn-default navbar-btn"
+-                class="dropdown-toggle btn btn-default"
 -                data-toggle="dropdown"
-+                class="dropdown-toggle btn btn-outline-primary navbar-btn"
++                class="dropdown-toggle btn btn-outline-primary"
 +                data-bs-toggle="dropdown"
                  aria-haspopup="true"
                  aria-expanded="false"


### PR DESCRIPTION
## Product Description
Before (large screen):
<img width="302" height="64" alt="image" src="https://github.com/user-attachments/assets/be96d975-bb36-4081-b3fb-9ef563ba4c7c" />

Before (small screen):
<img width="228" height="143" alt="image" src="https://github.com/user-attachments/assets/e40140ab-a40a-40c6-8154-20da5053f074" />

After (large and small screen):
<img width="302" height="62" alt="image" src="https://github.com/user-attachments/assets/03a3e1a6-3160-4b30-a771-dbdebccc9ba6" />



## Technical Summary
No ticket, just fixes some styling before this feature goes out.

## Safety Assurance

### Safety story
Just changes styling very lightly. Tested locally that the dropdown still expands and works correctly.

### Automated test coverage
Not for styling.

### QA Plan
Nope.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
