### PR TITLE
Upgrade to pytest 8.4

### DIFF
--- a/corehq/tests/pytest_plugins/util.py
+++ b/corehq/tests/pytest_plugins/util.py
@@ -11,7 +11,7 @@ def override_fixture(old_fixture):
         @wraps(new_fixture)
         def fixture(*a, **k):
             yield from new_fixture(*a, **k)
-        new_fixture.super = old_fixture.__pytest_wrapped__.obj
-        old_fixture.__pytest_wrapped__.obj = fixture
+        new_fixture.super = old_fixture._fixture_function
+        old_fixture._fixture_function = fixture
         return new_fixture
     return apply

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,16 +179,13 @@ test = [
     'flaky>=3.8', # required for pytest 8.2 (and possibly earlier versions)
     'freezegun',
     'radon>=5.0', # v5 no longer depends on flake8-polyfill
-    # pytest is pinned to a git commit until 8.4 is released.
-    # `minversion = 8.4` should also be set in [tool.pytest.ini_options] below at that time.
-    'pytest @ git+https://github.com/pytest-dev/pytest.git@85760bff2776989b365167c7aeb35c86308ab76b',
     'pytest-django',
     'pytest-unmagic',
     'coverage',
 ]
 
 [tool.pytest.ini_options]
-minversion = '8.1'
+minversion = '8.4'
 
 addopts = [
     '--strict-markers',

--- a/uv.lock
+++ b/uv.lock
@@ -2576,14 +2576,14 @@ wheels = [
 
 [[package]]
 name = "pytest-unmagic"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/b9c56b38fad9f2b6149bc4f6032f2899f04403f234abe5188b77b18c80e0/pytest_unmagic-1.0.0.tar.gz", hash = "sha256:52e5a6d2394a4feb84654e76f7ac0992ef925f80113de5297b9d1c3f84825fba", size = 10158, upload-time = "2024-10-22T19:10:25.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/53/7aef49cbf746057d6021d78085c6a7f03aced1c332e725ae1156057edcec/pytest_unmagic-1.0.1.tar.gz", hash = "sha256:5f73e96b31a13041bcd46c3e990f4fb4cedb5b555660d0cb78d8d5d9bc99064a", size = 10439, upload-time = "2025-07-14T13:05:36.183Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/15/d2ded304f9b62780045f823b8c0b99a9a1612dcfaaa5db4ec13ed566d0d2/pytest_unmagic-1.0.0-py3-none-any.whl", hash = "sha256:4da6eb3c5657ba4772a2c7992fa73e1eb1ad7e2f15defcadde39915be6c02a6f", size = 10754, upload-time = "2024-10-22T19:10:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9b/e2c66454df73d1ecbb18089f026666743ef52480e295eb6f9c77998b1a63/pytest_unmagic-1.0.1-py3-none-any.whl", hash = "sha256:54a02d746d20943240c9b84e212a9a7e19bc2707cb176f9b1d66677b28260a13", size = 10909, upload-time = "2025-07-14T13:05:35.177Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -512,7 +512,6 @@ dev = [
     { name = "ipython" },
     { name = "isort" },
     { name = "psutil" },
-    { name = "pytest" },
     { name = "pytest-django" },
     { name = "pytest-unmagic" },
     { name = "radon" },
@@ -547,7 +546,6 @@ test = [
     { name = "faker" },
     { name = "flaky" },
     { name = "freezegun" },
-    { name = "pytest" },
     { name = "pytest-django" },
     { name = "pytest-unmagic" },
     { name = "radon" },
@@ -688,7 +686,6 @@ dev = [
     { name = "ipython" },
     { name = "isort" },
     { name = "psutil", specifier = ">5.1.3" },
-    { name = "pytest", git = "https://github.com/pytest-dev/pytest.git?rev=85760bff2776989b365167c7aeb35c86308ab76b" },
     { name = "pytest-django" },
     { name = "pytest-unmagic" },
     { name = "radon", specifier = ">=5.0" },
@@ -723,7 +720,6 @@ test = [
     { name = "faker" },
     { name = "flaky", specifier = ">=3.8" },
     { name = "freezegun" },
-    { name = "pytest", git = "https://github.com/pytest-dev/pytest.git?rev=85760bff2776989b365167c7aeb35c86308ab76b" },
     { name = "pytest-django" },
     { name = "pytest-unmagic" },
     { name = "radon", specifier = ">=5.0" },
@@ -2553,13 +2549,18 @@ sdist = { url = "https://files.pythonhosted.org/packages/5c/7f/d328ea8f16b5e569a
 
 [[package]]
 name = "pytest"
-version = "8.4.0.dev34+g85760bff2"
-source = { git = "https://github.com/pytest-dev/pytest.git?rev=85760bff2776989b365167c7aeb35c86308ab76b#85760bff2776989b365167c7aeb35c86308ab76b" }
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This switches us off of an unreleased pytest version, which was required to [allow loading pytest hooks within the source code under test](https://github.com/pytest-dev/pytest/commit/85760bff2776989b365167c7aeb35c86308ab76b).

https://dimagi.atlassian.net/browse/SAAS-18331

## Safety Assurance

### Safety story

Affects tests only.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations