### PR TITLE
`plan_enabled()`

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -180,6 +180,16 @@ class SoftwarePlanEdition(object):
         PRO,
         STANDARD,
     ]
+    ASCENDING_ORDER = (
+        PAUSED,
+        FREE,
+        STANDARD,
+        PRO,
+        ADVANCED,
+        MANAGED_HOSTING,  # Equivalent of ADVANCED
+        RESELLER,  # Equivalent of ADVANCED
+        ENTERPRISE,
+    )
 
 
 class SoftwarePlanVisibility(object):
@@ -4073,30 +4083,3 @@ class InvoiceCommunicationHistory(CommunicationHistoryBase):
 
 class CustomerInvoiceCommunicationHistory(CommunicationHistoryBase):
     invoice = models.ForeignKey(CustomerInvoice, on_delete=models.PROTECT)
-
-
-def plan_enabled(plan, domain):
-    """
-    Returns ``True`` if the SoftwarePlanEdition of ``domain`` is at
-    ``plan`` or higher, otherwise returns ``False``.
-    """
-    subs = Subscription.get_active_subscription_by_domain(domain)
-    if not subs:
-        return False
-
-    ordered_plan_editions = [
-        SoftwarePlanEdition.PAUSED,
-        SoftwarePlanEdition.FREE,
-        SoftwarePlanEdition.STANDARD,
-        SoftwarePlanEdition.PRO,
-        SoftwarePlanEdition.ADVANCED,
-        SoftwarePlanEdition.MANAGED_HOSTING,  # Equivalent of ADVANCED
-        SoftwarePlanEdition.RESELLER,  # Equivalent of ADVANCED
-        SoftwarePlanEdition.ENTERPRISE,
-    ]
-    assert plan in ordered_plan_editions, (
-        f'Unable to evaluate {plan!r} plan.'
-    )
-    plan_index = ordered_plan_editions.index(subs.plan_version.plan.edition)
-    index_required = ordered_plan_editions.index(plan)
-    return plan_index >= index_required

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -1,11 +1,10 @@
 import datetime
 from decimal import Decimal
+from unittest import mock
 
 from django.core import mail
 from django.db import models
 from django.test import SimpleTestCase
-
-from unittest import mock
 
 from dimagi.utils.dates import add_months_to_date
 
@@ -28,6 +27,7 @@ from corehq.apps.accounting.tests.generator import (
     FakeStripeCardManager,
     FakeStripeCustomerManager,
 )
+from corehq.apps.accounting.tests.utils import mocked_stripe_api
 from corehq.apps.domain.models import Domain
 from corehq.apps.smsbillables.models import (
     SmsBillable,
@@ -37,7 +37,6 @@ from corehq.apps.smsbillables.models import (
     SmsUsageFeeCriteria,
 )
 from corehq.util.dates import get_previous_month_date_range
-from corehq.apps.accounting.tests.utils import mocked_stripe_api
 
 
 class TestBillingAccount(BaseAccountingTest):

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -4,7 +4,9 @@ from unittest import mock
 
 from django.core import mail
 from django.db import models
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
+
+import pytest
 
 from dimagi.utils.dates import add_months_to_date
 
@@ -17,9 +19,11 @@ from corehq.apps.accounting.models import (
     CustomerBillingRecord,
     CustomerInvoice,
     Invoice,
+    SoftwarePlanEdition,
     StripePaymentMethod,
     Subscription,
     SubscriptionType,
+    plan_enabled,
 )
 from corehq.apps.accounting.tests import generator
 from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
@@ -27,8 +31,13 @@ from corehq.apps.accounting.tests.generator import (
     FakeStripeCardManager,
     FakeStripeCustomerManager,
 )
-from corehq.apps.accounting.tests.utils import mocked_stripe_api
+from corehq.apps.accounting.tests.utils import (
+    DomainSubscriptionMixin,
+    mocked_stripe_api,
+)
+from corehq.apps.accounting.utils import clear_plan_version_cache
 from corehq.apps.domain.models import Domain
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.smsbillables.models import (
     SmsBillable,
     SmsGatewayFee,
@@ -349,3 +358,42 @@ class SimpleBillingAccountTest(SimpleTestCase):
     def test_has_enterprise_admin_does_case_insensitive_match(self):
         account = BillingAccount(is_customer_billing_account=True, enterprise_admin_emails=['TEST@dimagi.com'])
         self.assertTrue(account.has_enterprise_admin('test@DIMAGI.com'))
+
+
+class TestPlanEnabled(TestCase, DomainSubscriptionMixin):
+    domain = 'test-plan-enabled'
+
+    def setUp(self):
+        self.domain_obj = create_domain(self.domain)
+        self.addCleanup(self.domain_obj.delete)
+        self.addCleanup(clear_plan_version_cache)
+        self.addCleanup(Subscription.clear_caches, self.domain)
+
+    def test_std_pro_enabled(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.STANDARD)
+        assert plan_enabled(SoftwarePlanEdition.PRO, self.domain) is False
+
+    def test_pro_pro_enabled(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.PRO)
+        assert plan_enabled(SoftwarePlanEdition.PRO, self.domain) is True
+
+    def test_adv_pro_enabled(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.ADVANCED)
+        assert plan_enabled(SoftwarePlanEdition.PRO, self.domain) is True
+
+    def test_pro_std_enabled(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.PRO)
+        assert plan_enabled(SoftwarePlanEdition.STANDARD, self.domain) is True
+
+    def test_pro_adv_enabled(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.PRO)
+        assert plan_enabled(SoftwarePlanEdition.ADVANCED, self.domain) is False
+
+    def test_no_plan(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.PRO)
+        with pytest.raises(AssertionError):
+            plan_enabled("AIN'T GOT NO PLAN", self.domain)
+
+    def test_no_subs(self):
+        assert Subscription.get_active_subscription_by_domain(self.domain) is None
+        assert plan_enabled(SoftwarePlanEdition.PRO, self.domain) is False

--- a/corehq/apps/accounting/tests/test_utils.py
+++ b/corehq/apps/accounting/tests/test_utils.py
@@ -1,8 +1,17 @@
 from datetime import date
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
-from corehq.apps.accounting.utils import is_date_range_overlapping
+import pytest
+
+from corehq.apps.accounting.models import SoftwarePlanEdition, Subscription
+from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
+from corehq.apps.accounting.utils import (
+    clear_plan_version_cache,
+    is_date_range_overlapping,
+)
+from corehq.apps.accounting.utils.software_plans import plan_enabled
+from corehq.apps.domain.shortcuts import create_domain
 
 
 class TestIsDateRangeOverlapping(SimpleTestCase):
@@ -70,3 +79,42 @@ class TestIsDateRangeOverlapping(SimpleTestCase):
     def test_second_range_infinite_end_but_start_after_first_range_end(self):
         assert not is_date_range_overlapping(date(2024, 1, 1), date(2024, 12, 31),
                                              date(2025, 1, 1), None)
+
+
+class TestPlanEnabled(TestCase, DomainSubscriptionMixin):
+    domain = 'test-plan-enabled'
+
+    def setUp(self):
+        self.domain_obj = create_domain(self.domain)
+        self.addCleanup(self.domain_obj.delete)
+        self.addCleanup(clear_plan_version_cache)
+        self.addCleanup(Subscription.clear_caches, self.domain)
+
+    def test_std_pro_enabled(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.STANDARD)
+        assert plan_enabled(SoftwarePlanEdition.PRO, self.domain) is False
+
+    def test_pro_pro_enabled(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.PRO)
+        assert plan_enabled(SoftwarePlanEdition.PRO, self.domain) is True
+
+    def test_adv_pro_enabled(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.ADVANCED)
+        assert plan_enabled(SoftwarePlanEdition.PRO, self.domain) is True
+
+    def test_pro_std_enabled(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.PRO)
+        assert plan_enabled(SoftwarePlanEdition.STANDARD, self.domain) is True
+
+    def test_pro_adv_enabled(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.PRO)
+        assert plan_enabled(SoftwarePlanEdition.ADVANCED, self.domain) is False
+
+    def test_no_plan(self):
+        self.setup_subscription(self.domain, SoftwarePlanEdition.PRO)
+        with pytest.raises(AssertionError):
+            plan_enabled("AIN'T GOT NO PLAN", self.domain)
+
+    def test_no_subs(self):
+        assert Subscription.get_active_subscription_by_domain(self.domain) is None
+        assert plan_enabled(SoftwarePlanEdition.PRO, self.domain) is False

--- a/corehq/apps/accounting/utils/software_plans.py
+++ b/corehq/apps/accounting/utils/software_plans.py
@@ -1,4 +1,4 @@
-from corehq.apps.accounting.models import Subscription
+from corehq.apps.accounting.models import SoftwarePlanEdition, Subscription
 
 
 def upgrade_subscriptions_to_latest_plan_version(old_plan_version, web_user,
@@ -9,3 +9,22 @@ def upgrade_subscriptions_to_latest_plan_version(old_plan_version, web_user,
     new_plan_version = old_plan_version.plan.get_version()
     for subscription in subscriptions_needing_upgrade:
         subscription.upgrade_plan_for_consistency(new_plan_version, upgrade_note, web_user)
+
+
+def plan_enabled(plan, domain):
+    """
+    Returns ``True`` if the SoftwarePlanEdition of ``domain`` is at
+    ``plan`` or higher, otherwise returns ``False``.
+    """
+    assert plan in SoftwarePlanEdition.ASCENDING_ORDER, (
+        f'Unable to evaluate {plan!r} plan.'
+    )
+
+    subs = Subscription.get_active_subscription_by_domain(domain)
+    if not subs:
+        return False
+
+    domain_plan = subs.plan_version.plan.edition
+    domain_index = SoftwarePlanEdition.ASCENDING_ORDER.index(domain_plan)
+    index_required = SoftwarePlanEdition.ASCENDING_ORDER.index(plan)
+    return domain_index >= index_required


### PR DESCRIPTION
## Technical Summary

A utility function to check the features available to a domain based on its subscription level / plan.

:blowfish: 

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

Yes

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
