### PR TITLE
Temporarily remove EU from ServerLocation choices

### DIFF
--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -599,13 +599,14 @@ class TestExtractAppInfoForm(SimpleTestCase):
         self.assertEqual(form.cleaned_data['source_domain'], 'test-domain')
         self.assertEqual(form.cleaned_data['app_id'], '62891a383516c656850cc9c7e7b8d459')
 
-    def test_clean_app_url_with_valid_eu_server(self):
-        url = 'https://eu.commcarehq.org/a/test-domain/apps/view/62891a383516c656850cc9c7e7b8d459/'
-        form = forms.ExtractAppInfoForm(data={'app_url': url})
-        self.assertTrue(form.is_valid())
-        self.assertEqual(form.cleaned_data['source_server'], 'eu')
-        self.assertEqual(form.cleaned_data['source_domain'], 'test-domain')
-        self.assertEqual(form.cleaned_data['app_id'], '62891a383516c656850cc9c7e7b8d459')
+    # TODO: Enable this test case when EU server launched
+    # def test_clean_app_url_with_valid_eu_server(self):
+    #     url = 'https://eu.commcarehq.org/a/test-domain/apps/view/62891a383516c656850cc9c7e7b8d459/'
+    #     form = forms.ExtractAppInfoForm(data={'app_url': url})
+    #     self.assertTrue(form.is_valid())
+    #     self.assertEqual(form.cleaned_data['source_server'], 'eu')
+    #     self.assertEqual(form.cleaned_data['source_domain'], 'test-domain')
+    #     self.assertEqual(form.cleaned_data['app_id'], '62891a383516c656850cc9c7e7b8d459')
 
     def test_clean_app_url_without_trailing_slash(self):
         url = 'https://www.commcarehq.org/a/test-domain/apps/view/62891a383516c656850cc9c7e7b8d459'

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -125,19 +125,16 @@ def pkce_required(client_id):
 class ServerLocation:
     PRODUCTION = 'production'
     INDIA = 'india'
-    EU = 'eu'
-    ENVS = (PRODUCTION, INDIA, EU)
+    ENVS = (PRODUCTION, INDIA)
 
     SUBDOMAINS = {
         PRODUCTION: 'www',
         INDIA: 'india',
-        EU: 'eu',
     }
 
     CHOICES_DICT = {
         PRODUCTION: (SUBDOMAINS[PRODUCTION], _("United States")),
         INDIA: (SUBDOMAINS[INDIA], _("India")),
-        EU: (SUBDOMAINS[EU], _("European Union")),
     }
 
     @classmethod


### PR DESCRIPTION
## Product Description
Prevents EU from showing up in lists of cloud locations based on ServerLocation.

## Technical Summary
Fix to #36881 that should not have included EU yet.

## Safety Assurance

### Safety story
Just removes a choice from a data model that could have caused issues if someone tried to use it.

### Automated test coverage
Nope.

### QA Plan
Not this time.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
