### PR TITLE
Translate 'step x of y' correctly

### DIFF
--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -113,7 +113,9 @@ class FormStepNumber(LayoutObject):
     template = 'hqwebapp/crispy/form_step_number.html'
 
     def __init__(self, step_num, total_steps):
-        self.step_label = gettext("Step {} of {}".format(step_num, total_steps))
+        self.step_label = gettext(
+            "Step {step_num} of {total_steps}"
+        ).format(step_num=step_num, total_steps=total_steps)
 
     def render(self, form, context, template_pack=None, **kwargs):
         context.update({


### PR DESCRIPTION
## Product Description
Allows "Step 1 of 2" etc. to be translated correctly, as in the signup form:
<img width="488" height="379" alt="image" src="https://github.com/user-attachments/assets/be4d81b9-1980-479c-9175-d0734be02d9d" />


## Technical Summary
Just a fix to gettext/string formatting ordering.

## Safety Assurance

### Safety story
Small bugfix to display text, nothing risky here. Confirmed OK locally.

### Automated test coverage
Unlikely.

### QA Plan
No.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
