### PR TITLE
Allow debug environments to copy apps from staging

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -3083,7 +3083,7 @@ class ExtractAppInfoForm(forms.Form):
 
     def _get_source_server(self, parsed_url):
         server_mapping = {subdomain: server for server, subdomain
-                          in ServerLocation.SUBDOMAINS.items()}
+                          in ServerLocation.get_subdomains().items()}
 
         netloc = parsed_url.netloc.split(".")
 
@@ -3167,7 +3167,7 @@ class ImportAppForm(forms.Form):
         return app_file
 
     def construct_download_url(self, source_server, source_domain, app_id):
-        server_address = ServerLocation.SUBDOMAINS[source_server]
+        server_address = ServerLocation.get_subdomains()[source_server]
         return f"https://{server_address}.commcarehq.org/a/{source_domain}/apps/source/{app_id}/"
 
 

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta
 from unittest.mock import Mock, patch, MagicMock
 
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from dateutil.relativedelta import relativedelta
 
@@ -648,14 +648,14 @@ class TestExtractAppInfoForm(SimpleTestCase):
         self.assertFalse(form.is_valid())
         self.assertIn('The URL must be from a valid CommCare server', str(form.errors['app_url']))
 
-    @patch('corehq.apps.domain.forms.settings.SERVER_ENVIRONMENT', 'production')
+    @override_settings(SERVER_ENVIRONMENT='production')
     def test_clean_app_url_same_server_validation(self):
         url = 'https://www.commcarehq.org/a/test-domain/apps/view/62891a383516c656850cc9c7e7b8d459/'
         form = forms.ExtractAppInfoForm(data={'app_url': url})
         self.assertFalse(form.is_valid())
         self.assertIn('The source app url matches the current server', str(form.errors['app_url']))
 
-    @patch('corehq.apps.domain.forms.settings.SERVER_ENVIRONMENT', 'india')
+    @override_settings(SERVER_ENVIRONMENT='india')
     def test_clean_app_url_different_server_validation(self):
         url = 'https://www.commcarehq.org/a/test-domain/apps/view/62891a383516c656850cc9c7e7b8d459/'
         form = forms.ExtractAppInfoForm(data={'app_url': url})

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -642,6 +642,18 @@ class TestExtractAppInfoForm(SimpleTestCase):
         self.assertFalse(form.is_valid())
         self.assertIn('The URL must be from a valid CommCare server', str(form.errors['app_url']))
 
+    def test_staging_is_invalid_for_prod_environments(self):
+        url = 'https://staging.commcarehq.org/a/test-domain/apps/view/62891a383516c656850cc9c7e7b8d459/'
+        form = forms.ExtractAppInfoForm(data={'app_url': url})
+        self.assertFalse(form.is_valid())
+        self.assertIn('The URL must be from a valid CommCare server', str(form.errors['app_url']))
+
+    @override_settings(DEBUG=True)
+    def test_staging_is_valid_for_debug_environments(self):
+        url = 'https://staging.commcarehq.org/a/test-domain/apps/view/62891a383516c656850cc9c7e7b8d459/'
+        form = forms.ExtractAppInfoForm(data={'app_url': url})
+        self.assertTrue(form.is_valid())
+
     def test_clean_app_url_with_non_commcare_domain(self):
         url = 'https://india.foo.org/a/test-domain/apps/view/62891a383516c656850cc9c7e7b8d459/'
         form = forms.ExtractAppInfoForm(data={'app_url': url})

--- a/corehq/apps/domain/views/import_apps.py
+++ b/corehq/apps/domain/views/import_apps.py
@@ -100,8 +100,9 @@ class ImportAppStepsView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin
     def render_import_multimedia_instructions(self, request, source_server, source_domain, source_app_id,
                                               new_app_id):
         from corehq.apps.app_manager.views.utils import back_to_main
+        subdomain = ServerLocation.get_subdomains()[source_server]
         source_multimedia_url = (
-            f"https://{ServerLocation.SUBDOMAINS[source_server]}.commcarehq.org/a/"
+            f"https://{subdomain}.commcarehq.org/a/"
             f"{source_domain}/apps/view/{source_app_id}/settings/#multimedia-tab"
         )
         current_multimedia_url = reverse(BulkUploadMultimediaView.urlname, args=[self.domain, new_app_id])

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -148,3 +148,11 @@ class ServerLocation:
     }
 
     SUBDOMAINS = {env: server['subdomain'] for env, server in ENVS.items()}
+
+    @classmethod
+    def get_envs(cls):
+        return cls.ENVS
+
+    @classmethod
+    def get_subdomains(cls):
+        return {env: server['subdomain'] for env, server in cls.get_envs().items()}

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import Q
@@ -125,6 +126,7 @@ class ServerLocation:
     EU = 'eu'
     INDIA = 'india'
     PRODUCTION = 'production'
+    STAGING = 'staging'
 
     ENVS = {
         EU: {
@@ -147,10 +149,20 @@ class ServerLocation:
         },
     }
 
-    SUBDOMAINS = {env: server['subdomain'] for env, server in ENVS.items()}
+    STAGING_CONFIG = {
+        STAGING: {
+            'country_code': 'un',
+            'long_name': _("Staging"),
+            'short_name': _("Staging"),
+            'subdomain': 'staging',
+        }
+    }
 
     @classmethod
     def get_envs(cls):
+        if settings.DEBUG:
+            return cls.ENVS | cls.STAGING_CONFIG
+
         return cls.ENVS
 
     @classmethod

--- a/corehq/apps/hqwebapp/tests/test_models.py
+++ b/corehq/apps/hqwebapp/tests/test_models.py
@@ -159,5 +159,5 @@ class TestServerLocation(SimpleTestCase):
         }
 
     @override_settings(DEBUG=True)
-    def test_staging_subdomain_is_prsent_for_debug_environments(self):
+    def test_staging_subdomain_is_present_for_debug_environments(self):
         assert ServerLocation.get_subdomains()['staging'] == 'staging'

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -539,7 +539,7 @@ class HQLoginView(LoginView):
         is_domain_login = self.extra_context.get('domain')
         # also check the next param, because domain or other server-specific ids can exist there
         has_next_url = self.request.GET.get('next')
-        return (env in ServerLocation.ENVS
+        return (env in ServerLocation.get_envs()
                 and not is_domain_login
                 and not has_next_url)
 
@@ -560,7 +560,7 @@ class HQLoginView(LoginView):
         context['can_select_server'] = self.can_select_server()
         if self.can_select_server():
             context['server_choices'] = [
-                server for env, server in ServerLocation.ENVS.items()
+                server for env, server in ServerLocation.get_envs().items()
                 if env != settings.SERVER_ENVIRONMENT
             ]
         if domain and not is_domain_using_sso(domain):

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -33,14 +33,15 @@ from corehq.apps.users.models import CouchUser
 class RegisterWebUserForm(forms.Form):
     # Use: NewUserRegistrationView
     # Not inheriting from other forms to de-obfuscate the role of this form.
-    if settings.SERVER_ENVIRONMENT in ServerLocation.ENVS:
+    _envs = ServerLocation.get_envs()
+    if settings.SERVER_ENVIRONMENT in _envs:
         server_location = forms.ChoiceField(
             label=_("Cloud Location"),
             required=False,
             widget=forms.RadioSelect,
             choices=[
                 (server['subdomain'], _("{location_name} Cloud").format(location_name=server['long_name']))
-                for __, server in ServerLocation.ENVS.items()
+                for __, server in _envs.items()
             ],
             help_text=_(
                 "*You're creating an account and project space in the chosen cloud location.<br/>"
@@ -111,7 +112,8 @@ class RegisterWebUserForm(forms.Form):
         server_location_field = []
         if self.fields.get('server_location'):
             # safe to access because we only render the field if the current environment is in ServerLocation.ENVS
-            self.fields['server_location'].initial = ServerLocation.ENVS[settings.SERVER_ENVIRONMENT]['subdomain']
+            envs = ServerLocation.get_envs()
+            self.fields['server_location'].initial = envs[settings.SERVER_ENVIRONMENT]['subdomain']
             server_location_field = [
                 hqcrispy.RadioSelect(
                     'server_location',

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -216,7 +216,7 @@ class ProcessRegistrationView(JSONResponseMixin, View):
         message = None
         restricted_by_domain = None
         if is_existing:
-            current_env_data = ServerLocation.ENVS.get(settings.SERVER_ENVIRONMENT)
+            current_env_data = ServerLocation.get_envs().get(settings.SERVER_ENVIRONMENT)
             current_location = current_env_data['short_name'] if current_env_data else _("current")
             message = _(
                 'This email is already registered in the {location} cloud location. '
@@ -418,7 +418,7 @@ class RegisterDomainView(TemplateView):
             'env': env,
             'subdomain': server['subdomain'],
             'name': server['long_name'],
-        } for env, server in ServerLocation.ENVS.items() if env != settings.SERVER_ENVIRONMENT]
+        } for env, server in ServerLocation.get_envs().items() if env != settings.SERVER_ENVIRONMENT]
 
         context.update({
             'form': kwargs.get('form') or DomainRegistrationForm(),

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -201,8 +201,9 @@ def commcare_hq_names(request=None):
 def server_location_display(request):
     context = {}
     current_env = settings.SERVER_ENVIRONMENT
-    if current_env in ServerLocation.ENVS:
-        server = ServerLocation.ENVS.get(current_env)
+    envs = ServerLocation.get_envs()
+    if current_env in envs:
+        server = envs.get(current_env)
         context = {
             'server_display': {
                 'country_code': server['country_code'],


### PR DESCRIPTION
## Product Description
This PR allows debugging (localhost) environments to copy apps from staging (such as when a bug has been reproduced within a staging app).

## Technical Summary
This PR modifies the `ServerLocation` class to support staging. "Getter" methods were created rather than directly accessing the variables, so we can modify the behavior in the future.

## Feature Flag
None

## Safety Assurance

### Safety story
Verified that I could copy a staging app locally. Verified on staging that staging still displays the server environment on the welcome back screen, log in/signup page, and in the settings menu. Note that the staging behavior likely depends on another branch currently on staging.

### Automated test coverage
New tests added to `hqwebapp` and `domain`

### QA Plan
None planned

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
