### PR TITLE
Grant Edit access to all feature flag categories when creating a new superuser from command line.

### DIFF
--- a/corehq/apps/domain/management/commands/make_superuser.py
+++ b/corehq/apps/domain/management/commands/make_superuser.py
@@ -33,8 +33,11 @@ class Command(BaseCommand):
     def handle(self, username, **options):
         if not settings.ALLOW_MAKE_SUPERUSER_COMMAND:
             from dimagi.utils.web import get_site_domain
-            raise CommandError(f"""You cannot run this command in SaaS Enviornments.
-            Use https://{get_site_domain()}/hq/admin/superuser_management/ for granting superuser permissions""")
+            raise CommandError(
+                "You cannot run this command in SaaS environments. "
+                f"Use https://{get_site_domain()}/hq/admin/superuser_management/ "
+                "for granting superuser permissions."
+            )
         from corehq.apps.users.models import WebUser
         try:
             validate_email(username)

--- a/corehq/apps/domain/management/commands/tests/test_make_superuser.py
+++ b/corehq/apps/domain/management/commands/tests/test_make_superuser.py
@@ -7,21 +7,22 @@ from django.test import SimpleTestCase
 from corehq.apps.users.models import FakeUser
 
 
+@patch("corehq.apps.domain.management.commands.make_superuser.Command.grant_all_tags_edit_permissions")
 class TestEmailValidation(SimpleTestCase):
     """Tests the expected behavior of the management command's use of the
     `email_validator` library.
     """
 
-    def test_make_superuser(self):
+    def test_make_superuser(self, *args):
         with patch_fake_webuser():
             call_command("make_superuser", "test@dimagi.com")  # does not raise
 
-    def test_make_superuser_allows_special_domains(self):
+    def test_make_superuser_allows_special_domains(self, *args):
         # as-built with email_validator version 1.1.3
         with patch_fake_webuser():
             call_command("make_superuser", "test@example.com")  # does not raise
 
-    def test_make_superuser_rejects_invalid_email_syntax(self):
+    def test_make_superuser_rejects_invalid_email_syntax(self, *args):
         with patch_fake_webuser(), self.assertRaises(CommandError) as test:
             call_command("make_superuser", "somebody_at_dimagi.com")
         self.assertIsInstance(test.exception.__cause__, ValidationError)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Grant edit access to all feature flag categories when creating a new superuser from the command line. This does not apply to SaaS environments, as we restrict superuser creation to the UI only for them.


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-4564)

Rationale:
The feature flag edit restriction for superusers is primarily intended for Dimagi and not for self-hosters. Additionally, this change will allow any new environment (dev or self-hosted) to create superusers with access to all feature flags. They can still use the Superuser Management UI to manage permissions as needed.

Thanks to Ethan for pointing this out [here](https://github.com/dimagi/commcare-hq/pull/36762#discussion_r2266518761).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local. Small change

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
