### PR TITLE
Update username taken error message and Add Project page wording

### DIFF
--- a/corehq/apps/registration/templates/registration/domain_request.html
+++ b/corehq/apps/registration/templates/registration/domain_request.html
@@ -159,13 +159,13 @@
                     {% endblocktrans %}
                   {% endif %}
                   {% blocktrans %}
-                    To select a different
+                    To create a project in a different
                     <a
                       href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3101491209/CommCare+Cloud+Server+Locations"
                       target="_blank"
                       ><b>cloud location</b></a
-                    >, log into that location's site before creating your
-                    project:
+                    >, create an account for that cloud location first, then
+                    create a project.
                   {% endblocktrans %}
                 </p>
                 <ul>

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -216,7 +216,12 @@ class ProcessRegistrationView(JSONResponseMixin, View):
         message = None
         restricted_by_domain = None
         if is_existing:
-            message = _("There is already a user with this email.")
+            current_env_data = ServerLocation.ENVS.get(settings.SERVER_ENVIRONMENT)
+            current_location = current_env_data['short_name'] if current_env_data else _("current")
+            message = _(
+                'This email is already registered in the {location} cloud location. '
+                'Please <a href="{login_link}">sign in here</a>.'
+            ).format(location=current_location, login_link=reverse('login'))
         else:
             domain = email[email.find("@") + 1:]
             for account in BillingAccount.get_enterprise_restricted_signup_accounts():


### PR DESCRIPTION
## Product Description
Updates the error shown when a username is already taken
Before:
<img width="479" height="393" alt="image" src="https://github.com/user-attachments/assets/6c315edf-9fb8-4c2c-8a39-4270def94815" />



After:
<img width="480" height="410" alt="image" src="https://github.com/user-attachments/assets/61d08414-1405-4fb1-be5c-fe238a60a797" />


And wording in the "Cloud Location" section of the Add New Project page
Before:
<img width="690" height="171" alt="image" src="https://github.com/user-attachments/assets/52bfc4a1-f806-4ea8-b156-a5c4b0719853" />


After:
<img width="687" height="171" alt="image" src="https://github.com/user-attachments/assets/bb3653e9-3476-4a36-9112-d6b8a42988d6" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18425

## Safety Assurance

### Safety story
This just updates wording. Confirmed that the text looks correct and fills in the cloud location name (e.g. 'US') based on current server environment being present in ServerLocation.ENVS.

### Automated test coverage
Not here.

### QA Plan
Not planning on it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
"High" is automatically applied based on changes in the `registration` app, but this should be a low risk change.
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
