### PR TITLE
Align Dropdown clear button

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
@@ -198,7 +198,8 @@
   }
 }
 
-.select2-container--default.select2-container--disabled .select2-selection--single {
+.select2-container--default.select2-container--disabled
+  .select2-selection--single {
   border-color: $input-disabled-bg !important;
   background-color: $input-disabled-bg !important;
 }

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
@@ -112,8 +112,17 @@
 
 .select2-container--default
   .select2-selection--single.select2-selection--clearable {
+  display: flex;
+  align-items: center;
+
+  .select2-selection__rendered {
+    order: 1;
+    flex: 1 1 auto;
+  }
   .select2-selection__clear {
     font-size: 1.5em;
+    line-height: 1;
+    order: 2;
   }
 }
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
@@ -8,54 +8,39 @@
      margin-left: 10px;
      margin-bottom: 3px;
    }
-@@ -14,74 +15,185 @@
+@@ -14,74 +15,195 @@
  }
  
  // Static width for select2 widgets, which otherwise grow too large on form view's case management tab
 -.case-config-select2s(@width) {
 -    .select2-container {
 -        width: @width;
--    }
 +@mixin case-config-select2s($width) {
 +  .select2-container {
 +    width: $width;
 +  }
- 
--    // This needs a static width so that text-overflow: ellipsis will work in Firefox.
--    // Unusually specific selector to override select2's width: auto rule.
--    > .select2-choice > .select2-chosen {
--        width: @width - 35px;
--    }
++
 +  // This needs a static width so that text-overflow: ellipsis will work in Firefox.
 +  // Unusually specific selector to override select2's width: auto rule.
 +  > .select2-choice > .select2-chosen {
 +    width: $width - 35px;
 +  }
- }
- 
--.property-descriptions(@width) {
--    width: @width;
--    white-space: nowrap;
--    overflow: hidden;
--    text-overflow: ellipsis;
--    display: inline-block;
++}
++
 +@mixin property-descriptions($width) {
 +  width: $width;
 +  white-space: nowrap;
 +  overflow: hidden;
 +  text-overflow: ellipsis;
 +  display: inline-block;
- }
- 
--#case-config-ko, #usercase-config-ko {
--    @select2Width: 210px;
++}
++
 +#case-config-ko,
 +#usercase-config-ko {
 +  $select2Width: 210px;
- 
--    .case-config-select2s(@select2Width);
++
 +  @include case-config-select2s($select2Width);
- 
++
 +  .property-description {
 +    @include property-descriptions($select2Width);
 +  }
@@ -63,10 +48,33 @@
 +  .wide-select2s {
 +    $wideWidth: $select2Width * 1.5;
 +    @include case-config-select2s($wideWidth);
-     .property-description {
--      .property-descriptions(@select2Width);
++    .property-description {
 +      @include property-descriptions($wideWidth);
      }
+-
+-    // This needs a static width so that text-overflow: ellipsis will work in Firefox.
+-    // Unusually specific selector to override select2's width: auto rule.
+-    > .select2-choice > .select2-chosen {
+-        width: @width - 35px;
+-    }
+-}
+-
+-.property-descriptions(@width) {
+-    width: @width;
+-    white-space: nowrap;
+-    overflow: hidden;
+-    text-overflow: ellipsis;
+-    display: inline-block;
+-}
+-
+-#case-config-ko, #usercase-config-ko {
+-    @select2Width: 210px;
+-
+-    .case-config-select2s(@select2Width);
+-
+-    .property-description {
+-      .property-descriptions(@select2Width);
+-    }
 -
 -    .wide-select2s {
 -      @wideWidth: @select2Width * 1.5;
@@ -85,45 +93,28 @@
 +
 +  .select2-search-field {
      width: 100% !important;
-+  }
- 
+-
 -    .select2-selection.select2-selection--single {
 -        height: @input-height-base;
--    }
++  }
++
 +  .select2-input {
 +    width: 100% !important;
 +  }
 +}
- 
--    .select2-selection.select2-selection--multiple {
--        min-height: @input-height-base;
--    }
--
--    .select2-search-field {
--        width: 100% !important;
--    }
--
--    .select2-input {
--        width: 100% !important;
--    }
--
--    textarea.select2-search__field {    // Placeholder for multi-select
--        line-height: 21px;
--    }
++
 +.select2-search__field::placeholder {
 +  font-size: $font-size-base;
 +  font-family: $font-family-base;
- }
- 
- .select2-container.select2-container-active > .select2-choice {
--  .box-shadow(0 0 10px @cc-brand-mid);
++}
++
++.select2-container.select2-container-active > .select2-choice {
 +  box-shadow: 0 0 10px $cc-brand-mid;
- }
- 
- .select2-selection__placeholder {
--  color: @gray-base !important;
++}
++
++.select2-selection__placeholder {
 +  color: $gray-base !important;
- }
++}
 +
 +.select2-container--default .select2-selection--single,
 +.select2-container--default .select2-selection--multiple {
@@ -156,8 +147,17 @@
 +
 +.select2-container--default
 +  .select2-selection--single.select2-selection--clearable {
++  display: flex;
++  align-items: center;
++
++  .select2-selection__rendered {
++    order: 1;
++    flex: 1 1 auto;
++  }
 +  .select2-selection__clear {
 +    font-size: 1.5em;
++    line-height: 1;
++    order: 2;
 +  }
 +}
 +
@@ -186,7 +186,32 @@
 +    .select2-selection--single,
 +    .select2-selection--multiple {
 +      outline: 0;
-+    }
+     }
+-
+-    .select2-selection.select2-selection--multiple {
+-        min-height: @input-height-base;
+-    }
+-
+-    .select2-search-field {
+-        width: 100% !important;
+-    }
+-
+-    .select2-input {
+-        width: 100% !important;
+-    }
+-
+-    textarea.select2-search__field {    // Placeholder for multi-select
+-        line-height: 21px;
+-    }
+-}
+-
+-.select2-container.select2-container-active > .select2-choice {
+-  .box-shadow(0 0 10px @cc-brand-mid);
+-}
+-
+-.select2-selection__placeholder {
+-  color: @gray-base !important;
+-}
 +  }
 +}
 +
@@ -233,7 +258,8 @@
 +  }
 +}
 +
-+.select2-container--default.select2-container--disabled .select2-selection--single {
++.select2-container--default.select2-container--disabled
++  .select2-selection--single {
 +  border-color: $input-disabled-bg !important;
 +  background-color: $input-disabled-bg !important;
 +}


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Vertically aligns the "x" within the dropdown box

Before:
<img width="597" height="69" alt="Screenshot 2025-07-29 at 11 18 52 AM" src="https://github.com/user-attachments/assets/fc8b0be2-2983-4f8f-921c-2cd5291eaed0" />

After:
<img width="678" height="75" alt="Screenshot 2025-07-29 at 4 35 04 PM" src="https://github.com/user-attachments/assets/cc9e873c-c91e-44f0-b72b-7e714352ce9c" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-6085](https://dimagi.atlassian.net/browse/USH-6085)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
small UI change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-6085]: https://dimagi.atlassian.net/browse/USH-6085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ