### PR TITLE
Add tests for BulkEditChangeManger

### DIFF
--- a/corehq/apps/data_cleaning/tests/test_changes.py
+++ b/corehq/apps/data_cleaning/tests/test_changes.py
@@ -1,3 +1,4 @@
+import pytest
 from casexml.apps.case.mock import CaseFactory
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -45,16 +46,13 @@ class BulkEditChangeTest(TestCase):
             action_type=EditActionType.REPLACE,
             replace_string='Esperanza',
         )
-        self.assertEqual(change.edited_value(self.case), 'Esperanza')
-        self.assertEqual(
-            change.edited_value(
-                self.case,
-                edited_properties={
-                    'town': 'Segunda',
-                },
-            ),
-            'Esperanza',
-        )
+        assert change.edited_value(self.case) == 'Esperanza'
+        assert change.edited_value(
+            self.case,
+            edited_properties={
+                'town': 'Segunda',
+            }
+        ) == 'Esperanza'
 
     def test_replace_none(self):
         change = BulkEditChange(
@@ -62,7 +60,7 @@ class BulkEditChangeTest(TestCase):
             action_type=EditActionType.REPLACE,
             replace_string='Esperanza',
         )
-        self.assertEqual(change.edited_value(self.case), 'Esperanza')
+        assert change.edited_value(self.case) == 'Esperanza'
 
     def test_find_replace(self):
         change = BulkEditChange(
@@ -71,16 +69,13 @@ class BulkEditChangeTest(TestCase):
             find_string='Playa',
             replace_string='Punta',
         )
-        self.assertEqual(change.edited_value(self.case), 'Punta Bastimento')
-        self.assertEqual(
-            change.edited_value(
-                self.case,
-                edited_properties={
-                    'favorite_beach': 'Bastimento Playa',
-                },
-            ),
-            'Bastimento Punta',
-        )
+        assert change.edited_value(self.case) == 'Punta Bastimento'
+        assert change.edited_value(
+            self.case,
+            edited_properties={
+                'favorite_beach': 'Bastimento Playa',
+            }
+        ) == 'Bastimento Punta'
 
     def test_find_replace_none(self):
         change = BulkEditChange(
@@ -89,7 +84,7 @@ class BulkEditChangeTest(TestCase):
             find_string='Playa',
             replace_string='Punta',
         )
-        self.assertEqual(change.edited_value(self.case), None)
+        assert change.edited_value(self.case) is None
 
     def test_find_replace_regex(self):
         change = BulkEditChange(
@@ -99,16 +94,13 @@ class BulkEditChangeTest(TestCase):
             find_string='(\\s)+',
             replace_string=' ',
         )
-        self.assertEqual(change.edited_value(self.case), 'Brittney Claasen')
-        self.assertEqual(
-            change.edited_value(
-                self.case,
-                edited_properties={
-                    'friend': 'brittney \t\nclaasen',
-                },
-            ),
-            'brittney claasen',
-        )
+        assert change.edited_value(self.case) == 'Brittney Claasen'
+        assert change.edited_value(
+            self.case,
+            edited_properties={
+                'friend': 'brittney \t\nclaasen',
+            },
+        ) == 'brittney claasen'
 
     def test_find_replace_regex_none(self):
         change = BulkEditChange(
@@ -118,30 +110,27 @@ class BulkEditChangeTest(TestCase):
             find_string='(\\s)+',
             replace_string=' ',
         )
-        self.assertEqual(change.edited_value(self.case), None)
+        assert change.edited_value(self.case) is None
 
     def test_strip(self):
         change = BulkEditChange(
             prop_id='art',
             action_type=EditActionType.STRIP,
         )
-        self.assertEqual(change.edited_value(self.case), ':)')
-        self.assertEqual(
-            change.edited_value(
-                self.case,
-                edited_properties={
-                    'art': '    :-)\t\n  ',
-                },
-            ),
-            ':-)',
-        )
+        assert change.edited_value(self.case) == ':)'
+        assert change.edited_value(
+            self.case,
+            edited_properties={
+                'art': '    :-)\t\n  ',
+            },
+        ) == ':-)'
 
     def test_strip_none(self):
         change = BulkEditChange(
             prop_id='unset',
             action_type=EditActionType.STRIP,
         )
-        self.assertEqual(change.edited_value(self.case), None)
+        assert change.edited_value(self.case) is None
 
     def test_copy_replace(self):
         change = BulkEditChange(
@@ -149,17 +138,14 @@ class BulkEditChangeTest(TestCase):
             action_type=EditActionType.COPY_REPLACE,
             copy_from_prop_id='favorite_beach',
         )
-        self.assertEqual(change.edited_value(self.case), 'Playa Bastimento')
-        self.assertEqual(
-            change.edited_value(
-                self.case,
-                edited_properties={
-                    'favorite_beach': 'playa bastimento',
-                    'nearest_ocean': 'Atlantic',
-                },
-            ),
-            'playa bastimento',
-        )
+        assert change.edited_value(self.case) == 'Playa Bastimento'
+        assert change.edited_value(
+            self.case,
+            edited_properties={
+                'favorite_beach': 'playa bastimento',
+                'nearest_ocean': 'Atlantic',
+            },
+        ) == 'playa bastimento'
 
     def test_copy_replace_none(self):
         change = BulkEditChange(
@@ -167,145 +153,127 @@ class BulkEditChangeTest(TestCase):
             action_type=EditActionType.COPY_REPLACE,
             copy_from_prop_id='favorite_beach',
         )
-        self.assertEqual(change.edited_value(self.case), 'Playa Bastimento')
+        assert change.edited_value(self.case) == 'Playa Bastimento'
 
     def test_title_case(self):
         change = BulkEditChange(
             prop_id='nearest_ocean',
             action_type=EditActionType.TITLE_CASE,
         )
-        self.assertEqual(change.edited_value(self.case), 'Atlantic')
-        self.assertEqual(
-            change.edited_value(
-                self.case,
-                edited_properties={
-                    'nearest_ocean': 'atlantic  ',
-                },
-            ),
-            'Atlantic  ',
-        )
+        assert change.edited_value(self.case) == 'Atlantic'
+        assert change.edited_value(
+            self.case,
+            edited_properties={
+                'nearest_ocean': 'atlantic  ',
+            },
+        ) == 'Atlantic  '
 
     def test_title_case_none(self):
         change = BulkEditChange(
             prop_id='unset',
             action_type=EditActionType.TITLE_CASE,
         )
-        self.assertEqual(change.edited_value(self.case), None)
+        assert change.edited_value(self.case) is None
 
     def test_upper_case(self):
         change = BulkEditChange(
             prop_id='town',
             action_type=EditActionType.UPPER_CASE,
         )
-        self.assertEqual(change.edited_value(self.case), 'ISABEL SEGUNDA')
-        self.assertEqual(
-            change.edited_value(
-                self.case,
-                edited_properties={
-                    'town': 'isbel',
-                },
-            ),
-            'ISBEL',
-        )
+        assert change.edited_value(self.case) == 'ISABEL SEGUNDA'
+        assert change.edited_value(
+            self.case,
+            edited_properties={
+                'town': 'isbel',
+            },
+        ) == 'ISBEL'
 
     def test_upper_case_none(self):
         change = BulkEditChange(
             prop_id='unset',
             action_type=EditActionType.UPPER_CASE,
         )
-        self.assertEqual(change.edited_value(self.case), None)
+        assert change.edited_value(self.case) is None
 
     def test_lower_case(self):
         change = BulkEditChange(
             prop_id='town',
             action_type=EditActionType.LOWER_CASE,
         )
-        self.assertEqual(change.edited_value(self.case), 'isabel segunda')
-        self.assertEqual(
-            change.edited_value(
-                self.case,
-                edited_properties={
-                    'town': 'SEGUNDA',
-                },
-            ),
-            'segunda',
-        )
+        assert change.edited_value(self.case) == 'isabel segunda'
+        assert change.edited_value(
+            self.case,
+            edited_properties={
+                'town': 'SEGUNDA',
+            },
+        ) == 'segunda'
 
     def test_lower_case_none(self):
         change = BulkEditChange(
             prop_id='unset',
             action_type=EditActionType.LOWER_CASE,
         )
-        self.assertEqual(change.edited_value(self.case), None)
+        assert change.edited_value(self.case) is None
 
     def test_make_empty(self):
         change = BulkEditChange(
             prop_id='nearest_ocean',
             action_type=EditActionType.MAKE_EMPTY,
         )
-        self.assertEqual(change.edited_value(self.case), '')
-        self.assertEqual(
-            change.edited_value(
-                self.case,
-                edited_properties={
-                    'nearest_ocean': 'pacific',
-                },
-            ),
-            '',
-        )
+        assert change.edited_value(self.case) == ''
+        assert change.edited_value(
+            self.case,
+            edited_properties={
+                'nearest_ocean': 'pacific',
+            },
+        ) == ''
 
     def test_empty_none(self):
         change = BulkEditChange(
             prop_id='unset',
             action_type=EditActionType.MAKE_EMPTY,
         )
-        self.assertEqual(change.edited_value(self.case), '')
+        assert change.edited_value(self.case) == ''
 
     def test_make_null(self):
         change = BulkEditChange(
             prop_id='nearest_ocean',
             action_type=EditActionType.MAKE_NULL,
         )
-        self.assertEqual(change.edited_value(self.case), None)
-        self.assertEqual(
-            change.edited_value(
-                self.case,
-                edited_properties={
-                    'nearest_ocean': 'pacific',
-                },
-            ),
-            None,
-        )
+        assert change.edited_value(self.case) is None
+        assert change.edited_value(
+            self.case,
+            edited_properties={
+                'nearest_ocean': 'pacific',
+            },
+        ) is None
 
     def test_make_null_none(self):
         change = BulkEditChange(
             prop_id='unset',
             action_type=EditActionType.MAKE_NULL,
         )
-        self.assertEqual(change.edited_value(self.case), None)
+        assert change.edited_value(self.case) is None
 
     def test_reset(self):
         change = BulkEditChange(
             prop_id='nearest_ocean',
             action_type=EditActionType.RESET,
         )
-        self.assertEqual(change.edited_value(self.case), 'atlantic')
-        self.assertEqual(
-            change.edited_value(
-                self.case,
-                edited_properties={
-                    'nearest_ocean': 'pacific',
-                },
-            ),
-            'atlantic',
-        )
+        assert change.edited_value(self.case) == 'atlantic'
+        assert change.edited_value(
+            self.case,
+            edited_properties={
+                'nearest_ocean': 'pacific',
+            },
+        ) == 'atlantic'
 
     def test_reset_none(self):
         change = BulkEditChange(
             prop_id='unset',
             action_type=EditActionType.RESET,
         )
-        self.assertIsNone(change.edited_value(self.case))
+        assert change.edited_value(self.case) is None
 
 
 class BulkEditRecordChangesTest(TestCase):
@@ -356,8 +324,8 @@ class BulkEditRecordChangesTest(TestCase):
             session=self.session,
             doc_id=self.case.case_id,
         )
-        self.assertFalse(record.has_property_updates)
-        self.assertEqual(record.get_edited_case_properties(self.case), {})
+        assert not record.has_property_updates
+        assert record.get_edited_case_properties(self.case) == {}
 
     def test_single_change_to_record(self):
         record = BulkEditRecord.objects.create(
@@ -370,12 +338,12 @@ class BulkEditRecordChangesTest(TestCase):
             action_type=EditActionType.MAKE_NULL,
         )
         change.records.add(record)
-        self.assertTrue(record.has_property_updates)
+        assert record.has_property_updates
         edited_props = record.get_edited_case_properties(self.case)
-        self.assertEqual(edited_props, {'pot_type': None})
-        self.assertEqual(record.calculated_change_id, change.change_id)
-        self.assertEqual(record.calculated_properties, edited_props)
-        self.assertFalse(record.has_property_updates)
+        assert edited_props == {'pot_type': None}
+        assert record.calculated_change_id == change.change_id
+        assert record.calculated_properties == edited_props
+        assert not record.has_property_updates
 
     def test_multiple_changes_and_views_to_record(self):
         record = BulkEditRecord.objects.create(
@@ -396,11 +364,11 @@ class BulkEditRecordChangesTest(TestCase):
         change_two.records.add(record)
 
         # simulating the first view of the case in the table:
-        self.assertTrue(record.has_property_updates)
+        assert record.has_property_updates
         edited_props = record.get_edited_case_properties(self.case)
-        self.assertEqual(edited_props, {'name': 'WILD  \nRYE', 'pot_type': 'Terra Cotta'})
-        self.assertEqual(record.calculated_change_id, change_two.change_id)
-        self.assertEqual(record.calculated_properties, edited_props)
+        assert edited_props == {'name': 'WILD  \nRYE', 'pot_type': 'Terra Cotta'}
+        assert record.calculated_change_id == change_two.change_id
+        assert record.calculated_properties == edited_props
 
         change_three = BulkEditChange.objects.create(
             session=self.session,
@@ -413,11 +381,11 @@ class BulkEditRecordChangesTest(TestCase):
         change_three.records.add(record)
 
         # simulating the second view of the case in the table:
-        self.assertTrue(record.has_property_updates)
+        assert record.has_property_updates
         edited_props_two = record.get_edited_case_properties(self.case)
-        self.assertEqual(edited_props_two, {'name': 'WILD RYE', 'pot_type': 'Terra Cotta'})
-        self.assertEqual(record.calculated_change_id, change_three.change_id)
-        self.assertEqual(record.calculated_properties, edited_props_two)
+        assert edited_props_two == {'name': 'WILD RYE', 'pot_type': 'Terra Cotta'}
+        assert record.calculated_change_id == change_three.change_id
+        assert record.calculated_properties == edited_props_two
 
     def test_changes_to_multiple_records(self):
         record_one = BulkEditRecord.objects.create(
@@ -441,11 +409,11 @@ class BulkEditRecordChangesTest(TestCase):
         )
         change_two.records.add(record_one)
         edited_props_one = record_one.get_edited_case_properties(self.case)
-        self.assertEqual(record_one.calculated_change_id, change_two.change_id)
-        self.assertEqual(edited_props_one, {'name': 'Wild  \nRye'})
+        assert record_one.calculated_change_id == change_two.change_id
+        assert edited_props_one == {'name': 'Wild  \nRye'}
         edited_props_two = record_two.get_edited_case_properties(self.case_two)
-        self.assertEqual(record_two.calculated_change_id, change_one.change_id)
-        self.assertEqual(edited_props_two, {'name': 'Zesty flora'})
+        assert record_two.calculated_change_id == change_one.change_id
+        assert edited_props_two == {'name': 'Zesty flora'}
 
     def test_get_edited_case_properties_with_other_case(self):
         record = BulkEditRecord.objects.create(
@@ -458,5 +426,5 @@ class BulkEditRecordChangesTest(TestCase):
             action_type=EditActionType.LOWER_CASE,
         )
         change.records.add(record)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError, match="case.case_id doesn't match record.doc_id"):
             record.get_edited_case_properties(self.case_two)


### PR DESCRIPTION
## Technical Summary
Just adds a few small tests for `BulkEditChangeManager`

Also updates the `assert` and `raises` formatting in the `test_changes` suite.

https://dimagi.atlassian.net/browse/SAAS-18114

## Safety Assurance

### Safety story
safe change, just tests

### Automated test coverage
it's tests!

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
