### PR TITLE
Es/toggles UI

### DIFF
--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -108,18 +108,8 @@ function toggleItem(namespace, value, last_used, service_type) {
     self.last_used = ko.observable(last_used);
     self.service_type = ko.observable(service_type);
 
-
-    self.namespaceHtml = ko.computed(function () {
-        value = self.value();
-        if (value && value[0] === '!') {
-            value = value.replace(/^!/, '');
-        }
-        if (self.namespace() === 'domain') {
-            const url = initialPageData.reverse('domain_internal_settings', value);
-            return '<a href="' + url + '">domain <i class="fa fa-external-link"></i></a>';
-        } else {
-            return "<i class='fa fa-user'></i> " + self.namespace();
-        }
+    self.domainUrl = ko.computed(() => {
+        return initialPageData.reverse('domain_internal_settings', self.value());
     });
 
     return self;

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -110,7 +110,18 @@ function toggleItem(namespace, value, last_used, service_type) {
 
     self.dimagiUsers = ko.observableArray();
     self.showDimagiUsers = () => {
-        self.dimagiUsers.push('esoergel@dimagi.com');
+        if (_.isEmpty(self.dimagiUsers())) {
+            $.ajax({
+                url: initialPageData.reverse('get_dimagi_users', self.value()),
+            }).done((res) => {
+                let emails = _.isEmpty(res.emails) ? ['<None>'] : res.emails;
+                _.each(emails, (email) => {
+                    self.dimagiUsers.push(email);
+                });
+            });
+        } else {
+            self.dimagiUsers.removeAll();
+        }
     };
 
     self.domainUrl = ko.computed(() => {

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -108,11 +108,18 @@ function toggleItem(namespace, value, last_used, service_type) {
     self.last_used = ko.observable(last_used);
     self.service_type = ko.observable(service_type);
 
+    self.domainName = ko.computed(() => {
+        const val = self.value();
+        if (self.namespace() === 'domain' && val) {
+            return val.startsWith('!') ? val.slice(1) : val;
+        }
+    });
+
     self.dimagiUsers = ko.observableArray();
     self.showDimagiUsers = () => {
         if (_.isEmpty(self.dimagiUsers())) {
             $.ajax({
-                url: initialPageData.reverse('get_dimagi_users', self.value()),
+                url: initialPageData.reverse('get_dimagi_users', self.domainName()),
             }).done((res) => {
                 let emails = _.isEmpty(res.emails) ? ['<None>'] : res.emails;
                 _.each(emails, (email) => {
@@ -125,7 +132,7 @@ function toggleItem(namespace, value, last_used, service_type) {
     };
 
     self.domainUrl = ko.computed(() => {
-        return initialPageData.reverse('domain_internal_settings', self.value());
+        return initialPageData.reverse('domain_internal_settings', self.domainName());
     });
 
     return self;

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -8,6 +8,7 @@ import "hqwebapp/js/bootstrap3/knockout_bindings.ko";  // save button
 
 var PAD_CHAR = '&nbsp;';
 function toggleViewModel() {
+    // Represents the entire page
     var self = {};
     self.items = ko.observableArray();
     self.randomness = ko.observable();
@@ -32,12 +33,12 @@ function toggleViewModel() {
                 var fields = item.split(':'),
                     namespace = fields.length > 1 ? fields[0] : 'user',
                     value = fields.length > 1 ? fields[1] : fields[0];
-                return {
-                    namespace: ko.observable(self.padded_ns[namespace]),
-                    value: ko.observable(value),
-                    last_used: ko.observable(lastUsed[value]),
-                    service_type: ko.observable(serviceType[value]),
-                };
+                return toggleItem(
+                    self.padded_ns[namespace],
+                    value,
+                    lastUsed[value],
+                    serviceType[value],
+                );
             });
         self.items(_.sortBy(items, function (item) {
             return [item.last_used(), item.value()];
@@ -45,12 +46,7 @@ function toggleViewModel() {
     };
 
     self.addItem = function (namespace) {
-        self.items.push({
-            namespace: ko.observable(self.padded_ns[namespace]),
-            value: ko.observable(),
-            last_used: ko.observable(),
-            service_type: ko.observable(),
-        });
+        self.items.push(toggleItem(self.padded_ns[namespace]));
         self.change();
     };
 
@@ -99,16 +95,32 @@ function toggleViewModel() {
     self.saveButtonTop = self.createSaveButton();
     self.saveButtonBottom = self.createSaveButton();
 
-    self.getNamespaceHtml = function (namespace, value) {
+    return self;
+}
+
+
+// eslint-disable-next-line camelcase
+function toggleItem(namespace, value, last_used, service_type) {
+    // Represents an individual item; a domain or user
+    var self = {};
+    self.namespace = ko.observable(namespace);
+    self.value = ko.observable(value);
+    self.last_used = ko.observable(last_used);
+    self.service_type = ko.observable(service_type);
+
+
+    self.namespaceHtml = ko.computed(function () {
+        value = self.value();
         if (value && value[0] === '!') {
             value = value.replace(/^!/, '');
         }
-        if (namespace === 'domain') {
-            return '<a href="' + initialPageData.reverse('domain_internal_settings', value) + '">domain <i class="fa fa-external-link"></i></a>';
+        if (self.namespace() === 'domain') {
+            const url = initialPageData.reverse('domain_internal_settings', value);
+            return '<a href="' + url + '">domain <i class="fa fa-external-link"></i></a>';
         } else {
-            return "<i class='fa fa-user'></i> " + namespace;
+            return "<i class='fa fa-user'></i> " + self.namespace();
         }
-    };
+    });
 
     return self;
 }

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -108,6 +108,11 @@ function toggleItem(namespace, value, last_used, service_type) {
     self.last_used = ko.observable(last_used);
     self.service_type = ko.observable(service_type);
 
+    self.dimagiUsers = ko.observableArray();
+    self.showDimagiUsers = () => {
+        self.dimagiUsers.push('esoergel@dimagi.com');
+    };
+
     self.domainUrl = ko.computed(() => {
         return initialPageData.reverse('domain_internal_settings', self.value());
     });

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -240,7 +240,7 @@
             <td
               class="col-sm-2"
               style="border: 0; vertical-align: middle"
-              data-bind="html: $parent.getNamespaceHtml(namespace(), value())"
+              data-bind="html: namespaceHtml"
             ></td>
             <td
               class="col-sm-2"

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -240,8 +240,18 @@
             <td
               class="col-sm-2"
               style="border: 0; vertical-align: middle"
-              data-bind="html: namespaceHtml"
-            ></td>
+            >
+              <a style="display: none" data-bind="
+                visible: namespace() === 'domain',
+                attr: { href: domainUrl }
+              ">
+                domain <i class="fa fa-external-link"></i>
+              </a>
+              <span style="display: none"
+                data-bind="visible: namespace() != 'domain'">
+                <i class='fa fa-user'></i> user
+              </span>
+            </td>
             <td
               class="col-sm-2"
               style="border: 0; vertical-align: middle"

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -7,16 +7,23 @@
 {% block title %}{% trans "Edit Feature Flag: " %}{{ static_toggle.label }}{% endblock %}
 
 {% block stylesheets %}
-  <style>
-    .margin-vertical-sm {
-      margin-top: 5px;
-      margin-bottom: 5px;
-    }
+<style>
+  .margin-vertical-sm {
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
 
-    .label-release {
-      background-color: #c22eff !important;
-    }
-  </style>
+  .label-release {
+    background-color: #c22eff !important;
+  }
+
+  /* B5: replace with table-borderless and align-middle */
+  #feature-flag-items tbody td {
+    border: 0;
+    vertical-align: middle;
+  }
+</style>
+
 {% endblock %}
 
 {% block page_content %}
@@ -196,7 +203,7 @@
           </p>
         </div>
       {% endif %}
-      <table class="table table-condensed"><!-- B5: add table-borderless and remove `border: none` inline styles on table cells -->
+      <table class="table table-condensed" id="feature-flag-items">
         <thead>
           <tr>
             <th>
@@ -213,7 +220,7 @@
         </thead>
         <tbody data-bind="foreach: items">
           <tr>
-            <td class="col-sm-4" style="border: 0">
+            <td class="col-sm-4">
               <div class="input-group">
                 <span class="input-group-btn">
                   {% if can_edit_toggle %}
@@ -236,11 +243,7 @@
                 </span>
               </div>
             </td>
-            <!-- B5: replace inline styles with vertical alignment class: https://getbootstrap.com/docs/5.3/utilities/vertical-align/#css -->
-            <td
-              class="col-sm-2"
-              style="border: 0; vertical-align: middle"
-            >
+            <td class="col-sm-2">
               <a style="display: none" data-bind="
                 visible: namespace() === 'domain',
                 attr: { href: domainUrl }
@@ -254,12 +257,10 @@
             </td>
             <td
               class="col-sm-2"
-              style="border: 0; vertical-align: middle"
               data-bind="text: last_used"
             ></td>
             <td
               class="col-sm-4"
-              style="border: 0; vertical-align: middle"
               data-bind="text: service_type"
             ></td>
           </tr>

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -29,6 +29,7 @@
 {% block page_content %}
   {% registerurl 'edit_toggle' toggle.slug %}
   {% registerurl 'domain_internal_settings' '---' %}
+  {% registerurl 'get_dimagi_users' '---' %}
   {% initial_page_data 'items' toggle.enabled_users %}
   {% initial_page_data 'namespaces' namespaces %}
   {% initial_page_data 'last_used' last_used %}

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -214,6 +214,7 @@
               {% endif %}
             </th>
             <th>Namespace</th>
+            <th>Dimagi Users</th>
             <th>Latest Form Submission</th>
             <th>Subscription Plan</th>
           </tr>
@@ -243,7 +244,7 @@
                 </span>
               </div>
             </td>
-            <td class="col-sm-2">
+            <td class="col-sm-1">
               <a style="display: none" data-bind="
                 visible: namespace() === 'domain',
                 attr: { href: domainUrl }
@@ -256,12 +257,30 @@
               </span>
             </td>
             <td
+              class="col-sm-1"
+            >
+              <button
+                class="btn btn-secondary"
+                data-bind="
+                  visible: namespace() === 'domain',
+                  click: showDimagiUsers
+              ">
+                Dimagi Users
+              </button>
+            </td>
+            <td
               class="col-sm-2"
               data-bind="text: last_used"
             ></td>
             <td
               class="col-sm-4"
               data-bind="text: service_type"
+            ></td>
+          </tr>
+          <tr data-bind="if: !!dimagiUsers().length">
+            <td
+              colspan="5"
+              data-bind="text: dimagiUsers().join(', ')"
             ></td>
           </tr>
         </tbody>

--- a/corehq/apps/toggle_ui/urls.py
+++ b/corehq/apps/toggle_ui/urls.py
@@ -1,15 +1,18 @@
 from django.urls import re_path as url
 
+from corehq.apps.domain.utils import legacy_domain_re
 from corehq.apps.toggle_ui.views import (
     ToggleEditView,
     ToggleListView,
-    set_toggle,
     export_toggles,
+    get_dimagi_users,
+    set_toggle,
 )
 
 urlpatterns = [
     url(r'^$', ToggleListView.as_view(), name=ToggleListView.urlname),
     url(r'^export_toggles/$', export_toggles, name='export_toggles'),
+    url(r'^get_dimagi_users/(?P<domain>%s)/$' % legacy_domain_re, get_dimagi_users, name='get_dimagi_users'),
     url(r'^edit/(?P<toggle>[\w_-]+)/$', ToggleEditView.as_view(), name=ToggleEditView.urlname),
     url(r'^set_toggle/(?P<toggle_slug>[\w_-]+)/$', set_toggle, name='set_toggle'),
 ]

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -23,7 +23,7 @@ from corehq.apps.toggle_ui.utils import (
     find_static_toggle,
     get_subscription_info,
 )
-from corehq.apps.users.models import CouchUser
+from corehq.apps.users.models import CouchUser, WebUser
 from corehq.toggles import (
     ALL_NAMESPACES,
     ALL_TAG_GROUPS,
@@ -420,4 +420,11 @@ def export_toggles(request):
     return JsonResponse({
         "download_url": reverse("ajax_job_poll", kwargs={"download_id": download.download_id}),
         "download_id": download.download_id,
+    })
+
+
+@require_superuser_or_contractor
+def get_dimagi_users(request, domain):
+    return JsonResponse({
+        'emails': list(WebUser.get_dimagi_emails_by_domain(domain)),
     })


### PR DESCRIPTION
## Product Description

Add button to FF page to show the Dimagi users at the domain:
<img width="2156" height="694" alt="image" src="https://github.com/user-attachments/assets/713956af-d277-41f2-a497-6676b99e7d58" />

## Technical Summary
https://dimagi.atlassian.net/browse/USH-6139

I implemented this as a per-row action since the underlying logic is just awful.  It iterates over every user in the domain and checks their email address.

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
