### PR TITLE
Remove redundant HTML formatting in excel

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -32,6 +32,7 @@ from corehq.apps.es.aggregations import (
 )
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import location_safe
+from corehq.apps.reports.const import AllowedRenderings
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.exceptions import BadRequestError
 from corehq.apps.reports.filters.dates import SingleDateFilter
@@ -533,7 +534,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
             return '---'
         assigned_location_ids = user.get_location_ids(self.domain)
         primary_location_id = user.get_location_id(self.domain)
-        if getattr(self, 'rendered_as', None) == 'export':
+        if self.rendered_as == AllowedRenderings.EXPORT:
             # get text names for Excel export
             return self._get_assigned_location_names(primary_location_id, assigned_location_ids, user_loc_dict)
         else:

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -533,8 +533,23 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
             return '---'
         assigned_location_ids = user.get_location_ids(self.domain)
         primary_location_id = user.get_location_id(self.domain)
-        return self._get_formatted_assigned_location_names(primary_location_id, assigned_location_ids,
-                                                           user_loc_dict)
+        if getattr(self, 'rendered_as', None) == 'export':
+            # get text names for Excel export
+            return self._get_assigned_location_names(primary_location_id, assigned_location_ids, user_loc_dict)
+        else:
+            return self._get_formatted_assigned_location_names(primary_location_id, assigned_location_ids,
+                                                               user_loc_dict)
+
+    @staticmethod
+    def _get_assigned_location_names(primary_location_id, assigned_location_ids, user_loc_dict):
+        assigned_location_names = []
+        if primary_location_id in user_loc_dict:
+            assigned_location_names.append(user_loc_dict[primary_location_id])
+        other_assigned_location_ids = set(assigned_location_ids) - {primary_location_id}
+        for location_id in other_assigned_location_ids:
+            if location_id in user_loc_dict:
+                assigned_location_names.append(user_loc_dict[location_id])
+        return ', '.join(assigned_location_names)
 
     @staticmethod
     def _get_formatted_assigned_location_names(primary_location_id, assigned_location_ids, user_loc_dict):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Avoids including HTML formatting in an excel export of "User Last Activity Report" aka App Status Report.
This then removes redundant HTML formatting which is misinterpreted by Excel as text and also avoid duplication information rendering as shown in reference below.

**HTML formatting working well on browser**

<img width="664" height="298" alt="image" src="https://github.com/user-attachments/assets/e24f8303-16dd-4552-ac18-5bd5b5dd1f9f" />

<img width="664" height="298" alt="image" src="https://github.com/user-attachments/assets/32b84a1f-f0c6-4aa7-8035-6f2c5e15e466" />

-------------------
**Excel (Before)**
(Notice the duplicate rendering of the locations along with HTML formatting)

<img width="1041" height="101" alt="image" src="https://github.com/user-attachments/assets/735588e9-3883-48bf-8a09-5b0bb15f0e52" />

-------------------

**Excel (After)**
(Primary location still shown at the beginning)
<img width="813" height="101" alt="image" src="https://github.com/user-attachments/assets/ff340711-6f7e-40d7-a040-780efa9d3562" />



## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18534
This is an effort to fix bugs before GA'in the feature flag in future

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LOCATION_COLUMNS_APP_STATUS_REPORT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. The change is limited to just the feature flag.
There are unfortunately no tests for this at all but will get added in the GA effort.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
