### PR TITLE
Move Data Sharing setting to Project Information > Basic

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1389,18 +1389,12 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
         self.can_edit_eula = can_edit_eula
         additional_fields = []
         if self.can_edit_eula:
-            additional_fields = ['custom_eula', 'can_use_data']
+            additional_fields = ['custom_eula']
             self.fields['custom_eula'] = ChoiceField(
                 label="Custom Eula?",
                 choices=tf_choices(_('Yes'), _('No')),
                 required=False,
                 help_text='Set to "yes" if this project has a customized EULA as per their contract.'
-            )
-            self.fields['can_use_data'] = ChoiceField(
-                label="Can use project data?",
-                choices=tf_choices('Yes', 'No'),
-                required=False,
-                help_text='Set to "no" if this project opts out of data usage. Defaults to "yes".'
             )
 
         self.helper = hqcrispy.HQFormHelper()
@@ -1572,7 +1566,6 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
         } if self.cleaned_data["workshop_region"] else {}
         if self.can_edit_eula:
             kwargs['custom_eula'] = self.cleaned_data['custom_eula'] == 'true'
-            kwargs['can_use_data'] = self.cleaned_data['can_use_data'] == 'true'
 
         domain.update_deployment(
             countries=self.cleaned_data['countries'],

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -198,6 +198,13 @@ class TestDomainGlobalSettingsForm(TestCase):
         self.assertEqual(['Ensure this value is less than or equal to 1000.'],
                          form.errors.get("operator_call_limit"))
 
+    def test_opt_out_of_data_sharing_will_save_can_use_data_as_false(self):
+        form = self.create_form(domain=self.domain_obj, opt_out_of_data_sharing=True)
+        form.full_clean()
+        form.save(Mock(), self.domain_obj)
+        self.assertTrue('opt_out_of_data_sharing' in form.fields)
+        self.assertEqual(self.domain_obj.internal.can_use_data, False)
+
     def create_form(self, domain=None, **kwargs):
         data = {
             "hr_name": "foo",

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -129,7 +129,6 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
         if can_edit_eula:
             internal_attrs += [
                 'custom_eula',
-                'can_use_data',
             ]
         for attr in internal_attrs:
             val = getattr(self.domain_object.internal, attr)
@@ -179,23 +178,18 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
             )
             eula_props_changed = (
                 bool(old_attrs.custom_eula) != bool(self.domain_object.internal.custom_eula)
-                or bool(old_attrs.can_use_data) != bool(self.domain_object.internal.can_use_data)
             )
 
             if eula_props_changed and settings.EULA_CHANGE_EMAIL:
                 message = '\n'.join([
-                    '{user} changed either the EULA or data sharing properties for domain {domain}.',
+                    '{user} changed the EULA properties for domain {domain}.',
                     '',
-                    'The properties changed were:',
                     '- Custom eula: {eula_old} --> {eula_new}',
-                    '- Can use data: {can_use_data_old} --> {can_use_data_new}'
                 ]).format(
                     user=self.request.couch_user.username,
                     domain=self.domain,
                     eula_old=old_attrs.custom_eula,
                     eula_new=self.domain_object.internal.custom_eula,
-                    can_use_data_old=old_attrs.can_use_data,
-                    can_use_data_new=self.domain_object.internal.can_use_data,
                 )
                 send_mail_async.delay(
                     'Custom EULA or data use flags changed for {}'.format(self.domain),


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Before:
In Project Settings > Internal Data ( Dimagi Only ) > Project Information
This is default to "Yes"
<img width="1071" height="96" alt="image" src="https://github.com/user-attachments/assets/84c61912-84fd-42cf-abaf-5d8829d554bb" />

After:
In Project Settings > Project Information > Basic. 
This is default to unchecked.
<img width="466" height="146" alt="image" src="https://github.com/user-attachments/assets/5b41b28d-f76c-4b68-8282-66a421e926e0" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-18253

Unlike the previous settings, where when user select "Yes", we then save `True` to `can_use_data`, the new setting applied the logic reversely: if user check "Opt out", then we save `False` to `can_use_data`. This is to make sure we don't disrupt the Salesforce usage of `can_use_data` attribute, also make the settings very intuitive.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- No changes made to `InternalProperties` model. Thus our salesforce report relies on the `can_use_data` attribute won't be disrupted
- Tested locally also added new test to make sure the logic is applied correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
New test added in `corehq/apps/domain/tests/test_forms.py`'s `TestDomainGlobalSettingsForm`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not planning QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
