### PR TITLE
Remove "pdfs" for Image Upload Questions

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1054,7 +1054,7 @@ define("cloudcare/js/form_entry/entries", [
     function ImageEntry(question, options) {
         var self = this;
         FileEntry.call(this, question, options);
-        self.accept = "image/*,.pdf";
+        self.accept = "image/*";
     }
     ImageEntry.prototype = Object.create(FileEntry.prototype);
     ImageEntry.prototype.constructor = FileEntry;


### PR DESCRIPTION
# Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
For an Image Upload Question, the user is no longer able to select a "pdf" to upload.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-5852](https://dimagi.atlassian.net/browse/USH-5852)
All projects have been transitioned to using document upload question for pdf uploads.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-5852]: https://dimagi.atlassian.net/browse/USH-5852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ