### PR TITLE
Add tests for GeoJSON export

### DIFF
--- a/corehq/apps/export/tests/test_views.py
+++ b/corehq/apps/export/tests/test_views.py
@@ -1,0 +1,330 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from corehq import toggles
+from corehq.apps.data_dictionary.models import CaseProperty, CaseType
+from corehq.apps.domain.models import Domain
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.export.const import (
+    ALL_CASE_TYPE_EXPORT,
+    CASE_EXPORT,
+    FORM_EXPORT,
+)
+from corehq.apps.export.models.new import (
+    CaseExportInstance,
+    ExportColumn,
+    FormExportInstance,
+    GeopointItem,
+    PathNode,
+    ScalarItem,
+    TableConfiguration,
+)
+from corehq.apps.export.views.new import BaseExportView
+
+DOMAIN = 'test-domain'
+
+
+class TestableBaseExportView(BaseExportView):
+    """
+    Testable implementation of BaseExportView
+    """
+    export_type = None
+
+    def __init__(self, export_instance):
+        super().__init__()
+        self.export_instance = export_instance
+        self.args = [export_instance.domain]
+
+    @property
+    def export_helper(self):
+        return None
+
+
+class BaseExportViewTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(DOMAIN)
+        cls.addClassCleanup(cls.domain_obj.delete)
+
+        cls.case_type = CaseType.objects.create(
+            domain=cls.domain_obj.name,
+            name='test_case_type'
+        )
+        cls.gps_property1 = CaseProperty.objects.create(
+            case_type=cls.case_type,
+            name='location_gps',
+            data_type=CaseProperty.DataType.GPS
+        )
+        cls.gps_property2 = CaseProperty.objects.create(
+            case_type=cls.case_type,
+            name='home_location',
+            data_type=CaseProperty.DataType.GPS
+        )
+        cls.text_property = CaseProperty.objects.create(
+            case_type=cls.case_type,
+            name='name',
+            data_type=CaseProperty.DataType.PLAIN
+        )
+
+    def _create_form_export_instance_with_geopoint(self):
+        from corehq.apps.export.models.new import ScalarItem
+
+        geopoint_item = GeopointItem(
+            path=[
+                PathNode(name='form'),
+                PathNode(name='location'),
+                PathNode(name='gps_coords')
+            ]
+        )
+        geopoint_item2 = GeopointItem(
+            path=[
+                PathNode(name='form'),
+                PathNode(name='user_location')
+            ]
+        )
+        text_item = ScalarItem(
+            path=[
+                PathNode(name='form'),
+                PathNode(name='name')
+            ]
+        )
+        geo_column1 = ExportColumn(
+            label='GPS Coordinates',
+            item=geopoint_item,
+            selected=True
+        )
+        geo_column2 = ExportColumn(
+            label='User Location',
+            item=geopoint_item2,
+            selected=True
+        )
+        text_column = ExportColumn(
+            label='Name',
+            item=text_item,
+            selected=True
+        )
+        table_config = TableConfiguration(
+            label='Forms',
+            selected=True,
+            columns=[geo_column1, geo_column2, text_column]
+        )
+        export_instance = FormExportInstance(
+            domain=DOMAIN,
+            name='Test Form Export',
+            xmlns='test_xmlns',
+            tables=[table_config]
+        )
+        return export_instance
+
+    def _create_case_export_instance(self):
+        table_config = TableConfiguration(
+            label='Cases',
+            selected=True,
+            columns=[]
+        )
+        export_instance = CaseExportInstance(
+            domain=DOMAIN,
+            name='Test Case Export',
+            case_type='test_case_type',
+            tables=[table_config]
+        )
+        return export_instance
+
+
+class TestPossibleGeoProperties(BaseExportViewTestCase):
+
+    @patch.object(toggles.SUPPORT_GEO_JSON_EXPORT, 'enabled')
+    def test_possible_geo_properties_toggle_disabled(self, mock_toggle):
+        """
+        Test that _possible_geo_properties returns empty list when
+        toggle is disabled
+        """
+        mock_toggle.return_value = False
+
+        export_instance = self._create_form_export_instance_with_geopoint()
+        view = TestableBaseExportView(export_instance)
+        view.export_type = FORM_EXPORT
+
+        result = view._possible_geo_properties
+        self.assertEqual(result, [])
+
+    @patch.object(toggles.SUPPORT_GEO_JSON_EXPORT, 'enabled')
+    def test_possible_geo_properties_bulk_case_export(self, mock_toggle):
+        """
+        Test that _possible_geo_properties returns empty list for bulk
+        case export
+        """
+        mock_toggle.return_value = True
+
+        bulk_case_export_instance = CaseExportInstance(
+            domain=DOMAIN,
+            name='Test Bulk Case Export',
+            case_type=ALL_CASE_TYPE_EXPORT,
+            tables=[]
+        )
+        view = TestableBaseExportView(bulk_case_export_instance)
+        view.export_type = CASE_EXPORT
+
+        result = view._possible_geo_properties
+        self.assertEqual(result, [])
+
+    @patch.object(toggles.SUPPORT_GEO_JSON_EXPORT, 'enabled')
+    def test_possible_geo_properties_form_export(self, mock_toggle):
+        """
+        Test that _possible_geo_properties calls
+        _possible_form_geo_properties for form exports
+        """
+        mock_toggle.return_value = True
+
+        export_instance = self._create_form_export_instance_with_geopoint()
+        view = TestableBaseExportView(export_instance)
+        view.export_type = FORM_EXPORT
+
+        result = view._possible_geo_properties
+        expected = ['form.location.gps_coords', 'form.user_location']
+        self.assertEqual(result, expected)
+
+    @patch.object(toggles.SUPPORT_GEO_JSON_EXPORT, 'enabled')
+    def test_possible_geo_properties_case_export(self, mock_toggle):
+        """
+        Test that _possible_geo_properties calls
+        _possible_case_geo_properties for case exports
+        """
+        mock_toggle.return_value = True
+
+        export_instance = self._create_case_export_instance()
+        view = TestableBaseExportView(export_instance)
+        view.export_type = CASE_EXPORT
+
+        result = view._possible_geo_properties
+        expected = ['location_gps', 'home_location']
+        self.assertEqual(sorted(result), sorted(expected))
+
+
+class TestPossibleFormGeoProperties(BaseExportViewTestCase):
+
+    def test_possible_form_geo_properties_with_geopoint_items(self):
+        """
+        Test that _possible_form_geo_properties returns paths for
+        GeopointItem columns
+        """
+        export_instance = self._create_form_export_instance_with_geopoint()
+        view = TestableBaseExportView(export_instance)
+
+        result = view._possible_form_geo_properties
+        expected = ['form.location.gps_coords', 'form.user_location']
+        self.assertEqual(result, expected)
+
+    def test_possible_form_geo_properties_no_geopoint_items(self):
+        """
+        Test that _possible_form_geo_properties returns empty list when
+        no GeopointItem columns
+        """
+        text_item = ScalarItem(
+            path=[PathNode(name='form'), PathNode(name='name')]
+        )
+        text_column = ExportColumn(
+            label='Name',
+            item=text_item,
+            selected=True
+        )
+        table_config = TableConfiguration(
+            label='Forms',
+            selected=True,
+            columns=[text_column]
+        )
+        export_instance = FormExportInstance(
+            domain=DOMAIN,
+            name='Test Form Export',
+            xmlns='test_xmlns',
+            tables=[table_config]
+        )
+        view = TestableBaseExportView(export_instance)
+
+        result = view._possible_form_geo_properties
+        self.assertEqual(result, [])
+
+    def test_possible_form_geo_properties_empty_tables(self):
+        """
+        Test that _possible_form_geo_properties handles empty tables
+        gracefully
+        """
+        export_instance = FormExportInstance(
+            domain=DOMAIN,
+            name='Test Form Export',
+            xmlns='test_xmlns',
+            tables=[]
+        )
+        view = TestableBaseExportView(export_instance)
+
+        with self.assertRaises(IndexError):
+            view._possible_form_geo_properties
+
+
+class TestPossibleCaseGeoProperties(BaseExportViewTestCase):
+
+    def test_possible_case_geo_properties_with_gps_properties(self):
+        """
+        Test that _possible_case_geo_properties returns GPS case
+        properties
+        """
+        export_instance = self._create_case_export_instance()
+        view = TestableBaseExportView(export_instance)
+
+        result = view._possible_case_geo_properties
+        expected = ['location_gps', 'home_location']
+        self.assertEqual(sorted(result), sorted(expected))
+
+    def test_possible_case_geo_properties_no_gps_properties(self):
+        """
+        Test that _possible_case_geo_properties returns empty list when
+        no GPS properties
+        """
+        case_type_no_gps = CaseType.objects.create(
+            domain=DOMAIN,
+            name='no_gps_case_type'
+        )
+        CaseProperty.objects.create(
+            case_type=case_type_no_gps,
+            name='name',
+            data_type=CaseProperty.DataType.PLAIN
+        )
+        export_instance = CaseExportInstance(
+            domain=DOMAIN,
+            name='Test Case Export',
+            case_type='no_gps_case_type',
+            tables=[]
+        )
+        view = TestableBaseExportView(export_instance)
+
+        result = view._possible_case_geo_properties
+        self.assertEqual(result, [])
+
+    def test_possible_case_geo_properties_different_domain(self):
+        """
+        Test that _possible_case_geo_properties only returns properties
+        for the correct domain
+        """
+        other_domain = Domain(name='other-domain', is_active=True)
+        other_domain.save()
+        self.addCleanup(other_domain.delete)
+
+        other_case_type = CaseType.objects.create(
+            domain='other-domain',
+            name='test_case_type'
+        )
+        CaseProperty.objects.create(
+            case_type=other_case_type,
+            name='other_location',
+            data_type=CaseProperty.DataType.GPS
+        )
+        export_instance = self._create_case_export_instance()
+        view = TestableBaseExportView(export_instance)
+
+        result = view._possible_case_geo_properties
+        expected = ['location_gps', 'home_location']
+        self.assertEqual(sorted(result), sorted(expected))
+        self.assertNotIn('other_location', result)

--- a/corehq/apps/export/tests/test_views.py
+++ b/corehq/apps/export/tests/test_views.py
@@ -21,6 +21,7 @@ from corehq.apps.export.models.new import (
     TableConfiguration,
 )
 from corehq.apps.export.views.new import BaseExportView
+from corehq.util.test_utils import flag_enabled
 
 DOMAIN = 'test-domain'
 
@@ -138,29 +139,26 @@ class BaseExportViewTestCase(TestCase):
 
 class TestPossibleGeoProperties(BaseExportViewTestCase):
 
-    @patch.object(toggles.SUPPORT_GEO_JSON_EXPORT, 'enabled')
-    def test_possible_geo_properties_toggle_disabled(self, mock_toggle):
+    def test_possible_geo_properties_toggle_disabled(self):
         """
         Test that _possible_geo_properties returns empty list when
         toggle is disabled
         """
-        mock_toggle.return_value = False
-
         export_instance = self._create_form_export_instance_with_geopoint()
         view = TestableBaseExportView(export_instance)
         view.export_type = FORM_EXPORT
+        with patch.object(toggles.SUPPORT_GEO_JSON_EXPORT, 'enabled') as mock_toggle:
+            mock_toggle.return_value = False
 
-        result = view._possible_geo_properties
-        self.assertEqual(result, [])
+            result = view._possible_geo_properties
+            self.assertEqual(result, [])
 
-    @patch.object(toggles.SUPPORT_GEO_JSON_EXPORT, 'enabled')
-    def test_possible_geo_properties_bulk_case_export(self, mock_toggle):
+    @flag_enabled('SUPPORT_GEO_JSON_EXPORT')
+    def test_possible_geo_properties_bulk_case_export(self):
         """
         Test that _possible_geo_properties returns empty list for bulk
         case export
         """
-        mock_toggle.return_value = True
-
         bulk_case_export_instance = CaseExportInstance(
             domain=DOMAIN,
             name='Test Bulk Case Export',
@@ -173,14 +171,12 @@ class TestPossibleGeoProperties(BaseExportViewTestCase):
         result = view._possible_geo_properties
         self.assertEqual(result, [])
 
-    @patch.object(toggles.SUPPORT_GEO_JSON_EXPORT, 'enabled')
-    def test_possible_geo_properties_form_export(self, mock_toggle):
+    @flag_enabled('SUPPORT_GEO_JSON_EXPORT')
+    def test_possible_geo_properties_form_export(self):
         """
         Test that _possible_geo_properties calls
         _possible_form_geo_properties for form exports
         """
-        mock_toggle.return_value = True
-
         export_instance = self._create_form_export_instance_with_geopoint()
         view = TestableBaseExportView(export_instance)
         view.export_type = FORM_EXPORT
@@ -189,14 +185,12 @@ class TestPossibleGeoProperties(BaseExportViewTestCase):
         expected = ['form.location.gps_coords', 'form.user_location']
         self.assertEqual(result, expected)
 
-    @patch.object(toggles.SUPPORT_GEO_JSON_EXPORT, 'enabled')
-    def test_possible_geo_properties_case_export(self, mock_toggle):
+    @flag_enabled('SUPPORT_GEO_JSON_EXPORT')
+    def test_possible_geo_properties_case_export(self):
         """
         Test that _possible_geo_properties calls
         _possible_case_geo_properties for case exports
         """
-        mock_toggle.return_value = True
-
         export_instance = self._create_case_export_instance()
         view = TestableBaseExportView(export_instance)
         view.export_type = CASE_EXPORT

--- a/corehq/apps/export/tests/test_views.py
+++ b/corehq/apps/export/tests/test_views.py
@@ -29,6 +29,8 @@ class TestableBaseExportView(BaseExportView):
     """
     Testable implementation of BaseExportView
     """
+    __test__ = False
+
     export_type = None
 
     def __init__(self, export_instance):

--- a/corehq/apps/export/tests/test_views.py
+++ b/corehq/apps/export/tests/test_views.py
@@ -26,22 +26,12 @@ from corehq.util.test_utils import flag_enabled
 DOMAIN = 'test-domain'
 
 
-class TestableBaseExportView(BaseExportView):
-    """
-    Testable implementation of BaseExportView
-    """
-    __test__ = False
-
-    export_type = None
-
-    def __init__(self, export_instance):
-        super().__init__()
-        self.export_instance = export_instance
-        self.args = [export_instance.domain]
-
-    @property
-    def export_helper(self):
-        return None
+def get_base_export_view(export_instance, export_type=None):
+    view = BaseExportView()
+    view.args = [DOMAIN]
+    view.export_instance = export_instance
+    view.export_type = export_type
+    return view
 
 
 class BaseExportViewTestCase(TestCase):
@@ -145,8 +135,7 @@ class TestPossibleGeoProperties(BaseExportViewTestCase):
         toggle is disabled
         """
         export_instance = self._create_form_export_instance_with_geopoint()
-        view = TestableBaseExportView(export_instance)
-        view.export_type = FORM_EXPORT
+        view = get_base_export_view(export_instance, FORM_EXPORT)
         with patch.object(toggles.SUPPORT_GEO_JSON_EXPORT, 'enabled') as mock_toggle:
             mock_toggle.return_value = False
 
@@ -165,8 +154,7 @@ class TestPossibleGeoProperties(BaseExportViewTestCase):
             case_type=ALL_CASE_TYPE_EXPORT,
             tables=[]
         )
-        view = TestableBaseExportView(bulk_case_export_instance)
-        view.export_type = CASE_EXPORT
+        view = get_base_export_view(bulk_case_export_instance, CASE_EXPORT)
 
         result = view._possible_geo_properties
         self.assertEqual(result, [])
@@ -178,8 +166,7 @@ class TestPossibleGeoProperties(BaseExportViewTestCase):
         _possible_form_geo_properties for form exports
         """
         export_instance = self._create_form_export_instance_with_geopoint()
-        view = TestableBaseExportView(export_instance)
-        view.export_type = FORM_EXPORT
+        view = get_base_export_view(export_instance, FORM_EXPORT)
 
         result = view._possible_geo_properties
         expected = ['form.location.gps_coords', 'form.user_location']
@@ -192,8 +179,7 @@ class TestPossibleGeoProperties(BaseExportViewTestCase):
         _possible_case_geo_properties for case exports
         """
         export_instance = self._create_case_export_instance()
-        view = TestableBaseExportView(export_instance)
-        view.export_type = CASE_EXPORT
+        view = get_base_export_view(export_instance, CASE_EXPORT)
 
         result = view._possible_geo_properties
         expected = ['location_gps', 'home_location']
@@ -208,7 +194,7 @@ class TestPossibleFormGeoProperties(BaseExportViewTestCase):
         GeopointItem columns
         """
         export_instance = self._create_form_export_instance_with_geopoint()
-        view = TestableBaseExportView(export_instance)
+        view = get_base_export_view(export_instance)
 
         result = view._possible_form_geo_properties
         expected = ['form.location.gps_coords', 'form.user_location']
@@ -238,7 +224,7 @@ class TestPossibleFormGeoProperties(BaseExportViewTestCase):
             xmlns='test_xmlns',
             tables=[table_config]
         )
-        view = TestableBaseExportView(export_instance)
+        view = get_base_export_view(export_instance)
 
         result = view._possible_form_geo_properties
         self.assertEqual(result, [])
@@ -254,7 +240,7 @@ class TestPossibleFormGeoProperties(BaseExportViewTestCase):
             xmlns='test_xmlns',
             tables=[]
         )
-        view = TestableBaseExportView(export_instance)
+        view = get_base_export_view(export_instance)
 
         with self.assertRaises(IndexError):
             view._possible_form_geo_properties
@@ -268,7 +254,7 @@ class TestPossibleCaseGeoProperties(BaseExportViewTestCase):
         properties
         """
         export_instance = self._create_case_export_instance()
-        view = TestableBaseExportView(export_instance)
+        view = get_base_export_view(export_instance)
 
         result = view._possible_case_geo_properties
         expected = ['location_gps', 'home_location']
@@ -294,7 +280,7 @@ class TestPossibleCaseGeoProperties(BaseExportViewTestCase):
             case_type='no_gps_case_type',
             tables=[]
         )
-        view = TestableBaseExportView(export_instance)
+        view = get_base_export_view(export_instance)
 
         result = view._possible_case_geo_properties
         self.assertEqual(result, [])
@@ -318,7 +304,7 @@ class TestPossibleCaseGeoProperties(BaseExportViewTestCase):
             data_type=CaseProperty.DataType.GPS
         )
         export_instance = self._create_case_export_instance()
-        view = TestableBaseExportView(export_instance)
+        view = get_base_export_view(export_instance)
 
         result = view._possible_case_geo_properties
         expected = ['location_gps', 'home_location']

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -184,16 +184,11 @@ class BaseExportView(BaseProjectDataView):
     @property
     def _possible_form_geo_properties(self):
         export_table = self.export_instance.tables[0]
-        geo_props = []
-
-        for column in export_table.columns:
-            if column.item.doc_type == 'GeopointItem':
-                # show the path to the geo properties, not the column headers, because the
-                # paths do not change.
-                path_str = '.'.join([f"{node.name}" for node in column.item.path])
-                geo_props.append(path_str)
-
-        return geo_props
+        return [
+            col.item.readable_path
+            for col in export_table.columns
+            if col.item.doc_type == 'GeopointItem'
+        ]
 
     @property
     def _possible_case_geo_properties(self):


### PR DESCRIPTION
## Technical Summary

Preparatory work as part of investigating the "Support GeoJSON export in Case Exporter" feature flag.

This PR adds a few tests, and a small refactor.

Context:
* [SAAS-18103](https://dimagi.atlassian.net/browse/SAAS-18103)
* [GA Plan Template](https://docs.google.com/document/d/16eqNEVZFCDw3EXeVxbtr9CapZgDQCUBgobUhOZ6Yngs/edit)

## Feature Flag

support_geo_json_export

## Safety Assurance

### Safety story

* Mostly tests
* Small DRY refactor to reuse `GeopointItem.readable_path`, which is already covered by tests. Refactor verified by `TestPossibleFormGeoProperties.test_possible_form_geo_properties_with_geopoint_items()`

### Automated test coverage

Yes

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-18103]: https://dimagi.atlassian.net/browse/SAAS-18103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ