### PR TITLE
Add text-break class to break long words

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
@@ -12,7 +12,7 @@
                 'text-end': isButton && stylesContains('text-align-right'),
             }
         ">
-    <label class="caption form-label" data-bind="
+    <label class="caption form-label text-break" data-bind="
       css: labelWidth,
       attr: {
         id: entry.entryId + '-label',


### PR DESCRIPTION
## Product Description

Force long words in label to break instead of adding scroll bar.

Before:

<img width="1025" height="293" alt="image" src="https://github.com/user-attachments/assets/c83470f4-02fc-482b-bdfa-71baa994b866" />

After:

<img width="1021" height="308" alt="image" src="https://github.com/user-attachments/assets/94822f88-6bf0-4615-bbd2-fd88ff68ffb1" />


## Technical Summary

https://dimagi.atlassian.net/browse/USH-4643

## Feature Flag

None

## Safety Assurance

visual only

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
