### PR TITLE
Only show supported languages in settings

### DIFF
--- a/corehq/apps/hqwebapp/tests/test_timeout_middleware.py
+++ b/corehq/apps/hqwebapp/tests/test_timeout_middleware.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from unittest.mock import patch
 
 from django.conf import settings
 from django.test import Client, TestCase
@@ -96,7 +97,8 @@ class TestTimeout(TestCase):
         self.assertTrue(self.client.session.get('secure_session'))
         self._assert_session_expiry_in_minutes(self.secure_domain2.secure_sessions_timeout, self.client.session)
 
-    def test_multiple_secure(self):
+    @patch('corehq.apps.settings.views.get_languages_for_user', return_value=[])
+    def test_multiple_secure(self, mock_langs):
         # Session should apply minimum value of all relevant timeouts
         self.user = WebUser.get_by_username(self.user.username)
         self.user.add_as_web_user(self.secure_domain1.name, 'admin')

--- a/corehq/apps/hqwebapp/tests/test_timeout_middleware.py
+++ b/corehq/apps/hqwebapp/tests/test_timeout_middleware.py
@@ -33,6 +33,10 @@ class TestTimeout(TestCase):
         cls.secure_domain2.secure_sessions_timeout = 15
         cls.secure_domain2.save()
 
+        lang_patcher = patch('corehq.apps.settings.views.get_languages_for_user', return_value=[])
+        lang_patcher.start()
+        cls.addClassCleanup(lang_patcher.stop)
+
     def setUp(self):
         # Re-login for each test to create new session
         self.client = Client()
@@ -97,8 +101,7 @@ class TestTimeout(TestCase):
         self.assertTrue(self.client.session.get('secure_session'))
         self._assert_session_expiry_in_minutes(self.secure_domain2.secure_sessions_timeout, self.client.session)
 
-    @patch('corehq.apps.settings.views.get_languages_for_user', return_value=[])
-    def test_multiple_secure(self, mock_langs):
+    def test_multiple_secure(self):
         # Session should apply minimum value of all relevant timeouts
         self.user = WebUser.get_by_username(self.user.username)
         self.user.add_as_web_user(self.secure_domain1.name, 'admin')

--- a/corehq/apps/locations/tests/test_permissions.py
+++ b/corehq/apps/locations/tests/test_permissions.py
@@ -214,7 +214,7 @@ class TestAccessRestrictions(LocationHierarchyTestCase):
                       args=[self.domain, user._id])
         with mock.patch(
             'corehq.apps.users.views.mobile.users.get_domain_languages',
-            new=lambda *args: None,
+            new=lambda *args, **kwargs: None,
         ):
             self._assert_url_returns_status(url, status_code)
 

--- a/corehq/apps/settings/languages.py
+++ b/corehq/apps/settings/languages.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+
+
+def get_translated_languages():
+    """
+    Returns list of tuples, (language code, display name) for all languages
+    with translations supported by CommCare
+    """
+    languages = []
+    for code, name in settings.LANGUAGES:
+        display_name = format_language_for_display(code, name)
+        languages.append((code, display_name))
+    return languages
+
+
+def format_language_for_display(code, name):
+    return f"{code} ({name})"

--- a/corehq/apps/settings/languages.py
+++ b/corehq/apps/settings/languages.py
@@ -14,7 +14,9 @@ def get_languages_for_user(user):
     for domain_membership in user.domain_memberships:
         domain_languages.extend(get_domain_languages(domain_membership.domain))
 
-    return sorted(set(translated_languages + domain_languages))
+    # ensure only one language for each code is returned, giving precedent to translated_languages
+    deduped_languages = {code: name for code, name in (domain_languages + translated_languages)}
+    return sorted(list(deduped_languages.items()))
 
 
 def get_translated_languages():

--- a/corehq/apps/settings/languages.py
+++ b/corehq/apps/settings/languages.py
@@ -16,7 +16,7 @@ def get_languages_for_user(user):
 
     # ensure only one language for each code is returned, giving precedent to translated_languages
     deduped_languages = {code: name for code, name in (domain_languages + translated_languages)}
-    return sorted(list(deduped_languages.items()))
+    return sorted(deduped_languages.items())
 
 
 def get_translated_languages():

--- a/corehq/apps/settings/languages.py
+++ b/corehq/apps/settings/languages.py
@@ -1,5 +1,21 @@
 from django.conf import settings
 
+from corehq.apps.users.views import get_domain_languages
+
+
+def get_languages_for_user(user):
+    """
+    Returns all CommCare supported languages and any languages that have
+    explicitly been added to domains this user is a member of as a list
+    of tuples list((language code, display name))
+    """
+    translated_languages = get_translated_languages()
+    domain_languages = []
+    for domain_membership in user.domain_memberships:
+        domain_languages.extend(get_domain_languages(domain_membership.domain))
+
+    return sorted(set(translated_languages + domain_languages))
+
 
 def get_translated_languages():
     """

--- a/corehq/apps/settings/tests/test_languages.py
+++ b/corehq/apps/settings/tests/test_languages.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.es.apps import app_adapter
+from corehq.apps.es.tests.utils import es_test
+from corehq.apps.settings.languages import get_languages_for_user
+from corehq.apps.users.models import WebUser
+
+
+@override_settings(
+    LANGUAGES=[
+        ('en', 'English'),
+        ('es', 'Spanish'),
+        ('fra', 'French')
+    ]
+)
+@es_test(requires=[app_adapter])
+class GetLanguagesForUserTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = Domain.get_or_create_with_name('test-langs', is_active=True)
+        cls.addClassCleanup(cls.domain_obj.delete)
+        cls.user = WebUser.create(cls.domain_obj.name, 'lang-user', 'abc123', None, None)
+        cls.addClassCleanup(cls.user.delete, cls.domain_obj.name, None)
+
+    def test_no_domain_translations(self):
+        langs = get_languages_for_user(self.user)
+        assert langs == [
+            ('en', 'en (English)'),
+            ('es', 'es (Spanish)'),
+            ('fra', 'fra (French)'),
+        ]
+
+    def test_with_overlapping_domain_translations(self):
+        with patch('corehq.apps.settings.languages.get_domain_languages', return_value=[('es', 'es (Espanol)')]):
+            langs = get_languages_for_user(self.user)
+            assert langs == [
+                ('en', 'en (English)'),
+                ('es', 'es (Spanish)'),  # uses name specified in settings.LANGUAGES, not domain
+                ('fra', 'fra (French)'),
+            ]
+
+    def test_with_unique_domain_translations(self):
+        with patch('corehq.apps.settings.languages.get_domain_languages', return_value=[('hin', 'hin (Hindi)')]):
+            langs = get_languages_for_user(self.user)
+            assert langs == [
+                ('en', 'en (English)'),
+                ('es', 'es (Spanish)'),
+                ('fra', 'fra (French)'),
+                ('hin', 'hin (Hindi)'),
+            ]

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -18,7 +18,6 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, gettext_noop
 from django.views.decorators.debug import sensitive_post_parameters
 
-import langcodes
 import qrcode
 from django_otp import devices_for_user
 from memoized import memoized
@@ -69,6 +68,7 @@ from corehq.apps.settings.forms import (
     HQPhoneNumberMethodForm,
     HQTwoFactorMethodForm,
 )
+from corehq.apps.settings.languages import get_languages_for_user
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from corehq.apps.users.audit.change_messages import UserChangeMessage
@@ -160,7 +160,7 @@ class MyAccountSettingsView(BaseMyAccountView):
     @property
     @memoized
     def settings_form(self):
-        language_choices = langcodes.get_all_langs_for_select()
+        language_choices = get_languages_for_user(self.request.couch_user)
         from corehq.apps.users.forms import UpdateMyAccountInfoForm
         try:
             domain = self.request.domain

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -526,7 +526,11 @@ class EditWebUserView(BaseEditUserView):
         return super(EditWebUserView, self).post(request, *args, **kwargs)
 
 
-def get_domain_languages(domain):
+def get_domain_languages(domain, default_to_all_langs=False):
+    """
+    :param default_to_all_langs: returns all languages if no translations have
+    been setup for this domain yet
+    """
     app_languages = get_app_languages(domain)
     translations = SMSTranslations.objects.filter(domain=domain).first()
     sms_languages = translations.langs if translations else []
@@ -537,7 +541,10 @@ def get_domain_languages(domain):
         label = "{} ({})".format(lang_code, name) if name else lang_code
         domain_languages.append((lang_code, label))
 
-    return sorted(domain_languages) or langcodes.get_all_langs_for_select()
+    if not domain_languages and default_to_all_langs:
+        return langcodes.get_all_langs_for_select()
+
+    return sorted(domain_languages)
 
 
 class BaseRoleAccessView(BaseUserSettingsView):

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -16,6 +16,7 @@ from corehq.apps.custom_data_fields.models import CustomDataFieldsProfile, Custo
 from corehq.apps.programs.models import Program
 from corehq.apps.registry.utils import get_data_registry_dropdown_options
 from corehq.apps.reports.models import TableauVisualization, TableauUser
+from corehq.apps.settings.languages import format_language_for_display
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils.user_helpers import get_email_domain_from_username
 from corehq.toggles import TABLEAU_USER_SYNCING
@@ -538,7 +539,7 @@ def get_domain_languages(domain, default_to_all_langs=False):
     domain_languages = []
     for lang_code in app_languages.union(sms_languages):
         name = langcodes.get_name(lang_code)
-        label = "{} ({})".format(lang_code, name) if name else lang_code
+        label = format_language_for_display(lang_code, name) if name else lang_code
         domain_languages.append((lang_code, label))
 
     if not domain_languages and default_to_all_langs:

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -16,7 +16,6 @@ from corehq.apps.custom_data_fields.models import CustomDataFieldsProfile, Custo
 from corehq.apps.programs.models import Program
 from corehq.apps.registry.utils import get_data_registry_dropdown_options
 from corehq.apps.reports.models import TableauVisualization, TableauUser
-from corehq.apps.settings.languages import format_language_for_display
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.sso.utils.user_helpers import get_email_domain_from_username
 from corehq.toggles import TABLEAU_USER_SYNCING
@@ -532,6 +531,8 @@ def get_domain_languages(domain, default_to_all_langs=False):
     :param default_to_all_langs: returns all languages if no translations have
     been setup for this domain yet
     """
+    from corehq.apps.settings.languages import format_language_for_display
+
     app_languages = get_app_languages(domain)
     translations = SMSTranslations.objects.filter(domain=domain).first()
     sms_languages = translations.langs if translations else []

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -372,7 +372,7 @@ class EditCommCareUserView(BaseEditUserView):
         form = CommCareUserFormSet(data=data, domain=self.domain,
             editable_user=self.editable_user, request_user=self.request.couch_user, request=self.request)
 
-        form.user_form.load_language(language_choices=get_domain_languages(self.domain))
+        form.user_form.load_language(language_choices=get_domain_languages(self.domain, default_to_all_langs=True))
 
         if self.can_change_user_roles or self.couch_user.can_view_roles():
             form.user_form.load_roles(current_role=self.existing_role, role_choices=self.user_role_choices)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-17767

We currently show all possible languages in the dropdown for a user's default CommCare HQ language, even though we only support translations for a small subset of those languages.

The only gotcha here is that we want to show both the languages we have translations for, _and_ languages that the user's domain(s) has manually added translations for. This is so that if they interact with web apps, it uses that language. Ideally these two settings would be controlled separately, but this is at least an improvement.
 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Updated some automated tests for `get_domain_languages`.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
