### PR TITLE
Delete Web User usercase FF

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1118,14 +1118,6 @@ DYNAMICALLY_UPDATE_SEARCH_RESULTS = StaticToggle(
     parent_toggles=[SPLIT_SCREEN_CASE_SEARCH]
 )
 
-USH_USERCASES_FOR_WEB_USERS = StaticToggle(
-    'usercases_for_web_users',
-    "USH: Enable the creation of usercases for web users.",
-    TAG_CUSTOM,
-    help_link='https://confluence.dimagi.com/display/saas/USH%3A+Enable+Web+User+Usercase+Creation',
-    namespaces=[NAMESPACE_DOMAIN],
-)
-
 WEBAPPS_STICKY_SEARCH = StaticToggle(
     "webapps_sticky_search",
     "USH: Sticky search: In web apps, save user's most recent inputs on case search & claim screen.",

--- a/corehq/toggles/migrations/0003_delete_web_usercase_toggle.py
+++ b/corehq/toggles/migrations/0003_delete_web_usercase_toggle.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+from couchdbkit import ResourceNotFound
+
+from corehq.toggles import Toggle
+from corehq.toggles.models import generate_toggle_id
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _remove_feature_flag(*args, **kwargs):
+    toggle_id = generate_toggle_id(slug='usercases_for_web_users')
+    try:
+        toggle = Toggle.get(toggle_id)
+    except ResourceNotFound:
+        pass
+    else:
+        toggle.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('toggles', '0002_assign_permissions_superusers'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _remove_feature_flag,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -1234,6 +1234,7 @@ toggle_ui
 toggles
  0001_toggle_edit_permission
  0002_assign_permissions_superusers
+ 0003_delete_web_usercase_toggle
 translations
  0001_initial
  0002_transifexblacklist


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
`USH_USERCASES_FOR_WEB_USERS` FF will no longer be an option

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-6184](https://dimagi.atlassian.net/browse/USH-6184)
Usages of `USH_USERCASES_FOR_WEB_USERS` have all been removed in previous PRs. The feature has been GAed so the toggle can now be deleted.

This migration should not be merged to master until at least 2 weeks after the migration in https://github.com/dimagi/commcare-hq/pull/36899 has been merged. This is because that migration depends on the FF that is deleted in this PR.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
USH_USERCASES_FOR_WEB_USERS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The change is only removing a FF that is no longer used in any code logic.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
PR can be reverted but the deleted toggle document can not be reverted.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-6184]: https://dimagi.atlassian.net/browse/USH-6184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ