### PR TITLE
Allow markdown in question hint text in web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -1047,6 +1047,11 @@ define("cloudcare/js/form_entry/form_ui", [
                     return options.data ? markdown.render(options.data) : null;
                 },
             },
+            hint: {
+                update: function (options) {
+                    return options.data ? markdown.render(options.data) : null;
+                },
+            },
         };
 
         ko.mapping.fromJS(json, mapping, self);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -1049,6 +1049,9 @@ define("cloudcare/js/form_entry/form_ui", [
             },
             hint: {
                 update: function (options) {
+                    if (self.stylesContains(constants.HINT_AS_PLACEHOLDER)) {
+                        return options.data || null;
+                    }
                     return options.data ? markdown.render(options.data) : null;
                 },
             },

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
@@ -50,8 +50,8 @@
         <!-- /ko -->
         <span class="webapp-markdown-output" data-bind="html: ko.utils.unwrapObservable($data.caption_markdown) || caption()"></span>
       </div>
-      <span class="hint-text" data-bind="
-              text: ko.utils.unwrapObservable($data.hint),
+      <span class="hint-text webapp-markdown-output" data-bind="
+              html: ko.utils.unwrapObservable($data.hint),
               visible: !entry.useHintAsPlaceHolder()
           "></span>
       <!-- ko if: required() -->


### PR DESCRIPTION
## Product Description
**Before (app preview)**:
<img width="442" height="146" alt="image" src="https://github.com/user-attachments/assets/3eec0169-3bea-4588-ad5b-8eb50fca4977" />


**Before (web apps)**:
<img width="969" height="92" alt="image" src="https://github.com/user-attachments/assets/8de8dead-f95e-41c5-b02c-9a92bd0644cb" />


**After (app preview)**:
<img width="445" height="174" alt="image" src="https://github.com/user-attachments/assets/f0ea680e-7815-45a1-ae5c-9a88c0f6e23f" />

**After (web apps)**:
<img width="974" height="109" alt="image" src="https://github.com/user-attachments/assets/c3f9736b-1605-46d6-870c-94d07e0ff840" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18158
The linked ticket reported that `<` characters were rendering incorrectly in hint text when immediately followed by any other character, e.g. `<5`. This seems to be because the binding was for `text`, which makes no effort to render `&lt;` as `<`, rather than `html`, which does. To safely use the `html` binding, the hint text also had to be sanitized and therefore allow either basic HTML formatting or markdown. I opted for markdown, which we also allow for help text, and already give the impression in the form builder that we support:
<img width="573" height="175" alt="image" src="https://github.com/user-attachments/assets/81b5e07f-5926-47d3-9fb8-90c578c76bf0" />


## Safety Assurance

### Safety story
Tested locally. Hint text is sanitized in `markdown.render` in the same manner as other user-defined display text so is safe to render with the `html` binding.

### Automated test coverage
There is an automated test for rendering hint text used as a placeholder.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
