### PR TITLE
Prevent deleted apps from appearing in Web Apps

### DIFF
--- a/corehq/apps/cloudcare/tests/test_utils.py
+++ b/corehq/apps/cloudcare/tests/test_utils.py
@@ -16,7 +16,7 @@ from corehq.apps.cloudcare.models import ApplicationAccess, SQLAppGroup
 from corehq.apps.cloudcare.utils import (
     can_user_access_web_app,
     get_mobile_ucr_count,
-    get_web_app_ids_available_to_user,
+    get_web_apps_available_to_user,
     should_restrict_web_apps_usage,
 )
 from corehq.apps.domain.shortcuts import create_domain
@@ -314,17 +314,21 @@ class TestGetWebAppsAvailableToUser(TestCase):
 
     def assert_apps(self, expected):
         self.assertItemsEqual(
-            get_web_app_ids_available_to_user(self.domain, self.user),
-            expected,
+            [app['_id'] for app in get_web_apps_available_to_user(self.domain, self.user)],
+            expected
         )
 
-    @patch('corehq.apps.cloudcare.utils.can_user_access_web_app', return_value=True)
-    def test(self, *args):
+    def _make_app(self):
         factory = AppFactory(self.domain, name='foo')
         m0, f0 = factory.new_basic_module("bar", "bar")
         f0.source = get_simple_form(xmlns=f0.unique_id)
         app = factory.app
         app.save()
+        self.addCleanup(app.delete)
+        return app
+
+    def test(self):
+        app = self._make_app()
         self.assert_apps([])
 
         # Doesn't show up after cloudcare enabled 'cause there's no build
@@ -364,4 +368,16 @@ class TestGetWebAppsAvailableToUser(TestCase):
 
         build_3.is_released = True
         build_3.save()
+        self.assert_apps([])
+
+    def test_deleted_app_is_gone(self):
+        app = self._make_app()
+        app.cloudcare_enabled = True
+        app.save()
+        build_1 = app.make_build()
+        build_1.is_released = True
+        build_1.save()
+        self.assert_apps([build_1._id])
+        app.delete_app()
+        app.save()
         self.assert_apps([])

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -2,9 +2,12 @@ from django.conf import settings
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import (
+    get_app_ids_in_domain,
     get_apps_in_domain,
     get_latest_app_meta,
+    get_latest_build_doc,
     get_latest_build_id,
+    get_latest_released_app_doc,
     get_latest_released_build_id,
 )
 from corehq.util.quickcache import quickcache
@@ -28,6 +31,28 @@ def can_user_access_web_app(domain, user, app_id):
         has_access_via_group = app_access.user_can_access_app(user, app_id)
 
     return has_access_via_permission and has_access_via_group
+
+
+def _get_latest_build_for_web_apps(domain, username, app_id):
+    if (toggles.CLOUDCARE_LATEST_BUILD.enabled(domain) or toggles.CLOUDCARE_LATEST_BUILD.enabled(username)):
+        return get_latest_build_doc(domain, app_id)
+    else:
+        return get_latest_released_app_doc(domain, app_id)
+
+
+def get_web_apps_available_to_user(domain, user):
+    def is_web_app(app):
+        return app.get('cloudcare_enabled')
+
+    apps = []
+    app_ids = get_app_ids_in_domain(domain)
+    for app_id in app_ids:
+        if can_user_access_web_app(domain, user, app_id):
+            app = _get_latest_build_for_web_apps(domain, user.username, app_id)
+            if app and is_web_app(app):
+                apps.append(app)
+
+    return apps
 
 
 def get_latest_build_id_for_web_apps(domain, username, app_id):

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -60,7 +60,7 @@ from corehq.apps.cloudcare.utils import (
     can_user_access_web_app,
     get_latest_build_id_for_web_apps,
     get_mobile_ucr_count,
-    get_web_app_ids_available_to_user,
+    get_web_apps_available_to_user,
     should_restrict_web_apps_usage,
 )
 from corehq.apps.domain.decorators import (
@@ -112,9 +112,8 @@ class FormplayerMain(View):
                     return [_format_app_doc(build)]
             return []
 
-        build_ids = get_web_app_ids_available_to_user(domain, user)
-        apps = [_format_app_doc(get_app_doc(domain, build_id))
-                for build_id in build_ids]
+        apps = get_web_apps_available_to_user(domain, user)
+        apps = [_format_app_doc(app) for app in apps]
         return sorted(apps, key=lambda app: app['name'].lower())
 
     @staticmethod


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18492
More fallout from https://github.com/dimagi/commcare-hq/pull/36849
Deleted apps were still appearing - the new test fails on the old implementation

Revert to old web apps getter to avoid a bug - basically rolling back this change: cb10a818c41527722d29d0ce31c36cc4cc07097b.  Though it keeps the new behavior for mobile UCR.

The issue is that the new view completely excludes deleted apps from consideration, so it finds the last non-deleted app.  A fix will be either to include deleted apps in the view results, filtering them out in memory afterwards, or to make a separate query for app IDs on the domain and intersect the results.  For now I'll just revert.


## Feature Flag


## Safety Assurance
Local testing, plus new tests, and this is basically a partial revert.

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
