### PR TITLE
Use user_id instead of username for modal ids

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/users/partials/personalid_activation_modals.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/users/partials/personalid_activation_modals.html.diff.txt
@@ -1,12 +1,6 @@
 --- 
 +++ 
-@@ -2,16 +2,18 @@
- 
- <div
-   class="modal fade"
--  data-bind="attr: {id: 'activate_personalid_link_' + username()}"
-+  data-bind="attr: {id: 'activate_personalid_link_' + user_id()}"
- >
+@@ -7,11 +7,13 @@
    <div class="modal-dialog">
      <div class="modal-content">
        <div class="modal-header">
@@ -40,13 +34,7 @@
            data-bind="click: function(user) { user.is_personalid_link_active(true); }"
          >
            {% trans "Link" %}
-@@ -49,16 +52,18 @@
- 
- <div
-   class="modal fade"
--  data-bind="attr: {id: 'deactivate_personalid_link_' + username()}"
-+  data-bind="attr: {id: 'deactivate_personalid_link_' + user_id()}"
- >
+@@ -54,11 +57,13 @@
    <div class="modal-dialog">
      <div class="modal-content">
        <div class="modal-header">

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -439,7 +439,7 @@
                         type="button"
                         class="btn btn-default"
                         data-toggle="modal"
-                        data-bind="attr: {'data-target': '#deactivate_personalid_link_' + username()}"
+                        data-bind="attr: {'data-target': '#deactivate_personalid_link_' + user_id()}"
                       >
                         {% trans "Unlink PersonalID" %}
                       </button>
@@ -451,7 +451,7 @@
                         type="button"
                         class="btn btn-default"
                         data-toggle="modal"
-                        data-bind="attr: {'data-target': '#activate_personalid_link_' + username()}"
+                        data-bind="attr: {'data-target': '#activate_personalid_link_' + user_id()}"
                       >
                         {% trans "Link PersonalID" %}
                       </button>

--- a/corehq/apps/users/templates/users/partials/bootstrap3/personalid_activation_modals.html
+++ b/corehq/apps/users/templates/users/partials/bootstrap3/personalid_activation_modals.html
@@ -2,7 +2,7 @@
 
 <div
   class="modal fade"
-  data-bind="attr: {id: 'activate_personalid_link_' + username()}"
+  data-bind="attr: {id: 'activate_personalid_link_' + user_id()}"
 >
   <div class="modal-dialog">
     <div class="modal-content">
@@ -49,7 +49,7 @@
 
 <div
   class="modal fade"
-  data-bind="attr: {id: 'deactivate_personalid_link_' + username()}"
+  data-bind="attr: {id: 'deactivate_personalid_link_' + user_id()}"
 >
   <div class="modal-dialog">
     <div class="modal-content">


### PR DESCRIPTION

## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Bug fix https://dimagi.atlassian.net/browse/CI-296
This fixes unlink modals not getting opened.

## Technical Summary

Dots (.) coming from usernames make it to div id for the modals. The dots mess with css selectors which results in modals not getting open. This change replaces username with user_id like it is used for other modals already.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

NA


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
