### PR TITLE
preserve the form structure in the payload and return a json string

### DIFF
--- a/corehq/motech/repeaters/tests/test_connect_repeater.py
+++ b/corehq/motech/repeaters/tests/test_connect_repeater.py
@@ -64,8 +64,8 @@ def test_connect_repeater(mocked_super):
     generator = ConnectFormRepeaterPayloadGenerator(repeater)
     form = Mock()
     mocked_super.return_value = json.dumps(MOCK_FORM)
-    payload = generator.get_payload(None, form)
+    payload = json.loads(generator.get_payload(None, form))
     assert payload["metadata"] == FORM_META
-    assert payload["form.connect_path.deliver"] == DELIVER_JSON["deliver"]
+    assert payload["form"]["connect_path"]["deliver"] == DELIVER_JSON["deliver"]
     with pytest.raises(KeyError):
-        payload["form"]
+        payload["form"]["question_path"]


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This fixes two bugs with the connect repeater.
1) The payload generator is meant to return a json string, rather than a dictionary. I am not certain if it just wasn't being sent because of that, or the parser on the connect side was unable to interpret the payload, but strings are certainly the standard way in HQ, so this brings the new repeater into line with that.
2) Connect expects a "form" key, and it is generally nicer to deal with the form if the dictionary structure is maintained rather than flattening the keys with dots as the old implementation did. This preserves form structure.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
COMMCARE_CONNECT

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
There is limited usage of this repeater type (currently only one project), and the changes are tested.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There expected payload is tested and those tests have been updated to reflect the new structure.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
