### PR TITLE
Fixed project data export filter to correctly exclude web users

### DIFF
--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -807,7 +807,7 @@ class CaseExportFilterBuilder(AbstractExportFilterBuilder):
             ids_to_exclude = self.get_user_ids_for_user_types(
                 admin=HQUserType.ADMIN not in user_types,
                 unknown=HQUserType.UNKNOWN not in user_types,
-                web=HQUserType.WEB in user_types,
+                web=HQUserType.WEB not in user_types,
                 demo=HQUserType.DEMO_USER not in user_types,
                 # this should be true since we are excluding
                 commtrack=True,


### PR DESCRIPTION
## Product Description
When performing exports, the Project Data filter was not performing as [documented](https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143947350/Report+and+Export+Filters). According to the documentation, Project Data, by default, should exclude Web Users. Instead, specifying only the Project Data filter would display Web User cases. Specifying both Project Data and Web User filters would display the bug listed in the associated ticket, where Web Users would surprisingly be excluded from the results, rather than included.

This PR fixes this behavior so that Project Data will exclude cases owned by Web Users, unless the Web User filter is also applied.

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-18353.


## Feature Flag
No feature flag

## Safety Assurance

### Safety story
Verified locally that this change fixes the described problem.

### Automated test coverage
Updated affected tests within `TestFilterCaseESExportDownloadForm` and wrote a new regression test to cover the combination of Project Data and Web User filters.

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
