### PR TITLE
Tiny, nit-picky tweaks to AI guidelines

### DIFF
--- a/ai_guidelines.md
+++ b/ai_guidelines.md
@@ -92,7 +92,7 @@ codebase. These guidelines apply in the following circumstances:
 - Tests should be run with the `--reusedb=1` parameter to improve speed by
   avoiding resetting the test database. e.g.
   ```shell
-  $ source .venv/bin/activate && pytest --reusedb=1 path/to/test.py
+  $ uv run pytest --reusedb=1 path/to/test.py
   ```
 - Use pytest features and pytest conventions, like Pythonic `assert`
   statements, and parametrized tests for repetitive test cases.
@@ -104,11 +104,24 @@ codebase. These guidelines apply in the following circumstances:
 
 - The JavaScript Guide is documented under the `docs/js-guide/` directory.
 
-- Python is _optionally_ formatted using **yapf**:
-
+- Check JavaScript linting using
   ```shell
-  source .venv/bin/activate
-  yapf -i example/path/filename.py
+  $ npx eslint path/to/file.js
+  ```
+
+- Check Python linting using
+  ```shell
+  $ uv run flake8 path/to/file.py
+  ```
+
+- Python imports are kept clean and consistent using **isort**:
+  ```shell
+  $ uv run isort path/to/file.py
+  ```
+
+- Python is _optionally_ formatted using **yapf**:
+  ```shell
+  $ uv run yapf -i path/to/file.py
   ```
 
   AI Tool and Developer discretion is required:


### PR DESCRIPTION
## Technical Summary

Tiny, nit-picky tweaks to AI guidelines:
* Adds linting instructions
* Uses `uv run` instead of `source .venv/bin/activate && ...` to run Python CLI tools

I'll stop after this one, I promise. :roll_eyes:

## Safety Assurance

### Safety story

Non-code change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
