### PR TITLE
Add customer UI to enable or disable auto renew for a subscription

### DIFF
--- a/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
@@ -1,7 +1,6 @@
 {% extends "hqwebapp/bootstrap3/base_section.html" %}
 {% load hq_shared_tags %}
 {% load i18n %}
-
 {% js_entry_b3 'domain/js/current_subscription' %}
 
 {% block page_content %}
@@ -33,17 +32,24 @@
                   {{ plan.name }}
                 {% endif %}
               </h4>
-              <p><i class="fa fa-info-circle"></i>
+              <p>
+                <i class="fa fa-info-circle"></i>
                 {% if plan.is_paused %}
                   {% blocktrans with date_paused=plan.date_start pe=plan.previous_subscription_edition %}
-                    Your {{ pe }} Edition subscription was paused on {{ date_paused }}. Please subscribe to a plan to gain access to your project again.
+                    Your {{ pe }} Edition subscription was paused on
+                    {{ date_paused }}. Please subscribe to a plan to gain access
+                    to your project again.
                   {% endblocktrans %}
                 {% elif plan.is_trial %}
                   {% blocktrans with pn=plan.name trial_length=plan.trial_length %}
-                    The {{ trial_length }} Day Trial includes all the features present in the
-                    {{ pn }} Software Plan, which is our full set of features.
+                    The {{ trial_length }} Day Trial includes all the features
+                    present in the {{ pn }} Software Plan, which is our full set
+                    of features.
                   {% endblocktrans %}
-                {% else %}{{ plan.description|safe }}{% endif %}</p>
+                {% else %}
+                  {{ plan.description|safe }}
+                {% endif %}
+              </p>
             </div>
             {% if plan.do_not_invoice and not plan.is_paused %}
               <div class="alert alert-info">
@@ -56,13 +62,17 @@
               {% if plan.is_annual_plan and not plan.upgrade_available %}
                 <div style="margin-top: 10px;">
                   {% trans "Questions about your plan?" %}
-                  <a
-                    href="{% url "annual_plan_request_quote" domain %}"
-                  >{% trans "Contact us" %}</a>.
+                  <a href="{% url "annual_plan_request_quote" domain %}"
+                    >{% trans "Contact us" %}</a
+                  >.
                 </div>
               {% else %}
                 <p>
-                  <a class="btn btn-primary" style="margin-top:10px;" href="{{ change_plan_url }}">
+                  <a
+                    class="btn btn-primary"
+                    style="margin-top:10px;"
+                    href="{{ change_plan_url }}"
+                  >
                     {% if plan.is_paused %}
                       {% trans "Subscribe to Plan" %}
                     {% elif plan.is_annual_plan and plan.upgrade_available %}
@@ -96,7 +106,9 @@
         {% if not plan.is_trial and not plan.is_paused %}
           {% if plan.date_start %}
             <div class="form-group">
-              <label class="control-label col-sm-2">{% trans 'Date Started' %}</label>
+              <label class="control-label col-sm-2"
+                >{% trans 'Date Started' %}</label
+              >
               <div class="col-sm-10">
                 <p class="form-control-text">{{ plan.date_start }}</p>
               </div>
@@ -104,7 +116,9 @@
           {% endif %}
           {% if plan.date_end %}
             <div class="form-group">
-              <label class="control-label col-sm-2">{% trans 'Date Ending' %}</label>
+              <label class="control-label col-sm-2"
+                >{% trans 'Date Ending' %}</label
+              >
               <div class="col-sm-10">
                 <p class="form-control-text">{{ plan.date_end }}</p>
                 {% if plan.is_auto_renew %}
@@ -121,8 +135,10 @@
                   </div>
                 {% endif %}
                 {% if plan.next_subscription.can_renew %}
-                  <a href="{{ plan.next_subscription.renew_url }}"
-                     class="btn btn-primary">
+                  <a
+                    href="{{ plan.next_subscription.renew_url }}"
+                    class="btn btn-primary"
+                  >
                     {% trans "Renew Now" %}
                   </a>
                 {% endif %}
@@ -145,10 +161,11 @@
           {% endif %}
           <div data-bind="foreach: products">
             <div class="form-group">
-              <label class="control-label col-sm-2">{% trans 'Current Price' %}</label>
+              <label class="control-label col-sm-2"
+                >{% trans 'Current Price' %}</label
+              >
               <div class="col-sm-10">
-                <p class="form-control-text"
-                   data-bind="text: monthlyFee"></p>
+                <p class="form-control-text" data-bind="text: monthlyFee"></p>
               </div>
             </div>
           </div>
@@ -169,9 +186,7 @@
               {% trans "Next Subscription Plan" %}
             </label>
             <div class="col-sm-10">
-              <p class="form-control-text">
-                {{ plan.next_subscription.name }}
-              </p>
+              <p class="form-control-text">{{ plan.next_subscription.name }}</p>
             </div>
           </div>
           <div class="form-group">
@@ -211,7 +226,9 @@
                 {% endif %}
               </label>
               <div class="col-sm-10">
-                <p class="form-control-text js-general-credit">{{ plan.general_credit.amount }}</p>
+                <p class="form-control-text js-general-credit">
+                  {{ plan.general_credit.amount }}
+                </p>
               </div>
             </div>
           {% endif %}
@@ -219,25 +236,29 @@
             <div class="form-group">
               <div class="col-sm-10 col-sm-offset-2">
                 {% if can_purchase_credits %}
-                  <button type="button"
-                          class="btn btn-primary"
-                          data-toggle="modal"
-                          data-target="#paymentModal"
-                          data-bind="click: function(){triggerPayment($root.paymentHandler.CREDIT_CARD)}">
+                  <button
+                    type="button"
+                    class="btn btn-primary"
+                    data-toggle="modal"
+                    data-target="#paymentModal"
+                    data-bind="click: function(){triggerPayment($root.paymentHandler.CREDIT_CARD)}"
+                  >
                     {% trans 'Prepay by Credit Card' %}
                   </button>
-                  <button type="button"
-                          class="btn btn-default"
-                          data-toggle="modal"
-                          data-target="#paymentModal"
-                          data-bind="click: function(){triggerPayment($root.paymentHandler.WIRE)}">
+                  <button
+                    type="button"
+                    class="btn btn-default"
+                    data-toggle="modal"
+                    data-target="#paymentModal"
+                    data-bind="click: function(){triggerPayment($root.paymentHandler.WIRE)}"
+                  >
                     {% trans 'Generate Prepayment Invoice' %}
                   </button>
                 {% else %}
                   <span class="label label-default">
-                                        <i class="fa fa-info-circle"></i>
-                                        {% trans "Not Billing Admin, Can't Add Credit" %}
-                                    </span>
+                    <i class="fa fa-info-circle"></i>
+                    {% trans "Not Billing Admin, Can't Add Credit" %}
+                  </span>
                 {% endif %}
               </div>
             </div>
@@ -251,18 +272,23 @@
                 <label class="control-label col-sm-2">
                   {% trans 'Plan Credit' %}
                   <div class="hq-help">
-                    <a href="#"
-                       data-content="This is credit that can be applied to your software plan.
-                                            It's likely that someone from Dimagi added these credits for you."
-                       data-title="Account Plan Credit"
-                       data-original-title=""
-                       title="">
+                    <a
+                      href="#"
+                      data-content="This is credit that can be applied to your software plan.
+                                    It's likely that someone from Dimagi added these credits for you."
+                      data-title="Account Plan Credit"
+                      data-original-title=""
+                      title=""
+                    >
                       <i class="fa fa-question-circle"></i>
                     </a>
                   </div>
                 </label>
                 <div class="col-sm-10">
-                  <p class="form-control-text" data-bind="text: accountAmount"></p>
+                  <p
+                    class="form-control-text"
+                    data-bind="text: accountAmount"
+                  ></p>
                 </div>
               </div>
             </div>
@@ -271,19 +297,23 @@
                 <label class="control-label col-sm-2">
                   {% trans 'General Credit' %}
                   <div class="hq-help">
-                    <a href="#"
-                       data-content="This is credit that can be applied to either your software
-                                            plan or the features below. It's likely that someone from Dimagi added
-                                            these credits for you."
-                       data-title="Account General Credit"
-                       data-original-title=""
-                       title="">
+                    <a
+                      href="#"
+                      data-content="This is credit that can be applied to either your software
+                                    plan or the features below. It's likely that someone from Dimagi added
+                                    these credits for you."
+                      data-title="Account General Credit"
+                      data-original-title=""
+                      title=""
+                    >
                       <i class="fa fa-question-circle"></i>
                     </a>
                   </div>
                 </label>
                 <div class="col-sm-10">
-                  <p class="form-control-text">{{ plan.account_general_credit.amount }}</p>
+                  <p class="form-control-text">
+                    {{ plan.account_general_credit.amount }}
+                  </p>
                 </div>
               </div>
             {% endif %}
@@ -294,49 +324,49 @@
           {% if plan.has_credits_in_non_general_credit_line %}
             <table class="table table-bordered table-striped">
               <thead>
-              <tr>
-                <th>{% trans "Feature" %}</th>
-                <th>{% trans "Current Use" %}</th>
-                <th>{% trans "Remaining" %}</th>
-                <th>{% trans "Credits Available" %}</th>
-                {% if show_account_credits %}
-                  <th>{% trans "Account Credits Available" %}</th>
-                {% endif %}
-              </tr>
+                <tr>
+                  <th>{% trans "Feature" %}</th>
+                  <th>{% trans "Current Use" %}</th>
+                  <th>{% trans "Remaining" %}</th>
+                  <th>{% trans "Credits Available" %}</th>
+                  {% if show_account_credits %}
+                    <th>{% trans "Account Credits Available" %}</th>
+                  {% endif %}
+                </tr>
               </thead>
               <tbody data-bind="foreach: features">
-              <tr>
-                <td data-bind="text: name"></td>
-                <td data-bind="text: usage"></td>
-                <td data-bind="text: remaining"></td>
-                <td data-bind="text: amount"></td>
-                {% if show_account_credits %}
-                  <td data-bind="text: accountAmount"></td>
-                {% endif %}
-              </tr>
+                <tr>
+                  <td data-bind="text: name"></td>
+                  <td data-bind="text: usage"></td>
+                  <td data-bind="text: remaining"></td>
+                  <td data-bind="text: amount"></td>
+                  {% if show_account_credits %}
+                    <td data-bind="text: accountAmount"></td>
+                  {% endif %}
+                </tr>
               </tbody>
             </table>
           {% else %}
             <table class="table table-bordered table-striped">
               <thead>
-              <tr>
-                <th>{% trans "Feature" %}</th>
-                <th>{% trans "Included in Software Plan" %}</th>
-                <th>{% trans "Current Usage" %}</th>
-                {% if show_account_credits %}
-                  <th>{% trans "Account Credits Available" %}</th>
-                {% endif %}
-              </tr>
+                <tr>
+                  <th>{% trans "Feature" %}</th>
+                  <th>{% trans "Included in Software Plan" %}</th>
+                  <th>{% trans "Current Usage" %}</th>
+                  {% if show_account_credits %}
+                    <th>{% trans "Account Credits Available" %}</th>
+                  {% endif %}
+                </tr>
               </thead>
               <tbody data-bind="foreach: features">
-              <tr>
-                <td data-bind="text: name"></td>
-                <td data-bind="text: limit"></td>
-                <td data-bind="text: usage"></td>
-                {% if show_account_credits %}
-                  <td data-bind="text: accountAmount"></td>
-                {% endif %}
-              </tr>
+                <tr>
+                  <td data-bind="text: name"></td>
+                  <td data-bind="text: limit"></td>
+                  <td data-bind="text: usage"></td>
+                  {% if show_account_credits %}
+                    <td data-bind="text: accountAmount"></td>
+                  {% endif %}
+                </tr>
               </tbody>
             </table>
           {% endif %}
@@ -346,10 +376,10 @@
   </div>
 
   {% include 'accounting/partials/stripe_card_ko_template.html' %}
-
 {% endblock %}
 
-{% block modals %}{{ block.super }}
+{% block modals %}
+  {{ block.super }}
   {% include 'domain/partials/bootstrap3/payment_modal.html' with payment_modal_id="paymentModal" title_template="payment-method-modal-title" cost_item_template="cost-item-template" payment_complete_template="payment-complete-template" %}
   {% if can_set_auto_renew %}
     {% include 'domain/partials/bootstrap3/auto_renew_modal.html' %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
@@ -113,6 +113,20 @@
                     {% trans "Renew Plan" %}
                   </a>
                 {% endif %}
+                {% if can_set_auto_renew %}
+                  <button
+                    type="button"
+                    class="btn btn-default"
+                    data-toggle="modal"
+                    data-target="#auto-renew-modal"
+                  >
+                    {% if plan.is_auto_renew %}
+                      {% trans "Disable Auto Renewal" %}
+                    {% else %}
+                      {% trans "Enable Auto Renewal" %}
+                    {% endif %}
+                  </button>
+                {% endif %}
               </div>
             </div>
           {% endif %}
@@ -324,4 +338,7 @@
 
 {% block modals %}{{ block.super }}
   {% include 'domain/partials/bootstrap3/payment_modal.html' with payment_modal_id="paymentModal" title_template="payment-method-modal-title" cost_item_template="cost-item-template" payment_complete_template="payment-complete-template" %}
+  {% if can_set_auto_renew %}
+    {% include 'domain/partials/bootstrap3/auto_renew_modal.html' %}
+  {% endif %}
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
@@ -107,10 +107,23 @@
               <label class="control-label col-sm-2">{% trans 'Date Ending' %}</label>
               <div class="col-sm-10">
                 <p class="form-control-text">{{ plan.date_end }}</p>
+                {% if plan.is_auto_renew %}
+                  <div class="alert alert-success">
+                    {% blocktrans %}
+                      Your subscription will automatically renew.
+                    {% endblocktrans %}
+                  </div>
+                {% elif plan.next_subscription.can_renew %}
+                  <div class="alert alert-info">
+                    {% blocktrans with days_left=plan.days_left %}
+                      Your subscription will end in {{ days_left }} days.
+                    {% endblocktrans %}
+                  </div>
+                {% endif %}
                 {% if plan.next_subscription.can_renew %}
                   <a href="{{ plan.next_subscription.renew_url }}"
                      class="btn btn-primary">
-                    {% trans "Renew Plan" %}
+                    {% trans "Renew Now" %}
                   </a>
                 {% endif %}
                 {% if can_set_auto_renew %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
@@ -107,10 +107,23 @@
               <label class="form-label col-md-2">{% trans 'Date Ending' %}</label>
               <div class="col-md-10">
                 <p class="form-control-text">{{ plan.date_end }}</p>
+                {% if plan.is_auto_renew %}
+                  <div class="alert alert-success">
+                    {% blocktrans %}
+                      Your subscription will automatically renew.
+                    {% endblocktrans %}
+                  </div>
+                {% elif plan.next_subscription.can_renew %}
+                  <div class="alert alert-info">
+                    {% blocktrans with days_left=plan.days_left %}
+                      Your subscription will end in {{ days_left }} days.
+                    {% endblocktrans %}
+                  </div>
+                {% endif %}
                 {% if plan.next_subscription.can_renew %}
                   <a href="{{ plan.next_subscription.renew_url }}"
                      class="btn btn-primary">
-                    {% trans "Renew Plan" %}
+                    {% trans "Renew Now" %}
                   </a>
                 {% endif %}
                 {% if can_set_auto_renew %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
@@ -113,6 +113,20 @@
                     {% trans "Renew Plan" %}
                   </a>
                 {% endif %}
+                {% if can_set_auto_renew %}
+                  <button
+                    type="button"
+                    class="btn btn-default"
+                    data-bs-toggle="modal"
+                    data-bs-target="#auto-renew-modal"
+                  >
+                    {% if plan.is_auto_renew %}
+                      {% trans "Disable Auto Renewal" %}
+                    {% else %}
+                      {% trans "Enable Auto Renewal" %}
+                    {% endif %}
+                  </button>
+                {% endif %}
               </div>
             </div>
           {% endif %}
@@ -324,4 +338,7 @@
 
 {% block modals %}{{ block.super }}
   {% include 'domain/partials/bootstrap5/payment_modal.html' with payment_modal_id="paymentModal" title_template="payment-method-modal-title" cost_item_template="cost-item-template" payment_complete_template="payment-complete-template" %}
+  {% if can_set_auto_renew %}
+    {% include 'domain/partials/bootstrap5/auto_renew_modal.html' %}
+  {% endif %}
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
@@ -1,7 +1,6 @@
 {% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load hq_shared_tags %}
 {% load i18n %}
-
 {% js_entry 'domain/js/current_subscription' %}
 
 {% block page_content %}
@@ -33,17 +32,24 @@
                   {{ plan.name }}
                 {% endif %}
               </h4>
-              <p><i class="fa fa-info-circle"></i>
+              <p>
+                <i class="fa fa-info-circle"></i>
                 {% if plan.is_paused %}
                   {% blocktrans with date_paused=plan.date_start pe=plan.previous_subscription_edition %}
-                    Your {{ pe }} Edition subscription was paused on {{ date_paused }}. Please subscribe to a plan to gain access to your project again.
+                    Your {{ pe }} Edition subscription was paused on
+                    {{ date_paused }}. Please subscribe to a plan to gain access
+                    to your project again.
                   {% endblocktrans %}
                 {% elif plan.is_trial %}
                   {% blocktrans with pn=plan.name trial_length=plan.trial_length %}
-                    The {{ trial_length }} Day Trial includes all the features present in the
-                    {{ pn }} Software Plan, which is our full set of features.
+                    The {{ trial_length }} Day Trial includes all the features
+                    present in the {{ pn }} Software Plan, which is our full set
+                    of features.
                   {% endblocktrans %}
-                {% else %}{{ plan.description|safe }}{% endif %}</p>
+                {% else %}
+                  {{ plan.description|safe }}
+                {% endif %}
+              </p>
             </div>
             {% if plan.do_not_invoice and not plan.is_paused %}
               <div class="alert alert-info">
@@ -56,9 +62,9 @@
               {% if plan.is_annual_plan and not plan.upgrade_available %}
                 <div class="mt-3">
                   {% trans "Questions about your plan?" %}
-                  <a
-                    href="{% url "annual_plan_request_quote" domain %}"
-                  >{% trans "Contact us" %}</a>.
+                  <a href="{% url "annual_plan_request_quote" domain %}"
+                    >{% trans "Contact us" %}</a
+                  >.
                 </div>
               {% else %}
                 <p>
@@ -96,7 +102,9 @@
         {% if not plan.is_trial and not plan.is_paused %}
           {% if plan.date_start %}
             <div class="form-group">  {# todo B5: css-form-group #}
-              <label class="form-label col-md-2">{% trans 'Date Started' %}</label>
+              <label class="form-label col-md-2"
+                >{% trans 'Date Started' %}</label
+              >
               <div class="col-md-10">
                 <p class="form-control-text">{{ plan.date_start }}</p>
               </div>
@@ -104,7 +112,9 @@
           {% endif %}
           {% if plan.date_end %}
             <div class="form-group">  {# todo B5: css-form-group #}
-              <label class="form-label col-md-2">{% trans 'Date Ending' %}</label>
+              <label class="form-label col-md-2"
+                >{% trans 'Date Ending' %}</label
+              >
               <div class="col-md-10">
                 <p class="form-control-text">{{ plan.date_end }}</p>
                 {% if plan.is_auto_renew %}
@@ -121,8 +131,10 @@
                   </div>
                 {% endif %}
                 {% if plan.next_subscription.can_renew %}
-                  <a href="{{ plan.next_subscription.renew_url }}"
-                     class="btn btn-primary">
+                  <a
+                    href="{{ plan.next_subscription.renew_url }}"
+                    class="btn btn-primary"
+                  >
                     {% trans "Renew Now" %}
                   </a>
                 {% endif %}
@@ -145,10 +157,11 @@
           {% endif %}
           <div data-bind="foreach: products">
             <div class="form-group">  {# todo B5: css-form-group #}
-              <label class="form-label col-md-2">{% trans 'Current Price' %}</label>
+              <label class="form-label col-md-2"
+                >{% trans 'Current Price' %}</label
+              >
               <div class="col-md-10">
-                <p class="form-control-text"
-                   data-bind="text: monthlyFee"></p>
+                <p class="form-control-text" data-bind="text: monthlyFee"></p>
               </div>
             </div>
           </div>
@@ -169,9 +182,7 @@
               {% trans "Next Subscription Plan" %}
             </label>
             <div class="col-md-10">
-              <p class="form-control-text">
-                {{ plan.next_subscription.name }}
-              </p>
+              <p class="form-control-text">{{ plan.next_subscription.name }}</p>
             </div>
           </div>
           <div class="form-group">  {# todo B5: css-form-group #}
@@ -211,7 +222,9 @@
                 {% endif %}
               </label>
               <div class="col-md-10">
-                <p class="form-control-text js-general-credit">{{ plan.general_credit.amount }}</p>
+                <p class="form-control-text js-general-credit">
+                  {{ plan.general_credit.amount }}
+                </p>
               </div>
             </div>
           {% endif %}
@@ -219,25 +232,29 @@
             <div class="form-group">  {# todo B5: css-form-group #}
               <div class="col-md-10 offset-md-2">
                 {% if can_purchase_credits %}
-                  <button type="button"
-                          class="btn btn-primary"
-                          data-bs-toggle="modal"
-                          data-bs-target="#paymentModal"
-                          data-bind="click: function(){triggerPayment($root.paymentHandler.CREDIT_CARD)}">
+                  <button
+                    type="button"
+                    class="btn btn-primary"
+                    data-bs-toggle="modal"
+                    data-bs-target="#paymentModal"
+                    data-bind="click: function(){triggerPayment($root.paymentHandler.CREDIT_CARD)}"
+                  >
                     {% trans 'Prepay by Credit Card' %}
                   </button>
-                  <button type="button"
-                          class="btn btn-outline-primary"
-                          data-bs-toggle="modal"
-                          data-bs-target="#paymentModal"
-                          data-bind="click: function(){triggerPayment($root.paymentHandler.WIRE)}">
+                  <button
+                    type="button"
+                    class="btn btn-outline-primary"
+                    data-bs-toggle="modal"
+                    data-bs-target="#paymentModal"
+                    data-bind="click: function(){triggerPayment($root.paymentHandler.WIRE)}"
+                  >
                     {% trans 'Generate Prepayment Invoice' %}
                   </button>
                 {% else %}
                   <span class="badge text-bg-secondary">
-                                        <i class="fa fa-info-circle"></i>
-                                        {% trans "Not Billing Admin, Can't Add Credit" %}
-                                    </span>
+                    <i class="fa fa-info-circle"></i>
+                    {% trans "Not Billing Admin, Can't Add Credit" %}
+                  </span>
                 {% endif %}
               </div>
             </div>
@@ -251,18 +268,23 @@
                 <label class="form-label col-md-2">
                   {% trans 'Plan Credit' %}
                   <div class="hq-help">
-                    <a href="#"
-                       data-content="This is credit that can be applied to your software plan.
-                                            It's likely that someone from Dimagi added these credits for you."
-                       data-title="Account Plan Credit"
-                       data-original-title=""
-                       title="">
+                    <a
+                      href="#"
+                      data-content="This is credit that can be applied to your software plan.
+                                    It's likely that someone from Dimagi added these credits for you."
+                      data-title="Account Plan Credit"
+                      data-original-title=""
+                      title=""
+                    >
                       <i class="fa fa-question-circle"></i>
                     </a>
                   </div>
                 </label>
                 <div class="col-md-10">
-                  <p class="form-control-text" data-bind="text: accountAmount"></p>
+                  <p
+                    class="form-control-text"
+                    data-bind="text: accountAmount"
+                  ></p>
                 </div>
               </div>
             </div>
@@ -271,19 +293,23 @@
                 <label class="form-label col-md-2">
                   {% trans 'General Credit' %}
                   <div class="hq-help">
-                    <a href="#"
-                       data-content="This is credit that can be applied to either your software
-                                            plan or the features below. It's likely that someone from Dimagi added
-                                            these credits for you."
-                       data-title="Account General Credit"
-                       data-original-title=""
-                       title="">
+                    <a
+                      href="#"
+                      data-content="This is credit that can be applied to either your software
+                                    plan or the features below. It's likely that someone from Dimagi added
+                                    these credits for you."
+                      data-title="Account General Credit"
+                      data-original-title=""
+                      title=""
+                    >
                       <i class="fa fa-question-circle"></i>
                     </a>
                   </div>
                 </label>
                 <div class="col-md-10">
-                  <p class="form-control-text">{{ plan.account_general_credit.amount }}</p>
+                  <p class="form-control-text">
+                    {{ plan.account_general_credit.amount }}
+                  </p>
                 </div>
               </div>
             {% endif %}
@@ -294,49 +320,49 @@
           {% if plan.has_credits_in_non_general_credit_line %}
             <table class="table table-bordered table-striped">
               <thead>
-              <tr>
-                <th>{% trans "Feature" %}</th>
-                <th>{% trans "Current Use" %}</th>
-                <th>{% trans "Remaining" %}</th>
-                <th>{% trans "Credits Available" %}</th>
-                {% if show_account_credits %}
-                  <th>{% trans "Account Credits Available" %}</th>
-                {% endif %}
-              </tr>
+                <tr>
+                  <th>{% trans "Feature" %}</th>
+                  <th>{% trans "Current Use" %}</th>
+                  <th>{% trans "Remaining" %}</th>
+                  <th>{% trans "Credits Available" %}</th>
+                  {% if show_account_credits %}
+                    <th>{% trans "Account Credits Available" %}</th>
+                  {% endif %}
+                </tr>
               </thead>
               <tbody data-bind="foreach: features">
-              <tr>
-                <td data-bind="text: name"></td>
-                <td data-bind="text: usage"></td>
-                <td data-bind="text: remaining"></td>
-                <td data-bind="text: amount"></td>
-                {% if show_account_credits %}
-                  <td data-bind="text: accountAmount"></td>
-                {% endif %}
-              </tr>
+                <tr>
+                  <td data-bind="text: name"></td>
+                  <td data-bind="text: usage"></td>
+                  <td data-bind="text: remaining"></td>
+                  <td data-bind="text: amount"></td>
+                  {% if show_account_credits %}
+                    <td data-bind="text: accountAmount"></td>
+                  {% endif %}
+                </tr>
               </tbody>
             </table>
           {% else %}
             <table class="table table-bordered table-striped">
               <thead>
-              <tr>
-                <th>{% trans "Feature" %}</th>
-                <th>{% trans "Included in Software Plan" %}</th>
-                <th>{% trans "Current Usage" %}</th>
-                {% if show_account_credits %}
-                  <th>{% trans "Account Credits Available" %}</th>
-                {% endif %}
-              </tr>
+                <tr>
+                  <th>{% trans "Feature" %}</th>
+                  <th>{% trans "Included in Software Plan" %}</th>
+                  <th>{% trans "Current Usage" %}</th>
+                  {% if show_account_credits %}
+                    <th>{% trans "Account Credits Available" %}</th>
+                  {% endif %}
+                </tr>
               </thead>
               <tbody data-bind="foreach: features">
-              <tr>
-                <td data-bind="text: name"></td>
-                <td data-bind="text: limit"></td>
-                <td data-bind="text: usage"></td>
-                {% if show_account_credits %}
-                  <td data-bind="text: accountAmount"></td>
-                {% endif %}
-              </tr>
+                <tr>
+                  <td data-bind="text: name"></td>
+                  <td data-bind="text: limit"></td>
+                  <td data-bind="text: usage"></td>
+                  {% if show_account_credits %}
+                    <td data-bind="text: accountAmount"></td>
+                  {% endif %}
+                </tr>
               </tbody>
             </table>
           {% endif %}
@@ -346,10 +372,10 @@
   </div>
 
   {% include 'accounting/partials/stripe_card_ko_template.html' %}
-
 {% endblock %}
 
-{% block modals %}{{ block.super }}
+{% block modals %}
+  {{ block.super }}
   {% include 'domain/partials/bootstrap5/payment_modal.html' with payment_modal_id="paymentModal" title_template="payment-method-modal-title" cost_item_template="cost-item-template" payment_complete_template="payment-complete-template" %}
   {% if can_set_auto_renew %}
     {% include 'domain/partials/bootstrap5/auto_renew_modal.html' %}

--- a/corehq/apps/domain/templates/domain/partials/bootstrap3/auto_renew_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap3/auto_renew_modal.html
@@ -1,0 +1,51 @@
+{% load i18n %}
+
+<div class="modal fade" tabindex="-1" role="dialog" id="auto-renew-modal">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="{% trans 'Close' %}"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">
+          {% if plan.is_auto_renew %}
+            {% trans "Disable Auto Renewal" %}
+          {% else %}
+            {% trans "Enable Auto Renewal" %}
+          {% endif %}
+        </h4>
+      </div>
+      <div class="modal-body"></div>
+      <div class="modal-footer">
+        <form
+          method="post"
+          action="
+          {% if plan.is_auto_renew %}
+            {% url 'disable_auto_renew' domain %}
+          {% else %}
+            {% url 'enable_auto_renew' domain %}
+          {% endif %}"
+        >
+          {% csrf_token %}
+          <button type="button" class="btn btn-default" data-dismiss="modal">
+            {% trans "Cancel" %}
+          </button>
+          {% if plan.is_auto_renew %}
+            <button class="btn btn-danger" type="submit">
+              {% trans "Disable Auto Renewal" %}
+            </button>
+          {% else %}
+            <button class="btn btn-primary" type="submit">
+              {% trans "Enable Auto Renewal" %}
+            </button>
+          {% endif %}
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/corehq/apps/domain/templates/domain/partials/bootstrap3/auto_renew_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap3/auto_renew_modal.html
@@ -20,7 +20,70 @@
           {% endif %}
         </h4>
       </div>
-      <div class="modal-body"></div>
+      <div class="modal-body">
+        {% if plan.is_auto_renew %}
+          <p>{% trans "By disabling auto renewal:" %}</p>
+          <ul>
+            <li>
+              {% blocktrans with plan_name=plan.name date_end=plan.date_end %}
+                Your subscription to <b>{{ plan_name }}</b> will end on
+                {{ date_end }}.
+              {% endblocktrans %}
+            </li>
+            {% if plan.next_subscription.name %}
+              <li>
+                {% blocktrans with plan_name=plan.next_subscription.name date_start=plan.next_subscription.date_start %}
+                  Your upcoming subscription to <b>{{ plan_name }}</b> beginning
+                  {{ date_start }} will be canceled.
+                {% endblocktrans %}
+              </li>
+            {% endif %}
+            <li>
+              {% blocktrans %}
+                Your subscription will <strong>not</strong> automatically renew.
+              {% endblocktrans %}
+            </li>
+          </ul>
+        {% else %}
+          <p>
+            {% blocktrans %}
+              Based on currently available software plans, by enabling auto
+              renewal:
+            {% endblocktrans %}
+          </p>
+          <ul>
+            <li>
+              {% blocktrans with plan_name=plan.name date_end=plan.date_end next_plan_name=renewal_plan_preview.name %}
+                Your <b>{{ plan_name }}</b> subscription will automatically
+                renew to <b>{{ next_plan_name }}</b> on {{ date_end }}.
+              {% endblocktrans %}
+            </li>
+            <li>
+              {% blocktrans with price=renewal_plan_preview.price %}
+                Your new software plan will cost <b>{{ price }}</b>.
+              {% endblocktrans %}
+            </li>
+            {% if renewal_plan_preview.is_annual_plan %}
+              <li>
+                {% blocktrans %}
+                  Your new subscription will require upfront payment for 12
+                  months of software plan fees.
+                {% endblocktrans %}
+              </li>
+            {% endif %}
+          </ul>
+          <p>
+            {% blocktrans %}
+              For more information about CommCare software plans, visit
+              <a
+                href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/CommCare+Pricing+Overview#Detailed-Software-Plan-%26-Feature-Comparisons"
+                target="_blank"
+                >our help site</a
+              >.
+            {% endblocktrans %}
+          </p>
+        {% endif %}
+      </div>
       <div class="modal-footer">
         <form
           method="post"

--- a/corehq/apps/domain/templates/domain/partials/bootstrap3/auto_renew_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap3/auto_renew_modal.html
@@ -22,66 +22,9 @@
       </div>
       <div class="modal-body">
         {% if plan.is_auto_renew %}
-          <p>{% trans "By disabling auto renewal:" %}</p>
-          <ul>
-            <li>
-              {% blocktrans with plan_name=plan.name date_end=plan.date_end %}
-                Your subscription to <b>{{ plan_name }}</b> will end on
-                {{ date_end }}.
-              {% endblocktrans %}
-            </li>
-            {% if plan.next_subscription.name %}
-              <li>
-                {% blocktrans with plan_name=plan.next_subscription.name date_start=plan.next_subscription.date_start %}
-                  Your upcoming subscription to <b>{{ plan_name }}</b> beginning
-                  {{ date_start }} will be canceled.
-                {% endblocktrans %}
-              </li>
-            {% endif %}
-            <li>
-              {% blocktrans %}
-                Your subscription will <strong>not</strong> automatically renew.
-              {% endblocktrans %}
-            </li>
-          </ul>
+          {% include 'domain/partials/disable_auto_renew.html' with plan=plan only %}
         {% else %}
-          <p>
-            {% blocktrans %}
-              Based on currently available software plans, by enabling auto
-              renewal:
-            {% endblocktrans %}
-          </p>
-          <ul>
-            <li>
-              {% blocktrans with plan_name=plan.name date_end=plan.date_end next_plan_name=renewal_plan_preview.name %}
-                Your <b>{{ plan_name }}</b> subscription will automatically
-                renew to <b>{{ next_plan_name }}</b> on {{ date_end }}.
-              {% endblocktrans %}
-            </li>
-            <li>
-              {% blocktrans with price=renewal_plan_preview.price %}
-                Your new software plan will cost <b>{{ price }}</b>.
-              {% endblocktrans %}
-            </li>
-            {% if renewal_plan_preview.is_annual_plan %}
-              <li>
-                {% blocktrans %}
-                  Your new subscription will require upfront payment for 12
-                  months of software plan fees.
-                {% endblocktrans %}
-              </li>
-            {% endif %}
-          </ul>
-          <p>
-            {% blocktrans %}
-              For more information about CommCare software plans, visit
-              <a
-                href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/CommCare+Pricing+Overview#Detailed-Software-Plan-%26-Feature-Comparisons"
-                target="_blank"
-                >our help site</a
-              >.
-            {% endblocktrans %}
-          </p>
+          {% include 'domain/partials/enable_auto_renew.html' with plan=plan renewal_plan=renewal_plan_preview only %}
         {% endif %}
       </div>
       <div class="modal-footer">

--- a/corehq/apps/domain/templates/domain/partials/bootstrap5/auto_renew_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap5/auto_renew_modal.html
@@ -18,7 +18,70 @@
           {% endif %}
         </h4>
       </div>
-      <div class="modal-body"></div>
+      <div class="modal-body">
+        {% if plan.is_auto_renew %}
+          <p>{% trans "By disabling auto renewal:" %}</p>
+          <ul>
+            <li>
+              {% blocktrans with plan_name=plan.name date_end=plan.date_end %}
+                Your subscription to <b>{{ plan_name }}</b> will end on
+                {{ date_end }}.
+              {% endblocktrans %}
+            </li>
+            {% if plan.next_subscription.name %}
+              <li>
+                {% blocktrans with plan_name=plan.next_subscription.name date_start=plan.next_subscription.date_start %}
+                  Your upcoming subscription to <b>{{ plan_name }}</b> beginning
+                  {{ date_start }} will be canceled.
+                {% endblocktrans %}
+              </li>
+            {% endif %}
+            <li>
+              {% blocktrans %}
+                Your subscription will <strong>not</strong> automatically renew.
+              {% endblocktrans %}
+            </li>
+          </ul>
+        {% else %}
+          <p>
+            {% blocktrans %}
+              Based on currently available software plans, by enabling auto
+              renewal:
+            {% endblocktrans %}
+          </p>
+          <ul>
+            <li>
+              {% blocktrans with plan_name=plan.name date_end=plan.date_end next_plan_name=renewal_plan_preview.name %}
+                Your <b>{{ plan_name }}</b> subscription will automatically
+                renew to <b>{{ next_plan_name }}</b> on {{ date_end }}.
+              {% endblocktrans %}
+            </li>
+            <li>
+              {% blocktrans with price=renewal_plan_preview.price %}
+                Your new software plan will cost <b>{{ price }}</b>.
+              {% endblocktrans %}
+            </li>
+            {% if renewal_plan_preview.is_annual_plan %}
+              <li>
+                {% blocktrans %}
+                  Your new subscription will require upfront payment for 12
+                  months of software plan fees.
+                {% endblocktrans %}
+              </li>
+            {% endif %}
+          </ul>
+          <p>
+            {% blocktrans %}
+              For more information about CommCare software plans, visit
+              <a
+                href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/CommCare+Pricing+Overview#Detailed-Software-Plan-%26-Feature-Comparisons"
+                target="_blank"
+                >our help site</a
+              >.
+            {% endblocktrans %}
+          </p>
+        {% endif %}
+      </div>
       <div class="modal-footer">
         <form
           method="post"

--- a/corehq/apps/domain/templates/domain/partials/bootstrap5/auto_renew_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap5/auto_renew_modal.html
@@ -1,0 +1,53 @@
+{% load i18n %}
+
+<div class="modal" tabindex="-1" id="auto-renew-modal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="{% trans 'Close' %}"
+        ></button>
+        <h4 class="modal-title">
+          {% if plan.is_auto_renew %}
+            {% trans "Disable Auto Renewal" %}
+          {% else %}
+            {% trans "Enable Auto Renewal" %}
+          {% endif %}
+        </h4>
+      </div>
+      <div class="modal-body"></div>
+      <div class="modal-footer">
+        <form
+          method="post"
+          action="
+          {% if plan.is_auto_renew %}
+            {% url 'disable_auto_renew' domain %}
+          {% else %}
+            {% url 'enable_auto_renew' domain %}
+          {% endif %}"
+        >
+          {% csrf_token %}
+          <button
+            type="button"
+            class="btn btn-outline-primary"
+            data-bs-dismiss="modal"
+          >
+            {% trans "Cancel" %}
+          </button>
+          {% if plan.is_auto_renew %}
+            <button class="btn btn-danger" type="submit">
+              {% trans "Disable Auto Renewal" %}
+            </button>
+          {% else %}
+            <button class="btn btn-primary" type="submit">
+              {% trans "Enable Auto Renewal" %}
+            </button>
+          {% endif %}
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/corehq/apps/domain/templates/domain/partials/bootstrap5/auto_renew_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap5/auto_renew_modal.html
@@ -20,66 +20,9 @@
       </div>
       <div class="modal-body">
         {% if plan.is_auto_renew %}
-          <p>{% trans "By disabling auto renewal:" %}</p>
-          <ul>
-            <li>
-              {% blocktrans with plan_name=plan.name date_end=plan.date_end %}
-                Your subscription to <b>{{ plan_name }}</b> will end on
-                {{ date_end }}.
-              {% endblocktrans %}
-            </li>
-            {% if plan.next_subscription.name %}
-              <li>
-                {% blocktrans with plan_name=plan.next_subscription.name date_start=plan.next_subscription.date_start %}
-                  Your upcoming subscription to <b>{{ plan_name }}</b> beginning
-                  {{ date_start }} will be canceled.
-                {% endblocktrans %}
-              </li>
-            {% endif %}
-            <li>
-              {% blocktrans %}
-                Your subscription will <strong>not</strong> automatically renew.
-              {% endblocktrans %}
-            </li>
-          </ul>
+          {% include 'domain/partials/disable_auto_renew.html' with plan=plan only %}
         {% else %}
-          <p>
-            {% blocktrans %}
-              Based on currently available software plans, by enabling auto
-              renewal:
-            {% endblocktrans %}
-          </p>
-          <ul>
-            <li>
-              {% blocktrans with plan_name=plan.name date_end=plan.date_end next_plan_name=renewal_plan_preview.name %}
-                Your <b>{{ plan_name }}</b> subscription will automatically
-                renew to <b>{{ next_plan_name }}</b> on {{ date_end }}.
-              {% endblocktrans %}
-            </li>
-            <li>
-              {% blocktrans with price=renewal_plan_preview.price %}
-                Your new software plan will cost <b>{{ price }}</b>.
-              {% endblocktrans %}
-            </li>
-            {% if renewal_plan_preview.is_annual_plan %}
-              <li>
-                {% blocktrans %}
-                  Your new subscription will require upfront payment for 12
-                  months of software plan fees.
-                {% endblocktrans %}
-              </li>
-            {% endif %}
-          </ul>
-          <p>
-            {% blocktrans %}
-              For more information about CommCare software plans, visit
-              <a
-                href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/CommCare+Pricing+Overview#Detailed-Software-Plan-%26-Feature-Comparisons"
-                target="_blank"
-                >our help site</a
-              >.
-            {% endblocktrans %}
-          </p>
+          {% include 'domain/partials/enable_auto_renew.html' with plan=plan renewal_plan=renewal_plan_preview only %}
         {% endif %}
       </div>
       <div class="modal-footer">

--- a/corehq/apps/domain/templates/domain/partials/disable_auto_renew.html
+++ b/corehq/apps/domain/templates/domain/partials/disable_auto_renew.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+
+<p>{% trans "By disabling auto renewal:" %}</p>
+<ul>
+  <li>
+    {% blocktrans with plan_name=plan.name date_end=plan.date_end %}
+      Your subscription to <b>{{ plan_name }}</b> will end on {{ date_end }}.
+    {% endblocktrans %}
+  </li>
+  {% if plan.next_subscription.name %}
+    <li>
+      {% blocktrans with plan_name=plan.next_subscription.name date_start=plan.next_subscription.date_start %}
+        Your upcoming subscription to <b>{{ plan_name }}</b> beginning
+        {{ date_start }} will be canceled.
+      {% endblocktrans %}
+    </li>
+  {% endif %}
+  <li>
+    {% blocktrans %}
+      Your subscription will <strong>not</strong> automatically renew.
+    {% endblocktrans %}
+  </li>
+</ul>

--- a/corehq/apps/domain/templates/domain/partials/enable_auto_renew.html
+++ b/corehq/apps/domain/templates/domain/partials/enable_auto_renew.html
@@ -7,24 +7,33 @@
 </p>
 <ul>
   <li>
-    {% blocktrans with plan_name=plan.name date_end=plan.date_end next_plan_name=renewal_plan.name %}
-      Your <b>{{ plan_name }}</b> subscription will automatically renew to
-      <b>{{ next_plan_name }}</b> on {{ date_end }}.
-    {% endblocktrans %}
+    {% if plan.name != renewal_plan.name %}
+      {% blocktrans with plan_name=plan.name date_end=plan.date_end next_plan_name=renewal_plan.name %}
+        Your <b>{{ plan_name }}</b> subscription will automatically change to
+        the latest version of <b>{{ next_plan_name }}</b> on {{ date_end }}.
+        <br />
+        <strong>Note:</strong> This is different from your current software
+        plan.
+      {% endblocktrans %}
+    {% else %}
+      {% blocktrans with plan_name=plan.name date_end=plan.date_end %}
+        Your <b>{{ plan_name }}</b> subscription will automatically renew on
+        {{ date_end }}.
+      {% endblocktrans %}
+    {% endif %}
   </li>
   <li>
-    {% blocktrans with price=renewal_plan.price %}
-      Your new software plan will cost <b>{{ price }}</b>.
-    {% endblocktrans %}
-  </li>
-  {% if renewal_plan.is_annual_plan %}
-    <li>
-      {% blocktrans %}
-        Your new subscription will require upfront payment for 12 months of
-        software plan fees.
+    {% if renewal_plan.is_annual_plan %}
+      {% blocktrans with price=renewal_plan.price %}
+        Your renewed subscription will require upfront payment for 12 months of
+        software plan fees at <b>{{ price }}</b>.
       {% endblocktrans %}
-    </li>
-  {% endif %}
+    {% else %}
+      {% blocktrans with price=renewal_plan.price %}
+        Your subscription will renew at <b>{{ price }}</b>.
+      {% endblocktrans %}
+    {% endif %}
+  </li>
 </ul>
 <p>
   {% blocktrans %}

--- a/corehq/apps/domain/templates/domain/partials/enable_auto_renew.html
+++ b/corehq/apps/domain/templates/domain/partials/enable_auto_renew.html
@@ -1,0 +1,38 @@
+{% load i18n %}
+
+<p>
+  {% blocktrans %}
+    Based on currently available software plans, by enabling auto renewal:
+  {% endblocktrans %}
+</p>
+<ul>
+  <li>
+    {% blocktrans with plan_name=plan.name date_end=plan.date_end next_plan_name=renewal_plan.name %}
+      Your <b>{{ plan_name }}</b> subscription will automatically renew to
+      <b>{{ next_plan_name }}</b> on {{ date_end }}.
+    {% endblocktrans %}
+  </li>
+  <li>
+    {% blocktrans with price=renewal_plan.price %}
+      Your new software plan will cost <b>{{ price }}</b>.
+    {% endblocktrans %}
+  </li>
+  {% if renewal_plan.is_annual_plan %}
+    <li>
+      {% blocktrans %}
+        Your new subscription will require upfront payment for 12 months of
+        software plan fees.
+      {% endblocktrans %}
+    </li>
+  {% endif %}
+</ul>
+<p>
+  {% blocktrans %}
+    For more information about CommCare software plans, visit
+    <a
+      href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/CommCare+Pricing+Overview#Detailed-Software-Plan-%26-Feature-Comparisons"
+      target="_blank"
+      >our help site</a
+    >.
+  {% endblocktrans %}
+</p>

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -309,6 +309,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
                            if subscription is not None else None),
             'date_end': date_end,
             'cards': cards,
+            'is_auto_renew': subscription.auto_renew,
             'next_subscription': next_subscription,
             'has_credits_in_non_general_credit_line': has_credits_in_non_general_credit_line,
             'is_annual_plan': plan_version.plan.is_annual_plan,

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -261,6 +261,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
         subscription = Subscription.get_active_subscription_by_domain(self.domain)
         plan_version = subscription.plan_version if subscription else DefaultProductPlan.get_default_plan_version()
         date_end = None
+        days_left = None
         next_subscription = {
             'exists': False,
             'can_renew': False,
@@ -275,6 +276,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
                         if subscription.date_end is not None else "--")
 
             if subscription.date_end is not None:
+                days_left = (subscription.date_end - datetime.date.today()).days
                 if subscription.is_renewed:
                     next_subscription.update({
                         'exists': True,
@@ -288,7 +290,6 @@ class DomainSubscriptionView(DomainAccountingSettings):
                     })
 
                 else:
-                    days_left = (subscription.date_end - datetime.date.today()).days
                     next_subscription.update({
                         'can_renew': days_left <= 90,
                         'renew_url': reverse(SubscriptionRenewalView.urlname, args=[self.domain]),
@@ -324,6 +325,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
             'date_start': (subscription.date_start.strftime(USER_DATE_FORMAT)
                            if subscription is not None else None),
             'date_end': date_end,
+            'days_left': days_left,
             'cards': cards,
             'is_auto_renew': subscription.auto_renew,
             'next_subscription': next_subscription,

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -212,7 +212,6 @@ class DomainSubscriptionView(DomainAccountingSettings):
     def can_purchase_credits(self):
         return self.request.couch_user.can_edit_billing()
 
-    @property
     def can_set_auto_renew(self):
         can_access_auto_renewal = (
             SHOW_AUTO_RENEWAL.enabled(self.request.domain)
@@ -241,7 +240,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
 
     @property
     def renewal_plan_preview(self):
-        if not self.can_set_auto_renew or self.current_subscription.auto_renew:
+        if not self.can_set_auto_renew() or self.current_subscription.auto_renew:
             # details are only needed if user will see the option to enable auto renew
             return None
 
@@ -418,7 +417,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
             'plan': self.plan,
             'change_plan_url': reverse(SelectPlanView.urlname, args=[self.domain]),
             'can_purchase_credits': self.can_purchase_credits,
-            'can_set_auto_renew': self.can_set_auto_renew,
+            'can_set_auto_renew': self.can_set_auto_renew(),
             'renewal_plan_preview': self.renewal_plan_preview,
             'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
             'payment_error_messages': PAYMENT_ERROR_MESSAGES,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
@@ -1,17 +1,16 @@
 --- 
 +++ 
-@@ -1,8 +1,8 @@
+@@ -1,7 +1,7 @@
 -{% extends "hqwebapp/bootstrap3/base_section.html" %}
 +{% extends "hqwebapp/bootstrap5/base_section.html" %}
  {% load hq_shared_tags %}
  {% load i18n %}
- 
 -{% js_entry_b3 'domain/js/current_subscription' %}
 +{% js_entry 'domain/js/current_subscription' %}
  
  {% block page_content %}
    {% initial_page_data "stripe_public_key" stripe_public_key %}
-@@ -15,12 +15,12 @@
+@@ -14,12 +14,12 @@
    {% registerurl "domain_wire_payment" domain %}
  
    <div class="row">
@@ -28,33 +27,39 @@
              <div class="{{ plan.css_class }}">
                <h4>
                  {% if plan.is_paused %}
-@@ -54,7 +54,7 @@
+@@ -60,7 +60,7 @@
              {% endif %}
              {% if can_change_subscription %}
                {% if plan.is_annual_plan and not plan.upgrade_available %}
 -                <div style="margin-top: 10px;">
 +                <div class="mt-3">
                    {% trans "Questions about your plan?" %}
-                   <a
-                     href="{% url "annual_plan_request_quote" domain %}"
-@@ -62,7 +62,7 @@
+                   <a href="{% url "annual_plan_request_quote" domain %}"
+                     >{% trans "Contact us" %}</a
+@@ -68,11 +68,7 @@
                  </div>
                {% else %}
                  <p>
--                  <a class="btn btn-primary" style="margin-top:10px;" href="{{ change_plan_url }}">
+-                  <a
+-                    class="btn btn-primary"
+-                    style="margin-top:10px;"
+-                    href="{{ change_plan_url }}"
+-                  >
 +                  <a class="btn btn-primary mt-3" href="{{ change_plan_url }}">
                      {% if plan.is_paused %}
                        {% trans "Subscribe to Plan" %}
                      {% elif plan.is_annual_plan and plan.upgrade_available %}
-@@ -95,17 +95,17 @@
+@@ -105,21 +101,21 @@
          </div>
          {% if not plan.is_trial and not plan.is_paused %}
            {% if plan.date_start %}
 -            <div class="form-group">
--              <label class="control-label col-sm-2">{% trans 'Date Started' %}</label>
--              <div class="col-sm-10">
+-              <label class="control-label col-sm-2"
 +            <div class="form-group">  {# todo B5: css-form-group #}
-+              <label class="form-label col-md-2">{% trans 'Date Started' %}</label>
++              <label class="form-label col-md-2"
+                 >{% trans 'Date Started' %}</label
+               >
+-              <div class="col-sm-10">
 +              <div class="col-md-10">
                  <p class="form-control-text">{{ plan.date_start }}</p>
                </div>
@@ -62,28 +67,42 @@
            {% endif %}
            {% if plan.date_end %}
 -            <div class="form-group">
--              <label class="control-label col-sm-2">{% trans 'Date Ending' %}</label>
--              <div class="col-sm-10">
+-              <label class="control-label col-sm-2"
 +            <div class="form-group">  {# todo B5: css-form-group #}
-+              <label class="form-label col-md-2">{% trans 'Date Ending' %}</label>
++              <label class="form-label col-md-2"
+                 >{% trans 'Date Ending' %}</label
+               >
+-              <div class="col-sm-10">
 +              <div class="col-md-10">
                  <p class="form-control-text">{{ plan.date_end }}</p>
-                 {% if plan.next_subscription.can_renew %}
-                   <a href="{{ plan.next_subscription.renew_url }}"
-@@ -117,9 +117,9 @@
+                 {% if plan.is_auto_renew %}
+                   <div class="alert alert-success">
+@@ -146,8 +142,8 @@
+                   <button
+                     type="button"
+                     class="btn btn-default"
+-                    data-toggle="modal"
+-                    data-target="#auto-renew-modal"
++                    data-bs-toggle="modal"
++                    data-bs-target="#auto-renew-modal"
+                   >
+                     {% if plan.is_auto_renew %}
+                       {% trans "Disable Auto Renewal" %}
+@@ -160,40 +156,40 @@
              </div>
            {% endif %}
            <div data-bind="foreach: products">
 -            <div class="form-group">
--              <label class="control-label col-sm-2">{% trans 'Current Price' %}</label>
--              <div class="col-sm-10">
+-              <label class="control-label col-sm-2"
 +            <div class="form-group">  {# todo B5: css-form-group #}
-+              <label class="form-label col-md-2">{% trans 'Current Price' %}</label>
++              <label class="form-label col-md-2"
+                 >{% trans 'Current Price' %}</label
+               >
+-              <div class="col-sm-10">
 +              <div class="col-md-10">
-                 <p class="form-control-text"
-                    data-bind="text: monthlyFee"></p>
+                 <p class="form-control-text" data-bind="text: monthlyFee"></p>
                </div>
-@@ -127,31 +127,31 @@
+             </div>
            </div>
          {% endif %}
          {% if plan.next_subscription.exists and not plan.next_subscription.is_paused %}
@@ -108,9 +127,7 @@
              </label>
 -            <div class="col-sm-10">
 +            <div class="col-md-10">
-               <p class="form-control-text">
-                 {{ plan.next_subscription.name }}
-               </p>
+               <p class="form-control-text">{{ plan.next_subscription.name }}</p>
              </div>
            </div>
 -          <div class="form-group">
@@ -124,7 +141,7 @@
                <p class="form-control-text">
                  {{ plan.next_subscription.price }}
                </p>
-@@ -164,50 +164,50 @@
+@@ -206,26 +202,26 @@
          <div class="form form-horizontal">
            {% if plan.has_credits_in_non_general_credit_line %}
              <div data-bind="foreach: products">
@@ -154,8 +171,10 @@
                </label>
 -              <div class="col-sm-10">
 +              <div class="col-md-10">
-                 <p class="form-control-text js-general-credit">{{ plan.general_credit.amount }}</p>
-               </div>
+                 <p class="form-control-text js-general-credit">
+                   {{ plan.general_credit.amount }}
+                 </p>
+@@ -233,29 +229,29 @@
              </div>
            {% endif %}
            <div data-bind="with: prepayments">
@@ -164,32 +183,36 @@
 +            <div class="form-group">  {# todo B5: css-form-group #}
 +              <div class="col-md-10 offset-md-2">
                  {% if can_purchase_credits %}
-                   <button type="button"
-                           class="btn btn-primary"
--                          data-toggle="modal"
--                          data-target="#paymentModal"
-+                          data-bs-toggle="modal"
-+                          data-bs-target="#paymentModal"
-                           data-bind="click: function(){triggerPayment($root.paymentHandler.CREDIT_CARD)}">
+                   <button
+                     type="button"
+                     class="btn btn-primary"
+-                    data-toggle="modal"
+-                    data-target="#paymentModal"
++                    data-bs-toggle="modal"
++                    data-bs-target="#paymentModal"
+                     data-bind="click: function(){triggerPayment($root.paymentHandler.CREDIT_CARD)}"
+                   >
                      {% trans 'Prepay by Credit Card' %}
                    </button>
-                   <button type="button"
--                          class="btn btn-default"
--                          data-toggle="modal"
--                          data-target="#paymentModal"
-+                          class="btn btn-outline-primary"
-+                          data-bs-toggle="modal"
-+                          data-bs-target="#paymentModal"
-                           data-bind="click: function(){triggerPayment($root.paymentHandler.WIRE)}">
+                   <button
+                     type="button"
+-                    class="btn btn-default"
+-                    data-toggle="modal"
+-                    data-target="#paymentModal"
++                    class="btn btn-outline-primary"
++                    data-bs-toggle="modal"
++                    data-bs-target="#paymentModal"
+                     data-bind="click: function(){triggerPayment($root.paymentHandler.WIRE)}"
+                   >
                      {% trans 'Generate Prepayment Invoice' %}
                    </button>
                  {% else %}
 -                  <span class="label label-default">
 +                  <span class="badge text-bg-secondary">
-                                         <i class="fa fa-info-circle"></i>
-                                         {% trans "Not Billing Admin, Can't Add Credit" %}
-                                     </span>
-@@ -220,8 +220,8 @@
+                     <i class="fa fa-info-circle"></i>
+                     {% trans "Not Billing Admin, Can't Add Credit" %}
+                   </span>
+@@ -268,8 +264,8 @@
            <legend>{% trans 'Account Credit' %}</legend>
            <div class="form form-horizontal">
              <div data-bind="foreach: products">
@@ -199,15 +222,17 @@
 +                <label class="form-label col-md-2">
                    {% trans 'Plan Credit' %}
                    <div class="hq-help">
-                     <a href="#"
-@@ -234,14 +234,14 @@
+                     <a
+@@ -284,7 +280,7 @@
                      </a>
                    </div>
                  </label>
 -                <div class="col-sm-10">
 +                <div class="col-md-10">
-                   <p class="form-control-text" data-bind="text: accountAmount"></p>
-                 </div>
+                   <p
+                     class="form-control-text"
+                     data-bind="text: accountAmount"
+@@ -293,8 +289,8 @@
                </div>
              </div>
              {% if plan.account_general_credit and plan.account_general_credit.is_visible %}
@@ -217,20 +242,24 @@
 +                <label class="form-label col-md-2">
                    {% trans 'General Credit' %}
                    <div class="hq-help">
-                     <a href="#"
-@@ -255,7 +255,7 @@
+                     <a
+@@ -310,7 +306,7 @@
                      </a>
                    </div>
                  </label>
 -                <div class="col-sm-10">
 +                <div class="col-md-10">
-                   <p class="form-control-text">{{ plan.account_general_credit.amount }}</p>
-                 </div>
-               </div>
-@@ -323,5 +323,5 @@
- {% endblock %}
+                   <p class="form-control-text">
+                     {{ plan.account_general_credit.amount }}
+                   </p>
+@@ -380,8 +376,8 @@
  
- {% block modals %}{{ block.super }}
+ {% block modals %}
+   {{ block.super }}
 -  {% include 'domain/partials/bootstrap3/payment_modal.html' with payment_modal_id="paymentModal" title_template="payment-method-modal-title" cost_item_template="cost-item-template" payment_complete_template="payment-complete-template" %}
 +  {% include 'domain/partials/bootstrap5/payment_modal.html' with payment_modal_id="paymentModal" title_template="payment-method-modal-title" cost_item_template="cost-item-template" payment_complete_template="payment-complete-template" %}
+   {% if can_set_auto_renew %}
+-    {% include 'domain/partials/bootstrap3/auto_renew_modal.html' %}
++    {% include 'domain/partials/bootstrap5/auto_renew_modal.html' %}
+   {% endif %}
  {% endblock %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/partials/auto_renew_modal.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/partials/auto_renew_modal.html.diff.txt
@@ -23,7 +23,7 @@
          <h4 class="modal-title">
            {% if plan.is_auto_renew %}
              {% trans "Disable Auto Renewal" %}
-@@ -95,7 +93,11 @@
+@@ -38,7 +36,11 @@
            {% endif %}"
          >
            {% csrf_token %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/partials/auto_renew_modal.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/partials/auto_renew_modal.html.diff.txt
@@ -1,0 +1,38 @@
+--- 
++++ 
+@@ -1,17 +1,15 @@
+ {% load i18n %}
+ 
+-<div class="modal fade" tabindex="-1" role="dialog" id="auto-renew-modal">
+-  <div class="modal-dialog" role="document">
++<div class="modal" tabindex="-1" id="auto-renew-modal">
++  <div class="modal-dialog">
+     <div class="modal-content">
+       <div class="modal-header">
+         <button
+           type="button"
+-          class="close"
+-          data-dismiss="modal"
++          class="btn-close"
++          data-bs-dismiss="modal"
+           aria-label="{% trans 'Close' %}"
+-        >
+-          <span aria-hidden="true">&times;</span>
+-        </button>
++        ></button>
+         <h4 class="modal-title">
+           {% if plan.is_auto_renew %}
+             {% trans "Disable Auto Renewal" %}
+@@ -95,7 +93,11 @@
+           {% endif %}"
+         >
+           {% csrf_token %}
+-          <button type="button" class="btn btn-default" data-dismiss="modal">
++          <button
++            type="button"
++            class="btn btn-outline-primary"
++            data-bs-dismiss="modal"
++          >
+             {% trans "Cancel" %}
+           </button>
+           {% if plan.is_auto_renew %}


### PR DESCRIPTION
## Product Description
Changes to the Current Subscription page. These screenshots cover several, but not every possible combination of text elements.

**Before:**
<img width="377" height="83" alt="image" src="https://github.com/user-attachments/assets/29c39372-830c-440c-bd52-5b8db6ee32f8" />


**After (auto renewal disabled):**
<img width="543" height="150" alt="image" src="https://github.com/user-attachments/assets/b8d09470-f159-43ca-94ea-096a39a55ba5" />

<img width="604" height="278" alt="image" src="https://github.com/user-attachments/assets/9d74d653-1643-4191-bebe-a533254c39a3" />


**After (auto renewal enabled):**
<img width="526" height="151" alt="image" src="https://github.com/user-attachments/assets/c0841107-9761-4aa1-866a-ce194b803757" />

<img width="603" height="218" alt="image" src="https://github.com/user-attachments/assets/0db9aff3-b4ea-4ac1-99d3-1034fc6c21a2" />




## Technical Summary
[Tech Spec](https://docs.google.com/document/d/1kop7WTDE3HQdNhbWi0yoPbRjqdI4FLjFVHvtZ5CStJY/edit?usp=sharing), [Ticket](https://dimagi.atlassian.net/browse/SAAS-18406?atlOrigin=eyJpIjoiMzllOTAxNzAzOTc2NDIxN2E0MzA1ZDVlYWU1YWM4YzQiLCJwIjoiaiJ9)
There are a good number of conditional elements to the UI here.

If a subscription is eligible for auto renewal (meaning it is type `PRODUCT` and it has an end date):
- Auto renewal can be enabled when there is no "next subscription"
  - "Your subscription will require upfront payment" will appear in the confirmation modal when the new plan is a Pay Annually plan
- Auto renewal can be disabled when there is no "next subscription" or any "next subscription" was created by auto renewal
  - If such an auto-renewed subscription exists, it will be canceled upon disabling auto renewal. The user will see this noted in the confirmation modal.

Relatedly but with its conditional unchanged, the manual renewal button, now "Renew Now", will appear whenever the subscription is within 90 days of its end date and there is no "next subscription".

"Your subscription will automatically renew" will appear whenever auto renewal is enabled.
"Your subscription will end in xx days" will appear under the same conditions as the "Renew Now" button, when auto renewal is disabled.

This is a decently large PR in terms of lines changed, but much of it is duplicated B3/B5 files, auto-formatting, and bootstrap diffs. Review by commit.

## Feature Flag
Most changes feature flagged under `SHOW_AUTO_RENEWAL` while in development.

## Safety Assurance

### Safety story
Tested locally with a variety of software plans (annual/monthly, auto renew enabled/disabled, end date/no end date) to see the UI appears as expected, when expected, without errors, and that auto renewal can be enabled or disabled successfully. Briefly tested on staging as well.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
This will get QA with the rest of the auto renewal feature, before the feature flag is removed.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
