### PR TITLE
"Help Modal" Overlay Fix

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/includes/variables.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/includes/variables.less
@@ -109,8 +109,8 @@
 @zindexAccountingPricingTableHeader:  800;
 
 // Other Zindecies
-@zindex-hq-navigation:               1060;
 @zindex-select2-results:             1056;  // higher than $zindex-modal so select2s can be used in modals
+@zindex-hq-navigation:               1049;  // lower than bootstrap's $zindex-modal-background
 @zindex-cloudcare-debugger:          1040;
 @zindex-persistent-menu-nav:         1030;
 @zindex-persistent-menu-nav-arrow:   @zindex-persistent-menu-nav + 1;

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/includes/variables.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/includes/variables.less
@@ -1,35 +1,36 @@
 @import "@{b3-import-variables}";
 
 // Nunito Sans is used on dimagi.com and embedded in hqwebapp/base.html
-@font-family-sans-serif: "Nunito Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+@font-family-sans-serif: "Nunito Sans", "Helvetica Neue", Helvetica, Arial,
+  sans-serif;
 
-@font-size-base:  12px;
-@icon-font-path:  "../../bootstrap/fonts/";
+@font-size-base: 12px;
+@icon-font-path: "../../bootstrap/fonts/";
 
 // Main background & text
-@cc-bg:     #f2f2f1;
-@cc-text:   #1c2126;
+@cc-bg: #f2f2f1;
+@cc-text: #1c2126;
 
 // Success
-@cc-att-pos-extra-hi:   #e3f1df;
-@cc-att-pos-hi:   #bbe5b3;
-@cc-att-pos-mid:  #4aba32;
-@cc-att-pos-low:  #118043;
-@cc-att-pos-extra-low:  #173630;
+@cc-att-pos-extra-hi: #e3f1df;
+@cc-att-pos-hi: #bbe5b3;
+@cc-att-pos-mid: #4aba32;
+@cc-att-pos-low: #118043;
+@cc-att-pos-extra-low: #173630;
 
 // Error
-@cc-att-neg-extra-hi:   #fbeae6;
-@cc-att-neg-hi:   #fead9a;
-@cc-att-neg-mid:  #e73c27;
-@cc-att-neg-low:  #bf0712;
-@cc-att-neg-extra-low:  #340101;
+@cc-att-neg-extra-hi: #fbeae6;
+@cc-att-neg-hi: #fead9a;
+@cc-att-neg-mid: #e73c27;
+@cc-att-neg-low: #bf0712;
+@cc-att-neg-extra-low: #340101;
 
 // Warning/Attention
-@cc-light-warm-accent-extra-hi:   #fcf2cd;
-@cc-light-warm-accent-hi:   #ffea8a;
-@cc-light-warm-accent-mid:  #eec200;
-@cc-light-warm-accent-low:  #9c6f19;
-@cc-light-warm-accent-extra-low:  #573b00;
+@cc-light-warm-accent-extra-hi: #fcf2cd;
+@cc-light-warm-accent-hi: #ffea8a;
+@cc-light-warm-accent-mid: #eec200;
+@cc-light-warm-accent-low: #9c6f19;
+@cc-light-warm-accent-extra-low: #573b00;
 
 // Call to action
 @call-to-action-extra-hi: #f4f5fa;
@@ -39,62 +40,62 @@
 @call-to-action-extra-low: #000639;
 
 // Accent light blue: buttons on dark backgrounds, occasional secondary buttons (upload/download)
-@cc-light-cool-accent-hi:   #ccf3f4;
-@cc-light-cool-accent-mid:  #00bdc5;
-@cc-light-cool-accent-low:  #00799a;
+@cc-light-cool-accent-hi: #ccf3f4;
+@cc-light-cool-accent-mid: #00bdc5;
+@cc-light-cool-accent-low: #00799a;
 
 // Accent purples used in signup, which uses colors more like dimagi.com than HQ
-@color-purple-dark: #43467F;
-@color-purple-dark-inverse: #E3D0FF;
+@color-purple-dark: #43467f;
+@color-purple-dark-inverse: #e3d0ff;
 
 // Neutrals used as borders/backgrounds
-@cc-neutral-hi:   #d6d6d4;
-@cc-neutral-mid:  #685c53;
-@cc-neutral-low:  #373534;
+@cc-neutral-hi: #d6d6d4;
+@cc-neutral-mid: #685c53;
+@cc-neutral-low: #373534;
 
 // Blues used for links and app manager accents
-@cc-brand-hi:   #bcdeff;
-@cc-brand-mid:  #004ebc;
-@cc-brand-low:  #002c5f;
+@cc-brand-hi: #bcdeff;
+@cc-brand-mid: #004ebc;
+@cc-brand-low: #002c5f;
 
 // used in registration app only. will be merged into "brand" color Bootstrap 5 migration
-@commcare-blue:  #5D70D2;
+@commcare-blue: #5d70d2;
 
 // Accent colors used in few places (billing, web apps, one-offs). Minimize usage.
-@cc-dark-cool-accent-hi:  #d6c5ea;
+@cc-dark-cool-accent-hi: #d6c5ea;
 @cc-dark-cool-accent-mid: #9060c8;
 @cc-dark-cool-accent-low: #5d3f82;
 
-@cc-dark-warm-accent-hi:  #ffe3c2;
+@cc-dark-warm-accent-hi: #ffe3c2;
 @cc-dark-warm-accent-mid: #ff8400;
 @cc-dark-warm-accent-low: #994f00;
 
 // Main TWBS Colors
-@brand-primary:   @cc-brand-mid;
-@brand-success:   @cc-att-pos-mid;
-@brand-info:      @cc-light-cool-accent-mid;
-@brand-warning:   @cc-dark-warm-accent-mid;
-@brand-danger:    @cc-att-neg-mid;
+@brand-primary: @cc-brand-mid;
+@brand-success: @cc-att-pos-mid;
+@brand-info: @cc-light-cool-accent-mid;
+@brand-warning: @cc-dark-warm-accent-mid;
+@brand-danger: @cc-att-neg-mid;
 
 @text-color: @cc-text;
 
 @link-hover-color: @cc-brand-low;
 
-@btn-default-color:              @cc-text;
-@btn-default-bg:                 @cc-bg;
-@btn-default-border:             @cc-neutral-hi;
+@btn-default-color: @cc-text;
+@btn-default-bg: @cc-bg;
+@btn-default-border: @cc-neutral-hi;
 
-@navbar-height:                  60px;
-@navbar-padding-vertical:        ((@navbar-height - @line-height-computed) / 2);
-@navbar-default-bg:              @cc-bg;
+@navbar-height: 60px;
+@navbar-padding-vertical: ((@navbar-height - @line-height-computed) / 2);
+@navbar-default-bg: @cc-bg;
 
-@navbar-footer-height:            40px;
-@navbar-footer-link-color:        mix(darken(#ffffff, 10), @brand-primary, 90);
-@navbar-footer-link-color-hover:  @gray-lighter;
-@navbar-footer-button-color:      #474747;
+@navbar-footer-height: 40px;
+@navbar-footer-link-color: mix(darken(#ffffff, 10), @brand-primary, 90);
+@navbar-footer-link-color-hover: @gray-lighter;
+@navbar-footer-button-color: #474747;
 
-@btn-footer-color:  #ffffff;
-@btn-footer-bg:     #474747;
+@btn-footer-color: #ffffff;
+@btn-footer-bg: #474747;
 @btn-footer-border: #cccccc;
 
 @checkbox-default-color: @call-to-action-mid;
@@ -105,26 +106,25 @@
 // -------------------------
 // Also see Bootstrap 3's own master list:
 // bootstrap/less/variables.less
-@zindexDashboardSpinner:              500;
-@zindexAccountingPricingTableHeader:  800;
+@zindexDashboardSpinner: 500;
+@zindexAccountingPricingTableHeader: 800;
 
 // Other Zindecies
-@zindex-select2-results:             1056;  // higher than $zindex-modal so select2s can be used in modals
-@zindex-hq-navigation:               1049;  // lower than bootstrap's $zindex-modal-background
-@zindex-cloudcare-debugger:          1040;
-@zindex-persistent-menu-nav:         1030;
-@zindex-persistent-menu-nav-arrow:   @zindex-persistent-menu-nav + 1;
-@zindex-navbar:                      1000;
-@zindex-app-preview:                  998;
-@zindex-navbar-cloudcare:             995;
-@zindex-persistent-tile-cloudcare:    993;
-@zindex-formplayer-progress:          990;
-@zindex-report-loading:               100;
-@zindex-formplayer-scroll-to-bottom:    5;
-@zindex-next-error:                     5;  // Above the sticky submit button
-@zindex-formplayer-anchored-submit:     4;
+@zindex-select2-results: 1056; // higher than $zindex-modal so select2s can be used in modals
+@zindex-hq-navigation: 1049; // lower than bootstrap's $zindex-modal-background
+@zindex-cloudcare-debugger: 1040;
+@zindex-persistent-menu-nav: 1030;
+@zindex-persistent-menu-nav-arrow: @zindex-persistent-menu-nav + 1;
+@zindex-navbar: 1000;
+@zindex-app-preview: 998;
+@zindex-navbar-cloudcare: 995;
+@zindex-persistent-tile-cloudcare: 993;
+@zindex-formplayer-progress: 990;
+@zindex-report-loading: 100;
+@zindex-formplayer-scroll-to-bottom: 5;
+@zindex-next-error: 5; // Above the sticky submit button
+@zindex-formplayer-anchored-submit: 4;
 
-
-@input-border-radius-large:       5px;
-@input-color:                     #000;
-@cursor-disabled:                 'not-allowed';
+@input-border-radius-large: 5px;
+@input-color: #000;
+@cursor-disabled: "not-allowed";

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables_bootstrap3.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables_bootstrap3.scss
@@ -56,8 +56,8 @@ $zindexDashboardSpinner:              500;
 $zindexAccountingPricingTableHeader:  800;
 
 // Other Zindecies
-$zindex-hq-navigation:               1060;
 $zindex-select2-results:             1056;  // higher than $zindex-modal so select2s can be used in modals
+$zindex-hq-navigation:               1049;
 $zindex-cloudcare-debugger:          1040;
 $zindex-persistent-menu-nav:         1030;
 $zindex-persistent-menu-nav-arrow:   $zindex-persistent-menu-nav + 1;

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables_bootstrap3.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_variables_bootstrap3.scss
@@ -19,26 +19,25 @@ $gray: lighten($gray-base, 33.5%); // #555
 $gray-light: lighten($gray-base, 46.7%); // #777
 $gray-lighter: lighten($gray-base, 93.5%);
 
-$btn-default-color:              $cc-text;
-$btn-default-bg:                 $cc-bg;
-$btn-default-border:             $cc-neutral-hi;
+$btn-default-color: $cc-text;
+$btn-default-bg: $cc-bg;
+$btn-default-border: $cc-neutral-hi;
 
-$btn-footer-color:  #ffffff;
-$btn-footer-bg:     #474747;
+$btn-footer-color: #ffffff;
+$btn-footer-bg: #474747;
 $btn-footer-border: #cccccc;
 
 // Navigation Bar
-$navbar-height:                  60px;
-$navbar-padding-vertical:        calc(($navbar-height - 20px) / 2);
-$navbar-default-bg:              $cc-bg;
+$navbar-height: 60px;
+$navbar-padding-vertical: calc(($navbar-height - 20px) / 2);
+$navbar-default-bg: $cc-bg;
 
-$navbar-footer-height:            40px;
-$navbar-footer-link-color:        mix(darken(#ffffff, 10), $brand-primary, 90%);
-$navbar-footer-link-color-hover:  $gray-lighter;
-$navbar-footer-button-color:      #474747;
+$navbar-footer-height: 40px;
+$navbar-footer-link-color: mix(darken(#ffffff, 10), $brand-primary, 90%);
+$navbar-footer-link-color-hover: $gray-lighter;
+$navbar-footer-button-color: #474747;
 
 $navbar-mobile-height: 40px;
-
 
 // Misc variables originally only refrenced in bootstrap 3 stylesheets
 $grid-float-breakpoint: map-get($grid-breakpoints, "sm");
@@ -52,23 +51,23 @@ $checkbox-default-color: $call-to-action-mid;
 // -------------------------
 // Also see Bootstrap 5's own master list:
 // bootstrap5/scss/_variables.scss
-$zindexDashboardSpinner:              500;
-$zindexAccountingPricingTableHeader:  800;
+$zindexDashboardSpinner: 500;
+$zindexAccountingPricingTableHeader: 800;
 
 // Other Zindecies
-$zindex-select2-results:             1056;  // higher than $zindex-modal so select2s can be used in modals
-$zindex-hq-navigation:               1049;
-$zindex-cloudcare-debugger:          1040;
-$zindex-persistent-menu-nav:         1030;
-$zindex-persistent-menu-nav-arrow:   $zindex-persistent-menu-nav + 1;
-$zindex-navbar:                      1000;
-$zindex-app-preview:                  998;
-$zindex-navbar-cloudcare:             995;
-$zindex-persistent-tile-cloudcare:    993;
-$zindex-formplayer-progress:          990;
-$zindex-report-loading:               100;
-$zindex-formplayer-scroll-to-bottom:    5;
-$zindex-next-error:                     5;  // Above the sticky submit button
-$zindex-formplayer-anchored-submit:     4;
+$zindex-select2-results: 1056; // higher than $zindex-modal so select2s can be used in modals
+$zindex-hq-navigation: 1049;
+$zindex-cloudcare-debugger: 1040;
+$zindex-persistent-menu-nav: 1030;
+$zindex-persistent-menu-nav-arrow: $zindex-persistent-menu-nav + 1;
+$zindex-navbar: 1000;
+$zindex-app-preview: 998;
+$zindex-navbar-cloudcare: 995;
+$zindex-persistent-tile-cloudcare: 993;
+$zindex-formplayer-progress: 990;
+$zindex-report-loading: 100;
+$zindex-formplayer-scroll-to-bottom: 5;
+$zindex-next-error: 5; // Above the sticky submit button
+$zindex-formplayer-anchored-submit: 4;
 
-$cursor-disabled: 'not-allowed';
+$cursor-disabled: "not-allowed";

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables.style.diff.txt
@@ -4,10 +4,11 @@
 -@import "@{b3-import-variables}";
 -
 -// Nunito Sans is used on dimagi.com and embedded in hqwebapp/base.html
--@font-family-sans-serif: "Nunito Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+-@font-family-sans-serif: "Nunito Sans", "Helvetica Neue", Helvetica, Arial,
+-  sans-serif;
 -
--@font-size-base:  12px;
--@icon-font-path:  "../../bootstrap/fonts/";
+-@font-size-base: 12px;
+-@icon-font-path: "../../bootstrap/fonts/";
 +$prefix: bs;
 +
 +// Grid Containers
@@ -61,17 +62,17 @@
 +$badge-border-radius: .25em;
  
  // Main background & text
--@cc-bg:     #f2f2f1;
--@cc-text:   #1c2126;
+-@cc-bg: #f2f2f1;
+-@cc-text: #1c2126;
 +$cc-bg:     #f2f2f1;
 +$cc-text:   #1c2126;
  
  // Success
--@cc-att-pos-extra-hi:   #e3f1df;
--@cc-att-pos-hi:   #bbe5b3;
--@cc-att-pos-mid:  #4aba32;
--@cc-att-pos-low:  #118043;
--@cc-att-pos-extra-low:  #173630;
+-@cc-att-pos-extra-hi: #e3f1df;
+-@cc-att-pos-hi: #bbe5b3;
+-@cc-att-pos-mid: #4aba32;
+-@cc-att-pos-low: #118043;
+-@cc-att-pos-extra-low: #173630;
 +$cc-att-pos-extra-hi:   #e3f1df;
 +$cc-att-pos-hi:   #bbe5b3;
 +$cc-att-pos-mid:  #4aba32;
@@ -79,11 +80,11 @@
 +$cc-att-pos-extra-low:  #173630;
  
  // Error
--@cc-att-neg-extra-hi:   #fbeae6;
--@cc-att-neg-hi:   #fead9a;
--@cc-att-neg-mid:  #e73c27;
--@cc-att-neg-low:  #bf0712;
--@cc-att-neg-extra-low:  #340101;
+-@cc-att-neg-extra-hi: #fbeae6;
+-@cc-att-neg-hi: #fead9a;
+-@cc-att-neg-mid: #e73c27;
+-@cc-att-neg-low: #bf0712;
+-@cc-att-neg-extra-low: #340101;
 +$cc-att-neg-extra-hi:   #fbeae6;
 +$cc-att-neg-hi:   #fead9a;
 +$cc-att-neg-mid:  #e73c27;
@@ -91,11 +92,11 @@
 +$cc-att-neg-extra-low:  #340101;
  
  // Warning/Attention
--@cc-light-warm-accent-extra-hi:   #fcf2cd;
--@cc-light-warm-accent-hi:   #ffea8a;
--@cc-light-warm-accent-mid:  #eec200;
--@cc-light-warm-accent-low:  #9c6f19;
--@cc-light-warm-accent-extra-low:  #573b00;
+-@cc-light-warm-accent-extra-hi: #fcf2cd;
+-@cc-light-warm-accent-hi: #ffea8a;
+-@cc-light-warm-accent-mid: #eec200;
+-@cc-light-warm-accent-low: #9c6f19;
+-@cc-light-warm-accent-extra-low: #573b00;
 +$cc-light-warm-accent-extra-hi:   #fcf2cd;
 +$cc-light-warm-accent-hi:   #ffea8a;
 +$cc-light-warm-accent-mid:  #eec200;
@@ -115,73 +116,73 @@
 +$call-to-action-extra-low: #000639;
  
  // Accent light blue: buttons on dark backgrounds, occasional secondary buttons (upload/download)
--@cc-light-cool-accent-hi:   #ccf3f4;
--@cc-light-cool-accent-mid:  #00bdc5;
--@cc-light-cool-accent-low:  #00799a;
+-@cc-light-cool-accent-hi: #ccf3f4;
+-@cc-light-cool-accent-mid: #00bdc5;
+-@cc-light-cool-accent-low: #00799a;
 +$cc-light-cool-accent-hi:   #ccf3f4;
 +$cc-light-cool-accent-mid:  #00bdc5;
 +$cc-light-cool-accent-low:  #00799a;
  
  // Accent purples used in signup, which uses colors more like dimagi.com than HQ
--@color-purple-dark: #43467F;
--@color-purple-dark-inverse: #E3D0FF;
+-@color-purple-dark: #43467f;
+-@color-purple-dark-inverse: #e3d0ff;
 +$color-purple-dark: #43467F;
 +$color-purple-dark-inverse: #E3D0FF;
  
  // Neutrals used as borders/backgrounds
--@cc-neutral-hi:   #d6d6d4;
--@cc-neutral-mid:  #685c53;
--@cc-neutral-low:  #373534;
+-@cc-neutral-hi: #d6d6d4;
+-@cc-neutral-mid: #685c53;
+-@cc-neutral-low: #373534;
 +$cc-neutral-hi:   #d6d6d4;
 +$cc-neutral-mid:  #685c53;
 +$cc-neutral-low:  #373534;
  
  // Blues used for links and app manager accents
--@cc-brand-hi:   #bcdeff;
--@cc-brand-mid:  #004ebc;
--@cc-brand-low:  #002c5f;
+-@cc-brand-hi: #bcdeff;
+-@cc-brand-mid: #004ebc;
+-@cc-brand-low: #002c5f;
 -
 -// used in registration app only. will be merged into "brand" color Bootstrap 5 migration
--@commcare-blue:  #5D70D2;
+-@commcare-blue: #5d70d2;
 +$cc-brand-hi:   #bcdeff;
 +$cc-brand-mid:  #004ebc;
 +$cc-brand-low:  #002c5f;
  
  // Accent colors used in few places (billing, web apps, one-offs). Minimize usage.
--@cc-dark-cool-accent-hi:  #d6c5ea;
+-@cc-dark-cool-accent-hi: #d6c5ea;
 -@cc-dark-cool-accent-mid: #9060c8;
 -@cc-dark-cool-accent-low: #5d3f82;
 -
--@cc-dark-warm-accent-hi:  #ffe3c2;
+-@cc-dark-warm-accent-hi: #ffe3c2;
 -@cc-dark-warm-accent-mid: #ff8400;
 -@cc-dark-warm-accent-low: #994f00;
 -
 -// Main TWBS Colors
--@brand-primary:   @cc-brand-mid;
--@brand-success:   @cc-att-pos-mid;
--@brand-info:      @cc-light-cool-accent-mid;
--@brand-warning:   @cc-dark-warm-accent-mid;
--@brand-danger:    @cc-att-neg-mid;
+-@brand-primary: @cc-brand-mid;
+-@brand-success: @cc-att-pos-mid;
+-@brand-info: @cc-light-cool-accent-mid;
+-@brand-warning: @cc-dark-warm-accent-mid;
+-@brand-danger: @cc-att-neg-mid;
 -
 -@text-color: @cc-text;
 -
 -@link-hover-color: @cc-brand-low;
 -
--@btn-default-color:              @cc-text;
--@btn-default-bg:                 @cc-bg;
--@btn-default-border:             @cc-neutral-hi;
+-@btn-default-color: @cc-text;
+-@btn-default-bg: @cc-bg;
+-@btn-default-border: @cc-neutral-hi;
 -
--@navbar-height:                  60px;
--@navbar-padding-vertical:        ((@navbar-height - @line-height-computed) / 2);
--@navbar-default-bg:              @cc-bg;
+-@navbar-height: 60px;
+-@navbar-padding-vertical: ((@navbar-height - @line-height-computed) / 2);
+-@navbar-default-bg: @cc-bg;
 -
--@navbar-footer-height:            40px;
--@navbar-footer-link-color:        mix(darken(#ffffff, 10), @brand-primary, 90);
--@navbar-footer-link-color-hover:  @gray-lighter;
--@navbar-footer-button-color:      #474747;
+-@navbar-footer-height: 40px;
+-@navbar-footer-link-color: mix(darken(#ffffff, 10), @brand-primary, 90);
+-@navbar-footer-link-color-hover: @gray-lighter;
+-@navbar-footer-button-color: #474747;
 -
--@btn-footer-color:  #ffffff;
--@btn-footer-bg:     #474747;
+-@btn-footer-color: #ffffff;
+-@btn-footer-bg: #474747;
 -@btn-footer-border: #cccccc;
 -
 -@checkbox-default-color: @call-to-action-mid;
@@ -192,29 +193,28 @@
 -// -------------------------
 -// Also see Bootstrap 3's own master list:
 -// bootstrap/less/variables.less
--@zindexDashboardSpinner:              500;
--@zindexAccountingPricingTableHeader:  800;
+-@zindexDashboardSpinner: 500;
+-@zindexAccountingPricingTableHeader: 800;
 -
 -// Other Zindecies
--@zindex-hq-navigation:               1060;
--@zindex-select2-results:             1056;  // higher than $zindex-modal so select2s can be used in modals
--@zindex-cloudcare-debugger:          1040;
--@zindex-persistent-menu-nav:         1030;
--@zindex-persistent-menu-nav-arrow:   @zindex-persistent-menu-nav + 1;
--@zindex-navbar:                      1000;
--@zindex-app-preview:                  998;
--@zindex-navbar-cloudcare:             995;
--@zindex-persistent-tile-cloudcare:    993;
--@zindex-formplayer-progress:          990;
--@zindex-report-loading:               100;
--@zindex-formplayer-scroll-to-bottom:    5;
--@zindex-next-error:                     5;  // Above the sticky submit button
--@zindex-formplayer-anchored-submit:     4;
+-@zindex-select2-results: 1056; // higher than $zindex-modal so select2s can be used in modals
+-@zindex-hq-navigation: 1049; // lower than bootstrap's $zindex-modal-background
+-@zindex-cloudcare-debugger: 1040;
+-@zindex-persistent-menu-nav: 1030;
+-@zindex-persistent-menu-nav-arrow: @zindex-persistent-menu-nav + 1;
+-@zindex-navbar: 1000;
+-@zindex-app-preview: 998;
+-@zindex-navbar-cloudcare: 995;
+-@zindex-persistent-tile-cloudcare: 993;
+-@zindex-formplayer-progress: 990;
+-@zindex-report-loading: 100;
+-@zindex-formplayer-scroll-to-bottom: 5;
+-@zindex-next-error: 5; // Above the sticky submit button
+-@zindex-formplayer-anchored-submit: 4;
 -
--
--@input-border-radius-large:       5px;
--@input-color:                     #000;
--@cursor-disabled:                 'not-allowed';
+-@input-border-radius-large: 5px;
+-@input-color: #000;
+-@cursor-disabled: "not-allowed";
 +$cc-dark-cool-accent-hi:  #d6c5ea;
 +$cc-dark-cool-accent-mid: #9060c8;
 +$cc-dark-cool-accent-low: #5d3f82;

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables_bootstrap3.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/includes_variables._variables_bootstrap3.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,130 +1,74 @@
+@@ -1,130 +1,73 @@
 -@import "@{b3-import-variables}";
 +/*
 +These are Boostrap 3 variables that were carried over in the
@@ -10,7 +10,8 @@
 + */
  
 -// Nunito Sans is used on dimagi.com and embedded in hqwebapp/base.html
--@font-family-sans-serif: "Nunito Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+-@font-family-sans-serif: "Nunito Sans", "Helvetica Neue", Helvetica, Arial,
+-  sans-serif;
 +// V3 color references
 +$brand-primary: $primary;
 +$brand-success: $success;
@@ -18,48 +19,48 @@
 +$brand-warning: $warning;
 +$brand-danger: $danger;
  
--@font-size-base:  12px;
--@icon-font-path:  "../../bootstrap/fonts/";
+-@font-size-base: 12px;
+-@icon-font-path: "../../bootstrap/fonts/";
 +$text-color: $body-color;
  
 -// Main background & text
--@cc-bg:     #f2f2f1;
--@cc-text:   #1c2126;
+-@cc-bg: #f2f2f1;
+-@cc-text: #1c2126;
 +$gray-base: #000;
 +$gray: lighten($gray-base, 33.5%); // #555
 +$gray-light: lighten($gray-base, 46.7%); // #777
 +$gray-lighter: lighten($gray-base, 93.5%);
  
 -// Success
--@cc-att-pos-extra-hi:   #e3f1df;
--@cc-att-pos-hi:   #bbe5b3;
--@cc-att-pos-mid:  #4aba32;
--@cc-att-pos-low:  #118043;
--@cc-att-pos-extra-low:  #173630;
-+$btn-default-color:              $cc-text;
-+$btn-default-bg:                 $cc-bg;
-+$btn-default-border:             $cc-neutral-hi;
+-@cc-att-pos-extra-hi: #e3f1df;
+-@cc-att-pos-hi: #bbe5b3;
+-@cc-att-pos-mid: #4aba32;
+-@cc-att-pos-low: #118043;
+-@cc-att-pos-extra-low: #173630;
++$btn-default-color: $cc-text;
++$btn-default-bg: $cc-bg;
++$btn-default-border: $cc-neutral-hi;
  
 -// Error
--@cc-att-neg-extra-hi:   #fbeae6;
--@cc-att-neg-hi:   #fead9a;
--@cc-att-neg-mid:  #e73c27;
--@cc-att-neg-low:  #bf0712;
--@cc-att-neg-extra-low:  #340101;
-+$btn-footer-color:  #ffffff;
-+$btn-footer-bg:     #474747;
+-@cc-att-neg-extra-hi: #fbeae6;
+-@cc-att-neg-hi: #fead9a;
+-@cc-att-neg-mid: #e73c27;
+-@cc-att-neg-low: #bf0712;
+-@cc-att-neg-extra-low: #340101;
++$btn-footer-color: #ffffff;
++$btn-footer-bg: #474747;
 +$btn-footer-border: #cccccc;
  
 -// Warning/Attention
--@cc-light-warm-accent-extra-hi:   #fcf2cd;
--@cc-light-warm-accent-hi:   #ffea8a;
--@cc-light-warm-accent-mid:  #eec200;
--@cc-light-warm-accent-low:  #9c6f19;
--@cc-light-warm-accent-extra-low:  #573b00;
+-@cc-light-warm-accent-extra-hi: #fcf2cd;
+-@cc-light-warm-accent-hi: #ffea8a;
+-@cc-light-warm-accent-mid: #eec200;
+-@cc-light-warm-accent-low: #9c6f19;
+-@cc-light-warm-accent-extra-low: #573b00;
 +// Navigation Bar
-+$navbar-height:                  60px;
-+$navbar-padding-vertical:        calc(($navbar-height - 20px) / 2);
-+$navbar-default-bg:              $cc-bg;
++$navbar-height: 60px;
++$navbar-padding-vertical: calc(($navbar-height - 20px) / 2);
++$navbar-default-bg: $cc-bg;
  
 -// Call to action
 -@call-to-action-extra-hi: #f4f5fa;
@@ -67,74 +68,74 @@
 -@call-to-action-mid: #5c6ac5;
 -@call-to-action-low: #212f78;
 -@call-to-action-extra-low: #000639;
-+$navbar-footer-height:            40px;
-+$navbar-footer-link-color:        mix(darken(#ffffff, 10), $brand-primary, 90%);
-+$navbar-footer-link-color-hover:  $gray-lighter;
-+$navbar-footer-button-color:      #474747;
++$navbar-footer-height: 40px;
++$navbar-footer-link-color: mix(darken(#ffffff, 10), $brand-primary, 90%);
++$navbar-footer-link-color-hover: $gray-lighter;
++$navbar-footer-button-color: #474747;
  
 -// Accent light blue: buttons on dark backgrounds, occasional secondary buttons (upload/download)
--@cc-light-cool-accent-hi:   #ccf3f4;
--@cc-light-cool-accent-mid:  #00bdc5;
--@cc-light-cool-accent-low:  #00799a;
+-@cc-light-cool-accent-hi: #ccf3f4;
+-@cc-light-cool-accent-mid: #00bdc5;
+-@cc-light-cool-accent-low: #00799a;
 +$navbar-mobile-height: 40px;
  
 -// Accent purples used in signup, which uses colors more like dimagi.com than HQ
--@color-purple-dark: #43467F;
--@color-purple-dark-inverse: #E3D0FF;
- 
--// Neutrals used as borders/backgrounds
--@cc-neutral-hi:   #d6d6d4;
--@cc-neutral-mid:  #685c53;
--@cc-neutral-low:  #373534;
+-@color-purple-dark: #43467f;
+-@color-purple-dark-inverse: #e3d0ff;
 +// Misc variables originally only refrenced in bootstrap 3 stylesheets
 +$grid-float-breakpoint: map-get($grid-breakpoints, "sm");
 +$line-height-computed: 20px;
 +$border-radius-base: 4px;
 +$legend-border-color: #e5e5e5;
  
+-// Neutrals used as borders/backgrounds
+-@cc-neutral-hi: #d6d6d4;
+-@cc-neutral-mid: #685c53;
+-@cc-neutral-low: #373534;
+-
 -// Blues used for links and app manager accents
--@cc-brand-hi:   #bcdeff;
--@cc-brand-mid:  #004ebc;
--@cc-brand-low:  #002c5f;
+-@cc-brand-hi: #bcdeff;
+-@cc-brand-mid: #004ebc;
+-@cc-brand-low: #002c5f;
 -
 -// used in registration app only. will be merged into "brand" color Bootstrap 5 migration
--@commcare-blue:  #5D70D2;
+-@commcare-blue: #5d70d2;
 -
 -// Accent colors used in few places (billing, web apps, one-offs). Minimize usage.
--@cc-dark-cool-accent-hi:  #d6c5ea;
+-@cc-dark-cool-accent-hi: #d6c5ea;
 -@cc-dark-cool-accent-mid: #9060c8;
 -@cc-dark-cool-accent-low: #5d3f82;
 -
--@cc-dark-warm-accent-hi:  #ffe3c2;
+-@cc-dark-warm-accent-hi: #ffe3c2;
 -@cc-dark-warm-accent-mid: #ff8400;
 -@cc-dark-warm-accent-low: #994f00;
 -
 -// Main TWBS Colors
--@brand-primary:   @cc-brand-mid;
--@brand-success:   @cc-att-pos-mid;
--@brand-info:      @cc-light-cool-accent-mid;
--@brand-warning:   @cc-dark-warm-accent-mid;
--@brand-danger:    @cc-att-neg-mid;
+-@brand-primary: @cc-brand-mid;
+-@brand-success: @cc-att-pos-mid;
+-@brand-info: @cc-light-cool-accent-mid;
+-@brand-warning: @cc-dark-warm-accent-mid;
+-@brand-danger: @cc-att-neg-mid;
 -
 -@text-color: @cc-text;
 -
 -@link-hover-color: @cc-brand-low;
 -
--@btn-default-color:              @cc-text;
--@btn-default-bg:                 @cc-bg;
--@btn-default-border:             @cc-neutral-hi;
+-@btn-default-color: @cc-text;
+-@btn-default-bg: @cc-bg;
+-@btn-default-border: @cc-neutral-hi;
 -
--@navbar-height:                  60px;
--@navbar-padding-vertical:        ((@navbar-height - @line-height-computed) / 2);
--@navbar-default-bg:              @cc-bg;
+-@navbar-height: 60px;
+-@navbar-padding-vertical: ((@navbar-height - @line-height-computed) / 2);
+-@navbar-default-bg: @cc-bg;
 -
--@navbar-footer-height:            40px;
--@navbar-footer-link-color:        mix(darken(#ffffff, 10), @brand-primary, 90);
--@navbar-footer-link-color-hover:  @gray-lighter;
--@navbar-footer-button-color:      #474747;
+-@navbar-footer-height: 40px;
+-@navbar-footer-link-color: mix(darken(#ffffff, 10), @brand-primary, 90);
+-@navbar-footer-link-color-hover: @gray-lighter;
+-@navbar-footer-button-color: #474747;
 -
--@btn-footer-color:  #ffffff;
--@btn-footer-bg:     #474747;
+-@btn-footer-color: #ffffff;
+-@btn-footer-bg: #474747;
 -@btn-footer-border: #cccccc;
 -
 -@checkbox-default-color: @call-to-action-mid;
@@ -146,45 +147,44 @@
  // -------------------------
 -// Also see Bootstrap 3's own master list:
 -// bootstrap/less/variables.less
--@zindexDashboardSpinner:              500;
--@zindexAccountingPricingTableHeader:  800;
+-@zindexDashboardSpinner: 500;
+-@zindexAccountingPricingTableHeader: 800;
 +// Also see Bootstrap 5's own master list:
 +// bootstrap5/scss/_variables.scss
-+$zindexDashboardSpinner:              500;
-+$zindexAccountingPricingTableHeader:  800;
++$zindexDashboardSpinner: 500;
++$zindexAccountingPricingTableHeader: 800;
  
  // Other Zindecies
--@zindex-hq-navigation:               1060;
--@zindex-select2-results:             1056;  // higher than $zindex-modal so select2s can be used in modals
--@zindex-cloudcare-debugger:          1040;
--@zindex-persistent-menu-nav:         1030;
--@zindex-persistent-menu-nav-arrow:   @zindex-persistent-menu-nav + 1;
--@zindex-navbar:                      1000;
--@zindex-app-preview:                  998;
--@zindex-navbar-cloudcare:             995;
--@zindex-persistent-tile-cloudcare:    993;
--@zindex-formplayer-progress:          990;
--@zindex-report-loading:               100;
--@zindex-formplayer-scroll-to-bottom:    5;
--@zindex-next-error:                     5;  // Above the sticky submit button
--@zindex-formplayer-anchored-submit:     4;
-+$zindex-hq-navigation:               1060;
-+$zindex-select2-results:             1056;  // higher than $zindex-modal so select2s can be used in modals
-+$zindex-cloudcare-debugger:          1040;
-+$zindex-persistent-menu-nav:         1030;
-+$zindex-persistent-menu-nav-arrow:   $zindex-persistent-menu-nav + 1;
-+$zindex-navbar:                      1000;
-+$zindex-app-preview:                  998;
-+$zindex-navbar-cloudcare:             995;
-+$zindex-persistent-tile-cloudcare:    993;
-+$zindex-formplayer-progress:          990;
-+$zindex-report-loading:               100;
-+$zindex-formplayer-scroll-to-bottom:    5;
-+$zindex-next-error:                     5;  // Above the sticky submit button
-+$zindex-formplayer-anchored-submit:     4;
+-@zindex-select2-results: 1056; // higher than $zindex-modal so select2s can be used in modals
+-@zindex-hq-navigation: 1049; // lower than bootstrap's $zindex-modal-background
+-@zindex-cloudcare-debugger: 1040;
+-@zindex-persistent-menu-nav: 1030;
+-@zindex-persistent-menu-nav-arrow: @zindex-persistent-menu-nav + 1;
+-@zindex-navbar: 1000;
+-@zindex-app-preview: 998;
+-@zindex-navbar-cloudcare: 995;
+-@zindex-persistent-tile-cloudcare: 993;
+-@zindex-formplayer-progress: 990;
+-@zindex-report-loading: 100;
+-@zindex-formplayer-scroll-to-bottom: 5;
+-@zindex-next-error: 5; // Above the sticky submit button
+-@zindex-formplayer-anchored-submit: 4;
++$zindex-select2-results: 1056; // higher than $zindex-modal so select2s can be used in modals
++$zindex-hq-navigation: 1049;
++$zindex-cloudcare-debugger: 1040;
++$zindex-persistent-menu-nav: 1030;
++$zindex-persistent-menu-nav-arrow: $zindex-persistent-menu-nav + 1;
++$zindex-navbar: 1000;
++$zindex-app-preview: 998;
++$zindex-navbar-cloudcare: 995;
++$zindex-persistent-tile-cloudcare: 993;
++$zindex-formplayer-progress: 990;
++$zindex-report-loading: 100;
++$zindex-formplayer-scroll-to-bottom: 5;
++$zindex-next-error: 5; // Above the sticky submit button
++$zindex-formplayer-anchored-submit: 4;
  
--
--@input-border-radius-large:       5px;
--@input-color:                     #000;
--@cursor-disabled:                 'not-allowed';
-+$cursor-disabled: 'not-allowed';
+-@input-border-radius-large: 5px;
+-@input-color: #000;
+-@cursor-disabled: "not-allowed";
++$cursor-disabled: "not-allowed";


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This PR fixes a bug where the help message is blocked by the navigation menu on web apps.

Before:
<img width="890" height="255" alt="Screenshot 2025-09-25 at 12 44 48 AM" src="https://github.com/user-attachments/assets/8925e2c4-94ff-48cb-b1f5-c7739b6c5a56" />

After:
<img width="1014" height="253" alt="Screenshot 2025-09-25 at 4 53 01 AM" src="https://github.com/user-attachments/assets/7d25c25c-ed67-4e54-a565-af1365ccd8b6" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-6272](https://dimagi.atlassian.net/browse/USH-6272)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested. Also will test on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no automated test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[USH-6272]: https://dimagi.atlassian.net/browse/USH-6272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ