### PR TITLE
Feature preview status report

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -588,8 +588,8 @@ class FeaturePreviewStatsReport(AdminReport):
     def headers(self):
         return DataTablesHeader(
             DataTablesColumn(gettext_lazy("Domain")),
-            DataTablesColumn(gettext_lazy("Turned On By")),
-            DataTablesColumn(gettext_lazy("Turned On At")),
+            DataTablesColumn(gettext_lazy("Enabled By")),
+            DataTablesColumn(gettext_lazy("Enabled At")),
         )
 
     @property
@@ -608,7 +608,6 @@ class FeaturePreviewStatsReport(AdminReport):
             .distinct('item')
         )
 
-        domains_with_records = {record.item for record in records}
         for record in records:
             rows.append([
                 record.item,
@@ -616,12 +615,14 @@ class FeaturePreviewStatsReport(AdminReport):
                 record.created,
             ])
 
+        domains_with_records = {record.item for record in records}
         domains_without_records = set(domains) - domains_with_records
+
         for domain in domains_without_records:
             rows.append([
                 domain,
-                "Not recorded",
-                "Not recorded",
+                _("Not recorded"),
+                _("Not recorded"),
             ])
 
         return rows

--- a/corehq/apps/hqwebapp/utils/bootstrap/reports/stats.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/reports/stats.py
@@ -70,6 +70,7 @@ ALL_REPORTS = [
     hqadmin.UserAuditReport,
     hqadmin.DeployHistoryReport,
     hqadmin.UCRDataLoadReport,
+    hqadmin.FeaturePreviewStatsReport,
     DomainForwardingRepeatRecords,
     DomainLinkHistoryReport,
     ApiRequestLogReport,

--- a/corehq/apps/reports/filters/select.py
+++ b/corehq/apps/reports/filters/select.py
@@ -15,6 +15,7 @@ from corehq.apps.reports.filters.base import (
     BaseMultipleOptionFilter,
     BaseSingleOptionFilter,
 )
+from corehq.feature_previews import all_previews
 from corehq.motech.repeaters.const import State, UCRRestrictionFFStatus
 from corehq.motech.repeaters.models import Repeater
 
@@ -161,3 +162,13 @@ class UCRRebuildStatusFilter(BaseSingleOptionFilter):
             UCRRestrictionFFStatus.ShouldEnable,
             UCRRestrictionFFStatus.CanDisable,
         ]]
+
+
+class FeatureFilter(BaseSingleOptionFilter):
+    slug = "feature"
+    label = gettext_lazy("Feature")
+    default_text = gettext_lazy("Select Feature")
+
+    @property
+    def options(self):
+        return [(feature.slug, feature.label) for feature in all_previews()]

--- a/corehq/apps/reports/tests/test_dispatcher.py
+++ b/corehq/apps/reports/tests/test_dispatcher.py
@@ -53,6 +53,7 @@ class AdminReportDispatcherTests(SimpleTestCase):
             'deploy_history_report',
             'phone_number_report',
             'ucr_data_load',
+            'feature_preview_stats_report',
         })
 
 

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -64,6 +64,13 @@ def all_previews_by_name():
     return all_toggles_by_name_in_scope(globals(), toggle_class=FeaturePreview)
 
 
+def find_preview_by_slug(slug):
+    for preview in all_previews():
+        if preview.slug == slug:
+            return preview
+    return None
+
+
 def previews_dict(domain):
     by_name = all_previews_by_name()
     enabled = previews_enabled_for_domain(domain)

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -35,6 +35,7 @@ from corehq.apps.fixtures.interface import (
 from corehq.apps.hqadmin.reports import (
     AdminPhoneNumberReport,
     DeployHistoryReport,
+    FeaturePreviewStatsReport,
     UserAuditReport,
     UserListReport,
     UCRDataLoadReport,
@@ -326,6 +327,7 @@ ADMIN_REPORTS = (
     (_('Domain Stats'), (
         UserListReport,
         AdminPhoneNumberReport,
+        FeaturePreviewStatsReport,
         UserAuditReport,
         DeployHistoryReport,
         UCRDataLoadReport,

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -53,6 +53,7 @@ from corehq.apps.case_search.views import CSQLFixtureExpressionView
 from corehq.apps.geospatial.dispatchers import CaseManagementMapDispatcher
 from corehq.apps.hqadmin.reports import (
     DeployHistoryReport,
+    FeaturePreviewStatsReport,
     UserAuditReport,
     UserListReport,
     UCRDataLoadReport,
@@ -2704,7 +2705,7 @@ class AdminTab(UITab):
                     url=reverse('admin_report_dispatcher', args=(report.slug,)),
                     params="?{}".format(urlencode(report.default_params)) if report.default_params else ""
                 )
-            } for report in [UserAuditReport, UCRDataLoadReport]
+            } for report in [UserAuditReport, FeaturePreviewStatsReport, UCRDataLoadReport]
         ]))
         return sections
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Add a new report `FeaturePreviewStatusReport` under admin page. So Admins can know which domain turned on this feature in feature preview, who turned it on, when it is turned on without reaching out to a dev.
<img width="1280" height="564" alt="image" src="https://github.com/user-attachments/assets/7ee78c51-9dec-44e5-96de-c9a1bc9b3b71" />

Because the auditing of Feature Preview is just merged this week. So for domain who has a feature turned on may not have a audit record, for those domain we will just display the name and show "Not recorded" in the other two columns.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-18120

The report will treat `feature.get_enabled_domains()` as source of truth to get enabled domains for the feature. Then it will run a query to get the latest record from `ToggleAudit`

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe, just adding a new admin report.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
