### PR TITLE
Updates for Django 5.1 removals

### DIFF
--- a/corehq/apps/hqwebapp/tests/test_models.py
+++ b/corehq/apps/hqwebapp/tests/test_models.py
@@ -35,17 +35,17 @@ class TestAlerts(TestCase):
         alert = Alert.objects.create(**kwargs)
 
         active_alerts = Alert.get_active_alerts()
-        self.assertQuerysetEqual(active_alerts, [])
+        self.assertQuerySetEqual(active_alerts, [])
 
         alert.start_time = past_time
         alert.save()
         active_alerts = Alert.get_active_alerts()
-        self.assertQuerysetEqual(active_alerts, [alert])
+        self.assertQuerySetEqual(active_alerts, [alert])
 
         alert.end_time = past_time
         alert.save()
         active_alerts = Alert.get_active_alerts()
-        self.assertQuerysetEqual(active_alerts, [])
+        self.assertQuerySetEqual(active_alerts, [])
 
     def test_shows_alerts_without_schedule(self):
         kwargs = {
@@ -55,7 +55,7 @@ class TestAlerts(TestCase):
         alert = Alert.objects.create(**kwargs)
 
         active_alerts = Alert.get_active_alerts()
-        self.assertQuerysetEqual(active_alerts, [alert])
+        self.assertQuerySetEqual(active_alerts, [alert])
 
 
 class TestUserAccessLogManager(TestCase):

--- a/corehq/apps/sso/backends.py
+++ b/corehq/apps/sso/backends.py
@@ -119,7 +119,7 @@ class SsoBackend(ModelBackend):
 
         new_web_user = activate_new_user(
             username=username,
-            password=User.objects.make_random_password(),
+            password=None,  # disable password auth
             created_by=created_by,
             created_via=created_via,
             first_name=get_sso_user_first_name_from_session(request),

--- a/corehq/apps/users/tests/test_user_invitation.py
+++ b/corehq/apps/users/tests/test_user_invitation.py
@@ -185,6 +185,6 @@ class TestUserInvitation(TestCase):
         _, invite_uuid = self._setup_invitation_and_request()
         invitation = Invitation.objects.get(uuid=invite_uuid)
         invitation.delete(deleted_by="deleted_id")
-        InvitationHistory.objects.get(invitation=invitation, action=3)
+        InvitationHistory.objects.get(invitation_id=invitation.pk, action=3)
         with self.assertRaises(Invitation.DoesNotExist):
             Invitation.objects.get(uuid=invite_uuid)

--- a/corehq/util/auth.py
+++ b/corehq/util/auth.py
@@ -1,0 +1,55 @@
+import hashlib
+
+from django.contrib.auth.hashers import (
+    BasePasswordHasher,
+    mask_hash,
+    must_update_salt,
+)
+from django.utils.crypto import constant_time_compare
+from django.utils.translation import gettext_noop as _
+
+
+class SHA1PasswordHasher(BasePasswordHasher):
+    """
+    The SHA1 password hashing algorithm (not recommended)
+
+    Copied from django.contrib.auth.hashers because it was removed in v5.1.
+    Use to upgrade historical password hashes to a more secure
+    algorithm. Do not use as primary password hasher.
+    """
+
+    algorithm = "sha1"
+
+    def encode(self, password, salt):
+        self._check_encode_args(password, salt)
+        hash = hashlib.sha1((salt + password).encode()).hexdigest()
+        return "%s$%s$%s" % (self.algorithm, salt, hash)
+
+    def decode(self, encoded):
+        algorithm, salt, hash = encoded.split("$", 2)
+        assert algorithm == self.algorithm
+        return {
+            "algorithm": algorithm,
+            "hash": hash,
+            "salt": salt,
+        }
+
+    def verify(self, password, encoded):
+        decoded = self.decode(encoded)
+        encoded_2 = self.encode(password, decoded["salt"])
+        return constant_time_compare(encoded, encoded_2)
+
+    def safe_summary(self, encoded):
+        decoded = self.decode(encoded)
+        return {
+            _("algorithm"): decoded["algorithm"],
+            _("salt"): mask_hash(decoded["salt"], show=2),
+            _("hash"): mask_hash(decoded["hash"]),
+        }
+
+    def must_update(self, encoded):
+        decoded = self.decode(encoded)
+        return must_update_salt(decoded["salt"], self.salt_entropy)
+
+    def harden_runtime(self, password, encoded):
+        pass

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -24,8 +24,9 @@ WHITELIST = [
     ("ddtrace.internal.module", "pkg_resources is deprecated as an API"),
     ("eulxml", "pkg_resources is deprecated as an API"),
     ("pkg_resources", "pkg_resources.declare_namespace"),
-    ("", "", RemovedInDjango50Warning),
-    ("", "", RemovedInDjango51Warning),
+
+    ("tastypie.compat", "The django.utils.datetime_safe module is deprecated.", RemovedInDjango50Warning),
+    ("django.db.models.options", "'index_together' is deprecated", RemovedInDjango51Warning),
 
     # warnings that can be resolved with HQ code changes
     ("", "datetime.datetime.utcnow() is deprecated"),

--- a/settings.py
+++ b/settings.py
@@ -204,7 +204,7 @@ PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.PBKDF2PasswordHasher',
     'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
     'django.contrib.auth.hashers.BCryptPasswordHasher',
-    'django.contrib.auth.hashers.SHA1PasswordHasher',
+    'corehq.util.auth.SHA1PasswordHasher',
     'django.contrib.auth.hashers.MD5PasswordHasher',
 )
 PASSWORD_RESET_TIMEOUT = 3600


### PR DESCRIPTION
The remaining [ignored `RemovedInDjango5...` warnings](https://github.com/dimagi/commcare-hq/pull/36880/commits/ec6eda4c0128e048415ebd993ace9dc40f09cef4#diff-3ebb6be7e5b725fe02e02819f00b5fc0afe6cf3a66962d40e1bf17806733c568) will be addressed separately:
- `index_together` will be removed in a separate PR prior to upgrading Django.
- `tastypie.compat` can be removed in the PR that upgrades Django to 5.2.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Small changes to remove use of deprecated Django APIs.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations
