### PR TITLE
adds clarity to help text

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -676,7 +676,8 @@ class NewMobileWorkerForm(forms.Form):
         label=gettext_noop("Require Account Confirmation?"),
         help_text=gettext_noop(
             "The user's account will not be active until "
-            "they have confirmed their email and set a password."
+            "they have confirmed their email and set a password. "
+            "This requires that the mobile worker has access to an email address."
         ),
         required=False,
     )


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Adds "This requires that the mobile worker has access to an email address" to the help text for "Require Account Confirmation?" toggle

<img width="402" height="225" alt="Screenshot 2025-08-06 at 12 55 32 PM" src="https://github.com/user-attachments/assets/620d5952-cc30-47ff-bd59-e54af14bbebb" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This came from feedback on the CMC [comment](https://docs.google.com/document/d/1L7lcHq3uUiQn4XN6vGmt-UcOUOnc5OU6guOzvzcK-e0/edit?disco=AAABl8su0ys) for Two-Stage Mobile Worker Account Creation
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is only a text change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
