### PR TITLE
GA FF: Allow adding Case IDs to Report Builder reports

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -90,7 +90,6 @@ from corehq.apps.userreports.util import has_report_builder_access, get_ucr_data
 from corehq.toggles import (
     SHOW_RAW_DATA_SOURCES_IN_REPORT_BUILDER,
     OVERRIDE_EXPANDED_COLUMN_LIMIT_IN_REPORT_BUILDER,
-    SHOW_IDS_IN_REPORT_BUILDER,
     DATA_REGISTRY_UCR
 )
 from dimagi.utils.couch.undo import undo_delete
@@ -808,9 +807,7 @@ class CaseDataSourceHelper(ManagedReportBuilderDataSourceHelper):
             )
         properties[COMPUTED_OWNER_NAME_PROPERTY_ID] = self._get_owner_name_pseudo_property()
         properties[COMPUTED_USER_NAME_PROPERTY_ID] = self._get_user_name_pseudo_property()
-
-        if SHOW_IDS_IN_REPORT_BUILDER.enabled(self.domain):
-            properties['case_id'] = self._get_case_id_pseudo_property()
+        properties['case_id'] = self._get_case_id_pseudo_property()
 
         if SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER_TOGGLE.enabled(self.domain):
             properties[COMPUTED_OWNER_LOCATION_PROPERTY_ID] = self._get_owner_location_pseudo_property()

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -179,6 +179,7 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
             'user_id',
             'computed/owner_name',
             'computed/user_name',
+            'case_id',
         ]
         assert expected_property_names == list(builder.data_source_properties.keys())
         owner_name_prop = builder.data_source_properties['computed/owner_name']
@@ -245,6 +246,7 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
             'registry_property',
             'computed/owner_name',
             'computed/user_name',
+            'case_id',
             'commcare_project',
         ]
         assert expected_property_names == list(builder.data_source_properties.keys())
@@ -343,18 +345,6 @@ class DataSourceReferenceTest(ReportBuilderDBTest):
         first_name_prop = reference.data_source_properties['first_name']
         assert 'first_name' == first_name_prop.get_id()
         assert 'first_name' == first_name_prop.get_text()
-
-    @flag_enabled('SHOW_IDS_IN_REPORT_BUILDER')
-    def test_show_case_id(self):
-        case_data_source = get_case_data_source(self.app, self.case_type)
-        case_data_source.save()
-        builder = ApplicationCaseDataSourceHelper(
-            self.domain,
-            self.app,
-            DATA_SOURCE_TYPE_CASE,
-            self.case_type,
-        )
-        assert 'case_id' in builder.data_source_properties
 
 
 class ReportBuilderTest(ReportBuilderDBTest):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1555,13 +1555,6 @@ UNLIMITED_REPORT_BUILDER_REPORTS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-SHOW_IDS_IN_REPORT_BUILDER = StaticToggle(
-    'show_ids_in_report_builder',
-    'Allow adding Case IDs to report builder reports.',
-    TAG_SOLUTIONS_OPEN,
-    [NAMESPACE_DOMAIN],
-)
-
 
 ALLOW_USER_DEFINED_EXPORT_COLUMNS = StaticToggle(
     'allow_user_defined_export_columns',


### PR DESCRIPTION
## Product Description

This pull request adds "Case ID" to the columns available in Report Builder.

## Technical Summary

This feature is generally available for the Pro Plan and up. Report Builder is available for the Pro Plan and up, so no additional privilege is required.

:t-rex: Jira: [SAAS-18275](https://dimagi.atlassian.net/browse/SAAS-18275)

## Feature Flag

 `SHOW_IDS_IN_REPORT_BUILDER`

## Safety Assurance

### Safety story

Small change

### Automated test coverage

Yes

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-18275]: https://dimagi.atlassian.net/browse/SAAS-18275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ