### PR TITLE
Backfill Usercases Management Comnmand

### DIFF
--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -16,7 +16,7 @@ from corehq.apps.app_manager.exceptions import (
     AppValidationError,
     SavedAppBuildException,
 )
-from corehq.apps.users.models import CommCareUser, CouchUser, WebUser
+from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.toggles import USH_USERCASES_FOR_WEB_USERS, VELLUM_SAVE_TO_CASE
 from corehq.util.decorators import serial_task
@@ -34,22 +34,6 @@ def create_usercases(domain_name):
         users = CommCareUser.by_domain(domain_name)
     for user in users:
         sync_usercases(user, domain_name, sync_call_center=False)
-
-
-# This is temporarily created to support the usercase backfill
-# and can be deleted after the backfill is done
-@task(queue='background_queue', ignore_result=True)
-def create_usercases_for_user_type(domain_name,
-                                   include_commcare_users=False,
-                                   include_web_users=False):
-    from corehq.apps.callcenter.sync_usercase import sync_usercases_ignore_web_flag
-    users = []
-    if include_web_users:
-        users.extend(WebUser.by_domain(domain_name))
-    if include_commcare_users:
-        users.extend(CommCareUser.by_domain(domain_name))
-    for user in users:
-        sync_usercases_ignore_web_flag(user, domain_name)
 
 
 def autogenerate_build(app, username):

--- a/corehq/apps/callcenter/sync_usercase.py
+++ b/corehq/apps/callcenter/sync_usercase.py
@@ -260,3 +260,11 @@ def sync_usercases(user, domain, sync_call_center=True):
             _iter_call_center_case_helpers(user) if sync_call_center else [],
         ))
         _UserCaseHelper.commit(helpers)
+
+
+# This is temporarily created to backfill usercases
+# and can be deleted after the backfill is done
+def sync_usercases_ignore_web_flag(user, domain):
+    with CriticalSection([f"sync_user_case_for_{user.user_id}_{domain}"]):
+        helper = _get_sync_usercase_helper(user, domain, USERCASE_TYPE, user.get_id, None)
+        _UserCaseHelper.commit([helper])

--- a/corehq/apps/users/management/commands/create_usercases.py
+++ b/corehq/apps/users/management/commands/create_usercases.py
@@ -1,10 +1,14 @@
+import time
+from itertools import chain
+
 from django.core.management.base import BaseCommand
 
 from corehq import privileges
-from corehq.apps.app_manager.tasks import create_usercases_for_user_type
-from corehq.apps.domain.models import Domain
 from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.callcenter.sync_usercase import sync_usercases_ignore_web_flag
+from corehq.apps.domain.models import Domain
 from corehq.util.log import with_progress_bar
+from corehq.apps.users.models import CommCareUser, WebUser
 
 
 class Command(BaseCommand):
@@ -16,30 +20,41 @@ class Command(BaseCommand):
 
     def handle(self, domain, dry_run, **kwargs):
         all_domains = set([domain]) if domain else set(Domain.get_all_names())
+        processed_user_counter = 0
+        RATE_LIMIT = 5000
+        SLEEP_TIME = 60
+
+        def _sync_usercases_with_throttle(users, domain):
+            nonlocal processed_user_counter
+            for user in users:
+                sync_usercases_ignore_web_flag(user, domain)
+                processed_user_counter += 1
+                if processed_user_counter % RATE_LIMIT == 0:
+                    time.sleep(SLEEP_TIME)
 
         domains_both_created = 0
         domains_only_web_created = 0
 
-        for d in with_progress_bar(all_domains, length=len(all_domains)):
-            if not domain_has_privilege(d, privileges.USERCASE):
+        for domain in with_progress_bar(all_domains, length=len(all_domains)):
+            if not domain_has_privilege(domain, privileges.USERCASE):
                 continue
 
-            dom = Domain.get_by_name(d)
-            if not dom:
-                print(f"Domain {d} does not exist")
+            domain_obj = Domain.get_by_name(domain)
+            if not domain_obj:
+                print(f"Domain {domain} does not exist")
                 continue
 
-            if dom.usercase_enabled:
+            if domain_obj.usercase_enabled:
                 if not dry_run:
-                    create_usercases_for_user_type.delay(d, include_web_users=True)
-
+                    users = WebUser.by_domain(domain)
+                    _sync_usercases_with_throttle(users, domain)
                 domains_only_web_created += 1
             else:
                 if not dry_run:
-                    create_usercases_for_user_type.delay(d, include_commcare_users=True,
-                                                include_web_users=True)
-                    dom.usercase_enabled = True
-                    dom.save()
+                    users = chain(WebUser.by_domain(domain), CommCareUser.by_domain(domain))
+                    _sync_usercases_with_throttle(users, domain)
+                    domain_obj.usercase_enabled = True
+                    domain_obj.save()
                 domains_both_created += 1
 
         print(f"Domains with both CommCare and Web users usercases created/synced: {domains_both_created}")

--- a/corehq/apps/users/management/commands/create_usercases.py
+++ b/corehq/apps/users/management/commands/create_usercases.py
@@ -1,0 +1,32 @@
+from django.core.management.base import BaseCommand
+
+from corehq import privileges
+from corehq.apps.app_manager.tasks import create_usercases_for_user_type
+from corehq.apps.domain.models import Domain
+from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.util.log import with_progress_bar
+
+
+class Command(BaseCommand):
+    help = "Create usercases for all users in the domains with the usercase privilege"
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain', nargs='?')
+
+    def handle(self, domain, **kwargs):
+        all_domains = set([domain]) if domain else set(Domain.get_all_names())
+
+        for d in with_progress_bar(all_domains, length=len(all_domains)):
+            if not domain_has_privilege(d, privileges.USERCASE):
+                continue
+
+            dom = Domain.get_by_name(d)
+            if not dom:
+                print(f"Domain {d} does not exist")
+                continue
+
+            if dom.usercase_enabled:
+                create_usercases_for_user_type.delay(d, include_web_users=True)
+            else:
+                create_usercases_for_user_type.delay(d, include_commcare_users=True,
+                                                include_web_users=False)

--- a/corehq/apps/users/management/commands/create_usercases.py
+++ b/corehq/apps/users/management/commands/create_usercases.py
@@ -3,7 +3,7 @@ import time
 from django.core.management.base import BaseCommand
 
 from corehq import privileges
-from corehq.toggles import USH_USERCASES_FOR_WEB_USERS
+from corehq.toggles import USH_USERCASES_FOR_WEB_USERS, NAMESPACE_DOMAIN
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.callcenter.sync_usercase import sync_usercases_ignore_web_flag
 from corehq.apps.domain.models import Domain
@@ -58,7 +58,7 @@ class Command(BaseCommand):
                     )
                     users = (CouchUser.wrap_correctly(row['doc']) for row in rows)
                     _sync_usercases_with_throttle(users, domain)
-                    USH_USERCASES_FOR_WEB_USERS.set(domain, True)
+                    USH_USERCASES_FOR_WEB_USERS.set(domain, True, NAMESPACE_DOMAIN)
                 domains_only_web_created += 1
             else:
                 if not dry_run:
@@ -69,7 +69,7 @@ class Command(BaseCommand):
                     )
                     users = (CouchUser.wrap_correctly(row['doc']) for row in rows)
                     _sync_usercases_with_throttle(users, domain)
-                    USH_USERCASES_FOR_WEB_USERS.set(domain, True)
+                    USH_USERCASES_FOR_WEB_USERS.set(domain, True, NAMESPACE_DOMAIN)
                     domain_obj.usercase_enabled = True
                     domain_obj.save()
                 domains_both_created += 1

--- a/corehq/apps/users/management/commands/create_usercases.py
+++ b/corehq/apps/users/management/commands/create_usercases.py
@@ -32,11 +32,14 @@ class Command(BaseCommand):
             if dom.usercase_enabled:
                 if not dry_run:
                     create_usercases_for_user_type.delay(d, include_web_users=True)
+
                 domains_only_web_created += 1
             else:
                 if not dry_run:
                     create_usercases_for_user_type.delay(d, include_commcare_users=True,
                                                 include_web_users=True)
+                    dom.usercase_enabled = True
+                    dom.save()
                 domains_both_created += 1
 
         print(f"Domains with both CommCare and Web users usercases created/synced: {domains_both_created}")

--- a/corehq/apps/users/tests/test_create_usercases_command.py
+++ b/corehq/apps/users/tests/test_create_usercases_command.py
@@ -8,41 +8,49 @@ from django.test import SimpleTestCase
 class CreateUsercasesCommandCombinationsTests(SimpleTestCase):
 
     @patch('corehq.apps.users.management.commands.create_usercases.sync_usercases_ignore_web_flag')
+    @patch('corehq.apps.users.management.commands.create_usercases.USH_USERCASES_FOR_WEB_USERS')
     @patch('corehq.apps.users.management.commands.create_usercases.CommCareUser.by_domain')
     @patch('corehq.apps.users.management.commands.create_usercases.WebUser.by_domain')
     @patch('corehq.apps.users.management.commands.create_usercases.domain_has_privilege')
     @patch('corehq.apps.users.management.commands.create_usercases.Domain.get_by_name')
     @patch('corehq.apps.users.management.commands.create_usercases.Domain.get_all_names')
     def test_domain_combinations_enqueue_and_counts(
-        self, mock_all_names, mock_get_by_name, mock_has_priv, mock_web_by_domain, mock_cc_by_domain, mock_sync
+        self, mock_all_names, mock_get_by_name, mock_has_priv,
+        mock_web_by_domain, mock_cc_by_domain, mock_toggle, mock_sync
     ):
-        # Define domains with combinations of (has_privilege, usercase_enabled)
+        # Define domains with combinations of (has_privilege, usercase_enabled, usercase_toggle_enabled)
         combos = {
-            'priv_enabled': (True, True),   # expect only web user
-            'priv_disabled': (True, False),  # expect commcare user and web user
-            'nopriv_enabled': (False, True),  # expect skip
-            'nopriv_disabled': (False, False),  # expect skip
+            'priv_enabled_and_toggle_enabled': (True, True, True),  # expect skip
+            'priv_enabled_and_toggle_disabled': (True, True, False),  # expect only web user
+            'priv_disabled_and_toggle_enabled': (True, False, True),  # expect commcare user and web user
+            'priv_disabled_and_toggle_disabled': (True, False, False),  # expect commcare user and web user
+            'nopriv_enabled_and_toggle_enabled': (False, True, True),  # expect skip
+            'nopriv_enabled_and_toggle_disabled': (False, True, False),  # expect skip
+            'nopriv_disabled_and_toggle_enabled': (False, False, True),  # expect skip
+            'nopriv_disabled_and_toggle_disabled': (False, False, False),  # expect skip
         }
         mock_all_names.return_value = list(combos.keys())
 
         def _get_by_name(name):
-            _, usercase_enabled = combos[name]
+            _, usercase_enabled, _ = combos[name]
             return SimpleNamespace(usercase_enabled=usercase_enabled,
                                    save=lambda: None)
 
         def _has_priv(name, *_):
-            has_priv, _ = combos[name]
+            has_priv, _, _ = combos[name]
             return has_priv
 
+        mock_toggle.enabled.side_effect = lambda domain: combos[domain][2]
+
         def _web_users(domain):
-            if domain == 'priv_enabled':
+            if domain.startswith('priv_enabled'):
                 return [SimpleNamespace(), SimpleNamespace()]
-            if domain == 'priv_disabled':
+            if domain.startswith('priv_disabled'):
                 return [SimpleNamespace()]
             return []
 
         def _cc_users(domain):
-            if domain == 'priv_disabled':
+            if domain.startswith('priv_disabled'):
                 return [SimpleNamespace(), SimpleNamespace()]
             return []
 
@@ -53,8 +61,24 @@ class CreateUsercasesCommandCombinationsTests(SimpleTestCase):
 
         call_command('create_usercases')
 
-        # 2 web (priv_enabled) + 1 web (priv_disabled) + 2 commcare (priv_disabled) = 5
-        assert mock_sync.call_count == 5
+        # Processed domains:
+        # - priv_enabled_and_toggle_disabled: 2 web
+        # - priv_disabled_and_toggle_enabled: 1 web + 2 commcare
+        # - priv_disabled_and_toggle_disabled: 1 web + 2 commcare
+        # Total sync calls = 2 + 3 + 3 = 8
+        assert mock_sync.call_count == 8
 
         called_domains = {c.args[1] for c in mock_sync.call_args_list}
-        assert called_domains == {'priv_enabled', 'priv_disabled'}
+        assert called_domains == {
+            'priv_enabled_and_toggle_disabled',
+            'priv_disabled_and_toggle_enabled',
+            'priv_disabled_and_toggle_disabled',
+        }
+
+        # Flag set only for processed domains
+        set_domains = {c.args[0] for c in mock_toggle.set.call_args_list}
+        assert set_domains == {
+            'priv_enabled_and_toggle_disabled',
+            'priv_disabled_and_toggle_enabled',
+            'priv_disabled_and_toggle_disabled',
+        }

--- a/corehq/apps/users/tests/test_create_usercases_command.py
+++ b/corehq/apps/users/tests/test_create_usercases_command.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import SimpleTestCase
+
+
+class CreateUsercasesCommandCombinationsTests(SimpleTestCase):
+
+    @patch('corehq.apps.users.management.commands.create_usercases.create_usercases_for_user_type.delay')
+    @patch('corehq.apps.users.management.commands.create_usercases.domain_has_privilege')
+    @patch('corehq.apps.users.management.commands.create_usercases.Domain.get_by_name')
+    @patch('corehq.apps.users.management.commands.create_usercases.Domain.get_all_names')
+    def test_domain_combinations_enqueue_and_counts(
+        self, mock_all_names, mock_get_by_name, mock_has_priv, mock_delay
+    ):
+        # Define domains with combinations of (has_privilege, usercase_enabled)
+        combos = {
+            'priv_enabled': (True, True),   # expect only web user
+            'priv_disabled': (True, False),  # expect commcare user and web user
+            'nopriv_enabled': (False, True),  # expect skip
+            'nopriv_disabled': (False, False),  # expect skip
+        }
+        mock_all_names.return_value = list(combos.keys())
+
+        def _get_by_name(name):
+            _, usercase_enabled = combos[name]
+            return SimpleNamespace(usercase_enabled=usercase_enabled)
+
+        def _has_priv(name, *_):
+            has_priv, _ = combos[name]
+            return has_priv
+
+        mock_get_by_name.side_effect = _get_by_name
+        mock_has_priv.side_effect = _has_priv
+
+        call_command('create_usercases')
+
+        mock_delay.assert_any_call('priv_enabled', include_web_users=True)
+        mock_delay.assert_any_call('priv_disabled', include_commcare_users=True, include_web_users=True)
+
+        assert mock_delay.call_count == 2
+
+        called_domains = {c.args[0] for c in mock_delay.call_args_list}
+        assert 'nopriv_enabled' not in called_domains
+        assert 'nopriv_disabled' not in called_domains

--- a/corehq/apps/users/tests/test_create_usercases_command.py
+++ b/corehq/apps/users/tests/test_create_usercases_command.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import SimpleTestCase
+from corehq.toggles import NAMESPACE_DOMAIN
 from corehq.util.test_utils import generate_cases
 
 
@@ -64,6 +65,6 @@ class CreateUsercasesCommandCombinationsTests(SimpleTestCase):
         assert mock_sync.call_count == expected_sync_calls
 
         if expected_sync_calls > 0:
-            mock_toggle.set.assert_called_with(domain, True)
+            mock_toggle.set.assert_called_with(domain, True, NAMESPACE_DOMAIN)
         else:
             assert not mock_toggle.set.called

--- a/corehq/apps/users/tests/test_create_usercases_command.py
+++ b/corehq/apps/users/tests/test_create_usercases_command.py
@@ -3,10 +3,22 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import SimpleTestCase
+from corehq.util.test_utils import generate_cases
 
 
 class CreateUsercasesCommandCombinationsTests(SimpleTestCase):
 
+    @generate_cases([
+        # (domain, has_priv, usercase_enabled, toggle_enabled, expected_sync_calls)
+        ('priv_enabled_and_toggle_enabled', True, True, True, 0),  # skipped
+        ('priv_enabled_and_toggle_disabled', True, True, False, 2),  # expect web user
+        ('priv_disabled_and_toggle_enabled', True, False, True, 3),  # expect commcare user and web user
+        ('priv_disabled_and_toggle_disabled', True, False, False, 3),  # expect commcare user and web user
+        ('nopriv_enabled_and_toggle_enabled', False, True, True, 0),  # skipped (no priv)
+        ('nopriv_enabled_and_toggle_disabled', False, True, False, 0),  # skipped (no priv)
+        ('nopriv_disabled_and_toggle_enabled', False, False, True, 0),  # skipped (no priv)
+        ('nopriv_disabled_and_toggle_disabled', False, False, False, 0),  # skipped (no priv)
+    ])
     @patch('corehq.apps.users.management.commands.create_usercases.sync_usercases_ignore_web_flag')
     @patch('corehq.apps.users.management.commands.create_usercases.USH_USERCASES_FOR_WEB_USERS')
     @patch('corehq.apps.users.management.commands.create_usercases.CommCareUser.by_domain')
@@ -14,33 +26,18 @@ class CreateUsercasesCommandCombinationsTests(SimpleTestCase):
     @patch('corehq.apps.users.management.commands.create_usercases.domain_has_privilege')
     @patch('corehq.apps.users.management.commands.create_usercases.Domain.get_by_name')
     @patch('corehq.apps.users.management.commands.create_usercases.Domain.get_all_names')
-    def test_domain_combinations_enqueue_and_counts(
-        self, mock_all_names, mock_get_by_name, mock_has_priv,
-        mock_web_by_domain, mock_cc_by_domain, mock_toggle, mock_sync
+    def test_domain_combinations_sync_counts(
+        self, domain, has_priv, usercase_enabled, toggle_enabled, expected_sync_calls,
+        mock_all_names, mock_get_by_name, mock_has_priv,
+        mock_web_by_domain, mock_cc_by_domain, mock_toggle, mock_sync,
     ):
-        # Define domains with combinations of (has_privilege, usercase_enabled, usercase_toggle_enabled)
-        combos = {
-            'priv_enabled_and_toggle_enabled': (True, True, True),  # expect skip
-            'priv_enabled_and_toggle_disabled': (True, True, False),  # expect only web user
-            'priv_disabled_and_toggle_enabled': (True, False, True),  # expect commcare user and web user
-            'priv_disabled_and_toggle_disabled': (True, False, False),  # expect commcare user and web user
-            'nopriv_enabled_and_toggle_enabled': (False, True, True),  # expect skip
-            'nopriv_enabled_and_toggle_disabled': (False, True, False),  # expect skip
-            'nopriv_disabled_and_toggle_enabled': (False, False, True),  # expect skip
-            'nopriv_disabled_and_toggle_disabled': (False, False, False),  # expect skip
-        }
-        mock_all_names.return_value = list(combos.keys())
+        mock_all_names.return_value = [domain]
 
-        def _get_by_name(name):
-            _, usercase_enabled, _ = combos[name]
-            return SimpleNamespace(usercase_enabled=usercase_enabled,
-                                   save=lambda: None)
-
-        def _has_priv(name, *_):
-            has_priv, _, _ = combos[name]
-            return has_priv
-
-        mock_toggle.enabled.side_effect = lambda domain: combos[domain][2]
+        mock_get_by_name.return_value = SimpleNamespace(
+            usercase_enabled=usercase_enabled, save=lambda: None
+        )
+        mock_has_priv.side_effect = lambda _domain, _privilege: has_priv
+        mock_toggle.enabled.side_effect = lambda _domain: toggle_enabled
 
         def _web_users(domain):
             if domain.startswith('priv_enabled'):
@@ -54,31 +51,14 @@ class CreateUsercasesCommandCombinationsTests(SimpleTestCase):
                 return [SimpleNamespace(), SimpleNamespace()]
             return []
 
-        mock_get_by_name.side_effect = _get_by_name
-        mock_has_priv.side_effect = _has_priv
         mock_web_by_domain.side_effect = _web_users
         mock_cc_by_domain.side_effect = _cc_users
 
         call_command('create_usercases')
 
-        # Processed domains:
-        # - priv_enabled_and_toggle_disabled: 2 web
-        # - priv_disabled_and_toggle_enabled: 1 web + 2 commcare
-        # - priv_disabled_and_toggle_disabled: 1 web + 2 commcare
-        # Total sync calls = 2 + 3 + 3 = 8
-        assert mock_sync.call_count == 8
+        assert mock_sync.call_count == expected_sync_calls
 
-        called_domains = {c.args[1] for c in mock_sync.call_args_list}
-        assert called_domains == {
-            'priv_enabled_and_toggle_disabled',
-            'priv_disabled_and_toggle_enabled',
-            'priv_disabled_and_toggle_disabled',
-        }
-
-        # Flag set only for processed domains
-        set_domains = {c.args[0] for c in mock_toggle.set.call_args_list}
-        assert set_domains == {
-            'priv_enabled_and_toggle_disabled',
-            'priv_disabled_and_toggle_enabled',
-            'priv_disabled_and_toggle_disabled',
-        }
+        if expected_sync_calls > 0:
+            mock_toggle.set.assert_called_with(domain, True)
+        else:
+            assert not mock_toggle.set.called

--- a/corehq/apps/users/tests/test_create_usercases_command.py
+++ b/corehq/apps/users/tests/test_create_usercases_command.py
@@ -7,12 +7,14 @@ from django.test import SimpleTestCase
 
 class CreateUsercasesCommandCombinationsTests(SimpleTestCase):
 
-    @patch('corehq.apps.users.management.commands.create_usercases.create_usercases_for_user_type.delay')
+    @patch('corehq.apps.users.management.commands.create_usercases.sync_usercases_ignore_web_flag')
+    @patch('corehq.apps.users.management.commands.create_usercases.CommCareUser.by_domain')
+    @patch('corehq.apps.users.management.commands.create_usercases.WebUser.by_domain')
     @patch('corehq.apps.users.management.commands.create_usercases.domain_has_privilege')
     @patch('corehq.apps.users.management.commands.create_usercases.Domain.get_by_name')
     @patch('corehq.apps.users.management.commands.create_usercases.Domain.get_all_names')
     def test_domain_combinations_enqueue_and_counts(
-        self, mock_all_names, mock_get_by_name, mock_has_priv, mock_delay
+        self, mock_all_names, mock_get_by_name, mock_has_priv, mock_web_by_domain, mock_cc_by_domain, mock_sync
     ):
         # Define domains with combinations of (has_privilege, usercase_enabled)
         combos = {
@@ -25,22 +27,34 @@ class CreateUsercasesCommandCombinationsTests(SimpleTestCase):
 
         def _get_by_name(name):
             _, usercase_enabled = combos[name]
-            return SimpleNamespace(usercase_enabled=usercase_enabled)
+            return SimpleNamespace(usercase_enabled=usercase_enabled,
+                                   save=lambda: None)
 
         def _has_priv(name, *_):
             has_priv, _ = combos[name]
             return has_priv
 
+        def _web_users(domain):
+            if domain == 'priv_enabled':
+                return [SimpleNamespace(), SimpleNamespace()]
+            if domain == 'priv_disabled':
+                return [SimpleNamespace()]
+            return []
+
+        def _cc_users(domain):
+            if domain == 'priv_disabled':
+                return [SimpleNamespace(), SimpleNamespace()]
+            return []
+
         mock_get_by_name.side_effect = _get_by_name
         mock_has_priv.side_effect = _has_priv
+        mock_web_by_domain.side_effect = _web_users
+        mock_cc_by_domain.side_effect = _cc_users
 
         call_command('create_usercases')
 
-        mock_delay.assert_any_call('priv_enabled', include_web_users=True)
-        mock_delay.assert_any_call('priv_disabled', include_commcare_users=True, include_web_users=True)
+        # 2 web (priv_enabled) + 1 web (priv_disabled) + 2 commcare (priv_disabled) = 5
+        assert mock_sync.call_count == 5
 
-        assert mock_delay.call_count == 2
-
-        called_domains = {c.args[0] for c in mock_delay.call_args_list}
-        assert 'nopriv_enabled' not in called_domains
-        assert 'nopriv_disabled' not in called_domains
+        called_domains = {c.args[1] for c in mock_sync.call_args_list}
+        assert called_domains == {'priv_enabled', 'priv_disabled'}


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No inherent UI changes. But when the management command is ran, it will create usercases for domains that have USERCASE privilege.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-944](https://dimagi.atlassian.net/browse/USH-944)

Adds a management command to backfill/create usercases across projects that have the USERCASE privilege.

Behavior per domain:
- If usercase_enabled is True and the web user usercase FF is already enabled: skip.
- If usercase_enabled is True and the web user usercase FF is not enabled: create usercases for Web users only; enable USH_USERCASES_FOR_WEB_USERS.
- If usercase_enabled is False: create usercases for both CommCare and Web users; set usercase_enabled=True; enable USH_USERCASES_FOR_WEB_USERS.

The FF is enabled and usercase_enabled set to True after being processed so that it can be skipped upon rerun.

Includes throttling: after every 5,000 usercases synced globally within the command run, wait 60 seconds to respect the 5k/min ceiling. 5,000 was chosen to align with the global case update rate limit.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Locally tested and will test on staging. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
New tests: corehq/apps/users/tests/test_create_usercases_command.py

Covers all domain combinations (has/does not have USERCASE privilege, usercase_enabled True/False, FF enabled/disabled) and asserts:
- Web vs both web and commcare user are processed
- Domains without privilege are skipped and do not trigger any sync calls.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi.atlassian.net/browse/QA-1217

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
There is a [followup PR](https://github.com/dimagi/commcare-hq/pull/36899) with a migration that depends on the management command in this PR. If this PR is reverted, then that migration PR will also need to be reverted.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-944]: https://dimagi.atlassian.net/browse/USH-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ