### PR TITLE
Allow  commcare-user Case Type for Case List

### DIFF
--- a/corehq/apps/app_manager/app_schemas/tests/test_schema.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_schema.py
@@ -4,7 +4,6 @@ from django.test import SimpleTestCase
 
 from unittest.mock import MagicMock, patch
 
-from corehq.apps.app_manager import util as util
 from corehq.apps.app_manager.app_schemas.casedb_schema import get_casedb_schema, get_registry_schema
 from corehq.apps.app_manager.app_schemas.session_schema import (
     get_session_schema,
@@ -586,7 +585,7 @@ class SessionSchemaTests(BaseSchemaTest):
                         "reference": {
                             "hashtag": "#user",
                             "source": "casedb",
-                            "subset": util.USERCASE_TYPE,
+                            "subset": USERCASE_TYPE,
                             "subset_key": "@case_type",
                             "subset_filter": True,
                             "key": "hq_user_id",

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -273,9 +273,12 @@ class ApplicationValidator(ApplicationBaseValidator):
         if app_uses_usercase(self.app) and not domain_has_privilege(self.domain, privileges.USERCASE):
             errors.append({
                 'type': 'subscription',
-                'message': _('Your application is using User Properties and your current subscription does not '
-                             'support that. You can remove User Properties functionality by opening the User '
-                             'Properties tab in a form that uses it, and clicking "Remove User Properties".'),
+                'message': _(
+                    "Your application is using User Properties or using `commcare-user` as a menu's case type, "
+                    "and your current subscription does not support that. You can remove User Properties"
+                    "functionality by opening the User Properties tab in a form that uses it and clicking "
+                    "'Remove User Properties.'"
+                ),
             })
         return errors
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2827,7 +2827,8 @@ class Module(ModuleBase, ModuleDetailsMixin):
     def uses_usercase(self):
         """Return True if this module has any forms that use the usercase.
         """
-        return any(form.uses_usercase() for form in self.get_forms())
+        return (self.case_type == const.USERCASE_TYPE
+                or any(form.uses_usercase() for form in self.get_forms()))
 
     def grid_display_style(self):
         return self.display_style == 'grid'

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -114,7 +114,17 @@ module.valueIsReservedWord = function (valueNoSpaces) {
     return valueNoSpaces === 'commcare-user' || valueNoSpaces === 'user-owner-mapping-case';
 };
 
-module.reservedWordErrorMsg = gettext("This is a reserved case type. Please choose another name.");
+module.getReservedWordErrorMsg = function (valueNoSpaces) {
+    const reservedWordErrorMsg = {
+        'commcare-user': gettext(
+            'This is a reserved case type. Refer to ' +
+            '<a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955258/User+Case+Management" target="_blank" rel="noopener">doc</a> ' +
+            'before using.',
+        ),
+    };
+    const defaultReservedWordErrorMsg = gettext("This is a reserved case type. Please choose another name.");
+    return reservedWordErrorMsg[valueNoSpaces] || defaultReservedWordErrorMsg;
+};
 
 module.deprecatedCaseTypeErrorMsg = gettext("This case type has been deprecated in the Data Dictionary.");
 
@@ -606,7 +616,7 @@ var _initNewModuleOptionClicks = function () {
                 }
 
                 if (module.valueIsReservedWord(valueNoSpaces)) {
-                    displayError(module.reservedWordErrorMsg);
+                    displayError(module.getReservedWordErrorMsg(valueNoSpaces));
                     return;
                 }
 

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -99,7 +99,7 @@ $(function () {
     var showCaseTypeError = function (message) {
         var $caseTypeError = $('#case_type_error');
         $caseTypeError.css('display', 'block').removeClass('hide');
-        $caseTypeError.text(message);
+        $caseTypeError.html(message);
     };
     var hideCaseTypeError = function () {
         $('#case_type_error').addClass('hide');
@@ -154,7 +154,7 @@ $(function () {
         } else if (appManager.valueIsReservedWord(valueNoSpaces) && moduleType !== 'advanced') {
             $el.closest('.form-group').addClass('has-error');
             showCaseTypeError(
-                appManager.reservedWordErrorMsg,
+                appManager.getReservedWordErrorMsg(valueNoSpaces),
             );
 
         } else {

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -26,7 +26,6 @@ from corehq.apps.app_manager.const import (
     REGISTRY_WORKFLOW_SMART_LINK,
     USERCASE_ID,
     USERCASE_PREFIX,
-    USERCASE_TYPE,
     MOBILE_UCR_V1_FIXTURE_IDENTIFIER,
     MOBILE_UCR_V1_ALL_REFERENCES,
     MOBILE_UCR_V1_CASE_LIST_REFERENCES_PATTERN,
@@ -206,11 +205,10 @@ CASE_TYPE_REGEX = r'^[\w-]+$'
 _case_type_regex = re.compile(CASE_TYPE_REGEX)
 
 
-def is_valid_case_type(case_type, module):
+def is_valid_case_type(case_type):
     """
     Returns ``True`` if ``case_type`` is valid for ``module``
 
-    >>> from corehq.apps.app_manager.const import USERCASE_TYPE
     >>> from corehq.apps.app_manager.models import Module, AdvancedModule
     >>> is_valid_case_type('foo', Module())
     True
@@ -222,15 +220,9 @@ def is_valid_case_type(case_type, module):
     False
     >>> is_valid_case_type(None, Module())
     False
-    >>> is_valid_case_type(USERCASE_TYPE, Module())
-    False
-    >>> is_valid_case_type(USERCASE_TYPE, AdvancedModule())
-    True
     """
-    from corehq.apps.app_manager.models import AdvancedModule
     matches_regex = bool(_case_type_regex.match(case_type or ''))
-    prevent_usercase_type = (case_type != USERCASE_TYPE or isinstance(module, AdvancedModule))
-    return matches_regex and prevent_usercase_type
+    return matches_regex
 
 
 def module_case_hierarchy_has_circular_reference(module):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -693,9 +693,7 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
         module.case_details.short.no_items_text[lang] = request.POST.get("no_items_text")
     if should_edit("case_type"):
         case_type = request.POST.get("case_type", None)
-        if case_type == USERCASE_TYPE and not isinstance(module, AdvancedModule):
-            raise AppMisconfigurationError('"{}" is a reserved case type'.format(USERCASE_TYPE))
-        elif case_type and not is_valid_case_type(case_type, module):
+        if case_type and not is_valid_case_type(case_type):
             raise AppMisconfigurationError("case type is improperly formatted")
         else:
             old_case_type = module["case_type"]

--- a/corehq/apps/events/management/commands/set_attendee_case_type.py
+++ b/corehq/apps/events/management/commands/set_attendee_case_type.py
@@ -33,6 +33,6 @@ def valid_domain(domain_name):
 
 
 def valid_case_type(case_type):
-    if not is_valid_case_type(case_type, None):
+    if not is_valid_case_type(case_type):
         raise CommandError(f'Invalid case type {case_type!r}')
     return case_type


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This change allows `commcare-user` to be defined as the case type. When it is used, a warning message is displayed that notifies the user that it is a reserved case type and refers the user to the docs.

<img width="578" height="79" alt="Screenshot 2025-09-02 at 11 01 50 PM" src="https://github.com/user-attachments/assets/45515f41-984b-4789-a8d3-da05126c350b" />

If a domain loses privilege to usercases, then the app will error upon building a new version if the app contains a module that uses case type `commcare-user`
<img width="777" height="180" alt="Screenshot 2025-09-11 at 11 25 30 AM" src="https://github.com/user-attachments/assets/a18620e9-172a-428c-9edc-c4c7c3722f0b" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-6181](https://dimagi.atlassian.net/browse/USH-6181)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested. There are potentially risks with allowing `commcare-user` as a case type, but it is not a completely new workflow since it can be done in other ways.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
[QA-8034](https://dimagi.atlassian.net/browse/QA-8034)


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
If this PR is reverted, then apps that are built using `commcare-user` as a case type will continue to work. But will not be able to build a new version.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-6181]: https://dimagi.atlassian.net/browse/USH-6181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ