### PR TITLE
Only add the email form if it will be rendered

### DIFF
--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -50,15 +50,14 @@ class ProjectReport(GenericReportView):
     @property
     def template_context(self):
         context = super().template_context
-
-        email_form = EmailReportForm()
-        choices = [(e, e) for e in iter_web_user_emails(self.domain)]
-        if len(choices) <= MAX_WEB_USER_EMAILS:
-            email_form.fields['recipient_emails'].choices = choices
-        context.update({
-            'user_types': HQUserType.human_readable,
-            'email_form': email_form
-        })
+        context.update({'user_types': HQUserType.human_readable})
+        if self.rendered_as == 'view':
+            # Add the email form to the context if it will be rendered
+            email_form = EmailReportForm()
+            choices = [(e, e) for e in iter_web_user_emails(self.domain)]
+            if len(choices) <= MAX_WEB_USER_EMAILS:
+                email_form.fields['recipient_emails'].choices = choices
+            context.update({'email_form': email_form})
         return context
 
 

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -1,6 +1,7 @@
 import warnings
 from datetime import datetime
 from functools import wraps
+from itertools import islice
 
 from django.core.cache import cache
 from django.urls import reverse
@@ -54,8 +55,13 @@ class ProjectReport(GenericReportView):
         if self.rendered_as == 'view':
             # Add the email form to the context if it will be rendered
             email_form = EmailReportForm()
-            choices = [(e, e) for e in iter_web_user_emails(self.domain)]
-            if len(choices) <= MAX_WEB_USER_EMAILS:
+            # Fetch enough to tell whether there are too many.
+            emails = list(islice(
+                iter_web_user_emails(self.domain),
+                MAX_WEB_USER_EMAILS + 1
+            ))
+            if len(emails) <= MAX_WEB_USER_EMAILS:
+                choices = [(e, e) for e in emails]
                 email_form.fields['recipient_emails'].choices = choices
             context.update({'email_form': email_form})
         return context

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -772,10 +772,11 @@ class ScheduledReportsView(BaseProjectReportSectionView):
             args = ()
             selected_emails = kwargs.get('initial', {}).get('recipient_emails', [])
 
-        web_user_emails = list(iter_web_user_emails(self.domain))
-        for email in selected_emails:
-            if email not in web_user_emails:
-                web_user_emails = [email] + web_user_emails
+        selected_emails_set = set(selected_emails)
+        web_user_emails = selected_emails + [
+            e for e in iter_web_user_emails(self.domain)
+            if e not in selected_emails_set
+        ]
 
         from corehq.apps.reports.forms import ScheduledReportForm
         form = ScheduledReportForm(*args, **kwargs)

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -767,7 +767,7 @@ class ScheduledReportsView(BaseProjectReportSectionView):
         kwargs = {'initial': initial}
         if self.request.method == "POST":
             args = (self.request.POST, )
-            selected_emails = self.request.POST.getlist('recipient_emails', {})
+            selected_emails = self.request.POST.getlist('recipient_emails', [])
         else:
             args = ()
             selected_emails = kwargs.get('initial', {}).get('recipient_emails', [])


### PR DESCRIPTION
## Technical Summary

Follows up PR https://github.com/dimagi/commcare-hq/pull/36914

Addresses [this Sentry error](https://dimagi.sentry.io/issues/6859439250/?project=136860&referrer=github-pr-bot)

Also optimizes the other place that `iter_web_user_emails()` is used, so that it checks membership of a small set instead of a growing list.

## Safety Assurance

### Safety story

Tested locally:
* Scheduled report email recipients (for the set optimization)
* Daily Form Activity view (for the rendered form)
* Daily Form Activity async JSON data (for not the rendered form)

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
