### PR TITLE
Replace freezegun with time-machine

### DIFF
--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -4,7 +4,7 @@ from django.test import SimpleTestCase, TestCase
 
 import pytz
 from eulxml.xpath import parse as parse_xpath
-from freezegun import freeze_time
+from time_machine import travel
 
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from couchforms.geopoint import GeoPoint
@@ -66,14 +66,14 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         mock_get_timezone.assert_called_once()
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
-    @freeze_time('2023-05-16T13:01:51Z')
+    @travel('2023-05-16T13:01:51Z', tick=False)
     def test_system_datetime_property_comparison(self):
         parsed = parse_xpath("last_modified < datetime-add(now(), 'weeks', -2)")
         expected_filter = filters.date_range('modified_on', lt='2023-05-02T13:01:51+00:00')
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
-    @freeze_time('2023-05-16T13:01:51Z')
+    @travel('2023-05-16T13:01:51Z', tick=False)
     def test_system_datetime_property_match(self):
         parsed = parse_xpath("last_modified = now()")
         expected_filter = filters.term('modified_on', '2023-05-16T13:01:51+00:00')
@@ -104,14 +104,14 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         query = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, query, is_raw_query=True)
 
-    @freeze_time('2021-08-02')
+    @travel('2021-08-02', tick=False)
     def test_date_comparison_today(self):
         parsed = parse_xpath("dob >= today()")
         expected_filter = case_property_date_range('dob', gte='2021-08-02')
         query = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(expected_filter, query, is_raw_query=True)
 
-    @freeze_time('2023-05-16T13:01:51Z')
+    @travel('2023-05-16T13:01:51Z', tick=False)
     def test_date_property_comparison_now(self):
         parsed = parse_xpath("dob < datetime-add(now(), 'weeks', -2)")
         expected_filter = case_property_date_range('dob', lt='2023-05-02T13:01:51+00:00')
@@ -186,14 +186,14 @@ class TestFilterDsl(ElasticTestMixin, SimpleTestCase):
         with self.assertRaises(CaseFilterError):
             build_filter_from_ast(parse_xpath("parent/name > other_property"), SearchFilterContext("domain"))
 
-    @freeze_time('2021-08-02')
+    @travel('2021-08-02', tick=False)
     def test_filter_today(self):
         parsed = parse_xpath("age > today()")
         expected_filter = case_property_date_range('age', gt='2021-08-02')
         built_filter = build_filter_from_ast(parsed, SearchFilterContext("domain"))
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
-    @freeze_time('2021-08-02')
+    @travel('2021-08-02', tick=False)
     def test_filter_date_today(self):
         parsed = parse_xpath("age > date(today())")
         expected_filter = case_property_date_range('age', gt='2021-08-02')

--- a/corehq/apps/case_search/tests/test_value_functions.py
+++ b/corehq/apps/case_search/tests/test_value_functions.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 import pytest
 from eulxml.xpath import parse as parse_xpath
-from freezegun import freeze_time
+from time_machine import travel
 from testil import assert_raises, eq
 
 from corehq.apps.case_search.exceptions import XPathFunctionException
@@ -20,7 +20,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 
 
-@freeze_time('2021-08-02T22:03:16Z')
+@travel('2021-08-02T22:03:16Z', tick=False)
 class TestDateFunctions(TestCase):
     @classmethod
     def setUpClass(cls):
@@ -70,7 +70,7 @@ class TestDateFunctions(TestCase):
         eq(result, '2021-08-02T22:03:16+00:00')
 
 
-@freeze_time('2021-08-02T22:03:16Z')
+@travel('2021-08-02T22:03:16Z', tick=False)
 @pytest.mark.parametrize("expression, expected", [
     ("datetime('2021-08-02')", '2021-08-02T00:00:00+00:00'),
     ("datetime('2021-08-02T11:22:16')", '2021-08-02T11:22:16+00:00'),
@@ -84,7 +84,7 @@ def test_datetime(expression, expected):
     eq(result, expected)
 
 
-@freeze_time('2021-08-02T22:03:16Z')
+@travel('2021-08-02T22:03:16Z', tick=False)
 @pytest.mark.parametrize("expression, expected", [
     ("date-add('2020-02-29', 'years', 1)", "2021-02-28"),
     ("date-add('2020-02-29', 'years', 1.0)", "2021-02-28"),
@@ -147,7 +147,7 @@ def test_date_add_errors(expression):
         fn(node, SearchFilterContext("domain"))
 
 
-@freeze_time('2021-08-02T22:03:16Z')
+@travel('2021-08-02T22:03:16Z', tick=False)
 @pytest.mark.parametrize("expression, expected", [
     ("double('1.3')", 1.3),
     ("double('13')", 13.0),

--- a/corehq/apps/data_analytics/tests/test_tasks.py
+++ b/corehq/apps/data_analytics/tests/test_tasks.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from django.db.models import BooleanField, DateTimeField, IntegerField
 from django.test import TestCase
 
-from freezegun import freeze_time
+from time_machine import travel
 
 from dimagi.utils.parsing import json_format_datetime
 
@@ -25,7 +25,7 @@ class TestGetDomainsToUpdate(TestCase):
         domains = get_domains_to_update()
         self.assertEqual(domains, {domain.name})
 
-    @freeze_time('2024-01-10')
+    @travel('2024-01-10', tick=False)
     def test_domain_metrics_updated_over_one_week_ago_is_included(self):
         domain = self.index_domain('cp-over-one-week')
         self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 2, 23, 59))
@@ -33,7 +33,7 @@ class TestGetDomainsToUpdate(TestCase):
         domains = get_domains_to_update()
         self.assertEqual(domains, {domain.name})
 
-    @freeze_time('2024-01-10')
+    @travel('2024-01-10', tick=False)
     def test_domain_metrics_updated_exactly_one_week_ago_is_excluded(self):
         domain = self.index_domain('cp-one-week')
         self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 3))
@@ -41,7 +41,7 @@ class TestGetDomainsToUpdate(TestCase):
         domains = get_domains_to_update()
         self.assertEqual(domains, set())
 
-    @freeze_time('2024-01-10')
+    @travel('2024-01-10', tick=False)
     def test_domain_metrics_updated_less_than_one_week_ago_is_excluded(self):
         domain = self.index_domain('cp-less-than-one-week')
         self.create_domain_metrics(domain.name, last_modified=datetime(2024, 1, 4))
@@ -49,7 +49,7 @@ class TestGetDomainsToUpdate(TestCase):
         domains = get_domains_to_update()
         self.assertEqual(domains, set())
 
-    @freeze_time('2024-01-10')
+    @travel('2024-01-10', tick=False)
     def test_form_submission_in_the_last_day_is_included(self):
         domain = self.index_domain('form-from-today')
         self.index_form(domain.name, received_on=datetime(2024, 1, 9, 0, 0))
@@ -58,7 +58,7 @@ class TestGetDomainsToUpdate(TestCase):
         domains = get_domains_to_update()
         self.assertEqual(domains, {domain.name})
 
-    @freeze_time('2024-01-10')
+    @travel('2024-01-10', tick=False)
     def test_form_submission_over_one_day_ago_is_excluded(self):
         domain = self.index_domain('form-from-yesterday')
         self.index_form(domain.name, received_on=datetime(2024, 1, 8, 23, 59))
@@ -67,7 +67,7 @@ class TestGetDomainsToUpdate(TestCase):
         domains = get_domains_to_update()
         self.assertEqual(domains, set())
 
-    @freeze_time('2024-01-10')
+    @travel('2024-01-10', tick=False)
     def test_inactive_domain_is_excluded(self):
         domain = self.index_domain('inactive-domain', active=False)
         self.create_domain_metrics(domain.name)

--- a/corehq/apps/data_interfaces/tests/test_case_deduplication.py
+++ b/corehq/apps/data_interfaces/tests/test_case_deduplication.py
@@ -3,7 +3,7 @@ from itertools import chain
 from unittest.mock import patch, PropertyMock
 
 from django.test import TestCase
-from freezegun import freeze_time
+from time_machine import travel
 
 from faker import Faker
 
@@ -687,7 +687,7 @@ class CaseDeduplicationActionTest(TestCase):
         new_case.server_modified_on = current_time - timedelta(hours=1)
         mock_case_exists.return_value = False
 
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             self.rule.run_rule(new_case, datetime.now())
 
         created_duplicates = CaseDuplicateNew.objects.filter(case_id=new_case.case_id)

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -303,7 +303,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     name = StringProperty()
     is_active = BooleanProperty()
     # date_created is expected to be a naive datetime specified in UTC
-    # Defaulting to a lambda rather than utcnow directly to make freezegun function. Not ideal
+    # Defaulting to a lambda rather than utcnow directly to make time-machine function. Not ideal
     date_created = DateTimeProperty(default=lambda: datetime.utcnow())
     default_timezone = StringProperty(default=getattr(settings, "TIME_ZONE", "UTC"))
     default_geocoder_location = DictProperty()

--- a/corehq/apps/domain/tests/test_auth.py
+++ b/corehq/apps/domain/tests/test_auth.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.http.request import HttpRequest
 from django.test import SimpleTestCase, TestCase
 
-from freezegun import freeze_time
+from time_machine import travel
 
 from corehq.apps.domain.auth import (
     ApiKeyFallbackBackend,
@@ -145,7 +145,7 @@ class ApiKeyFallbackTests(TestCase):
 
         request = self._create_request()
 
-        with freeze_time(datetime(year=2020, month=3, day=9)):
+        with travel(datetime(year=2020, month=3, day=9), tick=False):
             self.assertEqual(self.backend.authenticate(request, 'test@dimagi.com', '1234'), user)
 
     def test_cannot_use_expired_key(self):
@@ -154,7 +154,7 @@ class ApiKeyFallbackTests(TestCase):
 
         request = self._create_request()
 
-        with freeze_time(datetime(year=2020, month=3, day=11)):
+        with travel(datetime(year=2020, month=3, day=11), tick=False):
             self.assertIsNone(self.backend.authenticate(request, 'test@dimagi.com', '1234'))
 
     def setUp(self):
@@ -289,7 +289,7 @@ class HQApiKeyAuthenticationTests(TestCase):
 
         auth = HQApiKeyAuthentication()
 
-        with freeze_time(datetime(year=2020, month=3, day=9)):
+        with travel(datetime(year=2020, month=3, day=9), tick=False):
             self.assertIs(auth.is_authenticated(request), True)
 
     def test_user_cannot_authenticate_with_expired_key(self):
@@ -299,7 +299,7 @@ class HQApiKeyAuthenticationTests(TestCase):
 
         auth = HQApiKeyAuthentication()
 
-        with freeze_time(datetime(year=2020, month=3, day=11)):
+        with travel(datetime(year=2020, month=3, day=11), tick=False):
             response = auth.is_authenticated(request)
             self.assertEqual(response.status_code, 401)
 

--- a/corehq/apps/domain/tests/test_models.py
+++ b/corehq/apps/domain/tests/test_models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from freezegun import freeze_time
+from time_machine import travel
 from django.test import SimpleTestCase, override_settings
 from corehq.apps.domain.models import Domain
 
@@ -14,7 +14,7 @@ class DomainTests(SimpleTestCase):
         domain = Domain()
         self.assertEqual(domain.get_odata_feed_limit(), 10)
 
-    @freeze_time('2023-06-05')
+    @travel('2023-06-05', tick=False)
     def test_date_created_defaults_to_utcnow_when_not_specified(self):
         domain = Domain()
         self.assertEqual(domain.date_created, datetime(year=2023, month=6, day=5))

--- a/corehq/apps/enterprise/tests/test_enterprise.py
+++ b/corehq/apps/enterprise/tests/test_enterprise.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase, override_settings
 from datetime import datetime
-from freezegun import freeze_time
+from time_machine import travel
 from unittest.mock import patch, MagicMock
 
 from corehq.apps.enterprise.exceptions import TooMuchRequestedDataError
@@ -127,7 +127,7 @@ class EnterpriseODataReportTests(SimpleTestCase):
         return report
 
 
-@freeze_time(datetime(month=10, day=1, year=2024))
+@travel(datetime(month=10, day=1, year=2024), tick=False)
 class EnterpriseFormReportTests(SimpleTestCase):
     def setUp(self):
         super().setUp()

--- a/corehq/apps/hqwebapp/tests/test_login_handlers.py
+++ b/corehq/apps/hqwebapp/tests/test_login_handlers.py
@@ -1,5 +1,5 @@
 from django.test import RequestFactory, TestCase
-from freezegun import freeze_time
+from time_machine import travel
 from django.contrib.auth.models import User
 from corehq.apps.hqwebapp.models import UserAccessLog
 
@@ -27,7 +27,7 @@ class TestLoginAccessHandler(TestCase):
 
 
 class TestHandleLogin(TestCase):
-    @freeze_time('2020-01-02 03:20:15')
+    @travel('2020-01-02 03:20:15', tick=False)
     def test_login_stores_correct_fields_in_database(self):
         factory = RequestFactory()
         user = User(username='test_user')
@@ -50,7 +50,7 @@ class TestHandleLogout(TestCase):
         factory = RequestFactory()
         self.request = factory.post('/logout')
 
-    @freeze_time('2020-01-02 03:20:15')
+    @travel('2020-01-02 03:20:15', tick=False)
     def test_logout_stores_correct_fields_in_database(self):
         user = User(username='test_user')
         self.request.META['HTTP_USER_AGENT'] = 'Mozilla'
@@ -73,7 +73,7 @@ class TestHandleLogout(TestCase):
 
 
 class TestHandleFailedLogin(TestCase):
-    @freeze_time('2020-01-02 03:20:15')
+    @travel('2020-01-02 03:20:15', tick=False)
     def test_logout_stores_correct_fields_in_database(self):
         factory = RequestFactory()
         request = factory.post('/login')

--- a/corehq/apps/locations/tests/test_api_resources.py
+++ b/corehq/apps/locations/tests/test_api_resources.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from freezegun import freeze_time
+from time_machine import travel
 
 from corehq.apps.api.tests.utils import APIResourceTest
 from corehq.apps.locations.models import LocationType, SQLLocation
@@ -455,7 +455,7 @@ class TestV0_6LocationsList(APIResourceTest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        with freeze_time(datetime(2025, 1, 1)):
+        with travel(datetime(2025, 1, 1), tick=False):
             cls.location_types, cls.locations = setup_locations_and_types(
                 cls.domain.name,
                 cls.location_type_names,
@@ -465,7 +465,7 @@ class TestV0_6LocationsList(APIResourceTest):
             cls.locations['Middlesex'].location_id = 'middlesex_uuid'
             cls.locations['Middlesex'].save()
 
-        with freeze_time(datetime(2025, 4, 1)):
+        with travel(datetime(2025, 4, 1), tick=False):
             cls.locations['Boston'].save()
             cls.locations['Cambridge'].save()
 

--- a/corehq/apps/reports/tests/test_daterange.py
+++ b/corehq/apps/reports/tests/test_daterange.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.test import SimpleTestCase
-from freezegun import freeze_time
+from time_machine import travel
 
 from corehq.apps.reports.daterange import (
     get_all_daterange_choices,
@@ -23,7 +23,7 @@ class DateRangeTest(SimpleTestCase):
                 get_daterange_start_end_dates(daterange.slug)
 
 
-@freeze_time('1829-08-03')
+@travel('1829-08-03', tick=False)
 class KnownRangesTests(SimpleTestCase):
 
     def setUp(self):
@@ -83,7 +83,7 @@ class KnownRangesTests(SimpleTestCase):
     def test_currentindianfinancialyear(self):
         def check_dates(on_date, expected_start_date, expected_end_date):
             date_class = datetime.date
-            with freeze_time(on_date):
+            with travel(on_date, tick=False):
                 start_date, end_date = get_daterange_start_end_dates('currentindianfinancialyear')
 
                 # to avoid false positives when compared with mock

--- a/corehq/apps/reports/tests/test_util.py
+++ b/corehq/apps/reports/tests/test_util.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 from django.test import SimpleTestCase, TestCase
 
 from testil import eq
-from freezegun import freeze_time
+from time_machine import travel
 
 from corehq.apps.reports.util import get_user_id_from_form, datespan_from_beginning
 from corehq.form_processor.exceptions import XFormNotFound
@@ -28,7 +28,7 @@ DOMAIN = 'test_domain'
 USER_ID = "5bc1315c-da6f-466d-a7c4-4580bc84a7b9"
 
 
-@freeze_time("2023-02-10")
+@travel("2023-02-10", tick=False)
 class TestDateSpanFromBeginning(SimpleTestCase):
     def test_start_and_end_date_dont_change_in_utc(self):
         start_time = datetime(year=2020, month=4, day=5)

--- a/corehq/apps/saved_reports/tests/test_tasks.py
+++ b/corehq/apps/saved_reports/tests/test_tasks.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 from django.test import SimpleTestCase, TestCase
-from freezegun import freeze_time
+from time_machine import travel
 import datetime
 
 from ..exceptions import ReportNotFound
@@ -12,7 +12,7 @@ from .. import tasks
 CURRENT_DATE = datetime.date(2020, 1, 2)
 
 
-@freeze_time(CURRENT_DATE)
+@travel(CURRENT_DATE, tick=False)
 class PurgeOldScheduledReportLogsTests(TestCase):
     def test_purges_entries_older_than_three_months(self):
         self._create_log_at_date(CURRENT_DATE - datetime.timedelta(weeks=12, days=1))

--- a/corehq/apps/settings/tests/test_forms.py
+++ b/corehq/apps/settings/tests/test_forms.py
@@ -3,7 +3,7 @@ from zoneinfo import ZoneInfo
 
 from django.test import SimpleTestCase, override_settings
 
-from freezegun import freeze_time
+from time_machine import travel
 from two_factor.forms import totp
 
 from ..forms import HQApiKeyForm, HQTOTPDeviceForm, HQTwoFactorMethodForm
@@ -39,7 +39,7 @@ class TestHQTwoFactorMethodForm(SimpleTestCase):
         return {choice[0] for choice in choices}
 
 
-@freeze_time(datetime(2025, 3, 6))
+@travel(datetime(2025, 3, 6), tick=False)
 class TestHQTOTPDeviceForm(SimpleTestCase):
     @classmethod
     def setUpClass(cls):
@@ -82,7 +82,7 @@ class HQApiKeyTests(SimpleTestCase):
 
     def test_when_expiration_is_specified_expiration_is_autopopulated_to_max_expiration(self):
         current_time = datetime(year=2023, month=1, day=1)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             form = HQApiKeyForm(max_allowed_expiration_days=30)
             self.assertEqual(form.fields['expiration_date'].initial, '2023-01-31')
 
@@ -95,7 +95,7 @@ class HQApiKeyTests(SimpleTestCase):
 
     def test_when_expiration_is_specified_help_text_includes_max_expiration(self):
         current_time = datetime(year=2023, month=1, day=1)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             form = HQApiKeyForm(max_allowed_expiration_days=30)
             self.assertEqual(
                 form.fields['expiration_date'].help_text,
@@ -105,7 +105,7 @@ class HQApiKeyTests(SimpleTestCase):
 
     def test_expiration_supports_year_values(self):
         current_time = datetime(year=2023, month=1, day=1)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             form = HQApiKeyForm(max_allowed_expiration_days=365)
             self.assertEqual(
                 form.fields['expiration_date'].help_text,
@@ -115,7 +115,7 @@ class HQApiKeyTests(SimpleTestCase):
 
     def test_expiration_supports_unofficial_expiration_windows(self):
         current_time = datetime(year=2023, month=1, day=1)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             form = HQApiKeyForm(max_allowed_expiration_days=22)
             self.assertEqual(
                 form.fields['expiration_date'].help_text,
@@ -129,20 +129,20 @@ class HQApiKeyTests(SimpleTestCase):
 
     def test_valid_expiration_date_with_maximum_expiration_window(self):
         current_time = datetime(year=2023, month=1, day=1)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             form = HQApiKeyForm(self._form_data(expiration_date='2023-01-31'), max_allowed_expiration_days=30)
             self.assertTrue(form.is_valid())
 
     def test_expired_key_is_not_valid(self):
         current_time = datetime(year=2023, month=1, day=2)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             form = HQApiKeyForm(self._form_data(expiration_date='2023-01-01'))
             self.assertFalse(form.is_valid())
             self.assertEqual(form.errors['expiration_date'], ['Expiration Date must be in the future'])
 
     def test_expiration_dates_greater_than_maximum_are_invalid(self):
         current_time = datetime(year=2023, month=1, day=1)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             form = HQApiKeyForm(self._form_data(expiration_date='2023-02-01'), max_allowed_expiration_days=30)
             self.assertFalse(form.is_valid())
             self.assertEqual(
@@ -153,7 +153,7 @@ class HQApiKeyTests(SimpleTestCase):
     def test_expiration_date_is_localized(self):
         tz = ZoneInfo('US/Eastern')
         current_time = datetime(year=2023, month=1, day=2, hour=23, tzinfo=tz)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             form = HQApiKeyForm(max_allowed_expiration_days=30, timezone=tz)
             # 11 PM Eastern time will wrap over to the next day in UTC
             # So if we aren't localizing the date, this would be '2023-02-02'

--- a/corehq/apps/sso/tests/test_tasks.py
+++ b/corehq/apps/sso/tests/test_tasks.py
@@ -2,7 +2,7 @@ import datetime
 from unittest.mock import ANY, patch
 
 from django.test import TestCase
-from freezegun import freeze_time
+from time_machine import travel
 
 from corehq.apps.accounting.models import SoftwarePlanEdition
 from corehq.apps.accounting.tests import generator as accounting_generator
@@ -119,7 +119,7 @@ class TestSSOTasks(TestCase):
         self.idp.save()
         # test alerts
         for num_days in remind_days:
-            with freeze_time(expires - datetime.timedelta(days=num_days)):
+            with travel(expires - datetime.timedelta(days=num_days), tick=False):
                 with patch("corehq.apps.sso.tasks.send_html_email_async.delay") as mock_send:
                     idp_cert_expires_reminder()
                     if assert_reminder:
@@ -157,7 +157,7 @@ class TestSSOTasks(TestCase):
         self.idp.save()
         # test alerts
         for num_days in remind_days:
-            with freeze_time(expires - datetime.timedelta(days=num_days)):
+            with travel(expires - datetime.timedelta(days=num_days), tick=False):
                 with patch("corehq.apps.sso.tasks.send_html_email_async.delay") as mock_send:
                     send_api_token_expiration_reminder()
                     if assert_reminder:
@@ -251,7 +251,7 @@ class EnforceKeyExpirationTaskTests(TestCase):
         key = self._create_key_for_user(user, expiration_date=None)
 
         current_time = datetime.datetime(year=2024, month=8, day=1)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             num_updates = enforce_key_expiration_for_idp(idp)
 
         key.refresh_from_db()
@@ -264,7 +264,7 @@ class EnforceKeyExpirationTaskTests(TestCase):
         self._create_key_for_user(user, expiration_date=None)
 
         current_time = datetime.datetime(year=2024, month=8, day=1)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             num_updates = enforce_key_expiration_for_idp(idp)
 
         self.assertEqual(num_updates, 0)
@@ -275,7 +275,7 @@ class EnforceKeyExpirationTaskTests(TestCase):
         self._create_key_for_user(user, expiration_date=None)
 
         current_time = datetime.datetime(year=2024, month=8, day=1)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             num_updates = enforce_key_expiration_for_idp(idp)
 
         self.assertEqual(num_updates, 0)
@@ -286,7 +286,7 @@ class EnforceKeyExpirationTaskTests(TestCase):
         key = self._create_key_for_user(user, expiration_date=None)
 
         current_time = datetime.datetime(year=2024, month=8, day=1)
-        with freeze_time(current_time):
+        with travel(current_time, tick=False):
             update_sso_user_api_key_expiration_dates(idp.id)
 
         key.refresh_from_db()

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase, TestCase
 
-from freezegun import freeze_time
+from time_machine import travel
 from jsonobject.exceptions import BadValueError
 
 from corehq.apps.domain.models import AllowedUCRExpressionSettings
@@ -367,7 +367,7 @@ class DataSourceConfigurationTests(TestCase):
 
     def test_last_modified_date_updates_successfully(self):
         initial_date = datetime.datetime(2020, 1, 1)
-        with freeze_time(initial_date) as frozen_time:
+        with travel(initial_date, tick=False) as frozen_time:
             datasource = DataSourceConfiguration(
                 domain='mod-test', table_id='mod-test',
                 referenced_doc_type='XFormInstance')
@@ -375,7 +375,7 @@ class DataSourceConfigurationTests(TestCase):
             self.addCleanup(datasource.delete)
 
             previous_modified_date = datasource.last_modified
-            frozen_time.tick(delta=datetime.timedelta(hours=1))
+            frozen_time.shift(datetime.timedelta(hours=1))
             datasource.save()
 
         self.assertGreater(datasource.last_modified, previous_modified_date)

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -1,7 +1,7 @@
 from django.http import HttpRequest
 from django.test import TestCase
 
-from freezegun import freeze_time
+from time_machine import travel
 
 from corehq.apps.userreports.exceptions import BadSpecError, UserReportsError
 from corehq.apps.userreports.models import (
@@ -614,7 +614,7 @@ class TestReportAggregationSQL(ConfigurableReportAggregationTestMixin, TestCase)
         )
 
 
-@freeze_time("2020-12-30")
+@travel("2020-12-30", tick=False)
 class TestReportMultipleAggregationsSQL(ConfigurableReportAggregationTestMixin, TestCase):
     @classmethod
     def _create_data(cls):

--- a/corehq/apps/users/tests/test_device_rate_limiter.py
+++ b/corehq/apps/users/tests/test_device_rate_limiter.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from freezegun import freeze_time
+from time_machine import travel
 
 from corehq.apps.cloudcare.const import DEVICE_ID as CLOUDCARE_DEVICE_ID
 from corehq.apps.users.device_rate_limiter import DEVICE_LIMIT_PER_USER_KEY, REDIS_KEY_PREFIX, device_rate_limiter
@@ -7,7 +7,7 @@ from corehq.apps.users.models import CommCareUser
 from corehq.project_limits.models import SystemLimit
 
 
-@freeze_time("2024-12-10 12:05:43")
+@travel("2024-12-10 12:05:43", tick=False)
 class TestDeviceRateLimiter(TestCase):
 
     domain = 'device-rate-limit-test'
@@ -49,7 +49,7 @@ class TestDeviceRateLimiter(TestCase):
         self.assertFalse(device_rate_limiter.rate_limit_device(self.domain, new_user, 'existing-device-id'))
 
     def test_allowed_after_waiting_one_minute(self):
-        with freeze_time("2024-12-10 12:05:43") as frozen_time:
+        with travel("2024-12-10 12:05:43", tick=False) as frozen_time:
             device_rate_limiter.rate_limit_device(self.domain, self.user, 'existing-device-id')
             self.assertTrue(device_rate_limiter.rate_limit_device(self.domain, self.user, 'new-device-id'))
             frozen_time.move_to("2024-12-10 12:06:15")

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_prune.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_prune.py
@@ -3,7 +3,7 @@ import datetime
 from django.test import TestCase
 
 from casexml.apps.case.tests.util import delete_all_sync_logs
-from freezegun import freeze_time
+from time_machine import travel
 
 from casexml.apps.phone.models import (
     SimplifiedSyncLog,
@@ -15,7 +15,7 @@ from casexml.apps.phone.tasks import SYNCLOG_RETENTION_DAYS, prune_synclogs
 from corehq.util.test_utils import DocTestMixin
 
 
-@freeze_time('2021-08-02')
+@travel('2021-08-02', tick=False)
 class SyncLogPruneTest(TestCase, DocTestMixin):
     maxDiff = None
 

--- a/corehq/ex-submodules/couchforms/tests/test_analytics.py
+++ b/corehq/ex-submodules/couchforms/tests/test_analytics.py
@@ -3,7 +3,7 @@ import uuid
 
 from django.test import TestCase
 
-from freezegun import freeze_time
+from time_machine import travel
 
 from couchforms.analytics import (
     domain_has_submission_in_last_30_days,
@@ -219,7 +219,7 @@ class CouchformsESAnalyticsTest(TestCase):
         self.assertTrue(domain_has_submission_in_last_30_days(self.domain))
 
     def test_not_domain_has_submission_in_last_30_days(self):
-        with freeze_time(self.now + self._60_days):
+        with travel(self.now + self._60_days, tick=False):
             self.assertFalse(domain_has_submission_in_last_30_days(self.domain))
 
     def test_get_first_form_submission_received(self):

--- a/corehq/motech/generic_inbound/tests/test_api_hl7.py
+++ b/corehq/motech/generic_inbound/tests/test_api_hl7.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from freezegun import freeze_time
+from time_machine import travel
 
 from corehq import privileges
 from corehq.form_processor.models import CommCareCase
@@ -27,7 +27,7 @@ class TestGenericInboundAPIViewHL7(GenericInboundAPIViewBaseTest):
         FormProcessorTestUtils.delete_all_cases_forms_ledgers(cls.domain_name)
         super().tearDownClass()
 
-    @freeze_time('2023-05-02 13:01:51')
+    @travel('2023-05-02 13:01:51', tick=False)
     def test_post_hl7(self):
         response_content = self._test_generic_api({
             'facility': {
@@ -43,7 +43,7 @@ class TestGenericInboundAPIViewHL7(GenericInboundAPIViewBaseTest):
         self._check_logging(log, response_content)
         self._check_data(log, {"facility": "GOOD HEALTH HOSPITAL"})
 
-    @freeze_time('2023-05-02 13:01:51')
+    @travel('2023-05-02 13:01:51', tick=False)
     def test_post_not_supported_type(self):
         generic_api = self._make_api({}, backend=ApiBackendOptions.hl7)
         url = reverse('generic_inbound_api', args=[self.domain_name, generic_api.url_key])
@@ -56,7 +56,7 @@ class TestGenericInboundAPIViewHL7(GenericInboundAPIViewBaseTest):
                    "MSA|AE||Error parsing HL7: Invalid message"
         self.assertEqual(response.content.decode(), expected)
 
-    @freeze_time('2023-05-02 13:01:51')
+    @travel('2023-05-02 13:01:51', tick=False)
     def test_validation_errors(self):
         api = self._make_api(
             property_expressions={

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -11,7 +11,7 @@ from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
 from dateutil.parser import isoparse
-from freezegun import freeze_time
+from time_machine import travel
 from nose.tools import assert_in
 
 from corehq.motech.models import ConnectionSettings
@@ -963,7 +963,7 @@ class TestRepeatRecordMethods(TestCase):
             payload_id="abc123",
             registered_at=now - hour,
         )
-        with freeze_time(now):
+        with travel(now, tick=False):
             record.postpone_by(3 * hour)
         self.assertEqual(record.next_check, now + 3 * hour)
 
@@ -1050,7 +1050,7 @@ class TestDataSourceUpdateManager(TestCase):
 
     def test_get_oldest_date(self):
         ten_days_ago = datetime.today() - timedelta(days=10)
-        with freeze_time(ten_days_ago):
+        with travel(ten_days_ago, tick=False):
             DataSourceUpdate.objects.create(
                 domain='test-domain',
                 data_source_id=uuid4(),

--- a/corehq/motech/repeaters/tests/test_tasks.py
+++ b/corehq/motech/repeaters/tests/test_tasks.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 from django.test import SimpleTestCase, TestCase
 
 import pytest
-from freezegun import freeze_time
+from time_machine import travel
 
 from corehq.motech.models import ConnectionSettings, RequestLog
 from corehq.util.test_utils import flag_enabled
@@ -411,7 +411,7 @@ class TestUpdateRepeater(SimpleTestCase):
         mock_lock.release.assert_called_once()
 
 
-@freeze_time('2025-01-01')
+@travel('2025-01-01', tick=False)
 class TestGetWaitDurationSeconds(TestCase):
 
     @classmethod

--- a/corehq/tests/pytest_plugins/patches.py
+++ b/corehq/tests/pytest_plugins/patches.py
@@ -12,7 +12,6 @@ def pytest_sessionstart():
     patch_django_test_case()
     patch_assertItemsEqual()
     patch_testcase_databases()
-    extend_freezegun_ignore_list()
     patch_es_user_signals()
     patch_foreign_value_caches()
     patch_domain_deletion()
@@ -63,13 +62,3 @@ def patch_django_test_case():
 def patch_assertItemsEqual():
     import unittest
     unittest.TestCase.assertItemsEqual = unittest.TestCase.assertCountEqual
-
-
-GLOBAL_FREEZEGUN_IGNORE_LIST = ["kafka."]
-
-
-def extend_freezegun_ignore_list():
-    """Extend the freezegun ignore list"""
-    import freezegun
-
-    freezegun.configure(extend_ignore_list=GLOBAL_FREEZEGUN_IGNORE_LIST)

--- a/corehq/tests/pytest_plugins/timelimit.py
+++ b/corehq/tests/pytest_plugins/timelimit.py
@@ -5,6 +5,7 @@ import time
 import warnings
 
 import pytest
+from time_machine import escape_hatch
 from unmagic.scope import get_active
 
 
@@ -29,7 +30,6 @@ class MaxTestTimePlugin:
 
     def __init__(self):
         self.limits = None
-        self.time = time.time  # evade time-machine
 
     @pytest.hookimpl(wrapper=True)
     def pytest_runtest_setup(self, item):
@@ -52,6 +52,11 @@ class MaxTestTimePlugin:
         if duration > limit:
             raise AssertionError(f"{event} time limit ({limit}) exceeded: {duration}")
         self.limits = None
+
+    def time(self):
+        if escape_hatch.is_travelling():
+            return escape_hatch.time.time()
+        return time.time()
 
 
 def get_float(value, default):

--- a/corehq/tests/pytest_plugins/timelimit.py
+++ b/corehq/tests/pytest_plugins/timelimit.py
@@ -29,7 +29,7 @@ class MaxTestTimePlugin:
 
     def __init__(self):
         self.limits = None
-        self.time = time.time  # evade freezegun
+        self.time = time.time  # evade time-machine
 
     @pytest.hookimpl(wrapper=True)
     def pytest_runtest_setup(self, item):

--- a/corehq/util/tests/test_celery_utils.py
+++ b/corehq/util/tests/test_celery_utils.py
@@ -4,7 +4,6 @@ import pytest
 from celery.schedules import crontab
 from time_machine import travel
 from nose.tools import assert_equal, assert_raises
-from testil import eq
 
 from corehq.util.celery_utils import deserialize_run_every_setting, run_periodic_task_again
 
@@ -36,7 +35,7 @@ def test_deserialize_run_every_setting():
 
 
 def make_cases():
-    now = datetime.utcnow()
+    now = datetime(2025, 6, 5, 4, 3, 2)
     all_hours = list(range(0, 24))
     all_hours_except_now = list(set(all_hours) - {now.hour})
     one_second = timedelta(seconds=1)
@@ -111,4 +110,4 @@ def test_run_periodic_task_again(name):
     run_every, last_run, duration, expected, now = TEST_CASES[name]
     with travel(now, tick=False):
         run_again = run_periodic_task_again(run_every, last_run, duration)
-    eq(run_again, expected)
+    assert run_again == expected

--- a/corehq/util/tests/test_celery_utils.py
+++ b/corehq/util/tests/test_celery_utils.py
@@ -2,7 +2,7 @@ from datetime import timedelta, datetime
 
 import pytest
 from celery.schedules import crontab
-from freezegun import freeze_time
+from time_machine import travel
 from nose.tools import assert_equal, assert_raises
 from testil import eq
 
@@ -109,6 +109,6 @@ TEST_CASES = make_cases()
 @pytest.mark.parametrize("name", TEST_CASES)
 def test_run_periodic_task_again(name):
     run_every, last_run, duration, expected, now = TEST_CASES[name]
-    with freeze_time(now):
+    with travel(now, tick=False):
         run_again = run_periodic_task_again(run_every, last_run, duration)
     eq(run_again, expected)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,8 +177,8 @@ test = [
     'requests-mock',
     'Faker',
     'flaky>=3.8', # required for pytest 8.2 (and possibly earlier versions)
-    'freezegun',
     'radon>=5.0', # v5 no longer depends on flake8-polyfill
+    'time-machine',
     'pytest-django',
     'pytest-unmagic',
     'coverage',

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,6 @@ dev = [
     { name = "fixture" },
     { name = "flake8" },
     { name = "flaky" },
-    { name = "freezegun" },
     { name = "git-build-branch" },
     { name = "gnureadline" },
     { name = "ipython" },
@@ -517,6 +516,7 @@ dev = [
     { name = "radon" },
     { name = "requests-mock" },
     { name = "testil" },
+    { name = "time-machine" },
     { name = "wheel" },
     { name = "yapf" },
 ]
@@ -545,12 +545,12 @@ test = [
     { name = "fakecouch" },
     { name = "faker" },
     { name = "flaky" },
-    { name = "freezegun" },
     { name = "pytest-django" },
     { name = "pytest-unmagic" },
     { name = "radon" },
     { name = "requests-mock" },
     { name = "testil" },
+    { name = "time-machine" },
 ]
 
 [package.metadata]
@@ -680,7 +680,6 @@ dev = [
     { name = "fixture" },
     { name = "flake8", specifier = ">=6.0" },
     { name = "flaky", specifier = ">=3.8" },
-    { name = "freezegun" },
     { name = "git-build-branch" },
     { name = "gnureadline" },
     { name = "ipython" },
@@ -691,6 +690,7 @@ dev = [
     { name = "radon", specifier = ">=5.0" },
     { name = "requests-mock" },
     { name = "testil" },
+    { name = "time-machine" },
     { name = "wheel" },
     { name = "yapf" },
 ]
@@ -719,12 +719,12 @@ test = [
     { name = "fakecouch" },
     { name = "faker" },
     { name = "flaky", specifier = ">=3.8" },
-    { name = "freezegun" },
     { name = "pytest-django" },
     { name = "pytest-unmagic" },
     { name = "radon", specifier = ">=5.0" },
     { name = "requests-mock" },
     { name = "testil" },
+    { name = "time-machine" },
 ]
 
 [[package]]
@@ -1406,18 +1406,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/15/e9/2e8405104def81ac30cee88dbf4215ee91d95113da3ede21e403f5085130/flower-2.0.0.tar.gz", hash = "sha256:5657785d728a54914256c34fd0551fe2d7152aab08062ebc645bf86b97b8aec5", size = 3220325, upload-time = "2023-06-17T23:04:49.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/a5/835ea6c3b84a3e5ef44e1640a842483ac475a44caf3e123c79abe2ea6635/flower-2.0.0-py2.py3-none-any.whl", hash = "sha256:571f9ed1c57a622e862de35eceb8a4244f023fbcfb7175f53e45ebe679f46d90", size = 383513, upload-time = "2023-06-17T23:04:46.924Z" },
-]
-
-[[package]]
-name = "freezegun"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ef/722b8d71ddf4d48f25f6d78aa2533d505bf3eec000a7cacb8ccc8de61f2f/freezegun-1.5.1.tar.gz", hash = "sha256:b29dedfcda6d5e8e083ce71b2b542753ad48cfec44037b3fc79702e2980a89e9", size = 33697, upload-time = "2024-05-11T17:32:53.911Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/0b/0d7fee5919bccc1fdc1c2a7528b98f65c6f69b223a3fd8f809918c142c36/freezegun-1.5.1-py3-none-any.whl", hash = "sha256:bf111d7138a8abe55ab48a71755673dbaa4ab87f4cff5634a4442dfec34c15f1", size = 17569, upload-time = "2024-05-11T17:32:51.715Z" },
 ]
 
 [[package]]
@@ -3137,6 +3125,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "time-machine"
+version = "2.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/17/4a28bd7834a98b8fa2f96c6af9b22822f75f0e7593653b5b3234e559a8d8/time_machine-2.17.0.tar.gz", hash = "sha256:bc31f23aa4c31b6567a7e5b2bbb0d1a0c0a1340c6d050c1f1b71cd0e2e76cb7f", size = 13357, upload-time = "2025-08-05T15:20:17.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/f8/6d47f24a536657cb0120984dfdfb1e0ef5046876493d839d9d6acb62ceac/time_machine-2.17.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b74ff0463b3ca47adec9660be2b91ac15dc15e85616cecd3d526e50d006a15bf", size = 17488, upload-time = "2025-08-05T15:19:16.417Z" },
+    { url = "https://files.pythonhosted.org/packages/59/de/4035b3a46eecb1c8beef963715bcdc6bebef6cab0f5159815058eef2d181/time_machine-2.17.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0f1b96579296b124a8b85661315875c7036d09bfe985e602196bf7531bec577b", size = 13962, upload-time = "2025-08-05T15:19:17.424Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0b/88b16180e45c28461b46e649d9228a65087f3383069104149e28c62df01a/time_machine-2.17.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ba557aa2485a942f08e9f7a6e0605d90e597f8208d9eec43994dfc55c792a5df", size = 28701, upload-time = "2025-08-05T15:19:18.52Z" },
+    { url = "https://files.pythonhosted.org/packages/84/34/b8bb83f50f6c898a49c5be9fec812591b7948ab1bcc2bb2ab660ca88326f/time_machine-2.17.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9681fd2966d1279b92cf9734c85305f1ba924cb66f8f7dffe3dc53c105e67ae0", size = 30692, upload-time = "2025-08-05T15:19:19.466Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b2/4de343c1d1fa3c788f9770d372ed77619951748a7b2c1f2bcac0b1b26a22/time_machine-2.17.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:06896406b22cb5bf0665386127ec140098efd07253b91e3a9bb7bc49ef282b56", size = 31614, upload-time = "2025-08-05T15:19:20.895Z" },
+    { url = "https://files.pythonhosted.org/packages/62/14/9709374921d3c8d65cfbd74980aff5c5e66c48702ca6d072b09d06526e30/time_machine-2.17.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0895e81874b81066d68e88744bd261b119cb100e0dc79e7930d527fb166f2514", size = 30505, upload-time = "2025-08-05T15:19:22.203Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/c9/d369908aefb1e2cacb8d4f09cca850e1c13883b11d09009aee6ecc74c0a7/time_machine-2.17.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3dbb4205ab7fcbe6c2bd3ac381fa6d896ec9a025b6efad02444b00a7b6b0e921", size = 28679, upload-time = "2025-08-05T15:19:23.237Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/6a/5352ade0b4467f2e6b47449659953afa30a52ffb536e84bc6518326718d6/time_machine-2.17.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c6363772ded138ed9d2bb312efd528dfffc7a719541b2e0c46c3afc044e8d973", size = 30222, upload-time = "2025-08-05T15:19:24.387Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9a/9ceec84be9ef1993b028e2ab09b425cb58ee324b9313ec10be83bd29bf15/time_machine-2.17.0-cp313-cp313-win32.whl", hash = "sha256:79addc4e83d6a6003a81bb7becf9a46e73f79132d5b2f5311b45e1b9f1e14807", size = 16201, upload-time = "2025-08-05T15:19:25.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3b/39890aded8016649dcc7f1ec891725dce75cdb23576ab7a8697e2102b4f9/time_machine-2.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:47ab5947541526a322926d7ab30a6b3c9b8dfd0e23a345afa3cda80147a06130", size = 17073, upload-time = "2025-08-05T15:19:26.431Z" },
+    { url = "https://files.pythonhosted.org/packages/59/72/2bac1a52d4fb26a2f35fe103af68dedb844a7f5484d7c481bd6aac9b3413/time_machine-2.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:ab37bbe5f233667d0a1aa14f81ed0a85f402cc72c2f9e10e190f404a2ff057cc", size = 15447, upload-time = "2025-08-05T15:19:27.384Z" },
+    { url = "https://files.pythonhosted.org/packages/70/53/280947f1f718d6a1ab26502f6e74e694dd52221860822cb996ffc1ba00be/time_machine-2.17.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2852334b4ae8442dd182c2623dea79aa5167eb5dc558a63a116617db8b96a573", size = 18160, upload-time = "2025-08-05T15:19:28.323Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d3/48a9e53dd222261434e92c691308561b50c933d7ae4d1ab9b98f64cb3528/time_machine-2.17.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9abb2098d22a17d0255a1768c7caa0ffe70f3c2c936a5351a7c81555f28b768d", size = 14274, upload-time = "2025-08-05T15:19:29.228Z" },
+    { url = "https://files.pythonhosted.org/packages/72/13/b832d7ec0480b2a5d4ede67749c89d5ef8ebb8ed7847852888e4aff71846/time_machine-2.17.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1fc270f6220762c31d5afe2f0f3e05bea2366c51368db18c43c303a9640e84c8", size = 34870, upload-time = "2025-08-05T15:19:30.196Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f3/91be773deb38a96c312aba7a7b5a03188b9fc9a84fec03ba551d437a77e7/time_machine-2.17.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9f6afd89664d2e30a6e57f3ce9aeb53502064167f628f14bf6927d5a2cbd2101", size = 36477, upload-time = "2025-08-05T15:19:31.651Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/45/4b878dfefffc4093e7eb1997a2fa3fc392a10b9bc10ed19013b9b0c3903d/time_machine-2.17.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2844002ff867d083c267bb19ecf7fb326e964c01a0a9cc323dd2f55d275fdb9d", size = 38048, upload-time = "2025-08-05T15:19:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/02/91824603ae9f45bc35dcc56f4e9b58821ce0a60a5c96e043a374813e1ef1/time_machine-2.17.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a8228b79be107bb0eb76ece610545b5a9d88bf398d0cbeb1ab5363fe026939fa", size = 36439, upload-time = "2025-08-05T15:19:33.604Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/aa/d4a102148a1a7a25d7bfa47f36fa1a4fc62637c4112ca2fd0d41203d9b53/time_machine-2.17.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8137ea6c680bd62554f15e36b9f384406790f0b2605bdbc4fe52f0b9e4644ff5", size = 34508, upload-time = "2025-08-05T15:19:34.606Z" },
+    { url = "https://files.pythonhosted.org/packages/82/48/77a14d9c876273086848ddd0bf8fd255813e2cd74bda7e449d159c52bea3/time_machine-2.17.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7c216990c381c4a3f25fb648377cd1022d65cfbf0023ecbab12f78c9f02066cf", size = 35604, upload-time = "2025-08-05T15:19:35.658Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/5b0d30d2d756f1ec631a75a9c0c61b2e121426d9ca4e313b986ca5ef94f3/time_machine-2.17.0-cp313-cp313t-win32.whl", hash = "sha256:f22139193db761cb470e20a954aa86157e1b51b3e03f1ece879d235fef3a13e1", size = 16662, upload-time = "2025-08-05T15:19:36.69Z" },
+    { url = "https://files.pythonhosted.org/packages/21/53/fa0ed23fb5ad4aff986c310e5049f4e354a9c2d995dbfae042b5d7bd194c/time_machine-2.17.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8b37d391555e316248a3c227a298959034a23e5fc6e059e1f1fe591d0f58fe77", size = 17775, upload-time = "2025-08-05T15:19:37.948Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/37/e8b2b85dfdaa68cee7a16684366a8defe240bef5c9a8780eac0783a5930b/time_machine-2.17.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c4ab494d787e571b53323c130349d667c4d91bd74a0278758cf9edc1ecfc7098", size = 15573, upload-time = "2025-08-05T15:19:38.967Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d3/028f9c3661c3fff8e53730151939c5a5bdca9489d5b8d59e1ffdb806a3e0/time_machine-2.17.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:ce7f9967f1a744b1b0c8c2c29aca0a20468077041907b4e4288a82a4988e7fcf", size = 17510, upload-time = "2025-08-05T15:19:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/52f6d0ae707944d4cadc16f8c1c4c720f1ea23251290edf0f17fda757270/time_machine-2.17.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6673ce6e3000d8e42104d0dd5d5b6a367ca6c69d215704f72da74e354e5f860e", size = 13953, upload-time = "2025-08-05T15:19:41.395Z" },
+    { url = "https://files.pythonhosted.org/packages/19/56/9045a2b54df55f0df1105e2949edbe4030a5b64542555202ae61456886e7/time_machine-2.17.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0d59b492109dcfe424885a3ef50555cfeb0ccc71e58ad4e027babfc91809adb1", size = 28649, upload-time = "2025-08-05T15:19:42.731Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/dfe5f9a9624b6e18be2e116789eea615a489aa71a36c9aa6a03c36a6e1c5/time_machine-2.17.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1594e8e1d970675a87615f3fe59d212d527b54f0315ae577fef0c0d7baf42275", size = 30775, upload-time = "2025-08-05T15:19:43.855Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/19/98ef48cab5c16327117558b05a96c707bb25fb30b2177c4c5b12892ca35b/time_machine-2.17.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49e1e7be05eb0396e0e71373c552061bd644e8973a5a0139ea76a328c7b794a0", size = 31665, upload-time = "2025-08-05T15:19:44.928Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/09/eee2ca0409012a78a7ecf5a165bfe2f3baaa668b460c8e7fb6004c0cf2a1/time_machine-2.17.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7bd4e0120184c377827050bbe41760a385943d64291089855a6ccdf3f5dc554e", size = 30574, upload-time = "2025-08-05T15:19:45.972Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8c/009515834c7668b09b084f03104e05bd906b1ca0630321d2ebe6d6e00c9d/time_machine-2.17.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:fd8859dbba8f214a4c733a00cd84a1da1262510e6d8a1adac0c10478b61c018a", size = 28593, upload-time = "2025-08-05T15:19:46.957Z" },
+    { url = "https://files.pythonhosted.org/packages/94/8e/de7c4ba4c8891570b29a7cf47babe93a020d51b10713f7e9cb25445a4d62/time_machine-2.17.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7b8cfa7412093a4ca0eb218e6f042ef476a3fbf0035a07405c095f0fdf2c4ab5", size = 30296, upload-time = "2025-08-05T15:19:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/70/a37621b293d312d3b6d2140d593f8f6d58842ee1c68dfd40286d4d321db5/time_machine-2.17.0-cp314-cp314-win32.whl", hash = "sha256:71f432058917fb2405a9d0005886d4680d30f1a36de400bb5f726b5106b67566", size = 16290, upload-time = "2025-08-05T15:19:48.918Z" },
+    { url = "https://files.pythonhosted.org/packages/74/05/ee42ab62574ff20199a39127439e927cfcb68d65b0ee82bae10d8ae67496/time_machine-2.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:bec64a2d1e33c14438b94f80b241e9e7a3e543cfcb70ae9c12020b17c23728d2", size = 17151, upload-time = "2025-08-05T15:19:50.011Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/db/9b0675488d6b4526814d697331e1646e055ae0e29e3452e74e88bbd98faa/time_machine-2.17.0-cp314-cp314-win_arm64.whl", hash = "sha256:b12c419bc5d23a3153976177c24bf95d666af3ef32acb73947145eb18e051854", size = 15478, upload-time = "2025-08-05T15:19:51.006Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f3/04ba0fa1d4d95b29eee1cd6b7adf81ff62dc4e6d15d940eca52ac442b649/time_machine-2.17.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:239e069a3b09f68082ffa7fbd500078a99ed0a80defb8d0b3f1607be74532166", size = 18161, upload-time = "2025-08-05T15:19:52.343Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/ee/416d6e8254c9e3d262738927490661fa7ed8067d377ab7af4b932b914e23/time_machine-2.17.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ddd4d92bd51c536e11469f3c9ff40b7604b8d02425da2243d8a8e498d9a1cc71", size = 14273, upload-time = "2025-08-05T15:19:53.447Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/90/90045f06548fe4bc5bb3ba0e8d7b765134abde6bcc871dbb48460f90a76e/time_machine-2.17.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b38b77bdd8a45820bbdaad6c031b71b925b442b78cef84c05d98f5d52e5f4c7e", size = 34860, upload-time = "2025-08-05T15:19:54.452Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/64/0a1676ad8671ee2652e734347ac57a283780f07a7c24610f5c4948395a5e/time_machine-2.17.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:dc22a40dc78613fae6092d577845cc47e84fff5b83749b4f405e923cc186829e", size = 36493, upload-time = "2025-08-05T15:19:55.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/73/da80da3400c732b5b118331cc31b1725e5c886c8120e9a46c35be2cfbdb5/time_machine-2.17.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:05ea377c8b57dc74395ba05cd6a1c63dc2b23db5f709f704a39c8fe920bb6135", size = 38047, upload-time = "2025-08-05T15:19:56.532Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/12/32a8e0f0a4f8de599bdcebbc4738f8959759ae6b2e880867e4453bd4d8e6/time_machine-2.17.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4d93d2838d05676ae892eaa6f9e52e3c3697fd58e3c9c7a288302bc00a55afb9", size = 36453, upload-time = "2025-08-05T15:19:57.53Z" },
+    { url = "https://files.pythonhosted.org/packages/18/61/633b23f9f515bdf8331264e4530b622513a95482897a93db354888ca9d63/time_machine-2.17.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:32ec169809838cc68cd03ee878a93742b7d4c83f87f494816bfa9ca4b053f244", size = 34509, upload-time = "2025-08-05T15:19:58.53Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/39/686d69635cc0a9c2b5e3e639982504803ea45877e14f81a34f5f158b230d/time_machine-2.17.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:657444bac9cb0e1326aa83936df0ff1ed99e66e2142555ad9a6f32f3c5dd6560", size = 35616, upload-time = "2025-08-05T15:19:59.588Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8c/ca9eb63adceaf2895d40d37f67bb0bb5e304e010bcb46573e7e845acb67f/time_machine-2.17.0-cp314-cp314t-win32.whl", hash = "sha256:4c7e18d92375070c43be2a54e40ec1a25fd82b1955e11f72cb4d61d47c76cf42", size = 16842, upload-time = "2025-08-05T15:20:01.074Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d6/e08acb5071787b22438872dd9e7966f00cb6c8e2bad8cf8be5242a8fa9b5/time_machine-2.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e64eaecc26631f69c17925d3e5a1da4a50956f02d63b6589eb5f9b401b17ce67", size = 17998, upload-time = "2025-08-05T15:20:02.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/95/9b7562f26c9b9d34b8658a9e9fc4c710e8162c000201f81ff3c68c1af840/time_machine-2.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:d83d2e4cc1db49441bed3320e0d3225d027db456912fceabfe393e4664d5027f", size = 15619, upload-time = "2025-08-05T15:20:03.49Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`time-machine` is MUCH faster than `freezegun`.

Bonus: fix flaky `test_run_periodic_task_again[cron_enough_time]`, which always failed when `second` field of `datetime.utcnow()` was 0 or 59.

## Safety Assurance

### Safety story

Affects tests only plus one comment in a non-test file.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations