### PR TITLE
GA TWO_STAGE_USER_PROVISIONING

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -91,7 +91,7 @@ standard_v2 = community_v2 + [
     privileges.PHONE_APK_HEARTBEAT,
     privileges.FORM_CASE_IDS_CASE_IMPORTER,
     privileges.EXPORT_MULTISORT,
-    privileges.TWO_STAGE_MOBILE_WORKER_CREATION,
+    privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION,
 ]
 
 

--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -91,6 +91,7 @@ standard_v2 = community_v2 + [
     privileges.PHONE_APK_HEARTBEAT,
     privileges.FORM_CASE_IDS_CASE_IMPORTER,
     privileges.EXPORT_MULTISORT,
+    privileges.TWO_STAGE_MOBILE_WORKER_CREATION,
 ]
 
 

--- a/corehq/apps/accounting/migrations/0107_two_stage_mobile_worker_creation_priv.py
+++ b/corehq/apps/accounting/migrations/0107_two_stage_mobile_worker_creation_priv.py
@@ -2,7 +2,7 @@ from django.core.management import call_command
 from django.db import migrations
 
 from corehq.apps.accounting.models import SoftwarePlanEdition
-from corehq.privileges import TWO_STAGE_MOBILE_WORKER_CREATION
+from corehq.privileges import TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION
 from corehq.util.django_migrations import skip_on_fresh_install
 
 
@@ -17,7 +17,7 @@ def _add_data_cleaning_to_enterprise(apps, schema_editor):
     ))
     call_command(
         'cchq_prbac_grandfather_privs',
-        TWO_STAGE_MOBILE_WORKER_CREATION,
+        TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION,
         skip_edition=skip_editions,
         noinput=True,
     )
@@ -30,7 +30,7 @@ def _reverse(apps, schema_editor):
     ))
     call_command(
         'cchq_prbac_revoke_privs',
-        TWO_STAGE_MOBILE_WORKER_CREATION,
+        TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION,
         skip_edition=skip_editions,
         delete_privs=False,
         check_privs_exist=True,
@@ -38,7 +38,7 @@ def _reverse(apps, schema_editor):
     )
 
     from corehq.apps.hqadmin.management.commands.cchq_prbac_bootstrap import Command
-    Command.OLD_PRIVILEGES.append(TWO_STAGE_MOBILE_WORKER_CREATION)
+    Command.OLD_PRIVILEGES.append(TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     call_command('cchq_prbac_bootstrap')
 
 

--- a/corehq/apps/accounting/migrations/0107_two_stage_mobile_worker_creation_priv.py
+++ b/corehq/apps/accounting/migrations/0107_two_stage_mobile_worker_creation_priv.py
@@ -1,0 +1,56 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.privileges import TWO_STAGE_MOBILE_WORKER_CREATION
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+
+@skip_on_fresh_install
+def _add_data_cleaning_to_enterprise(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+
+    skip_editions = ','.join((
+        SoftwarePlanEdition.PAUSED,
+        SoftwarePlanEdition.FREE,
+    ))
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        TWO_STAGE_MOBILE_WORKER_CREATION,
+        skip_edition=skip_editions,
+        noinput=True,
+    )
+
+
+def _reverse(apps, schema_editor):
+    skip_editions = ','.join((
+        SoftwarePlanEdition.PAUSED,
+        SoftwarePlanEdition.FREE,
+    ))
+    call_command(
+        'cchq_prbac_revoke_privs',
+        TWO_STAGE_MOBILE_WORKER_CREATION,
+        skip_edition=skip_editions,
+        delete_privs=False,
+        check_privs_exist=True,
+        noinput=True,
+    )
+
+    from corehq.apps.hqadmin.management.commands.cchq_prbac_bootstrap import Command
+    Command.OLD_PRIVILEGES.append(TWO_STAGE_MOBILE_WORKER_CREATION)
+    call_command('cchq_prbac_bootstrap')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0106_alter_billingcontactinfo_company_name'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _add_data_cleaning_to_enterprise,
+            reverse_code=_reverse,
+        ),
+    ]

--- a/corehq/apps/accounting/migrations/0107_two_stage_mobile_worker_creation_priv.py
+++ b/corehq/apps/accounting/migrations/0107_two_stage_mobile_worker_creation_priv.py
@@ -8,7 +8,7 @@ from corehq.util.django_migrations import skip_on_fresh_install
 
 
 @skip_on_fresh_install
-def _add_data_cleaning_to_enterprise(apps, schema_editor):
+def _add_two_stage_mw_creation_to_standard(apps, schema_editor):
     call_command('cchq_prbac_bootstrap')
 
     skip_editions = ','.join((

--- a/corehq/apps/accounting/migrations/0107_two_stage_mobile_worker_creation_priv.py
+++ b/corehq/apps/accounting/migrations/0107_two_stage_mobile_worker_creation_priv.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(
-            _add_data_cleaning_to_enterprise,
+            _add_two_stage_mw_creation_to_standard,
             reverse_code=_reverse,
         ),
     ]

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -284,7 +284,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             raise BadRequest(e.message)
         try:
             email = bundle.data.get('email', '').lower()
-            if (toggles.TWO_STAGE_USER_PROVISIONING.enabled(kwargs['domain'])
+            if (domain_has_privilege(kwargs['domain'], privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
                     and (require_account_confirmation or send_confirmation_email)):
                 self.validate_new_user_input(require_account_confirmation, send_confirmation_email,
                                              email, password)
@@ -355,7 +355,8 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             raise BadRequest(_('The request resulted in the following errors: {}').format(formatted_errors))
         assert bundle.obj.domain == kwargs['domain']
 
-        if toggles.TWO_STAGE_USER_PROVISIONING.enabled(kwargs['domain']) and send_confirmation_email:
+        if (domain_has_privilege(kwargs['domain'], privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
+                and send_confirmation_email):
             if bundle.obj.is_account_confirmed:
                 raise BadRequest(_("The confirmation email can not be sent "
                                    "because this user's account is already confirmed."))

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -284,7 +284,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             raise BadRequest(e.message)
         try:
             email = bundle.data.get('email', '').lower()
-            if (domain_has_privilege(kwargs['domain'], privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
+            if (domain_has_privilege(kwargs['domain'], privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
                     and (require_account_confirmation or send_confirmation_email)):
                 self.validate_new_user_input(require_account_confirmation, send_confirmation_email,
                                              email, password)
@@ -355,7 +355,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             raise BadRequest(_('The request resulted in the following errors: {}').format(formatted_errors))
         assert bundle.obj.domain == kwargs['domain']
 
-        if (domain_has_privilege(kwargs['domain'], privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
+        if (domain_has_privilege(kwargs['domain'], privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
                 and send_confirmation_email):
             if bundle.obj.is_account_confirmed:
                 raise BadRequest(_("The confirmation email can not be sent "

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -8,6 +8,7 @@ from django.utils.http import urlencode
 from flaky import flaky
 from tastypie.bundle import Bundle
 
+from corehq import privileges
 from corehq.apps.api.resources import v0_5, v1_0
 from corehq.apps.custom_data_fields.models import (
     PROFILE_SLUG,
@@ -40,7 +41,7 @@ from corehq.apps.users.signals import update_user_in_es
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.const import USER_CHANGE_VIA_API
 from corehq.util.es.testing import sync_users_to_es
-from corehq.util.test_utils import flag_enabled
+from corehq.util.test_utils import flag_enabled, privilege_enabled
 
 from ..resources.v0_5 import BadRequest, UserDomainsResource
 from .utils import APIResourceTest
@@ -203,7 +204,7 @@ class TestCommCareUserResource(APIResourceTest):
                          [self.loc1.location_id, self.loc2.location_id])
         self.assertEqual(user_back.get_location_id(self.domain.name), self.loc1.location_id)
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     @patch('corehq.apps.users.account_confirmation.send_account_confirmation')
     def test_create_and_send_confirmation_email(self, mock_send_account_confirmation):
         self.assertEqual(0, len(CommCareUser.by_domain(self.domain.name)))
@@ -223,7 +224,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertNotEqual(mobile_user, None)
         self.assertEqual(mock_send_account_confirmation.call_count, 1)
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     def test_create_and_send_confirmation_email_invalid_input(self):
         user_json = {
             "username": "jdoe",
@@ -446,7 +447,7 @@ class TestCommCareUserResource(APIResourceTest):
             "non-editable field 'username', 'default_phone_number' must be a string\"}"
         )
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     @patch('corehq.apps.users.account_confirmation.send_account_confirmation')
     def test_update_and_send_confirmation_email(self, mock_send_account_confirmation):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234", created_by=None,
@@ -463,7 +464,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(mock_send_account_confirmation.call_count, 1)
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     @patch('corehq.apps.users.account_confirmation.send_account_confirmation')
     def test_update_and_send_confirmation_already_confirmed(self, mock_send_account_confirmation):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
@@ -483,7 +484,7 @@ class TestCommCareUserResource(APIResourceTest):
                          "this user's account is already confirmed.")
         self.assertEqual(mock_send_account_confirmation.call_count, 0)
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     @patch('corehq.apps.users.account_confirmation.send_account_confirmation')
     def test_update_and_send_confirmation_no_email(self, mock_send_account_confirmation):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234", created_by=None,
@@ -501,7 +502,7 @@ class TestCommCareUserResource(APIResourceTest):
                          "This user has no email. You must provide the user's email to send a confirmation email.")
         self.assertEqual(mock_send_account_confirmation.call_count, 0)
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     def test_update_cant_change_account_confirmation(self):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
                                    created_by=None, created_via=None, phone_number="50253311398")

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -248,17 +248,18 @@ def get_active_users_by_email(email, domain=None):
         if user.username.lower() == email.lower():
             yield user
         else:
-            # also any mobile workers with domains with TWO_STAGE_MOBILE_WORKER_CREATION privilege
+            # also any mobile workers with domains with TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION privilege
             # should be included
             couch_user = CouchUser.get_by_username(user.username, strict=True)
             if (couch_user
                     and couch_user.is_commcare_user()
-                    and domain_has_privilege(couch_user.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
+                    and domain_has_privilege(couch_user.domain,
+                                             privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
                     and (domain is None or couch_user.domain == domain)):
                 yield user
             # intentionally excluded:
             # - WebUsers who have changed their email address from their login (though could revisit this)
-            # - CommCareUsers not belonging to domains with TWO_STAGE_MOBILE_WORKER_CREATION privilege
+            # - CommCareUsers not belonging to domains with TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION privilege
 
 
 class HQApiKeyAuthentication(ApiKeyAuthentication):

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -20,9 +20,11 @@ from django.utils import timezone
 from dimagi.utils.django.request import mutable_querydict
 from dimagi.utils.web import get_ip
 
+from corehq import privileges
+
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.receiverwrapper.util import DEMO_SUBMIT_MODE
 from corehq.apps.users.models import CouchUser, HQApiKey, ConnectIDUserLink
-from corehq.toggles import TWO_STAGE_USER_PROVISIONING
 from corehq.util.hmac_request import validate_request_hmac
 from corehq.util.metrics import metrics_counter
 
@@ -246,16 +248,17 @@ def get_active_users_by_email(email, domain=None):
         if user.username.lower() == email.lower():
             yield user
         else:
-            # also any mobile workers from TWO_STAGE_USER_PROVISIONING domains should be included
+            # also any mobile workers with domains with TWO_STAGE_MOBILE_WORKER_CREATION privilege
+            # should be included
             couch_user = CouchUser.get_by_username(user.username, strict=True)
             if (couch_user
                     and couch_user.is_commcare_user()
-                    and TWO_STAGE_USER_PROVISIONING.enabled(couch_user.domain)
+                    and domain_has_privilege(couch_user.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
                     and (domain is None or couch_user.domain == domain)):
                 yield user
             # intentionally excluded:
             # - WebUsers who have changed their email address from their login (though could revisit this)
-            # - CommCareUsers not belonging to domains with TWO_STAGE_USER_PROVISIONING enabled
+            # - CommCareUsers not belonging to domains with TWO_STAGE_MOBILE_WORKER_CREATION privilege
 
 
 class HQApiKeyAuthentication(ApiKeyAuthentication):

--- a/corehq/apps/domain/tests/test_password_reset.py
+++ b/corehq/apps/domain/tests/test_password_reset.py
@@ -1,10 +1,12 @@
 from django.test import TestCase
 
+from corehq import privileges
+
 from corehq.apps.domain.auth import get_active_users_by_email
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser, CommCareUser
 from corehq.apps.users.util import generate_mobile_username
-from corehq.util.test_utils import flag_enabled
+from corehq.util.test_utils import privilege_enabled
 
 
 class PasswordResetTest(TestCase):
@@ -44,7 +46,7 @@ class PasswordResetTest(TestCase):
         results = list(get_active_users_by_email(email))
         self.assertEqual(0, len(results))
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     def test_mobile_worker_included_with_flag(self):
         email = 'mw-included@example.com'
         mobile_worker = CommCareUser.create(self.domain, 'mw-included', 's3cr3t', None, None, email=email)
@@ -63,7 +65,7 @@ class PasswordResetTest(TestCase):
         self.assertEqual(1, len(results))
         self.assertEqual(active_user.username, results[0].username)
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     def test_domain_limited_mobile_worker_lookup(self):
         other_domain = 'other-domain'
         email = 'active-user@example.com'

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -239,6 +239,9 @@ class Command(BaseCommand):
              name='App Dependencies',
              description='Set Android app dependencies that must be installed before using a CommCare app'),
         Role(slug=privileges.BULK_DATA_EDITING, name='Bulk Data Editing', description=''),
+        Role(slug=privileges.TWO_STAGE_MOBILE_WORKER_CREATION, name='Two Stage Mobile Worker Creation',
+             description='Allows two-stage user provisioning '
+                         '(users confirm and set their own passwords via email)'),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -239,7 +239,8 @@ class Command(BaseCommand):
              name='App Dependencies',
              description='Set Android app dependencies that must be installed before using a CommCare app'),
         Role(slug=privileges.BULK_DATA_EDITING, name='Bulk Data Editing', description=''),
-        Role(slug=privileges.TWO_STAGE_MOBILE_WORKER_CREATION, name='Two Stage Mobile Worker Creation',
+        Role(slug=privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION,
+             name='Two Stage Mobile Worker Account Creation',
              description='Allows two-stage user provisioning '
                          '(users confirm and set their own passwords via email)'),
     ]

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -38,6 +38,9 @@ from two_factor.plugins.phonenumber.views import (
 from dimagi.utils.web import json_response
 
 from corehq import toggles
+from corehq import privileges
+
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.decorators import (
     active_domains_required,
     login_and_domain_required,
@@ -471,7 +474,7 @@ def _show_link_to_webapps(user):
         if user.domain_memberships:
             membership = user.domain_memberships[0]
             if membership.role and membership.role.default_landing_page == "webapps":
-                if toggles.TWO_STAGE_USER_PROVISIONING.enabled(membership.domain):
+                if domain_has_privilege(membership.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION):
                     return True
     return False
 

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -474,7 +474,7 @@ def _show_link_to_webapps(user):
         if user.domain_memberships:
             membership = user.domain_memberships[0]
             if membership.role and membership.role.default_landing_page == "webapps":
-                if domain_has_privilege(membership.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION):
+                if domain_has_privilege(membership.domain, privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION):
                     return True
     return False
 

--- a/corehq/apps/users/account_confirmation.py
+++ b/corehq/apps/users/account_confirmation.py
@@ -51,10 +51,10 @@ def should_send_account_confirmation(couch_user):
 
 def send_account_confirmation(commcare_user):
     from corehq.apps.hqwebapp.tasks import send_html_email_async
-    from corehq.apps.users.views.mobile import CommCareUserConfirmAccountView
+    from corehq.apps.users.views.mobile import CommCareUserConfirmAccountViewByEmailView
     encrypted_user_info = encrypt_account_confirmation_info(commcare_user)
     template_params = _get_account_confirmation_template_params(
-        commcare_user, encrypted_user_info, CommCareUserConfirmAccountView.urlname
+        commcare_user, encrypted_user_info, CommCareUserConfirmAccountViewByEmailView.urlname
     )
     template_params.update(project_logo_emails_context(commcare_user.domain))
 

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -21,8 +21,10 @@ from crispy_forms.layout import Fieldset, Layout, Submit
 from django_countries.data import COUNTRIES
 
 from corehq import toggles
+from corehq import privileges
 from dimagi.utils.dates import get_date_from_month_and_year_string
 
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import set_analytics_opt_out
 from corehq.apps.app_manager.models import validate_lang
 from corehq.apps.custom_data_fields.edit_entity import CustomDataEditor
@@ -59,7 +61,6 @@ from corehq.pillows.utils import MOBILE_USER_TYPE, WEB_USER_TYPE
 from corehq.feature_previews import USE_LOCATION_DISPLAY_NAME
 from corehq.toggles import (
     DEACTIVATE_WEB_USERS,
-    TWO_STAGE_USER_PROVISIONING,
     TWO_STAGE_USER_PROVISIONING_BY_SMS,
 )
 from corehq.util.global_request import get_request_domain
@@ -782,9 +783,7 @@ class NewMobileWorkerForm(forms.Form):
                 '',
                 data_bind='value: location_id',
             )
-
-        self.two_stage_provisioning_enabled = TWO_STAGE_USER_PROVISIONING.enabled(self.domain)
-        if self.two_stage_provisioning_enabled:
+        if domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION):
             confirm_account_field = crispy.Field(
                 'force_account_confirmation',
                 data_bind='checked: force_account_confirmation',

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -783,7 +783,7 @@ class NewMobileWorkerForm(forms.Form):
                 '',
                 data_bind='value: location_id',
             )
-        if domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION):
+        if domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION):
             confirm_account_field = crispy.Field(
                 'force_account_confirmation',
                 data_bind='checked: force_account_confirmation',

--- a/corehq/apps/users/tests/test_confirm_account_view.py
+++ b/corehq/apps/users/tests/test_confirm_account_view.py
@@ -2,11 +2,13 @@ from django.test import TestCase
 from django.urls import reverse
 from unittest.mock import Mock, patch
 
+from corehq import privileges
+
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.domain.utils import encrypt_account_confirmation_info
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.views.mobile.users import CommCareUserConfirmAccountView
-from corehq.util.test_utils import flag_enabled
+from corehq.util.test_utils import privilege_enabled
 
 
 class TestMobileWorkerConfirmAccountView(TestCase):
@@ -38,7 +40,7 @@ class TestMobileWorkerConfirmAccountView(TestCase):
     def tearDown(self):
         self.user.delete(self.domain, deleted_by=None)
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     def test_expected_workflow(self):
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code)
@@ -48,7 +50,7 @@ class TestMobileWorkerConfirmAccountView(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(404, response.status_code)
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     def test_user_id_not_found(self):
         mock_commcare_user = Mock()
         mock_commcare_user.get_id = 'missing-id'
@@ -57,13 +59,13 @@ class TestMobileWorkerConfirmAccountView(TestCase):
         response = self.client.get(reverse('commcare_user_confirm_account', args=[self.domain, encrypted_info]))
         self.assertEqual(404, response.status_code)
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     def test_user_domain_mismatch(self):
         response = self.client.get(reverse('commcare_user_confirm_account',
                                            args=['wrong-domain', self.user.get_id]))
         self.assertEqual(404, response.status_code)
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     def test_account_active(self):
         self.user.is_account_confirmed = True
         self.user.is_active = True
@@ -72,7 +74,7 @@ class TestMobileWorkerConfirmAccountView(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertContains(response, 'Your account is already confirmed')
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     def test_account_inactive_but_confirmed(self):
         self.user.is_account_confirmed = True
         self.user.is_active = False
@@ -81,7 +83,7 @@ class TestMobileWorkerConfirmAccountView(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertContains(response, 'your account has been deactivated')
 
-    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     @patch.object(CommCareUserConfirmAccountView, '_expiration_time_in_hours', new_callable=Mock(return_value=-1))
     def test_invite_expired_message(self, mock_expiration_time):
         response = self.client.get(self.url)

--- a/corehq/apps/users/tests/test_confirm_account_view.py
+++ b/corehq/apps/users/tests/test_confirm_account_view.py
@@ -7,7 +7,7 @@ from corehq import privileges
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.domain.utils import encrypt_account_confirmation_info
 from corehq.apps.users.models import CommCareUser
-from corehq.apps.users.views.mobile.users import CommCareUserConfirmAccountView
+from corehq.apps.users.views.mobile.users import CommCareUserConfirmAccountViewByEmailView
 from corehq.util.test_utils import privilege_enabled
 
 
@@ -46,9 +46,10 @@ class TestMobileWorkerConfirmAccountView(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertContains(response, 'Confirm your account')
 
-    def test_feature_flag_not_enabled(self):
+    def test_does_not_have_privilege(self):
         response = self.client.get(self.url)
-        self.assertEqual(404, response.status_code)
+        print("response.content.decode()", response.content.decode())
+        self.assertContains(response, "you do not have access to Two-stage Mobile Worker Account Creation")
 
     @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
     def test_user_id_not_found(self):
@@ -84,7 +85,8 @@ class TestMobileWorkerConfirmAccountView(TestCase):
         self.assertContains(response, 'your account has been deactivated')
 
     @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
-    @patch.object(CommCareUserConfirmAccountView, '_expiration_time_in_hours', new_callable=Mock(return_value=-1))
+    @patch.object(CommCareUserConfirmAccountViewByEmailView, '_expiration_time_in_hours',
+                  new_callable=Mock(return_value=-1))
     def test_invite_expired_message(self, mock_expiration_time):
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code)

--- a/corehq/apps/users/tests/test_confirm_account_view.py
+++ b/corehq/apps/users/tests/test_confirm_account_view.py
@@ -48,7 +48,7 @@ class TestMobileWorkerConfirmAccountView(TestCase):
 
     def test_does_not_have_privilege(self):
         response = self.client.get(self.url)
-        print("response.content.decode()", response.content.decode())
+        self.assertEqual(200, response.status_code)
         self.assertContains(response, "you do not have access to Two-stage Mobile Worker Account Creation")
 
     @privilege_enabled(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -74,7 +74,7 @@ from .views.mobile.users import (
     toggle_demo_mode,
     update_user_groups,
     user_download_job_poll,
-    CommCareUserConfirmAccountView,
+    CommCareUserConfirmAccountViewByEmailView,
     send_confirmation_email,
     send_confirmation_sms,
     CommcareUserUploadJobPollView,
@@ -247,8 +247,8 @@ urlpatterns = [
     ),
     url(
         r'^commcare/confirm_account/(?P<user_invite_hash>[\S-]+)/$',
-        CommCareUserConfirmAccountView.as_view(),
-        name=CommCareUserConfirmAccountView.urlname
+        CommCareUserConfirmAccountViewByEmailView.as_view(),
+        name=CommCareUserConfirmAccountViewByEmailView.urlname
     ),
     url(
         r'^commcare/account_confirmed/$',

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1723,7 +1723,7 @@ def change_password(request, domain, login_id):
     commcare_user = CommCareUser.get_by_user_id(login_id, domain)
     json_dump = {}
     if (not commcare_user or not user_can_access_other_user(domain, request.couch_user, commcare_user)
-            or (domain_has_privilege(domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
+            or (domain_has_privilege(domain, privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
                 and commcare_user.self_set_password)):
         raise Http404()
     django_user = commcare_user.get_django_user()

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1723,7 +1723,8 @@ def change_password(request, domain, login_id):
     commcare_user = CommCareUser.get_by_user_id(login_id, domain)
     json_dump = {}
     if (not commcare_user or not user_can_access_other_user(domain, request.couch_user, commcare_user)
-            or (toggles.TWO_STAGE_USER_PROVISIONING.enabled(domain) and commcare_user.self_set_password)):
+            or (domain_has_privilege(domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
+                and commcare_user.self_set_password)):
         raise Http404()
     django_user = commcare_user.get_django_user()
     if request.method == "POST":

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1594,13 +1594,11 @@ class CommCareUserConfirmAccountView(TemplateView, DomainViewMixin):
 
 
 @location_safe
+@method_decorator(requires_privilege_with_fallback(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION),
+                name="dispatch")
 class CommCareUserConfirmAccountViewByEmailView(CommCareUserConfirmAccountView):
     template_name = "users/commcare_user_confirm_account.html"
     urlname = "commcare_user_confirm_account"
-
-    @method_decorator(requires_privilege_with_fallback(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION))
-    def dispatch(self, request, *args, **kwargs):
-        return super(CommCareUserConfirmAccountViewByEmailView, self).dispatch(request, *args, **kwargs)
 
     @property
     @memoized
@@ -1640,13 +1638,10 @@ class CommCareUserAccountConfirmedView(TemplateView, DomainViewMixin):
 
 
 @location_safe
+@method_decorator(toggles.TWO_STAGE_USER_PROVISIONING_BY_SMS.required_decorator(), name="dispatch")
 class CommCareUserConfirmAccountBySMSView(CommCareUserConfirmAccountView):
     urlname = "commcare_user_confirm_account_sms"
     HOURS_IN_A_DAY = 24
-
-    @method_decorator(toggles.TWO_STAGE_USER_PROVISIONING_BY_SMS.required_decorator())
-    def dispatch(self, request, *args, **kwargs):
-        return super(CommCareUserConfirmAccountBySMSView, self).dispatch(request, *args, **kwargs)
 
     @property
     @memoized

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -332,9 +332,11 @@ class EditCommCareUserView(BaseEditUserView):
             messages.error(self.request, _(
                 "There were some errors while saving user's locations. Please check the 'Locations' tab"
             ))
-        if toggles.TWO_STAGE_USER_PROVISIONING.enabled(self.domain) and self.editable_user.self_set_password:
+        if (domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
+                and self.editable_user.self_set_password):
             context['reset_password_form'] = ''
-        if self.editable_user.is_active and toggles.TWO_STAGE_USER_PROVISIONING.enabled(self.domain):
+        if (self.editable_user.is_active
+                and domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION)):
             context.update({
                 'send_password_reset_email_form': SendCommCareUserPasswordResetEmailForm()
             })
@@ -732,9 +734,8 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
 
     @property
     def two_stage_user_confirmation(self):
-        return toggles.TWO_STAGE_USER_PROVISIONING.enabled(
-            self.domain
-        ) or toggles.TWO_STAGE_USER_PROVISIONING_BY_SMS.enabled(self.domain)
+        return (domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
+                or toggles.TWO_STAGE_USER_PROVISIONING_BY_SMS.enabled(self.domain))
 
     @property
     def page_context(self):

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -332,11 +332,11 @@ class EditCommCareUserView(BaseEditUserView):
             messages.error(self.request, _(
                 "There were some errors while saving user's locations. Please check the 'Locations' tab"
             ))
-        if (domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
+        if (domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
                 and self.editable_user.self_set_password):
             context['reset_password_form'] = ''
         if (self.editable_user.is_active
-                and domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION)):
+                and domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)):
             context.update({
                 'send_password_reset_email_form': SendCommCareUserPasswordResetEmailForm()
             })
@@ -734,7 +734,7 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
 
     @property
     def two_stage_user_confirmation(self):
-        return (domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_CREATION)
+        return (domain_has_privilege(self.domain, privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION)
                 or toggles.TWO_STAGE_USER_PROVISIONING_BY_SMS.enabled(self.domain))
 
     @property
@@ -1598,7 +1598,7 @@ class CommCareUserConfirmAccountViewByEmailView(CommCareUserConfirmAccountView):
     template_name = "users/commcare_user_confirm_account.html"
     urlname = "commcare_user_confirm_account"
 
-    @method_decorator(requires_privilege_with_fallback(privileges.TWO_STAGE_MOBILE_WORKER_CREATION))
+    @method_decorator(requires_privilege_with_fallback(privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION))
     def dispatch(self, request, *args, **kwargs):
         return super(CommCareUserConfirmAccountViewByEmailView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1521,10 +1521,6 @@ class CommCareUserConfirmAccountView(TemplateView, DomainViewMixin):
     strict_domain_fetching = True
     ONE_HOUR_IN_SECONDS = 60 * 60
 
-    @toggles.any_toggle_enabled(toggles.TWO_STAGE_USER_PROVISIONING_BY_SMS, toggles.TWO_STAGE_USER_PROVISIONING)
-    def dispatch(self, request, *args, **kwargs):
-        return super(CommCareUserConfirmAccountView, self).dispatch(request, *args, **kwargs)
-
     @property
     @memoized
     def user_invite_hash(self):
@@ -1602,6 +1598,10 @@ class CommCareUserConfirmAccountViewByEmailView(CommCareUserConfirmAccountView):
     template_name = "users/commcare_user_confirm_account.html"
     urlname = "commcare_user_confirm_account"
 
+    @method_decorator(requires_privilege_with_fallback(privileges.TWO_STAGE_MOBILE_WORKER_CREATION))
+    def dispatch(self, request, *args, **kwargs):
+        return super(CommCareUserConfirmAccountViewByEmailView, self).dispatch(request, *args, **kwargs)
+
     @property
     @memoized
     def form(self):
@@ -1643,6 +1643,10 @@ class CommCareUserAccountConfirmedView(TemplateView, DomainViewMixin):
 class CommCareUserConfirmAccountBySMSView(CommCareUserConfirmAccountView):
     urlname = "commcare_user_confirm_account_sms"
     HOURS_IN_A_DAY = 24
+
+    @method_decorator(toggles.TWO_STAGE_USER_PROVISIONING_BY_SMS.required_decorator())
+    def dispatch(self, request, *args, **kwargs):
+        return super(CommCareUserConfirmAccountBySMSView, self).dispatch(request, *args, **kwargs)
 
     @property
     @memoized

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1540,22 +1540,6 @@ class CommCareUserConfirmAccountView(TemplateView, DomainViewMixin):
     def user(self):
         return get_document_or_404(CommCareUser, self.domain, self.user_id)
 
-    @property
-    @memoized
-    def form(self):
-        if self.request.method == 'POST':
-            return MobileWorkerAccountConfirmationForm(self.request.POST)
-        else:
-            return MobileWorkerAccountConfirmationForm(initial={
-                'username': self.user.raw_username,
-                'full_name': self.user.full_name,
-                'email': self.user.email,
-            })
-
-    @property
-    def _expiration_time_in_hours(self):
-        return 1
-
     def get_context_data(self, **kwargs):
         context = super(CommCareUserConfirmAccountView, self).get_context_data(**kwargs)
         context.update({
@@ -1611,6 +1595,28 @@ class CommCareUserConfirmAccountView(TemplateView, DomainViewMixin):
         if hours_elapsed <= self._expiration_time_in_hours:
             return True
         return False
+
+
+@location_safe
+class CommCareUserConfirmAccountViewByEmailView(CommCareUserConfirmAccountView):
+    template_name = "users/commcare_user_confirm_account.html"
+    urlname = "commcare_user_confirm_account"
+
+    @property
+    @memoized
+    def form(self):
+        if self.request.method == 'POST':
+            return MobileWorkerAccountConfirmationForm(self.request.POST)
+        else:
+            return MobileWorkerAccountConfirmationForm(initial={
+                'username': self.user.raw_username,
+                'full_name': self.user.full_name,
+                'email': self.user.email,
+            })
+
+    @property
+    def _expiration_time_in_hours(self):
+        return 1
 
 
 @location_safe

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -120,7 +120,7 @@ CASE_LIST_EXPLORER = 'case_list_explorer'
 
 CASE_COPY = 'case_copy'
 
-TWO_STAGE_MOBILE_WORKER_CREATION = 'two_stage_mobile_worker_creation'
+TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION = 'two_stage_mobile_worker_account_creation'
 
 CASE_DEDUPE = 'case_deduplicate'
 CUSTOM_DOMAIN_ALERTS = 'custom_domain_alerts'
@@ -191,7 +191,7 @@ MAX_PRIVILEGES = [
     CUSTOM_DOMAIN_ALERTS,
     APP_DEPENDENCIES,
     BULK_DATA_EDITING,
-    TWO_STAGE_MOBILE_WORKER_CREATION,
+    TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -272,5 +272,5 @@ class Titles(object):
             CASE_DEDUPE: _("Deduplication Rules"),
             CUSTOM_DOMAIN_ALERTS: _("Custom domain banners"),
             APP_DEPENDENCIES: _("App Dependencies"),
-            TWO_STAGE_MOBILE_WORKER_CREATION: _("Two-stage mobile worker account creation"),
+            TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION: _("Two-stage Mobile Worker Account Creation"),
         }.get(privilege, privilege)

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -120,6 +120,8 @@ CASE_LIST_EXPLORER = 'case_list_explorer'
 
 CASE_COPY = 'case_copy'
 
+TWO_STAGE_MOBILE_WORKER_CREATION = 'two_stage_mobile_worker_creation'
+
 CASE_DEDUPE = 'case_deduplicate'
 CUSTOM_DOMAIN_ALERTS = 'custom_domain_alerts'
 APP_DEPENDENCIES = 'app_dependencies'
@@ -189,6 +191,7 @@ MAX_PRIVILEGES = [
     CUSTOM_DOMAIN_ALERTS,
     APP_DEPENDENCIES,
     BULK_DATA_EDITING,
+    TWO_STAGE_MOBILE_WORKER_CREATION,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -269,4 +272,5 @@ class Titles(object):
             CASE_DEDUPE: _("Deduplication Rules"),
             CUSTOM_DOMAIN_ALERTS: _("Custom domain banners"),
             APP_DEPENDENCIES: _("App Dependencies"),
+            TWO_STAGE_MOBILE_WORKER_CREATION: _("Two-stage mobile worker account creation"),
         }.get(privilege, privilege)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2070,7 +2070,8 @@ ADD_ROW_INDEX_TO_MOBILE_UCRS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-TWO_STAGE_USER_PROVISIONING = StaticToggle(
+TWO_STAGE_USER_PROVISIONING = FrozenPrivilegeToggle(
+    privileges.TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION,
     'two_stage_user_provisioning',
     'Enable two-stage user provisioning (users confirm and set their own passwords via email).',
     TAG_SOLUTIONS_LIMITED,

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -222,6 +222,7 @@ class privilege_enabled:
         'corehq.pillows.case_search.domain_has_privilege',
         'django_prbac.decorators.has_privilege',
         'corehq.apps.data_cleaning.utils.cases.domain_has_privilege',
+        'corehq.apps.domain.auth.domain_has_privilege',
     )
 
     def __init__(self, privilege_slug):

--- a/migrations.lock
+++ b/migrations.lock
@@ -126,6 +126,7 @@ accounting
  0104_fix_priv_community_rename
  0105_alter_billingcontactinfo_city_and_more
  0106_alter_billingcontactinfo_company_name
+ 0107_two_stage_mobile_worker_creation_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Moved the Feature Flag TWO_STAGE_USER_PROVISIONING to general availability. It will be available on the Standard Plan and higher.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-6117](https://dimagi.atlassian.net/browse/USH-6117) and [USH-5990](https://dimagi.atlassian.net/browse/USH-5990)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
TWO_STAGE_USER_PROVISIONING

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
Tested locally and [QA was done](https://dimagi.atlassian.net/browse/QA-7939) on the entire feature flagged feature. The changes here just change the feature flag checks to privilege checks so QA is not needed again.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
test exists for two stage mobile worker creation via API, mobile worker confirmation view endpoint, and the users returned via forget workflow.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
The feature flagged feature was QA'ed as a whole as part of [QA-7939](https://dimagi.atlassian.net/browse/QA-7939)

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [X] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-6117]: https://dimagi.atlassian.net/browse/USH-6117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USH-5990]: https://dimagi.atlassian.net/browse/USH-5990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QA-7939]: https://dimagi.atlassian.net/browse/QA-7939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ