### PR TITLE
Tweak deletion messaging for data dictionary case properties

### DIFF
--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
@@ -4,199 +4,255 @@
 
 <!-- modal for deprecating case type -->
 <script type="text/html" id="deprecate-case-type">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal">
-            <span aria-hidden="true">&times;</span>
-          </button>
-          <h4 class="modal-title">
-            {% blocktrans %}
-              Deprecate
-              '<span data-bind="text: $root.activeCaseType()"></span>'
-              Case Type
-            {% endblocktrans %}
-          </h4>
-        </div>
-        <div class="modal-body">
-          {% blocktrans %}
-            <p>
-              There are a total of
-              <strong>
-                <span data-bind="text: activeCaseTypeModuleCount()"></span> application module(s)
-              </strong>
-              that are currently using this case type.
-            </p>
-            <p>
-              Deprecating this case type will have the following effects:
-            </p>
-            <ul>
-              <li>This case type will not be available from the reports filtering menu.</li>
-              <li>All case properties/groups for this case type will be deprecated.</li>
-              <li>New exports cannot be created with this case type.</li>
-              <li>Case imports cannot be done for cases with this case type.</li>
-              <li>New automatic rules cannot be created with this case type.</li>
-            </ul>
-            <p>
-              For more information on deprecated case types, see the
-              <a target="_blank" href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary#Deprecating-%26-Delete-Case-Types-and-Case-Properties">following documentation</a>.
-            </p>
-          {% endblocktrans %}
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
-          <button type="button" class="btn btn-primary" id="gtm-deprecate-case-type-confirm" data-dismiss="modal" data-bind="click: $root.deprecateCaseType">{% trans "Confirm" %}</button>
-        </div>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">
+          {% blocktrans %} Deprecate '<span
+            data-bind="text: $root.activeCaseType()"
+          ></span
+          >' Case Type {% endblocktrans %}
+        </h4>
+      </div>
+      <div class="modal-body">
+        {% blocktrans %}
+        <p>
+          There are a total of
+          <strong>
+            <span data-bind="text: activeCaseTypeModuleCount()"></span>
+            application module(s)
+          </strong>
+          that are currently using this case type.
+        </p>
+        <p>Deprecating this case type will have the following effects:</p>
+        <ul>
+          <li>
+            This case type will not be available from the reports filtering
+            menu.
+          </li>
+          <li>
+            All case properties/groups for this case type will be deprecated.
+          </li>
+          <li>New exports cannot be created with this case type.</li>
+          <li>Case imports cannot be done for cases with this case type.</li>
+          <li>New automatic rules cannot be created with this case type.</li>
+        </ul>
+        <p>
+          For more information on deprecated case types, see the
+          <a
+            target="_blank"
+            href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary#Deprecating-%26-Delete-Case-Types-and-Case-Properties"
+            >following documentation</a
+          >.
+        </p>
+        {% endblocktrans %}
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">
+          {% trans "Cancel" %}
+        </button>
+        <button
+          type="button"
+          class="btn btn-primary"
+          id="gtm-deprecate-case-type-confirm"
+          data-dismiss="modal"
+          data-bind="click: $root.deprecateCaseType"
+        >
+          {% trans "Confirm" %}
+        </button>
       </div>
     </div>
+  </div>
 </script>
 
 <!-- Modal for deprecating geospatial case property -->
-<div id="deprecate-geospatial-prop-modal" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-                <h4 class="modal-title">
-                    {% trans "Deprecate GPS property" %}
-                </h4>
-            </div>
-            <div class="modal-body">
-                <p>
-                    {% blocktrans %}
-                    This GPS case property is currently being used to store the geolocation for cases.
-                    {% endblocktrans %}
-                </p>
-                <p>
-                    {% blocktrans %}
-                    Deprecating this case property may result in unintended behaviour, and so
-                    it is advised to first change the selected custom case property in
-                    <a href="{{ geospatial_settings_url }}">
-                        geospatial settings
-                    </a>
-                    before deprecating this case property.
-                    {% endblocktrans %}
-                </p>
+<div
+  id="deprecate-geospatial-prop-modal"
+  class="modal fade"
+  tabindex="-1"
+  role="dialog"
+>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="Close"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">{% trans "Deprecate GPS property" %}</h4>
+      </div>
+      <div class="modal-body">
+        <p>
+          {% blocktrans %}
+            This GPS case property is currently being used to store the
+            geolocation for cases.
+          {% endblocktrans %}
+        </p>
+        <p>
+          {% blocktrans %}
+            Deprecating this case property may result in unintended behaviour,
+            and so it is advised to first change the selected custom case
+            property in
+            <a href="{{ geospatial_settings_url }}"> geospatial settings </a>
+            before deprecating this case property.
+          {% endblocktrans %}
+        </p>
 
-                <p>
-                    {% blocktrans %}
-                    Would you like to proceed with deprecating this case property?
-                    {% endblocktrans %}
-                </p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">
-                    {% trans 'Cancel' %}
-                </button>
-                <button id="deprecate-geospatial-prop-btn" type="button" class="btn btn-primary">
-                    {% trans 'Confirm' %}
-                </button>
-            </div>
-        </div>
+        <p>
+          {% blocktrans %}
+            Would you like to proceed with deprecating this case property?
+          {% endblocktrans %}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">
+          {% trans 'Cancel' %}
+        </button>
+        <button
+          id="deprecate-geospatial-prop-btn"
+          type="button"
+          class="btn btn-primary"
+        >
+          {% trans 'Confirm' %}
+        </button>
+      </div>
     </div>
+  </div>
 </div>
 
 <!-- Modal for deleting case property -->
 <div id="delete-case-prop-modal" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-                <h4 class="modal-title">
-                    {% blocktrans %}
-                        Delete
-                        '<span id="delete-case-prop-name"></span>'
-                        Case Property
-                    {% endblocktrans %}
-                </h4>
-            </div>
-            <div class="modal-body">
-                <p>
-                    {% blocktrans %}
-                        There are currently no cases that store data with this case property, so it is safe to delete.
-                    {% endblocktrans %}
-                </p>
-                <p>
-                    {% blocktrans %}
-                    Please note that if a new form or case was updated to the server recently that makes this property
-                    unsafe to delete, this will only be reflected in the Data Dictionary after a short while. This is not
-                    a blocking action and the case property can be created again if needed in the future. Please refer to
-                    <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary" target="_blank">the documentation</a>
-                    for additional information about this action.
-                    {% endblocktrans %}
-                </p>
-                <p>
-                    {% blocktrans %}
-                        Would you like to remove this case property from the data dictionary?
-                        Once confirmed, the case property will be deleted upon clicking the "Save" button.
-                    {% endblocktrans %}
-                </p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">
-                    {% trans 'Cancel' %}
-                </button>
-                <button id="delete-case-prop-btn" type="button" class="btn btn-danger">
-                    <i class="fa fa-trash"></i>
-                    {% trans 'Confirm' %}
-                </button>
-            </div>
-        </div>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="Close"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">
+          {% blocktrans %}
+            Delete '<span id="delete-case-prop-name"></span>' Case Property
+          {% endblocktrans %}
+        </h4>
+      </div>
+      <div class="modal-body">
+        <p>
+          {% blocktrans %}
+            There are currently no cases that store data with this case
+            property, so it is safe to delete.
+          {% endblocktrans %}
+        </p>
+        <p>
+          {% blocktrans %}
+            Please note that if a new form or case was updated to the server
+            recently that makes this property unsafe to delete, this will only
+            be reflected in the Data Dictionary after a short while. This is not
+            a blocking action and the case property can be created again if
+            needed in the future. Please refer to
+            <a
+              href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary"
+              target="_blank"
+              >the documentation</a
+            >
+            for additional information about this action.
+          {% endblocktrans %}
+        </p>
+        <p>
+          {% blocktrans %}
+            Would you like to remove this case property from the data
+            dictionary? Once confirmed, the case property will be deleted upon
+            clicking the "Save" button.
+          {% endblocktrans %}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">
+          {% trans 'Cancel' %}
+        </button>
+        <button id="delete-case-prop-btn" type="button" class="btn btn-danger">
+          <i class="fa fa-trash"></i>
+          {% trans 'Confirm' %}
+        </button>
+      </div>
     </div>
+  </div>
 </div>
 
 <!-- Modal for deleting case type -->
 <div id="delete-case-type-modal" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-                <h4 class="modal-title">
-                    {% blocktrans %}
-                    Delete
-                    '<span data-bind="text: $root.activeCaseType()"></span>'
-                    Case Type
-                    {% endblocktrans %}
-                </h4>
-            </div>
-            <div class="modal-body">
-                <p>
-                    {% blocktrans %}
-                    There are no cases that use this case type or store data with any of its case properties.
-                    Therefore, it is safe to delete this case type.
-                    {% endblocktrans %}
-                </p>
-                <p>
-                    {% blocktrans %}
-                    Please note that all case properties for this case type will also be deleted.
-                    Furthermore, if a new form or case was updated to the server recently that makes this case type
-                    unsafe to delete, this will only be reflected in the Data Dictionary after a short while. This is not
-                    a blocking action and the case type can be created again if needed in the future. Please refer to
-                    <a href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary" target="_blank">the documentation</a>
-                    for additional information about this action.
-                    {% endblocktrans %}
-                </p>
-                <p>
-                    {% blocktrans %}
-                    Would you like to proceed with deleting this case type?
-                    {% endblocktrans %}
-                </p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">
-                    {% trans 'Cancel' %}
-                </button>
-                <button id="delete-case-type-btn" type="button" class="btn btn-danger" data-dismiss="modal" data-bind="click: $root.deleteCaseType">
-                    <i class="fa fa-trash"></i>
-                    {% trans 'Delete' %}
-                </button>
-            </div>
-        </div>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="Close"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">
+          {% blocktrans %}
+            Delete '<span data-bind="text: $root.activeCaseType()"></span>' Case
+            Type
+          {% endblocktrans %}
+        </h4>
+      </div>
+      <div class="modal-body">
+        <p>
+          {% blocktrans %}
+            There are no cases that use this case type or store data with any of
+            its case properties. Therefore, it is safe to delete this case type.
+          {% endblocktrans %}
+        </p>
+        <p>
+          {% blocktrans %}
+            Please note that all case properties for this case type will also be
+            deleted. Furthermore, if a new form or case was updated to the
+            server recently that makes this case type unsafe to delete, this
+            will only be reflected in the Data Dictionary after a short while.
+            This is not a blocking action and the case type can be created again
+            if needed in the future. Please refer to
+            <a
+              href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143944977/Data+Dictionary"
+              target="_blank"
+              >the documentation</a
+            >
+            for additional information about this action.
+          {% endblocktrans %}
+        </p>
+        <p>
+          {% blocktrans %}
+            Would you like to proceed with deleting this case type?
+          {% endblocktrans %}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">
+          {% trans 'Cancel' %}
+        </button>
+        <button
+          id="delete-case-type-btn"
+          type="button"
+          class="btn btn-danger"
+          data-dismiss="modal"
+          data-bind="click: $root.deleteCaseType"
+        >
+          <i class="fa fa-trash"></i>
+          {% trans 'Delete' %}
+        </button>
+      </div>
     </div>
+  </div>
 </div>

--- a/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/partials/confirmation_modals.html
@@ -131,8 +131,8 @@
                 </p>
                 <p>
                     {% blocktrans %}
-                        Would you like to mark this case property as deleted? Once confirmed the case
-                        property will be deleted upon clicking the "Save" button.
+                        Would you like to remove this case property from the data dictionary?
+                        Once confirmed, the case property will be deleted upon clicking the "Save" button.
                     {% endblocktrans %}
                 </p>
             </div>


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The previous wording asked a user if they wanted to "mark this case property as deleted", suggesting it was a status, similar to deprecation. Because deleting a case property entirely removes the property from the data dictionary's knowledge, I updated the wording to try to prevent the assumption that this deletion would extend beyond the data dictionary.

## Technical Summary
Associated ticket: https://dimagi.atlassian.net/browse/SAAS-17713

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Just a wording change, should have no effects on functionality

### Automated test coverage
No tests

### QA Plan
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
