### PR TITLE
Include access logs in audit user report

### DIFF
--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -2,12 +2,10 @@ import csv
 from datetime import timedelta
 from itertools import chain
 
+import attr
+from dimagi.utils.parsing import string_to_datetime
 from django.contrib.auth.models import User
 from django.db.models import ForeignKey, Min
-
-import attr
-
-from dimagi.utils.parsing import string_to_datetime
 
 from corehq.apps.users.models import Invitation, WebUser
 from corehq.util.models import ForeignValue

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -110,6 +110,11 @@ def get_domain_first_access_times(domains, start_date=None, end_date=None):
 
 
 def write_generic_log_event(writer, event):
+    row = get_generic_log_event_row(event)
+    writer.writerow(row)
+
+
+def get_action_and_resource(event):
     action = ''
     resource = ''
     if event.doc_type == 'NavigationEventAudit':
@@ -120,16 +125,21 @@ def write_generic_log_event(writer, event):
         action = event.access_type
         resource = event.path
 
-    writer.writerow([
+    return action, resource
+
+
+def get_generic_log_event_row(event):
+    action, resource = get_action_and_resource(event)
+    return [
         event.event_date,
         event.doc_type,
         event.user,
-        event.domain,
+        event.domain or '',
         event.ip_address,
         action,
         resource,
         event.description,
-    ])
+    ]
 
 
 def write_export_from_all_log_events(file_obj, start, end):

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -15,7 +15,7 @@ from corehq.util.models import ForeignValue
 from ..models import AccessAudit, NavigationEventAudit
 
 
-def filters_for_navigation_event_query(user, domain=None, start_date=None, end_date=None):
+def filters_for_audit_event_query(user, domain=None, start_date=None, end_date=None):
     where = get_date_range_where(start_date, end_date)
     if user:
         where['user'] = user
@@ -24,9 +24,22 @@ def filters_for_navigation_event_query(user, domain=None, start_date=None, end_d
     return where
 
 
+def all_audit_events_by_user(user, domain=None, start_date=None, end_date=None):
+    return chain(
+        navigation_events_by_user(user, domain, start_date, end_date),
+        access_events_by_user(user, domain, start_date, end_date),
+    )
+
+
 def navigation_events_by_user(user, domain=None, start_date=None, end_date=None):
-    where = filters_for_navigation_event_query(user, domain, start_date, end_date)
+    where = filters_for_audit_event_query(user, domain, start_date, end_date)
     query = NavigationEventAudit.objects.filter(**where)
+    return AuditWindowQuery(query)
+
+
+def access_events_by_user(user, domain=None, start_date=None, end_date=None):
+    where = filters_for_audit_event_query(user, domain, start_date, end_date)
+    query = AccessAudit.objects.filter(**where)
     return AuditWindowQuery(query)
 
 

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -18,6 +18,7 @@ from corehq.apps.auditcare.models import NavigationEventAudit
 from corehq.apps.auditcare.utils.export import (
     filters_for_navigation_event_query,
     navigation_events_by_user,
+    get_generic_log_event_row,
 )
 from corehq.apps.es.aggregations import TermsAggregation
 from corehq.apps.es.case_search import CaseSearchES
@@ -134,11 +135,13 @@ class UserAuditReport(AdminReport, DatespanMixin):
     def headers(self):
         return DataTablesHeader(
             DataTablesColumn(gettext_lazy("Date")),
+            DataTablesColumn(gettext_lazy("Doc Type")),
             DataTablesColumn(gettext_lazy("Username")),
             DataTablesColumn(gettext_lazy("Domain")),
             DataTablesColumn(gettext_lazy("IP Address")),
-            DataTablesColumn(gettext_lazy("Request Method")),
-            DataTablesColumn(gettext_lazy("Request Path")),
+            DataTablesColumn(gettext_lazy("Action")),
+            DataTablesColumn(gettext_lazy("Resource")),
+            DataTablesColumn(gettext_lazy("Description")),
         )
 
     @property
@@ -155,15 +158,9 @@ class UserAuditReport(AdminReport, DatespanMixin):
             self.selected_user, self.selected_domain, self.datespan.startdate, self.datespan.enddate
         )
         for event in events:
-            rows.append([
-                event.event_date,
-                event.user,
-                event.domain or '',
-                event.ip_address,
-                event.request_method,
-                event.request_path
-            ])
-        return rows
+            row = get_generic_log_event_row(event)
+            rows.append(row)
+
 
     @memoized
     def _is_limit_exceeded(self):

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -16,8 +16,8 @@ from dimagi.utils.logging import notify_exception
 from corehq.apps.accounting.models import SoftwarePlanEdition, Subscription
 from corehq.apps.auditcare.models import NavigationEventAudit
 from corehq.apps.auditcare.utils.export import (
-    filters_for_navigation_event_query,
-    navigation_events_by_user,
+    filters_for_audit_event_query,
+    all_audit_events_by_user,
     get_generic_log_event_row,
 )
 from corehq.apps.es.aggregations import TermsAggregation
@@ -154,17 +154,19 @@ class UserAuditReport(AdminReport, DatespanMixin):
             return []
 
         rows = []
-        events = navigation_events_by_user(
+        events = all_audit_events_by_user(
             self.selected_user, self.selected_domain, self.datespan.startdate, self.datespan.enddate
         )
         for event in events:
             row = get_generic_log_event_row(event)
             rows.append(row)
 
+        # sort by date asc
+        return sorted(rows, key=lambda x: x[0])
 
     @memoized
     def _is_limit_exceeded(self):
-        where = filters_for_navigation_event_query(
+        where = filters_for_audit_event_query(
             user=self.selected_user,
             domain=self.selected_domain,
             start_date=self.datespan.startdate,

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -1,23 +1,21 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
 
+from dateutil.parser import parse
+from dimagi.utils.logging import notify_exception
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, gettext_noop
-
-from dateutil.parser import parse
 from memoized import memoized
-
-from dimagi.utils.logging import notify_exception
 
 from corehq.apps.accounting.models import SoftwarePlanEdition, Subscription
 from corehq.apps.auditcare.models import NavigationEventAudit
 from corehq.apps.auditcare.utils.export import (
-    filters_for_audit_event_query,
     all_audit_events_by_user,
+    filters_for_audit_event_query,
     get_generic_log_event_row,
 )
 from corehq.apps.es.aggregations import TermsAggregation


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
<img width="1549" height="458" alt="image" src="https://github.com/user-attachments/assets/42244b73-2900-4f34-885d-1c660eea95d8" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Currently it isn't clear to support what information is included in audit logs since we only show navigation logs in the report. This makes it impossible to see events like failed login attempts.

This change makes it so that the report support can view shares the same data as what is included in an auditcare export. This way support can actually use this report as a point of reference for what to expect if they proceed with a full export.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This change makes it so that more code is shared between this audit user report and the function to export audit logs. Both of these are internal tools that could potentially be shared with users upon request, but otherwise is not an actively used public feature.

As far as the subtle change to default to an empty string if `domain` is None, the python csv lib already treats None as an empty string when writing data, as [these docs](https://docs.python.org/3/library/csv.html#csv.writer) say:
> To make it as easy as possible to interface with modules which implement the DB API, the value [None](https://docs.python.org/3/library/constants.html#None) is written as the empty string


### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
