### PR TITLE
Fix image upload question

### DIFF
--- a/corehq/ex-submodules/couchforms/const.py
+++ b/corehq/ex-submodules/couchforms/const.py
@@ -23,6 +23,7 @@ DEVICE_LOG_XMLNS = 'http://code.javarosa.org/devicereport'
 # Should be in sync with file extensions supported by CommCare
 # https://github.com/dimagi/commcare-android/blob/ef45074bbb8647339387e179a2baca89fb394a23/app/src/org/commcare/utils/FormUploadUtil.java#LL63C1-L63C1
 VALID_ATTACHMENT_FILE_EXTENSION_MAP = {
+    "image/*": ["jpg", "jpeg", "png"],
     "image/*,.pdf": ["jpg", "jpeg", "png", "pdf"],
     "audio/*": ["3ga", "mp3", "wav", "amr", "qcp", "ogg"],
     "video/*": ["3gpp", "3gp", "3gp2", "3g2", "mp4", "mpg4", "mpeg4", "m4v", "mpg", "mpeg"],


### PR DESCRIPTION
## Product Description

Fix a bug with the image upload question type in web apps
<img width="1915" height="799" alt="image" src="https://github.com/user-attachments/assets/42c6e022-5561-4085-9625-6bb02bbebd43" />

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18357
Introduced in https://github.com/dimagi/commcare-hq/pull/36846 Confusingly, that `accepts` val is meant to parallel this python constant - it's not actually a comma-separated list of types

This is the line that was failing after the change above, I believe: https://github.com/dimagi/commcare-hq/blob/410c191e781a4ddce4c04fe1eb1374661c727893/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js#L998-L998.  `extensionsMap` comes directly from `VALID_ATTACHMENT_FILE_EXTENSION_MAP`, so it makes sense that this would trigger the error

## Feature Flag


## Safety Assurance


### Safety story
Local testing

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change