### PR TITLE
Form question required asterik wrapping fix

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
@@ -3,7 +3,9 @@
 
 <script type="text/html" id="question-fullform-ko-template">
   <div data-bind="class:questionTileWidth">
-  <div class="q row" data-bind="
+    <div
+      class="q row"
+      data-bind="
             css: {
                 error: error,
                 required: $data.required,
@@ -11,80 +13,120 @@
                 'text-center': isButton && stylesContains('text-align-center'),
                 'text-end': isButton && stylesContains('text-align-right'),
             }
-        ">
-    <label class="caption form-label text-break" data-bind="
+        "
+    >
+      <label
+        class="caption form-label text-break"
+        data-bind="
       css: labelWidth,
       attr: {
         id: entry.entryId + '-label',
         'for': entry.entryId,
       },
-      visible: hasLabelContent">
-      {# appearance attributes TEXT_ALIGN_CENTER TEXT_ALIGN_RIGHT #}
-      <div class="overflow-auto" data-bind="css: {
+      visible: hasLabelContent"
+      >
+        {# appearance attributes TEXT_ALIGN_CENTER TEXT_ALIGN_RIGHT #}
+        <div
+          class="overflow-auto"
+          data-bind="css: {
           'text-center': stylesContains('text-align-center'),
           'text-end': stylesContains('text-align-right'),
-        }">
-        <!-- ko if: help() -->
-        <a
-          class="help-text-trigger float-end ms-3 mb-1"
-          role="button"
-          href="javascript:void(0)"
-          title="{% trans 'Show help dialog' %}"
-        ><i class="fa fa-question-circle"></i></a>
-        <div class="modal fade" role="dialog">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-body">
-                <button type="button" class="btn-close float-end" data-bs-dismiss="modal" aria-label="{% trans_html_attr "Close" %}"></button>
-                <p class="webapp-markdown-output" align="left" data-bind="html: help"></p>
-                <div class="widget-multimedia" data-bind="
+        }"
+        >
+          <!-- ko if: help() -->
+          <a
+            class="help-text-trigger float-end ms-3 mb-1"
+            role="button"
+            href="javascript:void(0)"
+            title="{% trans 'Show help dialog' %}"
+            ><i class="fa fa-question-circle"></i
+          ></a>
+          <div class="modal fade" role="dialog">
+            <div class="modal-dialog">
+              <div class="modal-content">
+                <div class="modal-body">
+                  <button
+                    type="button"
+                    class="btn-close float-end"
+                    data-bs-dismiss="modal"
+                    aria-label="{% trans_html_attr 'Close' %}"
+                  ></button>
+                  <p
+                    class="webapp-markdown-output"
+                    align="left"
+                    data-bind="html: help"
+                  ></p>
+                  <div
+                    class="widget-multimedia"
+                    data-bind="
                     template: {
                       name: 'widget-help-multimedia-ko-template',
                       data: $data
-                    } ">
+                    } "
+                  ></div>
                 </div>
               </div>
             </div>
           </div>
+          <!-- /ko -->
+          <div class="caption-text">
+            <span
+              class="webapp-markdown-output"
+              data-bind="html: ko.utils.unwrapObservable($data.caption_markdown) || caption()"
+            ></span>
+          </div>
         </div>
-        <!-- /ko -->
-        <div class="caption-text">
-          <span class="webapp-markdown-output" data-bind="html: ko.utils.unwrapObservable($data.caption_markdown) || caption()"></span>
-        </div>
-      </div>
-      <span class="hint-text webapp-markdown-output" data-bind="
+        <span
+          class="hint-text webapp-markdown-output"
+          data-bind="
               html: ko.utils.unwrapObservable($data.hint),
               visible: !entry.useHintAsPlaceHolder()
-          "></span>
-      <!-- ko if: required() -->
-      <span class="sr-only">{% trans "A response is required for this question." %}</span>
-      <!-- /ko -->
-    </label>
-    <div class="widget-container controls" data-bind="css: controlWidth">
-      <div class="widget" data-bind="
+          "
+        ></span>
+        <!-- ko if: required() -->
+        <span class="sr-only"
+          >{% trans "A response is required for this question." %}</span
+        >
+        <!-- /ko -->
+      </label>
+      <div class="widget-container controls" data-bind="css: controlWidth">
+        <div
+          class="widget"
+          data-bind="
         template: { name: entryTemplate, data: entry, afterRender: afterRender },
-      ">
-      </div>
-      <div class="widget-multimedia" data-bind="
+      "
+        ></div>
+        <div
+          class="widget-multimedia"
+          data-bind="
                 template: { name: 'widget-multimedia-ko-template', data: $data }"
-      >
-      </div>
-      <div class="text-danger error-message" data-bind="
+        ></div>
+        <div
+          class="text-danger error-message"
+          data-bind="
                 visible: error,
                 text: error
-            "></div>
-      <div class="text-danger error-message" data-bind="
+            "
+        ></div>
+        <div
+          class="text-danger error-message"
+          data-bind="
                 visible: serverError,
                 text: serverError
-            "></div>
+            "
+        ></div>
+      </div>
+      <span class="ix" data-bind="text: ixInfo($data)"></span>
+      <div class="eoq"></div>
     </div>
-    <span class="ix" data-bind="text: ixInfo($data)"></span>
-    <div class="eoq"></div>
-  </div>
-  <div class="form-group-required-label"
-       aria-hidden="true"
-       data-bind="visible: $data.required, css: {
+    <div
+      class="form-group-required-label"
+      aria-hidden="true"
+      data-bind="visible: $data.required, css: {
                       on: $root.forceRequiredVisible,
-                    }">{% trans 'Sorry, this response is required!' %}</div>
+                    }"
+    >
+      {% trans 'Sorry, this response is required!' %}
+    </div>
   </div>
 </script>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/question.html
@@ -48,7 +48,9 @@
           </div>
         </div>
         <!-- /ko -->
-        <span class="caption-text webapp-markdown-output" data-bind="html: ko.utils.unwrapObservable($data.caption_markdown) || caption()"></span>
+        <div class="caption-text">
+          <span class="webapp-markdown-output" data-bind="html: ko.utils.unwrapObservable($data.caption_markdown) || caption()"></span>
+        </div>
       </div>
       <span class="hint-text webapp-markdown-output" data-bind="
               html: ko.utils.unwrapObservable($data.hint),

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/webforms.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/webforms.scss
@@ -62,11 +62,16 @@ input:invalid {
   border-color: #b94a48;
 }
 
+.required .caption .caption-text {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 3px;
+}
+
 .required .caption .caption-text::after {
   content: '*';
   font-weight: bold;
   color: $danger;
-  margin: 0 0 0 3px;
   display: inline;
 }
 

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/webforms.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/webforms.scss
@@ -20,7 +20,9 @@
   }
 
   .peg {
-    box-shadow: 0 0 10px #004ebc, 0 0 5px #004ebc;
+    box-shadow:
+      0 0 10px #004ebc,
+      0 0 5px #004ebc;
   }
 }
 
@@ -43,14 +45,14 @@ video {
 }
 
 .dirty .widget {
-    background-color: lightblue;
+  background-color: lightblue;
 }
 
 .loading {
   position: absolute;
   right: 0px;
   line-height: 30px;
-  font-size: 18px
+  font-size: 18px;
 }
 
 .error-message {
@@ -69,14 +71,14 @@ input:invalid {
 }
 
 .required .caption .caption-text::after {
-  content: '*';
+  content: "*";
   font-weight: bold;
   color: $danger;
   display: inline;
 }
 
 .required-group .gr-header .caption::before {
-  content: '*';
+  content: "*";
   font-weight: bold;
   color: $danger;
   margin: 0 3px;


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
There was a bug where if markdown is used for a question display text, it would result in the required asterik being displayed on the next line instead of inline.

This PR fixes that bug and displays the asterik inline to the right of the display text.

A visual difference now is that the asterik is now places to the right of the text label block. Meaning that it will not always be next to the last word. For example:

Before:
<img width="298" height="106" alt="Screenshot 2025-09-24 at 1 14 32 AM" src="https://github.com/user-attachments/assets/dadb5c0b-cae2-4892-b392-8f0992aa5efe" />

After:

<img width="199" height="119" alt="Screenshot 2025-09-24 at 2 09 46 AM" src="https://github.com/user-attachments/assets/c4eead76-7d14-481c-a6a5-f7e461988a6b" />
<img width="444" height="100" alt="Screenshot 2025-09-24 at 2 10 04 AM" src="https://github.com/user-attachments/assets/e97fdc7f-1f80-4194-bfcd-a87ba5600317" />

After:


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-6269
](https://dimagi.atlassian.net/browse/USH-6269)
The cause of the bug is that text created as markdown are displayed as blocks. To fix this, we needed to make the contents of `caption-text` inline. However, `webapp-markdown-output` would contain multiple elements with line breaks. To keep those line breaks, `webapp-markdown-output` is kept as a block within the `caption-text` element.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
purely visual chanage. Tested on staging with BHA app and all supported markdowns.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
