### PR TITLE
Run uv lock --check as part of tests

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -145,6 +145,7 @@ function run_tests {
             su cchq -c scripts/test-prod-entrypoints.sh
             scripts/test-serializer-pickle-files.sh
             su cchq -c scripts/test-django-migrations.sh
+            uv lock --check
         fi
         delta=$(($(date +%s) - $now))
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Daniel and I realized that when switching to uv, the [test-make-requirements.sh](https://github.com/dimagi/commcare-hq/pull/36391/files#diff-5e860f41be7c40cf999c4ca9d12d7983b6ba66e8eba75321ebcd9b50dd320a98) script was removed but not replaced. This was not intentional as we still want tests to fail if the uv.lock file is out of sync with the pyproject.toml file, which is what `uv lock --check` should accomplish.

There is a known issue/bug in `uv lock --check` where a dependency not specified in pyrpoject.toml is not flagged by `uv lock --check`. We will create a followup with uv for that, but it is still good to get this out as it could catch other issues.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
A simple change to our test script. This will fail on PRs where uv.lock is out of sync with  
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
