### PR TITLE
Skip fetching ancestors when no locations

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -300,12 +300,15 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         :param kwargs: extra parameters
         :return: dict
         """
+        grouped_location = {}
+        if not location_ids:
+            return grouped_location
+
         where = Q(domain=self.domain, location_id__in=location_ids)
         location_ancestors = SQLLocation.objects.get_ancestors(where)
         location_by_id = {location.location_id: location for location in location_ancestors}
         location_by_pk = {location.id: location for location in location_ancestors}
 
-        grouped_location = {}
         for location_id in location_ids:
 
             location_parents = []


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user facing change

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Just something I noticed when working on https://dimagi.atlassian.net/browse/SAAS-17956.
This change skips the query itself that fails when there are no locations to get ancestors for.
Error stack trace [here](https://dimagi.atlassian.net/browse/SAAS-17956?focusedCommentId=394357)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LOCATION_COLUMNS_APP_STATUS_REPORT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
