### PR TITLE
Exclude deprecated properties in count for case property warning

### DIFF
--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -109,7 +109,7 @@ from corehq.apps.app_manager.xform import (
 from corehq.apps.data_dictionary.util import (
     get_case_property_deprecated_dict,
     get_case_property_description_dict,
-    get_custom_case_property_count,
+    get_case_property_count,
 )
 from corehq.apps.domain.decorators import (
     LoginAndDomainMixin,
@@ -786,7 +786,7 @@ def get_form_view_context(
         'reserved_words': load_case_reserved_words(),
         'usercasePropertiesMap': usercase_properties_map,
     }
-    case_property_count = get_custom_case_property_count(domain, case_config_options['caseType'])
+    case_property_count = get_case_property_count(domain, case_config_options['caseType'])
     context = {
         'nav_form': form,
         'xform_languages': languages,

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -19,7 +19,7 @@ var caseType = function (
     fhirResourceType,
     deprecated,
     moduleCount,
-    propertiesCount,
+    propertyCount,
     geoCaseProp,
     isSafeToDelete,
     changeSaveButton,
@@ -30,7 +30,7 @@ var caseType = function (
     self.name = name || gettext("No Name");
     self.deprecated = deprecated;
     self.appCount = moduleCount;  // The number of application modules using this case type
-    self.propertyCount = propertiesCount;
+    self.propertyCount = propertyCount;
     self.url = "#" + name;
     self.fhirResourceType = ko.observable(fhirResourceType);
     self.groups = ko.observableArray();
@@ -423,7 +423,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                         caseTypeData.fhir_resource_type,
                         caseTypeData.is_deprecated,
                         caseTypeData.module_count,
-                        caseTypeData.properties_count,
+                        caseTypeData.property_count,
                         data.geo_case_property,
                         caseTypeData.is_safe_to_delete,
                         changeSaveButton,

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -20,6 +20,7 @@ var caseType = function (
     deprecated,
     moduleCount,
     propertyCount,
+    deprecatedPropertyCount,
     geoCaseProp,
     isSafeToDelete,
     changeSaveButton,
@@ -31,6 +32,7 @@ var caseType = function (
     self.deprecated = deprecated;
     self.appCount = moduleCount;  // The number of application modules using this case type
     self.propertyCount = propertyCount;
+    self.deprecatedPropertyCount = deprecatedPropertyCount;
     self.url = "#" + name;
     self.fhirResourceType = ko.observable(fhirResourceType);
     self.groups = ko.observableArray();
@@ -424,6 +426,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                         caseTypeData.is_deprecated,
                         caseTypeData.module_count,
                         caseTypeData.property_count,
+                        caseTypeData.deprecated_property_count,
                         data.geo_case_property,
                         caseTypeData.is_safe_to_delete,
                         changeSaveButton,
@@ -628,7 +631,8 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
 
     self.activeCaseType.subscribe(function () {
         const caseType = self.getActiveCaseType();
-        self.casePropertyWarningViewModel.updateViewModel(caseType.name, caseType.propertyCount);
+        const nonDeprecatedPropertyCount = caseType.propertyCount - caseType.deprecatedPropertyCount;
+        self.casePropertyWarningViewModel.updateViewModel(caseType.name, nonDeprecatedPropertyCount);
     });
 
     self.showDeprecated = function () {

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -35,9 +35,6 @@ from corehq.util.workbook_reading.datamodels import Cell
 class GenerateDictionaryTest(TestCase):
     domain = uuid.uuid4().hex
 
-    def tearDown(self):
-        CaseType.objects.filter(domain=self.domain).delete()
-
     def test_no_types(self, mock):
         mock.return_value = {}
         with self.assertNumQueries(1):
@@ -123,11 +120,6 @@ class DeleteCasePropertyTest(TestCase):
         cls.case_prop_obj = CaseProperty(case_type=cls.case_type_obj, name=cls.case_prop_name)
         cls.case_prop_obj.save()
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.case_type_obj.delete()
-        super().tearDownClass()
-
     def test_delete_case_property(self):
         error = delete_case_property(self.case_prop_name, self.case_type, self.domain)
         does_exist = CaseProperty.objects.filter(
@@ -190,9 +182,6 @@ class MiscUtilTest(TestCase):
             'bar': 'col_2',
             'test column': 'col_3',
         }
-
-    def tearDown(self):
-        CaseType.objects.filter(domain=self.domain).delete()
 
     def test_no_data_dict_info(self):
         case_type_name = 'bare'

--- a/corehq/apps/data_dictionary/tests/test_views.py
+++ b/corehq/apps/data_dictionary/tests/test_views.py
@@ -12,9 +12,9 @@ from corehq.apps.data_dictionary.models import (
     CaseType,
 )
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.geospatial.const import GPS_POINT_CASE_PROPERTY
 from corehq.apps.es import case_search_adapter
 from corehq.apps.es.tests.utils import es_test
+from corehq.apps.geospatial.const import GPS_POINT_CASE_PROPERTY
 from corehq.apps.users.models import HqPermissions, WebUser
 from corehq.apps.users.models_role import UserRole
 from corehq.util.test_utils import flag_disabled, flag_enabled, privilege_enabled

--- a/corehq/apps/data_dictionary/tests/test_views.py
+++ b/corehq/apps/data_dictionary/tests/test_views.py
@@ -452,6 +452,7 @@ class DataDictionaryJsonTest(DataDictionaryViewTestBase):
                     "is_deprecated": False,
                     "module_count": 0,
                     "property_count": cls.case_type_obj.properties.count(),
+                    "deprecated_property_count": cls.case_type_obj.properties.filter(deprecated=True).count(),
                 },
             ],
             "geo_case_property": GPS_POINT_CASE_PROPERTY,
@@ -465,6 +466,9 @@ class DataDictionaryJsonTest(DataDictionaryViewTestBase):
                     "is_deprecated": True,
                     "module_count": 0,
                     "property_count": cls.deprecated_case_type_obj.properties.count(),
+                    "deprecated_property_count": cls.deprecated_case_type_obj.properties.filter(
+                        deprecated=True
+                    ).count(),
                 }
             )
         return expected_output
@@ -481,6 +485,7 @@ class DataDictionaryJsonTest(DataDictionaryViewTestBase):
         expected_output = {
             "name": case_type_obj.name,
             "property_count": case_type_obj.properties.count(),
+            "deprecated_property_count": case_type_obj.properties.filter(deprecated=True).count(),
             "_links": {
                 "self": f"http://testserver/a/{cls.domain_name}"
                         f"/data_dictionary/json/{case_type_obj.name}/"

--- a/corehq/apps/data_dictionary/tests/test_views.py
+++ b/corehq/apps/data_dictionary/tests/test_views.py
@@ -388,12 +388,12 @@ class DataDictionaryJsonTest(DataDictionaryViewTestBase):
         )
         cls.case_properties_with_group = cls._create_properties_for_case_type(
             case_type=cls.case_type_obj,
-            properties_count=2,
+            property_count=2,
             group=cls.group_obj
         )
         cls.case_properties_without_group = cls._create_properties_for_case_type(
             case_type=cls.case_type_obj,
-            properties_count=2,
+            property_count=2,
         )
 
         cls.deprecated_case_type_obj = CaseType.objects.create(
@@ -428,9 +428,9 @@ class DataDictionaryJsonTest(DataDictionaryViewTestBase):
         )
 
     @classmethod
-    def _create_properties_for_case_type(cls, case_type, properties_count, group=None):
+    def _create_properties_for_case_type(cls, case_type, property_count, group=None):
         case_properties = []
-        for index in range(properties_count):
+        for index in range(property_count):
             prop_name = ''.join(random.choices(string.ascii_lowercase + string.digits, k=7))
             case_prop_obj = CaseProperty.objects.create(
                 case_type=case_type,
@@ -451,7 +451,7 @@ class DataDictionaryJsonTest(DataDictionaryViewTestBase):
                     "is_safe_to_delete": True,
                     "is_deprecated": False,
                     "module_count": 0,
-                    "properties_count": cls.case_type_obj.properties.count(),
+                    "property_count": cls.case_type_obj.properties.count(),
                 },
             ],
             "geo_case_property": GPS_POINT_CASE_PROPERTY,
@@ -464,7 +464,7 @@ class DataDictionaryJsonTest(DataDictionaryViewTestBase):
                     "is_safe_to_delete": True,
                     "is_deprecated": True,
                     "module_count": 0,
-                    "properties_count": cls.deprecated_case_type_obj.properties.count(),
+                    "property_count": cls.deprecated_case_type_obj.properties.count(),
                 }
             )
         return expected_output
@@ -480,7 +480,7 @@ class DataDictionaryJsonTest(DataDictionaryViewTestBase):
     ):
         expected_output = {
             "name": case_type_obj.name,
-            "properties_count": case_type_obj.properties.count(),
+            "property_count": case_type_obj.properties.count(),
             "_links": {
                 "self": f"http://testserver/a/{cls.domain_name}"
                         f"/data_dictionary/json/{case_type_obj.name}/"

--- a/corehq/apps/data_dictionary/tests/test_views.py
+++ b/corehq/apps/data_dictionary/tests/test_views.py
@@ -355,7 +355,7 @@ class TestDeprecateOrRestoreCaseTypeView(DataDictionaryViewTestBase):
 
 @es_test(requires=[case_search_adapter], setup_class=True)
 @privilege_enabled(privileges.DATA_DICTIONARY)
-class CaseTypesTest(DataDictionaryViewTestBase):
+class DataDictionaryJsonCaseTypesTest(DataDictionaryViewTestBase):
 
     @classmethod
     def setUpClass(cls):
@@ -470,7 +470,7 @@ class CaseTypesTest(DataDictionaryViewTestBase):
 
 @es_test(requires=[case_search_adapter], setup_class=True)
 @privilege_enabled(privileges.DATA_DICTIONARY)
-class CasePropertiesTest(DataDictionaryViewTestBase):
+class DataDictionaryJsonCasePropertiesTest(DataDictionaryViewTestBase):
 
     @classmethod
     def setUpClass(cls):

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -422,11 +422,11 @@ def update_url_query_params(url, params):
     return parsed_url._replace(query=merged_params).geturl()
 
 
-def get_custom_case_property_count(domain, case_type):
-    """This excludes system properties"""
+def get_case_property_count(domain, case_type):
+    """This excludes system and deprecated properties"""
     try:
         case_type = CaseType.objects.get(domain=domain, name=case_type)
     except CaseType.DoesNotExist:
         return 0
 
-    return case_type.properties.count()
+    return case_type.properties.filter(property__deprecated=False).count()

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -429,4 +429,4 @@ def get_case_property_count(domain, case_type):
     except CaseType.DoesNotExist:
         return 0
 
-    return case_type.properties.filter(property__deprecated=False).count()
+    return case_type.properties.filter(deprecated=False).count()


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18051

Review by commit 🐟 

The initial ask is pretty straightforward. When viewing the case config page or data dictionary, we show a warning to users if the number of case properties for the current case type exceeds a threshold. Currently this number includes deprecated case properties, but we want to exclude them from this count.

This was very straightforward for the case config page since we just pull the count of case properties specifically for this warning, and can change that function to exclude deprecated properties without consequence.

The data dictionary on the other hand relied on the total case property count for other things like pagination. It might be overkill, but I decided to return the total count, and the deprecated count, leaving the frontend to subtract off that number to determine the number of non-deprecated case properties. This felt much clearer from a code readability perspective.

I then wanted to add tests for my new deprecated property count and found the data dictionary tests hard to edit. The helper to assert the response for every test makes it so that we have to enable things for all tests (like the CASE_IMPORT_DATA_DICTIONARY_VALIDATION flag), and I find generally makes it challenging to add new tests easily. I hope the changes I made are an improvement, but let me know if you disagree. I think I may have added some fairly useless tests, but was trying to account for the fact that the tests were certainly thorough before given they asserted the entire response.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Pretty minor change that results in the worst case, displaying a warning when we shouldn't (or not displaying it when we should). That doesn't block anyone so the blast radius should be pretty small.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests to ensure deprecated case property counts are valid for the data dictionary.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
