### PR TITLE
Set `SHOW_RAW_DATA_SOURCES_IN_REPORT_BUILDER` deprecated

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1801,7 +1801,7 @@ AGGREGATE_UCRS = StaticToggle(
 SHOW_RAW_DATA_SOURCES_IN_REPORT_BUILDER = StaticToggle(
     'show_raw_data_sources_in_report_builder',
     'Allow building report builder reports directly from raw UCR Data Sources',
-    TAG_SOLUTIONS_CONDITIONAL,
+    TAG_DEPRECATED,
     namespaces=[NAMESPACE_DOMAIN],
 )
 


### PR DESCRIPTION
## Product Description

Sets the "Allow building report builder reports directly from raw UCR Data Sources" feature flag as deprecated

## Technical Summary

Changes the tag of the feature flag.

:t-rex: Jira: [SAAS-18559](https://dimagi.atlassian.net/browse/SAAS-18559)

## Feature Flag

`SHOW_RAW_DATA_SOURCES_IN_REPORT_BUILDER`

## Safety Assurance

### Safety story

Tiny change. Does not affect functionality.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-18559]: https://dimagi.atlassian.net/browse/SAAS-18559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ