### PR TITLE
Restore runtime.txt for dependabot

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,0 +1,9 @@
+python-3.9
+# Specifies the python version that dependabot should use.
+# Dependabot failed with a vague error when this runtime.txt file was removed:
+# django     | dependency_file_content_not_changed | { "message": "Content did not change!" }
+#
+# NOTE: the full "allowed syntax" of this file isn't well documented. If you
+# suspect problems with the contents of this file, try:
+# - removing all comments
+# - using a full version, including patch (e.g. 'python-3.9.14')


### PR DESCRIPTION
Dependabot began failing with a vague error ([example](https://github.com/dimagi/commcare-hq/actions/runs/17153450567/job/48664756840)) when this file was removed. Attempting to add it back to see if it fixes the error. This is starting with the Python version (3.9) that was previously working. The plan is to bump the version to a newer Python if this fixes the error.

Motivation: there have not been any new Python security vulnerabilities reported in this repo for quite a while. It is unclear if that is related to these dependabot failures.

PR where runtime.txt was removed: https://github.com/dimagi/commcare-hq/pull/36651

## Safety Assurance

### Safety story

Affects dependabot runtime only.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations