### PR TITLE
feat: support sending password reset passwords via commcare user API

### DIFF
--- a/docs/api/mobile-worker.rst
+++ b/docs/api/mobile-worker.rst
@@ -278,3 +278,36 @@ Endpoint Specifications
 
 **Authentication**
     For more information, please review  `API Authentication <https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2279637003/CommCare+API+Overview#API-Authentication>`_.
+
+Send Password Reset Email (Mobile Worker)
+=========================================
+
+Overview
+--------
+
+**Purpose**
+    Send a password reset email to a CommCare (mobile-worker) user.
+
+**Permissions Required**
+    Edit Mobile Workers & Edit Access API's
+
+Endpoint Specifications
+-----------------------
+
+**URL**
+
+.. code-block:: text
+
+    https://www.commcarehq.org/a/[domain]/api/user/v1/[id]/email_password_reset/
+
+**Method**
+
+.. code-block:: text
+
+    POST
+
+Request & Response Details
+---------------------------
+
+- **Request Body**: Empty
+- **Success**: Returns HTTP 202 Accepted with an empty body.


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
https://github.com/dimagi/commcare-hq/pull/36689 introduced support for admins to manually trigger a password reset for a mobile worker. This PR extends to support that via API via `/a/<domain>/api/user/v1/<user_id>/email_password_reset/`

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-6178](https://dimagi.atlassian.net/browse/USH-6178)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I tested this locally. This PR is labeled as high risk, but the changes are introduced to a new endpoint. So if there was a bug with this, it should be limited to this newly introduced endpoint. So there is no risk to anything existing.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA for rationale explained in safety story.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-6178]: https://dimagi.atlassian.net/browse/USH-6178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ