### PR TITLE
Release deactivating web users feature

### DIFF
--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -89,7 +89,7 @@ def check_headers(user_specs, domain, upload_couch_user, is_web_upload=False):
                 ))
             headers.discard(old_name)
 
-    if is_web_upload and toggles.DEACTIVATE_WEB_USERS.enabled(domain):
+    if is_web_upload:
         conditionally_allowed_headers.add('is_active_in_domain')
     if toggles.DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
         conditionally_allowed_headers.add('domain')

--- a/corehq/apps/users/bulk_download.py
+++ b/corehq/apps/users/bulk_download.py
@@ -27,7 +27,7 @@ from corehq.apps.users.dbaccessors import (
     get_web_users_by_filters,
 )
 from corehq.apps.users.models import DeactivateMobileWorkerTrigger, UserRole, CouchUser, HqPermissions
-from corehq.toggles import DEACTIVATE_WEB_USERS, TABLEAU_USER_SYNCING
+from corehq.toggles import TABLEAU_USER_SYNCING
 from corehq.util.workbook_json.excel import (
     alphanumeric_sort_key,
     flatten_json,
@@ -198,9 +198,8 @@ def make_web_user_dict(user, location_cache, domain):
         'last_login (read only)': user.last_login,
         'remove': '',
         'domain': domain,
+        'is_active_in_domain': str(user.is_active_in_domain(domain) if user.is_active else ''),
     }
-    if DEACTIVATE_WEB_USERS.enabled(domain):
-        dict['is_active_in_domain'] = str(user.is_active_in_domain(domain) if user.is_active else '')
 
     return dict
 
@@ -329,10 +328,8 @@ def parse_web_users(domain, user_filters, owner, task=None, total_count=None):
 
     user_headers = [
         'username', 'first_name', 'last_name', 'email', 'role', 'last_access_date (read only)',
-        'last_login (read only)', 'status', 'remove'
+        'last_login (read only)', 'status', 'remove', 'is_active_in_domain',
     ]
-    if DEACTIVATE_WEB_USERS.enabled(domain):
-        user_headers += ['is_active_in_domain']
     user_headers.extend(user_data_contributor.get_headers())
     if domain_has_privilege(domain, privileges.LOCATIONS):
         user_headers.extend(json_to_headers(

--- a/corehq/apps/users/dbaccessors.py
+++ b/corehq/apps/users/dbaccessors.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 
-from corehq import toggles
 from dimagi.utils.couch.database import iter_bulk_delete, iter_docs
 
 from corehq.apps.es import UserES
@@ -290,15 +289,11 @@ def get_all_user_rows(domain, include_web_users=True, include_mobile_users=True,
     if include_inactive:
         states.append('inactive')
 
-    view_name = 'users/by_domain'
-    if toggles.DEACTIVATE_WEB_USERS.enabled(domain):
-        view_name = 'users_by_domain/view'
-
     for flag in states:
         for doc_type in doc_types:
             key = [flag, domain, doc_type]
             for row in CommCareUser.get_db().view(
-                    view_name,
+                    'users_by_domain/view',
                     startkey=key,
                     endkey=key + [{}],
                     reduce=count_only,

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -59,10 +59,7 @@ from corehq.apps.user_importer.helpers import UserChangeLogger
 from corehq.const import LOADTEST_HARD_LIMIT, USER_CHANGE_VIA_WEB
 from corehq.pillows.utils import MOBILE_USER_TYPE, WEB_USER_TYPE
 from corehq.feature_previews import USE_LOCATION_DISPLAY_NAME
-from corehq.toggles import (
-    DEACTIVATE_WEB_USERS,
-    TWO_STAGE_USER_PROVISIONING_BY_SMS,
-)
+from corehq.toggles import TWO_STAGE_USER_PROVISIONING_BY_SMS
 from corehq.util.global_request import get_request_domain
 
 from ..hqwebapp.signals import clear_login_attempts
@@ -1660,9 +1657,8 @@ class UserFilterForm(forms.Form):
                 ),
                 data_bind="slideVisible: !isCrossDomain() && location_id",
             ),
+            "user_active_status",
         ]
-        if self.user_type == MOBILE_USER_TYPE or DEACTIVATE_WEB_USERS.enabled(self.domain):
-            fields.append("user_active_status")
 
         fieldset_label = _('Filter and Download Users')
         if self.user_type == MOBILE_USER_TYPE:

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -103,7 +103,6 @@
                               action: function() { goToPage(1); },
                               placeholder: '{% trans_html_attr "Search Users..." %}'"></search-box>
         </div>
-        {% if request|toggle_enabled:"DEACTIVATE_WEB_USERS" %}
         <div class="col-sm-6">
           <button id="gtm-show-disabled-web-users" type="button" class="btn btn-default pull-right"
                     data-bind="visible: showActiveUsers(), click: function() { showActiveUsers(false); }">
@@ -114,7 +113,6 @@
               {% trans 'Show Active Web Users' %}
           </button>
         </div>
-        {% endif %}
       </div>
       <div class="alert alert-danger" data-bind="visible: error, text: error"></div>
       <div data-bind="visible: showLoadingSpinner">

--- a/corehq/apps/users/tests/test_dbaccessors.py
+++ b/corehq/apps/users/tests/test_dbaccessors.py
@@ -36,8 +36,6 @@ from corehq.apps.users.models import (
 )
 from corehq.apps.users.role_utils import initialize_domain_with_default_roles
 
-from corehq.util.test_utils import flag_enabled
-
 
 @es_test(requires=[user_adapter], setup_class=True)
 class AllCommCareUsersTest(TestCase):
@@ -387,38 +385,6 @@ class AllCommCareUsersTest(TestCase):
             self.assertTrue(id in all_ids)
 
     def test_get_all_user_rows_no_inactive(self):
-        all_rows = get_all_user_rows(self.ccdomain.name, include_inactive=False)
-        all_ids = [row['id'] for row in all_rows]
-        self.assertEqual(5, len(all_ids))
-        user_ids = [
-            self.ccuser_1._id,
-            self.ccuser_2._id,
-            self.web_user._id,
-            self.location_restricted_web_user._id,
-            self.web_user_inactive_domain._id
-        ]
-        for id in user_ids:
-            self.assertTrue(id in all_ids)
-
-    @flag_enabled('DEACTIVATE_WEB_USERS')
-    def test_get_all_user_rows_FF(self):
-        all_rows = get_all_user_rows(self.ccdomain.name)
-        all_ids = [row['id'] for row in all_rows]
-        self.assertEqual(7, len(all_ids))
-        user_ids = [
-            self.ccuser_1._id,
-            self.ccuser_2._id,
-            self.web_user._id,
-            self.ccuser_inactive._id,
-            self.location_restricted_web_user._id,
-            self.web_user_inactive_sso._id,
-            self.web_user_inactive_domain._id
-        ]
-        for id in user_ids:
-            self.assertTrue(id in all_ids)
-
-    @flag_enabled('DEACTIVATE_WEB_USERS')
-    def test_get_all_user_rows_no_inactive_FF(self):
         all_rows = get_all_user_rows(self.ccdomain.name, include_inactive=False)
         all_ids = [row['id'] for row in all_rows]
         self.assertEqual(4, len(all_ids))

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -883,8 +883,7 @@ def paginate_web_users(request, domain):
             'reactivateUrl': '',
         }
         # Omit option to deactivate/reactivate for a domain if user access is controlled by an IdentityProvider
-        if (IdentityProvider.get_required_identity_provider(u.username) is None
-                and toggles.DEACTIVATE_WEB_USERS.enabled(domain)):
+        if IdentityProvider.get_required_identity_provider(u.username) is None:
             if u.is_active_in_domain(domain):
                 user.update({
                     'deactivateUrl': (
@@ -990,7 +989,6 @@ def undo_remove_web_user(request, domain, record_id):
 
 @always_allow_project_access
 @require_can_edit_web_users
-@toggles.DEACTIVATE_WEB_USERS.required_decorator()
 @require_POST
 @location_safe
 def deactivate_web_user(request, domain, couch_user_id):
@@ -1005,7 +1003,6 @@ def deactivate_web_user(request, domain, couch_user_id):
 
 @always_allow_project_access
 @require_can_edit_web_users
-@toggles.DEACTIVATE_WEB_USERS.required_decorator()
 @require_POST
 @location_safe
 def reactivate_web_user(request, domain, couch_user_id):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2767,14 +2767,6 @@ FILTERED_BULK_USER_DOWNLOAD = FrozenPrivilegeToggle(
                'commcarepublic/pages/2143957165/Bulk+Mobile+User+Management')
 )
 
-DEACTIVATE_WEB_USERS = StaticToggle(
-    slug='deactivate_web_users',
-    label='USH: Deactivate Web Users',
-    tag=TAG_RELEASE,
-    namespaces=[NAMESPACE_DOMAIN],
-    description='Allow domains to deactivate web users just for that domain',
-)
-
 APPLICATION_ERROR_REPORT = StaticToggle(
     'application_error_report',
     label='Show Application Error Report',


### PR DESCRIPTION
## Product Description
[CMC: Manual Deactivation of Web Users](https://docs.google.com/document/d/1S3zPwKKMufaUZsq3f32Km4W8ugKVme6KUdbQJQ1zr4k/edit?tab=t.0)
Releases the DEACTIVATE_WEB_USERS feature flag, allowing web users to be deactivated by individual projects.  This deactivates them only on that project, not site-wide.



## Technical Summary
https://dimagi.atlassian.net/browse/USH-6041

## Feature Flag
Releases the DEACTIVATE_WEB_USERS feature flag

## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan
Been through a bunch of QA, and out behind the FF for a while

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
