### PR TITLE
Show a special SSO error page when a SingleSignOnError is raised

### DIFF
--- a/corehq/apps/sso/middleware.py
+++ b/corehq/apps/sso/middleware.py
@@ -1,0 +1,20 @@
+from django.shortcuts import render
+from django.utils.deprecation import MiddlewareMixin
+
+from corehq.apps.sso.exceptions import SingleSignOnError
+
+
+class SingleSignOnErrorMiddleware(MiddlewareMixin):
+    """
+    Catches SingleSignOnError anywhere in view processing
+    and shows a dedicated SSO error page instead of a 500.
+    """
+
+    def process_exception(self, request, exception):
+        if isinstance(exception, SingleSignOnError):
+            return render(
+                request,
+                'sso/sso_error.html',
+                {'error': exception},
+                status=503,
+            )

--- a/corehq/apps/sso/templates/sso/sso_error.html
+++ b/corehq/apps/sso/templates/sso/sso_error.html
@@ -1,0 +1,31 @@
+{% extends login_template %}
+{% load i18n %}
+
+{% block title %}{% trans "Single Sign-On Error" %}{% endblock title %}
+
+{% block login-content %}
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-xs-12">
+        <div class="reg-form-container sign-in-container">
+          <div class="form-bubble form-bubble-lg">
+            <h2>
+              {% blocktrans %}
+                Single Sign-On
+              {% endblocktrans %}
+            </h2>
+            <p class="lead">
+              {{ error }}
+            </p>
+            <p>
+              {% blocktrans %}
+                This error is likely due to a misconfiguration with your project's
+                SSO settings. Please contact your project administrator to resolve this issue.
+              {% endblocktrans %}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock login-content %}

--- a/settings.py
+++ b/settings.py
@@ -176,6 +176,7 @@ MIDDLEWARE = [
     'corehq.apps.locations.middleware.LocationAccessMiddleware',
     'corehq.apps.cloudcare.middleware.CloudcareMiddleware',
     'field_audit.middleware.FieldAuditMiddleware',
+    'corehq.apps.sso.middleware.SingleSignOnErrorMiddleware',
 ]
 
 X_FRAME_OPTIONS = 'DENY'


### PR DESCRIPTION
## Product Description
Right now, raising the `SingleSignOnError` error shows the standard 500 page. This makes it look like the issue is on our end, when it is really an SSO configuration issue.

With this PR and new middleware, if a `SingleSignOnError` is raised by a view, we show the user a more helpful error page  so they understand that the issue is with their IdP's configuration, not CommCare HQ.

<img width="914" height="496" alt="Screenshot 2025-08-07 at 11 28 09 AM" src="https://github.com/user-attachments/assets/a7518199-d192-491b-9c34-18ac868a1a9a" />

https://dimagi.atlassian.net/browse/SAAS-18117

## Safety Assurance

### Safety story
safe, straightforward change. tested this middleware locally with a regular exception view, and a view that raises the `SingleSignOnError`. This will not disrupt other errors from triggering the 500 page.

### Automated test coverage
n/a

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
