### PR TITLE
Load JSON String in Connect Repeater

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -713,6 +713,8 @@ class ConnectFormRepeaterPayloadGenerator(FormRepeaterJsonPayloadGenerator):
 
     def get_payload(self, repeat_record, form):
         form_json = super().get_payload(repeat_record, form)
+        # res.serialize from super() returns a JSON string
+        form_json = json.loads(form_json)
         fields = ("domain", "id", "app_id", "build_id", "received_on", "metadata")
         constructed_dict = {}
         for field in fields:

--- a/corehq/motech/repeaters/tests/test_connect_repeater.py
+++ b/corehq/motech/repeaters/tests/test_connect_repeater.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 from unittest.mock import Mock, patch
@@ -62,7 +63,7 @@ def test_connect_repeater(mocked_super):
     repeater = ConnectFormRepeater(domain="test")
     generator = ConnectFormRepeaterPayloadGenerator(repeater)
     form = Mock()
-    mocked_super.return_value = MOCK_FORM
+    mocked_super.return_value = json.dumps(MOCK_FORM)
     payload = generator.get_payload(None, form)
     assert payload["metadata"] == FORM_META
     assert payload["form.connect_path.deliver"] == DELIVER_JSON["deliver"]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/CI-219).
Sentry error [here](https://dimagi.sentry.io/issues/6809459732/?environment=india&project=136860&query=domain%3Akmc-experiments&referrer=issue-stream).

A [related PR](https://github.com/dimagi/commcare-hq/pull/36842) introduced a change to the `ConnectFormRepeaterPayloadGenerator` repeater to call the super class so that filtering is applied to a standard form repeater payload. The issue however, is that the Connect repeater expects the `FormRepeaterJsonPayloadGenerator` super class to return a dict, but it actually returns a JSON string in its `get_payload()` function. Specfically, through the use of the `XFormInstanceResource.serialize()` function. This ends up causing an `AttributeError` exception to be raised.

This PR resolves the above exception by first loading the JSON string before trying to access its keys.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`COMMCARE_CONNECT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Unit tests.

This change will only affect custom repeaters which are currently only being used by a single project.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There are tests for the payload generation.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
