### PR TITLE
Set build_id when creating new form from old form

### DIFF
--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -75,6 +75,7 @@ class FormProcessorSQL(object):
         new_form.user_id = user_id
         new_form.domain = existing_form.domain
         new_form.app_id = existing_form.app_id
+        new_form.build_id = existing_form.build_id
         cls.store_attachments(new_form, [Attachment(
             name=ATTACHMENT_NAME,
             raw_content=new_xml,

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -116,4 +116,5 @@ class FormSubmissionBuilderTests(TestCase, TestXmlMixin):
 
         new_xform = XFormInstance.objects.partitioned_get(xform.form_id)
         old_xform = XFormInstance.objects.partitioned_get(new_xform.deprecated_form_id)
-        self.assertEqual(old_xform.build_id, new_xform.build_id)
+        self.assertEqual(old_xform.build_id, 'b1234')
+        self.assertEqual(new_xform.build_id, 'b1234')

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -104,3 +104,16 @@ class FormSubmissionBuilderTests(TestCase, TestXmlMixin):
         updates = {'eight': 'ocho'}
         errors = FormProcessorInterface(DOMAIN).update_responses(xform, updates, 'user1')
         self.assertEqual(['eight'], errors)
+
+    def test_update_responses_preserves_build_id(self):
+        formxml = FormSubmissionBuilder(form_id='123', form_properties={'nine': 'nueve'}).as_xml_string()
+        xform = submit_form_locally(formxml, DOMAIN).xform
+        xform.build_id = 'b1234'
+        xform.save()
+
+        updates = {'eight': 'ocho'}
+        FormProcessorInterface(DOMAIN).update_responses(xform, updates, 'user1')
+
+        new_xform = XFormInstance.objects.partitioned_get(xform.form_id)
+        old_xform = XFormInstance.objects.partitioned_get(new_xform.deprecated_form_id)
+        self.assertEqual(old_xform.build_id, new_xform.build_id)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18324

This is only called via the edit_form endpoint. When editing a form, it is reasonable to copy the build_id over from the old to the new form.

I will backfill edited forms that do not have this information in a separate PR.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is a very safe change. Currently when editing a form, the new form has a null build_id. This is not correct, and results in confusing behavior for the user. An edited form should preserve the build information related to the original submission, since you can only edit answers to existing questions for that form (rather than add new questions/remove questions/take actions that would make the build_id irrelevant).

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
