### PR TITLE
Exclude @dimagi.com users from project web users

### DIFF
--- a/corehq/apps/accounting/usage.py
+++ b/corehq/apps/accounting/usage.py
@@ -60,4 +60,5 @@ def get_web_user_usage(domains):
     return (UserES()
             .domain(domains)
             .web_users()
+            .exclude_dimagi_users()
             .count())

--- a/corehq/apps/es/tests/test_users_es.py
+++ b/corehq/apps/es/tests/test_users_es.py
@@ -115,7 +115,7 @@ class TestIsActiveOnDomain(TestCase):
         cls.cc_user_active_other_domain = cls.make_cc_user('cc_user_active_other_domain', cls.other_domain)
         cls.cc_user_inactive_other_domain = cls.make_cc_user(
             'cc_user_inactive_other_domain', cls.other_domain, is_active=False)
-        cls.web_user_active = cls.make_web_user('web_user_active', active_domains=[cls.domain])
+        cls.web_user_active = cls.make_web_user('web_user_active@dimagi.com', active_domains=[cls.domain])
         cls.web_user_inactive = cls.make_web_user('web_user_inactive', inactive_domains=[cls.domain])
         cls.web_user_active_other_domain = cls.make_web_user(
             'web_user_active_other_domain', active_domains=[cls.other_domain])
@@ -159,7 +159,7 @@ class TestIsActiveOnDomain(TestCase):
             'cc_user_inactive',
             'cc_user_active_other_domain',
             'cc_user_inactive_other_domain',
-            'web_user_active',
+            'web_user_active@dimagi.com',
             'web_user_inactive',
             'web_user_active_other_domain',
             'web_user_inactive_other_domain',
@@ -174,7 +174,7 @@ class TestIsActiveOnDomain(TestCase):
             UserES().domain(self.domain).values_list('username', flat=True),
         ) == Counter([
             'cc_user_active',
-            'web_user_active',
+            'web_user_active@dimagi.com',
             'web_user_active_both_domains',
             'web_user_active_inactive_other',
         ])
@@ -199,7 +199,7 @@ class TestIsActiveOnDomain(TestCase):
         ) == Counter([
             'cc_user_active',
             'cc_user_inactive',
-            'web_user_active',
+            'web_user_active@dimagi.com',
             'web_user_inactive',
             'web_user_active_both_domains',
             'web_user_inactive_both_domains',
@@ -216,7 +216,7 @@ class TestIsActiveOnDomain(TestCase):
         ) == Counter([
             'cc_user_active',
             'cc_user_active_other_domain',
-            'web_user_active',
+            'web_user_active@dimagi.com',
             'web_user_active_other_domain',
             'web_user_active_both_domains',
             'web_user_active_inactive_other',
@@ -243,7 +243,19 @@ class TestIsActiveOnDomain(TestCase):
         web_user_emails = iter_web_user_emails(self.domain)
         assert isinstance(web_user_emails, types.GeneratorType)
         assert Counter(list(web_user_emails)) == Counter([
-            'web_user_active',
+            'web_user_active@dimagi.com',
+            'web_user_active_both_domains',
+            'web_user_active_inactive_other',
+        ])
+
+    def test_exclude_dimagi_users(self):
+        assert Counter(
+            UserES()
+            .domain([self.domain])
+            .web_users()
+            .exclude_dimagi_users()
+            .values_list('username', flat=True)
+        ) == Counter([
             'web_user_active_both_domains',
             'web_user_active_inactive_other',
         ])

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -48,6 +48,7 @@ class UserES(HQESQuery):
             created,
             mobile_users,
             web_users,
+            exclude_dimagi_users,
             user_ids,
             location,
             login_as_user,
@@ -222,6 +223,11 @@ def admin_users():
 def demo_users():
     """Matches users who has is_demo_user set to True"""
     return filters.term("is_demo_user", True)
+
+
+def exclude_dimagi_users():
+    """Exclude users whose username ends with @dimagi.com"""
+    return filters.NOT(filters.wildcard("username.exact", "*@dimagi.com"))
 
 
 def created(gt=None, gte=None, lt=None, lte=None):


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-18434

## Safety Assurance

### Safety story

Adds a simple exclusion condition to an ES query. The function where this is used is only called in two places, both in accounting web user usage contexts.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations