### PR TITLE
Stop using APIs deprectated in Django 5+

### DIFF
--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -18,6 +18,7 @@ from django.http import (
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_noop
 from django.views.generic import View
@@ -1327,7 +1328,7 @@ class TriggerRemovedSsoUserAutoDeactivationView(BaseTriggerAccountingTestView):
             auto_deactivate_removed_sso_users()
             messages.success(
                 request,
-                format_html(
+                mark_safe(  # nosec: no user input
                     'Successfully triggered auto deactivation of web users'
                 )
             )

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -149,7 +149,7 @@ def _process_spreadsheet_columns(spreadsheet, max_columns=None):
             'uence.dimagi.com/display/commcarepublic/Case+Configuration">case '
             'property names</a>. They must start with a letter, and can only '
             'contain letters, numbers and underscores. Please update the '
-            'following: {}.').format(', '.join(invalid_column_names)))
+            'following: {}.'), ', '.join(invalid_column_names))
         raise ImporterRawError(error_message)
 
     if row_count == 0:

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -10,7 +10,7 @@ from django.template.base import Variable, VariableDoesNotExist
 from django.template.loader import render_to_string
 from django.templatetags import i18n
 from django.urls import reverse
-from django.utils.html import conditional_escape, format_html
+from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
@@ -395,9 +395,11 @@ def chevron(value):
     Displays a green up chevron if value > 0, and a red down chevron if value < 0
     """
     if value > 0:
-        return format_html('<span class="fa fa-chevron-up" style="color: #006400;"></span>')
+        return mark_safe(  # nosec: no user input
+            '<span class="fa fa-chevron-up" style="color: #006400;"></span>')
     elif value < 0:
-        return format_html('<span class="fa fa-chevron-down" style="color: #8b0000;"> </span>')
+        return mark_safe(  # nosec: no user input
+            '<span class="fa fa-chevron-down" style="color: #8b0000;"> </span>')
     else:
         return ''
 

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -125,11 +125,12 @@ def _to_html(val, key=None, level=0):
             fmt = USER_DATE_FORMAT
 
         iso = val.isoformat()
-        ret = format_html("<time title='{title}' datetime='{iso}'>{display}</time>".format(
+        ret = format_html(
+            "<time title='{title}' datetime='{iso}'>{display}</time>",
             title=iso,
             iso=iso,
             display=safe_strftime(val, fmt)
-        ))
+        )
     else:
         if val is None:
             val = '---'

--- a/corehq/apps/hqwebapp/tests/utils/test_translation.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_translation.py
@@ -65,15 +65,6 @@ class TestLazyMarkSafe(SimpleTestCase):
 
 
 class TestLazyFormatHTML(SimpleTestCase):
-    @custom_translations({'Translate Me': 'Translated'})
-    def test_no_params(self):
-        translation_promise = format_html_lazy(gettext_lazy('Translate Me'))
-
-        with translation.override(CUSTOM_LANGUAGE):
-            translated = str(translation_promise)
-
-        self.assertEqual(translated, 'Translated')
-
     @custom_translations({'Format {}': 'Translated {} Format'})
     def test_with_params(self):
         translation_promise = format_html_lazy(gettext_lazy('Format {}'), 'Success')

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -273,7 +273,7 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
                 "cases which are assigned to a Case Sharing Group/Location. To learn "
                 "more about Case Sharing click "
                 "<a href='{}' target='blank'>here</a>."
-            ).format(help_link))
+            ), help_link)
 
     _default_landmarks = [30, 60, 90]
 

--- a/corehq/apps/reports/standard/users/reports.py
+++ b/corehq/apps/reports/standard/users/reports.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.html import format_html
+from django.utils.html import conditional_escape, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
@@ -232,13 +232,13 @@ class UserHistoryReport(GetParamsMixin, DatespanMixin, GenericTabularReport, Pro
                 if isinstance(value, dict):
                     value = self._html_list(value)
                 elif isinstance(value, list):
-                    value = format_html(", ".join(value))
+                    value = format_html_join(", ", "{}", ((v,) for v in value))
                 else:
-                    value = format_html(str(value))
+                    value = conditional_escape(value)
                 items.append("<li>{}: {}</li>".format(key, value))
         elif isinstance(changes, list):
-            items = ["<li>{}</li>".format(format_html(change)) for change in changes]
-        return mark_safe(f"<ul class='list-unstyled'>{''.join(items)}</ul>")
+            items = format_html_join("", "<li>{}</li>", ((c,) for c in changes))
+        return mark_safe(f"<ul class='list-unstyled'>{items}</ul>")  # nosec: items sanitized
 
     def _user_history_details_cell(self, changes, domain, for_export):
         properties = UserHistoryReport.get_primary_properties(domain)

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -10,6 +10,7 @@ from django.core.validators import EmailValidator, validate_email
 from django.template.loader import get_template, render_to_string
 from django.urls import reverse
 from django.utils.functional import cached_property
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, gettext_noop
 
@@ -534,7 +535,7 @@ class SetUserPasswordForm(SetPasswordForm):
 
         if self.project.strong_mobile_passwords:
             self.fields['new_password1'].widget = forms.TextInput()
-            self.fields['new_password1'].help_text = format_html_lazy(
+            self.fields['new_password1'].help_text = mark_safe(  # nosec: no user input
                 '<span id="help_text" data-bind="html: passwordHelp, css: color, click: firstSuggestion">')
             initial_password = generate_strong_password()
 

--- a/corehq/motech/repeaters/views/repeat_record_display.py
+++ b/corehq/motech/repeaters/views/repeat_record_display.py
@@ -56,7 +56,7 @@ class RepeatRecordDisplay:
     @property
     def state(self):
         label_cls, label_text = _get_state_tuple(self.record)
-        return format_html(f'<span class="label label-{label_cls}">{label_text}</span>')
+        return format_html('<span class="label label-{}">{}</span>', label_cls, label_text)
 
     def _format_date(self, date):
         if not date:


### PR DESCRIPTION
- Avoid accessing a private attribute whose implementation has changed in Django 5+.
- Adjust deprecated usage of `format_html()` without args or kwargs.

:blowfish: Review by commit.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story

Changes are either very simple and easy to validate correctness or affect test code only.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations. It may be necessary to ignore some deprecation warnings if it is rolled back after the Django 5.2 upgrade.