### PR TITLE
Pkv/connect messaging inbound fixes

### DIFF
--- a/corehq/apps/sms/handlers/fallback.py
+++ b/corehq/apps/sms/handlers/fallback.py
@@ -40,6 +40,9 @@ def fallback_handler(verified_number, text, msg):
                                     metadata=outbound_meta)
         outbound_subevent.completed()
     elif is_connect_message:
+        # Connect Messages are not processed in the if statement above.
+        # This check ensures that all connect messages have the correct
+        # metadata saved.
         msg.save()
 
     inbound_subevent.completed()

--- a/corehq/apps/sms/handlers/fallback.py
+++ b/corehq/apps/sms/handlers/fallback.py
@@ -4,13 +4,13 @@ from corehq.apps.sms.api import (
     add_msg_tags,
     send_message_to_verified_number,
 )
-from corehq.apps.sms.models import WORKFLOW_DEFAULT, ConnectMessagingNumber, MessagingEvent
+from corehq.apps.sms.models import WORKFLOW_DEFAULT, MessagingEvent
 
 
 def fallback_handler(verified_number, text, msg):
     domain_obj = Domain.get_by_name(verified_number.domain, strict=True)
 
-    is_connect_message = isinstance(verified_number, ConnectMessagingNumber)
+    is_connect_message = not verified_number.is_sms
     if is_connect_message:
         content_type = MessagingEvent.CONTENT_CONNECT
     else:

--- a/corehq/apps/sms/handlers/fallback.py
+++ b/corehq/apps/sms/handlers/fallback.py
@@ -23,6 +23,7 @@ def fallback_handler(verified_number, text, msg):
     inbound_meta = MessageMetadata(workflow=WORKFLOW_DEFAULT,
         messaging_subevent_id=inbound_subevent.pk)
     add_msg_tags(msg, inbound_meta)
+    msg.save()
 
     if domain_obj.use_default_sms_response and domain_obj.default_sms_response:
         outbound_subevent = logged_event.create_subevent_for_single_sms(

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1278,7 +1278,9 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
             date=datetime.utcnow(),
             recipient_type=MessagingEvent.get_recipient_type_from_doc_type(recipient_doc_type),
             recipient_id=recipient_id,
-            content_type=MessagingEvent.CONTENT_SMS,
+            content_type=(MessagingEvent.CONTENT_CONNECT
+                          if self.content_type == MessagingEvent.CONTENT_CONNECT
+                          else MessagingEvent.CONTENT_SMS),
             case_id=case.case_id if case else None,
             status=(MessagingEvent.STATUS_COMPLETED
                     if completed

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1288,7 +1288,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
 
     def create_subevent_for_content_type(self, recipient_doc_type=None,
             recipient_id=None, case=None, completed=False, content_type=None):
-        obj = MessagingSubEvent.objects.create(
+        subevent = MessagingSubEvent.objects.create(
             parent=self,
             domain=self.domain,
             date=datetime.utcnow(),
@@ -1300,7 +1300,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
                     if completed
                     else MessagingEvent.STATUS_IN_PROGRESS),
         )
-        return obj
+        return subevent
 
     @property
     def subevents(self):

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1288,11 +1288,12 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
 
     def create_subevent_for_content_type(self, recipient_doc_type=None,
             recipient_id=None, case=None, completed=False, content_type=None):
+        recipient_type = MessagingEvent.get_recipient_type_from_doc_type(recipient_doc_type)
         subevent = MessagingSubEvent.objects.create(
             parent=self,
             domain=self.domain,
             date=datetime.utcnow(),
-            recipient_type=MessagingEvent.get_recipient_type_from_doc_type(recipient_doc_type),
+            recipient_type=recipient_type,
             recipient_id=recipient_id,
             content_type=content_type or self.content_type,
             case_id=case.case_id if case else None,


### PR DESCRIPTION
## Product Description
Fixed two minor issues that led to Connect Messages shown with redacted details in Messaging History report.
- Connect Message `MessagingSubEvents` were tagged as SMS instead of ConnectMessage leading to message data being processed incorrectly by the report code.
- Fallback handler was not saving the `ConnectMessage` object after adding metadata which led to missing `MessagingSubEvent` information when requesting the event details leading to 500 error.

## Technical Summary
[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-879)


## Feature Flag
COMMCARE_CONNECT


## Safety Assurance
### Safety story
- Tested Locally with a working messaging setup using API call.
- Will update this section once tested on staging.

### Automated test coverage


### QA Plan
- None

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
