### PR TITLE
Add comments about how to keep upload types in sync

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1054,6 +1054,7 @@ define("cloudcare/js/form_entry/entries", [
     function ImageEntry(question, options) {
         var self = this;
         FileEntry.call(this, question, options);
+        // Must match a key in VALID_ATTACHMENT_FILE_EXTENSION_MAP corehq/ex-submodules/couchforms/const.py
         self.accept = "image/*";
     }
     ImageEntry.prototype = Object.create(FileEntry.prototype);
@@ -1066,6 +1067,7 @@ define("cloudcare/js/form_entry/entries", [
         var self = this;
         FileEntry.call(this, question, options);
         self.accept = ".pdf,.xlsx,.docx,.html,.txt,.rtf,.msg";
+        // Must match a key in VALID_ATTACHMENT_FILE_EXTENSION_MAP corehq/ex-submodules/couchforms/const.py
         self.acceptedMimeTypes = "application/*,text/*";
     }
     DocumentEntry.prototype = Object.create(FileEntry.prototype);
@@ -1077,6 +1079,7 @@ define("cloudcare/js/form_entry/entries", [
     function AudioEntry(question, options) {
         var self = this;
         FileEntry.call(this, question, options);
+        // Must match a key in VALID_ATTACHMENT_FILE_EXTENSION_MAP corehq/ex-submodules/couchforms/const.py
         self.accept = "audio/*";
     }
     AudioEntry.prototype = Object.create(FileEntry.prototype);
@@ -1088,6 +1091,7 @@ define("cloudcare/js/form_entry/entries", [
     function VideoEntry(question, options) {
         var self = this;
         FileEntry.call(this, question, options);
+        // Must match a key in VALID_ATTACHMENT_FILE_EXTENSION_MAP corehq/ex-submodules/couchforms/const.py
         self.accept = "video/*";
     }
     VideoEntry.prototype = Object.create(FileEntry.prototype);
@@ -1100,6 +1104,7 @@ define("cloudcare/js/form_entry/entries", [
         var self = this;
         FileEntry.call(this, question, options);
         self.templateType = 'signature';
+        // Must match a key in VALID_ATTACHMENT_FILE_EXTENSION_MAP corehq/ex-submodules/couchforms/const.py
         self.accept = 'image/*,.pdf';
 
         self.afterRender = function () {

--- a/corehq/ex-submodules/couchforms/const.py
+++ b/corehq/ex-submodules/couchforms/const.py
@@ -22,6 +22,7 @@ DEVICE_LOG_XMLNS = 'http://code.javarosa.org/devicereport'
 
 # Should be in sync with file extensions supported by CommCare
 # https://github.com/dimagi/commcare-android/blob/ef45074bbb8647339387e179a2baca89fb394a23/app/src/org/commcare/utils/FormUploadUtil.java#LL63C1-L63C1
+# And in question types extending FileEntry in corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
 VALID_ATTACHMENT_FILE_EXTENSION_MAP = {
     "image/*": ["jpg", "jpeg", "png"],
     "image/*,.pdf": ["jpg", "jpeg", "png", "pdf"],


### PR DESCRIPTION
## Product Description

A recent change caused a P3 since the values in these two location were not kept in sync. Just adding some comments
to prevent this in future

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6195

## Feature Flag

No

## Safety Assurance

Just comments

### Safety story

No testing needed

### Automated test coverage

No testing needed

### QA Plan

No testing needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
