### PR TITLE
Add option to run pillows with gevent

### DIFF
--- a/corehq/apps/userreports/adaptercache.py
+++ b/corehq/apps/userreports/adaptercache.py
@@ -21,10 +21,10 @@ class TTLCache:
     """
     TTL_48_HOURS = 48 * 60 * 60  # in seconds
 
-    def __init__(self, iter_adapters, timeout=TTL_48_HOURS):
+    def __init__(self, iter_adapters, adapter_cache=None, timeout=TTL_48_HOURS):
         self.iter_adapters = iter_adapters
         self.domain_last_seen = {}
-        self.adapters = AdapterCache()
+        self.adapters = adapter_cache or AdapterCache()
         self.timeout = timeout
         self.last_refresh = datetime.now(UTC)
 

--- a/corehq/apps/userreports/adaptercache.py
+++ b/corehq/apps/userreports/adaptercache.py
@@ -1,5 +1,8 @@
+from functools import wraps
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
+
+from gevent.lock import BoundedSemaphore
 
 
 class TTLCache:
@@ -46,6 +49,19 @@ class TTLCache:
                 self.domain_last_seen[domain_] = now
         return self.adapters[domain]
 
+    @wraps(_load_adapters)
+    def _load_adapters(self, domain):
+        # locking decorator for _load_adapters defined above
+        lock = self.adapters.locks[domain]
+        while domain not in self.adapters:
+            if lock.acquire(blocking=False):
+                try:
+                    return self._load_adapters.__wrapped__(self, domain)
+                finally:
+                    lock.release()
+            lock.wait()  # wait for concurrent load to finish
+        return self.adapters[domain]
+
     def refresh(self):
         """Reload changed adapters and prune stale entries from the cache"""
         now = datetime.now(UTC)
@@ -70,6 +86,16 @@ class TTLCache:
         for config_id, updated_domains in updated.items():
             for domain in self.adapters.entries.keys() - updated_domains:
                 self.adapters.entries[domain].pop(config_id, None)
+
+    @wraps(refresh)
+    def refresh(self):
+        # locking decorator for refresh defined above
+        lock = self.adapters.refresh_lock
+        if lock.acquire(blocking=False):
+            try:
+                self.refresh.__wrapped__(self)
+            finally:
+                lock.release()
 
     def remove(self, domain, adapter):
         """Remove adapter from domain's cached adapters."""
@@ -116,6 +142,8 @@ class AdapterCache:
 
     def __init__(self):
         self.entries = defaultdict(dict)
+        self.locks = defaultdict(BoundedSemaphore)
+        self.refresh_lock = BoundedSemaphore()
 
     def get(self, domain):
         """Return a list of adapters for domain, None if there are none.
@@ -149,5 +177,6 @@ class AdapterCache:
         """Discard adapter(s) for domain."""
         if adapter is None:
             self.entries.pop(domain, None)
+            self.locks.pop(domain, None)
         else:
             self.entries[domain].pop(adapter.config_id, None)

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -29,7 +29,7 @@ from corehq.pillows.base import is_couch_change_for_sql_domain
 from corehq.util.metrics import metrics_counter, metrics_histogram_timer
 from corehq.util.timer import TimingContext
 
-from .adaptercache import MigrationCache, TTLCache
+from .adaptercache import AdapterCache, MigrationCache, TTLCache
 from .const import KAFKA_TOPICS
 from .data_source_providers import (
     DynamicDataSourceProvider,
@@ -44,6 +44,7 @@ from .util import get_indicator_adapter
 
 REBUILD_CHECK_INTERVAL = 3 * 60 * 60  # in seconds
 LONG_UCR_LOGGING_THRESHOLD = 0.5
+_SHARED_ADAPTER_CACHES = defaultdict(AdapterCache)
 
 
 class WarmShutdown(object):
@@ -121,13 +122,14 @@ def _get_indicator_adapter_for_pillow(config):
 class UcrTableManager(ABC):
     """Base class for table managers that encapsulates the bootstrap and refresh
     functionality."""
-    def __init__(self, bootstrap_interval, run_migrations):
+    def __init__(self, bootstrap_interval, run_migrations, adapter_cache):
         """
         :param bootstrap_interval: time in seconds when SQL tables are rebuilt.
         :param run_migrations: If True, rebuild tables if the data source changes. Otherwise,
             do not attempt to change database
+        :param adapter_cache: AdapterCache. May be shared across multiple table managers.
         """
-        self.cache = TTLCache(self.iter_adapters)
+        self.cache = TTLCache(self.iter_adapters, adapter_cache)
         self.is_dedicated_migration_process = False
         if run_migrations:
             interval = bootstrap_interval or REBUILD_CHECK_INTERVAL
@@ -256,7 +258,7 @@ class ConfigurableReportTableManager(UcrTableManager):
 
     def __init__(self, data_source_providers, ucr_division=None,
                  include_ucrs=None, exclude_ucrs=None, bootstrap_interval=None,
-                 run_migrations=True):
+                 run_migrations=True, adapter_cache=None):
         """Initializes the processor for UCRs
 
         Keyword Arguments:
@@ -266,7 +268,7 @@ class ConfigurableReportTableManager(UcrTableManager):
         include_ucrs -- list of ucr 'table_ids' to be included in this processor
         exclude_ucrs -- list of ucr 'table_ids' to be excluded in this processor
         """
-        super().__init__(bootstrap_interval, run_migrations)
+        super().__init__(bootstrap_interval, run_migrations, adapter_cache)
         self.data_source_providers = data_source_providers
         self.ucr_division = ucr_division
         self.include_ucrs = include_ucrs
@@ -315,10 +317,10 @@ class ConfigurableReportTableManager(UcrTableManager):
 
 class RegistryDataSourceTableManager(UcrTableManager):
 
-    def __init__(self, bootstrap_interval=None, run_migrations=True):
+    def __init__(self, bootstrap_interval=None, run_migrations=True, adapter_cache=None):
         """Initializes the processor for UCRs backed by a data registry
         """
-        super().__init__(bootstrap_interval, run_migrations)
+        super().__init__(bootstrap_interval, run_migrations, adapter_cache)
         self.data_source_provider = RegistryDataSourceProvider()
 
     def iter_configs(self, domain):
@@ -589,13 +591,15 @@ def get_ucr_processor(data_source_providers,
         exclude_ucrs=exclude_ucrs,
         bootstrap_interval=bootstrap_interval,
         run_migrations=run_migrations,
+        adapter_cache=_SHARED_ADAPTER_CACHES[get_ucr_processor],
     )
     return ConfigurableReportPillowProcessor(table_manager)
 
 
 def get_data_registry_ucr_processor(run_migrations):
     table_manager = RegistryDataSourceTableManager(
-        run_migrations=run_migrations
+        run_migrations=run_migrations,
+        adapter_cache=_SHARED_ADAPTER_CACHES[get_data_registry_ucr_processor],
     )
     return ConfigurableReportPillowProcessor(table_manager)
 
@@ -617,7 +621,8 @@ def get_kafka_ucr_pillow(pillow_id='kafka-ucr-main', ucr_division=None,
         ucr_division=ucr_division,
         include_ucrs=include_ucrs,
         exclude_ucrs=exclude_ucrs,
-        run_migrations=(process_num == 0)  # only first process runs migrations
+        run_migrations=(process_num == 0),  # only first process runs migrations
+        adapter_cache=_SHARED_ADAPTER_CACHES[get_kafka_ucr_pillow],
     )
     return ConfigurableReportKafkaPillow(
         processor=ConfigurableReportPillowProcessor(table_manager),
@@ -650,7 +655,8 @@ def get_kafka_ucr_static_pillow(pillow_id='kafka-ucr-static', ucr_division=None,
         include_ucrs=include_ucrs,
         exclude_ucrs=exclude_ucrs,
         bootstrap_interval=7 * 24 * 60 * 60,  # 1 week
-        run_migrations=(process_num == 0)  # only first process runs migrations
+        run_migrations=(process_num == 0),  # only first process runs migrations
+        adapter_cache=_SHARED_ADAPTER_CACHES[get_kafka_ucr_static_pillow],
     )
     return ConfigurableReportKafkaPillow(
         processor=ConfigurableReportPillowProcessor(table_manager),
@@ -681,7 +687,8 @@ def get_location_pillow(pillow_id='location-ucr-pillow', include_ucrs=None,
             DynamicDataSourceProvider('Location'),
             StaticDataSourceProvider('Location')
         ],
-        include_ucrs=include_ucrs
+        include_ucrs=include_ucrs,
+        adapter_cache=_SHARED_ADAPTER_CACHES[get_location_pillow],
     )
     ucr_processor = ConfigurableReportPillowProcessor(table_manager)
     checkpoint = KafkaPillowCheckpoint(pillow_id, [LOCATION_TOPIC])

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -107,7 +107,7 @@ class UcrTableManagerTest(SimpleTestCase):
             def iter_configs_since(self, timestamp):
                 raise NotImplementedError
 
-        manager = TestManager(None, False)
+        manager = TestManager(None, False, None)
         adapters = list(manager.iter_adapters('one'))
         assert adapters == [
             ('one', Adapter(Config(1))),
@@ -126,7 +126,7 @@ class UcrTableManagerTest(SimpleTestCase):
                 yield 'one', Config(1)
                 yield 'two', Config(1)
 
-        manager = TestManager(None, False)
+        manager = TestManager(None, False, None)
         adapters = list(manager.iter_adapters(since=datetime.now(UTC)))
         assert adapters == [
             ('one', Adapter(Config(1))),

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -19,6 +19,7 @@ from corehq.apps.userreports.models import (
     DataSourceConfiguration,
     ReportConfiguration, RegistryDataSourceConfiguration,
 )
+from corehq.apps.userreports.pillow import _SHARED_ADAPTER_CACHES
 from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.sql_db.connections import connection_manager
 
@@ -44,6 +45,7 @@ def bootstrap_pillow(pillow, *configs, rebuild_adapters=False):
     for config in configs:
         configs_by_domain.setdefault(config.domain, []).append(config)
 
+    _SHARED_ADAPTER_CACHES.clear()
     for proc in pillow.processors:
         if hasattr(proc, 'table_manager'):
             proc.table_manager.data_source_providers = [

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -217,6 +217,10 @@ class ConstructedPillow:
             for change in chunk:
                 self.process_with_error_handling(change, processor)
 
+        pillow_logging.info(
+            '[%s %s] Processing %s changes',
+            self.pillow_id, self.process_num, len(changes_chunk),
+        )
         for processor in self.batch_processors:
             if not changes_chunk:
                 return set(), 0

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -61,6 +61,7 @@ class ConstructedPillow:
                  change_processed_event_handler=None, processor_chunk_size=0,
                  is_dedicated_migration_process=False):
         self.pillow_id = name
+        self.process_num = process_num
         self.checkpoint = checkpoint
         self.change_feed = change_feed
         self.processor_chunk_size = processor_chunk_size
@@ -104,7 +105,7 @@ class ConstructedPillow:
         """
         Main entry point for running pillows forever.
         """
-        pillow_logging.info("Starting pillow %s" % self.pillow_id)
+        pillow_logging.info("Starting pillow %s %s", self.pillow_id, self.process_num)
         scope = Scope.get_current_scope()
         scope.set_tag("pillow_name", self.get_name())
         if self.is_dedicated_migration_process:
@@ -228,13 +229,9 @@ class ConstructedPillow:
                 except Exception as ex:
                     notify_exception(
                         None,
-                        "{pillow_name} Error in processing changes chunk: {ex}".format(
-                            pillow_name=self.get_name(),
-                            ex=ex
-                        ),
-                        details={
-                            'change_ids': [c.id for c in changes_chunk]
-                        })
+                        f"[{self.pillow_id} {self.process_num}] Error in processing changes chunk: {ex}",
+                        details={'change_ids': [c.id for c in changes_chunk]},
+                    )
                     self._record_batch_exception_in_datadog(processor)
                     # fall back to processing one by one
                     reprocess_serially(changes_chunk, processor)
@@ -266,9 +263,7 @@ class ConstructedPillow:
             try:
                 handle_pillow_error(self, change, ex)
             except Exception as e:
-                notify_exception(None, 'processor error in pillow {} {}'.format(
-                    self.get_name(), e,
-                ))
+                notify_exception(None, f'[{self.pillow_id} {self.process_num}] processor error: {e}')
                 raise
         if is_success:
             self._record_change_success_in_datadog(change)
@@ -443,8 +438,9 @@ class ChangeEventHandler(metaclass=ABCMeta):
 def handle_pillow_error(pillow, change, exception):
     from pillow_retry.models import PillowError, path_from_object
 
-    pillow_logging.exception("[%s] Error on change: %s, %s" % (
+    pillow_logging.exception("[%s %s] Error on change: %s, %s" % (
         pillow.get_name(),
+        pillow.process_num,
         change['id'],
         exception,
     ))

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -4,6 +4,7 @@ from collections import Counter, defaultdict
 from datetime import datetime
 
 from django.conf import settings
+from django.core.signals import request_finished
 from memoized import memoized
 
 from sentry_sdk import Scope
@@ -129,6 +130,12 @@ class ConstructedPillow:
             updated = self.checkpoint.touch(min_interval=CHECKPOINT_MIN_WAIT)
         if updated:
             self._record_checkpoint_in_datadog()
+        self._close_old_connections()
+
+    def _close_old_connections(self):
+        # Prevent connection timeout
+        # https://github.com/jneight/django-db-geventpool#using-orm-when-not-serving-requests
+        request_finished.send(sender=self.pillow_id)
 
     @property
     @memoized

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -160,7 +160,6 @@ class BulkElasticProcessor(ElasticProcessor, BulkPillowProcessor):
     """
 
     def process_changes_chunk(self, changes_chunk):
-        logger.info('Processing chunk of changes in BulkElasticProcessor')
         if self.change_filter_fn:
             changes_chunk = [
                 change for change in changes_chunk

--- a/corehq/ex-submodules/pillowtop/run_pillowtop.py
+++ b/corehq/ex-submodules/pillowtop/run_pillowtop.py
@@ -1,7 +1,70 @@
 import multiprocessing
 import sys
 
+import gevent
+
 from pillowtop import get_all_pillow_instances
+from pillowtop.utils import get_pillow_by_name
+
+
+def run_pillow_by_name(
+    pillow_name,
+    *,
+    num_processes,
+    process_number,
+    gevent_workers=None,
+    processor_chunk_size,
+    dedicated_migration_process=False,
+    exclude_ucrs=(),
+):
+    assert 0 <= process_number < num_processes
+    assert processor_chunk_size
+
+    options = {
+        'processor_chunk_size': processor_chunk_size,
+        'dedicated_migration_process': dedicated_migration_process,
+    }
+    if exclude_ucrs:
+        options['exclude_ucrs'] = exclude_ucrs
+
+    if gevent_workers is not None:
+        if gevent_workers < 2:
+            sys.exit("cannot run less than 2 gevent workers")
+        if process_number > 0 or not dedicated_migration_process:
+            if dedicated_migration_process:
+                num_processes -= 1
+                process_number -= 1
+            run_gevent_pillows(pillow_name, num_processes, process_number, gevent_workers, options)
+            return
+        # the migration process (process_number == 0) is always run in a
+        # single process without gevent workers.
+
+    pillow = get_pillow_by_name(
+        pillow_name,
+        num_processes=num_processes,
+        process_num=process_number,
+        **options
+    )
+    start_pillow(pillow)
+
+
+def run_gevent_pillows(pillow_name, num_processes, process_number, gevent_workers, options):
+    # In the case of a dedicated migration process, worker 1 will be
+    # assigned partitions 0..N by KafkaChangeFeed._filter_partitions
+    # Importantly, no worker will have process_num == 0 when there is
+    # a dedicated migration process, so no worker will run migrations.
+    assert 'gevent_workers' not in options, options
+    offset = 1 if options['dedicated_migration_process'] else 0
+    workers = []
+    for worker_num in range(gevent_workers):
+        workers.append(gevent.spawn(
+            run_pillow_by_name,
+            pillow_name,
+            num_processes=num_processes * gevent_workers + offset,
+            process_number=process_number * gevent_workers + offset + worker_num,
+            **options
+        ))
+    gevent.joinall(workers)
 
 
 def start_pillows(pillows=None):

--- a/corehq/ex-submodules/pillowtop/tests/test_run_pillowtop.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_run_pillowtop.py
@@ -121,6 +121,8 @@ def patch_pillow_starter(exclude_ucrs=None):
 
     started = []
     with (
+        # bypass run_gevent_worker because it loops forever
+        patch('pillowtop.run_pillowtop.run_gevent_worker', run_pillow_by_name),
         patch('pillowtop.run_pillowtop.get_pillow_by_name', _get_pillow),
         patch('pillowtop.run_pillowtop.start_pillow', _start_pillow),
     ):

--- a/corehq/ex-submodules/pillowtop/tests/test_run_pillowtop.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_run_pillowtop.py
@@ -1,0 +1,127 @@
+from unittest.mock import patch
+
+import pytest
+from testil import Config
+from unmagic import fixture
+
+from ..run_pillowtop import run_pillow_by_name
+
+
+def test_run_pillow_by_name_single_process():
+    started = patch_pillow_starter()
+    run_pillow_by_name(
+        pillow_name='fake',
+        num_processes=1,
+        process_number=0,
+        processor_chunk_size=100,
+        dedicated_migration_process=False,
+        exclude_ucrs=['abc', 'def'],
+    )
+    assert started == ["worker 0 of 1 exclude_ucrs=['abc', 'def']"]
+
+
+def test_run_pillow_by_name_dedicated_migration_process():
+    started = patch_pillow_starter()
+    run_pillow_by_name(
+        pillow_name='fake',
+        num_processes=1,
+        process_number=0,
+        processor_chunk_size=100,
+        dedicated_migration_process=True,
+        exclude_ucrs='',
+    )
+    assert started == ['migrate 0 of 1']
+
+
+def test_run_pillow_by_name_with_gevent_workers_migration_process():
+    started = patch_pillow_starter()
+    run_pillow_by_name(
+        pillow_name='fake',
+        num_processes=4,
+        process_number=0,
+        gevent_workers=3,
+        processor_chunk_size=100,
+        dedicated_migration_process=True,
+        exclude_ucrs='',
+    )
+    assert started == ['migrate 0 of 4']
+
+
+def test_run_pillow_by_name_with_gevent_workers():
+    started = patch_pillow_starter()
+    run_pillow_by_name(
+        pillow_name='fake',
+        num_processes=4,
+        process_number=1,
+        gevent_workers=3,
+        processor_chunk_size=100,
+        dedicated_migration_process=True,
+        exclude_ucrs='',
+    )
+    assert started == ['worker 1 of 10', 'worker 2 of 10', 'worker 3 of 10']
+
+
+def test_run_pillow_by_name_with_gevent_workers_and_no_migration_process():
+    started = patch_pillow_starter()
+    run_pillow_by_name(
+        pillow_name='fake',
+        num_processes=4,
+        process_number=1,
+        gevent_workers=3,
+        processor_chunk_size=100,
+        dedicated_migration_process=False,
+        exclude_ucrs='',
+    )
+    assert started == ['worker 3 of 12', 'worker 4 of 12', 'worker 5 of 12']
+
+
+def test_run_pillow_by_name_with_gevent_workers_exclude_ucrs():
+    started = patch_pillow_starter()
+    run_pillow_by_name(
+        pillow_name='fake',
+        num_processes=4,
+        process_number=0,
+        gevent_workers=2,
+        processor_chunk_size=100,
+        dedicated_migration_process=False,
+        exclude_ucrs=['abc'],
+    )
+    assert started == [
+        "worker 0 of 8 exclude_ucrs=['abc']",
+        "worker 1 of 8 exclude_ucrs=['abc']",
+    ]
+
+
+@pytest.mark.parametrize("workers", [0, 1, -1])
+def test_run_pillow_by_name_with_too_few_gevent_workers(workers):
+    started = patch_pillow_starter()
+    with pytest.raises(SystemExit):
+        run_pillow_by_name(
+            pillow_name='fake',
+            num_processes=4,
+            process_number=1,
+            gevent_workers=workers,
+            processor_chunk_size=100,
+        )
+    assert not started
+
+
+@fixture
+def patch_pillow_starter(exclude_ucrs=None):
+    def _get_pillow(name, **args):
+        return Config(name=name, **args)
+
+    def _start_pillow(pillow):
+        assert pillow.name == 'fake'
+        assert pillow.processor_chunk_size == 100
+        dmp = pillow.dedicated_migration_process
+        worker = "migrate" if dmp and pillow.process_num == 0 else "worker"
+        exclude = f" exclude_ucrs={pillow.exclude_ucrs}" if 'exclude_ucrs' in pillow else ""
+        started.append(f"{worker} {pillow.process_num} of {pillow.num_processes}{exclude}")
+
+    started = []
+    with (
+        patch('pillowtop.run_pillowtop.get_pillow_by_name', _get_pillow),
+        patch('pillowtop.run_pillowtop.start_pillow', _start_pillow),
+    ):
+        yield started

--- a/corehq/ex-submodules/pillowtop/tests/utils.py
+++ b/corehq/ex-submodules/pillowtop/tests/utils.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from corehq.apps.es.transient_util import doc_adapter_from_index_name
 from corehq.util.es.elasticsearch import TransportError
 
@@ -56,3 +58,18 @@ def make_fake_constructed_pillow(pillow_id, checkpoint_id):
         processor=LoggingProcessor(),
     )
     return pillow
+
+
+def _do_not_close_old_connections(self):
+    """Do not close database connections when running tests
+
+    Prevents "connection already closed" errors in tests that process
+    pillow changes.
+    """
+
+
+pillow_connection_cleanup_patch = patch.object(
+    ConstructedPillow,
+    '_close_old_connections',
+    _do_not_close_old_connections
+)

--- a/corehq/tests/pytest_plugins/patches.py
+++ b/corehq/tests/pytest_plugins/patches.py
@@ -7,11 +7,13 @@ def pytest_sessionstart():
     from corehq.form_processor.tests.utils import patch_testcase_databases
     from corehq.util.es.testing import patch_es_user_signals
     from corehq.util.test_utils import patch_foreign_value_caches
+    from pillowtop.tests.utils import pillow_connection_cleanup_patch
 
     patch_unittest_TestCase_doClassCleanup()
     patch_django_test_case()
     patch_assertItemsEqual()
     patch_testcase_databases()
+    pillow_connection_cleanup_patch.start()
     patch_es_user_signals()
     patch_foreign_value_caches()
     patch_domain_deletion()


### PR DESCRIPTION
Adds a `--gevent-workers=N` option that spawns N gevent workers in non-migration processes (processes other than process number 0 when there is a dedicated migration process) on the `run_ptop` management command. The number of pillow processors can be calculated with the formula:
```py
gevent_workers * (num_processes - (1 if dedicated_migration_process else 0))
```

If there is no dedicated migration process, gevent worker number 0 in each process will attempt to run migrations. However, there is a shared (Redis) locking mechanism that allows multiple workers to coordinate migration activity, limiting the frequency of migrations and preventing duplicate work (see `TaskCoordinator` added in [an earlier PR](https://github.com/dimagi/commcare-hq/pull/36819)).

https://dimagi.atlassian.net/browse/SAAS-18388

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Changes in this PR enable concurrent pillow processing within a single process. The code has been evaluated for concurrency safety, and at this time there are no known usages of shared resources, etc. that may cause concurrency issues. However, it is possible that something was overlooked, so QA testing will be carried out on staging to improve confidence in the solution.

### Automated test coverage

Yes.

### QA Plan

https://dimagi.atlassian.net/browse/QA-8068

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations