### PR TITLE
Use middleware to set display language to logged in user's language

### DIFF
--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -112,7 +112,7 @@ from corehq.util.metrics.const import TAG_UNKNOWN, MPM_MAX
 from corehq.util.metrics.utils import sanitize_url
 from corehq.util.public_only_requests.public_only_requests import get_public_only_session
 from corehq.util.timezones.conversions import ServerTime, UserTime
-from corehq.util.view_utils import reverse
+from corehq.util.view_utils import reverse, set_language_cookie
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from corehq.apps.sso.utils.domain_helpers import is_domain_using_sso
@@ -1568,14 +1568,5 @@ def set_language(request):
     lang_code = request.POST.get("language")
     valid_lang_codes = [lang_code for lang_code, __ in settings.LANGUAGES]
     if lang_code and lang_code in valid_lang_codes:
-        response.set_cookie(
-            settings.LANGUAGE_COOKIE_NAME,
-            lang_code,
-            max_age=settings.LANGUAGE_COOKIE_AGE,
-            path=settings.LANGUAGE_COOKIE_PATH,
-            domain=settings.LANGUAGE_COOKIE_DOMAIN,
-            secure=settings.LANGUAGE_COOKIE_SECURE,
-            httponly=settings.LANGUAGE_COOKIE_HTTPONLY,
-            samesite=settings.LANGUAGE_COOKIE_SAMESITE,
-        )
+        response = set_language_cookie(response, lang_code)
     return response

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -40,7 +40,7 @@ from django.utils import html
 from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
-from django.utils.translation import gettext_noop, activate
+from django.utils.translation import gettext_noop
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.debug import sensitive_post_parameters
@@ -434,10 +434,8 @@ def _login(req, domain_name, custom_login_page, extra_context=None):
     if 'auth-username' in req.POST:
         couch_user = CouchUser.get_by_username(req.POST['auth-username'].lower())
         if couch_user:
-            response.set_cookie(settings.LANGUAGE_COOKIE_NAME, couch_user.language)
             # reset cookie to an empty list on login to show domain alerts again
             response.set_cookie('viewed_domain_alerts', [])
-            activate(couch_user.language)
 
     return response
 

--- a/corehq/util/view_utils.py
+++ b/corehq/util/view_utils.py
@@ -205,3 +205,17 @@ def get_date_param(request, param_name, timezone=None):
         if timezone:
             value = UserTime(value, tzinfo=timezone).server_time().done()
         return value
+
+
+def set_language_cookie(response, lang_code):
+    response.set_cookie(
+        settings.LANGUAGE_COOKIE_NAME,
+        lang_code,
+        max_age=settings.LANGUAGE_COOKIE_AGE,
+        path=settings.LANGUAGE_COOKIE_PATH,
+        domain=settings.LANGUAGE_COOKIE_DOMAIN,
+        secure=settings.LANGUAGE_COOKIE_SECURE,
+        httponly=settings.LANGUAGE_COOKIE_HTTPONLY,
+        samesite=settings.LANGUAGE_COOKIE_SAMESITE,
+    )
+    return response

--- a/settings.py
+++ b/settings.py
@@ -162,6 +162,7 @@ MIDDLEWARE = [
     'corehq.util.global_request.middleware.GlobalRequestMiddleware',
     'corehq.apps.users.middleware.UsersMiddleware',
     'corehq.middleware.SentryContextMiddleware',
+    'corehq.middleware.SyncUserLanguageMiddleware',
     'corehq.apps.domain.middleware.DomainMigrationMiddleware',
     'corehq.middleware.TimeoutMiddleware',
     'corehq.middleware.LogLongRequestMiddleware',


### PR DESCRIPTION
## Product Description
Fixes an issue where the display language could change partway through 2fa login, and also ensures logging in from any source (including SSO) will set the display language to the user's account language. Previously, logging in from SSO would not set the display language upon login.

Has the added benefit of not setting the display language when it's not defined in account settings -- for example if a user is viewing the home screen in Spanish and logs into an account with no default language set, they will continue to see HQ in Spanish.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18164
Where we were previously setting the active language in `_login` would apply immediately after a username was submitted in POST data for the form. This meant that for multi-step logins like 2fa, the display language could change after the first step, that it was never changed for SSO logins (because the submit button is replaced with an external link), and also that the display language could be changed to a user's account language simply by entering any user's email and clicking the submit button.

I worked through a couple different ideas to get to the point of using middleware here. I had hoped I could use the `HQLoginView` as the right location for this, but SSO logins don't go through that full view and are instead redirected to the identity provider, then right back into HQ. Rather than defining several different places where the language could be set (HQLoginView and both types of SSO login completion) or attempting to hook into the `user_logged_in` signal which isn't part of the regular request/response cycle, I opted for a middleware because it seemed cleaner and more consistent. This way, also, if the language cookie gets deleted somehow, it will be correctly set again on the next request.

## Safety Assurance

### Safety story
Middleware is higher risk by default because it affects every request. This is simple code, and because we're handling the situation where `couch_user` is `None`, or where it doesn't have a `language` set and simply doing nothing in those cases, there's not a lot to worry about here. We can also be confident that `request.LANGUAGE_CODE` is set so long as this follows `LocaleMiddleware` in ordering. Adds some automated testing for good measure.

Tested locally and on staging with basic and 2fa login, as well as on staging with SSO login, plus general navigation around the site.

### Automated test coverage
Adds `TestSyncUserLanguageMiddleware`

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
