### PR TITLE
Refactor ServerLocation

### DIFF
--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -126,7 +126,7 @@ class ServerLocation:
     INDIA = 'india'
     PRODUCTION = 'production'
 
-    DATA = {
+    ENVS = {
         INDIA: {
             'country_code': 'in',
             'long_name': _("India"),
@@ -141,11 +141,10 @@ class ServerLocation:
         },
     }
 
-    ENVS = DATA.keys()
-    SUBDOMAINS = {env: server['subdomain'] for env, server in DATA.items()}
+    SUBDOMAINS = {env: server['subdomain'] for env, server in ENVS.items()}
 
     @classmethod
     def sorted_form_choices(cls):
-        env = settings.SERVER_ENVIRONMENT
-        sorted_keys = sorted(cls.ENVS, key=lambda x: x != env)
-        return [(cls.DATA[key]['subdomain'], cls.DATA[key]['long_name']) for key in sorted_keys]
+        current_env = settings.SERVER_ENVIRONMENT
+        sorted_keys = sorted(cls.ENVS.keys(), key=lambda x: x != current_env)
+        return [(cls.ENVS[key]['subdomain'], cls.ENVS[key]['long_name']) for key in sorted_keys]

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -125,7 +125,6 @@ def pkce_required(client_id):
 class ServerLocation:
     INDIA = 'india'
     PRODUCTION = 'production'
-    ENVS = (INDIA, PRODUCTION)
 
     DATA = {
         INDIA: {
@@ -141,6 +140,8 @@ class ServerLocation:
             'subdomain': 'www',
         },
     }
+
+    ENVS = DATA.keys()
     SUBDOMAINS = {env: server['subdomain'] for env, server in DATA.items()}
 
     @classmethod

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -123,22 +123,28 @@ def pkce_required(client_id):
 
 
 class ServerLocation:
-    PRODUCTION = 'production'
     INDIA = 'india'
-    ENVS = (PRODUCTION, INDIA)
+    PRODUCTION = 'production'
+    ENVS = (INDIA, PRODUCTION)
 
-    SUBDOMAINS = {
-        PRODUCTION: 'www',
-        INDIA: 'india',
+    DATA = {
+        INDIA: {
+            'country_code': 'in',
+            'long_name': _("India"),
+            'short_name': _("India"),
+            'subdomain': 'india',
+        },
+        PRODUCTION: {
+            'country_code': 'us',
+            'long_name': _("United States"),
+            'short_name': _("US"),
+            'subdomain': 'www',
+        },
     }
-
-    CHOICES_DICT = {
-        PRODUCTION: (SUBDOMAINS[PRODUCTION], _("United States")),
-        INDIA: (SUBDOMAINS[INDIA], _("India")),
-    }
+    SUBDOMAINS = {env: server['subdomain'] for env, server in DATA.items()}
 
     @classmethod
-    def choices(cls):
+    def sorted_form_choices(cls):
         env = settings.SERVER_ENVIRONMENT
         sorted_keys = sorted(cls.ENVS, key=lambda x: x != env)
-        return [cls.CHOICES_DICT[key] for key in sorted_keys]
+        return [(cls.DATA[key]['subdomain'], cls.DATA[key]['long_name']) for key in sorted_keys]

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -411,9 +411,9 @@ class RegisterDomainView(TemplateView):
 
         server_locations = [{
             'env': env,
-            'subdomain': server_info[0],
-            'name': server_info[1],
-        } for env, server_info in ServerLocation.CHOICES_DICT.items() if env != settings.SERVER_ENVIRONMENT]
+            'subdomain': server['subdomain'],
+            'name': server['long_name'],
+        } for env, server in ServerLocation.DATA.items() if env != settings.SERVER_ENVIRONMENT]
 
         context.update({
             'form': kwargs.get('form') or DomainRegistrationForm(),

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -413,7 +413,7 @@ class RegisterDomainView(TemplateView):
             'env': env,
             'subdomain': server['subdomain'],
             'name': server['long_name'],
-        } for env, server in ServerLocation.DATA.items() if env != settings.SERVER_ENVIRONMENT]
+        } for env, server in ServerLocation.ENVS.items() if env != settings.SERVER_ENVIRONMENT]
 
         context.update({
             'form': kwargs.get('form') or DomainRegistrationForm(),

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -3,13 +3,14 @@ import datetime
 from django.conf import settings
 from django.http import Http404
 from django.urls import resolve, reverse
-from django.utils.translation import gettext_lazy, gettext as _
+from django.utils.translation import gettext as _
 from django_prbac.utils import has_privilege
 
 from corehq import feature_previews, privileges, toggles
 from corehq.apps.accounting.models import BillingAccount, Subscription, SubscriptionType
 from corehq.apps.accounting.utils import domain_has_privilege, get_privileges
 from corehq.apps.analytics.utils.hubspot import is_hubspot_js_allowed_for_request
+from corehq.apps.hqwebapp.models import ServerLocation
 from corehq.apps.hqwebapp.utils import get_environment_friendly_name
 from corehq.apps.hqwebapp.utils import bootstrap
 
@@ -198,24 +199,16 @@ def commcare_hq_names(request=None):
 
 
 def server_location_display(request):
-    SERVER_LOCATION_DISPLAY = {
-        'production': {
-            'country_code': 'us',
-            'hr_name': gettext_lazy("US"),
-        },
-        'india': {
-            'country_code': 'in',
-            'hr_name': gettext_lazy("India"),
-        },
-        'eu': {
-            'country_code': 'eu',
-            'hr_name': gettext_lazy("EU"),
-        },
-    }
     context = {}
     env = settings.SERVER_ENVIRONMENT
-    if env in SERVER_LOCATION_DISPLAY.keys():
-        context = {'server_display': SERVER_LOCATION_DISPLAY[env]}
+    if env in ServerLocation.ENVS:
+        server = ServerLocation.DATA.get(env)
+        context = {
+            'server_display': {
+                'country_code': server['country_code'],
+                'hr_name': server['short_name'],
+            }
+        }
     return context
 
 

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -200,9 +200,9 @@ def commcare_hq_names(request=None):
 
 def server_location_display(request):
     context = {}
-    env = settings.SERVER_ENVIRONMENT
-    if env in ServerLocation.ENVS:
-        server = ServerLocation.DATA.get(env)
+    current_env = settings.SERVER_ENVIRONMENT
+    if current_env in ServerLocation.ENVS:
+        server = ServerLocation.ENVS.get(current_env)
         context = {
             'server_display': {
                 'country_code': server['country_code'],


### PR DESCRIPTION
- Put all info into a dict to pull out by key
- Rename choices() -> sorted_form_choices()
- Use for server_location_display context processor

## Product Description
No user-facing impact.

## Technical Summary
Allows this data model to be used as a broader source of truth for information about our different environments, including in the `server_location_display`. If reviewers have thoughts about the overall structure of this class and its data I'd be happy to hear them; this refactor is an attempt to keep it clean while adding additional keys for each environment.

## Safety Assurance

### Safety story
Tested locally that there are no adverse effects and places where we should see the server names are still correct (Add New Project, login screen on india/prod, settings dropdown on india/prod). There are also some automated tests that would catch any major regression.

### Automated test coverage
There are automated tests for TestExtractAppInfoForm and for the server_location_display where this model is used.

### QA Plan
Not planning it here.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
