### PR TITLE
Clean up API Key property

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -109,7 +109,6 @@ from .user_data import SQLUserData  # noqa
 from corehq import toggles, privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.mobile_auth.utils import generate_aes_key
-from corehq.util.soft_assert.api import soft_assert
 
 
 WEB_USER = 'web'
@@ -3203,20 +3202,6 @@ class HQApiKey(models.Model):
         # From tastypie
         new_uuid = uuid4()
         return hmac.new(new_uuid.bytes, digestmod=sha1).hexdigest()
-
-    # Remove this after key fields are deleted and verified no errors occur
-    @property
-    def key(self):
-        _soft_assert_api_key = soft_assert(to='jtang@dimagi.com', send_to_ops=False)
-        _soft_assert_api_key(False,
-                             f"Attempted to access api key directly for user {self.user} and name {self.name}")
-        return self.plaintext_key
-
-    @key.setter
-    def key(self, value):
-        _soft_assert_api_key = soft_assert(to='jtang@dimagi.com', send_to_ops=False)
-        _soft_assert_api_key(False, f"Attempted to set api key directly for user {self.user} and name {self.name}")
-        self.plaintext_key = value
 
     @property
     def plaintext_key(self):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user facing effects

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Follow up to https://github.com/dimagi/commcare-hq/pull/35680. Out of precaution, that PR introduced a key property to catch any references to the `key` field that may have been missed. Since that PR has been deployed (~1 month), there have been no assertions that this property has been accessed. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This PR deletes a property that is not being used.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
