### PR TITLE
Revert part of https://github.com/dimagi/commcare-hq/pull/36849

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -584,17 +584,17 @@ def get_case_sharing_apps_in_domain(domain, exclude_app_id=None):
     return [a for a in apps if a.case_sharing and exclude_app_id != a.id]
 
 
-def get_latest_app_meta(domain, target):
+def get_latest_app_ids(domain, target="release"):
     """:param target: should be set to one of: 'save', 'build', 'release'"""
     from .models import Application
     prefix = {'save': 'SAVE', 'build': 'BUILD', 'release': 'RELEASE'}[target]
     # The key is [target, domain, origin_id, version]
     # reduce with group_level=3 yields the highest version for each
     # (target, domain, origin_id)
-    return [res['value'] for res in Application.get_db().view(
+    return [res['value']['_id'] for res in list(Application.get_db().view(
         'latest_apps/view',
         startkey=[prefix, domain],
         endkey=[prefix, domain, {}],
         group_level=3,
         reduce=True,
-    )]
+    ))]

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -151,6 +151,11 @@ def get_build_doc_by_version(domain, app_id, version):
     return get_build_by_version(domain, app_id, version, return_doc=True)
 
 
+def get_build_doc_by_build_id(build_id):
+    from .models import Application
+    return Application.get_db().get(build_id)
+
+
 def wrap_app(app_doc, wrap_cls=None):
     """Will raise DocTypeError if it can't figure out the correct class"""
     from corehq.apps.app_manager.util import get_correct_app_class

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -172,7 +172,7 @@ def get_current_app_version(domain, app_id):
     return result['value']['version']
 
 
-def get_app_doc(domain, app_id):
+def get_current_app_doc(domain, app_id):
     from .models import Application
     app = Application.get_db().get(app_id)
     if app.get('domain', None) != domain:
@@ -181,7 +181,7 @@ def get_app_doc(domain, app_id):
 
 
 def get_current_app(domain, app_id):
-    return wrap_app(get_app_doc(domain, app_id))
+    return wrap_app(get_current_app_doc(domain, app_id))
 
 
 def get_app_cached(domain, app_id):
@@ -216,7 +216,7 @@ def get_app(domain, app_id, wrap_cls=None, latest=False, target=None):
 
     Here are some common usages and the simpler dbaccessor alternatives:
         current_app = get_app(domain, app_id)
-                    = get_app_doc(domain, app_id)
+                    = get_current_app_doc(domain, app_id)
         latest_released_build = get_app(domain, app_id, latest=True)
                               = get_latest_released_app_doc(domain, app_id)
         latest_build = get_app(domain, app_id, latest=True, target='build')
@@ -245,7 +245,7 @@ def get_app(domain, app_id, wrap_cls=None, latest=False, target=None):
             # If the app_id passed in was the working copy, just use that app.
             # If it's a build, get the working copy.
             if app.get('copy_of'):
-                app = get_app_doc(domain, app_id)
+                app = get_current_app_doc(domain, app_id)
         else:
             app = get_latest_released_app_doc(domain, app_id) or app
 

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -19,7 +19,7 @@ from corehq.apps.app_manager.const import (
     MOBILE_UCR_VERSION_1,
     MOBILE_UCR_VERSION_2,
 )
-from corehq.apps.app_manager.dbaccessors import get_app_doc
+from corehq.apps.app_manager.dbaccessors import get_app_cached
 from corehq.apps.cloudcare.utils import get_web_app_ids_available_to_user
 from corehq.apps.userreports.exceptions import (
     ReportConfigurationNotFoundError,
@@ -31,7 +31,6 @@ from corehq.apps.userreports.reports.data_source import (
 )
 from corehq.apps.userreports.reports.filters.factory import ReportFilterFactory
 from corehq.util.metrics import metrics_histogram
-from corehq.util.quickcache import quickcache
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.xml_utils import serialize
@@ -135,11 +134,17 @@ def _parse_apps(restore_state, restore_user):
     if restore_state.params.app:
         apps = [restore_state.params.app]
     elif toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY.enabled(restore_user.domain):
-        configs = []
+        needed_versions = set()
+        mobile_ucr_configs = []
         for build_id in get_web_app_ids_available_to_user(restore_user.domain, restore_user._couch_user):
-            for config in _get_mobile_ucr_configs_cached(restore_user.domain, build_id):
-                configs.append(ReportAppConfig.wrap(config))
-        return {MOBILE_UCR_VERSION_2}, configs
+            app = get_app_cached(restore_user.domain, build_id)
+            if not is_remote_app(app):
+                needed_versions.add(app.get('mobile_ucr_restore_version', MOBILE_UCR_VERSION_2))
+                for module in app['modules']:
+                    if module['doc_type'] == 'ReportModule':
+                        for report_config in module['report_configs']:
+                            mobile_ucr_configs.append(ReportAppConfig.wrap(report_config))
+        return needed_versions, mobile_ucr_configs
     else:
         apps = get_apps_in_domain(restore_user.domain, include_remote=False)
 
@@ -154,18 +159,6 @@ def _get_mobile_ucr_configs(apps):
         for module in app_.get_report_modules()
         for report_config in module.report_configs
     ]
-
-
-@quickcache(['domain', 'build_id'], timeout=24 * 60 * 60)
-def _get_mobile_ucr_configs_cached(domain, build_id):
-    app = get_app_doc(domain, build_id)
-    configs = []
-    if not is_remote_app(app):
-        for module in app['modules']:
-            if module['doc_type'] == 'ReportModule':
-                for report_config in module['report_configs']:
-                    configs.append(report_config)
-    return configs
 
 
 report_fixture_generator = ReportFixturesProvider()

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -144,15 +144,16 @@ def _parse_apps(restore_state, restore_user):
         apps = get_apps_in_domain(restore_user.domain, include_remote=False)
 
     needed_versions = {app.mobile_ucr_restore_version for app in apps}
-    return needed_versions, list(_get_mobile_ucr_configs(apps))
+    return needed_versions, _get_mobile_ucr_configs(apps)
 
 
 def _get_mobile_ucr_configs(apps):
-    for app in apps:
-        for module in app.get_report_modules():
-            for report_config in module.report_configs:
-                _add_app_info_to_report_config(report_config, app)
-                yield report_config
+    return [
+        report_config
+        for app_ in apps
+        for module in app_.get_report_modules()
+        for report_config in module.report_configs
+    ]
 
 
 @quickcache(['domain', 'build_id'], timeout=24 * 60 * 60)
@@ -163,18 +164,8 @@ def _get_mobile_ucr_configs_cached(domain, build_id):
         for module in app['modules']:
             if module['doc_type'] == 'ReportModule':
                 for report_config in module['report_configs']:
-                    _add_app_info_to_report_config(report_config, app)
                     configs.append(report_config)
     return configs
-
-
-def _add_app_info_to_report_config(report_config, app):
-    # This is useful for debugging - has no in-product purpose
-    report_config['__app'] = {
-        'app_id': app['copy_of'] or app['_id'],
-        'build_id': app['_id'],
-        'app_version': app['version'],
-    }
 
 
 report_fixture_generator = ReportFixturesProvider()
@@ -473,15 +464,9 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
         for row in rows:
             rows_elem.append(row)
 
-        app_info = getattr(report_config, '__app', {})
         report_elem = E.fixture(
-            id=ReportFixturesProviderV2._report_fixture_id(report_config.uuid),
-            user_id=restore_user.user_id,
-            report_id=report_config.report_id,
-            indexed='true',
-            app_id=app_info.get('app_id') or '',
-            build_id=app_info.get('build_id') or '',
-            app_version=str(app_info.get('app_version') or ''),
+            id=ReportFixturesProviderV2._report_fixture_id(report_config.uuid), user_id=restore_user.user_id,
+            report_id=report_config.report_id, indexed='true'
         )
         report_elem.append(rows_elem)
         yield report_elem

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -19,8 +19,7 @@ from corehq.apps.app_manager.const import (
     MOBILE_UCR_VERSION_1,
     MOBILE_UCR_VERSION_2,
 )
-from corehq.apps.app_manager.dbaccessors import get_app_cached
-from corehq.apps.cloudcare.utils import get_web_app_ids_available_to_user
+from corehq.apps.cloudcare.utils import get_web_apps_available_to_user
 from corehq.apps.userreports.exceptions import (
     ReportConfigurationNotFoundError,
     UserReportsError,
@@ -136,8 +135,7 @@ def _parse_apps(restore_state, restore_user):
     elif toggles.RESTORE_ACCESSIBLE_REPORTS_ONLY.enabled(restore_user.domain):
         needed_versions = set()
         mobile_ucr_configs = []
-        for build_id in get_web_app_ids_available_to_user(restore_user.domain, restore_user._couch_user):
-            app = get_app_cached(restore_user.domain, build_id)
+        for app in get_web_apps_available_to_user(restore_user.domain, restore_user._couch_user):
             if not is_remote_app(app):
                 needed_versions.add(app.get('mobile_ucr_restore_version', MOBILE_UCR_VERSION_2))
                 for module in app['modules']:

--- a/corehq/apps/app_manager/tests/data/fixtures/expected_v2_report.xml
+++ b/corehq/apps/app_manager/tests/data/fixtures/expected_v2_report.xml
@@ -2,7 +2,7 @@
   <fixture id="commcare-reports-filters:c0ffee">
 	  <filters />
   </fixture>
-  <fixture id="commcare-reports:c0ffee" user_id="mock-user-id" report_id="deadbeef" indexed="true" app_id="" build_id="" app_version="">
+  <fixture id="commcare-reports:c0ffee" user_id="mock-user-id" report_id="deadbeef" indexed="true">
     <rows last_sync="2017-09-11T06:35:20">
       <row index="0" is_total_row="False">
         <row_index>0</row_index>

--- a/corehq/apps/app_manager/tests/data/fixtures/expected_v2_report_total.xml
+++ b/corehq/apps/app_manager/tests/data/fixtures/expected_v2_report_total.xml
@@ -2,7 +2,7 @@
   <fixture id="commcare-reports-filters:c0ffee">
     <filters/>
   </fixture>
-  <fixture id="commcare-reports:c0ffee" user_id="mock-user-id" report_id="deadbeef" indexed="true" app_id="" build_id="" app_version="">
+  <fixture id="commcare-reports:c0ffee" user_id="mock-user-id" report_id="deadbeef" indexed="true">
     <rows last_sync="2017-09-11T06:35:20">
       <row index="0" is_total_row="False">
         <row_index>0</row_index>

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -21,7 +21,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_built_app_ids_with_submissions_for_app_ids_and_versions,
     get_current_app,
     get_latest_app_ids_and_versions,
-    get_latest_app_meta,
+    get_latest_app_ids,
     get_latest_build_doc,
     get_latest_released_app_doc,
     get_latest_released_app_version,
@@ -345,8 +345,8 @@ class TestAppGetters(TestCase):
         self.assertEqual(res, {'bar', 'case'})
 
 
-class TestGetLatestAppMeta(TestCase):
-    domain = 'test-get_latest_app_meta'
+class TestGetLatestAppIds(TestCase):
+    domain = 'test-get_latest_app_ids'
 
     @classmethod
     @patch_validate_xform()
@@ -388,29 +388,32 @@ class TestGetLatestAppMeta(TestCase):
         cls.project.delete()
         super().tearDownClass()
 
-    def assert_latest_apps(self, target, expected):
+    def test_get_latest_apps_save(self):
         self.assertItemsEqual(
-            [app['_id'] for app in get_latest_app_meta(self.domain, target)],
-            expected,
+            get_latest_app_ids(self.domain, 'save'),
+            [
+                self.app_no_builds.app._id,
+                self.built_app.app._id,
+                self.released_app.app._id,
+                self.app_with_unreleased_changes.app._id,
+            ],
         )
 
-    def test_get_latest_apps_save(self):
-        self.assert_latest_apps('save', [
-            self.app_no_builds.app._id,
-            self.built_app.app._id,
-            self.released_app.app._id,
-            self.app_with_unreleased_changes.app._id,
-        ])
-
     def test_get_latest_apps_build(self):
-        self.assert_latest_apps('build', [
-            self.built_app.build._id,
-            self.released_app.build._id,
-            self.app_with_unreleased_changes.build._id,
-        ])
+        self.assertItemsEqual(
+            get_latest_app_ids(self.domain, 'build'),
+            [
+                self.built_app.build._id,
+                self.released_app.build._id,
+                self.app_with_unreleased_changes.build._id,
+            ],
+        )
 
     def test_get_latest_apps_release(self):
-        self.assert_latest_apps('release', [
-            self.released_app.build._id,
-            self.app_with_unreleased_changes.build._id,
-        ])
+        self.assertItemsEqual(
+            get_latest_app_ids(self.domain, 'release'),
+            [
+                self.released_app.build._id,
+                self.app_with_unreleased_changes.build._id,
+            ],
+        )

--- a/corehq/apps/cloudcare/models.py
+++ b/corehq/apps/cloudcare/models.py
@@ -1,6 +1,17 @@
+from couchdbkit import ResourceNotFound
 from django.db import DEFAULT_DB_ALIAS, models
+from memoized import memoized
 
+from dimagi.ext.couchdbkit import (
+    BooleanProperty,
+    Document,
+    DocumentSchema,
+    SchemaListProperty,
+    StringProperty,
+)
 
+from corehq.apps.app_manager.models import Application
+from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
 from corehq.apps.groups.models import Group
 
 

--- a/corehq/apps/cloudcare/tests/test_utils.py
+++ b/corehq/apps/cloudcare/tests/test_utils.py
@@ -16,7 +16,7 @@ from corehq.apps.cloudcare.models import ApplicationAccess, SQLAppGroup
 from corehq.apps.cloudcare.utils import (
     can_user_access_web_app,
     get_mobile_ucr_count,
-    get_web_app_ids_available_to_user,
+    get_web_apps_available_to_user,
     should_restrict_web_apps_usage,
 )
 from corehq.apps.domain.shortcuts import create_domain
@@ -303,7 +303,7 @@ class TestCanUserAccessWebApp(TestCase):
 @patch_validate_xform()
 @patch('corehq.apps.app_manager.models._refresh_data_dictionary', MagicMock)
 class TestGetWebAppsAvailableToUser(TestCase):
-    domain = 'test-get_web_app_ids_available_to_user'
+    domain = 'test-get_web_apps_available_to_user'
 
     @classmethod
     def setUpClass(cls):
@@ -314,7 +314,7 @@ class TestGetWebAppsAvailableToUser(TestCase):
 
     def assert_apps(self, expected):
         self.assertItemsEqual(
-            get_web_app_ids_available_to_user(self.domain, self.user),
+            [app['_id'] for app in get_web_apps_available_to_user(self.domain, self.user)],
             expected,
         )
 

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -2,9 +2,12 @@ from django.conf import settings
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import (
+    get_app_ids_in_domain,
     get_apps_in_domain,
     get_latest_app_meta,
+    get_latest_build_doc,
     get_latest_build_id,
+    get_latest_released_app_doc,
     get_latest_released_build_id,
 )
 from corehq.util.quickcache import quickcache

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -2,10 +2,8 @@ from django.conf import settings
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import (
-    get_app_cached,
     get_app_ids_in_domain,
     get_apps_in_domain,
-    get_latest_app_meta,
     get_latest_build_doc,
     get_latest_build_id,
     get_latest_released_app_doc,
@@ -34,6 +32,13 @@ def can_user_access_web_app(domain, user, app_id):
     return has_access_via_permission and has_access_via_group
 
 
+def _get_latest_build_for_web_apps(domain, username, app_id):
+    if (toggles.CLOUDCARE_LATEST_BUILD.enabled(domain) or toggles.CLOUDCARE_LATEST_BUILD.enabled(username)):
+        return get_latest_build_doc(domain, app_id)
+    else:
+        return get_latest_released_app_doc(domain, app_id)
+
+
 def get_latest_build_id_for_web_apps(domain, username, app_id):
     if (toggles.CLOUDCARE_LATEST_BUILD.enabled(domain) or toggles.CLOUDCARE_LATEST_BUILD.enabled(username)):
         return get_latest_build_id(domain, app_id)
@@ -42,17 +47,21 @@ def get_latest_build_id_for_web_apps(domain, username, app_id):
 
 
 def get_web_apps_available_to_user(domain, user):
-    target = 'build' if (
-        toggles.CLOUDCARE_LATEST_BUILD.enabled(domain)
-        or toggles.CLOUDCARE_LATEST_BUILD.enabled(user.username)
-    ) else 'release'
-    build_ids = [
-        app_meta['_id'] for app_meta in get_latest_app_meta(domain, target)
-        if app_meta['cloudcare_enabled']
-        and can_user_access_web_app(domain, user, app_meta['origin_id'])
-    ]
-    for build_id in build_ids:
-        yield get_app_cached(domain, build_id)
+    """
+    The fetch_app_fn is a function to fetch app docs, and should accept a domain, username and app_id if overridden
+    """
+    def is_web_app(app):
+        return app.get('cloudcare_enabled')
+
+    apps = []
+    app_ids = get_app_ids_in_domain(domain)
+    for app_id in app_ids:
+        if can_user_access_web_app(domain, user, app_id):
+            app = _get_latest_build_for_web_apps(domain, user.username, app_id)
+            if app and is_web_app(app):
+                apps.append(app)
+
+    return apps
 
 
 def should_show_preview_app(request, app, username):

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -2,6 +2,7 @@ from django.conf import settings
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import (
+    get_app_cached,
     get_app_ids_in_domain,
     get_apps_in_domain,
     get_latest_app_meta,
@@ -40,16 +41,18 @@ def get_latest_build_id_for_web_apps(domain, username, app_id):
         return get_latest_released_build_id(domain, app_id)
 
 
-def get_web_app_ids_available_to_user(domain, user):
+def get_web_apps_available_to_user(domain, user):
     target = 'build' if (
         toggles.CLOUDCARE_LATEST_BUILD.enabled(domain)
         or toggles.CLOUDCARE_LATEST_BUILD.enabled(user.username)
     ) else 'release'
-    return [
+    build_ids = [
         app_meta['_id'] for app_meta in get_latest_app_meta(domain, target)
         if app_meta['cloudcare_enabled']
         and can_user_access_web_app(domain, user, app_meta['origin_id'])
     ]
+    for build_id in build_ids:
+        yield get_app_cached(domain, build_id)
 
 
 def should_show_preview_app(request, app, username):

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -43,7 +43,6 @@ from corehq.apps.accounting.utils import (
 )
 from corehq.apps.app_manager.dbaccessors import (
     get_app,
-    get_app_cached,
     get_build_doc_by_build_id,
 )
 from corehq.apps.cloudcare.const import (
@@ -61,7 +60,7 @@ from corehq.apps.cloudcare.utils import (
     can_user_access_web_app,
     get_latest_build_id_for_web_apps,
     get_mobile_ucr_count,
-    get_web_app_ids_available_to_user,
+    get_web_apps_available_to_user,
     should_restrict_web_apps_usage,
 )
 from corehq.apps.domain.decorators import (
@@ -113,9 +112,8 @@ class FormplayerMain(View):
                     return [_format_app_doc(build)]
             return []
 
-        build_ids = get_web_app_ids_available_to_user(domain, user)
-        apps = [_format_app_doc(get_app(domain, build_id))
-                for build_id in build_ids]
+        apps = get_web_apps_available_to_user(domain, user)
+        apps = [_format_app_doc(app) for app in apps]
         return sorted(apps, key=lambda app: app['name'].lower())
 
     @staticmethod

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -44,7 +44,7 @@ from corehq.apps.accounting.utils import (
 from corehq.apps.app_manager.dbaccessors import (
     get_app,
     get_app_cached,
-    get_app_doc,
+    get_build_doc_by_build_id,
 )
 from corehq.apps.cloudcare.const import (
     PREVIEW_APP_ENVIRONMENT,
@@ -108,13 +108,13 @@ class FormplayerMain(View):
     def get_web_apps_for_user(self, domain, user, app_id=None, build_id=None):
         if app_id and build_id:
             if can_user_access_web_app(domain, user, app_id):
-                build = get_app_doc(domain, build_id)
+                build = get_build_doc_by_build_id(build_id)
                 if build.get('cloudcare_enabled'):
                     return [_format_app_doc(build)]
             return []
 
         build_ids = get_web_app_ids_available_to_user(domain, user)
-        apps = [_format_app_doc(get_app_doc(domain, build_id))
+        apps = [_format_app_doc(get_app(domain, build_id))
                 for build_id in build_ids]
         return sorted(apps, key=lambda app: app['name'].lower())
 

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -43,6 +43,7 @@ from corehq.apps.accounting.utils import (
 )
 from corehq.apps.app_manager.dbaccessors import (
     get_app,
+    get_app_cached,
     get_app_doc,
 )
 from corehq.apps.cloudcare.const import (

--- a/corehq/apps/ota/management/commands/time_restore.py
+++ b/corehq/apps/ota/management/commands/time_restore.py
@@ -6,7 +6,7 @@ import csv
 from couchdbkit import ResourceNotFound
 from lxml import etree
 
-from corehq.apps.app_manager.dbaccessors import get_app_doc
+from corehq.apps.app_manager.dbaccessors import get_current_app_doc
 from corehq.apps.hqadmin.views.users import AdminRestoreView
 from corehq.apps.ota.views import get_restore_response
 from corehq.apps.users.models import CouchUser
@@ -33,7 +33,7 @@ class Command(BaseCommand):
                 return
         if app_id:
             try:
-                get_app_doc(domain, app_id)
+                get_current_app_doc(domain, app_id)
             except ResourceNotFound:
                 print("App '{}' not found".format(app_id))
                 return


### PR DESCRIPTION
## Product Description

The migration is taking longer than expected and it is unclear how much time is remaining. So in light of the upcoming deployment we are taking out the code that uses the new view.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-5933

## Feature Flag

No

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- This PR can only be reverted if the initial couch migration completes and the new view is available.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
