### PR TITLE
An alternate solution for adding location columns to User Last Activity Report

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -334,7 +334,9 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
 
         if self.include_location_data():
             location_ids = {user['location_id'] for user in users if user['location_id']}
-            grouped_ancestor_locs = self.get_bulk_ancestors(location_ids)
+            grouped_ancestor_locs = {}
+            if location_ids:
+                grouped_ancestor_locs = self.get_bulk_ancestors(location_ids)
             self.required_loc_columns = self.get_location_columns(grouped_ancestor_locs)
 
         loc_names_dict = self._locations_names_dict(users)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Current behavior 
**UI**
<img width="1586" height="564" alt="image" src="https://github.com/user-attachments/assets/33d8e8b4-f862-46bf-a466-f1778dbce3d4" />


**Excel**
Without feature flag
<img width="1282" height="143" alt="image" src="https://github.com/user-attachments/assets/20a78a4f-9909-4cce-a632-eff7984f18a6" />

With feature flag
<img width="1282" height="143" alt="image" src="https://github.com/user-attachments/assets/0d3cf1be-77f4-4e9a-8b96-bd81368f82eb" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
