### PR TITLE
Add web user emails to EmailForm context

### DIFF
--- a/corehq/apps/es/tests/test_users_es.py
+++ b/corehq/apps/es/tests/test_users_es.py
@@ -69,7 +69,7 @@ class TestUserDataFilters(TestCase):
                    .get_ids())
 
         expected_ids = [self.user_no_data.user_id, self.user_empty_data.user_id, self.user_other_data.user_id]
-        self.assertCountEqual(results, expected_ids)
+        assert Counter(results) == Counter(expected_ids)
 
     def test_missing_or_empty_user_data_multiple_properties(self):
         results = (UserES()
@@ -79,7 +79,7 @@ class TestUserDataFilters(TestCase):
                    .get_ids())
 
         expected_ids = [self.user_no_data.user_id, self.user_empty_data.user_id]
-        self.assertCountEqual(results, expected_ids)
+        assert Counter(results) == Counter(expected_ids)
 
     def test_missing_user_data_property(self):
         results = (UserES()
@@ -88,7 +88,7 @@ class TestUserDataFilters(TestCase):
                    .get_ids())
 
         expected_ids = [self.user_no_data.user_id, self.user_other_data.user_id]
-        self.assertCountEqual(results, expected_ids)
+        assert Counter(results) == Counter(expected_ids)
 
     def test_empty_user_data_property(self):
         results = (UserES()
@@ -97,7 +97,7 @@ class TestUserDataFilters(TestCase):
                    .get_ids())
 
         expected_ids = [self.user_empty_data.user_id]
-        self.assertCountEqual(results, expected_ids)
+        assert Counter(results) == Counter(expected_ids)
 
 
 @es_test(requires=[user_adapter], setup_class=True)
@@ -152,95 +152,92 @@ class TestIsActiveOnDomain(TestCase):
         return user
 
     def test_get_all(self):
-        self.assertItemsEqual(
-            UserES().values_list('username', flat=True),
-            [
-                'cc_user_active',
-                'cc_user_inactive',
-                'cc_user_active_other_domain',
-                'cc_user_inactive_other_domain',
-                'web_user_active',
-                'web_user_inactive',
-                'web_user_active_other_domain',
-                'web_user_inactive_other_domain',
-                'web_user_active_both_domains',
-                'web_user_inactive_both_domains',
-                'web_user_active_inactive_other',
-                'web_user_inactive_active_other',
-            ]
-        )
+        assert Counter(
+            UserES().values_list('username', flat=True)
+        ) == Counter([
+            'cc_user_active',
+            'cc_user_inactive',
+            'cc_user_active_other_domain',
+            'cc_user_inactive_other_domain',
+            'web_user_active',
+            'web_user_inactive',
+            'web_user_active_other_domain',
+            'web_user_inactive_other_domain',
+            'web_user_active_both_domains',
+            'web_user_inactive_both_domains',
+            'web_user_active_inactive_other',
+            'web_user_inactive_active_other',
+        ])
 
     def test_get_active_in_domain(self):
-        self.assertItemsEqual(
+        assert Counter(
             UserES().domain(self.domain).values_list('username', flat=True),
-            [
-                'cc_user_active',
-                'web_user_active',
-                'web_user_active_both_domains',
-                'web_user_active_inactive_other',
-            ]
-        )
+        ) == Counter([
+            'cc_user_active',
+            'web_user_active',
+            'web_user_active_both_domains',
+            'web_user_active_inactive_other',
+        ])
 
     def test_get_inactive_in_domain(self):
-        self.assertItemsEqual(
-            UserES().domain(self.domain, include_inactive=True, include_active=False)
-            .values_list('username', flat=True),
-            [
-                'cc_user_inactive',
-                'web_user_inactive',
-                'web_user_inactive_both_domains',
-                'web_user_inactive_active_other',
-            ]
-        )
+        assert Counter(
+            UserES()
+            .domain(self.domain, include_inactive=True, include_active=False)
+            .values_list('username', flat=True)
+        ) == Counter([
+            'cc_user_inactive',
+            'web_user_inactive',
+            'web_user_inactive_both_domains',
+            'web_user_inactive_active_other',
+        ])
 
     def test_get_all_in_domain(self):
-        self.assertItemsEqual(
-            UserES().domain(self.domain, include_inactive=True).values_list('username', flat=True),
-            [
-                'cc_user_active',
-                'cc_user_inactive',
-                'web_user_active',
-                'web_user_inactive',
-                'web_user_active_both_domains',
-                'web_user_inactive_both_domains',
-                'web_user_active_inactive_other',
-                'web_user_inactive_active_other',
-            ]
-        )
+        assert Counter(
+            UserES()
+            .domain(self.domain, include_inactive=True)
+            .values_list('username', flat=True)
+        ) == Counter([
+            'cc_user_active',
+            'cc_user_inactive',
+            'web_user_active',
+            'web_user_inactive',
+            'web_user_active_both_domains',
+            'web_user_inactive_both_domains',
+            'web_user_active_inactive_other',
+            'web_user_inactive_active_other',
+        ])
 
     def test_get_active_in_domains(self):
         domains = [self.domain, self.other_domain]
-        self.assertItemsEqual(
+        assert Counter(
             UserES()
             .domain(domains)
-            .values_list('username', flat=True),
-            [
-                'cc_user_active',
-                'cc_user_active_other_domain',
-                'web_user_active',
-                'web_user_active_other_domain',
-                'web_user_active_both_domains',
-                'web_user_active_inactive_other',
-                'web_user_inactive_active_other',
-            ]
-        )
+            .values_list('username', flat=True)
+        ) == Counter([
+            'cc_user_active',
+            'cc_user_active_other_domain',
+            'web_user_active',
+            'web_user_active_other_domain',
+            'web_user_active_both_domains',
+            'web_user_active_inactive_other',
+            'web_user_inactive_active_other',
+        ])
 
     def test_get_inactive_in_domains(self):
         domains = [self.domain, self.other_domain]
-        self.assertItemsEqual(
+        assert Counter(
             UserES()
             .domain(domains, include_active=False, include_inactive=True)
-            .values_list('username', flat=True),
-            [
-                'cc_user_inactive',
-                'cc_user_inactive_other_domain',
-                'web_user_inactive',
-                'web_user_inactive_other_domain',
-                'web_user_inactive_both_domains',
-                'web_user_active_inactive_other',
-                'web_user_inactive_active_other',
-            ]
-        )
+            .values_list('username', flat=True)
+        ) == Counter([
+            'cc_user_inactive',
+            'cc_user_inactive_other_domain',
+            'web_user_inactive',
+            'web_user_inactive_other_domain',
+            'web_user_inactive_both_domains',
+            'web_user_active_inactive_other',
+            'web_user_inactive_active_other',
+        ])
 
     def test_iter_web_user_emails(self):
         web_user_emails = iter_web_user_emails(self.domain)

--- a/corehq/apps/es/tests/test_users_es.py
+++ b/corehq/apps/es/tests/test_users_es.py
@@ -1,3 +1,6 @@
+import types
+from collections import Counter
+
 from django.test import TestCase
 
 from corehq.apps.domain.shortcuts import create_domain
@@ -6,6 +9,7 @@ from corehq.apps.es.users import (
     UserES,
     _empty_user_data_property,
     _missing_user_data_property,
+    iter_web_user_emails,
     missing_or_empty_user_data_property,
     user_adapter,
 )
@@ -237,3 +241,12 @@ class TestIsActiveOnDomain(TestCase):
                 'web_user_inactive_active_other',
             ]
         )
+
+    def test_iter_web_user_emails(self):
+        web_user_emails = iter_web_user_emails(self.domain)
+        assert isinstance(web_user_emails, types.GeneratorType)
+        assert Counter(list(web_user_emails)) == Counter([
+            'web_user_active',
+            'web_user_active_both_domains',
+            'web_user_active_inactive_other',
+        ])

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -321,3 +321,16 @@ def missing_or_empty_user_data_property(property_name):
         _missing_user_data_property(property_name),
         _empty_user_data_property(property_name),
     )
+
+
+def iter_web_user_emails(domain_name):
+    return (
+        hit['email'] or hit['username']
+        for hit in (
+            UserES()
+            .domain(domain_name)
+            .web_users()
+            .fields(('email', 'username'))
+            .scroll()
+        )
+    )

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -10,7 +10,7 @@ import dateutil
 from memoized import memoized
 
 from corehq import toggles
-from corehq.apps.users.dbaccessors import get_all_user_rows
+from corehq.apps.es.users import iter_web_user_emails
 from dimagi.utils.dates import DateSpan
 from dimagi.utils.logging import notify_exception
 
@@ -52,17 +52,7 @@ class ProjectReport(GenericReportView):
         context = super().template_context
 
         email_form = EmailReportForm()
-        web_user_emails = (
-            row['doc'].get('email') or row['doc'].get('username')
-            for row in get_all_user_rows(
-                self.domain,
-                include_web_users=True,
-                include_inactive=False,
-                include_mobile_users=False,
-                include_docs=True,
-            )
-        )
-        choices = [(e, e) for e in web_user_emails]
+        choices = [(e, e) for e in iter_web_user_emails(self.domain)]
         if len(choices) <= MAX_WEB_USER_EMAILS:
             email_form.fields['recipient_emails'].choices = choices
         context.update({

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -59,6 +59,7 @@ from corehq.apps.domain.decorators import (
 )
 from corehq.apps.domain.models import Domain, DomainAuditRecordEntry
 from corehq.apps.domain.views.base import BaseDomainView
+from corehq.apps.es.users import iter_web_user_emails
 from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp.doc_info import DocInfo, get_doc_info_by_id
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
@@ -90,13 +91,8 @@ from corehq.apps.saved_reports.tasks import (
 )
 from corehq.apps.userreports.util import \
     default_language as ucr_default_language
-from corehq.apps.users.dbaccessors import get_all_user_rows
 from corehq.apps.users.decorators import require_permission
-from corehq.apps.users.models import (
-    CommCareUser,
-    HqPermissions,
-    WebUser,
-)
+from corehq.apps.users.models import CommCareUser, HqPermissions
 from corehq.apps.users.permissions import (
     CASE_EXPORT_PERMISSION,
     DEID_EXPORT_PERMISSION,
@@ -776,12 +772,7 @@ class ScheduledReportsView(BaseProjectReportSectionView):
             args = ()
             selected_emails = kwargs.get('initial', {}).get('recipient_emails', [])
 
-        web_user_emails = [
-            WebUser.wrap(row['doc']).get_email()
-            for row in get_all_user_rows(self.domain, include_web_users=True,
-                                         include_inactive=False, include_mobile_users=False,
-                                         include_docs=True)
-        ]
+        web_user_emails = list(iter_web_user_emails(self.domain))
         for email in selected_emails:
             if email not in web_user_emails:
                 web_user_emails = [email] + web_user_emails

--- a/corehq/apps/saved_reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/saved_reports/tests/test_scheduled_reports.py
@@ -7,6 +7,7 @@ from django.test import SimpleTestCase, TestCase
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es.cases import case_adapter
 from corehq.apps.es.forms import form_adapter
+from corehq.apps.es.users import user_adapter
 from corehq.apps.es.tests.utils import es_test
 from corehq.apps.reports.views import get_scheduled_report_response
 from corehq.apps.saved_reports.models import ReportConfig, ReportNotification
@@ -239,7 +240,7 @@ class ScheduledReportTest(TestCase):
 
 @patch('corehq.apps.reports.standard.monitoring.util.get_simplified_users',
        new=lambda q: [])
-@es_test(requires=[case_adapter, form_adapter], setup_class=True)
+@es_test(requires=[case_adapter, form_adapter, user_adapter], setup_class=True)
 class ScheduledReportSendingTest(TestCase):
 
     domain = 'test-scheduled-reports'


### PR DESCRIPTION
## Product Description

This change allows users to select the email addresses of web users when emailing a report.

e.g.

<img width="620" height="406" alt="image" src="https://github.com/user-attachments/assets/f72109be-6941-4e9f-a6e2-2de51cc7abd8" />

The interface still allows the user to add non-web-user addresses, as before (like "foo@example.com" in the example above).

## Technical Summary

Context: [SAAS-18350](https://dimagi.atlassian.net/browse/SAAS-18350)

## Safety Assurance

### Safety story

* Small change
* Tested locally
* Uses a similar approach as [ScheduledReportForm](https://github.com/dimagi/commcare-hq/blob/fd9cf55d0f97a63d9bfd33a99bc0c85ba80a3947/corehq/apps/reports/views.py#L792)

### Automated test coverage

No

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-18350]: https://dimagi.atlassian.net/browse/SAAS-18350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ