### PR TITLE
Add show_auto_renewal feature flag for development

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2050,6 +2050,16 @@ ACCOUNTING_TESTING_TOOLS = StaticToggle(
     [NAMESPACE_USER]
 )
 
+SHOW_AUTO_RENEWAL = StaticToggle(
+    'show_auto_renewal',
+    'Show Auto Renewal',
+    TAG_PRODUCT,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+    Show options to enable or disable Auto Renewal for a subscription while the feature is in development.
+    """
+)
+
 ADD_ROW_INDEX_TO_MOBILE_UCRS = StaticToggle(
     'add_row_index_to_mobile_ucrs',
     'Add row index to mobile UCRs as the first column to retain original order of data',


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18402
Will be used to gate options for a user to enable or disable auto renewal on a subscription while the Auto Renewals feature is in development. Could also just be called `AUTO_RENEWAL` but the emphasis here is on UI interactivity.

## Feature Flag
Adds `SHOW_AUTO_RENEWAL`

## Safety Assurance

### Safety story
Just adds a feature flag.

### Automated test coverage
n/a

### QA Plan
n/a



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
