### PR TITLE
Add `hq_environment` user property for server side metrics sent to Google Analytics

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -788,6 +788,11 @@ def record_event(event_name, couch_user, event_properties=None):
         'client_id': couch_user.userID,
         'user_id': couch_user.userID,
         'timestamp_micros': timestamp,
+        'user_properties': {
+            'hq_environment': {
+                'value': settings.ANALYTICS_CONFIG.get('HQ_INSTANCE')
+            }
+        },
         'events': [{
             'name': event_name,
             'params': event_properties,

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -769,9 +769,10 @@ def generate_partner_reports():
     )
 
 
-def record_event(event_name, couch_user, event_properties=None):
+def record_google_analytics_event(event_name, couch_user, event_properties=None):
     """
-    Record an event in Google Analytics.
+    Record an event in Google Analytics via the Measurement Protocol.
+    See https://developers.google.com/analytics/devguides/collection/protocol/ga4 for details.
     """
     if not couch_user.analytics_enabled:
         return
@@ -799,11 +800,11 @@ def record_event(event_name, couch_user, event_properties=None):
         }]
     }
 
-    _record_event_task.delay(json.dumps(event_body))
+    _record_google_analytics_event_task.delay(json.dumps(event_body))
 
 
 @analytics_task()
-def _record_event_task(event_json):
+def _record_google_analytics_event_task(event_json):
     ga_secret = settings.ANALYTICS_IDS.get('GOOGLE_ANALYTICS_SECRET', None)
     ga_measurement_id = settings.ANALYTICS_IDS.get('GOOGLE_ANALYTICS_MEASUREMENT_ID', None)
 

--- a/corehq/apps/enterprise/api/resources.py
+++ b/corehq/apps/enterprise/api/resources.py
@@ -14,7 +14,7 @@ from corehq.apps.accounting.utils.account import (
     get_account_or_404,
     request_has_permissions_for_enterprise_admin,
 )
-from corehq.apps.analytics.tasks import record_event
+from corehq.apps.analytics.tasks import record_google_analytics_event
 from corehq.apps.api.odata.utils import FieldMetadata
 from corehq.apps.api.odata.views import add_odata_headers
 from corehq.apps.api.resources import HqBaseResource
@@ -192,7 +192,7 @@ class ODataEnterpriseReportResource(ODataResource):
             return data
         elif status == ReportTaskProgress.STATUS_NEW:
             progress.start_task(self.get_report_task(request))
-            record_event(ENTERPRISE_API_ACCESS, request.couch_user, {
+            record_google_analytics_event(ENTERPRISE_API_ACCESS, request.couch_user, {
                 'api_type': self.REPORT_SLUG
             })
 
@@ -432,7 +432,7 @@ class FormSubmissionResource(ODataEnterpriseReportResource):
         converter = EnterpriseFormReportConverter()
         query_kwargs = converter.get_kwargs_from_map(request.GET)
         if converter.is_initial_query(request.GET):
-            record_event(ENTERPRISE_API_ACCESS, request.couch_user, {
+            record_google_analytics_event(ENTERPRISE_API_ACCESS, request.couch_user, {
                 'api_type': self.REPORT_SLUG
             })
 

--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -24,7 +24,7 @@ import codecs
 
 from corehq.apps.accounting.decorators import always_allow_project_access
 from corehq.apps.accounting.models import SoftwarePlanEdition
-from corehq.apps.analytics.tasks import record_event
+from corehq.apps.analytics.tasks import record_google_analytics_event
 from corehq.apps.enterprise.decorators import require_enterprise_admin
 from corehq.apps.enterprise.exceptions import TooMuchRequestedDataError
 from corehq.apps.enterprise.metric_events import ENTERPRISE_REPORT_REQUEST
@@ -215,7 +215,7 @@ def enterprise_dashboard_email(request, domain, slug):
         'email': request.couch_user.username,
     })
 
-    record_event(ENTERPRISE_REPORT_REQUEST, request.couch_user, {
+    record_google_analytics_event(ENTERPRISE_REPORT_REQUEST, request.couch_user, {
         'report_type': slug
     })
 

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -75,7 +75,7 @@ def activate_new_user(
     username, password, created_by, created_via, first_name=None, last_name=None, is_domain_admin=False,
     domain=None, ip=None, atypical_user=False, language=None, commit=True
 ):
-    from corehq.apps.analytics.tasks import record_event
+    from corehq.apps.analytics.tasks import record_google_analytics_event
     now = datetime.utcnow()
 
     new_user = WebUser.create(
@@ -113,7 +113,7 @@ def activate_new_user(
     # Engagement time appears necessary for this event to show up within GA debug view
     # (when 'debug_mode': '1' is also supplied)
     # Leaving engagement time in as there doesn't seem a good reason to remove it
-    record_event('backend_new_user', new_user, {'engagement_time_msec': 1000})
+    record_google_analytics_event('backend_new_user', new_user, {'engagement_time_msec': 1000})
 
     return new_user
 

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -9,7 +9,7 @@ from corehq.util.soft_assert.api import soft_assert
 from memoized import memoized
 from django.db import DEFAULT_DB_ALIAS
 
-from corehq.apps.analytics.tasks import record_event
+from corehq.apps.analytics.tasks import record_google_analytics_event
 from corehq.apps.enterprise.models import EnterpriseMobileWorkerSettings
 from corehq.apps.users.decorators import get_permission_name
 from corehq.apps.users.models import HqPermissions
@@ -934,7 +934,7 @@ class WebImporter:
             if user_row.error:
                 ret["errors"].append(user_row.error)
         if self.enabled_count > 0 or self.disabled_count > 0:
-            record_event(self.STATUS_CHANGED, self.upload_user, {
+            record_google_analytics_event(self.STATUS_CHANGED, self.upload_user, {
                 'domain': self.upload_domain,
                 'enabled_count': self.enabled_count,
                 'disabled_count': self.disabled_count,


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Add `hq_environment` user property for server side metrics sent to Google Analytics

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Simply adds a new `hq_environment` property that will allow filtering via environment in Google Analytics reports. This is also in line with what we send for front end metrics through GTM.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local. Minor change with respect to GA metrics.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
