### PR TITLE
Reduce pillow lag on low volume partitions

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -155,7 +155,8 @@ class KafkaChangeFeed(ChangeFeed):
             for partition in self._consumer.partitions_for_topic(topic):
                 topic_partitions.append(TopicPartition(topic, partition))
 
-        self._consumer.assign(self._filter_partitions(topic_partitions))
+        self.topic_partitions = self._filter_partitions(topic_partitions)
+        self._consumer.assign(self.topic_partitions)
         return self._consumer
 
     def _filter_offsets(self, offsets) -> Optional[Dict[TopicPartition, int]]:

--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -17,7 +17,7 @@ from corehq.apps.change_feed.exceptions import UnknownDocumentStore
 from corehq.apps.change_feed.topics import validate_offsets
 
 MIN_TIMEOUT = 500
-MAX_TIMEOUT = 1000 * 60 * 60 * 24  # 1 day in ms
+MAX_TIMEOUT = 1000 * 10  # 10 seconds in ms
 
 
 class KafkaChangeFeed(ChangeFeed):

--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -61,6 +61,10 @@ class KafkaChangeFeed(ChangeFeed):
     ) -> Iterator[Change]:
         """
         ``since`` must be a dictionary of topic partition offsets, or None
+
+        Yields `None` if `forever` is `True` and the consumer times out,
+        at which point the timeout is reset and the consumer continues
+        listening for and yielding changes as they arrive.
         """
         timeout = MAX_TIMEOUT if forever else MIN_TIMEOUT
         start_from_latest = since is None
@@ -89,13 +93,14 @@ class KafkaChangeFeed(ChangeFeed):
             for topic_partition, offset in since.items():
                 self.consumer.seek(TopicPartition(topic_partition[0], topic_partition[1]), int(offset))
 
-        try:
+        while True:
             for message in self.consumer:
                 self._processed_topic_offsets[(message.topic, message.partition)] = message.offset
                 yield change_from_kafka_message(message)
-        except StopIteration:
-            # no need to do anything since this is just telling us we've reached the end of the feed
-            pass
+            # consumer timed out
+            if not forever:
+                break
+            yield None  # avoid excessive lag while waiting for the next change
 
     def get_current_checkpoint_offsets(self):
         # the way kafka works, the checkpoint should increment by 1 because

--- a/corehq/ex-submodules/pillowtop/feed/interface.py
+++ b/corehq/ex-submodules/pillowtop/feed/interface.py
@@ -151,6 +151,7 @@ class ChangeFeed(metaclass=ABCMeta):
     """
 
     sequence_format = 'text'
+    topic_partitions = (None,)
 
     @abstractmethod
     def iter_changes(self, since, forever):

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -165,42 +165,33 @@ class ConstructedPillow:
             at the end of the batch, otherwise is updated for every change.
         """
         context = PillowRuntimeContext(changes_seen=0)
-        min_wait_seconds = 30
-
-        def process_offset_chunk(chunk, context):
-            if not chunk:
-                return
-            self._batch_process_with_error_handling(chunk)
-            self._update_checkpoint(chunk[-1], context)
-
-        # keep track of chunk for batch processors
         changes_chunk = []
-        last_process_time = datetime.utcnow()
 
         for change in self.change_feed.iter_changes(since=since or None, forever=forever):
             context.changes_seen += 1
-            if change:
+            if change or changes_chunk:
                 if self.batch_processors:
                     # Queue and process in chunks for both batch
                     #   and serial processors
-                    changes_chunk.append(change)
+                    if change is not None:
+                        changes_chunk.append(change)
                     chunk_full = len(changes_chunk) == self.processor_chunk_size
-                    time_elapsed = (datetime.utcnow() - last_process_time).seconds > min_wait_seconds
-                    if chunk_full or time_elapsed:
-                        last_process_time = datetime.utcnow()
+                    # change is None means consumer timeout -> process partial chunk to avoid lag
+                    if chunk_full or (change is None and changes_chunk):
                         self._batch_process_with_error_handling(changes_chunk)
-                        # update checkpoint for just the latest change
                         self._update_checkpoint(changes_chunk[-1], context)
-                        # reset for next chunk
                         changes_chunk = []
                 else:
                     # process all changes one by one
+                    assert change is not None
                     processing_time = self.process_with_error_handling(change)
                     self._record_change_in_datadog(change, processing_time)
                     self._update_checkpoint(change, context)
             else:
                 self._update_checkpoint(None, None)
-        process_offset_chunk(changes_chunk, context)
+        if changes_chunk:
+            self._batch_process_with_error_handling(changes_chunk)
+            self._update_checkpoint(changes_chunk[-1], context)
 
     def _batch_process_with_error_handling(self, changes_chunk):
         """

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -113,7 +113,10 @@ class ConstructedPillow:
             self._run_migrations_forever()
         else:
             while True:
-                self.process_changes(since=self.get_last_checkpoint_sequence(), forever=True)
+                try:
+                    self.process_changes(since=self.get_last_checkpoint_sequence(), forever=True)
+                except PillowtopCheckpointReset:
+                    pass
 
     def _run_migrations_forever(self):
         for processor in self.processors:
@@ -201,7 +204,7 @@ class ConstructedPillow:
             process_offset_chunk(changes_chunk, context)
         except PillowtopCheckpointReset:
             process_offset_chunk(changes_chunk, context)
-            self.process_changes(since=self.get_last_checkpoint_sequence(), forever=forever)
+            raise
         if forever:
             if context.changes_seen and change:
                 self._update_checkpoint(change, context)

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -201,9 +201,6 @@ class ConstructedPillow:
             else:
                 self._update_checkpoint(None, None)
         process_offset_chunk(changes_chunk, context)
-        if forever:
-            if context.changes_seen and change:
-                self._update_checkpoint(change, context)
 
     def _batch_process_with_error_handling(self, changes_chunk):
         """

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -4,11 +4,11 @@ from collections import Counter, defaultdict
 from datetime import datetime
 
 from django.conf import settings
-from django.core.signals import request_finished
 from memoized import memoized
 
 from sentry_sdk import Scope
 
+from corehq.sql_db.connections import cleanup_connections
 from corehq.util.metrics import metrics_counter, metrics_gauge
 from corehq.util.metrics.const import MPM_MAX
 from corehq.util.timer import TimingContext
@@ -133,12 +133,7 @@ class ConstructedPillow:
             updated = self.checkpoint.touch(min_interval=CHECKPOINT_MIN_WAIT)
         if updated:
             self._record_checkpoint_in_datadog()
-        self._close_old_connections()
-
-    def _close_old_connections(self):
-        # Prevent connection timeout
-        # https://github.com/jneight/django-db-geventpool#using-orm-when-not-serving-requests
-        request_finished.send(sender=self.pillow_id)
+        cleanup_connections(self.pillow_id)
 
     @property
     @memoized

--- a/corehq/ex-submodules/pillowtop/run_pillowtop.py
+++ b/corehq/ex-submodules/pillowtop/run_pillowtop.py
@@ -5,6 +5,8 @@ import gevent
 
 from dimagi.utils.logging import notify_exception
 
+from corehq.sql_db.connections import cleanup_connections
+
 from pillowtop import get_all_pillow_instances
 from pillowtop.utils import get_pillow_by_name
 
@@ -76,6 +78,7 @@ def run_gevent_worker(pillow_name, *, process_number, **kw):
             run_pillow_by_name(pillow_name, process_number=process_number, **kw)
         except Exception as exc:
             notify_exception(None, f"[{pillow_name} {process_number}] Unexpected gevent pillow exit: {exc}")
+            cleanup_connections(pillow_name)
 
 
 def start_pillows(pillows=None):

--- a/corehq/ex-submodules/pillowtop/tests/test_pillow.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_pillow.py
@@ -90,6 +90,7 @@ def test_process_changes(cfg, expected_calls):
         patch.object(pillow, '_batch_process_with_error_handling', batch_proc),
         patch.object(pillow, 'process_with_error_handling', serial_proc),
         patch.object(pillow, '_record_change_in_datadog'),
+        patch.object(pillow, '_record_timeout_in_datadog'),
         patch.object(pillow, '_update_checkpoint', checkpoint),
     ):
         pillow.process_changes(since=None, forever=cfg.forever)

--- a/corehq/ex-submodules/pillowtop/tests/test_pillow.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_pillow.py
@@ -20,7 +20,6 @@ cfg = Config(batch=True, changes=[1], chunk_size=1, forever=True)
         "checkpoint 2 seen=2",
     ]),
     (cfg(changes=[1, None], chunk_size=2), [
-        "checkpoint None",
         "batch [1]",
         "checkpoint 1 seen=2",
     ]),

--- a/corehq/ex-submodules/pillowtop/tests/test_pillow.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_pillow.py
@@ -14,11 +14,9 @@ cfg = Config(batch=True, changes=[1], chunk_size=1, forever=True)
     (cfg, [
         "batch [1]",
         "checkpoint 1 seen=1",
-        "checkpoint 1 seen=1",
     ]),
     (cfg(changes=[1, 2], chunk_size=2), [
         "batch [1, 2]",
-        "checkpoint 2 seen=2",
         "checkpoint 2 seen=2",
     ]),
     (cfg(changes=[1, None], chunk_size=2), [
@@ -33,11 +31,9 @@ cfg = Config(batch=True, changes=[1], chunk_size=1, forever=True)
     (cfg(changes=[1], chunk_size=2), [
         "batch [1]",
         "checkpoint 1 seen=1",
-        "checkpoint 1 seen=1",
     ]),
     (cfg(batch=False), [
         "serial 1",
-        "checkpoint 1 seen=1",
         "checkpoint 1 seen=1",
     ]),
     (cfg(batch=False, changes=[None]), [

--- a/corehq/ex-submodules/pillowtop/tests/test_pillow.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_pillow.py
@@ -21,7 +21,7 @@ cfg = Config(batch=True, changes=[1], chunk_size=1, forever=True)
     ]),
     (cfg(changes=[1, None], chunk_size=2), [
         "batch [1]",
-        "checkpoint 1 seen=2",
+        "checkpoint 1 seen=1",
     ]),
     (cfg(changes=[None]), [
         "checkpoint None",

--- a/corehq/ex-submodules/pillowtop/tests/test_pillow.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_pillow.py
@@ -1,0 +1,99 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from testil import Config
+
+from ..pillow.interface import ConstructedPillow
+
+cfg = Config(batch=True, changes=[1], chunk_size=1, forever=True)
+
+
+@pytest.mark.parametrize("cfg, expected_calls", [
+    (cfg, [
+        "batch [1]",
+        "checkpoint 1 seen=1",
+        "checkpoint 1 seen=1",
+    ]),
+    (cfg(changes=[1, 2], chunk_size=2), [
+        "batch [1, 2]",
+        "checkpoint 2 seen=2",
+        "checkpoint 2 seen=2",
+    ]),
+    (cfg(changes=[1, None], chunk_size=2), [
+        "checkpoint None",
+        "batch [1]",
+        "checkpoint 1 seen=2",
+    ]),
+    (cfg(changes=[None]), [
+        "checkpoint None",
+    ]),
+    (cfg(changes=[]), []),
+    (cfg(changes=[1], chunk_size=2), [
+        "batch [1]",
+        "checkpoint 1 seen=1",
+        "checkpoint 1 seen=1",
+    ]),
+    (cfg(batch=False), [
+        "serial 1",
+        "checkpoint 1 seen=1",
+        "checkpoint 1 seen=1",
+    ]),
+    (cfg(batch=False, changes=[None]), [
+        "checkpoint None",
+    ]),
+    (cfg(forever=False), [
+        "batch [1]",
+        "checkpoint 1 seen=1",
+    ]),
+    (cfg(changes=[1, 2], chunk_size=2, forever=False), [
+        "batch [1, 2]",
+        "checkpoint 2 seen=2",
+    ]),
+    (cfg(changes=[None], forever=False), [
+        "checkpoint None",
+    ]),
+    (cfg(changes=[1], chunk_size=2, forever=False), [
+        "batch [1]",
+        "checkpoint 1 seen=1",
+    ]),
+    (cfg(batch=False, forever=False), [
+        "serial 1",
+        "checkpoint 1 seen=1",
+    ]),
+    (cfg(batch=False, changes=[None], forever=False), [
+        "checkpoint None",
+    ]),
+])
+def test_process_changes(cfg, expected_calls):
+    class feed:
+        def iter_changes(**args):
+            for change in cfg.changes:
+                yield change
+
+    def batch_proc(changes):
+        calls.append(f"batch {changes}")
+
+    def serial_proc(change):
+        calls.append(f"serial {change}")
+
+    def checkpoint(change, context):
+        seen = "" if context is None else f" seen={context.changes_seen}"
+        calls.append(f"checkpoint {change}{seen}")
+
+    print(cfg)
+    pillow = ConstructedPillow(
+        name='TestPillow',
+        checkpoint=Mock(),
+        change_feed=feed,
+        processor=Config(supports_batch_processing=cfg.batch),
+        processor_chunk_size=cfg.chunk_size,
+    )
+    calls = []
+    with (
+        patch.object(pillow, '_batch_process_with_error_handling', batch_proc),
+        patch.object(pillow, 'process_with_error_handling', serial_proc),
+        patch.object(pillow, '_record_change_in_datadog'),
+        patch.object(pillow, '_update_checkpoint', checkpoint),
+    ):
+        pillow.process_changes(since=None, forever=cfg.forever)
+    assert calls == expected_calls

--- a/corehq/ex-submodules/pillowtop/tests/utils.py
+++ b/corehq/ex-submodules/pillowtop/tests/utils.py
@@ -4,7 +4,7 @@ from corehq.apps.es.transient_util import doc_adapter_from_index_name
 from corehq.util.es.elasticsearch import TransportError
 
 from pillowtop.checkpoints.manager import PillowCheckpoint
-from pillowtop.pillow.interface import ConstructedPillow
+from pillowtop.pillow import interface
 
 
 TEST_ES_MAPPING = {
@@ -43,7 +43,7 @@ def get_index_mapping(es, index, doc_type):
         return {}
 
 
-class FakeConstructedPillow(ConstructedPillow):
+class FakeConstructedPillow(interface.ConstructedPillow):
     pass
 
 
@@ -60,7 +60,7 @@ def make_fake_constructed_pillow(pillow_id, checkpoint_id):
     return pillow
 
 
-def _do_not_close_old_connections(self):
+def _do_not_close_old_connections(sender):
     """Do not close database connections when running tests
 
     Prevents "connection already closed" errors in tests that process
@@ -69,7 +69,7 @@ def _do_not_close_old_connections(self):
 
 
 pillow_connection_cleanup_patch = patch.object(
-    ConstructedPillow,
-    '_close_old_connections',
+    interface,
+    'cleanup_connections',
     _do_not_close_old_connections
 )

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -61,7 +61,7 @@ class SessionHelper(object):
             try:
                 yield session
                 session.commit()
-            except:
+            except:  # noqa: E722
                 session.rollback()
                 raise
             finally:
@@ -209,7 +209,18 @@ def _close_connections(**kwargs):
     Session.remove()  # todo: unclear whether this is necessary
     connection_manager.close_scoped_sessions()
 
+
 signals.request_finished.connect(_close_connections)
+
+
+def cleanup_connections(sender):
+    """Close old connections
+
+    Use in long-running processes that use Django and/or SQLAlchemy
+    ORM but do not serve Django web requests.
+    https://github.com/jneight/django-db-geventpool#using-orm-when-not-serving-requests
+    """
+    signals.request_finished.send(sender=sender)
 
 
 @unit_testing_only


### PR DESCRIPTION
With the new [option to use gevent for pillow processing](https://github.com/dimagi/commcare-hq/pull/36902), it may be possible to increase throughput by significantly increasing the number of Kafka partitions. However, that could create significant processing lag on individual partitions due to thin distribution across many partitions.

High-level changes in this PR:
- Reduce the wait-for-next-change timeout (was 1 day, now 10 seconds) on Kafka change feed and change the control flow so timeouts are indicated by a null change, allowing the change processor to process a partial batch without excessive waiting.
- Add a 10 second "heartbeat" parameter to the Couch change feed so it has similar control flow characteristics as the new Kafka change feed.
- Test and simplify pillow change consumer logic.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

New tests were added for all changes.

### Automated test coverage

Yes.

### QA Plan

These changes will be deployed and monitored on staging for a while to ensure that they work and do not cause new errors in the logs.

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations