### PR TITLE
Clarify `render_as`. Use a constant

### DIFF
--- a/corehq/apps/reports/const.py
+++ b/corehq/apps/reports/const.py
@@ -1,3 +1,5 @@
+from enum import StrEnum, auto
+
 from django.utils.translation import gettext_lazy as _
 
 USER_QUERY_LIMIT = 5000
@@ -18,3 +20,14 @@ TABLEAU_ROLES = (
 HQ_TABLEAU_GROUP_NAME = 'HQ'
 
 LONG_RUNNING_CLE_THRESHOLD = 10
+
+
+class AllowedRenderings(StrEnum):
+    JSON = auto()
+    ASYNC = auto()
+    FILTERS = auto()
+    EXPORT = auto()
+    MOBILE = auto()
+    EMAIL = auto()
+    PARTIAL = auto()
+    PRINT = auto()

--- a/corehq/apps/reports/const.py
+++ b/corehq/apps/reports/const.py
@@ -31,3 +31,4 @@ class AllowedRenderings(StrEnum):
     EMAIL = auto()
     PARTIAL = auto()
     PRINT = auto()
+    VIEW = auto()

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -123,17 +123,17 @@ class ReportDispatcher(View):
     @datespan_default
     def dispatch(self, request, domain=None, report_slug=None, render_as=None,
                  permissions_check=None, *args, **kwargs):
-        render_as = render_as or 'view'
+        render_as = render_as or AllowedRenderings.VIEW
         domain = domain or getattr(request, 'domain', None)
 
         redirect_slug = self._redirect_slug(report_slug)
 
-        if redirect_slug and render_as == 'email':
+        if redirect_slug and render_as == AllowedRenderings.EMAIL:
             # todo saved reports should probably change the slug to the redirected slug. this seems like a hack.
             raise Http404
         elif redirect_slug:
             new_args = [domain] if domain else []
-            if render_as != 'view':
+            if render_as != AllowedRenderings.VIEW:
                 new_args.append(render_as)
             new_args.append(redirect_slug)
             return HttpResponseRedirect(reverse(self.name(), args=new_args))
@@ -273,7 +273,7 @@ class CustomProjectReportDispatcher(ProjectReportDispatcher):
 
     def dispatch(self, request, *args, **kwargs):
         render_as = kwargs.get('render_as')
-        if not render_as == 'email':
+        if not render_as == AllowedRenderings.EMAIL:
             return self.dispatch_with_priv(request, *args, **kwargs)
         if not domain_has_privilege(request.domain, privileges.CUSTOM_REPORTS):
             raise PermissionDenied()

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -27,6 +27,7 @@ from corehq.apps.reports.exceptions import BadRequestError
 from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from corehq.util.quickcache import quickcache
 
+from .const import AllowedRenderings
 from .lookup import ReportLookup
 
 datespan_default = datespan_in_request(
@@ -194,7 +195,7 @@ class ReportDispatcher(View):
 
     @classmethod
     def allowed_renderings(cls):
-        return ['json', 'async', 'filters', 'export', 'mobile', 'email', 'partial', 'print']
+        return [e.value for e in AllowedRenderings]
 
     @classmethod
     def navigation_sections(cls, request, domain):

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -7,7 +7,6 @@ from django.views.generic.base import View
 from django_prbac.exceptions import PermissionDenied
 from django_prbac.utils import has_privilege
 
-from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from dimagi.utils.decorators.datespan import datespan_in_request
 from dimagi.utils.modules import to_function
 
@@ -20,12 +19,15 @@ from corehq.apps.domain.decorators import (
     track_domain_request,
 )
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
+from corehq.apps.hqwebapp.utils.bootstrap import set_bootstrap_version5
+from corehq.apps.hqwebapp.utils.bootstrap.reports.debug import (
+    reports_bootstrap5_template_debugger,
+)
 from corehq.apps.reports.exceptions import BadRequestError
+from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from corehq.util.quickcache import quickcache
 
 from .lookup import ReportLookup
-from ..hqwebapp.utils.bootstrap import set_bootstrap_version5
-from ..hqwebapp.utils.bootstrap.reports.debug import reports_bootstrap5_template_debugger
 
 datespan_default = datespan_in_request(
     from_param="startdate",
@@ -332,5 +334,7 @@ class ReleaseManagementReportDispatcher(ReportDispatcher):
     map_name = 'RELEASE_MANAGEMENT_REPORTS'
 
     def permissions_check(self, report, request, domain=None, is_navigation_check=False):
-        from corehq.apps.linked_domain.util import can_user_access_linked_domains
+        from corehq.apps.linked_domain.util import (
+            can_user_access_linked_domains,
+        )
         return can_user_access_linked_domains(request.couch_user, domain)

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -123,6 +123,7 @@ class GenericReportView(object):
     section_name = None  # string. ex: "Reports"
     dispatcher = None  # ReportDispatcher subclass
     toggles = ()  # Optionally provide toggles to turn on/off the report
+    rendered_as = None  # Set by ReportDispatcher.dispatch()
 
     # whether to use caching on @request_cache methods. will ignore this if CACHE_REPORTS is set to False
     is_cacheable = False

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -34,7 +34,7 @@ from corehq.util.timezones.utils import get_timezone
 from corehq.util.view_utils import absolute_reverse, request_as_dict, reverse
 
 from .cache import request_cache
-from .const import EXPORT_PAGE_LIMIT
+from .const import EXPORT_PAGE_LIMIT, AllowedRenderings
 from .datatables import DataTablesHeader
 from .exceptions import BadRequestError
 from .filters.dates import DatespanFilter
@@ -568,7 +568,11 @@ class GenericReportView(object):
     @property
     def js_options(self):
         try:
-            async_url = self.get_url(domain=self.domain, render_as='async', relative=True)
+            async_url = self.get_url(
+                domain=self.domain,
+                render_as=AllowedRenderings.ASYNC,
+                relative=True,
+            )
         except NoReverseMatch:
             async_url = ''
         return {
@@ -973,7 +977,7 @@ class GenericTabularReport(GenericReportView):
 
     @property
     def pagination_source(self):
-        return self.get_url(domain=self.domain, render_as='json')
+        return self.get_url(domain=self.domain, render_as=AllowedRenderings.JSON)
 
     _pagination = None
 

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -785,10 +785,6 @@ class GenericReportView(object):
 
     @classmethod
     def get_url(cls, domain=None, render_as=None, relative=False, **kwargs):
-        # NOTE: I'm pretty sure this doesn't work if you ever pass in render_as
-        # but leaving as is for now, as it should be obvious as soon as that
-        # breaks something
-
         if render_as is not None and render_as not in cls.dispatcher.allowed_renderings():
             raise ValueError('The render_as parameter is not one of the following allowed values: %s' %
                              ', '.join(cls.dispatcher.allowed_renderings()))

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -28,20 +28,18 @@ from dimagi.utils.web import json_request, json_response
 from corehq.apps.domain.utils import normalize_domain_name
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.utils.bootstrap.paths import get_bootstrap5_path
-from corehq.apps.reports.cache import request_cache
-from corehq.apps.reports.const import EXPORT_PAGE_LIMIT
-from corehq.apps.reports.datatables import DataTablesHeader
-from corehq.apps.reports.exceptions import BadRequestError
-from corehq.apps.reports.filters.dates import DatespanFilter
-from corehq.apps.reports.tasks import export_all_rows_task
-from corehq.apps.reports.util import (
-    DatatablesPagination,
-    DatatablesServerSideParams,
-)
 from corehq.apps.saved_reports.models import ReportConfig
 from corehq.apps.users.models import CouchUser
 from corehq.util.timezones.utils import get_timezone
 from corehq.util.view_utils import absolute_reverse, request_as_dict, reverse
+
+from .cache import request_cache
+from .const import EXPORT_PAGE_LIMIT
+from .datatables import DataTablesHeader
+from .exceptions import BadRequestError
+from .filters.dates import DatespanFilter
+from .tasks import export_all_rows_task
+from .util import DatatablesPagination, DatatablesServerSideParams
 
 CHART_SPAN_MAP = {1: '10', 2: '6', 3: '4', 4: '3', 5: '2', 6: '2'}
 

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -789,9 +789,6 @@ class GenericReportView(object):
         # but leaving as is for now, as it should be obvious as soon as that
         # breaks something
 
-        if isinstance(cls, cls):
-            domain = getattr(cls, 'domain')
-            render_as = getattr(cls, 'rendered_as')
         if render_as is not None and render_as not in cls.dispatcher.allowed_renderings():
             raise ValueError('The render_as parameter is not one of the following allowed values: %s' %
                              ', '.join(cls.dispatcher.allowed_renderings()))

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -51,7 +51,7 @@ class ProjectReport(GenericReportView):
     @property
     def template_context(self):
         context = super().template_context
-        context.update({'user_types': HQUserType.human_readable})
+        context['user_types'] = HQUserType.human_readable
         if self.rendered_as == 'view':
             # Add the email form to the context if it will be rendered
             email_form = EmailReportForm()
@@ -63,7 +63,7 @@ class ProjectReport(GenericReportView):
             if len(emails) <= MAX_WEB_USER_EMAILS:
                 choices = [(e, e) for e in emails]
                 email_form.fields['recipient_emails'].choices = choices
-            context.update({'email_form': email_form})
+            context['email_form'] = email_form
         return context
 
 

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -449,6 +449,10 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
                 email_text = content_json['report']
 
             email_html = mark_safe(email_text)  # nosec: this is HTML we generate
+            # `render_as` is not an `AllowedRendering` value because
+            # `dispatch_func()` returns `ConfigurableReportView.as_view()`
+            # or `CustomConfigurableReportDispatcher.as_view()`, and those
+            # classes don't extend `GenericReportView`.
             excel_attachment = dispatch_func(render_as='excel') if attach_excel else None
             return ReportContent(email_html, excel_attachment)
         except PermissionDenied:

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -273,6 +273,8 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     def get(self, request, *args, **kwargs):
         if self.has_permissions(self.domain, request.couch_user):
             self.get_spec_or_404()
+            # render_as` is not an `AllowedRendering` value because
+            # `ConfigurableReportView` doesn't extend `GenericReportView`
             if kwargs.get('render_as') == 'email':
                 return self.email_response
             elif kwargs.get('render_as') == 'excel':


### PR DESCRIPTION
## Technical Summary

Refactor: Clarifies how `GenericReportView` uses the `render_as` URL param.

:blowfish: Easier to review by commit

## Safety Assurance

### Safety story

Does not change functionality.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
