### PR TITLE
Stop skipping fixtures for BHA

### DIFF
--- a/custom/bha/tasks.py
+++ b/custom/bha/tasks.py
@@ -4,13 +4,11 @@ from celery.schedules import crontab
 from dateutil.relativedelta import relativedelta
 
 from corehq.apps.celery import periodic_task
-from corehq.toggles import PRIME_FORMPLAYER_DBS_BHA, SKIP_FIXTURES_ON_RESTORE
-
 from corehq.apps.formplayer_api.tasks import (
-    prime_formplayer_db_for_user,
     get_users_for_priming,
+    prime_formplayer_db_for_user,
 )
-
+from corehq.toggles import PRIME_FORMPLAYER_DBS_BHA
 
 # Include users that have synced in the last 2 weeks
 SYNC_WINDOW_HOURS = 24 * 14
@@ -20,25 +18,14 @@ SYNC_WINDOW_HOURS = 24 * 14
 TASK_WINDOW_CUTOFF_HOUR = 14
 
 PRIME_FORMPLAYER_HOUR = 12
-REENABLE_FEATURE_FLAG_HOUR = PRIME_FORMPLAYER_HOUR + 1
 
 
 # Start priming at 12PM UTC (5AM GMT-7) so that the task is completed by 2PM UTC (7AM GMT-7).
 @periodic_task(run_every=crontab(minute=0, hour=PRIME_FORMPLAYER_HOUR), queue='ush_background_tasks')
 def bha_prime_formplayer_dbs():
     domains = PRIME_FORMPLAYER_DBS_BHA.get_enabled_domains()
-    for domain in domains:
-        SKIP_FIXTURES_ON_RESTORE.set(domain, False, 'domain')
     date_window = datetime.utcnow() - relativedelta(hours=SYNC_WINDOW_HOURS)
     for domain in domains:
         users = get_users_for_priming(domain, date_window)
         for row in users:
             prime_formplayer_db_for_user.delay(domain, row[0], row[1], task_cutoff_hour=TASK_WINDOW_CUTOFF_HOUR)
-
-
-# This is temporary while investigating restore slowness caused by fixtures.
-@periodic_task(run_every=crontab(minute=0, hour=REENABLE_FEATURE_FLAG_HOUR), queue='ush_background_tasks')
-def reenable_skip_fixtures_feature_flag():
-    domains = PRIME_FORMPLAYER_DBS_BHA.get_enabled_domains()
-    for domain in domains:
-        SKIP_FIXTURES_ON_RESTORE.set(domain, True, 'domain')


### PR DESCRIPTION
## Product Description
In conjunction with manually disabling the "Skip Fixture Syncs on Restores," this change will stop re-enabling it with the daily restore priming task ("USH-BHA: Control which domains will be included in the prime formplayer task runs").  The hope is that this will address a bug where users are not receiving a new lookup table in their restores.

## Technical Summary
https://dimagi.atlassian.net/browse/USH-6174
I have a theory that a race condition meant that disabling that feature flag didn't actually take effect in time for the restores.  This would explain intermittent reports of a new fixture not appearing, despite this specific accommodation.  Feature flag lookups are cached heavily in a couple different ways, and they should be correctly invalidated, but it's conceivable that the invalidation took longer than it took a restore to start for some of these users.

Clearing user data does consistently resolve the issue, which is consistent with the theory.  If this change is not sufficient to resolve the issue, we can force a full sync for all users like so:

```
Clear and resync all users who've synced in the last two weeks:
$ manage.py prime_formplayer_restores --domains co-carecoordination --last-synced-hours 336 --clear-user-data
```

## Feature Flag

USH-BHA: Control which domains will be included in the prime formplayer task runs

Skip Fixture Syncs on Restores


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change