### PR TITLE
Switch to Django 5.2 supported password hasher

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -200,11 +200,10 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 PASSWORD_HASHERS = (
-    # this is the default list with SHA1 moved to the front
-    'django.contrib.auth.hashers.SHA1PasswordHasher',
     'django.contrib.auth.hashers.PBKDF2PasswordHasher',
     'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
     'django.contrib.auth.hashers.BCryptPasswordHasher',
+    'django.contrib.auth.hashers.SHA1PasswordHasher',
     'django.contrib.auth.hashers.MD5PasswordHasher',
     'django.contrib.auth.hashers.UnsaltedMD5PasswordHasher',
     'django.contrib.auth.hashers.CryptPasswordHasher',


### PR DESCRIPTION
`SHA1PasswordHasher` was [removed in Django 5.1](https://docs.djangoproject.com/en/5.2/releases/5.1/#features-removed-in-5-1).

Passwords hashed with `SHA1PasswordHasher` will be [automatically updated](https://docs.djangoproject.com/en/5.2/topics/auth/passwords/#password-upgrading) with the default (now `PBKDF2PasswordHasher`) on next login. I don't know why [we changed the default Django hasher many years ago](https://github.com/dimagi/commcare-hq/pull/2253).

It is important to do this as soon as possible to seamlessly migrate users to a more secure and supported password hashing algorithm before upgrading to Django 5. It's unclear right now if we will copy `SHA1PasswordHasher` into HQ so we can retain support for it over a longer period of time, or if we will remove it and effectively force users who have not logged in since this PR is merged to change their password using the _forgot password_ workflow. The latter is the easiest path forward for us, but could be a rough transition for folks who have not logged in for a while.

## Safety Assurance

### Safety story

Settings change with no user-facing effects.

### Automated test coverage

No.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations