### PR TITLE
Use 'cloud' instead of 'server'

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
@@ -8,7 +8,7 @@
     <p class="lead text-center">
       {{ server_display.flag }}
       {% blocktrans with server_display.hr_name as server_location %}
-        {{ server_location }} Server
+        {{ server_location }} Cloud
       {% endblocktrans %}
     </p>
   {% endif %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
@@ -8,7 +8,7 @@
     <p class="lead text-center">
       {{ server_display.flag }}
       {% blocktrans with server_display.hr_name as server_location %}
-        {{ server_location }} Server
+        {{ server_location }} Cloud
       {% endblocktrans %}
     </p>
   {% endif %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/global_navigation_bar.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap3/global_navigation_bar.html
@@ -94,7 +94,7 @@
             </li>
             {% if server_display %}
                 <li class="nav-divider divider"></li>
-                <li class="dropdown-header nav-header">{% trans 'Server Location' %}</li>
+                <li class="dropdown-header nav-header">{% trans 'Cloud Location' %}</li>
                 <li class="server-location">
                     {{ server_display.flag }}
                     {% trans server_display.hr_name %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/global_navigation_bar.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/bootstrap5/global_navigation_bar.html
@@ -101,7 +101,7 @@
         </li>
         {% if server_display %}
           <li><hr class="dropdown-divider"></li>
-          <li class="dropdown-header nav-header">{% trans 'Server Location' %}</li>
+          <li class="dropdown-header nav-header">{% trans 'Cloud Location' %}</li>
           <li class="dropdown-item-text">
             {{ server_display.flag }}
             {% trans server_display.hr_name %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/global_navigation_bar.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/includes/global_navigation_bar.html.diff.txt
@@ -162,7 +162,7 @@
 -            </li>
 -            {% if server_display %}
 -                <li class="nav-divider divider"></li>
--                <li class="dropdown-header nav-header">{% trans 'Server Location' %}</li>
+-                <li class="dropdown-header nav-header">{% trans 'Cloud Location' %}</li>
 -                <li class="server-location">
 -                    {{ server_display.flag }}
 -                    {% trans server_display.hr_name %}
@@ -196,7 +196,7 @@
 +        </li>
 +        {% if server_display %}
 +          <li><hr class="dropdown-divider"></li>
-+          <li class="dropdown-header nav-header">{% trans 'Server Location' %}</li>
++          <li class="dropdown-header nav-header">{% trans 'Cloud Location' %}</li>
 +          <li class="dropdown-item-text">
 +            {{ server_display.flag }}
 +            {% trans server_display.hr_name %}

--- a/corehq/apps/registration/templates/registration/domain_request.html
+++ b/corehq/apps/registration/templates/registration/domain_request.html
@@ -120,6 +120,10 @@
               </div>
               <div class="col-xs-11">
                 <h5><b>{% trans "Subscription" %}</b></h5>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-xs-11 col-xs-push-1">
                 <p>
                   {% blocktrans %}
                     All new projects start on CommCare's free edition. Once you
@@ -139,6 +143,10 @@
               </div>
               <div class="col-xs-11">
                 <h5><b>{% trans "Cloud Location" %}</b></h5>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-xs-11 col-xs-push-1">
                 <p>
                   {% if server_display %}
                     {% blocktrans with server_display.hr_name as server_location %}

--- a/corehq/apps/registration/templates/registration/domain_request.html
+++ b/corehq/apps/registration/templates/registration/domain_request.html
@@ -180,7 +180,7 @@
                 </ul>
                 <p>
                   {% blocktrans %}
-                    Please note: projects <strong>cannot</strong> be transferred
+                    Please note: Projects <strong>cannot</strong> be transferred
                     between cloud locations after creation.
                   {% endblocktrans %}
                 </p>

--- a/corehq/apps/registration/templates/registration/domain_request.html
+++ b/corehq/apps/registration/templates/registration/domain_request.html
@@ -138,28 +138,28 @@
                 {% include 'registration/partials/icon_stack.html' with icon_class='fcc fcc-globe' %}
               </div>
               <div class="col-xs-11">
-                <h5><b>{% trans "Server Location" %}</b></h5>
+                <h5><b>{% trans "Cloud Location" %}</b></h5>
                 <p>
                   {% if server_display %}
                     {% blocktrans with server_display.hr_name as server_location %}
-                      This project will be hosted on the {{ server_location }}
-                      server.
+                      This project will be hosted on the <strong>{{ server_location }}
+                      cloud</strong>.
                     {% endblocktrans %}
                   {% else %}
                     {% blocktrans %}
-                      This project will be hosted on the current server.
+                      This project will be hosted on a private cloud.
                     {% endblocktrans %}
                   {% endif %}
                   {% blocktrans %}
-                    To select a
+                    To select a different
                     <a
                       href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3101491209/CommCare+Cloud+Server+Locations"
                       target="_blank"
-                      ><b>different server</b></a
-                    >, log into that server's site before creating your project.
+                      ><b>cloud location</b></a
+                    >, log into that location's site before creating your project.
                     <br />
                     Please note: projects <strong>cannot</strong> be transferred
-                    between servers after creation.
+                    between cloud locations after creation.
                   {% endblocktrans %}
                 </p>
               </div>

--- a/corehq/apps/registration/templates/registration/domain_request.html
+++ b/corehq/apps/registration/templates/registration/domain_request.html
@@ -142,8 +142,8 @@
                 <p>
                   {% if server_display %}
                     {% blocktrans with server_display.hr_name as server_location %}
-                      This project will be hosted on the <strong>{{ server_location }}
-                      cloud</strong>.
+                      This project will be hosted on the
+                      <strong>{{ server_location }} cloud</strong>.
                     {% endblocktrans %}
                   {% else %}
                     {% blocktrans %}
@@ -156,8 +156,22 @@
                       href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3101491209/CommCare+Cloud+Server+Locations"
                       target="_blank"
                       ><b>cloud location</b></a
-                    >, log into that location's site before creating your project.
-                    <br />
+                    >, log into that location's site before creating your
+                    project:
+                  {% endblocktrans %}
+                </p>
+                <ul>
+                  {% for server in server_locations %}
+                    <li>
+                      <a
+                        href="https://{{ server.subdomain }}.commcarehq.org{{ request.path }}"
+                        >{% trans server.name %}</a
+                      >
+                    </li>
+                  {% endfor %}
+                </ul>
+                <p>
+                  {% blocktrans %}
                     Please note: projects <strong>cannot</strong> be transferred
                     between cloud locations after creation.
                   {% endblocktrans %}

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -38,6 +38,7 @@ from corehq.apps.domain.exceptions import (
 )
 from corehq.apps.domain.extension_points import has_custom_clean_password
 from corehq.apps.domain.models import Domain, LicenseAgreement
+from corehq.apps.hqwebapp.models import ServerLocation
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.registration.forms import (
     DomainRegistrationForm,
@@ -408,12 +409,19 @@ class RegisterDomainView(TemplateView):
             'url': reverse("domain_accept_invitation", args=[i.domain, i.uuid]) + '?no_redirect=true',
         } for i in invitations]
 
+        server_locations = [{
+            'env': env,
+            'subdomain': server_info[0],
+            'name': server_info[1],
+        } for env, server_info in ServerLocation.CHOICES_DICT.items() if env != settings.SERVER_ENVIRONMENT]
+
         context.update({
             'form': kwargs.get('form') or DomainRegistrationForm(),
             'invitation_links': invitation_links,
             'is_new_user': self.is_new_user,
             'name': self.request.user.first_name or self.request.user.username,
             'pricing_page_url': settings.PRICING_PAGE_URL,
+            'server_locations': server_locations,
             'show_multiple_invites': len(invitations) > 1,
         })
         return context


### PR DESCRIPTION
## Product Description
Before:
<img width="353" height="74" alt="image" src="https://github.com/user-attachments/assets/65d7dfc4-5b90-4893-9803-daefa2db92e1" />

<img width="728" height="352" alt="image" src="https://github.com/user-attachments/assets/39f53a29-e750-432a-8ac9-d09e53d18508" />


After:
<img width="350" height="66" alt="image" src="https://github.com/user-attachments/assets/e3197549-e35e-45ea-8304-0ddea446dcc2" />

<img width="725" height="413" alt="image" src="https://github.com/user-attachments/assets/b32ce29e-ecef-42f5-bd2e-918581cceb0d" />



## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18370
Updates some references to 'server' to read 'cloud'. Adds additional context and links to the Add New Project page.

## Safety Assurance

### Safety story
Text changes here are simple and safe. Otherwise, this is basically just adding some page context from a preexisting source, then showing that on the page.

### Automated test coverage
Not likely.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
