### PR TITLE
Add Action filter in User Audit Report

### DIFF
--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -10,7 +10,7 @@ from django.db.models import ForeignKey, Min
 from corehq.apps.users.models import Invitation, WebUser
 from corehq.util.models import ForeignValue
 
-from ..models import AccessAudit, NavigationEventAudit
+from ..models import ACCESS_CHOICES, AccessAudit, NavigationEventAudit
 
 
 def filters_for_audit_event_query(user, domain=None, start_date=None, end_date=None):
@@ -140,7 +140,7 @@ def get_action_and_resource(event):
         resource = event.request_path
     else:
         assert event.doc_type == 'AccessAudit'
-        action = event.access_type
+        action = ACCESS_CHOICES[event.access_type]
         resource = event.path
 
     return action, resource

--- a/corehq/apps/reports/filters/select.py
+++ b/corehq/apps/reports/filters/select.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
 from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
+from corehq.apps.auditcare.models import ACCESS_CHOICES
 from corehq.apps.commtrack.const import USER_LOCATION_OWNER_MAP_TYPE
 from corehq.apps.groups.models import Group
 from corehq.apps.reports.analytics.esaccessors import (
@@ -169,3 +170,14 @@ class FeatureFilter(BaseSingleOptionFilter):
     @property
     def options(self):
         return [(feature.slug, feature.label) for feature in all_previews()]
+
+
+class UserAuditActionFilter(BaseSingleOptionFilter):
+    slug = "action"
+    label = gettext_lazy("Action")
+    default_text = gettext_lazy("Show All")
+
+    @property
+    def options(self):
+        return [("GET", "GET"), ("POST", "POST"), ("PUT", "PUT"), ("DELETE", "DELETE"),
+                *ACCESS_CHOICES.items()]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Sometimes support receive request like "who changed this? / who delete this?", and it is not easy to find those logs because most of our `NavigationEventAudit` is "GET" request. So I believe adding a filter for "action" column will allow them to just filtering by "POST" or "DELETE" request, which is easier to locate suspicious user log.

<img width="680" height="282" alt="image" src="https://github.com/user-attachments/assets/ee4472d2-cd04-4660-864f-ef459d65cf0b" />

Sample report
<img width="1053" height="697" alt="image" src="https://github.com/user-attachments/assets/11ceba5e-eeec-4b43-9f93-4b52b10e54c8" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-18069

This report now returns two audit types. For `AccessAudit` we filter on `access_type` via standard ORM. For `NavigationEventAudit`, `headers` is our custom `NullJsonField` stored as `TEXT`, so we filter the action by casting to `JSONB` and extracting: `headers::jsonb->>'REQUEST_METHOD' = %s`

Regarding performance, I tested by using `EXPLAIN (ANALYZE)` to rule out the concern that the raw sql code will do a sequential table scan on the whole table. It turns out because we will always specify a date range, and specify either a domain or a username, the REQUEST_METHOD check is evaluated only after the query has already narrowed results using the date range (partition pruning) and the domain/user index. In other words, Postgres first restricts rows by date and domain/user, then applies the JSON filter to that smaller subset. This avoids scanning the entire table and limits the REQUEST_METHOD check to only relevant rows.

Except for that, since I have limit the maximum records to 4000, so execution stops once 4000 matches are found, which bounds total work.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not planning on QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
