### PR TITLE
Migration for "Enable All Add-Ons"

### DIFF
--- a/corehq/apps/app_manager/migrations/0031_enable_all_add_ons.py
+++ b/corehq/apps/app_manager/migrations/0031_enable_all_add_ons.py
@@ -1,0 +1,51 @@
+from django.db import migrations
+
+from corehq.apps.app_manager.add_ons import _ADD_ONS
+from corehq.apps.app_manager.dbaccessors import get_app_ids_in_domain
+from corehq.apps.app_manager.models import Application
+from corehq.apps.domain.models import Domain
+from corehq.toggles import StaticToggle
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+def get_enabled_domains():
+    """
+    Returns the domains that had the ENABLE_ALL_ADD_ONS toggle enabled,
+    even after the toggle has been deleted.
+    """
+    # Allows migration to be run before or after code changes
+    toggle = StaticToggle('enable_all_add_ons', '', '')
+    return toggle.get_enabled_domains()
+
+
+@skip_on_fresh_install
+def enable_all_add_ons(apps, schema_editor):
+    """
+    Enable all add-ons for all applications in all domains with the
+    ENABLE_ALL_ADD_ONS toggle enabled.
+    """
+    all_add_ons_enabled = {slug: True for slug in _ADD_ONS.keys()}
+
+    for domain_name in get_enabled_domains():
+        if not Domain.get_by_name(domain_name):
+            continue
+
+        app_ids = get_app_ids_in_domain(domain_name)
+        for app_id in app_ids:
+            app = Application.get(app_id)
+            if app and not app.is_remote_app():
+                app.add_ons.update(all_add_ons_enabled)
+                app.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('app_manager', '0030_credentialapplication'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            enable_all_add_ons,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -183,6 +183,7 @@ app_manager
  0028_case_list_custom_variable_xml_to_dict
  0029_delete_case_list_custom_variable_xml
  0030_credentialapplication
+ 0031_enable_all_add_ons
 auditcare
  0001_sqlmodels
  0002_uniques


### PR DESCRIPTION
## Technical Summary

This migration is the first of two PRs. The migration allows us to drop the `ENABLE_ALL_ADD_ONS` feature flag by enabling all add-ons for all apps.

The feature flag is to be replaced with a button, visible with a new privilege. That change is in a second PR.

This migration can be run before or after the code change.

:t-rex: Jira: [SAAS-18165](https://dimagi.atlassian.net/browse/SAAS-18165)

:memo: Docs: [Mockup](https://docs.google.com/document/d/1ya2lVM4iNwvEfLmRG_XOp0oCF-bYGRifNG4sdDDVzwY/edit?tab=t.0#heading=h.61davr6yv0ta)

## Feature Flag

`ENABLE_ALL_ADD_ONS`

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

No

### QA Plan

No

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-18165]: https://dimagi.atlassian.net/browse/SAAS-18165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ