### PR TITLE
Exclude deleted apps from mobile UCR fixture

### DIFF
--- a/corehq/apps/cloudcare/tests/test_utils.py
+++ b/corehq/apps/cloudcare/tests/test_utils.py
@@ -16,6 +16,7 @@ from corehq.apps.cloudcare.models import ApplicationAccess, SQLAppGroup
 from corehq.apps.cloudcare.utils import (
     can_user_access_web_app,
     get_mobile_ucr_count,
+    get_web_app_ids_available_to_user,
     get_web_apps_available_to_user,
     should_restrict_web_apps_usage,
 )
@@ -315,6 +316,10 @@ class TestGetWebAppsAvailableToUser(TestCase):
     def assert_apps(self, expected):
         self.assertItemsEqual(
             [app['_id'] for app in get_web_apps_available_to_user(self.domain, self.user)],
+            expected
+        )
+        self.assertItemsEqual(
+            [app_id for app_id in get_web_app_ids_available_to_user(self.domain, self.user)],
             expected
         )
 

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -63,6 +63,12 @@ def get_latest_build_id_for_web_apps(domain, username, app_id):
 
 
 def get_web_app_ids_available_to_user(domain, user):
+    # TODO: once WEB_APPS_PERMISSIONS_VIA_GROUPS is removed, just use
+    # role.permissions.web_apps_list if applicable
+    accessible_app_ids = [
+        app_id for app_id in get_app_ids_in_domain(domain)
+        if can_user_access_web_app(domain, user, app_id)
+    ]
     target = 'build' if (
         toggles.CLOUDCARE_LATEST_BUILD.enabled(domain)
         or toggles.CLOUDCARE_LATEST_BUILD.enabled(user.username)
@@ -70,7 +76,7 @@ def get_web_app_ids_available_to_user(domain, user):
     return [
         app_meta['_id'] for app_meta in get_latest_app_meta(domain, target)
         if app_meta['cloudcare_enabled']
-        and can_user_access_web_app(domain, user, app_meta['origin_id'])
+        and app_meta['origin_id'] in accessible_app_ids
     ]
 
 

--- a/corehq/apps/cloudcare/utils.py
+++ b/corehq/apps/cloudcare/utils.py
@@ -63,8 +63,6 @@ def get_latest_build_id_for_web_apps(domain, username, app_id):
 
 
 def get_web_app_ids_available_to_user(domain, user):
-    # TODO: once WEB_APPS_PERMISSIONS_VIA_GROUPS is removed, just use
-    # role.permissions.web_apps_list if applicable
     accessible_app_ids = [
         app_id for app_id in get_app_ids_in_domain(domain)
         if can_user_access_web_app(domain, user, app_id)


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.slack.com/archives/C0B44C0Q2/p1757980314084099?thread_ts=1757919671.979689&cid=C0B44C0Q2
https://dimagi.atlassian.net/browse/USH-6268
https://github.com/dimagi/commcare-hq/pull/36849 inadvertently added deleted apps into the results.  This PR removes them again.  Was planning on doing this anyways, but some projects had issues with deleted apps containing broken mobile UCR configurations, which was causing the whole UCR fixture generation process to fail.

## Feature Flag
RESTORE_ACCESSIBLE_REPORTS_ONLY

## Safety Assurance


### Safety story
Relying on automated tests here

### Automated test coverage

### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change