### PR TITLE
Test `fields_to_validate()`

### DIFF
--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -429,19 +429,31 @@ class TestFieldsToValidate(TestCase):
             name='test-case-type',
             domain=cls.domain,
         )
-        cls.date_prop = CaseProperty(
-            name='date_property',
+        cls.date_prop_1 = CaseProperty(
+            name='date_property_1',
             case_type=cls.case_type,
             data_type=CaseProperty.DataType.DATE,
         )
-        cls.select_prop = CaseProperty(
-            name='select_property',
+        cls.date_prop_2 = CaseProperty(
+            name='date_property_2',
+            case_type=cls.case_type,
+            data_type=CaseProperty.DataType.DATE,
+        )
+        cls.select_prop_1 = CaseProperty(
+            name='select_property_1',
+            case_type=cls.case_type,
+            data_type=CaseProperty.DataType.SELECT,
+        )
+        cls.select_prop_2 = CaseProperty(
+            name='select_property_2',
             case_type=cls.case_type,
             data_type=CaseProperty.DataType.SELECT,
         )
         CaseProperty.objects.bulk_create([
-            cls.date_prop,
-            cls.select_prop,
+            cls.date_prop_1,
+            cls.date_prop_2,
+            cls.select_prop_1,
+            cls.select_prop_2,
             CaseProperty(
                 name='plain_property',
                 case_type=cls.case_type,
@@ -481,7 +493,14 @@ class TestFieldsToValidate(TestCase):
 
     def test_fields_to_validate_returns_only_date_and_select_properties(self):
         result = fields_to_validate(self.domain, self.case_type.name)
-        expected_names = {'date_property', 'select_property'}
+        expected_names = {
+            'date_property_1',
+            'date_property_2',
+            'select_property_1',
+            'select_property_2',
+        }
         assert set(result.keys()) == expected_names
-        assert result['date_property'] == self.date_prop
-        assert result['select_property'] == self.select_prop
+        assert result['date_property_1'] == self.date_prop_1
+        assert result['date_property_2'] == self.date_prop_2
+        assert result['select_property_1'] == self.select_prop_1
+        assert result['select_property_2'] == self.select_prop_2

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -332,7 +332,10 @@ def fields_to_validate(domain, case_type_name):
     props = CaseProperty.objects.filter(
         case_type__domain=domain,
         case_type__name=case_type_name,
-        data_type__in=('date', 'select'),
+        data_type__in=(
+            CaseProperty.DataType.DATE,
+            CaseProperty.DataType.SELECT,
+        ),
     )
     return {prop.name: prop for prop in props}
 

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -323,12 +323,11 @@ def get_data_dict_deprecated_case_types(domain):
 
 
 def fields_to_validate(domain, case_type_name):
-    filter_kwargs = {
-        'case_type__domain': domain,
-        'case_type__name': case_type_name,
-        'data_type__in': ['date', 'select'],
-    }
-    props = CaseProperty.objects.filter(**filter_kwargs)
+    props = CaseProperty.objects.filter(
+        case_type__domain=domain,
+        case_type__name=case_type_name,
+        data_type__in=('date', 'select'),
+    )
     return {prop.name: prop for prop in props}
 
 

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -323,6 +323,12 @@ def get_data_dict_deprecated_case_types(domain):
 
 
 def fields_to_validate(domain, case_type_name):
+    """
+    Returns a dictionary {case_property_name: CaseProperty} of case
+    properties whose data type is "date" or "select" (multiple choice).
+
+    (Only date and multiple choice case properties are validated.)
+    """
     props = CaseProperty.objects.filter(
         case_type__domain=domain,
         case_type__name=case_type_name,


### PR DESCRIPTION
## Technical Summary

Small change. Adds a test and makes a small refactor for `corehq.apps.data_dictionary.util.fields_to_validate()`.

:t-rex: Jira: [SAAS-18499](https://dimagi.atlassian.net/browse/SAAS-18499)

:office: 

## Feature Flag

`CASE_IMPORT_DATA_DICTIONARY_VALIDATION`

## Safety Assurance

### Safety story

Test and refactor only. No change to functionality.

### Automated test coverage

Yes

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-18499]: https://dimagi.atlassian.net/browse/SAAS-18499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ