### PR TITLE
Fix _filter_domains_to_skip

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -91,6 +91,7 @@ def _filter_by_hash(configs, ucr_division):
 
 def _filter_domains_to_skip(configs):
     """Return a list of configs whose domain exists on this environment"""
+    configs = list(configs)  # convert generator to list for multiple passes
     domain_names = list({config.domain for config in configs if config.is_static})
     existing_domains = list(get_domain_ids_by_names(domain_names))
     for config in configs:

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -291,6 +291,7 @@ class ConfigurableReportTableManager(UcrTableManager):
         for provider in self.data_source_providers:
             configs = provider.get_data_sources_modified_since(timestamp)
             for config in self._filter_configs(configs):
+                pillow_logging.info(f'updating modified data source: {config.domain}: {config._id}')
                 yield (config.domain, config)
 
     def _filter_configs(self, configs):
@@ -331,6 +332,7 @@ class RegistryDataSourceTableManager(UcrTableManager):
     def iter_configs_since(self, timestamp):
         configs = self.data_source_provider.get_data_sources_modified_since(timestamp)
         for config in _filter_invalid_config(configs):
+            pillow_logging.info(f'updating modified registry data source: {config.domain}: {config._id}')
             for domain in config.data_domains:
                 yield domain, config
 

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -152,6 +152,22 @@ class ConfigurableReportTableManagerDbTest(TestCase):
         adapters = table_manager.get_adapters(ds_1_domain)
         assert [a.config for a in adapters] == [data_source_1]
 
+    def test_table_adapters_for_migration_process(self):
+        # this test is for a regression in _filter_domains_to_skip
+        skip_domain_filter_patch.stop()  # unpatch _filter_domains_to_skip
+        self.addCleanup(skip_domain_filter_patch.start)
+        data_source_1 = get_sample_data_source()
+        ds_1_domain = data_source_1.domain
+        data_source_1.save()
+
+        table_manager = ConfigurableReportTableManager([MockDataSourceProvider({
+            ds_1_domain: [data_source_1]
+        })], run_migrations=True, ucr_division='0f')
+        table_manager.configure_dedicated_migration_process()
+
+        adapters = table_manager.migration_cache.get_adapters()
+        assert [a.config for a in adapters] == [data_source_1]
+
     @patch("corehq.apps.userreports.pillow.rebuild_sql_tables")
     def test_complete_integration(self, mock_rebuild_sql_tables):
         data_source_1 = get_sample_data_source()


### PR DESCRIPTION
`_filter_domains_to_skip(<generator>)` returned no items because the generator was exhausted on first pass, and therefore yielded no items on the second pass. This bug caused the migration process to never load adapters to migrate, so it did nothing.

Bug introduced in f47f94c55c13bb4840de669c310e3323a607493e

Also restore data source update logging.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Tiny fix and added logging. Covered by tests.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations