### PR TITLE
Revert "Restore runtime.txt for dependabot"

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,9 +1,0 @@
-python-3.9
-# Specifies the python version that dependabot should use.
-# Dependabot failed with a vague error when this runtime.txt file was removed:
-# django     | dependency_file_content_not_changed | { "message": "Content did not change!" }
-#
-# NOTE: the full "allowed syntax" of this file isn't well documented. If you
-# suspect problems with the contents of this file, try:
-# - removing all comments
-# - using a full version, including patch (e.g. 'python-3.9.14')


### PR DESCRIPTION
Reverts dimagi/commcare-hq#36877, which did not fix the issue it was intended to fix.

Bug report filed on dependabot: https://github.com/dependabot/dependabot-core/issues/12940

## Safety Assurance

### Safety story

Affects dependabot runtime only.
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations