### PR TITLE
Allow setting subscription auto_renew in accounting UI

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -522,7 +522,10 @@ class SubscriptionForm(forms.Form):
     )
     most_recent_version = forms.ChoiceField(
         label=gettext_lazy("Version"), initial="True",
-        choices=(("True", "Show Most Recent Version"), ("False", "Show All Versions"))
+        choices=(
+            ("True", gettext_lazy("Show Most Recent Version")),
+            ("False", gettext_lazy("Show All Versions")),
+        )
     )
     plan_version = forms.IntegerField(
         label=gettext_lazy("Software Plan"),
@@ -541,8 +544,12 @@ class SubscriptionForm(forms.Form):
     no_invoice_reason = forms.CharField(
         label=gettext_lazy("Justify why \"Do Not Invoice\""), max_length=256, required=False
     )
-    do_not_email_invoice = forms.BooleanField(label="Do Not Email Invoices", required=False)
-    do_not_email_reminder = forms.BooleanField(label="Do Not Email Subscription Reminders", required=False)
+    do_not_email_invoice = forms.BooleanField(
+        label=gettext_lazy("Do Not Email Invoices"), required=False
+    )
+    do_not_email_reminder = forms.BooleanField(
+        label=gettext_lazy("Do Not Email Subscription Reminders"), required=False
+    )
     auto_generate_credits = forms.BooleanField(
         label=gettext_lazy("Auto-generate Plan Credits"), required=False
     )
@@ -632,8 +639,8 @@ class SubscriptionForm(forms.Form):
                 self.fields['plan_visibility'].initial
             )
             is_most_recent_version = subscription.plan_version.plan.get_version() == subscription.plan_version
-            most_recent_version_text = ("is most recent version" if is_most_recent_version
-                                        else "not most recent version")
+            most_recent_version_text = (_("is most recent version") if is_most_recent_version
+                                        else _("not most recent version"))
             self.fields['most_recent_version'].initial = is_most_recent_version
             most_recent_version_field = hqcrispy.B3TextField(
                 'most_recent_version',
@@ -676,9 +683,9 @@ class SubscriptionForm(forms.Form):
                 subscription.date_start is not None
                 and subscription.date_start <= today
             ):
-                self.fields['start_date'].help_text = '(already started)'
+                self.fields['start_date'].help_text = _('(already started)')
             if has_subscription_already_ended(subscription):
-                self.fields['end_date'].help_text = '(already ended)'
+                self.fields['end_date'].help_text = _('(already ended)')
 
             self.fields['plan_version'].required = False
             self.fields['domain'].required = False
@@ -686,21 +693,21 @@ class SubscriptionForm(forms.Form):
         else:
             account_field = crispy.Field(
                 'account', css_class="input-xxlarge",
-                placeholder="Search for Billing Account"
+                placeholder=_("Search for Billing Account")
             )
             if account_id is not None:
                 self.fields['account'].initial = account_id
 
             domain_field = crispy.Field(
                 'domain', css_class="input-xxlarge",
-                placeholder="Search for Project Space"
+                placeholder=_("Search for Project Space")
             )
             plan_edition_field = crispy.Field('plan_edition')
             plan_visibility_field = crispy.Field('plan_visibility')
             most_recent_version_field = crispy.Field('most_recent_version')
             plan_version_field = crispy.Field(
                 'plan_version', css_class="input-xxlarge",
-                placeholder="Search for Software Plan"
+                placeholder=_("Search for Software Plan")
             )
 
         self.helper = FormHelper()
@@ -713,13 +720,15 @@ class SubscriptionForm(forms.Form):
                 crispy.Field(
                     'active_accounts',
                     css_class='input-xxlarge accounting-async-select2',
-                    placeholder="Select Active Account",
+                    placeholder=_("Select Active Account"),
                     style="width: 100%;",
                 ),
             ])
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
-                '%s Subscription' % ('Edit' if is_existing else 'New'),
+                _('%s Subscription') % (
+                    _('Edit') if is_existing else _('New')
+                ),
                 account_field,
                 crispy.Div(*transfer_fields),
                 start_date_field,
@@ -736,7 +745,7 @@ class SubscriptionForm(forms.Form):
                 domain_field,
                 'salesforce_contract_id',
                 hqcrispy.B3MultiField(
-                    "Invoice Options",
+                    _("Invoice Options"),
                     crispy.Field('do_not_invoice', data_bind="checked: noInvoice"),
                     'skip_invoicing_if_no_feature_charges',
                 ),
@@ -744,13 +753,13 @@ class SubscriptionForm(forms.Form):
                     crispy.Field(
                         'no_invoice_reason', data_bind="attr: {required: noInvoice}"),
                     data_bind="visible: noInvoice"),
-                hqcrispy.B3MultiField("Email Options", 'do_not_email_invoice', 'do_not_email_reminder'),
-                hqcrispy.B3MultiField("Credit Options", 'auto_generate_credits'),
+                hqcrispy.B3MultiField(_("Email Options"), 'do_not_email_invoice', 'do_not_email_reminder'),
+                hqcrispy.B3MultiField(_("Credit Options"), 'auto_generate_credits'),
                 'service_type',
                 'pro_bono_status',
                 'funding_source',
                 hqcrispy.B3MultiField(
-                    "Skip Auto Pause",
+                    _("Skip Auto Pause"),
                     crispy.Field('skip_auto_downgrade', data_bind="checked: skipAutoDowngrade")
                 ),
                 crispy.Div(
@@ -759,14 +768,14 @@ class SubscriptionForm(forms.Form):
                     ),
                     data_bind="visible: skipAutoDowngrade",
                 ),
-                hqcrispy.B3MultiField("Auto Renew", 'auto_renew'),
+                hqcrispy.B3MultiField(_("Auto Renew"), 'auto_renew'),
                 'set_subscription'
             ),
             hqcrispy.FormActions(
                 crispy.ButtonHolder(
                     crispy.Submit(
                         'set_subscription',
-                        '%s Subscription' % ('Update' if is_existing else 'Create'),
+                        _('%s Subscription') % (_('Update') if is_existing else _('Create')),
                         css_class='disable-on-submit',
                     )
                 )

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -819,6 +819,7 @@ class SubscriptionForm(forms.Form):
             funding_source=self.cleaned_data['funding_source'],
             skip_auto_downgrade=self.cleaned_data['skip_auto_downgrade'],
             skip_auto_downgrade_reason=self.cleaned_data['skip_auto_downgrade_reason'],
+            auto_renew=self.cleaned_data['auto_renew'],
         )
 
     def clean_active_accounts(self):

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -578,6 +578,11 @@ class SubscriptionForm(forms.Form):
         max_length=256,
         required=False,
     )
+    auto_renew = forms.BooleanField(
+        label=gettext_lazy("Enable auto renewal"),
+        help_text=gettext_lazy("Applies if subscription has a future end date and is type 'Product'"),
+        required=False,
+    )
     set_subscription = forms.CharField(widget=forms.HiddenInput, required=False)
 
     def __init__(self, subscription, account_id, web_user, *args, **kwargs):
@@ -665,6 +670,7 @@ class SubscriptionForm(forms.Form):
             self.fields['funding_source'].initial = subscription.funding_source
             self.fields['skip_auto_downgrade'].initial = subscription.skip_auto_downgrade
             self.fields['skip_auto_downgrade_reason'].initial = subscription.skip_auto_downgrade_reason
+            self.fields['auto_renew'].initial = subscription.auto_renew
 
             if (
                 subscription.date_start is not None
@@ -753,6 +759,7 @@ class SubscriptionForm(forms.Form):
                     ),
                     data_bind="visible: skipAutoDowngrade",
                 ),
+                hqcrispy.B3MultiField("Auto Renew", 'auto_renew'),
                 'set_subscription'
             ),
             hqcrispy.FormActions(

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -506,10 +506,10 @@ class SubscriptionForm(forms.Form):
         label=gettext_lazy("Billing Account"),
         widget=forms.Select(choices=[]),
     )
-    start_date = forms.DateField(
+    date_start = forms.DateField(
         label=gettext_lazy("Start Date"), widget=forms.DateInput()
     )
-    end_date = forms.DateField(
+    date_end = forms.DateField(
         label=gettext_lazy("End Date"), widget=forms.DateInput(), required=False
     )
     plan_edition = forms.ChoiceField(
@@ -600,8 +600,8 @@ class SubscriptionForm(forms.Form):
         self.web_user = web_user
         today = datetime.date.today()
 
-        start_date_field = crispy.Field('start_date', css_class="date-picker")
-        end_date_field = crispy.Field('end_date', css_class="date-picker")
+        date_start_field = crispy.Field('date_start', css_class="date-picker")
+        date_end_field = crispy.Field('date_end', css_class="date-picker")
 
         if is_existing:
             # circular import
@@ -658,8 +658,8 @@ class SubscriptionForm(forms.Form):
                     subscription.subscriber.domain)
             )
 
-            self.fields['start_date'].initial = subscription.date_start.isoformat()
-            self.fields['end_date'].initial = (
+            self.fields['date_start'].initial = subscription.date_start.isoformat()
+            self.fields['date_end'].initial = (
                 subscription.date_end.isoformat()
                 if subscription.date_end is not None else subscription.date_end
             )
@@ -683,9 +683,9 @@ class SubscriptionForm(forms.Form):
                 subscription.date_start is not None
                 and subscription.date_start <= today
             ):
-                self.fields['start_date'].help_text = _('(already started)')
+                self.fields['date_start'].help_text = _('(already started)')
             if has_subscription_already_ended(subscription):
-                self.fields['end_date'].help_text = _('(already ended)')
+                self.fields['date_end'].help_text = _('(already ended)')
 
             self.fields['plan_version'].required = False
             self.fields['domain'].required = False
@@ -731,8 +731,8 @@ class SubscriptionForm(forms.Form):
                 ),
                 account_field,
                 crispy.Div(*transfer_fields),
-                start_date_field,
-                end_date_field,
+                date_start_field,
+                date_end_field,
                 crispy.Div(
                     crispy.HTML('<h4 style="margin-bottom: 20px;">%s</h4>'
                             % _("Software Plan"),),
@@ -814,8 +814,8 @@ class SubscriptionForm(forms.Form):
     @property
     def shared_keywords(self):
         return dict(
-            date_start=self.cleaned_data['start_date'],
-            date_end=self.cleaned_data['end_date'],
+            date_start=self.cleaned_data['date_start'],
+            date_end=self.cleaned_data['date_end'],
             do_not_invoice=self.cleaned_data['do_not_invoice'],
             no_invoice_reason=self.cleaned_data['no_invoice_reason'],
             do_not_email_invoice=self.cleaned_data['do_not_email_invoice'],
@@ -879,16 +879,16 @@ class SubscriptionForm(forms.Form):
                     account=account.name,
                 ))
 
-        start_date = self.cleaned_data.get('start_date')
-        if not start_date:
+        date_start = self.cleaned_data.get('date_start')
+        if not date_start:
             if self.subscription:
-                start_date = self.subscription.date_start
+                date_start = self.subscription.date_start
             else:
                 raise ValidationError(_("You must specify a start date"))
 
-        end_date = self.cleaned_data.get('end_date')
-        if end_date:
-            if start_date > end_date:
+        date_end = self.cleaned_data.get('date_end')
+        if date_end:
+            if date_start > date_end:
                 raise ValidationError(_("End date must be after start date."))
 
         return self.cleaned_data

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1358,7 +1358,7 @@ class Subscription(models.Model):
                             web_user=None, note=None, adjustment_method=None,
                             service_type=None, pro_bono_status=None, funding_source=None,
                             skip_invoicing_if_no_feature_charges=None, skip_auto_downgrade=None,
-                            skip_auto_downgrade_reason=None):
+                            skip_auto_downgrade_reason=None, auto_renew=None):
         adjustment_method = adjustment_method or SubscriptionAdjustmentMethod.INTERNAL
 
         self._update_dates(date_start, date_end)
@@ -1376,6 +1376,7 @@ class Subscription(models.Model):
             funding_source=funding_source,
             skip_auto_downgrade=skip_auto_downgrade,
             skip_auto_downgrade_reason=skip_auto_downgrade_reason,
+            auto_renew=auto_renew,
         )
 
         self.save()
@@ -1420,6 +1421,7 @@ class Subscription(models.Model):
             'funding_source',
             'skip_auto_downgrade',
             'skip_auto_downgrade_reason',
+            'auto_renew',
         }
 
         assert property_names >= set(kwargs.keys())
@@ -1450,6 +1452,7 @@ class Subscription(models.Model):
             skip_invoicing_if_no_feature_charges=self.skip_invoicing_if_no_feature_charges,
             skip_auto_downgrade=self.skip_auto_downgrade,
             skip_auto_downgrade_reason=self.skip_auto_downgrade_reason,
+            auto_renew=self.auto_renew,
         )
 
     @transaction.atomic
@@ -1461,7 +1464,7 @@ class Subscription(models.Model):
                     auto_generate_credits=False, is_trial=False,
                     do_not_email_invoice=False, do_not_email_reminder=False,
                     skip_invoicing_if_no_feature_charges=False,
-                    skip_auto_downgrade=False, skip_auto_downgrade_reason=None):
+                    skip_auto_downgrade=False, skip_auto_downgrade_reason=None, auto_renew=False):
         """
         Changing a plan TERMINATES the current subscription and
         creates a NEW SUBSCRIPTION where the old plan left off.
@@ -1509,6 +1512,7 @@ class Subscription(models.Model):
             funding_source=(funding_source or FundingSource.CLIENT),
             skip_auto_downgrade=skip_auto_downgrade,
             skip_auto_downgrade_reason=skip_auto_downgrade_reason or '',
+            auto_renew=auto_renew,
         )
 
         new_subscription.save()

--- a/corehq/apps/accounting/static/accounting/js/base_subscriptions_main.js
+++ b/corehq/apps/accounting/static/accounting/js/base_subscriptions_main.js
@@ -51,10 +51,10 @@ var invoiceModel = function () {
 };
 
 $(function () {
-    $("#id_start_date").datepicker({
+    $("#id_date_start").datepicker({
         dateFormat: "yy-mm-dd",
     });
-    $("#id_end_date").datepicker({
+    $("#id_date_end").datepicker({
         dateFormat: "yy-mm-dd",
     });
     $("#id_new_date_end").datepicker({

--- a/corehq/apps/accounting/tests/test_forms.py
+++ b/corehq/apps/accounting/tests/test_forms.py
@@ -267,8 +267,8 @@ class TestSubscriptionForm(BaseAccountingTest):
         )
         subscription_form.cleaned_data = {
             'active_accounts': self.customer_account.id,
-            'start_date': datetime.date.today(),
-            'end_date': None,
+            'date_start': datetime.date.today(),
+            'date_end': None,
             'do_not_invoice': None,
             'no_invoice_reason': None,
             'do_not_email_invoice': None,
@@ -299,8 +299,8 @@ class TestSubscriptionForm(BaseAccountingTest):
         )
         subscription_form.cleaned_data = {
             'active_accounts': self.account.id,
-            'start_date': datetime.date.today(),
-            'end_date': None,
+            'date_start': datetime.date.today(),
+            'date_end': None,
             'do_not_invoice': None,
             'no_invoice_reason': None,
             'do_not_email_invoice': None,

--- a/corehq/apps/accounting/tests/test_forms.py
+++ b/corehq/apps/accounting/tests/test_forms.py
@@ -280,7 +280,8 @@ class TestSubscriptionForm(BaseAccountingTest):
             'pro_bono_status': None,
             'funding_source': None,
             'skip_auto_downgrade': None,
-            'skip_auto_downgrade_reason': None
+            'skip_auto_downgrade_reason': None,
+            'auto_renew': None,
         }
 
         self.assertRaises(ValidationError, lambda: subscription_form.clean_active_accounts())
@@ -311,7 +312,8 @@ class TestSubscriptionForm(BaseAccountingTest):
             'pro_bono_status': None,
             'funding_source': None,
             'skip_auto_downgrade': None,
-            'skip_auto_downgrade_reason': None
+            'skip_auto_downgrade_reason': None,
+            'auto_renew': None,
         }
 
         self.assertRaises(ValidationError, lambda: subscription_form.clean_active_accounts())

--- a/corehq/apps/accounting/tests/test_forms.py
+++ b/corehq/apps/accounting/tests/test_forms.py
@@ -24,6 +24,7 @@ from corehq.apps.accounting.models import (
     FormSubmittingMobileWorkerHistory,
     Invoice,
     SoftwarePlanEdition,
+    SoftwarePlanVersion,
     Subscription,
 )
 from corehq.apps.accounting.tasks import (
@@ -317,6 +318,75 @@ class TestSubscriptionForm(BaseAccountingTest):
         }
 
         self.assertRaises(ValidationError, lambda: subscription_form.clean_active_accounts())
+
+    def test_form_data_create_subscription(self):
+        required_args = {
+            'account': self.account.id,
+            'domain': self.domain.name,
+            'plan_version': self.plan.id,
+        }
+        subscription_form = SubscriptionForm(
+            subscription=None,
+            account_id=self.plan.id,
+            web_user=self.web_user,
+        )
+
+        with patch('corehq.apps.accounting.forms.Subscription') as subscription_cls:
+            subscription_form.cleaned_data = {**required_args, **self.shared_keywords()}
+            subscription_form.create_subscription()
+            args, kwargs = subscription_cls.new_domain_subscription.call_args
+
+        assert args == (
+            BillingAccount.objects.get(id=self.account.id),
+            self.domain.name,
+            SoftwarePlanVersion.objects.get(id=self.plan.id),
+        )
+        assert kwargs['web_user'] == self.web_user
+        assert kwargs['internal_change']
+        for k, v in self.shared_keywords().items():
+            assert kwargs[k] == v
+
+    def test_form_data_update_subscription(self):
+        subscription = Subscription.new_domain_subscription(
+            domain=self.domain.name,
+            plan_version=self.plan,
+            account=self.account,
+        )
+        subscription_form = SubscriptionForm(
+            subscription=subscription,
+            account_id=self.plan.id,
+            web_user=self.web_user,
+        )
+
+        with patch.object(subscription, 'update_subscription') as update_subscription:
+            subscription_form.cleaned_data = {**self.shared_keywords()}
+            subscription_form.update_subscription()
+            kwargs = update_subscription.call_args.kwargs
+
+        assert kwargs['web_user'] == self.web_user
+        for k, v in self.shared_keywords().items():
+            assert kwargs[k] == v
+
+    @staticmethod
+    def shared_keywords():
+        # maps to SubscriptionForm.shared_keywords
+        return {
+            'date_start': datetime.date.today(),
+            'date_end': datetime.date.today() + datetime.timedelta(days=7),
+            'do_not_invoice': True,
+            'no_invoice_reason': 'I said so',
+            'do_not_email_invoice': True,
+            'do_not_email_reminder': True,
+            'auto_generate_credits': True,
+            'skip_invoicing_if_no_feature_charges': True,
+            'salesforce_contract_id': 'abc123',
+            'service_type': 'SubscriptionType',
+            'pro_bono_status': 'ProBonoStatus',
+            'funding_source': 'FundingSource',
+            'skip_auto_downgrade': True,
+            'skip_auto_downgrade_reason': 'You said so',
+            'auto_renew': True,
+        }
 
 
 class TestTriggerInvoiceForm(BaseInvoiceTestCase):

--- a/corehq/apps/accounting/tests/test_forms.py
+++ b/corehq/apps/accounting/tests/test_forms.py
@@ -268,21 +268,7 @@ class TestSubscriptionForm(BaseAccountingTest):
         )
         subscription_form.cleaned_data = {
             'active_accounts': self.customer_account.id,
-            'date_start': datetime.date.today(),
-            'date_end': None,
-            'do_not_invoice': None,
-            'no_invoice_reason': None,
-            'do_not_email_invoice': None,
-            'do_not_email_reminder': None,
-            'auto_generate_credits': None,
-            'skip_invoicing_if_no_feature_charges': None,
-            'salesforce_contract_id': None,
-            'service_type': None,
-            'pro_bono_status': None,
-            'funding_source': None,
-            'skip_auto_downgrade': None,
-            'skip_auto_downgrade_reason': None,
-            'auto_renew': None,
+            **self.shared_keywords(),
         }
 
         self.assertRaises(ValidationError, lambda: subscription_form.clean_active_accounts())
@@ -300,21 +286,7 @@ class TestSubscriptionForm(BaseAccountingTest):
         )
         subscription_form.cleaned_data = {
             'active_accounts': self.account.id,
-            'date_start': datetime.date.today(),
-            'date_end': None,
-            'do_not_invoice': None,
-            'no_invoice_reason': None,
-            'do_not_email_invoice': None,
-            'do_not_email_reminder': None,
-            'auto_generate_credits': None,
-            'skip_invoicing_if_no_feature_charges': None,
-            'salesforce_contract_id': None,
-            'service_type': None,
-            'pro_bono_status': None,
-            'funding_source': None,
-            'skip_auto_downgrade': None,
-            'skip_auto_downgrade_reason': None,
-            'auto_renew': None,
+            **self.shared_keywords(),
         }
 
         self.assertRaises(ValidationError, lambda: subscription_form.clean_active_accounts())


### PR DESCRIPTION
## Product Description
Adds "Auto Renew" field at the bottom of the account admin Subscription form:

<img width="702" height="160" alt="image" src="https://github.com/user-attachments/assets/f74bde51-1e1c-4a68-a647-51b9c6d16777" />


## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SAAS-18408), [Tech Spec](https://docs.google.com/document/d/1kop7WTDE3HQdNhbWi0yoPbRjqdI4FLjFVHvtZ5CStJY/edit?usp=sharing)
Adds a form field to the SubscriptionForm for `auto_renew` and saves that to the `Subscription` model. Also makes text on the SubscriptionForm consistently translatable -- previously it was about 50/50.

## Safety Assurance

### Safety story
Tested locally to see that `auto_renew` sets or unsets as expected and saves without error, when creating a new subscription or updating an existing one.

### Automated test coverage
Added a couple of basic tests that see the expected args are passed from form data to create or update a subscription.

### QA Plan
Not for this change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
