### PR TITLE
Setup venv before switching user (Dockerfile_incl)

### DIFF
--- a/Dockerfile_incl
+++ b/Dockerfile_incl
@@ -61,16 +61,18 @@ RUN npm -g install \
 RUN git config --global url."https://".insteadOf git://
 
 WORKDIR /vendor
+
+# setup venv
+COPY .python-version pyproject.toml uv.lock /tmp-project/
+RUN --mount=type=cache,target=/root/.cache/uv \
+  uv sync --locked --group=prod --no-dev --project=/tmp-project --no-install-project \
+  && rm -rf /tmp-project
+
 RUN mkdir /sharedfiles
 RUN groupadd -r cchq && \
     useradd -r -m -g cchq cchq && \
     chown cchq:cchq /vendor /sharedfiles
 USER cchq:cchq
-
-COPY .python-version pyproject.toml uv.lock /tmp-project/
-RUN --mount=type=cache,target=/root/.cache/uv \
-  uv sync --locked --group=prod --no-dev --project=/tmp-project --no-install-project \
-  && rm -rf /tmp-project
 
 COPY --chown=cchq:cchq package.json /vendor/
 RUN npm shrinkwrap && \


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
COPY seems to be done as root, and then RUN is run as the current user. We were attempting to rm -rf /tmp-project as the cchq user, but failed to do so due to lack of permissions. Presumably because the tmp-project directory was initially created by root as part of the COPY directive.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just a change to the Dockerfile_incl which is used strictly for other developers to write integrations with CommCare. Not even sure how much use this image sees, but good to at least fix it.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
