### PR TITLE
Add "Is Contractor" to offboarding list

### DIFF
--- a/corehq/apps/hqadmin/forms.py
+++ b/corehq/apps/hqadmin/forms.py
@@ -16,7 +16,7 @@ from corehq.apps.users.util import is_dimagi_email
 
 from email.utils import parseaddr
 
-from corehq.toggles import ALL_TAGS
+from corehq.toggles import ALL_TAGS, IS_CONTRACTOR
 
 
 class EmailForm(forms.Form):
@@ -153,7 +153,8 @@ def clean_data(cleaned_data, offboarding_list=False):
     EMAIL_INDEX = 1
     csv_email_list = cleaned_data.get('csv_email_list', '')
     all_users = User.objects.filter(Q(is_superuser=True) | Q(is_staff=True)
-                                    | (Q(is_active=True) & Q(username__endswith='@dimagi.com')))
+                                    | (Q(is_active=True) & Q(username__endswith='@dimagi.com'))
+                                    | Q(username__in=IS_CONTRACTOR.get_enabled_users()))
     if offboarding_list and not csv_email_list:
         cleaned_data['csv_email_list'] = all_users
         return cleaned_data

--- a/corehq/apps/hqadmin/forms.py
+++ b/corehq/apps/hqadmin/forms.py
@@ -124,7 +124,7 @@ class SuperuserManagementForm(forms.Form):
 
 class OffboardingUserListForm(forms.Form):
     csv_email_list = forms.CharField(
-        label="Comma/new-line seperated email addresses",
+        label="Comma/new-line separated email addresses",
         widget=forms.Textarea(attrs={"class": "vertical-resize"}),
         required=False
     )

--- a/corehq/apps/hqadmin/templates/hqadmin/offboarding_list.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/offboarding_list.html
@@ -27,7 +27,15 @@
           <th>{% translate "Developer" %}</th>
           <th>{% translate "Superuser" %}</th>
           <th>{% translate "Accounting Admin" %}</th>
-          <th>{% translate "Contractor (Feature Flag)" %}</th>
+          <th>{% translate "Is Contractor" %}
+            <a
+              href="https://dimagi.atlassian.net/wiki/spaces/saas/pages/2146600302/Superuser+Privileges#IS_CONTRACTOR-access"
+              target="_blank"
+              title="{% translate "Info" %}"
+            >
+              <i class="fa-solid fa-info-circle"></i>
+            </a>
+          </th>
           <th>{% translate "Active" %}</th>
           <th>{% translate "Two Factor Enabled" %}</th>
         </tr>

--- a/corehq/apps/hqadmin/templates/hqadmin/offboarding_list.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/offboarding_list.html
@@ -24,10 +24,10 @@
       <table class="table">
         <tr>
           <th>{% translate "Username" %}</th>
-          <th>{% translate "Developer" %}</th>
-          <th>{% translate "Superuser" %}</th>
-          <th>{% translate "Accounting Admin" %}</th>
-          <th>{% translate "Is Contractor" %}
+          <th class="text-center">{% translate "Developer" %}</th>
+          <th class="text-center">{% translate "Superuser" %}</th>
+          <th class="text-center">{% translate "Accounting Admin" %}</th>
+          <th class="text-center">{% translate "Is Contractor" %}
             <a
               href="https://dimagi.atlassian.net/wiki/spaces/saas/pages/2146600302/Superuser+Privileges#IS_CONTRACTOR-access"
               target="_blank"
@@ -36,18 +36,18 @@
               <i class="fa-solid fa-info-circle"></i>
             </a>
           </th>
-          <th>{% translate "Active" %}</th>
-          <th>{% translate "Two Factor Enabled" %}</th>
+          <th class="text-center">{% translate "Active" %}</th>
+          <th class="text-center">{% translate "Two Factor Enabled" %}</th>
         </tr>
         {% for user in users %}
           <tr>
             <td>{{ user.username }}</td>
-            <td>{% if user.is_staff %}<i class="fa fa-check"></i>{% endif %}</td>
-            <td>{% if user.is_superuser %}<i class="fa fa-check"></i>{% endif %}</td>
-            <td>{% if user.is_accounting_admin %}<i class="fa fa-check"></i>{% endif %}</td>
-            <td>{% if user.is_contractor %}<i class="fa fa-check"></i>{% endif %}</td>
-            <td>{% if user.is_active %}<i class="fa fa-check"></i>{% endif %}</td>
-            <td>{% if user.two_factor_enabled %}<i class="fa fa-check"></i>{% endif %}</td>
+            <td class="text-center">{% if user.is_staff %}<i class="fa fa-check"></i>{% endif %}</td>
+            <td class="text-center">{% if user.is_superuser %}<i class="fa fa-check"></i>{% endif %}</td>
+            <td class="text-center">{% if user.is_accounting_admin %}<i class="fa fa-check"></i>{% endif %}</td>
+            <td class="text-center">{% if user.is_contractor %}<i class="fa fa-check"></i>{% endif %}</td>
+            <td class="text-center">{% if user.is_active %}<i class="fa fa-check"></i>{% endif %}</td>
+            <td class="text-center">{% if user.two_factor_enabled %}<i class="fa fa-check"></i>{% endif %}</td>
           </tr>
         {% endfor %}
       </table>

--- a/corehq/apps/hqadmin/templates/hqadmin/offboarding_list.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/offboarding_list.html
@@ -27,6 +27,7 @@
           <th>{% translate "Developer" %}</th>
           <th>{% translate "Superuser" %}</th>
           <th>{% translate "Accounting Admin" %}</th>
+          <th>{% translate "Contractor (Feature Flag)" %}</th>
           <th>{% translate "Active" %}</th>
           <th>{% translate "Two Factor Enabled" %}</th>
         </tr>
@@ -36,6 +37,7 @@
             <td>{% if user.is_staff %}<i class="fa fa-check"></i>{% endif %}</td>
             <td>{% if user.is_superuser %}<i class="fa fa-check"></i>{% endif %}</td>
             <td>{% if user.is_accounting_admin %}<i class="fa fa-check"></i>{% endif %}</td>
+            <td>{% if user.is_contractor %}<i class="fa fa-check"></i>{% endif %}</td>
             <td>{% if user.is_active %}<i class="fa fa-check"></i>{% endif %}</td>
             <td>{% if user.two_factor_enabled %}<i class="fa fa-check"></i>{% endif %}</td>
           </tr>

--- a/corehq/apps/hqadmin/templates/hqadmin/superuser_management.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/superuser_management.html
@@ -32,27 +32,27 @@
       <table class="table">
         <tr>
           <th>{% translate "Username" %}</th>
-          <th>{% translate "Developer" %}</th>
-          <th>{% translate "Superuser" %}</th>
-          <th>{% translate "Can assign Superuser" %}</th>
-          <th>{% translate "Two Factor Enabled" %}</th>
+          <th class="text-center">{% translate "Developer" %}</th>
+          <th class="text-center">{% translate "Superuser" %}</th>
+          <th class="text-center">{% translate "Can assign Superuser" %}</th>
+          <th class="text-center">{% translate "Two Factor Enabled" %}</th>
           <th>{% translate "Feature Flag Edit Permissions" %}</th>
         </tr>
         {% for user in users %}
           <tr>
             <td>{{ user.username }}</td>
-            <td>
+            <td class="text-center">
               {% if user.is_staff %}<i class="fa fa-check"></i>{% endif %}
             </td>
-            <td>
+            <td class="text-center">
               {% if user.is_superuser %}<i class="fa fa-check"></i>{% endif %}
             </td>
-            <td>
+            <td class="text-center">
               {% if user.can_assign_superuser %}<i
                 class="fa fa-check"
               ></i>{% endif %}
             </td>
-            <td>
+            <td class="text-center">
               {% if user.two_factor_enabled %}<i
                 class="fa fa-check"
               ></i>{% endif %}


### PR DESCRIPTION
## Product Description
Adds "Is Contractor" column to the _Get users to offboard_ table and centers the ✓ columns (here and on the _Grant or revoke superuser access_ page)
<img width="1233" height="178" alt="image" src="https://github.com/user-attachments/assets/40646bfc-e562-4378-a2a4-f1bdefbbdaa7" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17974
This is the shorter-term fix for point two on that ticket, making elevated access auditable by showing these users in the list. Longer-term we may want to change or remove this feature flag all together, which would be slightly more involved so as not to disrupt existing uses.

## Safety Assurance

### Safety story
Tested locally and on staging to see it looks and works fine. Fairly small change plus some styling that only affects admin pages.

### Automated test coverage
Unlikely.

### QA Plan
Nope.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
