### PR TITLE
Remove extra asterisk from required questions

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
@@ -48,7 +48,7 @@
           </div>
         </div>
         <!-- /ko -->
-        <span class="webapp-markdown-output" data-bind="html: ko.utils.unwrapObservable($data.caption_markdown) || caption()"></span>
+        <span class="caption-text webapp-markdown-output" data-bind="html: ko.utils.unwrapObservable($data.caption_markdown) || caption()"></span>
       </div>
       <span class="hint-text webapp-markdown-output" data-bind="
               html: ko.utils.unwrapObservable($data.hint),

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/webforms.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/webforms.scss
@@ -62,7 +62,7 @@ input:invalid {
   border-color: #b94a48;
 }
 
-.required .caption .webapp-markdown-output::after {
+.required .caption .caption-text::after {
   content: '*';
   font-weight: bold;
   color: $danger;


### PR DESCRIPTION
## Product Description

Before:
<img width="911" height="290" alt="image" src="https://github.com/user-attachments/assets/20097af4-d91f-497e-ad99-1a083a2c8cae" />

After:
<img width="911" height="290" alt="image" src="https://github.com/user-attachments/assets/4f11c2e6-9ddb-4407-847b-6f0858b2c002" />

## Technical Summary
https://dimagi.atlassian.net/browse/SUPPORT-25476

This was a combination of these two PRs: https://github.com/dimagi/commcare-hq/pull/36790 https://github.com/dimagi/commcare-hq/pull/36932

The former used a CSS selector to determine where to put the asterisk, and the latter added another element that matches that selector, so we ended up with two.  This adds a new class to the proper element to more precisely target it.


## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
