### PR TITLE
Close old connections before attempting to store task state

### DIFF
--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -2,13 +2,11 @@ import datetime
 import inspect
 import logging
 
+from celery import current_app
+from celery.signals import after_task_publish, before_task_publish, task_postrun, task_prerun
+from dimagi.utils.parsing import string_to_utc_datetime
 from django.core.cache import cache
 from django.db import close_old_connections
-
-from celery.signals import after_task_publish, before_task_publish, task_postrun, task_prerun
-from celery import current_app
-
-from dimagi.utils.parsing import string_to_utc_datetime
 
 from corehq.util.metrics import push_metrics
 from corehq.util.quickcache import quickcache

--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -4,7 +4,10 @@ import logging
 
 from django.core.cache import cache
 
-from celery.signals import before_task_publish, task_postrun, task_prerun
+from celery.signals import after_task_publish, before_task_publish, task_postrun, task_prerun
+from celery import current_app
+
+from casexml.apps.phone.tasks import ASYNC_RESTORE_SENT
 
 from dimagi.utils.parsing import string_to_utc_datetime
 
@@ -20,6 +23,28 @@ def celery_add_time_sent(headers=None, body=None, **kwargs):
     if eta:
         eta = TimeToStartTimer.parse_iso8601(eta)
     TimeToStartTimer(task_id).start_timing(eta)
+
+
+@after_task_publish.connect
+def update_celery_state(sender=None, headers=None, **kwargs):
+    """Updates the celery task progress to "SENT"
+
+    When fetching an task from celery using the form AsyncResponse(task_id), if
+    task_id never exists, celery will not throw an error, it will just hang.
+    This function updates each task sent to celery to have a progress value of "SENT",
+    which means we can check that a task exists with the following pattern:
+    `AsyncResponse(task_id).status == "SENT"`
+
+    See
+    http://stackoverflow.com/questions/9824172/find-out-whether-celery-task-exists/10089358
+    for more info
+
+    """
+
+    task = current_app.tasks.get(sender)
+    backend = task.backend if task else current_app.backend
+
+    backend.store_result(headers['id'], None, ASYNC_RESTORE_SENT)
 
 
 @task_prerun.connect

--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -3,6 +3,7 @@ import inspect
 import logging
 
 from django.core.cache import cache
+from django.db import close_old_connections
 
 from celery.signals import after_task_publish, before_task_publish, task_postrun, task_prerun
 from celery import current_app
@@ -41,6 +42,8 @@ def update_celery_state(sender=None, headers=None, **kwargs):
 
     """
 
+    # ensure connection to DB is usable
+    close_old_connections()
     task = current_app.tasks.get(sender)
     backend = task.backend if task else current_app.backend
 

--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -7,12 +7,12 @@ from django.core.cache import cache
 from celery.signals import after_task_publish, before_task_publish, task_postrun, task_prerun
 from celery import current_app
 
-from casexml.apps.phone.tasks import ASYNC_RESTORE_SENT
-
 from dimagi.utils.parsing import string_to_utc_datetime
 
 from corehq.util.metrics import push_metrics
 from corehq.util.quickcache import quickcache
+
+CELERY_STATE_SENT = "SENT"
 
 
 @before_task_publish.connect
@@ -44,7 +44,7 @@ def update_celery_state(sender=None, headers=None, **kwargs):
     task = current_app.tasks.get(sender)
     backend = task.backend if task else current_app.backend
 
-    backend.store_result(headers['id'], None, ASYNC_RESTORE_SENT)
+    backend.store_result(headers['id'], None, CELERY_STATE_SENT)
 
 
 @task_prerun.connect

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -28,8 +28,8 @@ from itertools import chain, islice
 
 from casexml.apps.case.const import CASE_INDEX_EXTENSION as EXTENSION
 from casexml.apps.phone.const import ASYNC_RETRY_AFTER
-from casexml.apps.phone.tasks import ASYNC_RESTORE_SENT
 
+from corehq.celery_monitoring.signals import CELERY_STATE_SENT
 from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 from corehq.sql_db.routers import read_from_plproxy_standbys
 from corehq.toggles import LIVEQUERY_READ_FROM_STANDBYS, NAMESPACE_USER
@@ -377,7 +377,7 @@ def init_progress(async_task, total):
 
     def update_progress(done):
         async_task.update_state(
-            state=ASYNC_RESTORE_SENT,
+            state=CELERY_STATE_SENT,
             meta={
                 'done': done,
                 'total': total,

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -28,7 +28,6 @@ from itertools import chain, islice
 
 from casexml.apps.case.const import CASE_INDEX_EXTENSION as EXTENSION
 from casexml.apps.phone.const import ASYNC_RETRY_AFTER
-
 from corehq.celery_monitoring.signals import CELERY_STATE_SENT
 from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 from corehq.sql_db.routers import read_from_plproxy_standbys

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -31,6 +31,7 @@ from corehq.apps.app_manager.exceptions import CannotRestoreException
 from corehq.apps.domain.models import Domain
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.exceptions import NotFound
+from corehq.celery_monitoring.signals import CELERY_STATE_SENT
 from corehq.const import LOADTEST_HARD_LIMIT
 from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
 from corehq.util.metrics import metrics_counter, metrics_histogram, limit_domains
@@ -58,7 +59,7 @@ from .models import (
     get_properly_wrapped_sync_log,
 )
 from .restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
-from .tasks import ASYNC_RESTORE_SENT, get_async_restore_payload
+from .tasks import get_async_restore_payload
 from .utils import get_cached_items_with_count
 from .xml import (
     get_progress_element,
@@ -679,7 +680,7 @@ class RestoreConfig(object):
         task_id = self.async_restore_task_id_cache.get_value()
         if task_id:
             task = AsyncResult(task_id)
-            task_exists = task.status == ASYNC_RESTORE_SENT
+            task_exists = task.status == CELERY_STATE_SENT
         else:
             task = None
             task_exists = False

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -10,23 +10,21 @@ from uuid import uuid4
 from wsgiref.util import FileWrapper
 from xml.etree import cElementTree as ElementTree
 
-from django.conf import settings
-from django.http import HttpResponse, StreamingHttpResponse
-from django.utils.text import slugify
-
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult
-from looseversion import LooseVersion
-from memoized import memoized
-
-from casexml.apps.case.xml import V1, check_version
 from couchforms.openrosa_response import (
     ResponseNature,
     get_response_element,
     get_simple_response_xml,
 )
 from dimagi.utils.logging import notify_error
+from django.conf import settings
+from django.http import HttpResponse, StreamingHttpResponse
+from django.utils.text import slugify
+from looseversion import LooseVersion
+from memoized import memoized
 
+from casexml.apps.case.xml import V1, check_version
 from corehq.apps.app_manager.exceptions import CannotRestoreException
 from corehq.apps.domain.models import Domain
 from corehq.blobs import CODES, get_blob_db
@@ -34,7 +32,7 @@ from corehq.blobs.exceptions import NotFound
 from corehq.celery_monitoring.signals import CELERY_STATE_SENT
 from corehq.const import LOADTEST_HARD_LIMIT
 from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
-from corehq.util.metrics import metrics_counter, metrics_histogram, limit_domains
+from corehq.util.metrics import limit_domains, metrics_counter, metrics_histogram
 from corehq.util.timer import TimingContext
 
 from .checksum import CaseStateHash

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -5,9 +5,8 @@ from django.conf import settings
 from django.db import connections, router
 from django.db.models import Min
 
-from celery import current_app, current_task
+from celery import current_task
 from celery.schedules import crontab
-from celery.signals import after_task_publish
 
 from casexml.apps.phone.models import SyncLogSQL
 from dimagi.utils.logging import notify_exception
@@ -44,28 +43,6 @@ def get_async_restore_payload(restore_config, domain=None, username=None):
     restore_config.async_restore_task_id_cache.invalidate()
 
     return response.name
-
-
-@after_task_publish.connect
-def update_celery_state(sender=None, headers=None, **kwargs):
-    """Updates the celery task progress to "SENT"
-
-    When fetching an task from celery using the form AsyncResponse(task_id), if
-    task_id never exists, celery will not throw an error, it will just hang.
-    This function updates each task sent to celery to have a progress value of "SENT",
-    which means we can check that a task exists with the following pattern:
-    `AsyncResponse(task_id).status == "SENT"`
-
-    See
-    http://stackoverflow.com/questions/9824172/find-out-whether-celery-task-exists/10089358
-    for more info
-
-    """
-
-    task = current_app.tasks.get(sender)
-    backend = task.backend if task else current_app.backend
-
-    backend.store_result(headers['id'], None, ASYNC_RESTORE_SENT)
 
 
 @periodic_task(

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -17,7 +17,6 @@ from corehq.util.metrics import metrics_gauge
 log = logging.getLogger(__name__)
 
 ASYNC_RESTORE_QUEUE = 'async_restore_queue'
-ASYNC_RESTORE_SENT = "SENT"
 SYNCLOG_RETENTION_DAYS = 9 * 7  # 63 days
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -1,34 +1,34 @@
-from unittest import mock
 from io import BytesIO
-from django.test import TestCase, SimpleTestCase, override_settings
-from casexml.apps.phone.models import SyncLogSQL
-from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
+from unittest import mock
 
-from corehq.apps.app_manager.tests.util import TestXmlMixin
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult
+from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
+from django.test import SimpleTestCase, TestCase, override_settings
 
-from casexml.apps.case.xml import V2
 from casexml.apps.case.tests.util import (
     delete_all_cases,
     delete_all_sync_logs,
 )
-from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import sharded
+from casexml.apps.case.xml import V2
+from casexml.apps.phone.models import SyncLogSQL
 from casexml.apps.phone.restore import (
+    AsyncRestoreResponse,
+    RestoreCacheSettings,
     RestoreConfig,
     RestoreParams,
-    RestoreCacheSettings,
-    AsyncRestoreResponse,
     RestoreResponse,
 )
+from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
 from casexml.apps.phone.tasks import get_async_restore_payload
 from casexml.apps.phone.tests.utils import create_restore_user
+from corehq.apps.app_manager.tests.util import TestXmlMixin
+from corehq.apps.domain.models import Domain
+from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.celery_monitoring.signals import CELERY_STATE_SENT
+from corehq.form_processor.tests.utils import sharded
 from corehq.util.test_utils import flag_enabled
-from corehq.apps.receiverwrapper.util import submit_form_locally
-from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
 
 
 class BaseAsyncRestoreTest(TestCase):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -22,9 +22,10 @@ from casexml.apps.phone.restore import (
     AsyncRestoreResponse,
     RestoreResponse,
 )
-from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
+from casexml.apps.phone.tasks import get_async_restore_payload
 from casexml.apps.phone.tests.utils import create_restore_user
 from corehq.apps.users.dbaccessors import delete_all_users
+from corehq.celery_monitoring.signals import CELERY_STATE_SENT
 from corehq.util.test_utils import flag_enabled
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
@@ -124,7 +125,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         # the return value).
         restore_response = mock.MagicMock(return_value=RestoreResponse(None))
         with mock.patch.object(AsyncResult, 'get', restore_response) as get_result:
-            with mock.patch.object(AsyncResult, 'status', ASYNC_RESTORE_SENT):
+            with mock.patch.object(AsyncResult, 'status', CELERY_STATE_SENT):
                 subsequent_restore = self._restore_config(is_async=True)
                 self.assertIsNotNone(async_restore_task_id_cache.get_value())
                 subsequent_restore.get_payload()


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
We've seen errors like [this one](https://dimagi.sentry.io/issues/6889642147/events/d68b6d7e3b2a4f878ce3d4031220439c/distributions/?project=136860&statsPeriod=24h). Stack trace below:
```
Traceback (most recent call last):
  File "django/db/backends/base/base.py", line 308, in _cursor
    return self._prepare_cursor(self.create_cursor(name))
  File "django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "django/db/backends/postgresql/base.py", line 330, in create_cursor
    cursor = self.connection.cursor()
InterfaceError: connection already closed
Traceback (most recent call last):
  File "celery/utils/dispatch/signal.py", line 276, in send
    response = receiver(signal=self, sender=sender, **named)
  File "casexml/apps/phone/tasks.py", line 68, in update_celery_state
    backend.store_result(headers['id'], None, ASYNC_RESTORE_SENT)
  File "celery/backends/base.py", line 526, in store_result
    self._store_result(task_id, result, state, traceback,
  File "django_celery_results/backends/database.py", line 132, in _store_result
    self.TaskModel._default_manager.store_result(**task_props)
  File "django_celery_results/managers.py", line 43, in _inner
    return fun(*args, **kwargs)
  File "django_celery_results/managers.py", line 168, in store_result
    obj, created = self.using(using).get_or_create(task_id=task_id,
  File "django/db/models/query.py", line 916, in get_or_create
    return self.get(**kwargs), False
  File "django/db/models/query.py", line 633, in get
    num = len(clone)
  File "django/db/models/query.py", line 380, in __len__
    self._fetch_all()
  File "django/db/models/query.py", line 1881, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "django/db/models/query.py", line 91, in __iter__
    results = compiler.execute_sql(
  File "django/db/models/sql/compiler.py", line 1560, in execute_sql
    cursor = self.connection.cursor()
  File "django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "django/db/backends/base/base.py", line 330, in cursor
    return self._cursor()
  File "django/db/backends/base/base.py", line 307, in _cursor
    with self.wrap_database_errors:
  File "django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "django/db/backends/base/base.py", line 308, in _cursor
    return self._prepare_cursor(self.create_cursor(name))
  File "django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "django/db/backends/postgresql/base.py", line 330, in create_cursor
    cursor = self.connection.cursor()
InterfaceError: connection already closed
```

After some digging, it appears to be coming from heartbeat tasks especially, which makes sense given how frequently they run, but also that they run as part of a long running celery process, not a typical django request lifecycle where you wouldn't expect connections to be closed prematurely. I'm not sure if there is a better solution to this problem with long running processes, but going to try this out on staging to see if it resolves the issue.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
