### PR TITLE
Update ocs widget style

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/ocs_widget.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/ocs_widget.less
@@ -15,6 +15,7 @@ open-chat-studio-widget {
   --message-user-bg-color: @commcare-blue;
   --message-user-text-color: white;
   --message-assistant-text-color: black;
+  --message-system-text-color: black;
 
   // Confirmation Dialog
   --confirmation-button-confirm-bg-color: @commcare-blue;

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_ocs_widget.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_ocs_widget.scss
@@ -15,6 +15,7 @@ open-chat-studio-widget {
   --message-user-bg-color: #{$primary};
   --message-user-text-color: white;
   --message-assistant-text-color: black;
+  --message-system-text-color: black;
 
   // Confirmation Dialog
   --confirmation-button-confirm-bg-color: #{$primary};

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/ocs_widget._ocs_widget.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/ocs_widget._ocs_widget.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -8,15 +8,15 @@
+@@ -8,16 +8,16 @@
    z-index: 1000;
  
    //Launch Button
@@ -14,6 +14,7 @@
 +  --message-user-bg-color: #{$primary};
    --message-user-text-color: white;
    --message-assistant-text-color: black;
+   --message-system-text-color: black;
  
    // Confirmation Dialog
 -  --confirmation-button-confirm-bg-color: @commcare-blue;


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Updated text color to have a high contrast

Before
<img width="553" height="136" alt="image" src="https://github.com/user-attachments/assets/05cc2fb6-0767-4dc9-b3f6-b63bba5352bd" />

After
<img width="322" height="181" alt="image" src="https://github.com/user-attachments/assets/25fa46c0-adbc-4071-b3a9-46110c6a1a04" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-18430

For reviewer who're interested in the default styling of the widget, can refer to this doc: https://docs.openchatstudio.com/chat_widget/styling/#messages

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
The bot is currently gated behind "CommCare Companion AI Support Bot"

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe. Just change text color.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not planning on QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
