### PR TITLE
Re-align invitation columns on enterprise report

### DIFF
--- a/corehq/apps/enterprise/enterprise.py
+++ b/corehq/apps/enterprise/enterprise.py
@@ -223,7 +223,7 @@ class EnterpriseWebUserReport(EnterpriseReport):
                     self.format_date(user.last_login),
                     last_accessed_domain,
                     _('Active User'),
-                    str(domain_membership.is_active)
+                    str(domain_membership.is_active),
                 ]
                 + self.domain_properties(domain_obj))
         for invite in Invitation.by_domain(domain_obj.name):
@@ -234,7 +234,8 @@ class EnterpriseWebUserReport(EnterpriseReport):
                     invite.get_role_name(),
                     'N/A',
                     'N/A',
-                    _('Invited')
+                    _('Invited'),
+                    'N/A',
                 ]
                 + self.domain_properties(domain_obj))
         return rows


### PR DESCRIPTION
## Product Description
Make sure columns line up in Enterprise Web Users report.  Rows representing invitations were off

## Technical Summary
https://dimagi.atlassian.net/browse/USH-6256
Web users and invitations are mixed, so these lists must be homogenous.

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
