### PR TITLE
Add remaining BulkEditRecord tests

### DIFF
--- a/corehq/apps/data_cleaning/models/record.py
+++ b/corehq/apps/data_cleaning/models/record.py
@@ -107,7 +107,7 @@ class BulkEditRecord(models.Model):
         )
 
     @property
-    def should_reset_changes(self):
+    def should_reset_calculated_change_id(self):
         return self.changes.count() == 0 and self.calculated_change_id is not None
 
     def reset_changes(self, prop_id):
@@ -121,7 +121,7 @@ class BulkEditRecord(models.Model):
         if case.case_id != self.doc_id:
             raise ValueError("case.case_id doesn't match record.doc_id")
 
-        if self.should_reset_changes:
+        if self.should_reset_calculated_change_id:
             self.calculated_properties = None
             self.calculated_change_id = None
             self.save()

--- a/corehq/apps/data_cleaning/tests/test_records.py
+++ b/corehq/apps/data_cleaning/tests/test_records.py
@@ -27,17 +27,17 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
     def test_select_record(self):
         case_id = self._get_case_id()
         record = self.session.select_record(case_id)
-        self.assertEqual(record.session, self.session)
-        self.assertEqual(record.doc_id, case_id)
-        self.assertTrue(record.is_selected)
-        self.assertTrue(self.session.records.filter(doc_id=case_id).exists())
+        assert record.session == self.session
+        assert record.doc_id == case_id
+        assert record.is_selected
+        assert self.session.records.filter(doc_id=case_id).exists()
 
     def test_deselect_record(self):
         case_id = self._get_case_id()
         self.session.select_record(case_id)
         record = self.session.deselect_record(case_id)
-        self.assertIsNone(record)
-        self.assertFalse(self.session.records.filter(doc_id=case_id).exists())
+        assert record is None
+        assert not self.session.records.filter(doc_id=case_id).exists()
 
     def test_select_record_with_changes(self):
         case_id = self._get_case_id()
@@ -49,13 +49,13 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
         change = self._add_change_to_record(record)
 
         record = self.session.select_record(case_id)
-        self.assertEqual(record.session, self.session)
-        self.assertEqual(record.doc_id, case_id)
-        self.assertTrue(record.is_selected)
-        self.assertEqual(record.changes.count(), 1)
-        self.assertEqual(record.changes.first(), change)
+        assert record.session == self.session
+        assert record.doc_id == case_id
+        assert record.is_selected
+        assert record.changes.count() == 1
+        assert record.changes.first() == change
 
-        self.assertTrue(self.session.records.filter(doc_id=case_id).exists())
+        assert self.session.records.filter(doc_id=case_id).exists()
 
     def test_deselect_record_with_changes(self):
         case_id = self._get_case_id()
@@ -67,25 +67,25 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
         change = self._add_change_to_record(record)
 
         record = self.session.deselect_record(case_id)
-        self.assertIsNotNone(record)
-        self.assertEqual(record.session, self.session)
-        self.assertEqual(record.doc_id, case_id)
-        self.assertEqual(record.changes.count(), 1)
-        self.assertEqual(record.changes.first(), change)
-        self.assertFalse(record.is_selected)
+        assert record is not None
+        assert record.session == self.session
+        assert record.doc_id == case_id
+        assert record.changes.count() == 1
+        assert record.changes.first() == change
+        assert not record.is_selected
 
-        self.assertTrue(self.session.records.filter(doc_id=case_id).exists())
+        assert self.session.records.filter(doc_id=case_id).exists()
 
     def test_select_multiple_records(self):
         case_ids = [self._get_case_id() for _ in range(10)]
         self.session.select_multiple_records(case_ids)
         for case_id in case_ids:
             record = self.session.records.get(doc_id=case_id)
-            self.assertTrue(record.is_selected)
-            self.assertEqual(record.session, self.session)
-            self.assertEqual(record.doc_id, case_id)
-        self.assertEqual(self.session.records.count(), len(case_ids))
-        self.assertEqual(self.session.get_num_selected_records(), len(case_ids))
+            assert record.is_selected
+            assert record.session == self.session
+            assert record.doc_id == case_id
+        assert self.session.records.count() == len(case_ids)
+        assert self.session.get_num_selected_records() == len(case_ids)
 
     def test_select_multiple_records_some_existing(self):
         case_ids = [self._get_case_id() for _ in range(10)]
@@ -102,39 +102,39 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
             is_selected=False,
         )
         self._add_change_to_record(record)
-        self.assertEqual(self.session.records.count(), 3)
-        self.assertEqual(self.session.get_num_selected_records(), 1)
+        assert self.session.records.count() == 3
+        assert self.session.get_num_selected_records() == 1
         self.session.select_multiple_records(case_ids)
-        self.assertEqual(self.session.records.count(), len(case_ids) + 1)
-        self.assertEqual(self.session.get_num_selected_records(), len(case_ids))
+        assert self.session.records.count() == len(case_ids) + 1
+        assert self.session.get_num_selected_records() == len(case_ids)
 
     def test_deselect_multiple_records(self):
         case_ids = [self._get_case_id() for _ in range(10)]
         self.session.select_record(self._get_case_id())  # record not in case_ids
         self.session.select_multiple_records(case_ids)
-        self.assertEqual(self.session.get_num_selected_records(), len(case_ids) + 1)
+        assert self.session.get_num_selected_records() == len(case_ids) + 1
         self.session.deselect_multiple_records(case_ids)
-        self.assertEqual(self.session.records.count(), 1)
-        self.assertEqual(self.session.get_num_selected_records(), 1)
+        assert self.session.records.count() == 1
+        assert self.session.get_num_selected_records() == 1
 
     def test_deselect_multiple_records_some_edited(self):
         case_ids = [self._get_case_id() for _ in range(10)]
         self.session.select_multiple_records(case_ids)
         edited_record = self.session.records.get(doc_id=case_ids[5])
         self._add_change_to_record(edited_record)
-        self.assertEqual(self.session.get_num_selected_records(), len(case_ids))
+        assert self.session.get_num_selected_records() == len(case_ids)
         self.session.deselect_multiple_records(case_ids)
-        self.assertEqual(self.session.records.count(), 1)
-        self.assertEqual(self.session.get_num_selected_records(), 0)
+        assert self.session.records.count() == 1
+        assert self.session.get_num_selected_records() == 0
         edited_record = self.session.records.get(doc_id=case_ids[5])
-        self.assertFalse(edited_record.is_selected)
+        assert not edited_record.is_selected
 
     def test_get_unrecorded_doc_ids(self):
         case_ids = [self._get_case_id() for _ in range(10)]
         self.session.select_multiple_records(case_ids)
         unrecorded_case_ids = [self._get_case_id() for _ in range(5)]
-        self.assertListEqual(self.session.records.get_unrecorded_doc_ids(self.session, case_ids), [])
+        assert self.session.records.get_unrecorded_doc_ids(self.session, case_ids) == []
         all_case_ids = case_ids + unrecorded_case_ids
-        self.assertEqual(
-            set(self.session.records.get_unrecorded_doc_ids(self.session, all_case_ids)), set(unrecorded_case_ids)
+        assert set(self.session.records.get_unrecorded_doc_ids(self.session, all_case_ids)) == set(
+            unrecorded_case_ids
         )

--- a/corehq/apps/data_cleaning/tests/test_records.py
+++ b/corehq/apps/data_cleaning/tests/test_records.py
@@ -169,15 +169,15 @@ class BulkEditRecordChangesTest(BaseBulkEditSessionTest):
     domain_name = 'forest-friends'
     case_type = 'tree'
 
-    def test_should_reset_changes_no_changes(self):
+    def test_should_reset_calculated_change_id_no_changes(self):
         record = BulkEditRecord.objects.create(
             session=self.session,
             doc_id=str(uuid.uuid4()),
             is_selected=True,
         )
-        assert not record.should_reset_changes
+        assert not record.should_reset_calculated_change_id
 
-    def test_should_reset_changes(self):
+    def test_should_reset_calculated_change_id(self):
         record = BulkEditRecord.objects.create(
             session=self.session,
             doc_id=str(uuid.uuid4()),
@@ -185,9 +185,9 @@ class BulkEditRecordChangesTest(BaseBulkEditSessionTest):
         )
         record.calculated_change_id = uuid.uuid4()
         record.save()
-        assert record.should_reset_changes
+        assert record.should_reset_calculated_change_id
 
-    def test_should_reset_changes_with_changes(self):
+    def test_should_reset_calculated_change_id_with_changes(self):
         record = BulkEditRecord.objects.create(
             session=self.session,
             doc_id=str(uuid.uuid4()),
@@ -199,7 +199,7 @@ class BulkEditRecordChangesTest(BaseBulkEditSessionTest):
             action_type=EditActionType.STRIP,
         )
         change.records.add(record)
-        assert not record.should_reset_changes
+        assert not record.should_reset_calculated_change_id
 
     def test_reset_changes(self):
         record = BulkEditRecord.objects.create(

--- a/corehq/apps/data_cleaning/tests/test_records.py
+++ b/corehq/apps/data_cleaning/tests/test_records.py
@@ -138,3 +138,28 @@ class BulkEditRecordSelectionTest(BaseBulkEditSessionTest):
         assert set(self.session.records.get_unrecorded_doc_ids(self.session, all_case_ids)) == set(
             unrecorded_case_ids
         )
+
+
+class BulkEditRecordManagerTests(BaseBulkEditSessionTest):
+    domain_name = 'forest-friends'
+    case_type = 'tree'
+
+    def test_get_for_inline_editing_new(self):
+        doc_id = str(uuid.uuid4())
+        self.session.records.get_for_inline_editing(self.session, doc_id)
+        record = self.session.records.get(doc_id=doc_id)
+        assert record.session == self.session
+        assert record.doc_id == doc_id
+        assert not record.is_selected
+
+    def test_get_for_inline_editing_existing(self):
+        doc_id = str(uuid.uuid4())
+        record = BulkEditRecord.objects.create(
+            session=self.session,
+            doc_id=doc_id,
+            is_selected=True,
+        )
+        record = self.session.records.get_for_inline_editing(self.session, doc_id)
+        assert record.session == self.session
+        assert record.doc_id == doc_id
+        assert record.is_selected


### PR DESCRIPTION
## Technical Summary
Adds tests for:
- `BulkEditRecordManager.get_for_inline_editing`
- `BulkEditRecord.should_reset_calculated_change_id`
- `BulkEditRecord.reset_changes`

I also renamed `BulkEditRecord().should_reset_changes` to  `should_reset_calculated_change_id`. When this is checked it's not actually removing any changes or applying a "reset_changes" action, instead it is resetting the `calculated_change_id` left behind from the remove changes action (which is a bulk action done on the session, not the record)

https://dimagi.atlassian.net/browse/SAAS-18115

## Safety Assurance

### Safety story
safe change, mostly tests or clearly tested areas

### Automated test coverage
it's tests!

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
