### PR TITLE
Simplify password reset email parameters

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -437,12 +437,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
         if not dj_user.is_active:
             raise BadRequest(_("This user is inactive and cannot reset their password."))
 
-        send_password_reset_email(
-            [dj_user],
-            domain_override=None,
-            request=request,
-        )
-
+        send_password_reset_email([dj_user], request=request)
         self.log_throttled_access(request)
         return self.create_response(request, {}, response_class=http.HttpAccepted)
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -437,7 +437,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
         if not dj_user.is_active:
             raise BadRequest(_("This user is inactive and cannot reset their password."))
 
-        send_password_reset_email([dj_user], request=request)
+        send_password_reset_email([dj_user])
         self.log_throttled_access(request)
         return self.create_response(request, {}, response_class=http.HttpAccepted)
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -10,7 +10,6 @@ from dimagi.utils.parsing import string_to_boolean
 
 from django.urls import re_path as url
 from django.contrib.auth.models import User
-from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
 from django.db.models import Max, Min, Q
 from django.db.models.functions import TruncDate
@@ -441,10 +440,6 @@ class CommCareUserResource(v0_1.CommCareUserResource):
         send_password_reset_email(
             [dj_user],
             domain_override=None,
-            subject_template_name='registration/password_reset_subject.txt',
-            email_template_name='registration/password_reset_email.html',
-            use_https=request.is_secure(),
-            token_generator=default_token_generator,
             request=request,
         )
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1732,7 +1732,7 @@ class UsernameAwareEmailField(forms.EmailField):
 class HQPasswordResetForm(BasePasswordResetForm, NoAutocompleteMixin, forms.Form):
     email = UsernameAwareEmailField(label=gettext_lazy("Email"), max_length=254)
 
-    def save(self, request=None, **kwargs):
+    def save(self, **kwargs):
         """
         Generates a one-use only link for resetting password and sends to the
         user.
@@ -1745,7 +1745,7 @@ class HQPasswordResetForm(BasePasswordResetForm, NoAutocompleteMixin, forms.Form
         # get a password reset email.
         active_users = get_active_users_by_email(email)
 
-        super().save(active_users, request=request, **kwargs)
+        super().save(active_users, **kwargs)
 
 
 class UsernameOrEmailField(forms.CharField):
@@ -1778,7 +1778,7 @@ class DomainPasswordResetForm(BasePasswordResetForm, NoAutocompleteMixin, forms.
         self.cleaned_data["email"] = mobile_username_email
         return super().clean_email()
 
-    def save(self, request=None, **kwargs):
+    def save(self, **kwargs):
         """
         Generates a one-use only link for resetting password and sends to the
         user.
@@ -1791,7 +1791,7 @@ class DomainPasswordResetForm(BasePasswordResetForm, NoAutocompleteMixin, forms.
         # get a password reset email.
         active_users = get_active_users_by_email(email, self.domain)
 
-        super().save(active_users, request=request, **kwargs)
+        super().save(active_users, **kwargs)
 
 
 class ConfidentialDomainPasswordResetForm(DomainPasswordResetForm):

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1707,13 +1707,7 @@ class BasePasswordResetForm(NoAutocompleteMixin, forms.Form):
             raise forms.ValidationError(self.error_messages['unusable'])
         return email
 
-    def save(self, active_users, domain_override=None,
-             subject_template_name='registration/password_reset_subject.txt',
-             email_template_name='registration/password_reset_email.html',
-             # WARNING: Django 1.7 passes this in automatically. do not remove
-             html_email_template_name=None,
-             use_https=False, token_generator=default_token_generator,
-             from_email=None, request=None, **kwargs):
+    def save(self, active_users, request=None, **kwargs):
         send_password_reset_email(active_users, request)
 
 
@@ -1736,13 +1730,7 @@ class UsernameAwareEmailField(forms.EmailField):
 class HQPasswordResetForm(BasePasswordResetForm, NoAutocompleteMixin, forms.Form):
     email = UsernameAwareEmailField(label=gettext_lazy("Email"), max_length=254)
 
-    def save(self, domain_override=None,
-             subject_template_name='registration/password_reset_subject.txt',
-             email_template_name='registration/password_reset_email.html',
-             # WARNING: Django 1.7 passes this in automatically. do not remove
-             html_email_template_name=None,
-             use_https=False, token_generator=default_token_generator,
-             from_email=None, request=None, **kwargs):
+    def save(self, request=None, **kwargs):
         """
         Generates a one-use only link for resetting password and sends to the
         user.
@@ -1755,9 +1743,7 @@ class HQPasswordResetForm(BasePasswordResetForm, NoAutocompleteMixin, forms.Form
         # get a password reset email.
         active_users = get_active_users_by_email(email)
 
-        super().save(active_users, domain_override, subject_template_name,
-                     email_template_name, html_email_template_name, use_https,
-                     token_generator, from_email, request, **kwargs)
+        super().save(active_users, request=request, **kwargs)
 
 
 class UsernameOrEmailField(forms.CharField):
@@ -1790,13 +1776,7 @@ class DomainPasswordResetForm(BasePasswordResetForm, NoAutocompleteMixin, forms.
         self.cleaned_data["email"] = mobile_username_email
         return super().clean_email()
 
-    def save(self, domain_override=None,
-             subject_template_name='registration/password_reset_subject.txt',
-             email_template_name='registration/password_reset_email.html',
-             # WARNING: Django 1.7 passes this in automatically. do not remove
-             html_email_template_name=None,
-             use_https=False, token_generator=default_token_generator,
-             from_email=None, request=None, **kwargs):
+    def save(self, request=None, **kwargs):
         """
         Generates a one-use only link for resetting password and sends to the
         user.
@@ -1809,9 +1789,7 @@ class DomainPasswordResetForm(BasePasswordResetForm, NoAutocompleteMixin, forms.
         # get a password reset email.
         active_users = get_active_users_by_email(email, self.domain)
 
-        super().save(active_users, domain_override, subject_template_name,
-                     email_template_name, html_email_template_name, use_https,
-                     token_generator, from_email, request, **kwargs)
+        super().save(active_users, request=request, **kwargs)
 
 
 class ConfidentialDomainPasswordResetForm(DomainPasswordResetForm):

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1623,8 +1623,7 @@ class NoAutocompleteMixin(object):
                 field.widget.attrs.update({'autocomplete': 'off'})
 
 
-def send_password_reset_email(active_users, domain_override, subject_template_name,
-                              email_template_name, use_https, token_generator, request):
+def send_password_reset_email(active_users, domain_override, request):
     """
     Generates a one-use only link for resetting password and sends to the
     user.
@@ -1632,6 +1631,9 @@ def send_password_reset_email(active_users, domain_override, subject_template_na
     if settings.IS_SAAS_ENVIRONMENT:
         subject_template_name = 'registration/email/password_reset_subject_hq.txt'
         email_template_name = 'registration/email/password_reset_email_hq.html'
+    else:
+        subject_template_name = 'registration/password_reset_subject.txt',
+        email_template_name = 'registration/password_reset_email.html',
 
     # the code below is copied from default PasswordForm
     for user in active_users:
@@ -1660,8 +1662,8 @@ def send_password_reset_email(active_users, domain_override, subject_template_na
             'site_name': site_name,
             'uid': urlsafe_base64_encode(force_bytes(user.pk)),
             'user': user,
-            'token': token_generator.make_token(user),
-            'protocol': 'https' if use_https else 'http',
+            'token': default_token_generator.make_token(user),
+            'protocol': 'https' if request.is_secure() else 'http',
         }
         c.update(project_logo_emails_context(None, couch_user=couch_user))
         subject = render_to_string(subject_template_name, c)
@@ -1719,8 +1721,7 @@ class BasePasswordResetForm(NoAutocompleteMixin, forms.Form):
              html_email_template_name=None,
              use_https=False, token_generator=default_token_generator,
              from_email=None, request=None, **kwargs):
-        send_password_reset_email(active_users, domain_override, subject_template_name,
-                                  email_template_name, use_https, token_generator, request)
+        send_password_reset_email(active_users, domain_override, request)
 
 
 class UsernameAwareEmailField(forms.EmailField):

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -140,6 +140,7 @@ from corehq.toggles import (
     TWO_STAGE_USER_PROVISIONING_BY_SMS,
     USE_LOGO_IN_SYSTEM_EMAILS
 )
+from corehq.util.global_request import get_request
 from corehq.util.timezones.fields import TimeZoneField
 from corehq.util.timezones.forms import TimeZoneChoiceField
 
@@ -1623,7 +1624,7 @@ class NoAutocompleteMixin(object):
                 field.widget.attrs.update({'autocomplete': 'off'})
 
 
-def send_password_reset_email(active_users, request):
+def send_password_reset_email(active_users):
     """
     Generates a one-use only link for resetting password and sends to the
     user.
@@ -1640,6 +1641,7 @@ def send_password_reset_email(active_users, request):
         # a password marked as unusable
         if not user.has_usable_password():
             continue
+        request = get_request()
         current_site = get_current_site(request)
         couch_user = CouchUser.from_django_user(user)
         if not couch_user:
@@ -1707,8 +1709,8 @@ class BasePasswordResetForm(NoAutocompleteMixin, forms.Form):
             raise forms.ValidationError(self.error_messages['unusable'])
         return email
 
-    def save(self, active_users, request=None, **kwargs):
-        send_password_reset_email(active_users, request)
+    def save(self, active_users, **kwargs):
+        send_password_reset_email(active_users)
 
 
 class UsernameAwareEmailField(forms.EmailField):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -626,13 +626,9 @@ class SendCommCareUserPasswordResetEmailForm(forms.Form):
         )
         super(SendCommCareUserPasswordResetEmailForm, self).__init__(*args, **kwargs)
 
-    def save(self, domain_override=None,
-             subject_template_name='registration/password_reset_subject.txt',
-             email_template_name='registration/password_reset_email.html',
-             use_https=False, token_generator=default_token_generator, request=None):
+    def save(self, request=None, **kwargs):
         user_id = self.data.get('user_id')
         django_user = CommCareUser.get(user_id).get_django_user()
-
         send_password_reset_email([django_user], request)
 
 

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -5,7 +5,6 @@ import string
 from django import forms
 from django.conf import settings
 from django.contrib.auth.forms import SetPasswordForm
-from django.contrib.auth.tokens import default_token_generator
 from django.core.validators import EmailValidator, validate_email
 from django.template.loader import get_template, render_to_string
 from django.urls import reverse
@@ -634,8 +633,7 @@ class SendCommCareUserPasswordResetEmailForm(forms.Form):
         user_id = self.data.get('user_id')
         django_user = CommCareUser.get(user_id).get_django_user()
 
-        send_password_reset_email([django_user], domain_override, subject_template_name,
-                                  email_template_name, use_https, token_generator, request)
+        send_password_reset_email([django_user], domain_override, request)
 
 
 class NewMobileWorkerForm(forms.Form):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -626,10 +626,10 @@ class SendCommCareUserPasswordResetEmailForm(forms.Form):
         )
         super(SendCommCareUserPasswordResetEmailForm, self).__init__(*args, **kwargs)
 
-    def save(self, request=None, **kwargs):
+    def save(self, **kwargs):
         user_id = self.data.get('user_id')
         django_user = CommCareUser.get(user_id).get_django_user()
-        send_password_reset_email([django_user], request)
+        send_password_reset_email([django_user])
 
 
 class NewMobileWorkerForm(forms.Form):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -633,7 +633,7 @@ class SendCommCareUserPasswordResetEmailForm(forms.Form):
         user_id = self.data.get('user_id')
         django_user = CommCareUser.get(user_id).get_django_user()
 
-        send_password_reset_email([django_user], domain_override, request)
+        send_password_reset_email([django_user], request)
 
 
 class NewMobileWorkerForm(forms.Form):


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.atlassian.net/browse/USH-6243
Followup from https://github.com/dimagi/commcare-hq/pull/36872#discussion_r2298499400
There are a lot of pretty niche parameters to this function, copied from Django, which supports a lot more configurability than we need to.  I tried here to localize all that to the function that sends the email so it's more straightforward.

## Feature Flag


## Safety Assurance


### Safety story
Testing on staging


### Automated test coverage


### QA Plan
https://dimagi.atlassian.net/browse/QA-8093

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
