### PR TITLE
Use pdbp by default if available

### DIFF
--- a/corehq/tests/pytest_hooks.py
+++ b/corehq/tests/pytest_hooks.py
@@ -11,6 +11,13 @@ if ModuleWatchdog.is_installed():
     # in pytest startup because of ddtrace's pytest11 entry point(s).
     ModuleWatchdog.uninstall()
 
+try:
+    # install https://github.com/mdmintz/pdbp as default debugger if available
+    # pytest IO-capturing will be turned off automatically when debugging
+    import pdbp  # noqa: F401
+except ImportError:
+    pass
+
 pytest_plugins = [
     'unmagic',
     'corehq.tests.pytest_plugins.dividedwerun',


### PR DESCRIPTION
**Auto-merge is enabled.**

Prevents _OSError: pytest: reading from stdin while output is captured!_ And does not require pytest `-s` option when debugging with `breakpoint()`

NOTE: do not set `PYTHONBREAKPOINT=pdbp.set_trace`, as that will prevent pytest from automatically turning off IO-capture when debugging.

## Safety Assurance

### Safety story

Tests only, does not affect production code.
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations
