### PR TITLE
Add links to move between cloud locations on login screen

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap3/server_location_select.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap3/server_location_select.html
@@ -1,5 +1,14 @@
 {% load i18n %}
 
+<p class="text-center">
+  <a data-toggle="collapse" data-target="#server-location-select">
+    {% blocktrans %}
+      Looking to sign into a different cloud environment?
+    {% endblocktrans %}
+    <span class="caret"></span>
+  </a>
+</p>
+
 <div class="collapse" id="server-location-select">
   <div class="server-location-buttons">
     {% for server in server_choices %}

--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap3/server_location_select.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap3/server_location_select.html
@@ -24,5 +24,16 @@
       </a>
     {% endfor %}
   </div>
+  <p class="text-center">
+    <br />
+    {% blocktrans %}
+      Learn more about our
+      <a
+        href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3101491209/CommCare+Cloud+Server+Locations"
+        target="_blank"
+        >cloud environments</a
+      >.
+    {% endblocktrans %}
+  </p>
   <hr />
 </div>

--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap3/server_location_select.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap3/server_location_select.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+
+<div class="collapse" id="server-location-select">
+  <div class="server-location-buttons">
+    {% for server in server_choices %}
+      <a
+        class="btn btn-lg btn-default"
+        href="https://{{ server.subdomain }}.commcarehq.org{{ request.path }}"
+      >
+        <span class="fi fi-{{ server.country_code }}"></span>
+        {% blocktrans with server.short_name as server_name %}
+          {{ server_name }}
+          Cloud
+        {% endblocktrans %}
+      </a>
+    {% endfor %}
+  </div>
+  <hr />
+</div>

--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/server_location_select.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/server_location_select.html
@@ -1,5 +1,14 @@
 {% load i18n %}
 
+<p class="text-center">
+  <a data-bs-toggle="collapse" data-bs-target="#server-location-select">
+    {% blocktrans %}
+      Looking to sign into a different cloud environment?
+    {% endblocktrans %}
+    <span class="caret"></span>
+  </a>
+</p>
+
 <div class="collapse" id="server-location-select">
   <div class="server-location-buttons">
     {% for server in server_choices %}

--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/server_location_select.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/server_location_select.html
@@ -24,5 +24,16 @@
       </a>
     {% endfor %}
   </div>
+  <p class="text-center">
+    <br />
+    {% blocktrans %}
+      Learn more about our
+      <a
+        href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3101491209/CommCare+Cloud+Server+Locations"
+        target="_blank"
+        >cloud environments</a
+      >.
+    {% endblocktrans %}
+  </p>
   <hr />
 </div>

--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/server_location_select.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/server_location_select.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+
+<div class="collapse" id="server-location-select">
+  <div class="server-location-buttons">
+    {% for server in server_choices %}
+      <a
+        class="btn btn-lg btn-default"
+        href="https://{{ server.subdomain }}.commcarehq.org{{ request.path }}"
+      >
+        <span class="fi fi-{{ server.country_code }}"></span>
+        {% blocktrans with server.short_name as server_name %}
+          {{ server_name }}
+          Cloud
+        {% endblocktrans %}
+      </a>
+    {% endfor %}
+  </div>
+  <hr />
+</div>

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
@@ -5,12 +5,21 @@
     {{ current_page.page_name }}
   </h2>
   {% if server_display %}
-    <p class="lead text-center">
+    <h3 class="text-center">
       <span class="fi fi-{{ server_display.country_code }}"></span>
       {% blocktrans with server_display.hr_name as server_location %}
         {{ server_location }} Cloud
       {% endblocktrans %}
-    </p>
+    </h3>
+    {% if can_select_server %}
+      <p class="text-center">
+        <a>
+          {% blocktrans %}
+            Looking to sign into a different cloud environment?
+          {% endblocktrans %}
+        </a>
+      </p>
+    {% endif %}
   {% endif %}
 
   {% if messages %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
@@ -13,12 +13,13 @@
     </h3>
     {% if can_select_server %}
       <p class="text-center">
-        <a>
+        <a data-toggle="collapse" data-target="#server-location-select">
           {% blocktrans %}
             Looking to sign into a different cloud environment?
           {% endblocktrans %}
         </a>
       </p>
+      {% include 'login_and_password/partials/bootstrap3/server_location_select.html' %}
     {% endif %}
   {% endif %}
 

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap3/login.html
@@ -12,13 +12,6 @@
       {% endblocktrans %}
     </h3>
     {% if can_select_server %}
-      <p class="text-center">
-        <a data-toggle="collapse" data-target="#server-location-select">
-          {% blocktrans %}
-            Looking to sign into a different cloud environment?
-          {% endblocktrans %}
-        </a>
-      </p>
       {% include 'login_and_password/partials/bootstrap3/server_location_select.html' %}
     {% endif %}
   {% endif %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
@@ -13,12 +13,13 @@
     </h3>
     {% if can_select_server %}
       <p class="text-center">
-        <a>
+        <a data-bs-toggle="collapse" data-target="#server-location-select">
           {% blocktrans %}
             Looking to sign into a different cloud environment?
           {% endblocktrans %}
         </a>
       </p>
+      {% include 'login_and_password/partials/bootstrap5/server_location_select.html' %}
     {% endif %}
   {% endif %}
 

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
@@ -5,12 +5,21 @@
     {{ current_page.page_name }}
   </h2>
   {% if server_display %}
-    <p class="lead text-center">
+    <h3 class="text-center">
       <span class="fi fi-{{ server_display.country_code }}"></span>
       {% blocktrans with server_display.hr_name as server_location %}
         {{ server_location }} Cloud
       {% endblocktrans %}
-    </p>
+    </h3>
+    {% if can_select_server %}
+      <p class="text-center">
+        <a>
+          {% blocktrans %}
+            Looking to sign into a different cloud environment?
+          {% endblocktrans %}
+        </a>
+      </p>
+    {% endif %}
   {% endif %}
 
   {% if messages %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/bootstrap5/login.html
@@ -12,13 +12,6 @@
       {% endblocktrans %}
     </h3>
     {% if can_select_server %}
-      <p class="text-center">
-        <a data-bs-toggle="collapse" data-target="#server-location-select">
-          {% blocktrans %}
-            Looking to sign into a different cloud environment?
-          {% endblocktrans %}
-        </a>
-      </p>
       {% include 'login_and_password/partials/bootstrap5/server_location_select.html' %}
     {% endif %}
   {% endif %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/forms.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/forms.less
@@ -161,7 +161,7 @@ textarea.vertical-resize {
     color: @cc-brand-mid;
   }
 
-  .btn-default {
+  .btn-default:not(:hover) {
     background-color: @call-to-action-extra-hi;
   }
 }

--- a/corehq/apps/hqwebapp/static/registration/less/registration-main.less
+++ b/corehq/apps/hqwebapp/static/registration/less/registration-main.less
@@ -215,3 +215,8 @@ p.sso-message-block {
     text-align: center;
   }
 }
+
+.server-location-buttons {
+  display: flex;
+  justify-content: space-evenly;
+}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/login_and_password/partials/server_location_select.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/login_and_password/partials/server_location_select.html.diff.txt
@@ -1,0 +1,11 @@
+--- 
++++ 
+@@ -1,7 +1,7 @@
+ {% load i18n %}
+ 
+ <p class="text-center">
+-  <a data-toggle="collapse" data-target="#server-location-select">
++  <a data-bs-toggle="collapse" data-bs-target="#server-location-select">
+     {% blocktrans %}
+       Looking to sign into a different cloud environment?
+     {% endblocktrans %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/login_and_password/two_factor/core/login.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/login_and_password/two_factor/core/login.html.diff.txt
@@ -1,6 +1,15 @@
 --- 
 +++ 
-@@ -76,5 +76,5 @@
+@@ -12,7 +12,7 @@
+       {% endblocktrans %}
+     </h3>
+     {% if can_select_server %}
+-      {% include 'login_and_password/partials/bootstrap3/server_location_select.html' %}
++      {% include 'login_and_password/partials/bootstrap5/server_location_select.html' %}
+     {% endif %}
+   {% endif %}
+ 
+@@ -79,5 +79,5 @@
        {{ global_error }}
      </div>
    {% endfor %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/forms._forms.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/forms._forms.style.diff.txt
@@ -172,7 +172,7 @@
 -    color: @cc-brand-mid;
 -  }
 -
--  .btn-default {
+-  .btn-default:not(:hover) {
 -    background-color: @call-to-action-extra-hi;
 -  }
 -}

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -89,7 +89,7 @@ from corehq.apps.hqwebapp.forms import (
     HQAuthenticationTokenForm,
     HQBackupTokenForm
 )
-from corehq.apps.hqwebapp.models import HQOauthApplication
+from corehq.apps.hqwebapp.models import HQOauthApplication, ServerLocation
 from corehq.apps.hqwebapp.login_utils import get_custom_login_page
 from corehq.apps.hqwebapp.utils import get_environment_friendly_name
 from corehq.apps.hqwebapp.utils.bootstrap import get_bootstrap_version
@@ -525,6 +525,11 @@ class HQLoginView(LoginView):
                 return HttpResponseRedirect(idp.get_login_url(username=username))
         return super().post(*args, **kwargs)
 
+    def can_select_server(self):
+        env = settings.SERVER_ENVIRONMENT
+        domain = self.extra_context.get('domain')
+        return env in ServerLocation.ENVS and not domain
+
     def get_form_kwargs(self, step=None):
         kwargs = super().get_form_kwargs(step)
         # The forms need the request to properly log authentication failures
@@ -539,6 +544,7 @@ class HQLoginView(LoginView):
             and self.steps.current == self.AUTH_STEP
         )
         domain = context.get('domain')
+        context['can_select_server'] = self.can_select_server()
         if domain and not is_domain_using_sso(domain):
             # ensure that domain login pages not associated with SSO do not
             # enforce SSO on the login screen

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -527,7 +527,9 @@ class HQLoginView(LoginView):
 
     def can_select_server(self):
         env = settings.SERVER_ENVIRONMENT
+        # domain is server-specific, so we won't give the option to switch servers on domain logins
         is_domain_login = self.extra_context.get('domain')
+        # also check the next param, because domain or other server-specific ids can exist there
         has_next_url = self.request.GET.get('next')
         return (env in ServerLocation.ENVS
                 and not is_domain_login

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -527,8 +527,11 @@ class HQLoginView(LoginView):
 
     def can_select_server(self):
         env = settings.SERVER_ENVIRONMENT
-        domain = self.extra_context.get('domain')
-        return env in ServerLocation.ENVS and not domain
+        is_domain_login = self.extra_context.get('domain')
+        has_next_url = self.request.GET.get('next')
+        return (env in ServerLocation.ENVS
+                and not is_domain_login
+                and not has_next_url)
 
     def get_form_kwargs(self, step=None):
         kwargs = super().get_form_kwargs(step)

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -548,6 +548,11 @@ class HQLoginView(LoginView):
         )
         domain = context.get('domain')
         context['can_select_server'] = self.can_select_server()
+        if self.can_select_server():
+            context['server_choices'] = [
+                server for env, server in ServerLocation.ENVS.items()
+                if env != settings.SERVER_ENVIRONMENT
+            ]
         if domain and not is_domain_using_sso(domain):
             # ensure that domain login pages not associated with SSO do not
             # enforce SSO on the login screen


### PR DESCRIPTION
## Product Description
On login screen:

https://github.com/user-attachments/assets/72ffbfd8-8e05-4c47-ae38-be39d4c576be

Note: "Staging Cloud" with UN flag is shown here as an example only.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17739, https://dimagi.atlassian.net/browse/SAAS-18380
Adds button-styled links on the main login screen (but not domain-specific login pages) to move to the current page on another cloud location, based on choices in `ServerLocation` model.

## Safety Assurance

### Safety story
Tested locally and on staging by temporarily adding a `localdev` or `staging` environment to ServerLocation. There's a good chunk of new HTML here but very little in terms of functional code - just a bit of view context.

### Automated test coverage
Not for this change.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
