### PR TITLE
Add info about FF users to edit page and export

### DIFF
--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -108,18 +108,8 @@ function toggleItem(namespace, value, last_used, service_type) {
     self.last_used = ko.observable(last_used);
     self.service_type = ko.observable(service_type);
 
-
-    self.namespaceHtml = ko.computed(function () {
-        value = self.value();
-        if (value && value[0] === '!') {
-            value = value.replace(/^!/, '');
-        }
-        if (self.namespace() === 'domain') {
-            const url = initialPageData.reverse('domain_internal_settings', value);
-            return '<a href="' + url + '">domain <i class="fa fa-external-link"></i></a>';
-        } else {
-            return "<i class='fa fa-user'></i> " + self.namespace();
-        }
+    self.domainUrl = ko.computed(() => {
+        return initialPageData.reverse('domain_internal_settings', self.value());
     });
 
     return self;

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -109,7 +109,9 @@ function toggleItem(namespace, value, last_used, service_type) {
     self.service_type = ko.observable(service_type);
 
     self.domainUrl = ko.computed(() => {
-        return initialPageData.reverse('domain_internal_settings', self.value());
+        const val = self.value(),
+              domain = val.startsWith('!') ? val.slice(1) : val;
+        return initialPageData.reverse('domain_internal_settings', domain);
     });
 
     return self;

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -29,6 +29,7 @@ function toggleViewModel() {
     self.init_items = function (config) {
         const lastUsed = config.last_used || {},
             serviceType = config.service_type || {},
+            dimagiUsers = config.dimagi_users || {},
             items = _.map(config.items, function (item) {
                 var fields = item.split(':'),
                     namespace = fields.length > 1 ? fields[0] : 'user',
@@ -38,6 +39,7 @@ function toggleViewModel() {
                     value,
                     lastUsed[value],
                     serviceType[value],
+                    dimagiUsers[value],
                 );
             });
         self.items(_.sortBy(items, function (item) {
@@ -100,17 +102,18 @@ function toggleViewModel() {
 
 
 // eslint-disable-next-line camelcase
-function toggleItem(namespace, value, last_used, service_type) {
+function toggleItem(namespace, value, last_used, service_type, dimagi_users) {
     // Represents an individual item; a domain or user
     var self = {};
     self.namespace = ko.observable(namespace);
     self.value = ko.observable(value);
     self.last_used = ko.observable(last_used);
     self.service_type = ko.observable(service_type);
+    self.dimagi_users = ko.observable(dimagi_users);
 
     self.domainUrl = ko.computed(() => {
         const val = self.value(),
-              domain = val.startsWith('!') ? val.slice(1) : val;
+            domain = val.startsWith('!') ? val.slice(1) : val;
         return initialPageData.reverse('domain_internal_settings', domain);
     });
 
@@ -127,6 +130,7 @@ $(function () {
         is_random_editable: initialPageData.get('is_random_editable'),
         randomness: initialPageData.get('randomness'),
         service_type: initialPageData.get('service_type'),
+        dimagi_users: initialPageData.get('dimagi_users'),
     });
     $home.koApplyBindings(view);
     $home.on('change', 'input', view.change);

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -8,6 +8,7 @@ import "hqwebapp/js/bootstrap3/knockout_bindings.ko";  // save button
 
 var PAD_CHAR = '&nbsp;';
 function toggleViewModel() {
+    // Represents the entire page
     var self = {};
     self.items = ko.observableArray();
     self.randomness = ko.observable();
@@ -32,12 +33,12 @@ function toggleViewModel() {
                 var fields = item.split(':'),
                     namespace = fields.length > 1 ? fields[0] : 'user',
                     value = fields.length > 1 ? fields[1] : fields[0];
-                return {
-                    namespace: ko.observable(self.padded_ns[namespace]),
-                    value: ko.observable(value),
-                    last_used: ko.observable(lastUsed[value]),
-                    service_type: ko.observable(serviceType[value]),
-                };
+                return toggleItem(
+                    self.padded_ns[namespace],
+                    value,
+                    lastUsed[value],
+                    serviceType[value],
+                );
             });
         self.items(_.sortBy(items, function (item) {
             return [item.last_used(), item.value()];
@@ -45,12 +46,7 @@ function toggleViewModel() {
     };
 
     self.addItem = function (namespace) {
-        self.items.push({
-            namespace: ko.observable(self.padded_ns[namespace]),
-            value: ko.observable(),
-            last_used: ko.observable(),
-            service_type: ko.observable(),
-        });
+        self.items.push(toggleItem(self.padded_ns[namespace]));
         self.change();
     };
 
@@ -99,16 +95,32 @@ function toggleViewModel() {
     self.saveButtonTop = self.createSaveButton();
     self.saveButtonBottom = self.createSaveButton();
 
-    self.getNamespaceHtml = function (namespace, value) {
+    return self;
+}
+
+
+// eslint-disable-next-line camelcase
+function toggleItem(namespace, value, last_used, service_type) {
+    // Represents an individual item; a domain or user
+    var self = {};
+    self.namespace = ko.observable(namespace);
+    self.value = ko.observable(value);
+    self.last_used = ko.observable(last_used);
+    self.service_type = ko.observable(service_type);
+
+
+    self.namespaceHtml = ko.computed(function () {
+        value = self.value();
         if (value && value[0] === '!') {
             value = value.replace(/^!/, '');
         }
-        if (namespace === 'domain') {
-            return '<a href="' + initialPageData.reverse('domain_internal_settings', value) + '">domain <i class="fa fa-external-link"></i></a>';
+        if (self.namespace() === 'domain') {
+            const url = initialPageData.reverse('domain_internal_settings', value);
+            return '<a href="' + url + '">domain <i class="fa fa-external-link"></i></a>';
         } else {
-            return "<i class='fa fa-user'></i> " + namespace;
+            return "<i class='fa fa-user'></i> " + self.namespace();
         }
-    };
+    });
 
     return self;
 }

--- a/corehq/apps/toggle_ui/tasks.py
+++ b/corehq/apps/toggle_ui/tasks.py
@@ -20,7 +20,6 @@ from corehq.apps.domain.calculations import last_form_submission
 from corehq.apps.domain.models import Domain
 from corehq.apps.toggle_ui.utils import get_dimagi_users
 from corehq.apps.users.models import CouchUser
-from corehq.apps.users.util import is_dimagi_email
 from corehq.blobs import CODES, get_blob_db
 from corehq.const import USER_DATETIME_FORMAT
 from corehq.toggles import (
@@ -227,8 +226,8 @@ class _UsageInfo:
             return {"error": "User not found"}
 
         return {
-            "user_is_dimagi": is_dimagi_email(username),
-            "user_is_mobile": "commcarehq.org" in username,
+            "user_is_dimagi": user.is_dimagi,
+            "user_is_mobile": user.is_commcare_user(),
             "user_is_active": user.is_active_in_any_domain(),
             "user_last_login": user.last_login,
             "user_is_superuser": user.is_superuser,

--- a/corehq/apps/toggle_ui/tasks.py
+++ b/corehq/apps/toggle_ui/tasks.py
@@ -17,7 +17,7 @@ from soil.util import expose_blob_download
 from corehq.apps.celery import task
 from corehq.apps.domain.calculations import last_form_submission
 from corehq.apps.domain.models import Domain
-from corehq.apps.toggle_ui.utils import get_subscription_info, has_dimagi_user
+from corehq.apps.toggle_ui.utils import get_dimagi_users, get_subscription_info
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.util import is_dimagi_email
 from corehq.blobs import CODES, get_blob_db
@@ -113,7 +113,8 @@ def _write_toggle_data(filepath, toggles, increment_progress=None):
         "user_is_active", "user_is_dimagi", "user_is_mobile", "user_is_superuser", "user_last_login",
         # domain columns
         "domain_is_active", "domain_is_test", "domain_is_snapshot",
-        "domain_has_dimagi_user", "domain_last_form_submission", "domain_has_submission_in_last_30_days",
+        "domain_dimagi_users",
+        "domain_last_form_submission", "domain_has_submission_in_last_30_days",
         "domain_subscription_service_type", "domain_subscription_plan"
     ]
     with open(filepath, 'w', encoding='utf8') as file:
@@ -208,7 +209,7 @@ class _UsageInfo:
             "domain_is_active": domain_obj.is_active,
             "domain_is_test": {"true": "True", "false": "False", "none": "unknown"}[domain_obj.is_test],
             "domain_is_snapshot": domain_obj.is_snapshot,
-            "domain_has_dimagi_user": has_dimagi_user(domain),
+            "domain_dimagi_users": get_dimagi_users(domain),
             "domain_last_form_submission": last_form_submission(domain),
             "domain_has_submission_in_last_30_days": domain_has_submission_in_last_30_days(domain),
             "domain_subscription_service_type": service_type,

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -240,7 +240,7 @@
             <td
               class="col-sm-2"
               style="border: 0; vertical-align: middle"
-              data-bind="html: $parent.getNamespaceHtml(namespace(), value())"
+              data-bind="html: namespaceHtml"
             ></td>
             <td
               class="col-sm-2"

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -240,8 +240,18 @@
             <td
               class="col-sm-2"
               style="border: 0; vertical-align: middle"
-              data-bind="html: namespaceHtml"
-            ></td>
+            >
+              <a style="display: none" data-bind="
+                visible: namespace() === 'domain',
+                attr: { href: domainUrl }
+              ">
+                domain <i class="fa fa-external-link"></i>
+              </a>
+              <span style="display: none"
+                data-bind="visible: namespace() != 'domain'">
+                <i class='fa fa-user'></i> user
+              </span>
+            </td>
             <td
               class="col-sm-2"
               style="border: 0; vertical-align: middle"

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -7,16 +7,23 @@
 {% block title %}{% trans "Edit Feature Flag: " %}{{ static_toggle.label }}{% endblock %}
 
 {% block stylesheets %}
-  <style>
-    .margin-vertical-sm {
-      margin-top: 5px;
-      margin-bottom: 5px;
-    }
+<style>
+  .margin-vertical-sm {
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
 
-    .label-release {
-      background-color: #c22eff !important;
-    }
-  </style>
+  .label-release {
+    background-color: #c22eff !important;
+  }
+
+  /* B5: replace with table-borderless and align-middle */
+  #feature-flag-items tbody td {
+    border: 0;
+    vertical-align: middle;
+  }
+</style>
+
 {% endblock %}
 
 {% block page_content %}
@@ -196,7 +203,7 @@
           </p>
         </div>
       {% endif %}
-      <table class="table table-condensed"><!-- B5: add table-borderless and remove `border: none` inline styles on table cells -->
+      <table class="table table-condensed" id="feature-flag-items">
         <thead>
           <tr>
             <th>
@@ -213,7 +220,7 @@
         </thead>
         <tbody data-bind="foreach: items">
           <tr>
-            <td class="col-sm-4" style="border: 0">
+            <td class="col-sm-4">
               <div class="input-group">
                 <span class="input-group-btn">
                   {% if can_edit_toggle %}
@@ -236,11 +243,7 @@
                 </span>
               </div>
             </td>
-            <!-- B5: replace inline styles with vertical alignment class: https://getbootstrap.com/docs/5.3/utilities/vertical-align/#css -->
-            <td
-              class="col-sm-2"
-              style="border: 0; vertical-align: middle"
-            >
+            <td class="col-sm-2">
               <a style="display: none" data-bind="
                 visible: namespace() === 'domain',
                 attr: { href: domainUrl }
@@ -254,12 +257,10 @@
             </td>
             <td
               class="col-sm-2"
-              style="border: 0; vertical-align: middle"
               data-bind="text: last_used"
             ></td>
             <td
               class="col-sm-4"
-              style="border: 0; vertical-align: middle"
               data-bind="text: service_type"
             ></td>
           </tr>

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -33,6 +33,7 @@
   {% initial_page_data 'namespaces' namespaces %}
   {% initial_page_data 'last_used' last_used %}
   {% initial_page_data 'service_type' service_type %}
+  {% initial_page_data 'dimagi_users' dimagi_users %}
   {% initial_page_data 'is_random_editable' is_random_editable %}
   {% initial_page_data 'randomness' static_toggle.randomness %}
   {% if not usage_info %}
@@ -216,6 +217,7 @@
             <th>Namespace</th>
             <th>Latest Form Submission</th>
             <th>Subscription Plan</th>
+            <th>Dimagi Users</th>
           </tr>
         </thead>
         <tbody data-bind="foreach: items">
@@ -262,6 +264,10 @@
             <td
               class="col-sm-4"
               data-bind="text: service_type"
+            ></td>
+            <td
+              class="col-sm-4"
+              data-bind="text: dimagi_users"
             ></td>
           </tr>
         </tbody>

--- a/corehq/apps/toggle_ui/utils.py
+++ b/corehq/apps/toggle_ui/utils.py
@@ -1,20 +1,11 @@
-from corehq.toggles import all_toggles
-
-from corehq.apps.accounting.models import Subscription
 from corehq.apps.es import UserES
+from corehq.toggles import all_toggles
 
 
 def find_static_toggle(slug):
     for toggle in all_toggles():
         if toggle.slug == slug:
             return toggle
-
-
-def get_subscription_info(domain):
-    subscription = Subscription.get_active_subscription_by_domain(domain)
-    if subscription:
-        return subscription.service_type, subscription.plan_version.plan.name
-    return None, None
 
 
 def get_dimagi_users(domain):

--- a/corehq/apps/toggle_ui/utils.py
+++ b/corehq/apps/toggle_ui/utils.py
@@ -17,6 +17,17 @@ def get_subscription_info(domain):
     return None, None
 
 
-def has_dimagi_user(domain):
-    search_fields = ["base_username", "username"]
-    return UserES().web_users().domain(domain).search_string_query('@dimagi.com', search_fields).count()
+def get_dimagi_users(domain):
+    res = (
+        UserES()
+        .web_users()
+        .domain(domain)
+        .term('username', 'dimagi.com')
+        .size(10)
+        .source('username')
+        .run()
+    )
+    usernames = [r['username'] for r in res.hits]
+    if res.total > 10:
+        usernames.append('...')
+    return ', '.join(usernames)

--- a/corehq/apps/toggle_ui/utils.py
+++ b/corehq/apps/toggle_ui/utils.py
@@ -2,7 +2,6 @@ from corehq.toggles import all_toggles
 
 from corehq.apps.accounting.models import Subscription
 from corehq.apps.es import UserES
-from corehq.util.quickcache import quickcache
 
 
 def find_static_toggle(slug):
@@ -11,7 +10,6 @@ def find_static_toggle(slug):
             return toggle
 
 
-@quickcache(['domain'], timeout=60 * 10)
 def get_subscription_info(domain):
     subscription = Subscription.get_active_subscription_by_domain(domain)
     if subscription:
@@ -19,7 +17,6 @@ def get_subscription_info(domain):
     return None, None
 
 
-@quickcache(['domain'], timeout=60 * 10)
 def has_dimagi_user(domain):
     search_fields = ["base_username", "username"]
     return UserES().web_users().domain(domain).search_string_query('@dimagi.com', search_fields).count()

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -16,12 +16,12 @@ from couchforms.analytics import get_last_form_submission_received
 from soil import DownloadBase
 
 from corehq.apps.domain.decorators import require_superuser_or_contractor
-from corehq.apps.es import UserES
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.toggle_ui.models import ToggleAudit
 from corehq.apps.toggle_ui.tasks import generate_toggle_csv_download
 from corehq.apps.toggle_ui.utils import (
     find_static_toggle,
+    get_dimagi_users,
     get_subscription_info,
 )
 from corehq.apps.users.models import CouchUser
@@ -362,18 +362,7 @@ def _get_dimagi_users(toggle):
     for enabled in toggle.enabled_users:
         if _namespace_domain(enabled):
             domain = _enabled_item_name(enabled)
-            res = (
-                UserES()
-                .web_users()
-                .domain(domain)
-                .term('username', 'dimagi.com')
-                .size(10)
-                .source('username')
-                .run()
-            )
-            users_by_domain[domain] = ', '.join(r['username'] for r in res.hits)
-            if res.total > 10:
-                users_by_domain[domain] += ', ...'
+            users_by_domain[domain] = get_dimagi_users(domain)
     return users_by_domain
 
 


### PR DESCRIPTION
## Product Description

Adds a "Dimagi users" column to the FF edit page:
<img width="2143" height="688" alt="image" src="https://github.com/user-attachments/assets/37e39d9d-241b-49fc-b91c-696d3af6e785" />

Also adds two columns to the feature flags bulk export:

* `domain_dimagi_users` - users whose username matches "dimagi.com"
* `domain_billing_contacts` - the list of contact emails from the "Billing Information" page, as seen here:
 
<img width="2094" height="708" alt="image" src="https://github.com/user-attachments/assets/ac1644de-7fad-4486-8001-2bfbcfd71e4b" />



## Technical Summary
https://dimagi.atlassian.net/browse/USH-6139

The first few commits are kinda unrelated cleanup - I initially went with a different approach (https://github.com/dimagi/commcare-hq/pull/36863), since the way we get Dimagi emails is hilariously slow.  Then when drafting that PR I realized I should just do an efficient, if imperfect lookup, so I pivoted to this approach, but kept the cleanup commits.

## Feature Flag

Yes, all of them :laughing: 

## Safety Assurance

### Safety story
This is an admin-only change, so I think local testing is sufficient

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
