### PR TITLE
Remove bad fuzzy match for %(server_location)s Server

### DIFF
--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -24819,19 +24819,12 @@ msgstr "إنشاء رموز"
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "        %(entity_string)s Property\n"
-#| "      "
+#, python-format
 msgid ""
 "\n"
 "        %(server_location)s Server\n"
 "      "
 msgstr ""
-"\n"
-"        خاصية %(entity_string)s\n"
-"      "
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html

--- a/locale/ara/LC_MESSAGES/django.po
+++ b/locale/ara/LC_MESSAGES/django.po
@@ -23699,19 +23699,12 @@ msgstr "إنشاء رموز"
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "        %(entity_string)s Property\n"
-#| "      "
+#, python-format
 msgid ""
 "\n"
 "        %(server_location)s Server\n"
 "      "
 msgstr ""
-"\n"
-"        خاصية %(entity_string)s\n"
-"      "
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -24190,19 +24190,12 @@ msgstr "Generar Identificadores"
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "        %(entity_string)s Property\n"
-#| "      "
+#, python-format
 msgid ""
 "\n"
 "        %(server_location)s Server\n"
 "      "
 msgstr ""
-"\n"
-"        Propiedad de %(entity_string)s\n"
-"      "
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -24305,19 +24305,12 @@ msgstr "Generer des bons"
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "        %(entity_string)s Property\n"
-#| "      "
+#, python-format
 msgid ""
 "\n"
 "        %(server_location)s Server\n"
 "      "
 msgstr ""
-"\n"
-"        Propriété %(entity_string)s\n"
-"      "
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -23818,19 +23818,12 @@ msgstr "टोकन जेनरेट करें"
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "        %(entity_string)s Property\n"
-#| "      "
+#, python-format
 msgid ""
 "\n"
 "        %(server_location)s Server\n"
 "      "
 msgstr ""
-"\n"
-"        %(entity_string)s प्रॉपर्टी\n"
-"      "
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html

--- a/locale/ita/LC_MESSAGES/django.po
+++ b/locale/ita/LC_MESSAGES/django.po
@@ -24180,19 +24180,12 @@ msgstr "Genera token"
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "        %(entity_string)s Property\n"
-#| "      "
+#, python-format
 msgid ""
 "\n"
 "        %(server_location)s Server\n"
 "      "
 msgstr ""
-"\n"
-"        Proprietà %(entity_string)s\n"
-"      "
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -24138,19 +24138,12 @@ msgstr "Gerar Tokens"
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "        %(entity_string)s Property\n"
-#| "      "
+#, python-format
 msgid ""
 "\n"
 "        %(server_location)s Server\n"
 "      "
 msgstr ""
-"\n"
-"        Propriedade de %(entity_string)s\n"
-"      "
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -23975,19 +23975,12 @@ msgstr "Tengeneza Tokeni"
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "        %(entity_string)s Property\n"
-#| "      "
+#, python-format
 msgid ""
 "\n"
 "        %(server_location)s Server\n"
 "      "
 msgstr ""
-"\n"
-"        Mali ya %(entity_string)s\n"
-"      "
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -25300,19 +25300,12 @@ msgstr "Згенерувати токени"
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "        %(entity_string)s Property\n"
-#| "      "
+#, python-format
 msgid ""
 "\n"
 "        %(server_location)s Server\n"
 "      "
 msgstr ""
-"\n"
-"        Властивість %(entity_string)s\n"
-"      "
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html

--- a/locale/ukr/LC_MESSAGES/django.po
+++ b/locale/ukr/LC_MESSAGES/django.po
@@ -24036,19 +24036,12 @@ msgstr "Згенерувати токени"
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "        %(entity_string)s Property\n"
-#| "      "
+#, python-format
 msgid ""
 "\n"
 "        %(server_location)s Server\n"
 "      "
 msgstr ""
-"\n"
-"        Властивість %(entity_string)s\n"
-"      "
 
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
 #: corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html


### PR DESCRIPTION
## Product Description
Though this PR makes no visible changes, it will allow the " Server" text shown on login screens to be translated correctly instead of always being English:
<img width="490" height="429" alt="image" src="https://github.com/user-attachments/assets/ca3098f8-41cc-4eae-b5bb-8c1e1aeab6a5" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18189
In-depth explanation in the ticket with a couple of longer-term solutions proposed. In short, this is a one-time fix to remove a bad fuzzy match, so this particular highly visible string gets translated with future runs of our `update-translations` workflow. 

## Safety Assurance

### Safety story
Just updating translation files. Confirmed that running `makemessages` after removing the `fuzzy` marker does not re-apply the fuzzy match.

### Automated test coverage
Unlikely.

### QA Plan
Nope.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
