### PR TITLE
Hide Case Property Warning for survey forms

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -173,11 +173,12 @@ $(function () {
 
 
     var $casePropertyWarning = $('#case-property-warning');
-    const initialWarningData = initialPageData.get('case_property_warning');
-    const warningViewModel = new casePropertyWarningViewModel(initialWarningData.limit);
-    warningViewModel.updateViewModel(initialWarningData.type, initialWarningData.count);
-    $casePropertyWarning.koApplyBindings(warningViewModel);
-
+    if ($casePropertyWarning.length > 0) {
+        const initialWarningData = initialPageData.get('case_property_warning');
+        const warningViewModel = new casePropertyWarningViewModel(initialWarningData.limit);
+        warningViewModel.updateViewModel(initialWarningData.type, initialWarningData.count);
+        $casePropertyWarning.koApplyBindings(warningViewModel);
+    }
 
     // Advanced > XForm > Upload
     $("#xform_file_input").change(function () {


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
I was noticing a javascript error when viewing the case management/configuration page for survey forms. This was because _form_view.js_ was unconditionally loading the case management performance check, but the HTML to display that check was only being loaded for forms that used case management. 

This fix now only uses the performance view model if the associated HTML is found.

## Feature Flag
No feature flag

## Safety Assurance

### Safety story
Tested locally that no error appears for registration forms.
Overrode values to verify that the performance warning still appears for forms that do use case management.
This warning is also displayed for the data dictionary, but I don't believe anything needed to be changed there.

### Automated test coverage

Purely frontend changes, so no tests.

### QA Plan

No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
