### PR TITLE
Move the asterics for required fields to the right

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/webforms.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/webforms.scss
@@ -62,7 +62,14 @@ input:invalid {
   border-color: #b94a48;
 }
 
-.required .caption::before,
+.required .caption .webapp-markdown-output::after {
+  content: '*';
+  font-weight: bold;
+  color: $danger;
+  margin: 0 0 0 3px;
+  display: inline;
+}
+
 .required-group .gr-header .caption::before {
   content: '*';
   font-weight: bold;


### PR DESCRIPTION
## Product Description

To make sure the question labels line up on the left, move the asterisk to the right. 

Before:
<img width="357" height="240" alt="image" src="https://github.com/user-attachments/assets/f0ea085c-35b3-457a-9cee-8ba8ca9ad3a0" />

After:
<img width="386" height="247" alt="image" src="https://github.com/user-attachments/assets/1698fdea-77ae-42f1-a334-4ee7f63f6f9b" />


## Technical Summary

https://dimagi.atlassian.net/browse/USH-4132

## Feature Flag

None

## Safety Assurance

Visual only

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
