### PR TITLE
Ability to export the payments report

### DIFF
--- a/corehq/apps/hqwebapp/tables/elasticsearch/tables.py
+++ b/corehq/apps/hqwebapp/tables/elasticsearch/tables.py
@@ -146,6 +146,10 @@ class ElasticTableData(TableData):
         else:
             return 0
 
+    def get_all_records(self):
+        for record in self.query.scroll():
+            yield self.table.record_class(record, self.table.request, **self.record_kwargs)
+
     @staticmethod
     def get_es_results(query):
         try:

--- a/corehq/apps/hqwebapp/tables/export.py
+++ b/corehq/apps/hqwebapp/tables/export.py
@@ -112,7 +112,14 @@ class TableExportMixin(TableExportConfig, SingleTableMixin):
         if isinstance(table, ElasticTable):
             table.request = self.request
             table.rows = BoundRows(data=table.data.get_all_records(), table=table)
+        table.context = self.export_table_context(table)
         return table
+
+    def export_table_context(self, table):
+        """
+        Can be overridden to provide additional context for the export.
+        """
+        return {}
 
     def trigger_export(self, recipient_list=None, subject=None):
         self._validate_export_dependencies()

--- a/corehq/apps/hqwebapp/tables/export.py
+++ b/corehq/apps/hqwebapp/tables/export.py
@@ -1,5 +1,6 @@
 import io
 
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext as _
 
 from django_tables2.views import SingleTableMixin
@@ -68,7 +69,14 @@ class TableExportMixin(TableExportConfig, SingleTableMixin):
     Mixin to add export functionality to django-tables2 based views.
     Attributes:
         exclude_columns_in_export (tuple): Columns to exclude from the export. Defaults to empty tuple.
+    Usage:
+        - Inherit this mixin in a view that uses django-tables2.
+        - Define `table_class` as the django-tables2 table class to use.
+        - Optionally set `export_format`, `export_file_name`, and `export_sheet_name` to customize export
+          configurations.
+        - Trigger export by calling the `trigger_export()` method.
     """
+
     exclude_columns_in_export = ()
 
     def export_to_file(self):
@@ -90,3 +98,17 @@ class TableExportMixin(TableExportConfig, SingleTableMixin):
         Can be overridden for customization.
         """
         return self.table_class(data=self.get_table_data())
+
+    def trigger_export(self):
+        self._validate_export_dependencies()
+        return self._trigger_async_export()
+
+    def _validate_export_dependencies(self):
+        if not getattr(self, 'request', None):
+            raise ImproperlyConfigured("TableExportMixin requires `self.request`.")
+        if not getattr(self, 'table_class', None):
+            raise ImproperlyConfigured("TableExportMixin requires `self.table_class`.")
+
+    def _trigger_async_export(self):
+        # TODO: Implement the logic to trigger an asynchronous export task.
+        pass

--- a/corehq/apps/hqwebapp/tables/export.py
+++ b/corehq/apps/hqwebapp/tables/export.py
@@ -26,14 +26,12 @@ class TableExportConfig:
     Configuration for export functionality.
     Attributes:
         export_format (str): Override to set the export format from backend. Defaults to XLS_2007.
-        export_file_name (str): Name for the exported file (without extension). Defaults to the class name.
-        export_sheet_name (str): Name for the worksheet. Defaults to export_file_name
+        export_sheet_name (str): Name for the worksheet. Defaults to the class name.
     """
     export_format = None
-    export_file_name = None
     export_sheet_name = None
 
-    EXPORT_CONFIG_KEYS = {"export_file_name", "export_format", "export_sheet_name"}
+    EXPORT_CONFIG_KEYS = {"export_format", "export_sheet_name"}
 
     _SUPPORTED_FORMATS = [
         Format.CSV,
@@ -45,13 +43,8 @@ class TableExportConfig:
         Format.JSON
     ]
 
-    @memoized
     def get_export_sheet_name(self):
-        return self.export_sheet_name or self.get_export_file_name()
-
-    @memoized
-    def get_export_file_name(self):
-        return self.export_file_name or self.__class__.__name__
+        return self.export_sheet_name or self.__class__.__name__
 
     @memoized
     def get_export_format(self):
@@ -75,7 +68,7 @@ class TableExportMixin(TableExportConfig, SingleTableMixin):
     """
     Mixin to add export functionality to django-tables2 based views.
     Attributes:
-        report_title (str): Title of the report to be used in the export. Defaults to class name.
+        report_title (str): Title of the report, used in the export file name. Defaults to the class name.
         exclude_columns_in_export (tuple): Columns to exclude from the export. Defaults to empty tuple.
     Usage:
         - Inherit this mixin in a view that uses django-tables2.

--- a/corehq/apps/hqwebapp/tables/export.py
+++ b/corehq/apps/hqwebapp/tables/export.py
@@ -138,7 +138,7 @@ class TableExportMixin(TableExportConfig, SingleTableMixin):
             "user_id": self.request.couch_user.user_id,
             "request_params": dict(self.request.GET.lists()),
             "config": self.config_as_dict(),
-            "report_title": self.get_report_title(),
+            "report_title": self.report_title,
         }
 
     @memoized
@@ -164,6 +164,7 @@ class TableExportMixin(TableExportConfig, SingleTableMixin):
 
         view = cls()
         view.request = request
+        view.report_title = context['report_title']
         for config_key, config_value in context['config'].items():
             setattr(view, config_key, config_value)
 

--- a/corehq/apps/hqwebapp/tables/export.py
+++ b/corehq/apps/hqwebapp/tables/export.py
@@ -1,0 +1,92 @@
+import io
+
+from django.utils.translation import gettext as _
+
+from django_tables2.views import SingleTableMixin
+from memoized import memoized
+
+from couchexport.export import export_from_tables
+from couchexport.models import Format
+
+
+class TableExportException(Exception):
+    pass
+
+
+class TableExportConfig:
+    """
+    Configuration for export functionality.
+    Attributes:
+        export_format (str): Override to set the export format from backend. Defaults to XLS_2007.
+        export_file_name (str): Name for the exported file (without extension). Defaults to the class name.
+        export_sheet_name (str): Name for the worksheet. Defaults to export_file_name
+    """
+    export_format = None
+    export_file_name = None
+    export_sheet_name = None
+
+    EXPORT_CONFIG_KEYS = {"export_file_name", "export_format", "export_sheet_name"}
+
+    _SUPPORTED_FORMATS = [
+        Format.CSV,
+        Format.UNZIPPED_CSV,
+        Format.XLS,
+        Format.XLS_2007,
+        Format.HTML,
+        Format.ZIPPED_HTML,
+        Format.JSON
+    ]
+
+    @memoized
+    def get_export_sheet_name(self):
+        return self.export_sheet_name or self.get_export_file_name()
+
+    @memoized
+    def get_export_file_name(self):
+        return self.export_file_name or self.__class__.__name__
+
+    @memoized
+    def get_export_format(self):
+        export_format = self.export_format or self.request.GET.get('format', Format.XLS_2007)
+        self._validate_export_format(export_format)
+        return export_format
+
+    def _validate_export_format(self, export_format):
+        if export_format not in self._SUPPORTED_FORMATS:
+            raise TableExportException(
+                _("Unsupported export format: {}. Supported formats are: {}".format(
+                    export_format, ','.join(self._SUPPORTED_FORMATS)
+                ))
+            )
+
+    def config_as_dict(self):
+        return {key: getattr(self, key) for key in self.EXPORT_CONFIG_KEYS}
+
+
+class TableExportMixin(TableExportConfig, SingleTableMixin):
+    """
+    Mixin to add export functionality to django-tables2 based views.
+    Attributes:
+        exclude_columns_in_export (tuple): Columns to exclude from the export. Defaults to empty tuple.
+    """
+    exclude_columns_in_export = ()
+
+    def export_to_file(self):
+        file = io.BytesIO()
+        export_from_tables(self._export_table_data, file, self.get_export_format())
+        return file
+
+    @property
+    def _export_table_data(self):
+        """
+        Returns data in the format expected by export_from_tables:
+        [[sheet_name, [headers, row1, row2, ...]]]
+        """
+        table = self.get_table_for_export().as_values(exclude_columns=self.exclude_columns_in_export)
+        return [[self.get_export_sheet_name(), table]]
+
+    def get_table_for_export(self):
+        """
+        Can be overridden for customization.
+        """
+        return self.table_class(data=self.get_table_data())

--- a/corehq/apps/hqwebapp/tables/export.py
+++ b/corehq/apps/hqwebapp/tables/export.py
@@ -136,7 +136,7 @@ class TableExportMixin(TableExportConfig, SingleTableMixin):
             "domain": self.request.domain,
             "can_access_all_locations": self.request.can_access_all_locations,
             "user_id": self.request.couch_user.user_id,
-            "request_params": dict(self.request.GET.lists()),
+            "request_params": self.request.GET.urlencode(),
             "config": self.config_as_dict(),
             "report_title": self.report_title,
         }
@@ -152,11 +152,7 @@ class TableExportMixin(TableExportConfig, SingleTableMixin):
 
         request = HttpRequest()
         request.method = 'GET'
-
-        query_dict = QueryDict(mutable=True)
-        for key, values in context['request_params'].items():
-            query_dict.setlist(key, values)
-        request.GET = query_dict
+        request.GET = QueryDict(context['request_params'])
 
         request.domain = context['domain']
         request.couch_user = CouchUser.get_by_user_id(context['user_id'])

--- a/corehq/apps/hqwebapp/tables/export.py
+++ b/corehq/apps/hqwebapp/tables/export.py
@@ -116,15 +116,6 @@ class TableExportMixin(TableExportConfig, SingleTableMixin):
 
     def trigger_export(self, recipient_list=None, subject=None):
         self._validate_export_dependencies()
-        return self._trigger_async_export(recipient_list, subject)
-
-    def _validate_export_dependencies(self):
-        if not getattr(self, 'request', None):
-            raise ImproperlyConfigured("TableExportMixin requires `self.request`.")
-        if not getattr(self, 'table_class', None):
-            raise ImproperlyConfigured("TableExportMixin requires `self.table_class`.")
-
-    def _trigger_async_export(self, recipient_list, subject):
         export_all_rows_task.delay(
             class_path=f"{self.__class__.__module__}.{self.__class__.__name__}",
             export_context=self._get_export_context(),
@@ -132,6 +123,12 @@ class TableExportMixin(TableExportConfig, SingleTableMixin):
             subject=subject,
         )
         return HttpResponse(_("Export is being generated. You will receive an email when it is ready."))
+
+    def _validate_export_dependencies(self):
+        if not getattr(self, 'request', None):
+            raise ImproperlyConfigured("TableExportMixin requires `self.request`.")
+        if not getattr(self, 'table_class', None):
+            raise ImproperlyConfigured("TableExportMixin requires `self.table_class`.")
 
     def _get_export_context(self):
         """Returns context needed to reconstruct the view for async export"""

--- a/corehq/apps/hqwebapp/tables/tests/test_export.py
+++ b/corehq/apps/hqwebapp/tables/tests/test_export.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.query import QuerySet
+from django.http import QueryDict
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -39,7 +40,7 @@ class BaseTestView(TableExportMixin):
 
     def __init__(self, **kwargs):
         self.request = MagicMock()
-        self.request.GET = {}
+        self.request.GET = QueryDict()
         self.request.domain = "test-domain"
         self.request.can_access_all_locations = True
         self.request.couch_user = MagicMock(user_id="user-id")

--- a/corehq/apps/hqwebapp/tables/tests/test_export.py
+++ b/corehq/apps/hqwebapp/tables/tests/test_export.py
@@ -1,0 +1,177 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
+from django.db.models.query import QuerySet
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from corehq.apps.hqwebapp.tables.export import TableExportMixin, TableExportException
+from corehq.apps.hqwebapp.tasks import export_all_rows_task
+from couchexport.models import Format
+import django_tables2 as tables
+
+
+class DummyTable(tables.Table):
+    col1 = tables.Column()
+    col2 = tables.Column()
+
+
+class BaseTestView(TableExportMixin):
+    table_class = DummyTable
+    export_format = Format.XLS_2007
+    exclude_columns_in_export = ()
+
+    def __init__(self, **kwargs):
+        self.request = MagicMock()
+        self.request.GET = {}
+        self.request.domain = "test-domain"
+        self.request.can_access_all_locations = True
+        self.request.couch_user = MagicMock(user_id="user-id")
+
+
+class TableDataView(BaseTestView):
+    table_class = DummyTable
+    table_data = [
+        {"col1": "a", "col2": "b"},
+        {"col1": "c", "col2": "d"},
+    ]
+
+
+class ObjectListView(BaseTestView):
+
+    @property
+    def object_list(self):
+        for data in [
+            SimpleNamespace(col1="a", col2="b"),
+            SimpleNamespace(col1="c", col2="d"),
+        ]:
+            yield data
+
+
+class DummyModel(models.Model):
+    col1 = models.CharField(max_length=10)
+    col2 = models.CharField(max_length=10)
+
+    class Meta:
+        app_label = 'testapp'
+
+
+class QuerysetView(BaseTestView):
+
+    def get_queryset(self):
+        objs = [
+            DummyModel(col1="a", col2="b"),
+            DummyModel(col1="c", col2="d"),
+        ]
+        return self.fake_queryset(objs)
+
+    @staticmethod
+    def fake_queryset(objs):
+        qs = MagicMock(spec=QuerySet)
+        qs.__iter__.return_value = iter(objs)
+        qs.model = DummyModel
+        return qs
+
+
+class TestTableExportMixinExportData(TestCase):
+
+    def _assert_for_sheet_and_rows(self, view, sheet_name, rows_list):
+        self.assertEqual(sheet_name, view.get_export_sheet_name())
+        # Headers are capitalized in the export
+        self.assertEqual(rows_list[0], ['Col1', 'Col2'])
+        self.assertEqual(rows_list[1], ['a', 'b'])
+        self.assertEqual(rows_list[2], ['c', 'd'])
+
+    def test_with_table_data_attribute(self):
+        view = TableDataView()
+        sheet_name, rows = view._export_table_data[0]
+        self._assert_for_sheet_and_rows(view, sheet_name, list(rows))
+
+    def test_with_object_list_attribute(self):
+        view = ObjectListView()
+        sheet_name, rows = view._export_table_data[0]
+        self._assert_for_sheet_and_rows(view, sheet_name, list(rows))
+
+    def test_with_get_queryset_method(self):
+        view = QuerysetView()
+        sheet_name, rows = view._export_table_data[0]
+        self._assert_for_sheet_and_rows(view, sheet_name, list(rows))
+
+    def test_with_exclude_columns(self):
+        view = TableDataView()
+        view.exclude_columns_in_export = ('col1',)
+        sheet_name, rows = view._export_table_data[0]
+        rows_list = list(rows)
+        self.assertEqual(rows_list[0], ['Col2'])
+        self.assertEqual(rows_list[1], ['b'])
+        self.assertEqual(rows_list[2], ['d'])
+
+
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_EAGER_PROPAGATES=True
+)
+class TestTableExportMixinTriggerExport(TestCase):
+
+    @patch('corehq.apps.hqwebapp.tables.export.export_all_rows_task.delay')
+    def test_trigger_export_with_table_data(self, *args):
+        view = TableDataView()
+        response = view.trigger_export(recipient_list=None, subject=None)
+        self.assertEqual(
+            str(response.content, encoding='utf-8'),
+            "Export is being generated. You will receive an email when it is ready."
+        )
+
+    @patch('corehq.apps.hqwebapp.tables.export.export_all_rows_task.delay')
+    def test_trigger_export_with_object_list(self, *args):
+        view = ObjectListView()
+        response = view.trigger_export(recipient_list=None, subject=None)
+        self.assertEqual(
+            str(response.content, encoding='utf-8'),
+            "Export is being generated. You will receive an email when it is ready."
+        )
+
+    @patch('corehq.apps.hqwebapp.tables.export.export_all_rows_task.delay')
+    def test_trigger_export_with_get_queryset(self, *args):
+        view = QuerysetView()
+        response = view.trigger_export(recipient_list=None, subject=None)
+        self.assertEqual(
+            str(response.content, encoding='utf-8'),
+            "Export is being generated. You will receive an email when it is ready."
+        )
+
+    def test_trigger_export_without_table_class(self):
+        view = BaseTestView()
+        view.table_class = None
+        with self.assertRaises(ImproperlyConfigured) as err:
+            view.trigger_export()
+        self.assertEqual(
+            str(err.exception),
+            "TableExportMixin requires `self.table_class`."
+        )
+
+    def test_trigger_export_without_request(self):
+        view = BaseTestView()
+        view.request = None
+        with self.assertRaises(ImproperlyConfigured) as err:
+            view.trigger_export()
+        self.assertEqual(
+            str(err.exception),
+            "TableExportMixin requires `self.request`."
+        )
+
+    @patch('corehq.apps.hqwebapp.tables.export.export_all_rows_task', wraps=export_all_rows_task)
+    def test_trigger_export_with_invalid_export_format(self, *args):
+        view = TableDataView()
+        view.export_format = "INVALID_FORMAT"
+        with self.assertRaises(TableExportException) as err:
+            view.trigger_export()
+        self.assertEqual(
+            str(err.exception),
+            "Unsupported export format: {}. Supported formats are: {}".format(
+                view.export_format,
+                ','.join(view._SUPPORTED_FORMATS)
+            )
+        )

--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -10,11 +10,14 @@ from django.core.mail.message import EmailMessage
 from django.core.management import call_command
 from django.urls import reverse
 from django.template.defaultfilters import linebreaksbr
+from django.utils.module_loading import import_string
 from django.utils.translation import gettext as _
 
 from celery.exceptions import MaxRetriesExceededError
 from celery.schedules import crontab
+from celery.utils.log import get_task_logger
 
+from corehq.util.view_utils import absolute_reverse
 from dimagi.utils.django.email import (
     COMMCARE_MESSAGE_ID_HEADER,
     SES_CONFIGURATION_SET_HEADER,
@@ -31,6 +34,9 @@ from corehq.util.email_event_utils import get_bounced_system_emails
 from corehq.util.log import send_HTML_email
 from corehq.util.metrics import metrics_track_errors
 from corehq.util.models import TransientBounceEmail
+
+
+logger = get_task_logger(__name__)
 
 
 def mark_subevent_gateway_error(messaging_event_id, error, retrying=False):
@@ -364,3 +370,27 @@ def send_stale_case_data_info_to_admins():
         html_content=linebreaksbr(message),
         file_attachments=[csv_file]
     )
+
+
+@task(ignore_result=True, acks_late=True)
+def export_all_rows_task(class_path, export_context, recipient_list=None, subject=None):
+    from corehq.apps.reports.tasks import _store_excel_in_blobdb
+    from corehq.apps.reports.util import send_report_download_email
+
+    ReportClass = import_string(class_path)
+    report = ReportClass.reconstruct_from_export_context(export_context)
+    report_title = report.get_report_title()
+
+    file = report.export_to_file()
+    hash_id = _store_excel_in_blobdb(class_path, file, export_context['domain'], report_title)
+    logger.info(f'Stored report {report_title} with parameters: {export_context["request_params"]} '
+                f'in hash {hash_id}')
+    if not recipient_list:
+        recipient_list = [report.request.couch_user.get_email()]
+    for recipient in recipient_list:
+        link = absolute_reverse(
+            "export_report",
+            args=[export_context['domain'], str(hash_id), report.get_export_format()],
+        )
+        send_report_download_email(report_title, recipient, link, subject, domain=export_context['domain'])
+        logger.info(f'Sent {report_title} with hash {hash_id} to {recipient}')

--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -1,6 +1,5 @@
 import csv
 from io import StringIO
-
 from smtplib import SMTPDataError
 from urllib.parse import urlencode, urljoin
 
@@ -8,8 +7,8 @@ from django.conf import settings
 from django.core.mail import mail_admins
 from django.core.mail.message import EmailMessage
 from django.core.management import call_command
-from django.urls import reverse
 from django.template.defaultfilters import linebreaksbr
+from django.urls import reverse
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext as _
 
@@ -17,7 +16,6 @@ from celery.exceptions import MaxRetriesExceededError
 from celery.schedules import crontab
 from celery.utils.log import get_task_logger
 
-from corehq.util.view_utils import absolute_reverse
 from dimagi.utils.django.email import (
     COMMCARE_MESSAGE_ID_HEADER,
     SES_CONFIGURATION_SET_HEADER,
@@ -34,7 +32,7 @@ from corehq.util.email_event_utils import get_bounced_system_emails
 from corehq.util.log import send_HTML_email
 from corehq.util.metrics import metrics_track_errors
 from corehq.util.models import TransientBounceEmail
-
+from corehq.util.view_utils import absolute_reverse
 
 logger = get_task_logger(__name__)
 
@@ -374,8 +372,10 @@ def send_stale_case_data_info_to_admins():
 
 @task(ignore_result=True, acks_late=True)
 def export_all_rows_task(class_path, export_context, recipient_list=None, subject=None):
-    from corehq.apps.reports.util import store_excel_in_blobdb
-    from corehq.apps.reports.util import send_report_download_email
+    from corehq.apps.reports.util import (
+        send_report_download_email,
+        store_excel_in_blobdb,
+    )
 
     ReportClass = import_string(class_path)
     report = ReportClass.reconstruct_from_export_context(export_context)

--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -374,7 +374,7 @@ def send_stale_case_data_info_to_admins():
 
 @task(ignore_result=True, acks_late=True)
 def export_all_rows_task(class_path, export_context, recipient_list=None, subject=None):
-    from corehq.apps.reports.tasks import _store_excel_in_blobdb
+    from corehq.apps.reports.util import store_excel_in_blobdb
     from corehq.apps.reports.util import send_report_download_email
 
     ReportClass = import_string(class_path)
@@ -382,7 +382,7 @@ def export_all_rows_task(class_path, export_context, recipient_list=None, subjec
     report_title = report.get_report_title()
 
     file = report.export_to_file()
-    hash_id = _store_excel_in_blobdb(class_path, file, export_context['domain'], report_title)
+    hash_id = store_excel_in_blobdb(class_path, file, export_context['domain'], report_title)
     logger.info(f'Stored report {report_title} with parameters: {export_context["request_params"]} '
                 f'in hash {hash_id}')
     if not recipient_list:

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -118,6 +118,8 @@ class PaymentsVerificationReportView(BaseDomainView, PaymentsFiltersMixin):
 class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableView, TableExportMixin):
     urlname = 'payments_verify_table'
     table_class = PaymentsVerifyTable
+    report_title = _('Payments Verification Report')
+    exclude_columns_in_export = ('verify_select',)
 
     VERIFICATION_ROWS_LIMIT = 100
     REVERT_VERIFICATION_ROWS_LIMIT = 100

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -12,7 +12,6 @@ from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.es import CaseSearchES, filters
 from corehq.apps.es.case_search import (
     case_property_query,
-    wrap_case_search_hit,
 )
 from corehq.apps.geospatial.utils import get_celery_task_tracker
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
@@ -139,7 +138,7 @@ class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableV
         context_data = super().get_context_data(**kwargs)
 
         context_data['user_or_cases_verification_statuses'] = self._get_user_or_cases_verification_status(
-            context_data['page_obj'].object_list
+            context_data['table'].paginated_rows.data
         )
 
         return context_data
@@ -166,7 +165,7 @@ class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableV
     def _get_user_or_case_ids(object_list):
         user_or_case_ids = []
         for commcare_payment_case_details in object_list:
-            case = wrap_case_search_hit(commcare_payment_case_details)
+            case = commcare_payment_case_details.record.case
             if case_prop := case.get_case_property(PaymentProperties.USER_OR_CASE_ID):
                 user_or_case_ids.append(case_prop)
         return user_or_case_ids

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -144,6 +144,15 @@ class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableV
 
         return context_data
 
+    def export_table_context(self, table):
+        context = super().export_table_context(table)
+        table.rows = list(table.rows)
+        object_list = [row.record for row in table.rows]
+        context.update({
+            'user_or_cases_verification_statuses': self._get_user_or_cases_verification_status(object_list)
+        })
+        return context
+
     def _get_user_or_cases_verification_status(self, object_list):
         if not self.kyc_config:
             return {}

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -292,7 +292,12 @@ class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableV
 
     @hq_hx_action('get')
     def export(self, request, *args, **kwargs):
-        return self.trigger_export()
+        res = self.trigger_export()
+        return self.render_htmx_partial_response(
+            request,
+            'payments/partials/payments_export_alert.html',
+            {'message': res.content.decode('utf-8')}
+        )
 
 
 @method_decorator(use_bootstrap5, name='dispatch')

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -16,6 +16,7 @@ from corehq.apps.es.case_search import (
 from corehq.apps.geospatial.utils import get_celery_task_tracker
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.hqwebapp.tables.export import TableExportMixin
 from corehq.apps.hqwebapp.tables.pagination import SelectablePaginatedTableView
 from corehq.apps.integration.kyc.models import KycConfig
 from corehq.apps.integration.payments.const import (
@@ -114,7 +115,7 @@ class PaymentsVerificationReportView(BaseDomainView, PaymentsFiltersMixin):
 @method_decorator(login_and_domain_required, name='dispatch')
 @method_decorator(toggles.MTN_MOBILE_WORKER_VERIFICATION.required_decorator(), name='dispatch')
 @method_decorator(require_payments_report_access, name='dispatch')
-class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableView):
+class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableView, TableExportMixin):
     urlname = 'payments_verify_table'
     table_class = PaymentsVerifyTable
 
@@ -279,6 +280,10 @@ class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableV
                     self.REVERT_VERIFICATION_ROWS_LIMIT
                 ),
             )
+
+    @hq_hx_action('get')
+    def export(self, request, *args, **kwargs):
+        return self.trigger_export()
 
 
 @method_decorator(use_bootstrap5, name='dispatch')

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -10,9 +10,7 @@ from corehq.apps.case_importer.const import MOMO_PAYMENT_CASE_TYPE
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.es import CaseSearchES, filters
-from corehq.apps.es.case_search import (
-    case_property_query,
-)
+from corehq.apps.es.case_search import case_property_query
 from corehq.apps.geospatial.utils import get_celery_task_tracker
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import use_bootstrap5

--- a/corehq/apps/integration/templates/payments/partials/payments_export_alert.html
+++ b/corehq/apps/integration/templates/payments/partials/payments_export_alert.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+<div class="alert alert-success alert-dismissible fade show" role="alert">
+  {{ message }}
+  <button
+    type="button"
+    class="btn-close float-end"
+    data-bs-dismiss="alert"
+    aria-label="{% trans Close %}"
+  ></button>
+</div>

--- a/corehq/apps/integration/templates/payments/payments_verify_report.html
+++ b/corehq/apps/integration/templates/payments/payments_verify_report.html
@@ -24,44 +24,42 @@
 
   <div id="verify-alert"></div>
   <div id="revert-verification-alert"></div>
-  <div class="col-5 mb-2 mt-4">
-    <div class="row">
-      <div class="col-3">
-        <button
-          id="verify-selected-btn"
-          class="btn btn-primary"
-          type="button"
-          disabled="true"
-          data-bs-toggle="modal"
-          data-bs-target="#verify-confirmation-modal"
-        >
-          <span> {% trans "Verify Selected" %} </span>
-        </button>
-      </div>
-      <div class="col-4">
-        <button
-          id="revert-verification-selected-btn"
-          class="btn btn-primary"
-          type="button"
-          disabled="true"
-          data-bs-toggle="modal"
-          data-bs-target="#revert-verification-confirmation-modal"
-        >
-          <span> {% trans "Revert Verification" %} </span>
-        </button>
-      </div>
-      <div class="col-3">
-        <button
-          id="export-btn"
-          class="btn btn-primary"
-          type="button"
-          hx-get="{% url 'payments_verify_table' domain %}{% querystring %}"
-          hq-hx-action="export"
-        >
-          <i class="fa fa-share"></i>
-          <span> {% trans "Export to Excel" %} </span>
-        </button>
-      </div>
+  <div id="export-alert"></div>
+  <div class="mb-2 mt-4">
+    <div class="d-flex flex-wrap gap-3">
+      <button
+        id="verify-selected-btn"
+        class="btn btn-primary"
+        type="button"
+        disabled
+        data-bs-toggle="modal"
+        data-bs-target="#verify-confirmation-modal"
+      >
+        Verify Selected
+      </button>
+
+      <button
+        id="revert-verification-selected-btn"
+        class="btn btn-primary"
+        type="button"
+        disabled
+        data-bs-toggle="modal"
+        data-bs-target="#revert-verification-confirmation-modal"
+      >
+        Revert Verification
+      </button>
+
+      <button
+        id="export-btn"
+        class="btn btn-primary"
+        type="button"
+        hx-get="{% url 'payments_verify_table' domain %}{% querystring %}"
+        hq-hx-action="export"
+        hx-target="#export-alert"
+      >
+        <i class="fa fa-share"></i>
+        <span> {% trans "Export to Excel" %} </span>
+      </button>
     </div>
   </div>
   <div

--- a/corehq/apps/integration/templates/payments/payments_verify_report.html
+++ b/corehq/apps/integration/templates/payments/payments_verify_report.html
@@ -50,6 +50,18 @@
           <span> {% trans "Revert Verification" %} </span>
         </button>
       </div>
+      <div class="col-3">
+        <button
+          id="export-btn"
+          class="btn btn-primary"
+          type="button"
+          hx-get="{% url 'payments_verify_table' domain %}{% querystring %}"
+          hq-hx-action="export"
+        >
+          <i class="fa fa-share"></i>
+          <span> {% trans "Export to Excel" %} </span>
+        </button>
+      </div>
     </div>
   </div>
   <div

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import math
+import uuid
 from typing import List
 import warnings
 from collections import defaultdict, namedtuple
@@ -30,12 +31,15 @@ from corehq.apps.users.models import CommCareUser, WebUser, CouchUser
 from corehq.apps.users.permissions import get_extra_permissions
 from corehq.apps.users.util import user_id_to_username
 from corehq.apps.user_importer.helpers import spec_value_to_boolean_or_none
+from corehq.blobs import CODES, get_blob_db
 from corehq.form_processor.exceptions import XFormNotFound
 from corehq.form_processor.models import XFormInstance
 from corehq.toggles import TABLEAU_USER_SYNCING
+from corehq.util.dates import get_timestamp_for_filename
 from corehq.util.log import send_HTML_email
 from corehq.util.quickcache import quickcache
 from corehq.util.timezones.conversions import PhoneTime, ServerTime
+
 
 from .analytics.esaccessors import (
     get_all_user_ids_submitted,
@@ -1082,3 +1086,22 @@ def report_date_to_json(date, timezone, date_format, is_phonetime=True):
         return user_time.ui_string(date_format)
     else:
         return ''
+
+
+def store_excel_in_blobdb(report_class, file, domain, report_slug):
+    key = uuid.uuid4().hex
+    expired = 60 * 24 * 7  # 7 days
+    db = get_blob_db()
+
+    kw = {
+        "domain": domain,
+        "name": f"{report_slug}-{get_timestamp_for_filename()}",
+        "parent_id": key,
+        "type_code": CODES.tempfile,
+        "key": key,
+        "timeout": expired,
+        "properties": {"report_class": report_class}
+    }
+    file.seek(0)
+    db.put(file, **kw)
+    return key


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Adds the ability to export the payments report. The payments report will export all the rows based on the filters used in the report. The export itself will happen asynchronously, wherein user will receive an email to download the report once it is ready. This is line with the export feature used in other parts of HQ.

1. Button to export

<img width="2059" height="730" alt="image" src="https://github.com/user-attachments/assets/127b27cb-bf13-4117-80e1-aca0802a683d" />

2, Message after export button click

<img width="2059" height="730" alt="image" src="https://github.com/user-attachments/assets/69630012-5598-4bb5-bf44-626e61463562" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

[Ticket](https://dimagi.atlassian.net/browse/SC-4451)

- Adds an new export mixin class that provides export functionality for Django Tables2 based views with support for customization.
- Although Django Tables2 includes built-in export support which requires and additional module `tablib`, we do not use it here. Instead, this mixin integrates with HQ’s existing export module, ensuring consistency with other parts of HQ.
- Currently, the mixin supports asynchronous exports only. This is intentional, as asynchronous processing is generally the better default for potentially long-running tasks like data exports.That said, we could extend it to also support synchronous exports (e.g., for detailed reports with a small number of rows) when needed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
MTN_MOBILE_WORKER_VERIFICATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local. To be tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
New test cases included.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None. We have a plan to do a single QA once all enhancements are completed.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
