### PR TITLE
Fix failing test on master

### DIFF
--- a/corehq/apps/api/tests/test_ucr_resources.py
+++ b/corehq/apps/api/tests/test_ucr_resources.py
@@ -413,6 +413,7 @@ class TestConfigurableReportDataResource(APIResourceTest):
         ).decode('utf-8')
 
 
+@flag_enabled('API_THROTTLE_WHITELIST')
 class TestUCRPaginated(TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Product Description


## Technical Summary
There can be more than one case on the domain.  A usercase is created automatically, and can nondeterministically be the first one in the list returned, causing the test to fail

## Feature Flag


## Safety Assurance
Tests only

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
