### PR TITLE
Ignore Migrated/ing domains from backfilled usercase

### DIFF
--- a/corehq/apps/users/management/commands/create_usercases.py
+++ b/corehq/apps/users/management/commands/create_usercases.py
@@ -7,6 +7,7 @@ from corehq.toggles import USH_USERCASES_FOR_WEB_USERS, NAMESPACE_DOMAIN
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.callcenter.sync_usercase import sync_usercases_ignore_web_flag
 from corehq.apps.domain.models import Domain
+from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
 from corehq.apps.users.dbaccessors import get_all_user_rows
 from corehq.apps.users.models import CouchUser
 from corehq.util.log import with_progress_bar
@@ -37,7 +38,8 @@ class Command(BaseCommand):
         domains_only_web_created = 0
 
         for domain in with_progress_bar(all_domains, length=len(all_domains)):
-            if not domain_has_privilege(domain, privileges.USERCASE):
+            if (not domain_has_privilege(domain, privileges.USERCASE)
+                    or any_migrations_in_progress(domain)):
                 continue
 
             domain_obj = Domain.get_by_name(domain)

--- a/corehq/apps/users/tests/test_create_usercases_command.py
+++ b/corehq/apps/users/tests/test_create_usercases_command.py
@@ -27,13 +27,15 @@ class CreateUsercasesCommandCombinationsTests(SimpleTestCase):
     @patch('corehq.apps.users.management.commands.create_usercases.domain_has_privilege')
     @patch('corehq.apps.users.management.commands.create_usercases.Domain.get_by_name')
     @patch('corehq.apps.users.management.commands.create_usercases.Domain.get_all_names')
+    @patch('corehq.apps.users.management.commands.create_usercases.any_migrations_in_progress')
     def test_domain_combinations_sync_counts(
         self, domain, has_priv, usercase_enabled, toggle_enabled, expected_sync_calls,
-        mock_all_names, mock_get_by_name, mock_has_priv,
-        mock_get_all_user_rows, _mock_wrap, mock_toggle, mock_sync,
+        mock_any_migrations, mock_all_names, mock_get_by_name, mock_has_priv,
+        mock_get_all_user_rows, _mock_wrap, mock_toggle, mock_sync
     ):
         mock_all_names.return_value = [domain]
 
+        mock_any_migrations.return_value = False
         mock_get_by_name.return_value = SimpleNamespace(
             usercase_enabled=usercase_enabled, save=lambda: None
         )


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user facing change

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Follow up to https://github.com/dimagi/commcare-hq/pull/36898

Domains that are being migrating or have migrated can not have data on their domain edited. So usercases can not be created on those domains and should be skipped.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Minor change from the original management command. This excludes domains that have been migrated.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
