### PR TITLE
Add views for user to enable or disable auto renewal

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1630,7 +1630,11 @@ class Subscription(models.Model):
         # record renewal from old subscription
         SubscriptionAdjustment.record_adjustment(
             self, method=adjustment_method, note=note, web_user=web_user,
-            reason=SubscriptionAdjustmentReason.RENEW,
+            reason=SubscriptionAdjustmentReason.RENEW, related_subscription=renewed_subscription
+        )
+        SubscriptionAdjustment.record_adjustment(
+            renewed_subscription, method=adjustment_method, note=note, web_user=web_user,
+            reason=SubscriptionAdjustmentReason.CREATE
         )
 
         send_subscription_renewal_alert(self.subscriber.domain, renewed_subscription, self)

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1641,6 +1641,16 @@ class Subscription(models.Model):
 
         return renewed_subscription
 
+    def suppress_subscription(self):
+        if self.is_active:
+            raise SubscriptionAdjustmentError(
+                "Cannot suppress active subscription, id %d"
+                % self.id
+            )
+        else:
+            self.is_hidden_to_ops = True
+            self.save()
+
     def transfer_credits(self, subscription=None):
         """Transfers all credit balances related to an account or subscription
         (if specified).

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1,6 +1,5 @@
 import datetime
 import itertools
-from dateutil.relativedelta import relativedelta
 from decimal import Decimal
 from io import BytesIO
 from tempfile import NamedTemporaryFile
@@ -18,6 +17,7 @@ from django.utils.translation import gettext_lazy as _
 
 import jsonfield
 import stripe
+from dateutil.relativedelta import relativedelta
 from django_prbac.models import Role
 from memoized import memoized
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1572,6 +1572,7 @@ class Subscription(models.Model):
             method=adjustment_method, note=note, web_user=web_user,
         )
 
+    @transaction.atomic
     def renew_subscription(self, note=None, web_user=None,
                            adjustment_method=None,
                            service_type=None, pro_bono_status=None,

--- a/corehq/apps/accounting/tests/generator.py
+++ b/corehq/apps/accounting/tests/generator.py
@@ -3,12 +3,12 @@ import datetime
 import random
 import uuid
 from decimal import Decimal
+from unittest import mock
 
 from django.apps import apps
 from django.conf import settings
 from django.core.management import call_command
 
-from unittest import mock
 from nose.tools import nottest
 
 from dimagi.utils.data import generator as data_gen
@@ -24,11 +24,11 @@ from corehq.apps.accounting.models import (
     DefaultProductPlan,
     Feature,
     FeatureType,
+    Role,
     SoftwarePlan,
     SoftwarePlanEdition,
     SoftwarePlanVersion,
     SoftwareProductRate,
-    Role,
     Subscriber,
     Subscription,
     SubscriptionType,

--- a/corehq/apps/accounting/tests/generator.py
+++ b/corehq/apps/accounting/tests/generator.py
@@ -153,7 +153,7 @@ def custom_plan_version(name='Custom software plan', edition=SoftwarePlanEdition
 @unit_testing_only
 def generate_domain_subscription(account, domain, date_start, date_end,
                                  plan_version=None, service_type=SubscriptionType.NOT_SET,
-                                 is_active=False, do_not_invoice=False):
+                                 is_active=False, do_not_invoice=False, **kwargs):
     subscriber, _ = Subscriber.objects.get_or_create(domain=domain.name)
     subscription = Subscription(
         account=account,
@@ -163,7 +163,8 @@ def generate_domain_subscription(account, domain, date_start, date_end,
         date_end=date_end,
         service_type=service_type,
         is_active=is_active,
-        do_not_invoice=do_not_invoice
+        do_not_invoice=do_not_invoice,
+        **kwargs
     )
     subscription.save()
     return subscription

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -58,7 +58,6 @@ from corehq.apps.accounting.exceptions import (
     CreditLineError,
     InvoiceError,
     NewSubscriptionError,
-    SubscriptionAdjustmentError,
 )
 from corehq.apps.accounting.forms import (
     AdjustBalanceForm,
@@ -503,7 +502,7 @@ class EditSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
             self.cancel_subscription()
             messages.success(request, "The subscription has been cancelled.")
         elif SuppressSubscriptionForm.submit_kwarg in self.request.POST and self.suppress_form.is_valid():
-            self.suppress_subscription()
+            self.subscription.suppress_subscription()
             return HttpResponseRedirect(SubscriptionInterface.get_url())
         elif 'subscription_change_note' in self.request.POST and self.change_subscription_form.is_valid():
             try:
@@ -521,16 +520,6 @@ class EditSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
             web_user=self.request.user.username,
         )
         self.subscription_canceled = True
-
-    def suppress_subscription(self):
-        if self.subscription.is_active:
-            raise SubscriptionAdjustmentError(
-                "Cannot suppress active subscription, id %d"
-                % self.subscription.id
-            )
-        else:
-            self.subscription.is_hidden_to_ops = True
-            self.subscription.save()
 
 
 class NewSoftwarePlanView(AccountingSectionView):

--- a/corehq/apps/domain/tests/test_views.py
+++ b/corehq/apps/domain/tests/test_views.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from unittest.mock import PropertyMock, patch
 
-from django.contrib.messages import get_messages, ERROR
+from django.contrib.messages import ERROR, get_messages
 from django.test import RequestFactory, TestCase
 from django.test.client import Client
 from django.urls import reverse
@@ -18,17 +18,22 @@ from corehq.apps.accounting.models import (
 from corehq.apps.accounting.tests import generator
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.accounting.utils import clear_plan_version_cache
-from corehq.apps.app_manager.models import ActivityLevel, Application, CredentialApplication
+from corehq.apps.app_manager.dbaccessors import get_app
+from corehq.apps.app_manager.models import (
+    ActivityLevel,
+    Application,
+    CredentialApplication,
+)
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.domain.views import FlagsAndPrivilegesView
 from corehq.apps.domain.views.settings import (
     MAX_ACTIVE_ALERTS,
+    CredentialsApplicationSettingsView,
     EditDomainAlertView,
     FeaturePreviewsView,
     ManageDomainAlertsView,
-    CredentialsApplicationSettingsView,
 )
 from corehq.apps.hqwebapp.models import Alert
 from corehq.apps.toggle_ui.models import ToggleAudit
@@ -38,7 +43,6 @@ from corehq.motech.models import ConnectionSettings
 from corehq.motech.repeaters.models import AppStructureRepeater
 from corehq.toggles import NAMESPACE_DOMAIN, StaticToggle, Tag
 from corehq.util.test_utils import privilege_enabled
-from corehq.apps.app_manager.dbaccessors import get_app
 
 
 class TestDomainViews(TestCase, DomainSubscriptionMixin):

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -37,6 +37,8 @@ from corehq.apps.domain.views.accounting import (
     SelectPlanView,
     SubscriptionRenewalView,
     WireInvoiceView,
+    enable_subscription_auto_renew,
+    disable_subscription_auto_renew,
     pause_subscription,
 )
 from corehq.apps.domain.views.base import select, accept_all_invitations
@@ -162,6 +164,8 @@ domain_settings = [
     url(r'^subscription/change/account/$', ConfirmBillingAccountInfoView.as_view(),
         name=ConfirmBillingAccountInfoView.urlname),
     url(r'^subscription/change/pause/$', pause_subscription, name='pause_subscription'),
+    url(r'^subscription/auto_renew/disable/$', disable_subscription_auto_renew, name='disable_auto_renew'),
+    url(r'^subscription/auto_renew/enable/$', enable_subscription_auto_renew, name='enable_auto_renew'),
     url(r'^subscription/credits/make_payment/$', CreditsStripePaymentView.as_view(),
         name=CreditsStripePaymentView.urlname),
     url(r'^subscription/credits/make_wire_payment/$', CreditsWireInvoiceView.as_view(),

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1981,8 +1981,7 @@ def disable_subscription_auto_renew(request, domain):
                 reason=SubscriptionAdjustmentReason.CREATE
             ).exists()
             if next_created_by_auto_renew:
-                next_subscription.is_hidden_to_ops = True
-                next_subscription.save()
+                next_subscription.suppress_subscription()
 
         current_subscription.auto_renew = False
         current_subscription.save()

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1973,7 +1973,7 @@ def disable_subscription_auto_renew(request, domain):
     with transaction.atomic():
         next_subscription = current_subscription.next_subscription
         if next_subscription is not None:
-            # if next subscription was created by auto renewal, cancel that subscription
+            # if next subscription was created by auto renewal, suppress that subscription
             next_created_by_auto_renew = SubscriptionAdjustment.objects.filter(
                 subscription=next_subscription,
                 method=SubscriptionAdjustmentMethod.AUTO_RENEWAL,

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -13,8 +13,8 @@ from django.db.models import Sum
 from django.http import (
     Http404,
     HttpResponse,
-    HttpResponseRedirect,
     HttpResponseForbidden,
+    HttpResponseRedirect,
 )
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -29,12 +29,11 @@ from couchdbkit import ResourceNotFound
 from django_prbac.utils import has_privilege
 from memoized import memoized
 
-from corehq.apps.accounting.decorators import always_allow_project_access
-from corehq.apps.accounting.utils.unpaid_invoice import can_domain_unpause
 from dimagi.utils.web import json_response
 
 from corehq import privileges
 from corehq.apps.accounting.async_handlers import Select2BillingInfoHandler
+from corehq.apps.accounting.decorators import always_allow_project_access
 from corehq.apps.accounting.exceptions import (
     NewSubscriptionError,
     PaymentRequestError,
@@ -83,17 +82,18 @@ from corehq.apps.accounting.user_text import (
 from corehq.apps.accounting.utils import (
     fmt_dollar_amount,
     get_change_status,
+    get_paused_plan_context,
     is_downgrade,
     log_accounting_error,
-    quantize_accounting_decimal,
-    get_paused_plan_context,
     pause_current_subscription,
+    quantize_accounting_decimal,
 )
 from corehq.apps.accounting.utils.stripe import get_customer_cards
+from corehq.apps.accounting.utils.unpaid_invoice import can_domain_unpause
 from corehq.apps.domain.decorators import (
+    LoginAndDomainMixin,
     login_and_domain_required,
     require_superuser,
-    LoginAndDomainMixin,
 )
 from corehq.apps.domain.forms import (
     INTERNAL_SUBSCRIPTION_MANAGEMENT_FORMS,

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1948,8 +1948,7 @@ def enable_subscription_auto_renew(request, domain):
 
     next_subscription = current_subscription.next_subscription
     if next_subscription is not None:
-        # can't enable auto renewal because we don't know what to do with the next subscription
-        # this is blocked via UI but validate here as well
+        # the UI should already prevent this interaction, but enforcing from the server to make sure
         messages.error(
             request, _("Auto renewal cannot be enabled for the current subscription.")
         )


### PR DESCRIPTION
## Product Description
No UI yet, just adds backend functionality.

## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SAAS-18407), [Tech Spec](https://docs.google.com/document/d/1kop7WTDE3HQdNhbWi0yoPbRjqdI4FLjFVHvtZ5CStJY/edit?usp=sharing)
Adds `enable_auto_renew` and `disable_auto_renew` functional views that will be accessed when a user enables or disables auto renewal for their current subscription.

Additionally, cleans up the `SubscriptionAdjustment`s we create when renewing a subscription, to be consistent with what we already do when changing to a new plan. This makes it possible to look up whether a `next_subscription` was created by auto renewal. Also refactors an error message on subscription change-related views for DRYness.

## Feature Flag
This is not feature flagged. The corresponding UI to access these views will be under `SHOW_AUTO_RENEW` while in development.

## Safety Assurance

### Safety story
Automated tests confirm the most basic functionality, that `auto_renew` is set True or False on a subscription, as well as what to do with `next_subscription`s when they exist.

### Automated test coverage
Added automated tests `TestSetSubscriptionAutoRenew` that cover both `enable_` and `disable_` views.

### QA Plan
Auto-renewals will get QA holistically.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
