### PR TITLE
Automatically resize webapps text inputs

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -275,6 +275,19 @@ define("cloudcare/js/form_entry/entries", [
             return null;
         };
 
+        self.afterRender = function (elements) {
+            _.each(elements, function (el) {
+                if (el.nodeName === 'TEXTAREA') {
+                    const showFullText = () => {
+                        el.style.height = 'auto';
+                        el.style.height = el.scrollHeight + 3 + 'px';
+                    };
+                    showFullText();
+                    window.addEventListener('input', showFullText);
+                    window.addEventListener('resize', showFullText);
+                }
+            });
+        };
         self.enableReceiver(question, options);
     }
     FreeTextEntry.prototype = Object.create(EntrySingleAnswer.prototype);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -974,7 +974,9 @@ define("cloudcare/js/form_entry/form_ui", [
         self.entryTemplate = function () {
             return self.entry.templateType + '-entry-ko-template';
         };
-        self.afterRender = function () { self.entry.afterRender(); };
+        self.afterRender = function (elements, entry) {
+            self.entry.afterRender(elements, entry);
+        };
 
         self.ixInfo = function (o) {
             var fullIx = getIx(o);

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_text.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/entry_text.html
@@ -1,13 +1,29 @@
 <script type="text/html" id="text-entry-ko-template">
-  <textarea class="textfield form-control vertical-resize" data-bind="
-        value: $data.rawAnswer,
-        valueUpdate: valueUpdate,
-        css: { 'is-invalid': $parent.hasError() },
-        attr: {
-            placeholder: placeholderText,
-            maxlength: lengthLimit,
-            id: entryId,
-            'aria-required': $parent.required() ? 'true' : 'false',
-        },
-    "></textarea>
+  <textarea
+    class="textfield form-control vertical-resize d-print-none"
+    data-bind="
+      value: $data.rawAnswer,
+      valueUpdate: valueUpdate,
+      css: { 'is-invalid': $parent.hasError() },
+      attr: {
+          placeholder: placeholderText,
+          maxlength: lengthLimit,
+          id: entryId,
+          'aria-required': $parent.required() ? 'true' : 'false',
+      },
+    "
+  ></textarea>
+  {# Render as a div in print mode so the whole thing is visible #}
+  <div
+    class="textfield form-control d-none d-print-block"
+    data-bind="
+      text: $data.rawAnswer() || '&nbsp;',
+      css: { 'is-invalid': $parent.hasError() },
+      attr: {
+          placeholder: placeholderText,
+          maxlength: lengthLimit,
+          'aria-required': $parent.required() ? 'true' : 'false',
+      },
+    "
+  ></div>
 </script>


### PR DESCRIPTION
## Product Description

Text inputs in webapps forms currently start at two rows and don't change unless the user resizes them.  That means that long text is truncated unless you manually drag to expand the input box.  This is especially troublesome when printing forms, as in print view, the field might not be big enough to display everything even if it _was_ big enough before clicking "print".

This PR makes the fields start big enough to display any default value text and they resize automatically as you enter more information or resize the browser window, and they render in full on print.

Old way:
[Screencast from 2025-07-31 17-00-42.webm](https://github.com/user-attachments/assets/f73be288-beb8-4b41-835d-eec4667b6842)

New way:
[Screencast from 2025-07-31 16-59-33.webm](https://github.com/user-attachments/assets/f30f0c17-70da-4fa1-a937-c2f8551bcf53)


## Technical Summary
https://dimagi.atlassian.net/browse/USH-6074

This was much trickier than I'd expected.  Was hoping for a CSS-only solution, but it escapes me.  Under normal operation, setting `height` to `scrollHeight` on any relevant action does resolve the problem, so I did that in javascript.  However, even this doesn't work in print view, I think because it's a static page - `scrollHeight` is the height _before_ print view, not after, so setting it to that is wrong.  The best solution I could come up with is to drop the `textarea` in favor of a `div` when printing, and let the browser figure it out from there.  I suspect there's a maybe-better solution where this is a `contenteditable` div instead of a `textarea`, or maybe one with a hidden shadow textarea, but I'm wary of changing too much here.

## Feature Flag


## Safety Assurance
Currently on staging

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
