### PR TITLE
Add drag/drop and paste handling for images

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/rich_text_knockout_bindings.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/rich_text_knockout_bindings.js
@@ -124,7 +124,7 @@ async function uploadAndInsertImage(file, editor, options = {}) {
         editorImages.set(editor, editorImageSet);
 
         if (options.onComplete) {
-            options.onComplete(data);
+            options.onComplete();
         }
     } catch (error) {
         if (options.onError) {
@@ -290,13 +290,11 @@ ko.bindingHandlers.richEditor = {
                 },
             },
             theme: "snow",
-            // Disable Quill's native clipboard and drop handling
             clipboard: {
                 matchVisual: false,
             },
         });
 
-        // Handle paste events in the capture phase to intercept before Quill's handlers
         editor.root.addEventListener('paste', function (e) {
             if (initialPageData.get("read_only_mode")) {
                 return;
@@ -307,7 +305,6 @@ ko.bindingHandlers.richEditor = {
 
                 for (let i = 0; i < items.length; i++) {
                     if (items[i].type.indexOf('image') !== -1) {
-                        // Prevent default and stop propagation to avoid Quill's handling
                         e.preventDefault();
                         e.stopPropagation();
 
@@ -317,18 +314,17 @@ ko.bindingHandlers.richEditor = {
                         }
 
                         uploadAndInsertImage(file, editor);
-                        break; // Only handle the first image
+                        break;
                     }
                 }
             }
         }, true); // Using capture phase to intercept before Quill's handlers
 
-        // Completely disable Quill's drop handler
+        // Prevent Quill's from handeling the drop event
         editor.root.addEventListener('drop', function (e) {
             e.stopPropagation();
         }, true);
 
-        // Handle drag and drop images
         editor.root.addEventListener('dragover', function (e) {
             e.preventDefault();
             e.stopPropagation();
@@ -342,7 +338,6 @@ ko.bindingHandlers.richEditor = {
         }, { capture: true });
 
         editor.root.addEventListener('drop', function (e) {
-            // This needs to happen before anything else
             e.preventDefault();
             e.stopPropagation();
             if (initialPageData.get("read_only_mode")) {
@@ -355,7 +350,6 @@ ko.bindingHandlers.richEditor = {
                 if (file.type.indexOf('image') !== -1) {
                     uploadAndInsertImage(file, editor);
                 } else {
-                    // Handle non-image files
                     const reader = new FileReader();
                     reader.onload = function (e) {
                         const range = editor.getSelection() || { index: editor.getLength(), length: 0 };
@@ -364,7 +358,6 @@ ko.bindingHandlers.richEditor = {
                     reader.readAsText(file);
                 }
             } else if (e.dataTransfer.getData('text')) {
-                // Handle text drag and drop
                 const text = e.dataTransfer.getData('text');
                 const range = editor.getSelection() || { index: editor.getLength(), length: 0 };
                 editor.insertText(range.index, text);

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/rich_text_knockout_bindings.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/rich_text_knockout_bindings.js
@@ -146,18 +146,18 @@ function imageHandler() {
         const file = imageInput.files[0];
 
         await uploadAndInsertImage(file, self.quill, {
-            onStart: function() {
+            onStart: function () {
                 uploadProgress.classList.remove("d-none");
             },
-            onComplete: function() {
+            onComplete: function () {
                 imageInput.value = '';
                 uploadButton.removeEventListener('click', handleImage);
                 $modal.modal('hide');
             },
-            onError: function(error) {
+            onError: function (error) {
                 alert(error.message || gettext('Failed to upload image. Please try again.'));
             },
-        }).finally(function() {
+        }).finally(function () {
             uploadProgress.classList.add("d-none");
         });
     };
@@ -297,7 +297,7 @@ ko.bindingHandlers.richEditor = {
         });
 
         // Handle paste events in the capture phase to intercept before Quill's handlers
-        editor.root.addEventListener('paste', function(e) {
+        editor.root.addEventListener('paste', function (e) {
             if (initialPageData.get("read_only_mode")) {
                 return;
             }
@@ -324,34 +324,27 @@ ko.bindingHandlers.richEditor = {
         }, true); // Using capture phase to intercept before Quill's handlers
 
         // Completely disable Quill's drop handler
-        editor.root.addEventListener('drop', function(e) {
+        editor.root.addEventListener('drop', function (e) {
             e.stopPropagation();
         }, true);
 
         // Handle drag and drop images
-        editor.root.addEventListener('dragover', function(e) {
+        editor.root.addEventListener('dragover', function (e) {
             e.preventDefault();
             e.stopPropagation();
-            editor.root.classList.add('quill-drag-over');
             return false;
         }, { capture: true });
 
-        editor.root.addEventListener('dragleave', function(e) {
+        editor.root.addEventListener('dragleave', function (e) {
             e.preventDefault();
             e.stopPropagation();
-            editor.root.classList.remove('quill-drag-over');
             return false;
         }, { capture: true });
 
-        editor.root.addEventListener('drop', function(e) {
+        editor.root.addEventListener('drop', function (e) {
             // This needs to happen before anything else
             e.preventDefault();
             e.stopPropagation();
-
-            // This completely prevents Quill from handling the drop
-
-            editor.root.classList.remove('quill-drag-over');
-
             if (initialPageData.get("read_only_mode")) {
                 return false;
             }
@@ -364,7 +357,7 @@ ko.bindingHandlers.richEditor = {
                 } else {
                     // Handle non-image files
                     const reader = new FileReader();
-                    reader.onload = function(e) {
+                    reader.onload = function (e) {
                         const range = editor.getSelection() || { index: editor.getLength(), length: 0 };
                         editor.insertText(range.index, e.target.result);
                     };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/rich_text_knockout_bindings.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/rich_text_knockout_bindings.js
@@ -61,6 +61,80 @@ function deleteUnusedImages(editor, newImages) {
     }
 }
 
+/**
+ * Upload an image file and insert it into the Quill editor
+ *
+ * @param {File} file - The image file to upload
+ * @param {Quill} editor - The Quill editor instance
+ * @param {Object} options - Additional options
+ * @param {Function} options.onStart - Called when upload starts
+ * @param {Function} options.onComplete - Called when upload completes
+ * @param {Function} options.onError - Called when an error occurs
+ * @returns {Promise<void>}
+ */
+async function uploadAndInsertImage(file, editor, options = {}) {
+    if (!file) {
+        alert(gettext('No File selected'));
+        return;
+    }
+
+    if (options.onStart) {
+        options.onStart();
+    }
+
+    const uploadUrl = initialPageData.reverse("upload_messaging_image");
+    let formData = new FormData();
+    formData.append("upload", file, file.name || "image");
+
+    try {
+        const response = await fetch(uploadUrl, {
+            method: "POST",
+            body: formData,
+            headers: {
+                "X-CSRFTOKEN": $("#csrfTokenContainer").val(),
+            },
+        });
+
+        if (!response.ok) {
+            if (response.status === 400) {
+                const errorJson = await response.json();
+                throw Error(gettext('Failed to upload image: ') + errorJson.error.message);
+            }
+            throw Error(gettext('Failed to upload image. Please try again.'));
+        }
+
+        const data = await response.json();
+        const Delta = Quill.import("delta");
+        const selectionRange = editor.getSelection(true) || { index: editor.getLength(), length: 0 };
+
+        editor.updateContents(
+            new Delta()
+                .retain(selectionRange.index)
+                .delete(selectionRange.length)
+                .insert({
+                    image: data.url,
+                }, {
+                    alt: file.name || "image",
+                }),
+        );
+
+        // Track the image in editorImages
+        const editorImageSet = editorImages.get(editor) || new Set();
+        editorImageSet.add(data.url);
+        editorImages.set(editor, editorImageSet);
+
+        if (options.onComplete) {
+            options.onComplete(data);
+        }
+    } catch (error) {
+        if (options.onError) {
+            options.onError(error);
+        } else {
+            alert(error.message || gettext('Failed to upload image. Please try again.'));
+        }
+    }
+}
+
 function imageHandler() {
     const self = this;
     const $modal = $('#rich-text-image-dialog');
@@ -70,60 +144,22 @@ function imageHandler() {
 
     const handleImage = async function () {
         const file = imageInput.files[0];
-        if (!file) {
-            alert(gettext('No File selected'));
-            return;
-        }
-        uploadProgress.classList.remove("d-none");
 
-        const uploadUrl = initialPageData.reverse("upload_messaging_image");
-        let formData = new FormData();
-
-        formData.append("upload", file, file.name);
-        await fetch(uploadUrl, {
-            method: "POST",
-            body: formData,
-            headers: {
-                "X-CSRFTOKEN": $("#csrfTokenContainer").val(),
+        await uploadAndInsertImage(file, self.quill, {
+            onStart: function() {
+                uploadProgress.classList.remove("d-none");
             },
-        })
-            .then(function (response) {
-                if (!response.ok) {
-                    if (response.status === 400) {
-                        return response.json().then(function (errorJson) {
-                            throw Error(gettext('Failed to upload image: ') + errorJson.error.message);
-                        });
-                    }
-                    throw Error(gettext('Failed to upload image. Please try again.'));
-                }
-                return response.json();
-            })
-            .then(function (data) {
-                const Delta =  Quill.import("delta");
-                const selectionRange = self.quill.getSelection(true);
-                self.quill.updateContents(
-                    new Delta()
-                        .retain(selectionRange.index)
-                        .delete(selectionRange.length)
-                        .insert({
-                            image: data.url,
-                        }, {
-                            alt: file.name,
-                        }),
-                );
-                editorImages.get(self.quill).add(data.url);
-            })
-            .catch(function (error) {
+            onComplete: function() {
+                imageInput.value = '';
+                uploadButton.removeEventListener('click', handleImage);
+                $modal.modal('hide');
+            },
+            onError: function(error) {
                 alert(error.message || gettext('Failed to upload image. Please try again.'));
-            })
-            .finally(function () {
-                uploadProgress.classList.add("d-none");
-            });
-
-
-        imageInput.value = '';
-        uploadButton.removeEventListener('click', handleImage);
-        $modal.modal('hide');
+            },
+        }).finally(function() {
+            uploadProgress.classList.add("d-none");
+        });
     };
 
     uploadButton.addEventListener('click', handleImage);
@@ -254,7 +290,95 @@ ko.bindingHandlers.richEditor = {
                 },
             },
             theme: "snow",
+            // Disable Quill's native clipboard and drop handling
+            clipboard: {
+                matchVisual: false,
+            },
         });
+
+        // Handle paste events in the capture phase to intercept before Quill's handlers
+        editor.root.addEventListener('paste', function(e) {
+            if (initialPageData.get("read_only_mode")) {
+                return;
+            }
+
+            if (e.clipboardData && e.clipboardData.items) {
+                const items = e.clipboardData.items;
+
+                for (let i = 0; i < items.length; i++) {
+                    if (items[i].type.indexOf('image') !== -1) {
+                        // Prevent default and stop propagation to avoid Quill's handling
+                        e.preventDefault();
+                        e.stopPropagation();
+
+                        const file = items[i].getAsFile();
+                        if (!file) {
+                            continue;
+                        }
+
+                        uploadAndInsertImage(file, editor);
+                        break; // Only handle the first image
+                    }
+                }
+            }
+        }, true); // Using capture phase to intercept before Quill's handlers
+
+        // Completely disable Quill's drop handler
+        editor.root.addEventListener('drop', function(e) {
+            e.stopPropagation();
+        }, true);
+
+        // Handle drag and drop images
+        editor.root.addEventListener('dragover', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            editor.root.classList.add('quill-drag-over');
+            return false;
+        }, { capture: true });
+
+        editor.root.addEventListener('dragleave', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            editor.root.classList.remove('quill-drag-over');
+            return false;
+        }, { capture: true });
+
+        editor.root.addEventListener('drop', function(e) {
+            // This needs to happen before anything else
+            e.preventDefault();
+            e.stopPropagation();
+
+            // This completely prevents Quill from handling the drop
+
+            editor.root.classList.remove('quill-drag-over');
+
+            if (initialPageData.get("read_only_mode")) {
+                return false;
+            }
+
+            if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+                const file = e.dataTransfer.files[0];
+
+                if (file.type.indexOf('image') !== -1) {
+                    uploadAndInsertImage(file, editor);
+                } else {
+                    // Handle non-image files
+                    const reader = new FileReader();
+                    reader.onload = function(e) {
+                        const range = editor.getSelection() || { index: editor.getLength(), length: 0 };
+                        editor.insertText(range.index, e.target.result);
+                    };
+                    reader.readAsText(file);
+                }
+            } else if (e.dataTransfer.getData('text')) {
+                // Handle text drag and drop
+                const text = e.dataTransfer.getData('text');
+                const range = editor.getSelection() || { index: editor.getLength(), length: 0 };
+                editor.insertText(range.index, text);
+            }
+
+            return false;
+        }, true);
 
         const value = ko.utils.unwrapObservable(valueAccessor());
         editor.clipboard.dangerouslyPasteHTML(value);


### PR DESCRIPTION
## Product Description

Add drag/drop and paste handling for images to conditional alerts.

Mostly written by AI. I went over the changes and did not see any issues with it. Did some smaller clean up.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6073

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

Tested locally by saving a conditional alert. Previously drag/drop and copy/paste images did not show up after
reopening a conditional alert. Now they do.

Ethan tested a broad cast on staging. Both drag/drop and copy/paste images got send correctly.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
