### PR TITLE
Make sure credits in the new subscription will cover costs generated by previous subscription that are terminated

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -54,7 +54,7 @@ from corehq.apps.accounting.utils import (
     ensure_domain_instance,
     log_accounting_error,
     log_accounting_info,
-    months_from_date,
+    get_first_day_of_months_later,
 )
 from corehq.apps.accounting.utils.invoicing import (
     get_flagged_pay_annually_prepay_invoice,
@@ -690,7 +690,7 @@ class ProductLineItemFactory(LineItemFactory):
     def months_product_active_over_period(self, num_months):
         # Calculate the number of months out of num_months the subscription was active
         quantity = 0
-        date_start = months_from_date(self.invoice.date_end, -(num_months - 1))
+        date_start = get_first_day_of_months_later(self.invoice.date_end, -(num_months - 1))
         while date_start < self.invoice.date_end:
             if self.subscription.date_end and self.subscription.date_end <= date_start:
                 continue

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -54,7 +54,7 @@ from corehq.apps.accounting.utils import (
     ensure_domain_instance,
     log_accounting_error,
     log_accounting_info,
-    get_first_day_of_months_later,
+    get_first_day_x_months_later,
 )
 from corehq.apps.accounting.utils.invoicing import (
     get_flagged_pay_annually_prepay_invoice,
@@ -690,7 +690,7 @@ class ProductLineItemFactory(LineItemFactory):
     def months_product_active_over_period(self, num_months):
         # Calculate the number of months out of num_months the subscription was active
         quantity = 0
-        date_start = get_first_day_of_months_later(self.invoice.date_end, -(num_months - 1))
+        date_start = get_first_day_x_months_later(self.invoice.date_end, -(num_months - 1))
         while date_start < self.invoice.date_end:
             if self.subscription.date_end and self.subscription.date_end <= date_start:
                 continue

--- a/corehq/apps/accounting/mixins.py
+++ b/corehq/apps/accounting/mixins.py
@@ -3,7 +3,7 @@ from datetime import date, timedelta
 
 from corehq.apps.accounting.const import DAYS_PAST_DUE_TO_TRIGGER_DOWNGRADE
 from corehq.apps.accounting.models import CreditLine, Subscription
-from corehq.apps.accounting.utils import get_first_day_of_months_later
+from corehq.apps.accounting.utils import get_first_day_x_months_later
 from corehq.apps.accounting.utils.unpaid_invoice import Downgrade
 from corehq.apps.accounting.utils.invoicing import (
     get_oldest_overdue_invoice_over_threshold,
@@ -87,7 +87,7 @@ class BillingModalsMixin(object):
             if monthly_fee:
                 prepaid_credits = get_total_credits_available_for_product(current_subscription)
                 num_months_remaining = prepaid_credits / monthly_fee
-                prepaid_remaining_date = get_first_day_of_months_later(date.today(), int(num_months_remaining))
+                prepaid_remaining_date = get_first_day_x_months_later(date.today(), int(num_months_remaining))
                 partial_month_remaining = num_months_remaining % 1
                 num_days_in_month = 30  # Approximate
                 prepaid_remaining_date += timedelta(days=int(partial_month_remaining * num_days_in_month))

--- a/corehq/apps/accounting/mixins.py
+++ b/corehq/apps/accounting/mixins.py
@@ -3,7 +3,7 @@ from datetime import date, timedelta
 
 from corehq.apps.accounting.const import DAYS_PAST_DUE_TO_TRIGGER_DOWNGRADE
 from corehq.apps.accounting.models import CreditLine, Subscription
-from corehq.apps.accounting.utils import months_from_date
+from corehq.apps.accounting.utils import get_first_day_of_months_later
 from corehq.apps.accounting.utils.unpaid_invoice import Downgrade
 from corehq.apps.accounting.utils.invoicing import (
     get_oldest_overdue_invoice_over_threshold,
@@ -87,7 +87,7 @@ class BillingModalsMixin(object):
             if monthly_fee:
                 prepaid_credits = get_total_credits_available_for_product(current_subscription)
                 num_months_remaining = prepaid_credits / monthly_fee
-                prepaid_remaining_date = months_from_date(date.today(), int(num_months_remaining))
+                prepaid_remaining_date = get_first_day_of_months_later(date.today(), int(num_months_remaining))
                 partial_month_remaining = num_months_remaining % 1
                 num_days_in_month = 30  # Approximate
                 prepaid_remaining_date += timedelta(days=int(partial_month_remaining * num_days_in_month))

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -3527,53 +3527,33 @@ class CreditLine(models.Model):
 
     @classmethod
     def get_credits_for_line_item_in_invoice(cls, line_item, feature_type, is_product):
-        if feature_type:
-            return itertools.chain(
-                cls.get_credits_by_subscription_and_features(
-                    line_item.invoice.subscription,
-                    feature_type=feature_type,
-                ),
-                cls.get_credits_for_account(
-                    line_item.invoice.subscription.account,
-                    feature_type=feature_type,
-                )
+        return itertools.chain(
+            cls.get_credits_by_subscription_and_features(
+                line_item.invoice.subscription,
+                feature_type=feature_type,
+                is_product=is_product,
+            ),
+            cls.get_credits_for_account(
+                line_item.invoice.subscription.account,
+                feature_type=feature_type,
+                is_product=is_product,
             )
-        if is_product:
-            return itertools.chain(
-                cls.get_credits_by_subscription_and_features(
-                    line_item.invoice.subscription,
-                    is_product=True,
-                ),
-                cls.get_credits_for_account(
-                    line_item.invoice.subscription.account,
-                    is_product=True,
-                )
-            )
+        )
 
     @classmethod
     def get_credits_for_line_item_in_customer_invoice(cls, line_item, feature_type, is_product):
-        if feature_type:
-            return itertools.chain(
-                cls.get_credits_for_subscriptions(
-                    subscriptions=line_item.invoice.subscriptions.all(),
-                    feature_type=feature_type
-                ),
-                cls.get_credits_for_account(
-                    account=line_item.invoice.account,
-                    feature_type=feature_type
-                )
+        return itertools.chain(
+            cls.get_credits_for_subscriptions(
+                subscriptions=line_item.invoice.subscriptions.all(),
+                feature_type=feature_type,
+                is_product=is_product,
+            ),
+            cls.get_credits_for_account(
+                account=line_item.invoice.account,
+                feature_type=feature_type,
+                is_product=is_product,
             )
-        if is_product:
-            return itertools.chain(
-                cls.get_credits_for_subscriptions(
-                    subscriptions=line_item.invoice.subscriptions.all(),
-                    is_product=is_product
-                ),
-                cls.get_credits_for_account(
-                    account=line_item.invoice.account,
-                    is_product=is_product
-                )
-            )
+        )
 
     @classmethod
     def get_credits_for_invoice(cls, invoice):

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -38,8 +38,8 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         self._generate_non_autopayable_entities()
 
         # invoice date is 2 months before the end of the subscription (this is arbitrary)
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
-                                                           self.subscription_length - 2)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start,
+                                                          self.subscription_length - 2)
         self.create_invoices(invoice_date)
 
     def tearDown(self):

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -38,7 +38,8 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         self._generate_non_autopayable_entities()
 
         # invoice date is 2 months before the end of the subscription (this is arbitrary)
-        invoice_date = utils.months_from_date(self.subscription.date_start, self.subscription_length - 2)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
+                                                           self.subscription_length - 2)
         self.create_invoices(invoice_date)
 
     def tearDown(self):

--- a/corehq/apps/accounting/tests/test_autopay_with_api.py
+++ b/corehq/apps/accounting/tests/test_autopay_with_api.py
@@ -39,7 +39,8 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         self._generate_non_autopayable_entities()
 
         # invoice date is 2 months before the end of the subscription (this is arbitrary)
-        invoice_date = utils.months_from_date(self.subscription.date_start, self.subscription_length - 2)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
+                                                           self.subscription_length - 2)
         self.create_invoices(invoice_date)
 
     def _generate_autopayable_entities(self):

--- a/corehq/apps/accounting/tests/test_autopay_with_api.py
+++ b/corehq/apps/accounting/tests/test_autopay_with_api.py
@@ -39,8 +39,8 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         self._generate_non_autopayable_entities()
 
         # invoice date is 2 months before the end of the subscription (this is arbitrary)
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
-                                                           self.subscription_length - 2)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start,
+                                                          self.subscription_length - 2)
         self.create_invoices(invoice_date)
 
     def _generate_autopayable_entities(self):

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -529,6 +529,7 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
         # this is the key step where the expected transfer happens
         second_sub = first_sub.change_plan(pro_plan)
 
+        # manually set when the plan change happens otherwise it will be today
         first_sub = Subscription.visible_objects.get(id=first_sub.id)
         first_sub.date_end = datetime.date(2019, 9, 10)
         first_sub.save()
@@ -552,4 +553,11 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
 
         self.assertEqual(first_invoice.balance, Decimal('0.0000'))
         self.assertEqual(second_invoice.balance, Decimal('0.0000'))
+
+        # Credit calculation breakdown:
+        # - Initial credit: $5000.00
+        # - Standard plan (9/1-9/10): $300/month × (9/30) = $90.00
+        # - Pro plan (9/10-9/30): $600/month × (21/30) = $420.00
+        # - Total charges: $90 + $420 = $510.00
+        # - Expected remaining credit: $5000 - $510 = $4490.00
         self.assertEqual(self._get_credit_total(second_sub), Decimal('4490.0000'))

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -535,7 +535,7 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
             record_date=user_record_date
         )
 
-    def test_subscription_credits_transfer_in_invoice(self):
+    def test_any_type_credits_transfer_in_invoice(self):
         first_sub = Subscription.new_domain_subscription(
             self.account, self.domain.name, self.standard_plan,
             date_start=datetime.date(2019, 9, 1),

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -510,9 +510,9 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
         super(TestSubscriptionChangeTransfersSubscriptionLevelCredit, cls).tearDownClass()
 
     def _get_credit_total(self, subscription):
-        credit_lines = CreditLine.get_credits_by_subscription_and_features(
-            subscription
-        )
+        any_type_credit_lines = CreditLine.get_credits_by_subscription_and_features(subscription)
+        other_type_credit_lines = CreditLine.get_non_general_credits_by_subscription(subscription)
+        credit_lines = any_type_credit_lines.union(other_type_credit_lines)
         return sum([c.balance for c in credit_lines])
 
     def _change_plan_to_pro_on_date(self, subscription, date):

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -492,6 +492,12 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
             cls.domain, created_by=cls.billing_contact,
         )[0]
         generator.arbitrary_contact_info(cls.account, cls.billing_contact)
+        cls.standard_plan = DefaultProductPlan.get_default_plan_version(
+            edition=SoftwarePlanEdition.STANDARD
+        )
+        cls.pro_plan = DefaultProductPlan.get_default_plan_version(
+            edition=SoftwarePlanEdition.PRO
+        )
 
     def tearDown(self):
         for user in self.domain.all_users():
@@ -510,15 +516,8 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
         return sum([c.balance for c in credit_lines])
 
     def test_subscription_credits_transfer_in_invoice(self):
-        standard_plan = DefaultProductPlan.get_default_plan_version(
-            edition=SoftwarePlanEdition.STANDARD
-        )
-        pro_plan = DefaultProductPlan.get_default_plan_version(
-            edition=SoftwarePlanEdition.PRO
-        )
-
         first_sub = Subscription.new_domain_subscription(
-            self.account, self.domain.name, standard_plan,
+            self.account, self.domain.name, self.standard_plan,
             date_start=datetime.date(2019, 9, 1),
         )
         credit_amount = Decimal('5000.00')
@@ -527,7 +526,7 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
         )
 
         # this is the key step where the expected transfer happens
-        second_sub = first_sub.change_plan(pro_plan)
+        second_sub = first_sub.change_plan(self.pro_plan)
 
         # manually set when the plan change happens otherwise it will be today
         first_sub = Subscription.visible_objects.get(id=first_sub.id)

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -481,7 +481,7 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
 
     @classmethod
     def setUpClass(cls):
-        super(TestSubscriptionChangeTransfersSubscriptionLevelCredit, cls).setUpClass()
+        super().setUpClass()
 
         generator.bootstrap_test_software_plan_versions()
         generator.init_default_currency()
@@ -502,7 +502,7 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
     @classmethod
     def tearDownClass(cls):
         utils.clear_plan_version_cache()
-        super(TestSubscriptionChangeTransfersSubscriptionLevelCredit, cls).tearDownClass()
+        super().tearDownClass()
 
     def _get_credit_total(self, subscription):
         any_type_credit_lines = CreditLine.get_credits_by_subscription_and_features(subscription)

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -131,7 +131,7 @@ class TestCreditLines(BaseInvoiceTestCase):
         Tests line item credits for three invoicing periods.
         """
         for month_num in range(2, 5):
-            invoice_date = utils.months_from_date(self.subscription.date_start, month_num)
+            invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, month_num)
             tasks.calculate_users_in_all_domains(invoice_date)
             tasks.generate_invoices_based_on_date(invoice_date)
             invoice = self.subscription.invoice_set.latest('date_end')
@@ -163,7 +163,7 @@ class TestCreditLines(BaseInvoiceTestCase):
         # other subscription credit that shouldn't count toward this invoice
         other_domain = generator.arbitrary_domain()
         # so that the other subscription doesn't draw from the same account credits, have it start 4 months later
-        new_subscription_start = utils.months_from_date(self.subscription.date_start, 4)
+        new_subscription_start = utils.get_first_day_of_months_later(self.subscription.date_start, 4)
 
         other_subscription = generator.generate_domain_subscription(
             self.account,
@@ -232,7 +232,7 @@ class TestCreditLines(BaseInvoiceTestCase):
 
     def _test_final_invoice_balance(self):
         for month_num in range(2, 5):
-            invoice_date = utils.months_from_date(self.subscription.date_start, month_num)
+            invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, month_num)
             tasks.calculate_users_in_all_domains(invoice_date)
             tasks.generate_invoices_based_on_date(invoice_date)
             invoice = self.subscription.invoice_set.latest('date_end')
@@ -539,7 +539,7 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
 
         second_sub = self._change_plan_to_pro_on_date(first_sub, datetime.date(2019, 9, 10))
 
-        invoice_date = utils.months_from_date(first_sub.date_start, 1)
+        invoice_date = utils.get_first_day_of_months_later(first_sub.date_start, 1)
         user_record_date = invoice_date - relativedelta(days=1)
         DomainUserHistory.objects.create(
             domain=self.domain,

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -499,11 +499,6 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
             edition=SoftwarePlanEdition.PRO
         )
 
-    def tearDown(self):
-        for user in self.domain.all_users():
-            user.delete(self.domain.name, deleted_by=None)
-        super(BaseAccountingTest, self).tearDown()
-
     @classmethod
     def tearDownClass(cls):
         utils.clear_plan_version_cache()

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 from dateutil.relativedelta import relativedelta
 
-from dimagi.utils.dates import add_months_to_date
+from dimagi.utils.dates import add_months_to_date, first_of_next_month
 
 from corehq.apps.accounting import tasks, utils
 from corehq.apps.accounting.models import (
@@ -537,9 +537,10 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
             credit_amount, subscription=first_sub,
         )
 
-        second_sub = self._change_plan_to_pro_on_date(first_sub, datetime.date(2019, 9, 10))
+        change_date = datetime.date(2019, 9, 10)
+        second_sub = self._change_plan_to_pro_on_date(first_sub, change_date)
 
-        invoice_date = utils.get_first_day_of_months_later(first_sub.date_start, 1)
+        invoice_date = first_of_next_month(change_date)
         user_record_date = invoice_date - relativedelta(days=1)
         DomainUserHistory.objects.create(
             domain=self.domain,

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -131,7 +131,7 @@ class TestCreditLines(BaseInvoiceTestCase):
         Tests line item credits for three invoicing periods.
         """
         for month_num in range(2, 5):
-            invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, month_num)
+            invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, month_num)
             tasks.calculate_users_in_all_domains(invoice_date)
             tasks.generate_invoices_based_on_date(invoice_date)
             invoice = self.subscription.invoice_set.latest('date_end')
@@ -163,7 +163,7 @@ class TestCreditLines(BaseInvoiceTestCase):
         # other subscription credit that shouldn't count toward this invoice
         other_domain = generator.arbitrary_domain()
         # so that the other subscription doesn't draw from the same account credits, have it start 4 months later
-        new_subscription_start = utils.get_first_day_of_months_later(self.subscription.date_start, 4)
+        new_subscription_start = utils.get_first_day_x_months_later(self.subscription.date_start, 4)
 
         other_subscription = generator.generate_domain_subscription(
             self.account,
@@ -232,7 +232,7 @@ class TestCreditLines(BaseInvoiceTestCase):
 
     def _test_final_invoice_balance(self):
         for month_num in range(2, 5):
-            invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, month_num)
+            invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, month_num)
             tasks.calculate_users_in_all_domains(invoice_date)
             tasks.generate_invoices_based_on_date(invoice_date)
             invoice = self.subscription.invoice_set.latest('date_end')

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -559,7 +559,7 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
 
         # Credit calculation breakdown:
         # - Initial credit: $5000.00
-        # - Standard plan (9/1-9/10): $300/month × (9/30) = $90.00
+        # - Standard plan (9/1-9/9): $300/month × (9/30) = $90.00
         # - Pro plan (9/10-9/30): $600/month × (21/30) = $420.00
         # - Total charges: $90 + $420 = $510.00
         # - Expected remaining credit: $5000 - $510 = $4490.00
@@ -594,7 +594,7 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
 
         # Credit calculation breakdown:
         # - Initial credit: $5000.00
-        # - Standard plan fee (9/1-9/10): $300/month × (9/30) = $90.00
+        # - Standard plan fee (9/1-9/9): $300/month × (9/30) = $90.00
         # - Pro plan fee (9/10-9/30): $600/month × (21/30) = $420.00
         # - Total charges: $90 + $420 = $510.00
         # - Expected remaining credit: $5000 - $510 = $4490.00
@@ -629,14 +629,14 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
 
         # No product type credit and ANY type credit are added
         # Thus the balance will have the plan fee
-        # - Standard plan fee (9/1-9/10): $300/month × (9/30) = $90.00
+        # - Standard plan fee (9/1-9/9): $300/month × (9/30) = $90.00
         # - Pro plan fee (9/10-9/30): $600/month × (21/30) = $420.00
         self.assertEqual(first_invoice.balance, Decimal('90.0000'))
         self.assertEqual(second_invoice.balance, Decimal('420.0000'))
 
         # Credit calculation breakdown:
         # - Initial credit: $5000.00
-        # - Standard plan excess users (9/1-9/10): $1/user/month × (6 users) * (9/30) = $1.80
+        # - Standard plan excess users (9/1-9/9): $1/user/month × (6 users) * (9/30) = $1.80
         # - Pro plan excess users (9/10-9/30): $1/user/month × (4 users) * (21/30) = $2.80
         # - Total charges: $1.80 + $2.80 = $4.60
         # - Expected remaining credit: $5000 - $4.60 = $4995.40

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -542,7 +542,7 @@ class TestUserSubscriptionChangeTransfers(BaseAccountingTest):
             num_users=0,
             record_date=user_record_date
         )
-        tasks.generate_invoices_based_on_date(utils.months_from_date(first_sub.date_start, 1))
+        tasks.generate_invoices_based_on_date(invoice_date)
 
         self.assertEqual(first_sub.invoice_set.count(), 1)
         self.assertEqual(second_sub.invoice_set.count(), 1)

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -527,6 +527,14 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
         new_sub.save()
         return new_sub
 
+    def _generate_user_history(self, num_users, invoice_date):
+        user_record_date = invoice_date - relativedelta(days=1)
+        DomainUserHistory.objects.create(
+            domain=self.domain,
+            num_users=num_users,
+            record_date=user_record_date
+        )
+
     def test_subscription_credits_transfer_in_invoice(self):
         first_sub = Subscription.new_domain_subscription(
             self.account, self.domain.name, self.standard_plan,
@@ -541,12 +549,7 @@ class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest)
         second_sub = self._change_plan_to_pro_on_date(first_sub, change_date)
 
         invoice_date = first_of_next_month(change_date)
-        user_record_date = invoice_date - relativedelta(days=1)
-        DomainUserHistory.objects.create(
-            domain=self.domain,
-            num_users=0,
-            record_date=user_record_date
-        )
+        self._generate_user_history(num_users=0, invoice_date=invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)
 
         self.assertEqual(first_sub.invoice_set.count(), 1)

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -477,11 +477,11 @@ class TestCreditTransfers(BaseAccountingTest):
             self.assertEqual(credit_line.account.pk, self.account.pk)
 
 
-class TestUserSubscriptionChangeTransfers(BaseAccountingTest):
+class TestSubscriptionChangeTransfersSubscriptionLevelCredit(BaseAccountingTest):
 
     @classmethod
     def setUpClass(cls):
-        super(TestUserSubscriptionChangeTransfers, cls).setUpClass()
+        super(TestSubscriptionChangeTransfersSubscriptionLevelCredit, cls).setUpClass()
 
         generator.bootstrap_test_software_plan_versions()
         generator.init_default_currency()
@@ -501,7 +501,7 @@ class TestUserSubscriptionChangeTransfers(BaseAccountingTest):
     @classmethod
     def tearDownClass(cls):
         utils.clear_plan_version_cache()
-        super(TestUserSubscriptionChangeTransfers, cls).tearDownClass()
+        super(TestSubscriptionChangeTransfersSubscriptionLevelCredit, cls).tearDownClass()
 
     def _get_credit_total(self, subscription):
         credit_lines = CreditLine.get_credits_by_subscription_and_features(

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -123,7 +123,7 @@ class BaseCustomerInvoiceCase(BaseAccountingTest):
 class TestCustomerInvoice(BaseCustomerInvoiceCase):
 
     def test_multiple_subscription_invoice(self):
-        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start,
                                               random.randint(3, self.non_main_subscription_length))
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)
@@ -151,7 +151,7 @@ class TestCustomerInvoice(BaseCustomerInvoiceCase):
         """
         No invoices should be generated for the months after the end date of the subscriptions.
         """
-        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_end, 2)
+        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_end, 2)
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 0)
@@ -160,7 +160,7 @@ class TestCustomerInvoice(BaseCustomerInvoiceCase):
         """
         Test the customer invoice can still be created after one of the domains was deleted
         """
-        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start, 2)
+        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start, 2)
 
         domain_to_be_deleted = generator.arbitrary_domain()
         generator.generate_domain_subscription(
@@ -193,7 +193,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
         self.product_rate = self.main_subscription.plan_version.product_rate
 
     def test_product_line_items(self):
-        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start,
                                               random.randint(2, self.main_subscription_length))
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)
@@ -212,7 +212,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
     def test_product_line_items_in_quarterly_invoice(self):
         self.account.invoicing_plan = InvoicingPlan.QUARTERLY
         self.account.save()
-        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start, 14)
+        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start, 14)
         for months_before_invoice_date in range(3):
             user_date = date(invoice_date.year, invoice_date.month, 1)
             user_date -= relativedelta.relativedelta(months=months_before_invoice_date)
@@ -232,7 +232,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
     def test_product_line_items_in_yearly_invoice(self):
         self.account.invoicing_plan = InvoicingPlan.YEARLY
         self.account.save()
-        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start, 14)
+        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start, 14)
         for months_before_invoice_date in range(12):
             user_date = date(invoice_date.year, invoice_date.month, 1)
             user_date -= relativedelta.relativedelta(months=months_before_invoice_date)
@@ -255,7 +255,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
             account=self.account,
             is_product=True
         )
-        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start,
                                               random.randint(2, self.main_subscription_length))
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)
@@ -270,7 +270,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
             is_product=True,
             subscription=self.main_subscription
         )
-        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start,
                                               random.randint(2, self.main_subscription_length))
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)
@@ -288,7 +288,7 @@ class TestUserLineItem(BaseCustomerInvoiceCase):
         super(TestUserLineItem, self).setUp()
         self.user_rate = self.main_subscription.plan_version.feature_rates \
             .filter(feature__feature_type=FeatureType.USER).get()
-        self.invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
+        self.invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start,
                                                    random.randint(2, self.non_main_subscription_length))
 
     def test_under_limit(self):
@@ -431,10 +431,10 @@ class TestSmsLineItem(BaseCustomerInvoiceCase):
         self.sms_rate = self.main_subscription.plan_version.feature_rates.filter(
             feature__feature_type=FeatureType.SMS
         ).get()
-        self.invoice_date = utils.get_first_day_of_months_later(
+        self.invoice_date = utils.get_first_day_x_months_later(
             self.main_subscription.date_start, random.randint(2, self.non_main_subscription_length)
         )
-        self.sms_date = utils.get_first_day_of_months_later(self.invoice_date, -1)
+        self.sms_date = utils.get_first_day_x_months_later(self.invoice_date, -1)
 
     def tearDown(self):
         self._delete_sms_billables()
@@ -590,10 +590,10 @@ class TestQuarterlyInvoicing(BaseCustomerInvoiceCase):
         self.sms_rate = self.main_subscription.plan_version.feature_rates.filter(
             feature__feature_type=FeatureType.SMS
         ).get()
-        self.invoice_date = utils.get_first_day_of_months_later(
+        self.invoice_date = utils.get_first_day_x_months_later(
             self.main_subscription.date_start, random.randint(3, self.non_main_subscription_length)
         )
-        self.sms_date = utils.get_first_day_of_months_later(self.invoice_date, -1)
+        self.sms_date = utils.get_first_day_x_months_later(self.invoice_date, -1)
 
     def initialize_domain_user_history_objects(self):
         record_dates = []
@@ -640,7 +640,7 @@ class TestQuarterlyInvoicing(BaseCustomerInvoiceCase):
     def test_user_over_limit_in_yearly_invoice(self):
         self.account.invoicing_plan = InvoicingPlan.YEARLY
         self.account.save()
-        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start, 14)
+        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start, 14)
         tasks.generate_invoices_based_on_date(invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
 

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -123,7 +123,7 @@ class BaseCustomerInvoiceCase(BaseAccountingTest):
 class TestCustomerInvoice(BaseCustomerInvoiceCase):
 
     def test_multiple_subscription_invoice(self):
-        invoice_date = utils.months_from_date(self.main_subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
                                               random.randint(3, self.non_main_subscription_length))
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)
@@ -151,7 +151,7 @@ class TestCustomerInvoice(BaseCustomerInvoiceCase):
         """
         No invoices should be generated for the months after the end date of the subscriptions.
         """
-        invoice_date = utils.months_from_date(self.main_subscription.date_end, 2)
+        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_end, 2)
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 0)
@@ -160,7 +160,7 @@ class TestCustomerInvoice(BaseCustomerInvoiceCase):
         """
         Test the customer invoice can still be created after one of the domains was deleted
         """
-        invoice_date = utils.months_from_date(self.main_subscription.date_start, 2)
+        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start, 2)
 
         domain_to_be_deleted = generator.arbitrary_domain()
         generator.generate_domain_subscription(
@@ -193,7 +193,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
         self.product_rate = self.main_subscription.plan_version.product_rate
 
     def test_product_line_items(self):
-        invoice_date = utils.months_from_date(self.main_subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
                                               random.randint(2, self.main_subscription_length))
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)
@@ -212,7 +212,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
     def test_product_line_items_in_quarterly_invoice(self):
         self.account.invoicing_plan = InvoicingPlan.QUARTERLY
         self.account.save()
-        invoice_date = utils.months_from_date(self.main_subscription.date_start, 14)
+        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start, 14)
         for months_before_invoice_date in range(3):
             user_date = date(invoice_date.year, invoice_date.month, 1)
             user_date -= relativedelta.relativedelta(months=months_before_invoice_date)
@@ -232,7 +232,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
     def test_product_line_items_in_yearly_invoice(self):
         self.account.invoicing_plan = InvoicingPlan.YEARLY
         self.account.save()
-        invoice_date = utils.months_from_date(self.main_subscription.date_start, 14)
+        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start, 14)
         for months_before_invoice_date in range(12):
             user_date = date(invoice_date.year, invoice_date.month, 1)
             user_date -= relativedelta.relativedelta(months=months_before_invoice_date)
@@ -255,7 +255,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
             account=self.account,
             is_product=True
         )
-        invoice_date = utils.months_from_date(self.main_subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
                                               random.randint(2, self.main_subscription_length))
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)
@@ -270,7 +270,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
             is_product=True,
             subscription=self.main_subscription
         )
-        invoice_date = utils.months_from_date(self.main_subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
                                               random.randint(2, self.main_subscription_length))
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)
@@ -288,7 +288,7 @@ class TestUserLineItem(BaseCustomerInvoiceCase):
         super(TestUserLineItem, self).setUp()
         self.user_rate = self.main_subscription.plan_version.feature_rates \
             .filter(feature__feature_type=FeatureType.USER).get()
-        self.invoice_date = utils.months_from_date(self.main_subscription.date_start,
+        self.invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
                                                    random.randint(2, self.non_main_subscription_length))
 
     def test_under_limit(self):
@@ -431,10 +431,10 @@ class TestSmsLineItem(BaseCustomerInvoiceCase):
         self.sms_rate = self.main_subscription.plan_version.feature_rates.filter(
             feature__feature_type=FeatureType.SMS
         ).get()
-        self.invoice_date = utils.months_from_date(
+        self.invoice_date = utils.get_first_day_of_months_later(
             self.main_subscription.date_start, random.randint(2, self.non_main_subscription_length)
         )
-        self.sms_date = utils.months_from_date(self.invoice_date, -1)
+        self.sms_date = utils.get_first_day_of_months_later(self.invoice_date, -1)
 
     def tearDown(self):
         self._delete_sms_billables()
@@ -590,10 +590,10 @@ class TestQuarterlyInvoicing(BaseCustomerInvoiceCase):
         self.sms_rate = self.main_subscription.plan_version.feature_rates.filter(
             feature__feature_type=FeatureType.SMS
         ).get()
-        self.invoice_date = utils.months_from_date(
+        self.invoice_date = utils.get_first_day_of_months_later(
             self.main_subscription.date_start, random.randint(3, self.non_main_subscription_length)
         )
-        self.sms_date = utils.months_from_date(self.invoice_date, -1)
+        self.sms_date = utils.get_first_day_of_months_later(self.invoice_date, -1)
 
     def initialize_domain_user_history_objects(self):
         record_dates = []
@@ -640,7 +640,7 @@ class TestQuarterlyInvoicing(BaseCustomerInvoiceCase):
     def test_user_over_limit_in_yearly_invoice(self):
         self.account.invoicing_plan = InvoicingPlan.YEARLY
         self.account.save()
-        invoice_date = utils.months_from_date(self.main_subscription.date_start, 14)
+        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start, 14)
         tasks.generate_invoices_based_on_date(invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
 

--- a/corehq/apps/accounting/tests/test_invoice_line_items.py
+++ b/corehq/apps/accounting/tests/test_invoice_line_items.py
@@ -52,7 +52,7 @@ class TestProductLineItem(BaseInvoiceTestCase):
         - quantity is 1
         - subtotal = monthly fee
         """
-        invoice_date = utils.months_from_date(self.subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
         self.create_invoices(invoice_date)
         invoice = self.subscription.invoice_set.latest('date_created')
@@ -83,8 +83,8 @@ class TestProductLineItem(BaseInvoiceTestCase):
         - quantity > 1
         - subtotal = unit_cost * quantity
         """
-        first_invoice_date = utils.months_from_date(self.subscription.date_start, 1)
-        last_invoice_date = utils.months_from_date(self.subscription.date_end, 1)
+        first_invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
+        last_invoice_date = utils.get_first_day_of_months_later(self.subscription.date_end, 1)
         self.create_invoices(first_invoice_date, calculate_users=False)
         self.create_invoices(last_invoice_date, calculate_users=False)
 
@@ -140,7 +140,7 @@ class TestUserLineItem(BaseInvoiceTestCase):
         - unit_description is None
         - total and subtotals are 0.0
         """
-        invoice_date = utils.months_from_date(self.subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
 
         def num_users():
@@ -174,7 +174,7 @@ class TestUserLineItem(BaseInvoiceTestCase):
         - quantity is equal to number of commcare users in that domain minus the monthly_limit on the user rate
         - total and subtotals are equal to number of extra users * per_excess_fee
         """
-        invoice_date = utils.months_from_date(self.subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
 
         def num_users():
@@ -271,7 +271,7 @@ class TestFormSubmittingMobileWorkerLineItem(BaseInvoiceTestCase):
     def setup_invoice(self, num_form_submitting_workers):
         generator.arbitrary_commcare_users_for_domain(self.domain.name, num_form_submitting_workers)
 
-        invoice_date = utils.months_from_date(self.subscription.date_start, 2)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 2)
         record_date = invoice_date - datetime.timedelta(days=1)
         self._create_worker_history(DomainUserHistory, record_date)
         self._create_worker_history(FormSubmittingMobileWorkerHistory,
@@ -345,7 +345,7 @@ class TestWebUserLineItem(BaseInvoiceTestCase):
         - unit_description is None
         - total and subtotals are 0.0
         """
-        invoice_date = utils.months_from_date(self.subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
 
         num_active = random.randint(0, self.web_user_rate.monthly_limit)
@@ -373,7 +373,7 @@ class TestWebUserLineItem(BaseInvoiceTestCase):
         - quantity is equal to number of web users in that account minus the monthly_limit on the web user rate
         - total and subtotals are equal to number of extra users * per_excess_fee
         """
-        invoice_date = utils.months_from_date(self.subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
 
         num_active = random.randint(self.web_user_rate.monthly_limit + 1, self.web_user_rate.monthly_limit + 2)
@@ -402,7 +402,7 @@ class TestWebUserLineItem(BaseInvoiceTestCase):
         self.subscription.account.bill_web_user = False
         self.subscription.account.save()
 
-        invoice_date = utils.months_from_date(self.subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
 
         num_active = random.randint(self.web_user_rate.monthly_limit + 1, self.web_user_rate.monthly_limit + 2)
@@ -419,10 +419,10 @@ class TestSmsLineItem(BaseInvoiceTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestSmsLineItem, cls).setUpClass()
-        cls.invoice_date = utils.months_from_date(
+        cls.invoice_date = utils.get_first_day_of_months_later(
             cls.subscription_start_date, random.randint(2, cls.subscription_length)
         )
-        cls.sms_date = utils.months_from_date(cls.invoice_date, -1)
+        cls.sms_date = utils.get_first_day_of_months_later(cls.invoice_date, -1)
 
     def setUp(self):
         super().setUp()

--- a/corehq/apps/accounting/tests/test_invoice_line_items.py
+++ b/corehq/apps/accounting/tests/test_invoice_line_items.py
@@ -52,7 +52,7 @@ class TestProductLineItem(BaseInvoiceTestCase):
         - quantity is 1
         - subtotal = monthly fee
         """
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
         self.create_invoices(invoice_date)
         invoice = self.subscription.invoice_set.latest('date_created')
@@ -83,8 +83,8 @@ class TestProductLineItem(BaseInvoiceTestCase):
         - quantity > 1
         - subtotal = unit_cost * quantity
         """
-        first_invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
-        last_invoice_date = utils.get_first_day_of_months_later(self.subscription.date_end, 1)
+        first_invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, 1)
+        last_invoice_date = utils.get_first_day_x_months_later(self.subscription.date_end, 1)
         self.create_invoices(first_invoice_date, calculate_users=False)
         self.create_invoices(last_invoice_date, calculate_users=False)
 
@@ -140,7 +140,7 @@ class TestUserLineItem(BaseInvoiceTestCase):
         - unit_description is None
         - total and subtotals are 0.0
         """
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
 
         def num_users():
@@ -174,7 +174,7 @@ class TestUserLineItem(BaseInvoiceTestCase):
         - quantity is equal to number of commcare users in that domain minus the monthly_limit on the user rate
         - total and subtotals are equal to number of extra users * per_excess_fee
         """
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
 
         def num_users():
@@ -271,7 +271,7 @@ class TestFormSubmittingMobileWorkerLineItem(BaseInvoiceTestCase):
     def setup_invoice(self, num_form_submitting_workers):
         generator.arbitrary_commcare_users_for_domain(self.domain.name, num_form_submitting_workers)
 
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 2)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, 2)
         record_date = invoice_date - datetime.timedelta(days=1)
         self._create_worker_history(DomainUserHistory, record_date)
         self._create_worker_history(FormSubmittingMobileWorkerHistory,
@@ -345,7 +345,7 @@ class TestWebUserLineItem(BaseInvoiceTestCase):
         - unit_description is None
         - total and subtotals are 0.0
         """
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
 
         num_active = random.randint(0, self.web_user_rate.monthly_limit)
@@ -373,7 +373,7 @@ class TestWebUserLineItem(BaseInvoiceTestCase):
         - quantity is equal to number of web users in that account minus the monthly_limit on the web user rate
         - total and subtotals are equal to number of extra users * per_excess_fee
         """
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
 
         num_active = random.randint(self.web_user_rate.monthly_limit + 1, self.web_user_rate.monthly_limit + 2)
@@ -402,7 +402,7 @@ class TestWebUserLineItem(BaseInvoiceTestCase):
         self.subscription.account.bill_web_user = False
         self.subscription.account.save()
 
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
 
         num_active = random.randint(self.web_user_rate.monthly_limit + 1, self.web_user_rate.monthly_limit + 2)
@@ -419,10 +419,10 @@ class TestSmsLineItem(BaseInvoiceTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestSmsLineItem, cls).setUpClass()
-        cls.invoice_date = utils.get_first_day_of_months_later(
+        cls.invoice_date = utils.get_first_day_x_months_later(
             cls.subscription_start_date, random.randint(2, cls.subscription_length)
         )
-        cls.sms_date = utils.get_first_day_of_months_later(cls.invoice_date, -1)
+        cls.sms_date = utils.get_first_day_x_months_later(cls.invoice_date, -1)
 
     def setUp(self):
         super().setUp()

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -65,7 +65,7 @@ class TestInvoice(BaseInvoiceTestCase):
         self.assertEqual(self.subscription.invoice_set.count(), 0)
 
     def test_subscription_invoice(self):
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
         self.create_invoices(invoice_date)
         self.assertEqual(self.subscription.invoice_set.count(), 1)
@@ -85,7 +85,7 @@ class TestInvoice(BaseInvoiceTestCase):
         """
         No invoices should be generated for the months after the end date of the subscription.
         """
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_end, 2)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_end, 2)
         self.create_invoices(invoice_date, calculate_users=False)
         self.assertEqual(self.subscription.invoice_set.count(), 0)
 
@@ -147,7 +147,7 @@ class TestInvoice(BaseInvoiceTestCase):
         """Date Due doesn't get set if the invoice is very small"""
         self.subscription.plan_version = generator.custom_plan_version(monthly_fee=1.00)
         self.subscription.save()
-        invoice_date_small = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
+        invoice_date_small = utils.get_first_day_x_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date_small)
         small_invoice = self.subscription.invoice_set.first()
 
@@ -158,7 +158,7 @@ class TestInvoice(BaseInvoiceTestCase):
         """Date Due only gets set for a 'large' invoice (> $1)"""
         self.subscription.plan_version = generator.subscribable_plan_version(SoftwarePlanEdition.ADVANCED)
         self.subscription.save()
-        invoice_date_large = utils.get_first_day_of_months_later(self.subscription.date_start, 3)
+        invoice_date_large = utils.get_first_day_x_months_later(self.subscription.date_start, 3)
         self.create_invoices(invoice_date_large)
         large_invoice = self.subscription.invoice_set.first()
 
@@ -170,7 +170,7 @@ class TestInvoice(BaseInvoiceTestCase):
         self.subscription.plan_version = generator.custom_plan_version(monthly_fee=1.00)
         self.subscription.save()
         self.subscription.account.update_autopay_user(self.billing_contact, self.domain)
-        invoice_date_autopay = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
+        invoice_date_autopay = utils.get_first_day_x_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date_autopay)
 
         autopay_invoice = self.subscription.invoice_set.first()
@@ -185,7 +185,7 @@ class TestContractedInvoices(BaseInvoiceTestCase):
         self.subscription.service_type = SubscriptionType.IMPLEMENTATION
         self.subscription.save()
 
-        self.invoice_date = utils.get_first_day_of_months_later(
+        self.invoice_date = utils.get_first_day_x_months_later(
             self.subscription.date_start,
             random.randint(2, self.subscription_length)
         )
@@ -221,7 +221,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
     def test_implementation_subscription_with_dimagi_contact(self):
         self._setup_implementation_subscription_with_dimagi_contact()
 
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 1)
@@ -232,7 +232,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
     def test_implementation_subscription_without_dimagi_contact(self):
         self._setup_implementation_subscription_without_dimagi_contact()
 
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 1)
@@ -243,7 +243,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
     def test_product_subscription(self):
         self._setup_product_subscription()
 
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 2)
@@ -267,7 +267,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
     def test_unspecified_recipients_product(self):
         self._setup_product_subscription_with_admin_user()
 
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 1)
@@ -315,7 +315,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
             datetime.date(self.subscription.date_start.year, self.subscription.date_start.month + 1, 1))
         DomainInvoiceFactory(
             self.subscription.date_start,
-            utils.get_first_day_of_months_later(self.subscription.date_start, 1) - datetime.timedelta(days=1),
+            utils.get_first_day_x_months_later(self.subscription.date_start, 1) - datetime.timedelta(days=1),
             self.subscription.subscriber.domain,
             recipients=['recipient1@test.com', 'recipient2@test.com']
         ).create_invoices()
@@ -447,7 +447,7 @@ class TestFlaggedPayAnnuallyPrepayInvoice(BaseInvoiceTestCase):
         self.subscription.save()
 
     def create_invoices(self):
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, 1)
         super().create_invoices(invoice_date)
         return self.subscription.invoice_set.all()
 

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -65,7 +65,7 @@ class TestInvoice(BaseInvoiceTestCase):
         self.assertEqual(self.subscription.invoice_set.count(), 0)
 
     def test_subscription_invoice(self):
-        invoice_date = utils.months_from_date(self.subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
         self.create_invoices(invoice_date)
         self.assertEqual(self.subscription.invoice_set.count(), 1)
@@ -85,7 +85,7 @@ class TestInvoice(BaseInvoiceTestCase):
         """
         No invoices should be generated for the months after the end date of the subscription.
         """
-        invoice_date = utils.months_from_date(self.subscription.date_end, 2)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_end, 2)
         self.create_invoices(invoice_date, calculate_users=False)
         self.assertEqual(self.subscription.invoice_set.count(), 0)
 
@@ -147,7 +147,7 @@ class TestInvoice(BaseInvoiceTestCase):
         """Date Due doesn't get set if the invoice is very small"""
         self.subscription.plan_version = generator.custom_plan_version(monthly_fee=1.00)
         self.subscription.save()
-        invoice_date_small = utils.months_from_date(self.subscription.date_start, 1)
+        invoice_date_small = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date_small)
         small_invoice = self.subscription.invoice_set.first()
 
@@ -158,7 +158,7 @@ class TestInvoice(BaseInvoiceTestCase):
         """Date Due only gets set for a 'large' invoice (> $1)"""
         self.subscription.plan_version = generator.subscribable_plan_version(SoftwarePlanEdition.ADVANCED)
         self.subscription.save()
-        invoice_date_large = utils.months_from_date(self.subscription.date_start, 3)
+        invoice_date_large = utils.get_first_day_of_months_later(self.subscription.date_start, 3)
         self.create_invoices(invoice_date_large)
         large_invoice = self.subscription.invoice_set.first()
 
@@ -170,7 +170,7 @@ class TestInvoice(BaseInvoiceTestCase):
         self.subscription.plan_version = generator.custom_plan_version(monthly_fee=1.00)
         self.subscription.save()
         self.subscription.account.update_autopay_user(self.billing_contact, self.domain)
-        invoice_date_autopay = utils.months_from_date(self.subscription.date_start, 1)
+        invoice_date_autopay = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date_autopay)
 
         autopay_invoice = self.subscription.invoice_set.first()
@@ -185,7 +185,7 @@ class TestContractedInvoices(BaseInvoiceTestCase):
         self.subscription.service_type = SubscriptionType.IMPLEMENTATION
         self.subscription.save()
 
-        self.invoice_date = utils.months_from_date(
+        self.invoice_date = utils.get_first_day_of_months_later(
             self.subscription.date_start,
             random.randint(2, self.subscription_length)
         )
@@ -221,7 +221,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
     def test_implementation_subscription_with_dimagi_contact(self):
         self._setup_implementation_subscription_with_dimagi_contact()
 
-        invoice_date = utils.months_from_date(self.subscription.date_start, 1)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 1)
@@ -232,7 +232,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
     def test_implementation_subscription_without_dimagi_contact(self):
         self._setup_implementation_subscription_without_dimagi_contact()
 
-        invoice_date = utils.months_from_date(self.subscription.date_start, 1)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 1)
@@ -243,7 +243,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
     def test_product_subscription(self):
         self._setup_product_subscription()
 
-        invoice_date = utils.months_from_date(self.subscription.date_start, 1)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 2)
@@ -267,7 +267,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
     def test_unspecified_recipients_product(self):
         self._setup_product_subscription_with_admin_user()
 
-        invoice_date = utils.months_from_date(self.subscription.date_start, 1)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
         self.create_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 1)
@@ -315,7 +315,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
             datetime.date(self.subscription.date_start.year, self.subscription.date_start.month + 1, 1))
         DomainInvoiceFactory(
             self.subscription.date_start,
-            utils.months_from_date(self.subscription.date_start, 1) - datetime.timedelta(days=1),
+            utils.get_first_day_of_months_later(self.subscription.date_start, 1) - datetime.timedelta(days=1),
             self.subscription.subscriber.domain,
             recipients=['recipient1@test.com', 'recipient2@test.com']
         ).create_invoices()
@@ -447,7 +447,7 @@ class TestFlaggedPayAnnuallyPrepayInvoice(BaseInvoiceTestCase):
         self.subscription.save()
 
     def create_invoices(self):
-        invoice_date = utils.months_from_date(self.subscription.date_start, 1)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 1)
         super().create_invoices(invoice_date)
         return self.subscription.invoice_set.all()
 

--- a/corehq/apps/accounting/tests/test_race_condition_is_prevented.py
+++ b/corehq/apps/accounting/tests/test_race_condition_is_prevented.py
@@ -13,7 +13,7 @@ from corehq.util.dates import get_previous_month_date_range
 class UniqueConstraintInvoiceTest(BaseInvoiceTestCase):
 
     def test_unique_constraint_prevents_duplicate_invoice(self):
-        invoice_date = utils.months_from_date(self.subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
         invoice_start, invoice_end = get_previous_month_date_range(invoice_date)
 
@@ -38,7 +38,7 @@ class UniqueConstraintInvoiceTest(BaseInvoiceTestCase):
 
 class UniqueConstraintCustomerInvoiceTest(BaseCustomerInvoiceCase):
     def test_unique_constraint_prevents_duplicate_customer_invoice(self):
-        invoice_date = utils.months_from_date(self.main_subscription.date_start,
+        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
                                               random.randint(3, self.main_subscription_length))
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)

--- a/corehq/apps/accounting/tests/test_race_condition_is_prevented.py
+++ b/corehq/apps/accounting/tests/test_race_condition_is_prevented.py
@@ -13,7 +13,7 @@ from corehq.util.dates import get_previous_month_date_range
 class UniqueConstraintInvoiceTest(BaseInvoiceTestCase):
 
     def test_unique_constraint_prevents_duplicate_invoice(self):
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
         invoice_start, invoice_end = get_previous_month_date_range(invoice_date)
 
@@ -38,7 +38,7 @@ class UniqueConstraintInvoiceTest(BaseInvoiceTestCase):
 
 class UniqueConstraintCustomerInvoiceTest(BaseCustomerInvoiceCase):
     def test_unique_constraint_prevents_duplicate_customer_invoice(self):
-        invoice_date = utils.get_first_day_of_months_later(self.main_subscription.date_start,
+        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start,
                                               random.randint(3, self.main_subscription_length))
         calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices_based_on_date(invoice_date)

--- a/corehq/apps/accounting/tests/test_unpaid_invoice.py
+++ b/corehq/apps/accounting/tests/test_unpaid_invoice.py
@@ -41,7 +41,7 @@ def _generate_invoice_and_subscription(days_ago, is_customer_billing_account=Fal
     account.save()
 
     domain = generator.arbitrary_domain()
-    subscription_start_date = utils.months_from_date(invoice_due_date, -2)
+    subscription_start_date = utils.get_first_day_of_months_later(invoice_due_date, -2)
 
     subscription = generator.generate_domain_subscription(
         account,
@@ -56,7 +56,7 @@ def _generate_invoice_and_subscription(days_ago, is_customer_billing_account=Fal
     subscription.is_active = True
     subscription.save()
 
-    invoice_date = utils.months_from_date(invoice_due_date, -1)
+    invoice_date = utils.get_first_day_of_months_later(invoice_due_date, -1)
     DomainUserHistory.objects.create(
         domain=domain.name,
         num_users=20,

--- a/corehq/apps/accounting/tests/test_unpaid_invoice.py
+++ b/corehq/apps/accounting/tests/test_unpaid_invoice.py
@@ -41,7 +41,7 @@ def _generate_invoice_and_subscription(days_ago, is_customer_billing_account=Fal
     account.save()
 
     domain = generator.arbitrary_domain()
-    subscription_start_date = utils.get_first_day_of_months_later(invoice_due_date, -2)
+    subscription_start_date = utils.get_first_day_x_months_later(invoice_due_date, -2)
 
     subscription = generator.generate_domain_subscription(
         account,
@@ -56,7 +56,7 @@ def _generate_invoice_and_subscription(days_ago, is_customer_billing_account=Fal
     subscription.is_active = True
     subscription.save()
 
-    invoice_date = utils.get_first_day_of_months_later(invoice_due_date, -1)
+    invoice_date = utils.get_first_day_x_months_later(invoice_due_date, -1)
     DomainUserHistory.objects.create(
         domain=domain.name,
         num_users=20,

--- a/corehq/apps/accounting/tests/test_wire_invoice.py
+++ b/corehq/apps/accounting/tests/test_wire_invoice.py
@@ -12,10 +12,10 @@ class TestWireInvoice(BaseInvoiceTestCase):
 
     def setUp(self):
         super(TestWireInvoice, self).setUp()
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 2)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, 2)
         self.create_invoices(invoice_date)
 
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 3)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, 3)
         self.create_invoices(invoice_date)
 
         self.invoices = Invoice.objects.all()
@@ -42,10 +42,10 @@ class TestCustomerAccountWireInvoice(BaseInvoiceTestCase):
         self.account.is_customer_billing_account = True
         self.account.save()
 
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 2)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, 2)
         self.create_invoices(invoice_date)
 
-        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 3)
+        invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, 3)
         self.create_invoices(invoice_date)
 
     def test_factory(self):

--- a/corehq/apps/accounting/tests/test_wire_invoice.py
+++ b/corehq/apps/accounting/tests/test_wire_invoice.py
@@ -12,10 +12,10 @@ class TestWireInvoice(BaseInvoiceTestCase):
 
     def setUp(self):
         super(TestWireInvoice, self).setUp()
-        invoice_date = utils.months_from_date(self.subscription.date_start, 2)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 2)
         self.create_invoices(invoice_date)
 
-        invoice_date = utils.months_from_date(self.subscription.date_start, 3)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 3)
         self.create_invoices(invoice_date)
 
         self.invoices = Invoice.objects.all()
@@ -42,10 +42,10 @@ class TestCustomerAccountWireInvoice(BaseInvoiceTestCase):
         self.account.is_customer_billing_account = True
         self.account.save()
 
-        invoice_date = utils.months_from_date(self.subscription.date_start, 2)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 2)
         self.create_invoices(invoice_date)
 
-        invoice_date = utils.months_from_date(self.subscription.date_start, 3)
+        invoice_date = utils.get_first_day_of_months_later(self.subscription.date_start, 3)
         self.create_invoices(invoice_date)
 
     def test_factory(self):

--- a/corehq/apps/accounting/utils/__init__.py
+++ b/corehq/apps/accounting/utils/__init__.py
@@ -34,7 +34,7 @@ def log_accounting_info(message):
     logger.info("[BILLING] %s" % message)
 
 
-def get_first_day_of_months_later(reference_date, months_from_date):
+def get_first_day_x_months_later(reference_date, months_from_date):
     year, month = add_months(reference_date.year, reference_date.month, months_from_date)
     return datetime.date(year, month, 1)
 

--- a/corehq/apps/accounting/utils/__init__.py
+++ b/corehq/apps/accounting/utils/__init__.py
@@ -34,7 +34,7 @@ def log_accounting_info(message):
     logger.info("[BILLING] %s" % message)
 
 
-def months_from_date(reference_date, months_from_date):
+def get_first_day_of_months_later(reference_date, months_from_date):
     year, month = add_months(reference_date.year, reference_date.month, months_from_date)
     return datetime.date(year, month, 1)
 

--- a/corehq/apps/prototype/utils/fake_data.py
+++ b/corehq/apps/prototype/utils/fake_data.py
@@ -1,6 +1,6 @@
 import datetime
 import random
-from corehq.apps.accounting.utils import months_from_date
+from corehq.apps.accounting.utils import get_first_day_of_months_later
 
 
 def get_first_name():
@@ -51,4 +51,4 @@ def get_status():
 def get_past_date(months_away=None):
     months_away = months_away or [6, 12, 24, 48]
     today = datetime.datetime.today()
-    return months_from_date(today, -1 * random.choice(months_away)).strftime("%Y-%m-%d")
+    return get_first_day_of_months_later(today, -1 * random.choice(months_away)).strftime("%Y-%m-%d")

--- a/corehq/apps/prototype/utils/fake_data.py
+++ b/corehq/apps/prototype/utils/fake_data.py
@@ -1,6 +1,6 @@
 import datetime
 import random
-from corehq.apps.accounting.utils import get_first_day_of_months_later
+from corehq.apps.accounting.utils import get_first_day_x_months_later
 
 
 def get_first_name():
@@ -51,4 +51,4 @@ def get_status():
 def get_past_date(months_away=None):
     months_away = months_away or [6, 12, 24, 48]
     today = datetime.datetime.today()
-    return get_first_day_of_months_later(today, -1 * random.choice(months_away)).strftime("%Y-%m-%d")
+    return get_first_day_x_months_later(today, -1 * random.choice(months_away)).strftime("%Y-%m-%d")


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17805

Review by commit 🐠 

Do not be afraid of the number of commits here, a lot of them are just refactoring commits and are easy to review.
The number of files changed looks intimidating is because I renamed a util function!

The issue is, the domain has subscription A, in the middle of the month, it is changed to subscription B. All credits for subscription A is also transferred to subscription B. At the end of the month, when generating invoices, all costs incurred from subscription B will be covered by those credits, but since those credits are tied to subscription B, subscription A will remain unpaid, which can lead to domain being paused when overdue.

We already have logic implemented in https://github.com/dimagi/commcare-hq/pull/26831 to make sure `ANY` type credit will cover terminated subscriptions in the same month. But we didn't have logic to make sure other type of credits will. So this PR is to make sure that the same logic will be applied to other type of credits.

Some context to review this PR:
What consists of the total of an invoice:
- Plan fee
- Feature fee ( User, SMS, ... )
Both plan fee and feature fee is considered as line items.

Types of Credit:
- ANY ( Can be used to pay any fee left remained in the total)
- Product ( Can only be used to pay Plan fee)
- Feature ( Can only be used to pay Feature fee)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Added new tests in `corehq/apps/accounting/tests/test_credit_lines.py`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
