### PR TITLE
Superusers are active

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1076,6 +1076,11 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         # user.is_active concerns authentication - can a user log in?
         # domain_membership.is_active controls whether a user can access a domain
         # CommCareUsers are only in a single domain, so there's no distinction
+        if not domain_restricts_superusers(domain) and (
+            self.is_active and self.is_superuser
+        ):
+            return True
+
         domain_membership = self.get_domain_membership(domain)
         if domain_membership and self.is_active:
             return domain_membership.is_active


### PR DESCRIPTION
## Product Description
Fix reports for superusers who aren't members of the domain

## Technical Summary
The code change probably spells it out best.  In essence, superusers aren't members of the domain, so the domain membership is_active check fails.  This change carves out an exemption for superusers.

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
