### PR TITLE
Deprecate TURN_IO_BACKEND feature flag

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2307,7 +2307,7 @@ CASE_UPDATES_UCR_FILTERS = StaticToggle(
 TURN_IO_BACKEND = StaticToggle(
     'turn_io_backend',
     'Enable Turn.io SMS backend',
-    TAG_SOLUTIONS_LIMITED,
+    TAG_DEPRECATED,
     namespaces=[NAMESPACE_DOMAIN],
 )
 


### PR DESCRIPTION
## Product Description

Deprecates the "Turn.io SMS backend" feature flag. Projects for which the flag is currently enabled will continue to be able to use the feature, but the flag cannot be enabled for any other projects.

## Technical Summary

1-line change.

:t-rex: Jira: [SAAS-18510](https://dimagi.atlassian.net/browse/SAAS-18510)

**Auto-merge is enabled**

## Feature Flag

TURN_IO_BACKEND

## Safety Assurance

### Safety story

Only changes the `tag` param of a `StaticToggle`.

### Automated test coverage

No

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-18510]: https://dimagi.atlassian.net/browse/SAAS-18510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ