### PR TITLE
Script to substitute invalid build versions

### DIFF
--- a/subs_app_versions.py
+++ b/subs_app_versions.py
@@ -23,25 +23,6 @@ APP_IDS = [
 ]
 
 
-def get_by_path(dict_, path):
-    """
-    Get a value from a nested dictionary using an Iterable of keys as the path.
-
-    >>> some_dict = {'foo': {'bar': 1}}
-    >>> other_dict = {'foo': {'baz': 2}}
-    >>> get_by_path(some_dict, ('foo', 'bar'))
-    1
-    >>> get_by_path(other_dict, ('foo', 'bar'))
-    None
-    """
-    current = dict_
-    for key in path:
-        if not isinstance(current, dict) or key not in current:
-            return None
-        current = current[key]
-    return current
-
-
 def subs_app_versions(*, dry_run=True):
     print('Dry run' if dry_run else 'Live')
     modified = []
@@ -73,6 +54,25 @@ def is_version_ok(version):
         return True
     except BadValueError:
         return False
+
+
+def get_by_path(dict_, path):
+    """
+    Get a value from a nested dictionary using an Iterable of keys as the path.
+
+    >>> some_dict = {'foo': {'bar': 1}}
+    >>> other_dict = {'foo': {'baz': 2}}
+    >>> get_by_path(some_dict, ('foo', 'bar'))
+    1
+    >>> get_by_path(other_dict, ('foo', 'bar'))
+    None
+    """
+    current = dict_
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
 
 
 def subs_bad_version(app_id):

--- a/subs_app_versions.py
+++ b/subs_app_versions.py
@@ -19,7 +19,8 @@ VERSION_SUBSTITUTIONS = {
 }
 
 
-def subs_app_versions():
+def subs_app_versions(*, dry_run=True):
+    print('Dry run' if dry_run else 'Live')
     modified = []
     for hit in (
         AppES()
@@ -32,7 +33,8 @@ def subs_app_versions():
         if not is_version_ok(version):
             print('.', end='')
             modified.append((hit['domain'], hit['doc_id']))
-            subs_bad_version(hit['doc_id'], version)
+            if not dry_run:
+                subs_bad_version(hit['doc_id'], version)
     print_table(modified)
 
 
@@ -55,7 +57,7 @@ def subs_bad_version(app_id, version):
 def print_table(domain_app_id_pairs):
     if not domain_app_id_pairs:
         return
-    print('\nModified apps:\n')
+    print('\nAffected apps:\n')
     print('| Domain          | App ID                               |')
     print('| --------------- | ------------------------------------ |')
     for domain, app_id in domain_app_id_pairs:

--- a/subs_app_versions.py
+++ b/subs_app_versions.py
@@ -1,0 +1,53 @@
+"""
+This is a script intended to be run in a Django shell. It substitutes
+invalid build versions in Application.built_with.version.
+
+Context: https://dimagi.atlassian.net/browse/SAAS-18157
+"""
+from couchdbkit.exceptions import BadValueError
+from corehq.apps.app_manager.models import Application
+from corehq.apps.builds.models import SemanticVersionProperty
+from corehq.apps.es import filters
+from corehq.apps.es.apps import AppES
+
+VERSION_SUBSTITUTIONS = {
+    # From https://github.com/dimagi/commcare-hq/pull/20845
+    '1.2.dev': '1.2.999',
+    '1.2.0alpha': '1.2.998',
+    '1.3.0alpha': '1.3.999',
+    '2.25.w': '2.25.999',
+}
+
+
+def subs_app_versions():
+    for hit in (
+        AppES()
+        .doc_type('Application')
+        .is_build(build=False)
+        .NOT(filters.empty('built_with.version'))
+        .scroll()
+    ):
+        version = hit['built_with']['version']
+        if not is_version_ok(version):
+            print('.', end='')
+            subs_bad_version(hit['doc_id'], version)
+    print()
+
+
+def is_version_ok(version):
+    try:
+        SemanticVersionProperty().validate(version)
+        return True
+    except BadValueError:
+        return False
+
+
+def subs_bad_version(app_id, version):
+    subs = VERSION_SUBSTITUTIONS[version]  # Raise KeyError on unknown version
+    app_dict = Application.get_db().get(app_id)
+    app_dict['built_with']['version'] = subs
+    app = Application.wrap(app_dict)
+    app.save()
+
+
+subs_app_versions()

--- a/subs_app_versions.py
+++ b/subs_app_versions.py
@@ -20,6 +20,7 @@ VERSION_SUBSTITUTIONS = {
 
 
 def subs_app_versions():
+    modified = []
     for hit in (
         AppES()
         .doc_type('Application')
@@ -30,8 +31,9 @@ def subs_app_versions():
         version = hit['built_with']['version']
         if not is_version_ok(version):
             print('.', end='')
+            modified.append((hit['domain'], hit['doc_id']))
             subs_bad_version(hit['doc_id'], version)
-    print()
+    print_table(modified)
 
 
 def is_version_ok(version):
@@ -48,6 +50,16 @@ def subs_bad_version(app_id, version):
     app_dict['built_with']['version'] = subs
     app = Application.wrap(app_dict)
     app.save()
+
+
+def print_table(domain_app_id_pairs):
+    if not domain_app_id_pairs:
+        return
+    print('\nModified apps:\n')
+    print('| Domain          | App ID                               |')
+    print('| --------------- | ------------------------------------ |')
+    for domain, app_id in domain_app_id_pairs:
+        print(f'| {domain:<15} | {app_id:<36} |')
 
 
 subs_app_versions()


### PR DESCRIPTION
## Technical Summary

This is a script that substitutes invalid build versions in Application.built_with.version.

**It is intended to be run in a Django shell.**

**It is not for merging.**

Context:
* :t-rex: Jira: [SAAS-18157](https://dimagi.atlassian.net/browse/SAAS-18157)
* :octocat: Initial approach: https://github.com/dimagi/commcare-hq/pull/36911

## Safety Assurance

### Safety story

* Tested locally
* Tested ES query on Staging

### Automated test coverage

No

### QA Plan

No

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-18157]: https://dimagi.atlassian.net/browse/SAAS-18157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ