### PR TITLE
Add ServerLocation model for constructing environment URLs

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -3093,11 +3093,8 @@ class ExtractAppInfoForm(forms.Form):
         return cleaned_data
 
     def _get_source_server(self, parsed_url):
-        server_mapping = {
-            'www': 'production',
-            'india': 'india',
-            'eu': 'eu',
-        }
+        server_mapping = {subdomain: server for server, subdomain
+                          in ServerLocation.SUBDOMAINS.items()}
 
         netloc = parsed_url.netloc.split(".")
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -119,6 +119,7 @@ from corehq.apps.domain.models import (
 from corehq.apps.hqmedia.models import CommCareImage, LogoForSystemEmailsReference
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.crispy import DatetimeLocalWidget, HQFormHelper
+from corehq.apps.hqwebapp.models import ServerLocation
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.hqwebapp.widgets import (
     BootstrapCheckboxInput,
@@ -3180,8 +3181,7 @@ class ImportAppForm(forms.Form):
         return app_file
 
     def construct_download_url(self, source_server, source_domain, app_id):
-        from corehq.apps.domain.views.import_apps import SERVER_SUBDOMAIN_MAPPING
-        server_address = SERVER_SUBDOMAIN_MAPPING[source_server]
+        server_address = ServerLocation.SUBDOMAINS[source_server]
         return f"https://{server_address}.commcarehq.org/a/{source_domain}/apps/source/{app_id}/"
 
 

--- a/corehq/apps/domain/views/import_apps.py
+++ b/corehq/apps/domain/views/import_apps.py
@@ -11,13 +11,8 @@ from corehq.apps.domain.forms import ExtractAppInfoForm, ImportAppForm
 from corehq.apps.domain.views.base import DomainViewMixin
 from corehq.apps.hqmedia.views import BulkUploadMultimediaView
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.hqwebapp.models import ServerLocation
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
-
-SERVER_SUBDOMAIN_MAPPING = {
-    'production': 'www',
-    'india': 'india',
-    'eu': 'eu',
-}
 
 
 @method_decorator(
@@ -106,7 +101,7 @@ class ImportAppStepsView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin
                                               new_app_id):
         from corehq.apps.app_manager.views.utils import back_to_main
         source_multimedia_url = (
-            f"https://{SERVER_SUBDOMAIN_MAPPING[source_server]}.commcarehq.org/a/"
+            f"https://{ServerLocation.SUBDOMAINS[source_server]}.commcarehq.org/a/"
             f"{source_domain}/apps/view/{source_app_id}/settings/#multimedia-tab"
         )
         current_multimedia_url = reverse(BulkUploadMultimediaView.urlname, args=[self.domain, new_app_id])

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -122,7 +122,7 @@ def pkce_required(client_id):
         return False
 
 
-class ServerLocation(object):
+class ServerLocation:
     PRODUCTION = 'production'
     INDIA = 'india'
     EU = 'eu'

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -1,9 +1,11 @@
 from collections import namedtuple
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import Q
+from django.utils.translation import gettext_lazy as _
 
 import architect
 from oauth2_provider.settings import APPLICATION_MODEL
@@ -118,3 +120,22 @@ def pkce_required(client_id):
         return application.pkce_required
     except HQOauthApplication.DoesNotExist:
         return False
+
+
+class ServerLocation(object):
+    PRODUCTION = 'production'
+    INDIA = 'india'
+    EU = 'eu'
+    ENVS = (PRODUCTION, INDIA, EU)
+
+    CHOICES_DICT = {
+        PRODUCTION: ("www", _("United States")),
+        INDIA: ("india", _("India")),
+        EU: ("eu", _("European Union")),
+    }
+
+    @classmethod
+    def choices(cls):
+        env = settings.SERVER_ENVIRONMENT
+        sorted_keys = sorted(cls.ENVS, key=lambda x: x != env)
+        return [cls.CHOICES_DICT[key] for key in sorted_keys]

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -128,10 +128,16 @@ class ServerLocation:
     EU = 'eu'
     ENVS = (PRODUCTION, INDIA, EU)
 
+    SUBDOMAINS = {
+        PRODUCTION: 'www',
+        INDIA: 'india',
+        EU: 'eu',
+    }
+
     CHOICES_DICT = {
-        PRODUCTION: ("www", _("United States")),
-        INDIA: ("india", _("India")),
-        EU: ("eu", _("European Union")),
+        PRODUCTION: (SUBDOMAINS[PRODUCTION], _("United States")),
+        INDIA: (SUBDOMAINS[INDIA], _("India")),
+        EU: (SUBDOMAINS[EU], _("European Union")),
     }
 
     @classmethod


### PR DESCRIPTION
## Technical Summary
Cherry-picked from #36710 because this model will be used for constructing server links to be added in https://dimagi.atlassian.net/browse/SAAS-18370

## Safety Assurance

### Safety story
Cherry-picked previously-approved commits. This is a non-database model just used for constructing URLs.

### Automated test coverage

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
