### PR TITLE
Modernize add_ons.js

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/add_ons.js
+++ b/corehq/apps/app_manager/static/app_manager/js/add_ons.js
@@ -1,41 +1,42 @@
 import $ from "jquery";
-import _ from "underscore";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import hqMain from "hqwebapp/js/bootstrap3/main";
 import sectionChanger from "app_manager/js/section_changer";
 
-function EditAddOns(addOns, layout, saveUrl) {
-    var self = this;
-
-    self.addOns = addOns;
-    self.sections = _.map(layout, function (s) {
-        return _.extend(s, {
+class EditAddOns {
+    constructor(addOns, layout, saveUrl) {
+        this.addOns = addOns;
+        this.sections = layout.map(s => ({
+            ...s,
             collapse: sectionChanger.shouldCollapse("add-ons", s.slug, s.collapse),
+        }));
+        this.saveButton = hqMain.initSaveButton({
+            unsavedMessage: gettext("You have unsaved changes."),
+            save: () => {
+                // Send server map of slug => enabled
+                const data = Object.fromEntries(
+                    Object.entries(this.addOns).map(([slug, enabled]) => [slug, enabled ? 'on' : ''])
+                );
+                this.saveButton.ajax({
+                    url: saveUrl,
+                    type: 'post',
+                    data,
+                    error: () => {
+                        throw gettext("There was an error saving.");
+                    },
+                });
+            },
         });
-    });
-    self.saveButton = hqMain.initSaveButton({
-        unsavedMessage: gettext("You have unsaved changes."),
-        save: function () {
-            // Send server map of slug => enabled
-            var data = _.mapObject(self.addOns, function (a) { return a ? 'on' : ''; });
-            self.saveButton.ajax({
-                url: saveUrl,
-                type: 'post',
-                data: data,
-                error: function () {
-                    throw gettext("There was an error saving.");
-                },
-            });
-        },
-    });
-    self.update = function (addOn, e) {
-        self.addOns[addOn.slug] = e.currentTarget.checked;
-        self.saveButton.fire('change');
-    };
+    }
+
+    update(addOn, e) {
+        this.addOns[addOn.slug] = e.currentTarget.checked;
+        this.saveButton.fire('change');
+    }
 }
 
-$(function () {
-    var $addOns = $("#add-ons");
+$(() => {
+    const $addOns = $("#add-ons");
     if ($addOns.length) {
         $addOns.koApplyBindings(new EditAddOns(
             initialPageData.get("add_ons"),


### PR DESCRIPTION
*Opening just for discussion. Not to be merged.*

I asked GPT-5 to update `add_ons.js` to use ES6 features, and this is what it returned.

I'm sure we're onboard with using `const` instead of `var`. But how do we feel about

* Using arrow functions
* Using a class with a constructor instead of a constructor function
* Dropping Underscore in favor of native ES6

?

(Easier to review with whitespace off.)