### PR TITLE
Clean up some user invite UI to make it the "user fields on invite" FF ready for GAing

### DIFF
--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -14,7 +14,7 @@ from corehq.apps.accounting.utils import domain_has_privilege
 from crispy_forms.layout import HTML, Div, Field, Fieldset, Layout
 from memoized import memoized
 
-from corehq.apps.hqwebapp.crispy import HQFormHelper, HQModalFormHelper
+from corehq.apps.hqwebapp.crispy import FieldsetAccordionGroup, HQFormHelper, HQModalFormHelper
 from corehq import privileges
 
 from .models import (
@@ -142,6 +142,7 @@ class CustomDataEditor(object):
     def make_fieldsets(self, form_fields, is_post, field_name_includes_prefix=False):
         if self.ko_model:
             field_names = []
+            profile_names = []
             for field_name, field in form_fields.items():
                 data_bind_field_name = (
                     without_prefix(field_name, self.prefix) if field_name_includes_prefix else field_name)
@@ -153,19 +154,32 @@ class CustomDataEditor(object):
                     data_binds.append("select2: " + json.dumps([
                         {"id": id, "text": text} for id, text in field.widget.choices
                     ]))
-                field_names.append(Field(
-                    field_name,
-                    data_bind=", ".join(data_binds)
-                ))
+                if field_name.endswith(PROFILE_SLUG):
+                    profile_names.append(Field(
+                        field_name,
+                        data_bind=", ".join(data_binds)
+                    ))
+                else:
+                    field_names.append(Field(
+                        field_name,
+                        data_bind=", ".join(data_binds)
+                    ))
         else:
             field_names = list(form_fields)
+            profile_names = []
 
         form_fieldsets = []
-        if field_names:
+        if profile_names:
             form_fieldsets.append(Fieldset(
+                _("Profile"),
+                *profile_names,
+                css_class="custom-data-fieldset"
+            ))
+        if field_names:
+            form_fieldsets.append(FieldsetAccordionGroup(
                 _("Additional Information"),
                 *field_names,
-                css_class="custom-data-fieldset"
+                active=True
             ))
         if not is_post:
             form_fieldsets.append(self.uncategorized_form)

--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -172,14 +172,14 @@ class CustomDataEditor(object):
         if profile_names:
             form_fieldsets.append(Fieldset(
                 _("Profile"),
-                *profile_names,
-                css_class="custom-data-fieldset"
+                *profile_names
             ))
         if field_names:
             form_fieldsets.append(FieldsetAccordionGroup(
                 _("Additional Information"),
                 *field_names,
-                active=True
+                active=True,
+                css_class="custom-data-fieldset"
             ))
         if not is_post:
             form_fieldsets.append(self.uncategorized_form)

--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -322,12 +322,13 @@ class CustomDataEditor(object):
             self.field_view.urlname, args=[self.domain]
         ))
 
-        return Fieldset(
+        return FieldsetAccordionGroup(
             _("Unrecognized Information"),
             Div(
                 HTML(msg),
                 css_class="alert alert-warning",
                 css_id="js-unrecognized-data",
             ),
-            *help_div
+            *help_div,
+            active=True
         ) if len(help_div) else HTML('')

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap3/accordion_group.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap3/accordion_group.html
@@ -1,18 +1,21 @@
 <fieldset class="{{ div.css_class }}">
-    <legend>
-        <a class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
-           data-toggle="collapse"
-           {% if div.data_parent %}
-           data-parent="#{{ div.data_parent }}"
-           {% endif %}
-           href="#{{ div.css_id }}">
-            <i class="fa fa-angle-double-down"></i>
-            {{ div.name }}
-        </a>
-    </legend>
-    <div id="{{ div.css_id }}" class="panel-body collapse{% if div.active %} in{% endif %}" >
-        <div>
-            {{ fields|safe }}
-        </div>
-    </div>
+  <legend>
+    <a
+      class="accordion-toggle{% if not div.active %}collapsed{% endif %}"
+      data-toggle="collapse"
+      {% if div.data_parent %}
+        data-parent="#{{ div.data_parent }}"
+      {% endif %}
+      href="#{{ div.css_id }}"
+    >
+      <i class="fa fa-angle-double-down"></i>
+      {{ div.name }}
+    </a>
+  </legend>
+  <div
+    id="{{ div.css_id }}"
+    class="panel-body collapse{% if div.active %}in{% endif %}"
+  >
+    <div>{{ fields|safe }}</div>
+  </div>
 </fieldset>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap3/accordion_group.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap3/accordion_group.html
@@ -1,7 +1,7 @@
 <fieldset class="{{ div.css_class }}">
   <legend>
     <a
-      class="accordion-toggle{% if not div.active %}collapsed{% endif %}"
+      class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
       data-toggle="collapse"
       {% if div.data_parent %}
         data-parent="#{{ div.data_parent }}"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap3/accordion_group.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap3/accordion_group.html
@@ -1,4 +1,4 @@
-<fieldset>
+<fieldset class="{{ div.css_class }}">
     <legend>
         <a class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
            data-toggle="collapse"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap3/accordion_group.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap3/accordion_group.html
@@ -14,7 +14,7 @@
   </legend>
   <div
     id="{{ div.css_id }}"
-    class="panel-body collapse{% if div.active %}in{% endif %}"
+    class="panel-body collapse{% if div.active %} in{% endif %}"
   >
     <div>{{ fields|safe }}</div>
   </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/accordion_group.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/accordion_group.html
@@ -1,7 +1,7 @@
 <fieldset class="{{ div.css_class }}">
   <legend>
     <a
-      class="accordion-toggle{% if not div.active %}collapsed{% endif %}"
+      class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
       data-bs-toggle="collapse"
       {% if div.data_parent %}
         data-parent="#{{ div.data_parent }}"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/accordion_group.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/accordion_group.html
@@ -14,7 +14,7 @@
   </legend>
   <div
     id="{{ div.css_id }}"
-    class="card-body collapse{% if div.active %}in{% endif %}"
+    class="card-body collapse{% if div.active %} in{% endif %}"
   >
     <div>{{ fields|safe }}</div>
   </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/accordion_group.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/accordion_group.html
@@ -1,18 +1,21 @@
 <fieldset class="{{ div.css_class }}">
-    <legend>
-        <a class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
-           data-bs-toggle="collapse"
-           {% if div.data_parent %}
-           data-parent="#{{ div.data_parent }}"
-           {% endif %}
-           href="#{{ div.css_id }}">
-            <i class="fa fa-angle-double-down"></i>
-            {{ div.name }}
-        </a>
-    </legend>
-    <div id="{{ div.css_id }}" class="card-body collapse{% if div.active %} in{% endif %}" >
-        <div>
-            {{ fields|safe }}
-        </div>
-    </div>
+  <legend>
+    <a
+      class="accordion-toggle{% if not div.active %}collapsed{% endif %}"
+      data-bs-toggle="collapse"
+      {% if div.data_parent %}
+        data-parent="#{{ div.data_parent }}"
+      {% endif %}
+      href="#{{ div.css_id }}"
+    >
+      <i class="fa fa-angle-double-down"></i>
+      {{ div.name }}
+    </a>
+  </legend>
+  <div
+    id="{{ div.css_id }}"
+    class="card-body collapse{% if div.active %}in{% endif %}"
+  >
+    <div>{{ fields|safe }}</div>
+  </div>
 </fieldset>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/accordion_group.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/accordion_group.html
@@ -1,4 +1,4 @@
-<fieldset>
+<fieldset class="{{ div.css_class }}">
     <legend>
         <a class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
            data-bs-toggle="collapse"

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/crispy/accordion_group.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/crispy/accordion_group.html.diff.txt
@@ -1,20 +1,20 @@
 --- 
 +++ 
-@@ -1,7 +1,7 @@
- <fieldset>
-     <legend>
-         <a class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
--           data-toggle="collapse"
-+           data-bs-toggle="collapse"
-            {% if div.data_parent %}
-            data-parent="#{{ div.data_parent }}"
-            {% endif %}
-@@ -10,7 +10,7 @@
-             {{ div.name }}
-         </a>
-     </legend>
--    <div id="{{ div.css_id }}" class="panel-body collapse{% if div.active %} in{% endif %}" >
-+    <div id="{{ div.css_id }}" class="card-body collapse{% if div.active %} in{% endif %}" >
-         <div>
-             {{ fields|safe }}
-         </div>
+@@ -2,7 +2,7 @@
+   <legend>
+     <a
+       class="accordion-toggle{% if not div.active %}collapsed{% endif %}"
+-      data-toggle="collapse"
++      data-bs-toggle="collapse"
+       {% if div.data_parent %}
+         data-parent="#{{ div.data_parent }}"
+       {% endif %}
+@@ -14,7 +14,7 @@
+   </legend>
+   <div
+     id="{{ div.css_id }}"
+-    class="panel-body collapse{% if div.active %}in{% endif %}"
++    class="card-body collapse{% if div.active %}in{% endif %}"
+   >
+     <div>{{ fields|safe }}</div>
+   </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/crispy/accordion_group.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/crispy/accordion_group.html.diff.txt
@@ -3,7 +3,7 @@
 @@ -2,7 +2,7 @@
    <legend>
      <a
-       class="accordion-toggle{% if not div.active %}collapsed{% endif %}"
+       class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
 -      data-toggle="collapse"
 +      data-bs-toggle="collapse"
        {% if div.data_parent %}
@@ -13,8 +13,8 @@
    </legend>
    <div
      id="{{ div.css_id }}"
--    class="panel-body collapse{% if div.active %}in{% endif %}"
-+    class="card-body collapse{% if div.active %}in{% endif %}"
+-    class="panel-body collapse{% if div.active %} in{% endif %}"
++    class="card-body collapse{% if div.active %} in{% endif %}"
    >
      <div>{{ fields|safe }}</div>
    </div>

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1241,9 +1241,14 @@ class InviteWebUserView(BaseManageWebUserView):
         post_dict = None
         if self.request.method == 'POST':
             post_dict = self.request.POST
+
+        existing_custom_data = None
+        if self.invitation:
+            existing_custom_data = self.invitation.custom_user_data
         custom_data = CustomDataEditor(
             field_view=WebUserFieldsView,
             domain=self.domain,
+            existing_custom_data=existing_custom_data,
             post_dict=post_dict,
             ko_model="custom_fields",
             request_user=self.request.couch_user


### PR DESCRIPTION
## Product Description

* Move the profile field to its own section to make it more obvious that it is not just one of the other user fields
* Make the "Additional Information" and "Unrecognized Information" sections collapsible
* Fix "Unrecognizable Information" section on user invites was not showing up previously

<img width="1067" height="648" alt="image" src="https://github.com/user-attachments/assets/0a1e5d5a-b836-4e4e-8440-36e43d576a25" />

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6323
[GA proposal](https://docs.google.com/document/d/1IUPAQw9MujJXN3NQ2HwmTe43p3uSXqpWcjafpGyh0KA/edit?usp=sharing)
[Tech spec](https://docs.google.com/document/d/1_t48aNHHD6HVTo2HORMWJH4nCs190DgSE_xtf8potjA/edit?usp=sharing)

## Feature Flag

USH: Enable additional fields in web user invite form for enhanced user details

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
