### PR TITLE
Change email for requesting access to messaging features

### DIFF
--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -688,7 +688,7 @@ class TestViewGeneric(ViewsBase):
         'commcare_hq_names', 'langs', 'title_context_block', 'timezone', 'has_mobile_workers',
         'multimedia_state', 'bulk_app_translation_upload', 'show_training_modules', 'forloop', 'secure_cookies',
         'IS_ANALYTICS_ENVIRONMENT', 'module_type', 'icon_class', 'form_submit_history_url', 'btn_style',
-        'chat_widget_config',
+        'chat_widget_config', 'ACCOUNTS_EMAIL',
     }
 
     expected_keys_module = {
@@ -717,7 +717,7 @@ class TestViewGeneric(ViewsBase):
         'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'EULA_COMPLIANCE', 'sentry',
         'case_list_form_not_allowed_reasons', 'child_module_enabled', 'block', 'IS_ANALYTICS_ENVIRONMENT',
         'formats_supporting_case_list_optimizations', 'module_type', 'icon_class', 'form_submit_history_url',
-        'btn_style', 'chat_widget_config',
+        'btn_style', 'chat_widget_config', 'ACCOUNTS_EMAIL',
     }
 
     expected_keys_form = {
@@ -747,7 +747,7 @@ class TestViewGeneric(ViewsBase):
         'env', 'False', 'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'is_usercase_in_use',
         'module_loads_registry_case', 'EULA_COMPLIANCE', 'sentry', 'show_shadow_modules', 'show_custom_ref',
         'block', 'IS_ANALYTICS_ENVIRONMENT', 'module_type', 'icon_class', 'case_property_warning',
-        'form_submit_history_url', 'btn_style', 'chat_widget_config',
+        'form_submit_history_url', 'btn_style', 'chat_widget_config', 'ACCOUNTS_EMAIL',
     }
 
 

--- a/corehq/apps/sms/templates/sms/wall.html
+++ b/corehq/apps/sms/templates/sms/wall.html
@@ -6,7 +6,7 @@
   <p>
     {% blocktrans with next_plan.name as p_name%}
       To enable messaging features, please request access by sending an email
-      to <a href="mailto:{{ SALES_EMAIL }}">{{ SALES_EMAIL }}</a> from your work
+      to <a href="mailto:{{ ACCOUNTS_EMAIL }}">{{ ACCOUNTS_EMAIL }}</a> from your work
       email address containing the following information:
     {% endblocktrans %}
   </p>

--- a/corehq/apps/sms/templates/sms/wall.html
+++ b/corehq/apps/sms/templates/sms/wall.html
@@ -4,10 +4,10 @@
 {% block page_content %}
   <h2>{% trans "Request Access to Messaging Features" %}</h2>
   <p>
-    {% blocktrans with next_plan.name as p_name%}
-      To enable messaging features, please request access by sending an email
-      to <a href="mailto:{{ ACCOUNTS_EMAIL }}">{{ ACCOUNTS_EMAIL }}</a> from your work
-      email address containing the following information:
+    {% blocktrans with next_plan.name as p_name %}
+      To enable messaging features, please request access by sending an email to
+      <a href="mailto:{{ ACCOUNTS_EMAIL }}">{{ ACCOUNTS_EMAIL }}</a> from your
+      work email address containing the following information:
     {% endblocktrans %}
   </p>
   <ul>

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -219,6 +219,7 @@ def emails(request=None):
     a page-specific context variable.
     """
     return {
+        'ACCOUNTS_EMAIL': settings.ACCOUNTS_EMAIL,
         'SALES_EMAIL': settings.SALES_EMAIL,
         'SUPPORT_EMAIL': settings.SUPPORT_EMAIL,
         'PRIVACY_EMAIL': settings.PRIVACY_EMAIL,


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Simply change the requests for access to messaging feature to be received on email address configured for accounts instead of sales.

<img width="1557" height="873" alt="image" src="https://github.com/user-attachments/assets/d9b08f1b-e4c1-4b1a-95fc-233d0cb85015" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18254

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally, works well.
Also confirmed that the constant is set to relevant value in commcare-cloud for [production](https://github.com/dimagi/commcare-cloud/blob/f0844628df8f926bf21204c285653a1a70844c21/environments/production/public.yml#L8)

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
