### PR TITLE
Upgrade django-tastypie v0.14.6 -> v0.15.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1178,13 +1178,13 @@ wheels = [
 
 [[package]]
 name = "django-tastypie"
-version = "0.14.6"
+version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
     { name = "python-mimeparse" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/92/33d0b11bc6d8b5bf8675fd9f73492788c363007c61864186a425ff136041/django-tastypie-0.14.6.tar.gz", hash = "sha256:7f16928ffa5b1b390edd81fa0c15a239cca7fc1134d440ecaa2040b5edc549b8", size = 154751, upload-time = "2023-09-02T17:41:30.142Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/96/2e27e872d34f360ac6d02077b0027f4851b6cf049b36ee3add68e1740c27/django_tastypie-0.15.1.tar.gz", hash = "sha256:1eb41318b08c0ebc9b8a386871b45401a623e6a5566bf32ae3e17be2c59318b7", size = 156617, upload-time = "2025-02-23T19:19:45.489Z" }
 
 [[package]]
 name = "django-transfer"


### PR DESCRIPTION
For compatibility with Django 5: django.utils.datetime_safe is removed. The compatibility fix in tastypie is strange because it monkey patches Django rather than adjusting and removing the deprecated usage. Also, it still accesses the deprecated code path on django<5, so the warning exception cannot be removed until after django is upgraded.

See https://github.com/django-tastypie/django-tastypie/blob/03c4746f0a0f88628be5264bc8d4a19a0529b2f4/tastypie/compat.py#L24

## Safety Assurance

### Safety story

Reviewed release notes: [0.14.7](https://github.com/django-tastypie/django-tastypie/blob/master/docs/release_notes/v0.14.7.rst), [0.15.0](https://github.com/django-tastypie/django-tastypie/blob/master/docs/release_notes/v0.15.0.rst), [0.15.1](https://github.com/django-tastypie/django-tastypie/blob/master/docs/release_notes/v0.15.1.rst). No backward incompatibilities listed.

### Automated test coverage

Some.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations