### PR TITLE
Web Apps Maps + Multiselect UI fixes

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -648,7 +648,7 @@ define("cloudcare/js/formplayer/menus/views", [
             casesPerPageLimit: '.per-page-limit',
             searchMoreButton: '#search-more',
             scrollToBottomButton: '#scroll-to-bottom',
-            mapShowHideButton: '#hide-map-button',
+            mapShowHideButton: '.hide-map-button',
         };
     };
 
@@ -1004,7 +1004,7 @@ define("cloudcare/js/formplayer/menus/views", [
         showHideMap: function (e) {
             const mapDiv = $('#module-case-list-map');
             const moduleCaseList = $('#module-case-list');
-            const hideButton = $('#hide-map-button');
+            const hideButton = $('.hide-map-button');
             if (this.mapVisible) {
                 mapDiv.addClass("d-none");
                 moduleCaseList.removeClass('col-lg-7').addClass('col-lg');

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -901,7 +901,7 @@ define("cloudcare/js/formplayer/menus/views", [
         handleSmallScreenChange: function (enabled) {
             const self = this;
             self.smallScreenEnabled = enabled;
-            if (self.options.sidebarEnabled) {
+            if (self.options.sidebarEnabled || self.mapAvailable) {
                 self.positionStickyItems(enabled);
             }
         },

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/list.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/list.html
@@ -14,8 +14,11 @@
     {% include "cloudcare/partials/case_list/menu_header.html" %}
 
     <% if (isMultiSelect) { %>
-    <div class="case-list-actions d-grid gap-2 d-md-block">
+    <div class="case-list-actions d-grid gap-2 d-md-flex align-items-center">
       {% include 'cloudcare/partials/case_list/multi_select_continue_button.html' %}
+      <% if (mapAvailable) { %>
+        {% include "cloudcare/partials/case_list/show_map_button.html" with extra_classes="ms-auto d-none d-lg-block" %}
+      <% } %>
     </div>
     <% } %>
 

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/list.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/list.html
@@ -13,15 +13,6 @@
 
     {% include "cloudcare/partials/case_list/menu_header.html" %}
 
-    <% if (isMultiSelect) { %>
-    <div class="case-list-actions d-grid gap-2 d-md-flex align-items-center">
-      {% include 'cloudcare/partials/case_list/multi_select_continue_button.html' %}
-      <% if (mapAvailable) { %>
-        {% include "cloudcare/partials/case_list/show_map_button.html" with extra_classes="ms-auto d-none d-lg-block" %}
-      <% } %>
-    </div>
-    <% } %>
-
     <% if (!splitScreenToggleEnabled) { %>
     <div class="module-search-container">
       <div class="input-group input-group-lg">

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/menu_header.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/menu_header.html
@@ -31,10 +31,10 @@
 </div>
 
 <% if (isMultiSelect) { %>
-  <div class="case-list-actions d-grid gap-2 d-md-flex align-items-center">
-    {% include 'cloudcare/partials/case_list/multi_select_continue_button.html' %}
-    <% if (mapAvailable) { %>
-      {% include "cloudcare/partials/case_list/show_map_button.html" with extra_classes="ms-auto d-none d-lg-block" %}
-    <% } %>
-  </div>
+<div class="case-list-actions d-grid gap-2 d-md-flex align-items-center">
+  {% include 'cloudcare/partials/case_list/multi_select_continue_button.html' %}
+  <% if (mapAvailable) { %>
+  {% include "cloudcare/partials/case_list/show_map_button.html" with extra_classes="ms-auto d-none d-lg-block" %}
+  <% } %>
+</div>
 <% } %>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/menu_header.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/menu_header.html
@@ -29,3 +29,12 @@
   </div>
   <% } %>
 </div>
+
+<% if (isMultiSelect) { %>
+  <div class="case-list-actions d-grid gap-2 d-md-flex align-items-center">
+    {% include 'cloudcare/partials/case_list/multi_select_continue_button.html' %}
+    <% if (mapAvailable) { %>
+      {% include "cloudcare/partials/case_list/show_map_button.html" with extra_classes="ms-auto d-none d-lg-block" %}
+    <% } %>
+  </div>
+<% } %>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/menu_header.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/menu_header.html
@@ -3,14 +3,11 @@
 
 <div class="page-header menu-header clearfix" id="case-list-menu-header">
   <div class="float-end">
-    <% if (mapAvailable) { %>
-      <% if (isMultiSelect) { %>
-        {% include "cloudcare/partials/case_list/show_map_button.html" with extra_classes="float-end d-block d-lg-none" %}
-      <% } else { %>
-        {% include "cloudcare/partials/case_list/show_map_button.html" with extra_classes="float-end" %}
-      <% } %>
-    <% } %>
-    <% if (sidebarEnabled) { %>
+    <% if (mapAvailable) { %> <% if (isMultiSelect) { %>
+    {% include "cloudcare/partials/case_list/show_map_button.html" with extra_classes="float-end d-block d-lg-none" %}
+    <% } else { %>
+    {% include "cloudcare/partials/case_list/show_map_button.html" with extra_classes="float-end" %}
+    <% } %> <% } %> <% if (sidebarEnabled) { %>
     <button
       id="search-more"
       class="btn btn-primary d-xs-block d-sm-block d-md-block d-lg-none float-end"

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/menu_header.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/menu_header.html
@@ -4,20 +4,13 @@
 <div class="page-header menu-header clearfix" id="case-list-menu-header">
   <div class="float-end">
     <% if (mapAvailable) { %>
-    <button
-      id="hide-map-button"
-      class="btn btn-primary float-end"
-      type="button"
-      aria-expanded="true"
-      aria-controls="module-case-list-map"
-    >
-      <% if (mapVisible()) { %>
-        {% trans "Hide Map" %}
+      <% if (isMultiSelect) { %>
+        {% include "cloudcare/partials/case_list/show_map_button.html" with extra_classes="float-end d-block d-lg-none" %}
       <% } else { %>
-        {% trans "Show Map" %}
+        {% include "cloudcare/partials/case_list/show_map_button.html" with extra_classes="float-end" %}
       <% } %>
-    </button>
-    <% } %> <% if (sidebarEnabled) { %>
+    <% } %>
+    <% if (sidebarEnabled) { %>
     <button
       id="search-more"
       class="btn btn-primary d-xs-block d-sm-block d-md-block d-lg-none float-end"

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/show_map_button.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/show_map_button.html
@@ -5,9 +5,6 @@
   aria-expanded="true"
   aria-controls="module-case-list-map"
 >
-  <% if (mapVisible()) { %>
-    {% trans "Hide Map" %}
-  <% } else { %>
-    {% trans "Show Map" %}
-  <% } %>
+  <% if (mapVisible()) { %> {% trans "Hide Map" %} <% } else { %>
+  {% trans "Show Map" %} <% } %>
 </button>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/show_map_button.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/show_map_button.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+<button
+  class="btn btn-primary hide-map-button {{ extra_classes|default:'' }}"
+  type="button"
+  aria-expanded="true"
+  aria-controls="module-case-list-map"
+>
+  <% if (mapVisible()) { %>
+    {% trans "Hide Map" %}
+  <% } else { %>
+    {% trans "Show Map" %}
+  <% } %>
+</button>

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/case-tile.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/case-tile.scss
@@ -1,4 +1,4 @@
-#case-list-menu-header{
+#case-list-menu-header {
   padding-left: 1.5rem;
   padding-right: 1.5rem;
   background-color: white;
@@ -19,9 +19,9 @@
   margin: 0 5px 5px 5px;
   display: flex;
   justify-content: space-between;
-    #case-list-sort-by-btn {
-      background-color: transparent;
-    }
+  #case-list-sort-by-btn {
+    background-color: transparent;
+  }
 }
 
 #select-all-tile-checkbox {
@@ -93,8 +93,10 @@
       max-width: 100%;
     }
 
-    h1,h2,h3 {
-      margin-top: 0px
+    h1,
+    h2,
+    h3 {
+      margin-top: 0px;
     }
   }
 }
@@ -125,7 +127,6 @@
 
 #menu-region .module-menu-container,
 #menu-region .module-case-list-container {
-
   .white-border {
     border-right-color: transparent;
     border-right-style: solid;
@@ -150,12 +151,16 @@
       line-height: 12px;
       /* Vertically center the text (icon) */
       color: $call-to-action-hi;
-      text-shadow: -1px 0 $call-to-action-low, 0 1px $call-to-action-low, 1px 0 $call-to-action-low, 0 -1px $call-to-action-low;
+      text-shadow:
+        -1px 0 $call-to-action-low,
+        0 1px $call-to-action-low,
+        1px 0 $call-to-action-low,
+        0 -1px $call-to-action-low;
     }
   }
 
   .list-cell-wrapper-style {
-    display: block;         // override .card's display: flex rule
+    display: block; // override .card's display: flex rule
     margin: 10px 5px 0 5px;
     border-collapse: collapse;
     vertical-align: top;
@@ -183,22 +188,22 @@
     border-color: $primary;
   }
 
-  .case-tile-group{
+  .case-tile-group {
     margin: 10px;
     padding: 10px 0;
 
-    .group-data{
+    .group-data {
       flex-grow: 1;
       display: flex;
       flex-direction: column;
     }
-    .group-rows{
+    .group-rows {
       display: flex;
       flex-direction: column;
       gap: 10px;
       align-items: center;
     }
-    .group-row{
+    .group-row {
       background-color: white;
       width: 95%;
     }

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/case-tile.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/case-tile.scss
@@ -132,6 +132,7 @@
     border-right-width: 5px;
   }
 
+  .sticky-header,
   .sticky-map {
     top: 0px;
   }


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This PR made a number of changes:
For large+ screens:
-   If multiselect "continue" is displayed, then shift the "hide/show map" button down so that it is right above the map

For large - screens:
- For EntityScreen: make the entire header sticky if a map is available. (This is to make it consistent with the query screen)
- Fixes the sticky header to remove the gap above it
- fixes "continue" button being cut off by the map

https://github.com/user-attachments/assets/7a85b067-e58b-4cc8-aa11-319f24ccb860


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
I'm not a fan of how "hardcoded" the location and positioning of the "show/hide map" button is. It's dependent on whether `case-list-actions` `div` is created to house the multiselect "continue" button. But this is the cleanest solution I thought of to still have the "hide/show map" button horizontally aligned with the header in small screen and if multiselect isn't used.

[USH-4110](https://dimagi.atlassian.net/jira/software/c/projects/USH/boards/143?assignee=6304fc87a4f57644346b19b3&selectedIssue=USH-4110)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[Multiselect](https://www.commcarehq.org/hq/flags/edit/ush_case_list_multi_select/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is purely a UI change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-4110]: https://dimagi.atlassian.net/browse/USH-4110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ