### PR TITLE
Only index view if the design doc was pushed

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/couch/sync_docs.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/sync_docs.py
@@ -26,13 +26,14 @@ def sync_design_docs(db, design_dir, design_name, temp=None):
     """
     design_name_ = '%s-%s' % (design_name, temp) if temp else design_name
     docid = "_design/%s" % design_name_
-    push(design_dir, db, force=True, docid=docid)
-    log.info("synced '%s' in couchdb", design_name)
+    pushed = push(design_dir, db, force=True, docid=docid)
+    if pushed:
+        log.info("synced '%s' in couchdb", design_name)
 
-    if temp:
-        # Check if the design directory has a views subdirectory
-        has_views = os.path.exists(os.path.join(design_dir, 'views'))
-        index_design_docs(db, docid, design_name_, expect_views=has_views)
+        if temp:
+            # Check if the design directory has a views subdirectory
+            has_views = os.path.exists(os.path.join(design_dir, 'views'))
+            index_design_docs(db, docid, design_name_, expect_views=has_views)
 
 
 def verify_design_doc(db, design_doc_id, max_retries=5, retry_delay_s=1, expect_views=False):


### PR DESCRIPTION
## Product Description

when syncing docs `_design/tests` is not present in the staging environment. So it does not get pushed and the subsequent check fails.

## Technical Summary

https://dimagi.sentry.io/issues/6794907539/?environment=staging&project=136860&query=is%3Aunresolved&referrer=issue-stream

## Feature Flag

None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
