### PR TITLE
Fix DateRange Picker display issue

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -40,8 +40,18 @@ $.fn.createDateRangePicker = function (
         // Parse dates as local dates to avoid timezone conversion
         var startParts = startdate.split('-');
         var endParts = enddate.split('-');
-        config.startDate = new Date(startParts[0], startParts[1] - 1, startParts[2]);
-        config.endDate = new Date(endParts[0], endParts[1] - 1, endParts[2]);
+
+        config.startDate = new Date(
+            parseInt(startParts[0], 10),
+            parseInt(startParts[1], 10) - 1,
+            parseInt(startParts[2], 10),
+        );
+
+        config.endDate = new Date(
+            parseInt(endParts[0], 10),
+            parseInt(endParts[1], 10) - 1,
+            parseInt(endParts[2], 10),
+        );
     }
 
     $(this).daterangepicker(config);

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -38,19 +38,20 @@ $.fn.createDateRangePicker = function (
     var hasStartAndEndDate = !_.isEmpty(startdate) && !_.isEmpty(enddate);
     if (hasStartAndEndDate) {
         // Parse dates as local dates to avoid timezone conversion
+        // This operates specifically on a "YYYY-MM-DD" date.
         var startParts = startdate.split('-');
         var endParts = enddate.split('-');
 
         config.startDate = new Date(
-            parseInt(startParts[0], 10),
-            parseInt(startParts[1], 10) - 1,
-            parseInt(startParts[2], 10),
+            parseInt(startParts[0]),
+            parseInt(startParts[1]) - 1,
+            parseInt(startParts[2]),
         );
 
         config.endDate = new Date(
-            parseInt(endParts[0], 10),
-            parseInt(endParts[1], 10) - 1,
-            parseInt(endParts[2], 10),
+            parseInt(endParts[0]),
+            parseInt(endParts[1]) - 1,
+            parseInt(endParts[2]),
         );
     }
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/daterangepicker.config.js
@@ -37,8 +37,11 @@ $.fn.createDateRangePicker = function (
     };
     var hasStartAndEndDate = !_.isEmpty(startdate) && !_.isEmpty(enddate);
     if (hasStartAndEndDate) {
-        config.startDate = new Date(startdate);
-        config.endDate = new Date(enddate);
+        // Parse dates as local dates to avoid timezone conversion
+        var startParts = startdate.split('-');
+        var endParts = enddate.split('-');
+        config.startDate = new Date(startParts[0], startParts[1] - 1, startParts[2]);
+        config.endDate = new Date(endParts[0], endParts[1] - 1, endParts[2]);
     }
 
     $(this).daterangepicker(config);


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The Date Range filter in report is offset by an extra day for users in a timezone behind UTC.
For example:
1) when checking the worker activity report on April 16th, we expect the default range to be April 9th-16th. Instead we see April 8th-15th. 
2) When user select "Last 7 Days", we can see the range is Jul 3 - Jul 10, but after hit apply button, the range becomes Jul 2 - Jul 9.


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-17408

The issue was in the `createDateRangePicker` function. 
When initializing the date picker widget, the code was using:
```
config.startDate = new Date(startdate); 
config.endDate = new Date(enddate); 
```
When JavaScript's `new Date()` constructor receives a string in "YYYY-MM-DD" format, it interprets it as UTC time at midnight, then converts it to the local timezone for display. This caused dates to shift backward by the timezone offset. e.g., "2025-09-02" will first be interpreted as "2025-09-02 00:00:00 UTC", then based on user's timezone, if user is in Eastern Daylight Time, it will be displayed as "2025-09-01 20:00:00".

This PR modified the date parsing logic to create `Date` objects, `new Date(year, monthIndex, day)` will build the date as midnight in user's local time zone (not UTC), which avoids that unwanted conversion.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
NA

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. The change just only affect client-side date display.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not planning on QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
