### PR TITLE
Treat fuzzy translations as untranslated strings

### DIFF
--- a/corehq/apps/translations/management/commands/translate_po_files.py
+++ b/corehq/apps/translations/management/commands/translate_po_files.py
@@ -270,7 +270,7 @@ class PoTranslationFormat(TranslationFormat):
 
     @property
     def untranslated_messages(self):
-        return [msg for msg in self.all_message_objects if msg.msgstr == ""]
+        return [msg for msg in self.all_message_objects if msg.msgstr == "" or msg.fuzzy]
 
     @property
     def untranslated_messages_plural(self):
@@ -414,7 +414,11 @@ class PoTranslationFormat(TranslationFormat):
 
     def fill_translations(self, llm_output):
         for index, msg_str in llm_output.items():
-            self.translation_obj_map[index].msgstr = msg_str
+            msg_obj = self.translation_obj_map[index]
+            msg_obj.msgstr = msg_str
+            if msg_obj.fuzzy:
+                # no longer fuzzy, translated by AI
+                msg_obj.flags.remove('fuzzy')
 
     def save_output(self):
         """


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
https://dimagi.atlassian.net/browse/SAAS-18232
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
The fuzzy strings are not displayed to the users. They have been historically for the human translators who used to fix them manually. Since we are translating every msgid with LLMs, it makes sense to think of fuzzy strings as untranslated strings and get them translated again.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A
## Safety Assurance
The command runs on CI weekly. Have tested the output on Spanish translations. Works as expected. 


### Automated test coverage
Test were added for the changes and in general the command has great test coverage.
<!-- Identify the related test coverage and the tests it would catch -->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
