### PR TITLE
Add tests for BulkEditColumnManager

### DIFF
--- a/corehq/apps/data_cleaning/models/column.py
+++ b/corehq/apps/data_cleaning/models/column.py
@@ -44,14 +44,24 @@ class BulkEditColumnManager(models.Manager):
 
     def copy_to_session(self, source_session, dest_session):
         for column in self.filter(session=source_session):
-            self.model.objects.create(
+            existing = self.model.objects.filter(
                 session=dest_session,
-                index=column.index,
                 prop_id=column.prop_id,
-                label=column.label,
-                data_type=column.data_type,
-                is_system=column.is_system,
-            )
+            ).first()
+            if existing:
+                existing.label = column.label
+                existing.data_type = column.data_type
+                existing.index = column.index
+                existing.save()
+            else:
+                self.model.objects.create(
+                    session=dest_session,
+                    index=column.index,
+                    prop_id=column.prop_id,
+                    label=column.label,
+                    data_type=column.data_type,
+                    is_system=column.is_system,
+                )
 
     def create_for_session(self, session, prop_id, label, data_type=None):
         is_system_property = self.model.is_system_property(prop_id)

--- a/corehq/apps/data_cleaning/models/column.py
+++ b/corehq/apps/data_cleaning/models/column.py
@@ -11,19 +11,19 @@ from corehq.apps.data_cleaning.models.types import (
 
 class BulkEditColumnManager(models.Manager):
     use_for_related_fields = True
+    _DEFAULT_PROPERTIES_BY_SESSION_TYPE = {
+        BulkEditSessionType.CASE: (
+            'name',
+            'owner_name',
+            'date_opened',
+            'opened_by_username',
+            'last_modified',
+            '@status',
+        ),
+    }
 
     def create_session_defaults(self, session):
-        default_properties = {
-            BulkEditSessionType.CASE: (
-                'name',
-                'owner_name',
-                'date_opened',
-                'opened_by_username',
-                'last_modified',
-                '@status',
-            ),
-        }.get(session.session_type)
-
+        default_properties = self._DEFAULT_PROPERTIES_BY_SESSION_TYPE.get(session.session_type)
         if not default_properties:
             raise NotImplementedError(f'{session.session_type} default columns not yet supported')
 

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -384,6 +384,23 @@ class BulkEditSessionCaseColumnTests(BaseBulkEditSessionTest):
         assert new_column.data_type == DataType.TEXT
         assert new_column.is_system
 
+    def test_copy_to_session(self):
+        self.session.add_column('num_leaves', 'Number of Leaves', DataType.INTEGER)
+        self.session.add_column('pot_type', 'Pot Type', DataType.MULTIPLE_OPTION)
+        name_col = self.session.columns.get(prop_id='name')
+        name_col.label = 'Plant Name'
+        name_col.save()
+        new_session = BulkEditSession.objects.new_case_session(self.django_user, self.domain_name, self.case_type)
+        assert new_session.columns.count() == 6  # defaults
+        self.session.columns.copy_to_session(self.session, new_session)
+        assert new_session.columns.count() == 8
+        for new_column in new_session.columns.all():
+            old_column = self.session.columns.get(prop_id=new_column.prop_id)
+            assert new_column.index == old_column.index
+            assert new_column.label == old_column.label
+            assert new_column.data_type == old_column.data_type
+            assert new_column.is_system == old_column.is_system
+
 
 @es_test(requires=[case_search_adapter])
 class BulkEditSessionSelectionCountTests(CaseDataTestMixin, BaseBulkEditSessionTest):

--- a/corehq/apps/data_cleaning/tests/test_session.py
+++ b/corehq/apps/data_cleaning/tests/test_session.py
@@ -13,6 +13,7 @@ from corehq.apps.data_cleaning.models import (
     DataType,
     FilterMatchType,
 )
+from corehq.apps.data_cleaning.models.column import BulkEditColumnManager
 from corehq.apps.data_cleaning.tests.mixins import CaseDataTestMixin
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es import CaseSearchES, group_adapter, user_adapter
@@ -356,6 +357,13 @@ class BaseBulkEditSessionTest(TestCase):
 
 class BulkEditSessionCaseColumnTests(BaseBulkEditSessionTest):
     domain_name = 'session-test-case-columns'
+
+    def test_default_columns(self):
+        assert self.session.columns.count() == 6
+        default_columns = BulkEditColumnManager._DEFAULT_PROPERTIES_BY_SESSION_TYPE[BulkEditSessionType.CASE]
+        for index, column in enumerate(self.session.columns.all()):
+            assert column.prop_id == default_columns[index]
+            assert column.index == index
 
     def test_add_column(self):
         assert self.session.columns.count() == 6


### PR DESCRIPTION
## Technical Summary
Like the title says, this adds tests for `BulkEditColumnManager`.

I also make a couple small fixes in `copy_to_session` so that this method doesn't copy default columns and create a situation where there are two columns with the same `prop_id` in the same session.


## Safety Assurance

### Safety story
safe change, adds tests and makes a small modification that is tested.

### Automated test coverage
yes, this PR introduces new tests, but the `data_cleaning` module is already extensively tested

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
