### PR TITLE
Add super basic check for a product label

### DIFF
--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,0 +1,16 @@
+name: Labels
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [labeled, unlabeled, opened, reopened]
+
+jobs:
+  check_product_label:
+    name: 🏷️ Require a product label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if no 'product' label is present
+        if: ${{ !contains(join(github.event.pull_request.labels.*.name, ' '), 'product/') }}
+        run: exit 1


### PR DESCRIPTION
## Product Description
Requires that all PRs have  a `product/` label set on them.  This is already in our [contributing guidelines](https://github.com/dimagi/commcare-hq/blob/master/CONTRIBUTING.rst#product-labels)

Looks like this at the bottom of the PR:
<img width="1005" height="71" alt="image" src="https://github.com/user-attachments/assets/c2944037-f10e-4899-a3e8-18e9a9afe641" />


## Technical Summary
Super straightforward implementation, mostly copy/pasted from @orangejenny

## Feature Flag


## Safety Assurance


### Safety story
Only affects PR builds, no actual environments.

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change