### PR TITLE
Add EU to ServerLocation

### DIFF
--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -599,14 +599,13 @@ class TestExtractAppInfoForm(SimpleTestCase):
         self.assertEqual(form.cleaned_data['source_domain'], 'test-domain')
         self.assertEqual(form.cleaned_data['app_id'], '62891a383516c656850cc9c7e7b8d459')
 
-    # TODO: Enable this test case when EU server launched
-    # def test_clean_app_url_with_valid_eu_server(self):
-    #     url = 'https://eu.commcarehq.org/a/test-domain/apps/view/62891a383516c656850cc9c7e7b8d459/'
-    #     form = forms.ExtractAppInfoForm(data={'app_url': url})
-    #     self.assertTrue(form.is_valid())
-    #     self.assertEqual(form.cleaned_data['source_server'], 'eu')
-    #     self.assertEqual(form.cleaned_data['source_domain'], 'test-domain')
-    #     self.assertEqual(form.cleaned_data['app_id'], '62891a383516c656850cc9c7e7b8d459')
+    def test_clean_app_url_with_valid_eu_server(self):
+        url = 'https://eu.commcarehq.org/a/test-domain/apps/view/62891a383516c656850cc9c7e7b8d459/'
+        form = forms.ExtractAppInfoForm(data={'app_url': url})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['source_server'], 'eu')
+        self.assertEqual(form.cleaned_data['source_domain'], 'test-domain')
+        self.assertEqual(form.cleaned_data['app_id'], '62891a383516c656850cc9c7e7b8d459')
 
     def test_clean_app_url_without_trailing_slash(self):
         url = 'https://www.commcarehq.org/a/test-domain/apps/view/62891a383516c656850cc9c7e7b8d459'

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -122,10 +122,17 @@ def pkce_required(client_id):
 
 
 class ServerLocation:
+    EU = 'eu'
     INDIA = 'india'
     PRODUCTION = 'production'
 
     ENVS = {
+        EU: {
+            'country_code': 'eu',
+            'long_name': _("European Union"),
+            'short_name': _("EU"),
+            'subdomain': 'eu',
+        },
         INDIA: {
             'country_code': 'in',
             'long_name': _("India"),


### PR DESCRIPTION
## Product Description
Allows EU to show up on cloud location selectors, the add new project page, and with a flag on the login page and settings dropdown.

## Technical Summary
Essentially reverses https://github.com/dimagi/commcare-hq/pull/36892 (though the data structure has changed a bit), so that EU _will_ now show up in various places in HQ.

## Safety Assurance

### Safety story
Just adds an option to a data model. Uses of this model should work with however many ServerLocation choices there are.

### Automated test coverage
This uncomments a test that implicitly relies on EU being a choice for ServerLocation.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
