### PR TITLE
Add dropdown to move between cloud locations on signup screen

### DIFF
--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from datetime import datetime
 
-from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import Q
@@ -142,9 +141,3 @@ class ServerLocation:
     }
 
     SUBDOMAINS = {env: server['subdomain'] for env, server in ENVS.items()}
-
-    @classmethod
-    def sorted_form_choices(cls):
-        current_env = settings.SERVER_ENVIRONMENT
-        sorted_keys = sorted(cls.ENVS.keys(), key=lambda x: x != current_env)
-        return [(cls.ENVS[key]['subdomain'], cls.ENVS[key]['long_name']) for key in sorted_keys]

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -40,8 +40,8 @@ class RegisterWebUserForm(forms.Form):
             widget=forms.RadioSelect,
             choices=ServerLocation.sorted_form_choices(),
             help_text=_(
-                "*You're creating an account and project space on the chosen server. "
-                "An account or project space cannot be transferred between cloud locations. "
+                "*You're creating an account and project space in the chosen cloud location.<br/>"
+                "These cannot be transferred between cloud locations. "
                 "<a href='{help_link}' target='_blank'>Learn more</a>."
             ).format(
                 help_link=("https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3101491209/"

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -35,13 +35,14 @@ class RegisterWebUserForm(forms.Form):
     # Not inheriting from other forms to de-obfuscate the role of this form.
     if settings.SERVER_ENVIRONMENT in ServerLocation.ENVS:
         server_location = forms.ChoiceField(
-            label=_("Server Location"),
+            label=_("Cloud Location"),
             required=False,
             widget=forms.RadioSelect,
             choices=ServerLocation.sorted_form_choices(),
             help_text=_(
-                "*Once created, a project space cannot be transferred from one server to another. "
-                "For more information, visit <a href='{help_link}' target='_blank'>this help page</a>."
+                "*You're creating an account and project space on the chosen server. "
+                "An account or project space cannot be transferred between cloud locations. "
+                "<a href='{help_link}' target='_blank'>Learn more</a>."
             ).format(
                 help_link=("https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3101491209/"
                            "CommCare+Cloud+Server+Locations")

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -22,6 +22,7 @@ from corehq.apps.custom_data_fields.edit_entity import add_prefix, get_prefixed,
 from corehq.apps.domain.forms import NoAutocompleteMixin, clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp import crispy as hqcrispy
+from corehq.apps.hqwebapp.models import ServerLocation
 from corehq.apps.programs.models import Program
 from corehq.apps.reports.models import TableauUser
 from corehq.toggles import WEB_USER_INVITE_ADDITIONAL_FIELDS
@@ -32,7 +33,20 @@ from corehq.apps.users.models import CouchUser
 class RegisterWebUserForm(forms.Form):
     # Use: NewUserRegistrationView
     # Not inheriting from other forms to de-obfuscate the role of this form.
-
+    if settings.SERVER_ENVIRONMENT in ServerLocation.ENVS:
+        server_location = forms.ChoiceField(
+            label=_("Server Location"),
+            required=False,
+            widget=forms.RadioSelect,
+            choices=ServerLocation.sorted_form_choices(),
+            help_text=_(
+                "*Once created, a project space cannot be transferred from one server to another. "
+                "For more information, visit <a href='{help_link}' target='_blank'>this help page</a>."
+            ).format(
+                help_link=("https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3101491209/"
+                           "CommCare+Cloud+Server+Locations")
+            ),
+        )
     full_name = forms.CharField(label=_("Full Name"))
     email = forms.CharField(label=_("Professional Email"))
     password = forms.CharField(
@@ -90,6 +104,15 @@ class RegisterWebUserForm(forms.Form):
         if settings.ENFORCE_SSO_LOGIN and self.is_sso:
             self.fields['password'].required = False
 
+        server_location_field = []
+        if self.fields.get('server_location'):
+            server_location_field = [
+                hqcrispy.RadioSelect(
+                    'server_location',
+                    data_bind="checked: serverLocation"
+                ),
+            ]
+
         saas_fields = []
         if settings.IS_SAAS_ENVIRONMENT:
             persona_fields = [
@@ -141,6 +164,7 @@ class RegisterWebUserForm(forms.Form):
                 crispy.Fieldset(
                     _('Create Your Account'),
                     hqcrispy.FormStepNumber(1, 2),
+                    *server_location_field,
                     hqcrispy.InlineField(
                         'full_name',
                         css_class="input-lg",

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -38,7 +38,10 @@ class RegisterWebUserForm(forms.Form):
             label=_("Cloud Location"),
             required=False,
             widget=forms.RadioSelect,
-            choices=ServerLocation.sorted_form_choices(),
+            choices=[
+                (server['subdomain'], _("{location_name} Cloud").format(location_name=server['long_name']))
+                for __, server in ServerLocation.ENVS.items()
+            ],
             help_text=_(
                 "*You're creating an account and project space in the chosen cloud location.<br/>"
                 "These cannot be transferred between cloud locations. "
@@ -107,6 +110,8 @@ class RegisterWebUserForm(forms.Form):
 
         server_location_field = []
         if self.fields.get('server_location'):
+            # safe to access because we only render the field if the current environment is in ServerLocation.ENVS
+            self.fields['server_location'].initial = ServerLocation.ENVS[settings.SERVER_ENVIRONMENT]['subdomain']
             server_location_field = [
                 hqcrispy.RadioSelect(
                     'server_location',

--- a/corehq/apps/registration/static/registration/js/new_user.ko.js
+++ b/corehq/apps/registration/static/registration/js/new_user.ko.js
@@ -5,6 +5,7 @@ import RMI from "jquery.rmi/jquery.rmi";
 import noopMetrics from "analytix/js/noopMetrics";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import intlTelInput from "intl-tel-input/build/js/intlTelInput.min";
+import serverLocationSelect from "registration/js/server_location_select";
 import "jquery-ui/ui/effect";
 import "jquery-ui/ui/effects/effect-slide";
 import "jquery-ui-built-themes/redmond/jquery-ui.min.css";
@@ -47,6 +48,8 @@ var formViewModel = function (defaults, containerSelector, steps) {
     // ---------------------------------------------------------------------
     // Step 1 Fields
     // ---------------------------------------------------------------------
+    const serverLocationModel = serverLocationSelect({});
+    self.serverLocation = serverLocationModel.serverLocation;
     self.fullName = ko.observable(defaults.full_name)
         .extend({
             required: {

--- a/corehq/apps/registration/static/registration/js/server_location_select.js
+++ b/corehq/apps/registration/static/registration/js/server_location_select.js
@@ -1,0 +1,36 @@
+import ko from "knockout";
+
+const subdomainRegex = /(?<=:\/\/).*(?=\.commcarehq\.org)/;
+const subdomainMatch = function (url) {
+    return url.match(subdomainRegex);
+};
+
+const currentSubdomain = function (url) {
+    const match = subdomainMatch(url);
+    return match ? match[0] : "";
+};
+
+const replaceSubdomain = function (value, url) {
+    return url.replace(subdomainRegex, value);
+};
+
+const serverLocationSelect = function (options) {
+    const self = {};
+    const url = options.url || window.location.href;
+    const initialValue = options.initialValue || currentSubdomain(url);
+
+    self.setWindowHref = function (newUrl) {
+        window.location.href = newUrl;
+    };
+
+    self.serverLocation = ko.observable(initialValue);
+    self.serverLocation.subscribe(function (value) {
+        if (subdomainMatch(url)) {
+            const newUrl = replaceSubdomain(value, url);
+            self.setWindowHref(newUrl);
+        }
+    });
+    return self;
+};
+
+export default serverLocationSelect;

--- a/corehq/apps/registration/static/registration/js/server_location_select.js
+++ b/corehq/apps/registration/static/registration/js/server_location_select.js
@@ -19,7 +19,7 @@ const serverLocationSelect = function (options) {
     const url = options.url || window.location.href;
     const initialValue = options.initialValue || currentSubdomain(url);
 
-    self.setWindowHref = function (newUrl) {
+    self.navigateTo = function (newUrl) {
         window.location.href = newUrl;
     };
 
@@ -27,7 +27,7 @@ const serverLocationSelect = function (options) {
     self.serverLocation.subscribe(function (value) {
         if (subdomainMatch(url)) {
             const newUrl = replaceSubdomain(value, url);
-            self.setWindowHref(newUrl);
+            self.navigateTo(newUrl);
         }
     });
     return self;

--- a/corehq/apps/registration/static/registration/spec/main.js
+++ b/corehq/apps/registration/static/registration/spec/main.js
@@ -1,0 +1,5 @@
+import hqMocha from "mocha/js/main";
+
+import "registration/spec/server_location_select_spec";
+
+hqMocha.run();

--- a/corehq/apps/registration/static/registration/spec/server_location_select_spec.js
+++ b/corehq/apps/registration/static/registration/spec/server_location_select_spec.js
@@ -21,20 +21,20 @@ describe('serverLocationSelect', function () {
     it('should update url subdomain when serverLocation changes', function () {
         const url = 'https://test.commcarehq.org/some/path';
         const model = serverLocationSelect({ url });
-        const setWindowHref = sinon.stub(model, 'setWindowHref');
+        const navigateTo = sinon.stub(model, 'navigateTo');
 
         model.serverLocation('newsubdomain');
-        sinon.assert.calledOnce(setWindowHref);
-        sinon.assert.calledWith(setWindowHref, 'https://newsubdomain.commcarehq.org/some/path');
+        sinon.assert.calledOnce(navigateTo);
+        sinon.assert.calledWith(navigateTo, 'https://newsubdomain.commcarehq.org/some/path');
     });
 
     it('should not update url if same value is selected', function () {
         const url = 'https://test.commcarehq.org';
         const model = serverLocationSelect({ url });
-        const setWindowHref = sinon.stub(model, 'setWindowHref');
+        const navigateTo = sinon.stub(model, 'navigateTo');
 
         model.serverLocation('test');
-        sinon.assert.notCalled(setWindowHref);
+        sinon.assert.notCalled(navigateTo);
     });
 
 });

--- a/corehq/apps/registration/static/registration/spec/server_location_select_spec.js
+++ b/corehq/apps/registration/static/registration/spec/server_location_select_spec.js
@@ -1,0 +1,40 @@
+import sinon from "sinon";
+import serverLocationSelect from 'registration/js/server_location_select';
+
+describe('serverLocationSelect', function () {
+
+    it('should use initialValue when provided', function () {
+        const url = 'https://test.commcarehq.org';
+        const model = serverLocationSelect({
+            initialValue: 'custom',
+            url: url,
+        });
+        assert.equal(model.serverLocation(), 'custom');
+    });
+
+    it('should use current HQ subdomain if no initialValue', function () {
+        const url = 'https://test.commcarehq.org';
+        const model = serverLocationSelect({ url });
+        assert.equal(model.serverLocation(), 'test');
+    });
+
+    it('should update url subdomain when serverLocation changes', function () {
+        const url = 'https://test.commcarehq.org/some/path';
+        const model = serverLocationSelect({ url });
+        const setWindowHref = sinon.stub(model, 'setWindowHref');
+
+        model.serverLocation('newsubdomain');
+        sinon.assert.calledOnce(setWindowHref);
+        sinon.assert.calledWith(setWindowHref, 'https://newsubdomain.commcarehq.org/some/path');
+    });
+
+    it('should not update url if same value is selected', function () {
+        const url = 'https://test.commcarehq.org';
+        const model = serverLocationSelect({ url });
+        const setWindowHref = sinon.stub(model, 'setWindowHref');
+
+        model.serverLocation('test');
+        sinon.assert.notCalled(setWindowHref);
+    });
+
+});

--- a/corehq/apps/registration/templates/registration/spec/mocha.html
+++ b/corehq/apps/registration/templates/registration/spec/mocha.html
@@ -1,0 +1,4 @@
+{% extends "mocha/base.html" %}
+{% load hq_shared_tags %}
+
+{% js_entry_b3 "registration/spec/main" %}


### PR DESCRIPTION
## Product Description
On signup screen:
<img width="490" height="476" alt="image" src="https://github.com/user-attachments/assets/19fa615c-d947-46cb-b397-7a4ac2d4c326" />

<img width="488" height="477" alt="image" src="https://github.com/user-attachments/assets/5f27ca93-79c7-4837-b36e-7f96797eabcc" />

Note: "Local Development" is shown here as an example only.

## Technical Summary
Split from https://dimagi.atlassian.net/browse/SAAS-17739, with most commits cherry-picked from https://github.com/dimagi/commcare-hq/pull/36710
Conditionally adds a new form field `server_location` to the new user registration form. Uses knockout to bind to the value of this form field and, when the value changes, swap out the subdomain component of the current url in the user's browser with the new value.


## Safety Assurance

### Safety story
This functionality isn't overly complex: add a form field, get the value of the field, interpolate it into the current url and navigate to that url. There is some risk to modifying existing forms, especially important ones like registration. Automated testing for aspects of that form helps somewhat to protect against regression.

Tested functionality locally by changing `settings.SERVER_ENVIRONMENT` to production, or india or leaving it set to the local environment name and seeing that the dropdown appears and calls JS functions as expected.  Tested functionality on staging by temporarily adding a `STAGING` option to `ServerLocation` and seeing that it appears correctly and navigates between servers in a live environment as expected. Also ran through sign up workflow to see it is not affected.

### Automated test coverage
Basic automated tests added for new JS component.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
