### PR TITLE
[Bulk Data Editing] Add tests for filter and pinned filter managers

### DIFF
--- a/corehq/apps/data_cleaning/models/filters.py
+++ b/corehq/apps/data_cleaning/models/filters.py
@@ -212,12 +212,20 @@ class BulkEditPinnedFilterManager(models.Manager):
 
     def copy_to_session(self, source_session, dest_session):
         for pinned_filter in self.filter(session=source_session):
-            self.model.objects.create(
+            existing_filter = self.model.objects.filter(
                 session=dest_session,
-                index=pinned_filter.index,
                 filter_type=pinned_filter.filter_type,
-                value=pinned_filter.value,
-            )
+            ).first()
+            if existing_filter:
+                existing_filter.value = pinned_filter.value
+                existing_filter.save()
+            else:
+                self.model.objects.create(
+                    session=dest_session,
+                    index=pinned_filter.index,
+                    filter_type=pinned_filter.filter_type,
+                    value=pinned_filter.value,
+                )
 
 
 class BulkEditPinnedFilter(models.Model):

--- a/corehq/apps/data_cleaning/tests/test_filters.py
+++ b/corehq/apps/data_cleaning/tests/test_filters.py
@@ -46,7 +46,7 @@ from corehq.form_processor.tests.utils import FormProcessorTestUtils
 
 
 @pytest.mark.parametrize(
-    'category, valid_match_types',
+    ('category', 'valid_match_types'),
     [
         (
             DataType.FILTER_CATEGORY_TEXT,
@@ -150,70 +150,58 @@ class BulkEditFilterQueryTests(TestCase):
     def test_filter_query_is_empty(self):
         query = CaseSearchES().domain(self.domain)
         for data_type, _ in DataType.CHOICES:
-            active_filter = BulkEditFilter(
-                session=self.session,
-                prop_id='soil_contents',
-                data_type=data_type,
-                match_type=FilterMatchType.IS_EMPTY,
-            )
-            filtered_query = active_filter.filter_query(query)
-            expected_query = query.filter(exact_case_property_text_query('soil_contents', ''))
-            self.assertEqual(
-                filtered_query.es_query,
-                expected_query.es_query,
-                msg=f'{data_type} failed to filter the query properly for FilterMatchType.IS_EMPTY',
-            )
+            with self.subTest(data_type=data_type):
+                active_filter = BulkEditFilter(
+                    session=self.session,
+                    prop_id='soil_contents',
+                    data_type=data_type,
+                    match_type=FilterMatchType.IS_EMPTY,
+                )
+                filtered_query = active_filter.filter_query(query)
+                expected_query = query.filter(exact_case_property_text_query('soil_contents', ''))
+                assert filtered_query.es_query == expected_query.es_query
 
     def test_filter_query_is_not_empty(self):
         query = CaseSearchES().domain(self.domain)
         for data_type, _ in DataType.CHOICES:
-            active_filter = BulkEditFilter(
-                session=self.session,
-                prop_id='soil_contents',
-                data_type=data_type,
-                match_type=FilterMatchType.IS_NOT_EMPTY,
-            )
-            filtered_query = active_filter.filter_query(query)
-            expected_query = query.NOT(exact_case_property_text_query('soil_contents', ''))
-            self.assertEqual(
-                filtered_query.es_query,
-                expected_query.es_query,
-                msg=f'{data_type} failed to filter the query properly for FilterMatchType.IS_NOT_EMPTY',
-            )
+            with self.subTest(data_type=data_type):
+                active_filter = BulkEditFilter(
+                    session=self.session,
+                    prop_id='soil_contents',
+                    data_type=data_type,
+                    match_type=FilterMatchType.IS_NOT_EMPTY,
+                )
+                filtered_query = active_filter.filter_query(query)
+                expected_query = query.NOT(exact_case_property_text_query('soil_contents', ''))
+                assert filtered_query.es_query == expected_query.es_query
 
     def test_filter_query_is_missing(self):
         query = CaseSearchES().domain(self.domain)
         for data_type, _ in DataType.CHOICES:
-            active_filter = BulkEditFilter(
-                session=self.session,
-                prop_id='soil_contents',
-                data_type=data_type,
-                match_type=FilterMatchType.IS_MISSING,
-            )
-            filtered_query = active_filter.filter_query(query)
-            expected_query = query.filter(case_property_missing('soil_contents'))
-            self.assertEqual(
-                filtered_query.es_query,
-                expected_query.es_query,
-                msg=f'{data_type} failed to filter the query properly for FilterMatchType.IS_MISSING',
-            )
+            with self.subTest(data_type=data_type):
+                active_filter = BulkEditFilter(
+                    session=self.session,
+                    prop_id='soil_contents',
+                    data_type=data_type,
+                    match_type=FilterMatchType.IS_MISSING,
+                )
+                filtered_query = active_filter.filter_query(query)
+                expected_query = query.filter(case_property_missing('soil_contents'))
+                assert filtered_query.es_query == expected_query.es_query
 
     def test_filter_query_is_not_missing(self):
         query = CaseSearchES().domain(self.domain)
         for data_type, _ in DataType.CHOICES:
-            active_filter = BulkEditFilter(
-                session=self.session,
-                prop_id='soil_contents',
-                data_type=data_type,
-                match_type=FilterMatchType.IS_NOT_MISSING,
-            )
-            filtered_query = active_filter.filter_query(query)
-            expected_query = query.NOT(case_property_missing('soil_contents'))
-            self.assertEqual(
-                filtered_query.es_query,
-                expected_query.es_query,
-                msg=f'{data_type} failed to filter the query properly for FilterMatchType.IS_NOT_MISSING',
-            )
+            with self.subTest(data_type=data_type):
+                active_filter = BulkEditFilter(
+                    session=self.session,
+                    prop_id='soil_contents',
+                    data_type=data_type,
+                    match_type=FilterMatchType.IS_NOT_MISSING,
+                )
+                filtered_query = active_filter.filter_query(query)
+                expected_query = query.NOT(case_property_missing('soil_contents'))
+                assert filtered_query.es_query == expected_query.es_query
 
     def filter_query_remains_unchanged_for_other_match_types(self):
         query = CaseSearchES().domain(self.domain)
@@ -221,18 +209,15 @@ class BulkEditFilterQueryTests(TestCase):
             if match_type in dict(FilterMatchType.ALL_DATA_TYPES_CHOICES):
                 continue
             for data_type, _ in DataType.CHOICES:
-                active_filter = BulkEditFilter(
-                    session=self.session,
-                    prop_id='soil_contents',
-                    data_type=data_type,
-                    match_type=match_type,
-                )
-                filtered_query = active_filter.filter_query(query)
-                self.assertEqual(
-                    filtered_query.es_query,
-                    query.es_query,
-                    msg=f'filtered query should remain unchanged for {data_type}, {match_type}',
-                )
+                with self.subTest(data_type=data_type, match_type=match_type):
+                    active_filter = BulkEditFilter(
+                        session=self.session,
+                        prop_id='soil_contents',
+                        data_type=data_type,
+                        match_type=match_type,
+                    )
+                    filtered_query = active_filter.filter_query(query)
+                    assert filtered_query.es_query is query.es_query
 
 
 class BulkEditFilterXpathTest(TestCase):
@@ -243,7 +228,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.EXACT,
             value='Riny Iola',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "name = 'Riny Iola'")
+        assert active_filter.get_xpath_expression() == "name = 'Riny Iola'"
 
     def test_single_quote_xpath(self):
         active_filter = BulkEditFilter(
@@ -252,8 +237,8 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.EXACT,
             value="Happy's",
         )
-        self.assertEqual(active_filter.get_quoted_value(active_filter.value), '''"Happy's"''')
-        self.assertEqual(active_filter.get_xpath_expression(), '''name = "Happy's"''')
+        assert active_filter.get_quoted_value(active_filter.value) == '''"Happy's"'''
+        assert active_filter.get_xpath_expression() == '''name = "Happy's"'''
 
     def test_double_quote_xpath(self):
         active_filter = BulkEditFilter(
@@ -262,8 +247,8 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.EXACT,
             value='Zesty "orange" Flora',
         )
-        self.assertEqual(active_filter.get_quoted_value(active_filter.value), """'Zesty "orange" Flora'""")
-        self.assertEqual(active_filter.get_xpath_expression(), """name = 'Zesty "orange" Flora'""")
+        assert active_filter.get_quoted_value(active_filter.value) == """'Zesty "orange" Flora'"""
+        assert active_filter.get_xpath_expression() == """name = 'Zesty "orange" Flora'"""
 
     def test_mixed_quote_xpath(self):
         active_filter = BulkEditFilter(
@@ -272,22 +257,22 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.EXACT,
             value="""Zesty's "orange" Flora""",
         )
-        with self.assertRaises(UnsupportedFilterValueException):
+        with pytest.raises(UnsupportedFilterValueException):
             active_filter.get_quoted_value(active_filter.value)
-        with self.assertRaises(UnsupportedFilterValueException):
+        with pytest.raises(UnsupportedFilterValueException):
             active_filter.get_xpath_expression()
 
     def test_exact_number_xpath(self):
         active_filter = BulkEditFilter(
             prop_id='height_cm', data_type=DataType.DECIMAL, match_type=FilterMatchType.EXACT, value='11.2'
         )
-        self.assertEqual(active_filter.get_xpath_expression(), 'height_cm = 11.2')
+        assert active_filter.get_xpath_expression() == 'height_cm = 11.2'
 
     def test_exact_date_xpath(self):
         active_filter = BulkEditFilter(
             prop_id='watered_on', data_type=DataType.DATE, match_type=FilterMatchType.EXACT, value='2024-12-11'
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "watered_on = '2024-12-11'")
+        assert active_filter.get_xpath_expression() == "watered_on = '2024-12-11'"
 
     def test_is_not_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -296,7 +281,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.IS_NOT,
             value='11245523233',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "phone_num != '11245523233'")
+        assert active_filter.get_xpath_expression() == "phone_num != '11245523233'"
 
     def test_is_not_number_xpath(self):
         active_filter = BulkEditFilter(
@@ -305,7 +290,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.IS_NOT,
             value='5',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), 'num_leaves != 5')
+        assert active_filter.get_xpath_expression() == 'num_leaves != 5'
 
     def test_less_than_number_xpath(self):
         active_filter = BulkEditFilter(
@@ -314,7 +299,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.LESS_THAN,
             value='12.35',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), 'height_cm < 12.35')
+        assert active_filter.get_xpath_expression() == 'height_cm < 12.35'
 
     def test_less_than_date_xpath(self):
         active_filter = BulkEditFilter(
@@ -323,7 +308,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.LESS_THAN,
             value='2025-02-03 16:43',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "watered_on < '2025-02-03 16:43'")
+        assert active_filter.get_xpath_expression() == "watered_on < '2025-02-03 16:43'"
 
     def test_less_than_equal_number_xpath(self):
         active_filter = BulkEditFilter(
@@ -332,7 +317,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.LESS_THAN_EQUAL,
             value='35.5',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), 'weight_kg <= 35.5')
+        assert active_filter.get_xpath_expression() == 'weight_kg <= 35.5'
 
     def test_less_than_equal_date_xpath(self):
         active_filter = BulkEditFilter(
@@ -341,7 +326,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.LESS_THAN_EQUAL,
             value='2025-02-20 16:55',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "last_modified <= '2025-02-20 16:55'")
+        assert active_filter.get_xpath_expression() == "last_modified <= '2025-02-20 16:55'"
 
     def test_greater_than_number_xpath(self):
         active_filter = BulkEditFilter(
@@ -350,7 +335,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.GREATER_THAN,
             value='15',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), 'amount > 15')
+        assert active_filter.get_xpath_expression() == 'amount > 15'
 
     def test_greater_than_date_xpath(self):
         active_filter = BulkEditFilter(
@@ -359,7 +344,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.GREATER_THAN,
             value='2025-01-22',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "modified_on > '2025-01-22'")
+        assert active_filter.get_xpath_expression() == "modified_on > '2025-01-22'"
 
     def test_greater_than_equal_number_xpath(self):
         active_filter = BulkEditFilter(
@@ -368,7 +353,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.GREATER_THAN_EQUAL,
             value='23',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), 'num_branches >= 23')
+        assert active_filter.get_xpath_expression() == 'num_branches >= 23'
 
     def test_greater_than_equal_date_xpath(self):
         active_filter = BulkEditFilter(
@@ -377,7 +362,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.GREATER_THAN_EQUAL,
             value='2025-03-03',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "submitted_on >= '2025-03-03'")
+        assert active_filter.get_xpath_expression() == "submitted_on >= '2025-03-03'"
 
     def test_starts_with_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -386,7 +371,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.STARTS,
             value='st',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "starts-with(name, 'st')")
+        assert active_filter.get_xpath_expression() == "starts-with(name, 'st')"
 
     def test_starts_with_text_single_quote_xpath(self):
         active_filter = BulkEditFilter(
@@ -395,7 +380,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.STARTS,
             value="st's",
         )
-        self.assertEqual(active_filter.get_xpath_expression(), """starts-with(name, "st's")""")
+        assert active_filter.get_xpath_expression() == """starts-with(name, "st's")"""
 
     def test_starts_with_text_double_quote_xpath(self):
         active_filter = BulkEditFilter(
@@ -404,7 +389,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.STARTS,
             value='st"s',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), """starts-with(name, 'st"s')""")
+        assert active_filter.get_xpath_expression() == """starts-with(name, 'st"s')"""
 
     def test_starts_text_mixed_quote_xpath(self):
         active_filter = BulkEditFilter(
@@ -413,7 +398,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.STARTS,
             value="""st"s m'd""",
         )
-        with self.assertRaises(UnsupportedFilterValueException):
+        with pytest.raises(UnsupportedFilterValueException):
             active_filter.get_xpath_expression()
 
     def test_starts_not_text_xpath(self):
@@ -423,7 +408,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.STARTS_NOT,
             value='fo',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "not(starts-with(favorite_park, 'fo'))")
+        assert active_filter.get_xpath_expression() == "not(starts-with(favorite_park, 'fo'))"
 
     def test_fuzzy_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -432,7 +417,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.FUZZY,
             value='ceremic',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "fuzzy-match(pot_type, 'ceremic')")
+        assert active_filter.get_xpath_expression() == "fuzzy-match(pot_type, 'ceremic')"
 
     def test_fuzzy_not_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -441,7 +426,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.FUZZY_NOT,
             value='ceremic',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "not(fuzzy-match(pot_type, 'ceremic'))")
+        assert active_filter.get_xpath_expression() == "not(fuzzy-match(pot_type, 'ceremic'))"
 
     def test_phonetic_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -450,7 +435,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.PHONETIC,
             value='hi',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "phonetic-match(light_level, 'hi')")
+        assert active_filter.get_xpath_expression() == "phonetic-match(light_level, 'hi')"
 
     def test_phonetic_not_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -459,7 +444,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.PHONETIC_NOT,
             value='hi',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "not(phonetic-match(light_level, 'hi'))")
+        assert active_filter.get_xpath_expression() == "not(phonetic-match(light_level, 'hi'))"
 
     def test_is_any_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -468,9 +453,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.IS_ANY,
             value='yellow_leaves root_rot',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(), "selected-any(health_issues, 'yellow_leaves root_rot')"
-        )
+        assert active_filter.get_xpath_expression() == "selected-any(health_issues, 'yellow_leaves root_rot')"
 
     def test_is_not_any_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -479,9 +462,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.IS_NOT_ANY,
             value='fungus root_rot',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(), "not(selected-any(health_issues, 'fungus root_rot'))"
-        )
+        assert active_filter.get_xpath_expression() == "not(selected-any(health_issues, 'fungus root_rot'))"
 
     def test_is_all_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -490,7 +471,7 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.IS_ALL,
             value='bark worm_castings',
         )
-        self.assertEqual(active_filter.get_xpath_expression(), "selected-all(soil_contents, 'bark worm_castings')")
+        assert active_filter.get_xpath_expression() == "selected-all(soil_contents, 'bark worm_castings')"
 
     def test_is_not_all_text_xpath(self):
         active_filter = BulkEditFilter(
@@ -499,22 +480,18 @@ class BulkEditFilterXpathTest(TestCase):
             match_type=FilterMatchType.IS_NOT_ALL,
             value='bark worm_castings',
         )
-        self.assertEqual(
-            active_filter.get_xpath_expression(), "not(selected-all(soil_contents, 'bark worm_castings'))"
-        )
+        assert active_filter.get_xpath_expression() == "not(selected-all(soil_contents, 'bark worm_castings'))"
 
     def test_value_match_types_return_none_all_data_types_xpath(self):
         for match_type, _ in FilterMatchType.ALL_DATA_TYPES_CHOICES:
             for data_type, _ in DataType.CHOICES:
-                active_filter = BulkEditFilter(
-                    prop_id='a_property',
-                    data_type=data_type,
-                    match_type=match_type,
-                )
-                self.assertIsNone(
-                    active_filter.get_xpath_expression(),
-                    msg=f'{match_type} for {data_type} should not return an xpath expression',
-                )
+                with self.subTest(data_type=data_type, match_type=match_type):
+                    active_filter = BulkEditFilter(
+                        prop_id='a_property',
+                        data_type=data_type,
+                        match_type=match_type,
+                    )
+                    assert active_filter.get_xpath_expression() is None
 
 
 class TestReportFilterSubclasses(TestCase):
@@ -569,7 +546,7 @@ class TestReportFilterSubclasses(TestCase):
                 'target="_blank"> Filter Definitions</a>.',
             ],
         }
-        self.assertDictEqual(report_filter.filter_context, expected_context)
+        assert report_filter.filter_context == expected_context
 
     @mock.patch.object(Domain, 'uses_locations', lambda: True)  # removes dependency on accounting
     def test_case_owners_report_filter_context_locations(self):
@@ -605,25 +582,23 @@ class TestReportFilterSubclasses(TestCase):
                 '+Management#Search-for-Locations"target="_blank">Learn more</a>.',
             ],
         }
-        self.assertDictEqual(report_filter.filter_context, expected_context)
+        assert report_filter.filter_context == expected_context
 
     def test_case_owners_update_stored_value(self):
         self.request.POST = QueryDict('case_list_filter=project_data&case_list_filter=t__6&case_list_filter=t__3')
         self.request.method = 'POST'
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
-        self.assertIsNone(pinned_filter.value)
+        assert pinned_filter.value is None
         report_filter = CaseOwnersPinnedFilter(self.session, self.request, self.domain, use_bootstrap5=True)
         report_filter.update_stored_value()
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
-        self.assertEqual(pinned_filter.value, ['project_data', 't__6', 't__3'])
+        assert pinned_filter.value == ['project_data', 't__6', 't__3']
         expected_value = [
             {'id': 'project_data', 'text': '[Project Data]'},
             {'id': 't__6', 'text': '[Active Web Users]'},
             {'id': 't__3', 'text': '[Unknown Users]'},
         ]
-        self.assertEqual(
-            report_filter.filter_context['report_select2_config']['select']['selected'], expected_value
-        )
+        assert report_filter.filter_context['report_select2_config']['select']['selected'] == expected_value
 
     def test_case_status_report_filter_context(self):
         report_filter = CaseStatusPinnedFilter(self.session, self.request, self.domain, use_bootstrap5=True)
@@ -646,18 +621,18 @@ class TestReportFilterSubclasses(TestCase):
                 },
             },
         }
-        self.assertDictEqual(report_filter.filter_context, expected_context)
+        assert report_filter.filter_context == expected_context
 
     def test_case_status_update_stored_value(self):
         self.request.POST = QueryDict('is_open=open')
         self.request.method = 'POST'
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_STATUS)
-        self.assertIsNone(pinned_filter.value)
+        assert pinned_filter.value is None
         report_filter = CaseStatusPinnedFilter(self.session, self.request, self.domain, use_bootstrap5=True)
         report_filter.update_stored_value()
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_STATUS)
-        self.assertEqual(pinned_filter.value, ['open'])
-        self.assertEqual(report_filter.filter_context['report_select2_config']['select']['selected'], 'open')
+        assert pinned_filter.value == ['open']
+        assert report_filter.filter_context['report_select2_config']['select']['selected'] == 'open'
 
 
 @es_test(requires=[case_search_adapter, user_adapter, group_adapter], setup_class=True)
@@ -715,19 +690,19 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
     def test_default(self):
         query = CaseSearchES().domain(self.domain)
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
-        self.assertIsNone(pinned_filter.value)
+        assert pinned_filter.value is None
         filtered_query = pinned_filter.filter_query(query)
-        self.assertDictEqual(filtered_query.es_query, query.es_query)
+        assert filtered_query.es_query == query.es_query
 
     def test_default_location_restricted(self):
         query = CaseSearchES().domain(self.domain)
         pinned_filter = self.session_location_restricted.pinned_filters.get(
             filter_type=PinnedFilterType.CASE_OWNERS
         )
-        self.assertIsNone(pinned_filter.value)
+        assert pinned_filter.value is None
         filtered_query = pinned_filter.filter_query(query)
         expected_query = query_location_restricted_cases(query, self.domain, self.web_location_user)
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query
 
     def test_all_data(self):
         query = CaseSearchES().domain(self.domain)
@@ -735,7 +710,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.value = ['project_data', 'all_data', 't__5']
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
-        self.assertDictEqual(filtered_query.es_query, query.es_query)
+        assert filtered_query.es_query == query.es_query
 
     def test_all_data_location_restricted(self):
         # location restricted users can't view "all data", ensure that's the case
@@ -747,7 +722,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
         expected_query = query_location_restricted_cases(query, self.domain, self.web_location_user)
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query
 
     def test_deactivated(self):
         query = CaseSearchES().domain(self.domain)
@@ -756,7 +731,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.save()
         expected_query = query.OR(deactivated_case_owners(self.domain))
         filtered_query = pinned_filter.filter_query(query)
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query
 
     def test_deactivated_location_restricted(self):
         query = CaseSearchES().domain(self.domain)
@@ -767,7 +742,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.save()
         expected_query = query_location_restricted_cases(query, self.domain, self.web_location_user)
         filtered_query = pinned_filter.filter_query(query)
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query
 
     def test_selected_user_types(self):
         query = CaseSearchES().domain(self.domain)
@@ -780,20 +755,17 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
             (f't__{HQUserType.COMMTRACK}', False),
             (f't__{HQUserType.WEB}', False),
         ]:
-            pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
-            pinned_filter.value = [user_type]
-            pinned_filter.save()
-            filtered_query = pinned_filter.filter_query(query)
-            expected_query = (
-                query
-                if is_owners_empty
-                else query.OR(case_es.owner(get_case_owners(True, self.domain, pinned_filter.value)))
-            )
-            self.assertDictEqual(
-                filtered_query.es_query,
-                expected_query.es_query,
-                msg=f'expected query did not match for user type {user_type}',
-            )
+            with self.subTest(user_type=user_type, is_owners_empty=is_owners_empty):
+                pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_OWNERS)
+                pinned_filter.value = [user_type]
+                pinned_filter.save()
+                filtered_query = pinned_filter.filter_query(query)
+                expected_query = (
+                    query
+                    if is_owners_empty
+                    else query.OR(case_es.owner(get_case_owners(True, self.domain, pinned_filter.value)))
+                )
+                assert filtered_query.es_query == expected_query.es_query
 
     def test_selected_user_types_location_restricted(self):
         query = CaseSearchES().domain(self.domain)
@@ -806,18 +778,15 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
             f't__{HQUserType.COMMTRACK}',
             f't__{HQUserType.WEB}',
         ]:
-            pinned_filter = self.session_location_restricted.pinned_filters.get(
-                filter_type=PinnedFilterType.CASE_OWNERS
-            )
-            pinned_filter.value = [user_type]
-            pinned_filter.save()
-            filtered_query = pinned_filter.filter_query(query)
-            expected_query = query_location_restricted_cases(query, self.domain, self.web_location_user)
-            self.assertDictEqual(
-                filtered_query.es_query,
-                expected_query.es_query,
-                msg=f'expected query did not match for user type {user_type}',
-            )
+            with self.subTest(user_type=user_type):
+                pinned_filter = self.session_location_restricted.pinned_filters.get(
+                    filter_type=PinnedFilterType.CASE_OWNERS
+                )
+                pinned_filter.value = [user_type]
+                pinned_filter.save()
+                filtered_query = pinned_filter.filter_query(query)
+                expected_query = query_location_restricted_cases(query, self.domain, self.web_location_user)
+                assert filtered_query.es_query == expected_query.es_query
 
     def test_selected_user_ids(self):
         selected_user_ids = [self.users[0]._id, self.users[3]._id, self.users[4]._id]
@@ -827,7 +796,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
         expected_query = query.OR(case_es.owner(get_case_owners(True, self.domain, pinned_filter.value)))
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query
 
     def test_selected_user_ids_location_restricted(self):
         selected_user_ids = [self.users[0]._id, self.users[3]._id, self.users[4]._id]
@@ -843,7 +812,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
             self.domain,
             self.web_location_user,
         )
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query
 
     def test_groups(self):
         query = CaseSearchES().domain(self.domain)
@@ -852,7 +821,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
         expected_query = query.OR(case_es.owner(get_case_owners(True, self.domain, pinned_filter.value)))
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query
 
     def test_groups_location_restricted(self):
         query = CaseSearchES().domain(self.domain)
@@ -863,7 +832,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
         expected_query = query_location_restricted_cases(query, self.domain, self.web_location_user)
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query
 
     def test_location_ids(self):
         location_id = self.locations['Brooklyn'].location_id
@@ -873,7 +842,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
         expected_query = query.OR(case_es.owner(get_case_owners(True, self.domain, pinned_filter.value)))
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query
 
     def test_location_ids_location_restricted(self):
         location_id = self.locations['Brooklyn'].location_id
@@ -889,7 +858,7 @@ class TestCaseOwnersPinnedFilterQuery(BaseCaseOwnersTest):
             self.domain,
             self.web_location_user,
         )
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query
 
 
 @es_test(requires=[case_search_adapter], setup_class=True)
@@ -923,9 +892,9 @@ class TestCaseStatusPinnedFilterQuery(TestCase):
     def test_default(self):
         query = CaseSearchES().domain(self.domain)
         pinned_filter = self.session.pinned_filters.get(filter_type=PinnedFilterType.CASE_STATUS)
-        self.assertIsNone(pinned_filter.value)
+        assert pinned_filter.value is None
         filtered_query = pinned_filter.filter_query(query)
-        self.assertDictEqual(filtered_query.es_query, query.es_query)
+        assert filtered_query.es_query == query.es_query
 
     def test_open(self):
         query = CaseSearchES().domain(self.domain)
@@ -934,7 +903,7 @@ class TestCaseStatusPinnedFilterQuery(TestCase):
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
         expected_query = query.is_closed(False)
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query
 
     def test_closed(self):
         query = CaseSearchES().domain(self.domain)
@@ -943,4 +912,4 @@ class TestCaseStatusPinnedFilterQuery(TestCase):
         pinned_filter.save()
         filtered_query = pinned_filter.filter_query(query)
         expected_query = query.is_closed(True)
-        self.assertDictEqual(filtered_query.es_query, expected_query.es_query)
+        assert filtered_query.es_query == expected_query.es_query


### PR DESCRIPTION
## Technical Summary
This adds tests for `BulkEditFilterManger` and `BulkEditPinnedFilterManager`'s `copy_to_session` methods.

This also adds a test for the default pinned filters for a session.

Part of this ticket
https://dimagi.atlassian.net/browse/SAAS-16861

While working on these tests, I realized the `copy_to_session` behavior for `BulkEditPinnedFilterManager` is incorrect. It shouldn't create a new pinned filter if a pinned filter for that type already exists. Instead, the value should be updated.

I also updated the `assert` (and related) statements for the existing filter tests, and cleaned up a pytest decorator.


## Safety Assurance

### Safety story
very safe change. just adds tests and makes a small, very testable, bug fix to the `BulkEditPinnedFilterManager.copy_to_session` method.

### Automated test coverage
yes, adds more tests

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
