### PR TITLE
Add loading spinners for data dictionary

### DIFF
--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -450,6 +450,8 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                 }
                 self.fhirResourceType.subscribe(changeSaveButton);
                 self.removefhirResourceType.subscribe(changeSaveButton);
+            })
+            .always(function () {
                 callback();
             });
     };

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -723,6 +723,7 @@ $(function () {
     function ready() {
         doHashNavigation();
         $('#hq-content').parent().koApplyBindings(viewModel);
+        $('#dd-loading').addClass('hide');
     }
 
     window.onhashchange = doHashNavigation;

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -44,12 +44,14 @@ var caseType = function (
 
     self.groups.subscribe(changeSaveButton);
 
-    self.loadCaseProperties = function () {
+    self.loadCaseProperties = function (isLoading) {
         if (self.groups().length === 0) {
+            isLoading(true);
             const caseTypeUrl = self.dataUrl + self.name + '/';
             fetchCaseProperties(caseTypeUrl).then(() => {
                 self.groups.sort(sortGroupsFn);
                 self.resetSaveButton();
+                isLoading(false);
             });
         }
     };
@@ -325,6 +327,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
     self.showAll = ko.observable(false);
     self.availableDataTypes = typeChoices;
     self.fhirResourceTypes = ko.observableArray(fhirResourceTypes);
+    self.caseTypeIsLoading = ko.observable();
 
     self.casePropertyWarningViewModel = new casePropertyWarningViewModel(casePropertyLimit);
 
@@ -541,7 +544,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
                 return;
             }
         }
-        caseType.loadCaseProperties();
+        caseType.loadCaseProperties(self.caseTypeIsLoading);
         self.activeCaseType(caseType.name);
         self.fhirResourceType(caseType.fhirResourceType());
         self.removefhirResourceType(false);

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -720,10 +720,13 @@ $(function () {
         }
     }
 
-    window.onhashchange = doHashNavigation;
+    function ready() {
+        doHashNavigation();
+        $('#hq-content').parent().koApplyBindings(viewModel);
+    }
 
-    viewModel.init(doHashNavigation);
-    $('#hq-content').parent().koApplyBindings(viewModel);
+    window.onhashchange = doHashNavigation;
+    viewModel.init(ready);
     $('#download-dict').click(function () {
         googleAnalytics.track.event('Data Dictionary', 'downloaded data dictionary');
     });

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -185,6 +185,11 @@
   {% initial_page_data 'casePropertyLimit' case_property_limit %}
   {% initial_page_data 'read_only_mode' request.is_view_only %}
   {% url 'geospatial_settings' domain as geospatial_settings_url %}
+  <h4
+    id="dd-loading"
+  "><i class="fa fa-spin fa-spinner"></i>
+    {% trans "Loading data dictionary..." %}
+  </h4>
   <div class="ko-template">
     <div id="case-type-error" class="alert alert-danger" hidden>
       <p>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block page_navigation %}
-  <div class=ko-template">
+  <div class="ko-template">
     <h2 class="text-hq-nav-header">{% trans "Data Dictionary" %}</h2>
     <ul class="nav nav-hq-sidebar">
       <!-- ko foreach: caseTypes -->
@@ -185,9 +185,8 @@
   {% initial_page_data 'casePropertyLimit' case_property_limit %}
   {% initial_page_data 'read_only_mode' request.is_view_only %}
   {% url 'geospatial_settings' domain as geospatial_settings_url %}
-  <h4
-    id="dd-loading"
-  "><i class="fa fa-spin fa-spinner"></i>
+  <h4 id="dd-loading">
+    <i class="fa fa-spin fa-spinner"></i>
     {% trans "Loading data dictionary..." %}
   </h4>
   <div class="ko-template">
@@ -327,7 +326,7 @@
             <h4
               id="case-type-loading"
               data-bind="visible: caseTypeIsLoading"
-            "><i class="fa fa-spin fa-spinner"></i>
+            ><i class="fa fa-spin fa-spinner"></i>
               {% trans "Loading properties..." %}
             </h4>
             <div

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -324,6 +324,12 @@
               <div class="row-item-small"></div>
             {% endif %}
             </div>
+            <h4
+              id="case-type-loading"
+              data-bind="visible: caseTypeIsLoading"
+            "><i class="fa fa-spin fa-spinner"></i>
+              {% trans "Loading properties..." %}
+            </h4>
             <div
               data-bind="
                 sortable: {


### PR DESCRIPTION
## Product Description
Adds a loading spinner for the main content of the Data Dictionary when loading the page:
<img width="859" height="166" alt="image" src="https://github.com/user-attachments/assets/f1f2fa64-8402-4dcf-a10b-b0a9ee0f2f23" />


As well as the case properties table when loading or switching case types:
<img width="701" height="199" alt="image" src="https://github.com/user-attachments/assets/ef156318-5936-422d-ab28-e1538aa7966f" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17445
The two spinners are implemented in different ways, because the page load spinner wants to be shown once, before the knockout template is initialized (and `ko-template` class is removed, un-hiding the element), where the case properties spinner wants to be shown each time a set of case properties is loaded.

## Safety Assurance

### Safety story
Tested locally and on staging.

### Automated test coverage
Not for JS UI components.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
