### PR TITLE
Prevent Sliding Animation on Initial slideVisible Element Load

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -195,7 +195,7 @@
             {% endif %}
           </div>
           {% if request|toggle_enabled:'USH_INLINE_SEARCH' %}
-          <div class="form-group" data-bind="visible: inlineSearchVisible">
+          <div class="form-group" data-bind="slideVisible: inlineSearchVisible">
             <label class="control-label {% css_label_class %}">
               {% trans "Make search input available after search" %}
               <span class="hq-help-template" data-title="{% trans "Make search input available after search" %}"

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -230,6 +230,7 @@
               {% trans "Label for Searching" %}
               <span class="hq-help-template" data-title="{% trans "Label for Searching" %}"
                     data-content="{% trans_html_attr "This text is for the button to enter case search. It is also the header on the search results screen." %}">
+              </span>
             </label>
             <div class="{% css_field_class %}">
               {% input_trans module.search_config.search_label.label langs input_name='search_label' input_id='search_label' data_bind="value: search_label" %}
@@ -248,6 +249,7 @@
                 {% trans "Label for Searching Again" %}
                 <span class="hq-help-template" data-title="{% trans "Label for Searching Again" %}"
                       data-content="{% trans_html_attr "This text is for the search button displayed at the bottom of search results, so users can search again." %}">
+                </span>
               </label>
               <div class="{% css_field_class %}">
                 {% input_trans module.search_config.search_again_label.label langs input_name='search_again_label' input_id='search_again_label' data_bind="value: search_again_label" %}
@@ -266,6 +268,7 @@
               {% trans "Search Screen Title" %}
               <span class="hq-help-template" data-title="{% trans "Search Screen Title Translation" %}"
                     data-content="{% trans_html_attr "Define the title label displayed on the search screen." %}">
+              </span>
             </label>
             <div class="{% css_field_class %}">
               {% input_trans module.search_config.title_label langs input_name='title_label' input_id='title_label' data_bind="value: title_label" %}
@@ -276,6 +279,7 @@
               {% trans "Search Screen Subtitle" %}
               <span class="hq-help-template" data-title="{% trans "Search Screen Subtitle" %}"
                     data-content="{% trans_html_attr "Define descriptive text displayed on the search screen. Use text formatting to <strong>bold</strong> and <em>italicize</em> words, use bulleted lists, and <a target='_blank' href='https://help.commcarehq.org/display/commcarepublic/Text+Formatting'>more</a>." %}">
+              </span>
             </label>
             <div class="{% css_field_class %}">
               {% input_trans module.search_config.description langs input_name='description' input_id='description' data_bind="value: description" element_type="textarea" %}
@@ -310,6 +314,7 @@
               {% trans "Search Filter" %}
               <span class="hq-help-template" data-title="{% trans "Search Filter" %}"
                     data-content="{% trans_html_attr "An XPath expression to filter the search results." %}">
+              </span>
             </label>
             <div class="{% css_field_class %}">
               <textarea data-bind="
@@ -387,6 +392,7 @@
                   {% trans "Data Registry" %}
                   <span class="hq-help-template" data-title="{% trans "Data Registry" %}"
                         data-content="{% trans_html_attr "Select a Data Registry to use for searching.  Users with access will see results from the registry when performing this search." %}">
+                  </span>
               </label>
               <div class="{% css_field_class %}">
                   <select class="form-control" id="data-registry" data-bind="value: data_registry">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_search_properties.html
@@ -2,9 +2,7 @@
 {% load i18n %}
 {% load xforms_extras %}
 
-<legend>
-  {% trans "Case Search and Claim" %}
-</legend>
+<legend>{% trans "Case Search and Claim" %}</legend>
 
 <div data-bind="with: search">
   <div class="alert alert-info" data-bind="hidden: isEnabled">
@@ -13,38 +11,49 @@
   <form>
     <div class="panel panel-appmanager">
       <div class="panel-heading">
-        <h4 class="panel-title panel-title-nolink">{% trans "Search Properties" %}</h4>
+        <h4 class="panel-title panel-title-nolink">
+          {% trans "Search Properties" %}
+        </h4>
       </div>
       <div class="panel-body">
         <p>{% trans "Search against the following case properties." %}</p>
         <table class="table table-condensed">
           <thead data-bind="visible: search_properties().length > 0">
-          <tr>
-            <th class="col-sm-1"></th>
-            <th class="col-sm-4">{% trans "Case Property" %}</th>
-            <th class="col-sm-4">{% trans "Display Text" %}</th>
-            {% if js_options.search_prompt_appearance_enabled or js_options.default_value_expression_enabled %}
-              <th class="col-sm-2">{% trans "Other Options" %}</th>
-            {% endif %}
-            <th class="col-sm-1"></th>
-          </tr>
+            <tr>
+              <th class="col-sm-1"></th>
+              <th class="col-sm-4">{% trans "Case Property" %}</th>
+              <th class="col-sm-4">{% trans "Display Text" %}</th>
+              {% if js_options.search_prompt_appearance_enabled or js_options.default_value_expression_enabled %}
+                <th class="col-sm-2">{% trans "Other Options" %}</th>
+              {% endif %}
+              <th class="col-sm-1"></th>
+            </tr>
           </thead>
-          <tbody data-bind="foreach: search_properties, sortableList: search_properties">
+          <tbody
+            data-bind="foreach: search_properties, sortableList: search_properties"
+          >
             {% include "app_manager/partials/modules/case_search_property.html" %}
           </tbody>
         </table>
         <div class="btn-group">
-          <button type="button"
-                  class="btn btn-default"
-                  data-bind="click: addProperty">
+          <button
+            type="button"
+            class="btn btn-default"
+            data-bind="click: addProperty"
+          >
             <i class="fa fa-plus"></i> {% trans "Add Search Property" %}
           </button>
           {% if app.supports_grouped_case_search_properties %}
-            <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+            <button
+              class="btn btn-default dropdown-toggle"
+              data-toggle="dropdown"
+            >
               <span class="caret"></span>
             </button>
             <ul class="dropdown-menu">
-              <li data-bind="click: addGroupProperty"><a>{% trans "Add Group" %}</a></li>
+              <li data-bind="click: addGroupProperty">
+                <a>{% trans "Add Group" %}</a>
+              </li>
             </ul>
           {% endif %}
         </div>
@@ -52,46 +61,64 @@
     </div>
     <div class="panel panel-appmanager">
       <div class="panel-heading">
-        <h4 class="panel-title panel-title-nolink">{% trans "Default Search Filters" %}</h4>
+        <h4 class="panel-title panel-title-nolink">
+          {% trans "Default Search Filters" %}
+        </h4>
       </div>
       <div class="panel-body">
-        <p>{% trans "Filter based on a specific value of any case property. These are applied to every search and are hidden from the user." %}</p>
+        <p>
+          {% trans "Filter based on a specific value of any case property. These are applied to every search and are hidden from the user." %}
+        </p>
         <table class="table table-condensed">
           <thead data-bind="visible: default_properties().length > 0">
-          <tr>
-            <th class="col-sm-5">{% trans "Case Property" %}</th>
-            <th class="col-sm-6">{% trans "Value (XPath expression)" %}</th>
-            <th class="col-sm-1">&nbsp;</th>
-          </tr>
+            <tr>
+              <th class="col-sm-5">{% trans "Case Property" %}</th>
+              <th class="col-sm-6">{% trans "Value (XPath expression)" %}</th>
+              <th class="col-sm-1">&nbsp;</th>
+            </tr>
           </thead>
           <tbody data-bind="foreach: default_properties">
-          <tr>
-            <td class="col-sm-4" data-bind="css: {'has-error': $parent.isCommon(ko.unwrap(property()))}">
-
-              <input class="form-control" type="text" data-bind="value: property"/>
-              <div data-bind="visible: $parent.isCommon(ko.unwrap(property()))" class="help-block">
-                {% trans "A property is not allowed both here and Search Properties. Please remove from one of the lists" %}
-              </div>
-            </td>
-            <td class="col-sm-6">
-              <textarea
-                class="form-control vertical-resize"
-                rows="1"
-                data-bind="value: defaultValue"
-                spellcheck="false"
-              ></textarea>
-            </td>
-            <td class="col-sm-2">
-              <i style="cursor: pointer;" class="fa fa-remove"
-                 data-bind="click: $parent.removeDefaultProperty"></i>
-            </td>
-          </tr>
+            <tr>
+              <td
+                class="col-sm-4"
+                data-bind="css: {'has-error': $parent.isCommon(ko.unwrap(property()))}"
+              >
+                <input
+                  class="form-control"
+                  type="text"
+                  data-bind="value: property"
+                />
+                <div
+                  data-bind="visible: $parent.isCommon(ko.unwrap(property()))"
+                  class="help-block"
+                >
+                  {% trans "A property is not allowed both here and Search Properties. Please remove from one of the lists" %}
+                </div>
+              </td>
+              <td class="col-sm-6">
+                <textarea
+                  class="form-control vertical-resize"
+                  rows="1"
+                  data-bind="value: defaultValue"
+                  spellcheck="false"
+                ></textarea>
+              </td>
+              <td class="col-sm-2">
+                <i
+                  style="cursor: pointer;"
+                  class="fa fa-remove"
+                  data-bind="click: $parent.removeDefaultProperty"
+                ></i>
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>
-          <button type="button"
-                  class="btn btn-default"
-                  data-bind="click: addDefaultProperty">
+          <button
+            type="button"
+            class="btn btn-default"
+            data-bind="click: addDefaultProperty"
+          >
             <i class="fa fa-plus"></i> {% trans "Add default search property" %}
           </button>
         </p>
@@ -104,7 +131,9 @@
         </h4>
       </div>
       <div class="panel-body">
-        <p>{% trans "Sort search results by case property before filtering. These will affect the priority in which results are returned and are hidden from the user." %}</p>
+        <p>
+          {% trans "Sort search results by case property before filtering. These will affect the priority in which results are returned and are hidden from the user." %}
+        </p>
         <table class="table table-condensed">
           <thead data-bind="visible: custom_sort_properties().length > 0">
             <tr>
@@ -115,35 +144,32 @@
               <th></th>
             </tr>
           </thead>
-          <tbody data-bind="foreach: custom_sort_properties, sortableList: custom_sort_properties" class="ui-sortable">
+          <tbody
+            data-bind="foreach: custom_sort_properties, sortableList: custom_sort_properties"
+            class="ui-sortable"
+          >
             <tr>
               <td>
                 <i class="grip fa-solid fa-up-down icon-blue"></i>
               </td>
               <td class="form-group">
-                <input class="form-control" type="text" data-bind="value: property_name"/>
+                <input
+                  class="form-control"
+                  type="text"
+                  data-bind="value: property_name"
+                />
               </td>
               <td>
                 <select class="form-control" data-bind="value: sort_type">
-                  <option value="exact">
-                    {% trans "Exact" %}
-                  </option>
-                  <option value="date">
-                    {% trans "Date" %}
-                  </option>
-                  <option value="numeric">
-                    {% trans "Numeric" %}
-                  </option>
+                  <option value="exact">{% trans "Exact" %}</option>
+                  <option value="date">{% trans "Date" %}</option>
+                  <option value="numeric">{% trans "Numeric" %}</option>
                 </select>
               </td>
               <td>
                 <select class="form-control" data-bind="value: direction">
-                  <option value="ascending">
-                    {% trans "Ascending" %}
-                  </option>
-                  <option value="descending">
-                    {% trans "Descending" %}
-                  </option>
+                  <option value="ascending">{% trans "Ascending" %}</option>
+                  <option value="descending">{% trans "Descending" %}</option>
                 </select>
               </td>
               <td>
@@ -155,7 +181,10 @@
           </tbody>
         </table>
         <div class="form-group">
-          <button class="btn btn-default" data-bind="click: addCustomSortProperty">
+          <button
+            class="btn btn-default"
+            data-bind="click: addCustomSortProperty"
+          >
             <i class="fa fa-plus"></i>
             {% trans "Add custom sort property" %}
           </button>
@@ -164,140 +193,229 @@
     </div>
     <div class="panel panel-appmanager" data-bind="visible: isEnabled">
       <div class="panel-heading">
-        <h4 class="panel-title panel-title-nolink">{% trans "Search and Claim Options" %}</h4>
+        <h4 class="panel-title panel-title-nolink">
+          {% trans "Search and Claim Options" %}
+        </h4>
       </div>
       <div class="panel-body" data-bind="with: searchConfig">
         <div class="form-horizontal">
           <div class="form-group">
             {% if show_search_workflow %}
               <div class="form-group">
-                <label class="control-label {% css_label_class %}" for="search-workflow" data-bind="hidden: restrictWorkflowForDataRegistry">
+                <label
+                  class="control-label {% css_label_class %}"
+                  for="search-workflow"
+                  data-bind="hidden: restrictWorkflowForDataRegistry"
+                >
                   {% trans "Web Apps Search Workflow" %}
-                  <span class="hq-help-template" data-title="{% trans "Web Apps Search Workflow" %}"
-                        data-content="{% trans_html_attr "<strong>Normal Case List</strong> is the &quot;classic&quot; case search workflow.  <br><br><strong>Search First</strong> skips the Normal Case List view and lands the user on the Search screen. This is typically used for a &quot;Search Cases&quot; module.  <br><br><strong>See More</strong> is the same functionality as Normal Case List, except clicking the search button runs the default searches and returns the results. The user doesn't get to change the search criteria. This enables a workflow where the user sees what's in the local casedb then clicks &quot;See More&quot; to view all cases that fit the criteria.  <br><br><strong>Skip to Default Case Search Results</strong> always displays the results from the default case search. The user never sees the results of the casedb." %}">
+                  <span
+                    class="hq-help-template"
+                    data-title="{% trans "Web Apps Search Workflow" %}"
+                    data-content="{% trans_html_attr "<strong>Normal Case List</strong> is the &quot;classic&quot; case search workflow.  <br><br><strong>Search First</strong> skips the Normal Case List view and lands the user on the Search screen. This is typically used for a &quot;Search Cases&quot; module.  <br><br><strong>See More</strong> is the same functionality as Normal Case List, except clicking the search button runs the default searches and returns the results. The user doesn't get to change the search criteria. This enables a workflow where the user sees what's in the local casedb then clicks &quot;See More&quot; to view all cases that fit the criteria.  <br><br><strong>Skip to Default Case Search Results</strong> always displays the results from the default case search. The user never sees the results of the casedb." %}"
+                  >
                   </span>
                 </label>
-                <label class="control-label {% css_label_class %}" for="search-workflow" data-bind="visible: restrictWorkflowForDataRegistry">
+                <label
+                  class="control-label {% css_label_class %}"
+                  for="search-workflow"
+                  data-bind="visible: restrictWorkflowForDataRegistry"
+                >
                   {% trans "Web Apps Search Workflow" %}
-                  <span class="hq-help-template" data-title="{% trans "Web Apps Search Workflow (Data Registry)" %}"
-                        data-content="{% trans_html_attr "<strong>Search First</strong> skips the Normal Case List view and lands the user on the Search screen. This is the default for Data Registry search.  <br><br><strong>Skip to Default Case Search Results</strong> always displays the results from the default case search." %}">
+                  <span
+                    class="hq-help-template"
+                    data-title="{% trans "Web Apps Search Workflow (Data Registry)" %}"
+                    data-content="{% trans_html_attr "<strong>Search First</strong> skips the Normal Case List view and lands the user on the Search screen. This is the default for Data Registry search.  <br><br><strong>Skip to Default Case Search Results</strong> always displays the results from the default case search." %}"
+                  >
                   </span>
                 </label>
                 <div class="{% css_field_class %}">
-                  <select class="form-control" data-bind="value: workflow" id="search-workflow">
-                    <option value="classic" data-bind="hidden: restrictWorkflowForDataRegistry">{% trans "Normal Case List" %}</option>
-                    <option value="auto_launch">{% trans "Search First" %}</option>
-                    <option value="see_more" data-bind="hidden: restrictWorkflowForDataRegistry">{% trans "See More" %}</option>
-                    <option value="es_only">{% trans "Skip to Default Case Search Results" %}</option>
+                  <select
+                    class="form-control"
+                    data-bind="value: workflow"
+                    id="search-workflow"
+                  >
+                    <option
+                      value="classic"
+                      data-bind="hidden: restrictWorkflowForDataRegistry"
+                    >
+                      {% trans "Normal Case List" %}
+                    </option>
+                    <option value="auto_launch">
+                      {% trans "Search First" %}
+                    </option>
+                    <option
+                      value="see_more"
+                      data-bind="hidden: restrictWorkflowForDataRegistry"
+                    >
+                      {% trans "See More" %}
+                    </option>
+                    <option value="es_only">
+                      {% trans "Skip to Default Case Search Results" %}
+                    </option>
                   </select>
                 </div>
               </div>
             {% endif %}
           </div>
           {% if request|toggle_enabled:'USH_INLINE_SEARCH' %}
-          <div class="form-group" data-bind="slideVisible: inlineSearchVisible">
-            <label class="control-label {% css_label_class %}">
-              {% trans "Make search input available after search" %}
-              <span class="hq-help-template" data-title="{% trans "Make search input available after search" %}"
-                    data-content="{% trans_html_attr "Stores the search input values and makes the available via the 'search-input' instance. This also disables the 'Search Again' workflow." %}">
-              </span>
-            </label>
-            <div class="{% css_field_class %} checkbox">
-              <label>
-                <input type="checkbox" data-bind="checked: inline_search" />
-                <input type="hidden" name="search-input" data-bind="value: inline_search"/>
+            <div
+              class="form-group"
+              data-bind="slideVisible: inlineSearchVisible"
+            >
+              <label class="control-label {% css_label_class %}">
+                {% trans "Make search input available after search" %}
+                <span
+                  class="hq-help-template"
+                  data-title="{% trans "Make search input available after search" %}"
+                  data-content="{% trans_html_attr "Stores the search input values and makes the available via the 'search-input' instance. This also disables the 'Search Again' workflow." %}"
+                >
+                </span>
               </label>
-              <p class="help-block" data-bind="visible: inlineSearchActive">
-                Example: <span data-bind="text: exampleInstance" ></span>
-              </p>
+              <div class="{% css_field_class %} checkbox">
+                <label>
+                  <input type="checkbox" data-bind="checked: inline_search" />
+                  <input
+                    type="hidden"
+                    name="search-input"
+                    data-bind="value: inline_search"
+                  />
+                </label>
+                <p class="help-block" data-bind="visible: inlineSearchActive">
+                  Example: <span data-bind="text: exampleInstance"></span>
+                </p>
+              </div>
             </div>
-          </div>
-          <div class="form-group" data-bind="visible: inlineSearchActive">
-            <label class="control-label {% css_label_class %}">
-              {% trans "Search Input Instance Name" %}
-              <span class="hq-help-template" data-title="{% trans "Search Input Instance Name" %}"
-                    data-content="{% trans_html_attr "Customize the name used to reference the search input values.  If modified, you'll need to update any existing references to it." %}">
-              </span>
-            </label>
-            <div class="{% css_field_class %}">
-              <input type="text" name="instance_name" class="form-control" data-bind="value: instance_name"/>
-            </div>
-          </div>
-          {% endif %}
-          {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
-          <div class="form-group" data-bind="hidden: inlineSearchActive">
-            <label for="search_label" class="{% css_label_class %} control-label">
-              {% trans "Label for Searching" %}
-              <span class="hq-help-template" data-title="{% trans "Label for Searching" %}"
-                    data-content="{% trans_html_attr "This text is for the button to enter case search. It is also the header on the search results screen." %}">
-              </span>
-            </label>
-            <div class="{% css_field_class %}">
-              {% input_trans module.search_config.search_label.label langs input_name='search_label' input_id='search_label' data_bind="value: search_label" %}
-            </div>
-          </div>
-          <div class="case-search-multimedia-input" data-bind="hidden: inlineSearchActive">
-          <!-- stopBinding to avoid conflicts with the binding of enclosing template to a different object 'search'-->
-          <!-- binding for this partial is done via app_manager/js/nav_menu_media-->
-            <!-- ko stopBinding: true -->
-              {% include "app_manager/partials/nav_menu_media.html" with qualifier='case_search-search_label_media_' ICON_LABEL="Search Icon" AUDIO_LABEL="Search Audio" %}
-            <!-- /ko -->
-          </div>
-            {% if not request|toggle_enabled:'SPLIT_SCREEN_CASE_SEARCH' %}
-            <div class="form-group" data-bind="hidden: inlineSearchActive">
-              <label for="search_again_label" class="{% css_label_class %} control-label">
-                {% trans "Label for Searching Again" %}
-                <span class="hq-help-template" data-title="{% trans "Label for Searching Again" %}"
-                      data-content="{% trans_html_attr "This text is for the search button displayed at the bottom of search results, so users can search again." %}">
+            <div class="form-group" data-bind="visible: inlineSearchActive">
+              <label class="control-label {% css_label_class %}">
+                {% trans "Search Input Instance Name" %}
+                <span
+                  class="hq-help-template"
+                  data-title="{% trans "Search Input Instance Name" %}"
+                  data-content="{% trans_html_attr "Customize the name used to reference the search input values.  If modified, you'll need to update any existing references to it." %}"
+                >
                 </span>
               </label>
               <div class="{% css_field_class %}">
-                {% input_trans module.search_config.search_again_label.label langs input_name='search_again_label' input_id='search_again_label' data_bind="value: search_again_label" %}
+                <input
+                  type="text"
+                  name="instance_name"
+                  class="form-control"
+                  data-bind="value: instance_name"
+                />
               </div>
             </div>
-            <div class="case-search-multimedia-input" data-bind="hidden: inlineSearchActive">
-            <!-- stopBinding to avoid conflicts with the binding of enclosing template to a different object 'search'-->
-            <!-- binding for this partial is done via app_manager/js/nav_menu_media-->
+          {% endif %}
+          {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
+            <div class="form-group" data-bind="hidden: inlineSearchActive">
+              <label
+                for="search_label"
+                class="{% css_label_class %} control-label"
+              >
+                {% trans "Label for Searching" %}
+                <span
+                  class="hq-help-template"
+                  data-title="{% trans "Label for Searching" %}"
+                  data-content="{% trans_html_attr "This text is for the button to enter case search. It is also the header on the search results screen." %}"
+                >
+                </span>
+              </label>
+              <div class="{% css_field_class %}">
+                {% input_trans module.search_config.search_label.label langs input_name='search_label' input_id='search_label' data_bind="value: search_label" %}
+              </div>
+            </div>
+            <div
+              class="case-search-multimedia-input"
+              data-bind="hidden: inlineSearchActive"
+            >
+              <!-- stopBinding to avoid conflicts with the binding of enclosing template to a different object 'search'-->
+              <!-- binding for this partial is done via app_manager/js/nav_menu_media-->
               <!-- ko stopBinding: true -->
-                {% include "app_manager/partials/nav_menu_media.html" with qualifier='case_search-search_again_label_media_' ICON_LABEL="Search Again Icon" AUDIO_LABEL="Search Again Audio" %}
+              {% include "app_manager/partials/nav_menu_media.html" with qualifier='case_search-search_label_media_' ICON_LABEL="Search Icon" AUDIO_LABEL="Search Audio" %}
               <!-- /ko -->
             </div>
+            {% if not request|toggle_enabled:'SPLIT_SCREEN_CASE_SEARCH' %}
+              <div class="form-group" data-bind="hidden: inlineSearchActive">
+                <label
+                  for="search_again_label"
+                  class="{% css_label_class %} control-label"
+                >
+                  {% trans "Label for Searching Again" %}
+                  <span
+                    class="hq-help-template"
+                    data-title="{% trans "Label for Searching Again" %}"
+                    data-content="{% trans_html_attr "This text is for the search button displayed at the bottom of search results, so users can search again." %}"
+                  >
+                  </span>
+                </label>
+                <div class="{% css_field_class %}">
+                  {% input_trans module.search_config.search_again_label.label langs input_name='search_again_label' input_id='search_again_label' data_bind="value: search_again_label" %}
+                </div>
+              </div>
+              <div
+                class="case-search-multimedia-input"
+                data-bind="hidden: inlineSearchActive"
+              >
+                <!-- stopBinding to avoid conflicts with the binding of enclosing template to a different object 'search'-->
+                <!-- binding for this partial is done via app_manager/js/nav_menu_media-->
+                <!-- ko stopBinding: true -->
+                {% include "app_manager/partials/nav_menu_media.html" with qualifier='case_search-search_again_label_media_' ICON_LABEL="Search Again Icon" AUDIO_LABEL="Search Again Audio" %}
+                <!-- /ko -->
+              </div>
             {% endif %}
-          <div class="form-group">
-            <label for="search_screen_title" class="{% css_label_class %} control-label">
-              {% trans "Search Screen Title" %}
-              <span class="hq-help-template" data-title="{% trans "Search Screen Title Translation" %}"
-                    data-content="{% trans_html_attr "Define the title label displayed on the search screen." %}">
-              </span>
-            </label>
-            <div class="{% css_field_class %}">
-              {% input_trans module.search_config.title_label langs input_name='title_label' input_id='title_label' data_bind="value: title_label" %}
+            <div class="form-group">
+              <label
+                for="search_screen_title"
+                class="{% css_label_class %} control-label"
+              >
+                {% trans "Search Screen Title" %}
+                <span
+                  class="hq-help-template"
+                  data-title="{% trans "Search Screen Title Translation" %}"
+                  data-content="{% trans_html_attr "Define the title label displayed on the search screen." %}"
+                >
+                </span>
+              </label>
+              <div class="{% css_field_class %}">
+                {% input_trans module.search_config.title_label langs input_name='title_label' input_id='title_label' data_bind="value: title_label" %}
+              </div>
             </div>
-          </div>
-          <div class="form-group">
-            <label for="description" class="{% css_label_class %} control-label">
-              {% trans "Search Screen Subtitle" %}
-              <span class="hq-help-template" data-title="{% trans "Search Screen Subtitle" %}"
-                    data-content="{% trans_html_attr "Define descriptive text displayed on the search screen. Use text formatting to <strong>bold</strong> and <em>italicize</em> words, use bulleted lists, and <a target='_blank' href='https://help.commcarehq.org/display/commcarepublic/Text+Formatting'>more</a>." %}">
-              </span>
-            </label>
-            <div class="{% css_field_class %}">
-              {% input_trans module.search_config.description langs input_name='description' input_id='description' data_bind="value: description" element_type="textarea" %}
+            <div class="form-group">
+              <label
+                for="description"
+                class="{% css_label_class %} control-label"
+              >
+                {% trans "Search Screen Subtitle" %}
+                <span
+                  class="hq-help-template"
+                  data-title="{% trans "Search Screen Subtitle" %}"
+                  data-content="{% trans_html_attr "Define descriptive text displayed on the search screen. Use text formatting to <strong>bold</strong> and <em>italicize</em> words, use bulleted lists, and <a target='_blank' href='https://help.commcarehq.org/display/commcarepublic/Text+Formatting'>more</a>." %}"
+                >
+                </span>
+              </label>
+              <div class="{% css_field_class %}">
+                {% input_trans module.search_config.description langs input_name='description' input_id='description' data_bind="value: description" element_type="textarea" %}
+              </div>
             </div>
-          </div>
           {% endif %}
           <div class="form-group" data-bind="slideVisible: !auto_launch()">
-            <label for="search-display-condition" class="control-label {% css_label_class %}">
+            <label
+              for="search-display-condition"
+              class="control-label {% css_label_class %}"
+            >
               {% trans "Display Condition" %}
-              <span class="hq-help-template" data-title="{% trans "Display Condition" %}"
-                    data-content="{% trans_html_attr "If this XPath expression evaluates to false, the case search button will not be displayed on the case list. If no expression is given, the button will always be displayed on the case list." %}">
+              <span
+                class="hq-help-template"
+                data-title="{% trans "Display Condition" %}"
+                data-content="{% trans_html_attr "If this XPath expression evaluates to false, the case search button will not be displayed on the case list. If no expression is given, the button will always be displayed on the case list." %}"
+              >
               </span>
             </label>
             <div class="{% css_field_class %}">
-              <textarea class="form-control vertical-resize"
-                       id="search-display-condition"
-                       spellcheck="false"
-                       data-bind="
+              <textarea
+                class="form-control vertical-resize"
+                id="search-display-condition"
+                spellcheck="false"
+                data-bind="
                          value: search_button_display_condition,
                          xpathValidator: {
                            text: search_button_display_condition,
@@ -309,65 +427,89 @@
             </div>
           </div>
           {% if request|toggle_enabled:'USH_SEARCH_FILTER' %}
-          <div class="form-group">
-            <label for="search-filter" class="control-label {% css_label_class %}">
-              {% trans "Search Filter" %}
-              <span class="hq-help-template" data-title="{% trans "Search Filter" %}"
-                    data-content="{% trans_html_attr "An XPath expression to filter the search results." %}">
-              </span>
-            </label>
-            <div class="{% css_field_class %}">
-              <textarea data-bind="
+            <div class="form-group">
+              <label
+                for="search-filter"
+                class="control-label {% css_label_class %}"
+              >
+                {% trans "Search Filter" %}
+                <span
+                  class="hq-help-template"
+                  data-title="{% trans "Search Filter" %}"
+                  data-content="{% trans_html_attr "An XPath expression to filter the search results." %}"
+                >
+                </span>
+              </label>
+              <div class="{% css_field_class %}">
+                <textarea
+                  data-bind="
                           value: search_filter,
                           xpathValidator: {
                             text: search_filter,
                             allowCaseHashtags: true,
                             errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
                           }"
-                        class="form-control vertical-resize"
-                        id="search-filter"
-                        spellcheck="false"
-              ></textarea>
-              <p class="help-block">
-                <button class="pull-right btn-xs btn btn-default" data-bind="visible: setSearchFilterVisible, enable: setSearchFilterEnabled, click: setSearchFilter">
-                  <i class="fa-solid fa-reply"></i>
-                  {% trans "Copy case list filter" %}
-                </button>
-                {% trans "Example: age > 5" %}
-              </p>
+                  class="form-control vertical-resize"
+                  id="search-filter"
+                  spellcheck="false"
+                ></textarea>
+                <p class="help-block">
+                  <button
+                    class="pull-right btn-xs btn btn-default"
+                    data-bind="visible: setSearchFilterVisible, enable: setSearchFilterEnabled, click: setSearchFilter"
+                  >
+                    <i class="fa-solid fa-reply"></i>
+                    {% trans "Copy case list filter" %}
+                  </button>
+                  {% trans "Example: age > 5" %}
+                </p>
+              </div>
             </div>
-          </div>
           {% endif %}
           <div class="form-group">
-            <label for="claim-relevant-condition" class="control-label {% css_label_class %}">
+            <label
+              for="claim-relevant-condition"
+              class="control-label {% css_label_class %}"
+            >
               {% trans "Claim Condition" %}
-              <span class="hq-help-template" data-title="{% trans "Claim Condition" %}"
-                    data-content="{% trans_html_attr "If this expression evaluates to false, no case will be claimed." %}">
+              <span
+                class="hq-help-template"
+                data-title="{% trans "Claim Condition" %}"
+                data-content="{% trans_html_attr "If this expression evaluates to false, no case will be claimed." %}"
+              >
               </span>
             </label>
             <div class="{% css_field_class %}">
-              <textarea data-bind="
+              <textarea
+                data-bind="
                           value: additional_relevant,
                           xpathValidator: {
                             text: additional_relevant,
                             allowCaseHashtags: true,
                             errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
                           }"
-                        class="form-control vertical-resize"
-                        id="claim-relevant-condition"
-                        spellcheck="false"
+                class="form-control vertical-resize"
+                id="claim-relevant-condition"
+                spellcheck="false"
               ></textarea>
             </div>
           </div>
           <div class="form-group">
-            <label for="blacklisted-user-ids" class="control-label {% css_label_class %}">
+            <label
+              for="blacklisted-user-ids"
+              class="control-label {% css_label_class %}"
+            >
               {% trans "Don't search cases owned by the following ids" %}
-              <span class="hq-help-template" data-title="{% trans "Ignore Owners" %}"
-                    data-content="{% trans_html_attr "An XPath expression that will evaluate to a space separated list of ids." %}">
+              <span
+                class="hq-help-template"
+                data-title="{% trans "Ignore Owners" %}"
+                data-content="{% trans_html_attr "An XPath expression that will evaluate to a space separated list of ids." %}"
+              >
               </span>
             </label>
             <div class="{% css_field_class %}">
-              <textarea data-bind="
+              <textarea
+                data-bind="
                 value: blacklisted_owner_ids_expression,
                 xpathValidator: {
                   text: blacklisted_owner_ids_expression,
@@ -375,141 +517,200 @@
                   errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
                 }
               "
-                        class="form-control vertical-resize"
-                        id="blacklisted-user-ids"
-                        spellcheck="false"
+                class="form-control vertical-resize"
+                id="blacklisted-user-ids"
+                spellcheck="false"
               ></textarea>
               <p class="help-block">
                 {% blocktrans %}
-                  Example: instance('commcaresession')/session/context/userid or 'a1c0148dc2120c6b1762f5ac5aba2a15'
+                  Example: instance('commcaresession')/session/context/userid or
+                  'a1c0148dc2120c6b1762f5ac5aba2a15'
                 {% endblocktrans %}
               </p>
             </div>
           </div>
           {% if data_registry_enabled %}
-          <div class="form-group">
-              <label for="data-registry" class="{% css_label_class %} control-label">
-                  {% trans "Data Registry" %}
-                  <span class="hq-help-template" data-title="{% trans "Data Registry" %}"
-                        data-content="{% trans_html_attr "Select a Data Registry to use for searching.  Users with access will see results from the registry when performing this search." %}">
-                  </span>
+            <div class="form-group">
+              <label
+                for="data-registry"
+                class="{% css_label_class %} control-label"
+              >
+                {% trans "Data Registry" %}
+                <span
+                  class="hq-help-template"
+                  data-title="{% trans "Data Registry" %}"
+                  data-content="{% trans_html_attr "Select a Data Registry to use for searching.  Users with access will see results from the registry when performing this search." %}"
+                >
+                </span>
               </label>
               <div class="{% css_field_class %}">
-                  <select class="form-control" id="data-registry" data-bind="value: data_registry">
-                      <option value/>
-                      {% for registry in data_registries %}
-                          <option value="{{ registry.slug }}">{{ registry.name }}</option>
-                      {% endfor %}
-                  </select>
+                <select
+                  class="form-control"
+                  id="data-registry"
+                  data-bind="value: data_registry"
+                >
+                  <option value />
+                  {% for registry in data_registries %}
+                    <option value="{{ registry.slug }}">
+                      {{ registry.name }}
+                    </option>
+                  {% endfor %}
+                </select>
               </div>
-          </div>
-          <div class="form-group" data-bind="slideVisible: data_registry()">
-              <label for="data-registry" class="{% css_label_class %} control-label">
-                  {% trans "Data Registry Workflow" %}
+            </div>
+            <div class="form-group" data-bind="slideVisible: data_registry()">
+              <label
+                for="data-registry"
+                class="{% css_label_class %} control-label"
+              >
+                {% trans "Data Registry Workflow" %}
               </label>
               <div class="{% css_field_class %}">
-                  <select class="form-control" data-bind="value: data_registry_workflow">
-                    {% for slug, name in data_registry_workflow_choices %}
-                      <option value="{{ slug }}">{{ name }}</option>
-                    {% endfor %}
-                  </select>
+                <select
+                  class="form-control"
+                  data-bind="value: data_registry_workflow"
+                >
+                  {% for slug, name in data_registry_workflow_choices %}
+                    <option value="{{ slug }}">{{ name }}</option>
+                  {% endfor %}
+                </select>
               </div>
-          </div>
-          <div class="form-group" data-bind="visible: data_registry_workflow() == 'load_case'">
-              <label for="data-registry" class="{% css_label_class %} control-label">
-                  {% trans "Load Additional Data Registry Cases" %}
-                  <span class="hq-help-template" data-title="{% trans "Data Registry" %}"
-                        data-content="{% blocktrans %}
-                        Load additional cases from the Data Registry into the 'registry' instance for forms in this module.
-                        The case type of the case must be configured in the registry and in the module via the module's
-                        case type or the module's 'Additional Case List and Case Search Types' configuration.
-                        {% endblocktrans %}">
-                  </span>
+            </div>
+            <div
+              class="form-group"
+              data-bind="visible: data_registry_workflow() == 'load_case'"
+            >
+              <label
+                for="data-registry"
+                class="{% css_label_class %} control-label"
+              >
+                {% trans "Load Additional Data Registry Cases" %}
+                <span
+                  class="hq-help-template"
+                  data-title="{% trans "Data Registry" %}"
+                  data-content="{% blocktrans %}
+                    Load additional cases from the Data Registry into the
+                    'registry' instance for forms in this module. The case type
+                    of the case must be configured in the registry and in the
+                    module via the module's case type or the module's
+                    'Additional Case List and Case Search Types' configuration.
+                  {% endblocktrans %}"
+                >
+                </span>
               </label>
               <div class="{% css_field_class %}">
-                  <table class="table table-condensed">
-                    <thead data-bind="visible: additional_registry_cases().length > 0">
+                <table class="table table-condensed">
+                  <thead
+                    data-bind="visible: additional_registry_cases().length > 0"
+                  >
                     <tr>
                       <th class="col-sm-12">{% trans "Case ID XPath" %}</th>
                       <th class="col-sm-1"></th>
                     </tr>
-                    </thead>
-                    <tbody data-bind="foreach: additional_registry_cases, sortableList: additional_registry_cases">
-                      <tr>
-                        <td>
-                          <textarea data-bind="
+                  </thead>
+                  <tbody
+                    data-bind="foreach: additional_registry_cases, sortableList: additional_registry_cases"
+                  >
+                    <tr>
+                      <td>
+                        <textarea
+                          data-bind="
                               value: caseIdXpath,
                               xpathValidator: {
                                 text: caseIdXpath,
                                 allowCaseHashtags: false,
                                 errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
                               }"
-                                    class="form-control vertical-resize"
-                                    spellcheck="false"
-                          ></textarea>
-                        </td>
-                        <td>
-                          <i style="cursor: pointer;" class="fa fa-remove"
-                             data-bind="click: $parent.removeRegistryQuery"></i>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                  <button type="button" class="btn btn-default" data-bind="click: addRegistryQuery">
-                    <i class="fa fa-plus"></i> {% trans "Add Case ID to Data Registry Query" %}
-                  </button>
+                          class="form-control vertical-resize"
+                          spellcheck="false"
+                        ></textarea>
+                      </td>
+                      <td>
+                        <i
+                          style="cursor: pointer;"
+                          class="fa fa-remove"
+                          data-bind="click: $parent.removeRegistryQuery"
+                        ></i>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <button
+                  type="button"
+                  class="btn btn-default"
+                  data-bind="click: addRegistryQuery"
+                >
+                  <i class="fa fa-plus"></i>
+                  {% trans "Add Case ID to Data Registry Query" %}
+                </button>
               </div>
-          </div>
+            </div>
           {% endif %}
           {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
-          <div class="form-group">
-              <label for="custom-related-case-property" class="{% css_label_class %} control-label">
-                  {% trans "Case property with additional case id to add to results" %}
-                  <span class="hq-help-template" data-title="{% trans "Custom Related Case Property" %}"
-                        data-content="{% blocktrans %}
-                               Enter in the name of a case property that contains the ID of another
-                               case you'd like included in the results instance.  This is to allow
-                               you to configure your case list display to show properties of that
-                               related case. Read more on the
-                                <a href='https://confluence.dimagi.com/display/USH/Case+Search+Configuration'>Help Site</a>.
-                        {% endblocktrans %}">
-                  </span>
+            <div class="form-group">
+              <label
+                for="custom-related-case-property"
+                class="{% css_label_class %} control-label"
+              >
+                {% trans "Case property with additional case id to add to results" %}
+                <span
+                  class="hq-help-template"
+                  data-title="{% trans "Custom Related Case Property" %}"
+                  data-content="{% blocktrans %}
+                    Enter in the name of a case property that contains the ID of
+                    another case you'd like included in the results instance.
+                    This is to allow you to configure your case list display to
+                    show properties of that related case. Read more on the
+                    <a
+                      href="https://confluence.dimagi.com/display/USH/Case+Search+Configuration"
+                      >Help Site</a
+                    >.
+                  {% endblocktrans %}"
+                >
+                </span>
               </label>
               <div class="{% css_field_class %}">
-                  <input id="custom-related-case-property"
-                         type="text"
-                         class="form-control"
-                         data-bind="value: custom_related_case_property"/>
+                <input
+                  id="custom-related-case-property"
+                  type="text"
+                  class="form-control"
+                  data-bind="value: custom_related_case_property"
+                />
               </div>
-          </div>
-          <div class="form-group">
-            <label class="control-label {% css_label_class %}">
-              {% trans "Include all related cases in search results" %}
-            </label>
-            <div>
+            </div>
+            <div class="form-group">
+              <label class="control-label {% css_label_class %}">
+                {% trans "Include all related cases in search results" %}
+              </label>
+              <div>
+                <div class="{% css_field_class %} checkbox">
+                  <label>
+                    <input
+                      type="checkbox"
+                      data-bind="checked: include_all_related_cases"
+                    />
+                  </label>
+                </div>
+              </div>
+            </div>
+          {% endif %}
+          {% if request|toggle_enabled:'SPLIT_SCREEN_CASE_SEARCH' and not app.split_screen_dynamic_search %}
+            <div class="form-group">
+              <label class="control-label {% css_label_class %}">
+                {% trans "Clearing search terms resets search results" %}
+              </label>
               <div class="{% css_field_class %} checkbox">
                 <label>
-                  <input type="checkbox" data-bind="checked: include_all_related_cases"/>
+                  <input type="checkbox" data-bind="checked: search_on_clear" />
                 </label>
               </div>
             </div>
-          </div>
-          {% endif %}
-          {% if request|toggle_enabled:'SPLIT_SCREEN_CASE_SEARCH' and not app.split_screen_dynamic_search%}
-          <div class="form-group">
-            <label class="control-label {% css_label_class %}">
-              {% trans "Clearing search terms resets search results" %}
-            </label>
-            <div class="{% css_field_class %} checkbox">
-              <label>
-                <input type="checkbox" data-bind="checked: search_on_clear" />
-              </label>
-            </div>
-          </div>
           {% endif %}
           <span class="hide" id="searchFilterXpathErrorHtml">
             {% blocktrans %}
-              This is not a valid xpath expression. Check to make sure your parentheses match and you are referencing case properties correctly.
+              This is not a valid xpath expression. Check to make sure your
+              parentheses match and you are referencing case properties
+              correctly.
             {% endblocktrans %}
           </span>
         </div>

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/knockout_bindings.ko.js
@@ -415,10 +415,14 @@ ko.bindingHandlers.openRemoteModal = {
 };
 
 ko.bindingHandlers.slideVisible = {
+    init: function (element, valueAccessor) {
+        var value = ko.unwrap(valueAccessor());
+        $(element).toggle(value);
+    },
     'update': function (element, valueAccessor) {
         var value = ko.utils.unwrapObservable(valueAccessor());
         if (value) {
-            $(element).hide().slideDown();
+            $(element).slideDown();
         } else if (!value) {
             $(element).slideUp();
         }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/knockout_bindings.ko.js
@@ -421,10 +421,14 @@ ko.bindingHandlers.openRemoteModal = {
 };
 
 ko.bindingHandlers.slideVisible = {
+    init: function (element, valueAccessor) {
+        var value = ko.unwrap(valueAccessor());
+        $(element).toggle(value);
+    },
     'update': function (element, valueAccessor) {
         var value = ko.utils.unwrapObservable(valueAccessor());
         if (value) {
-            $(element).hide().slideDown();
+            $(element).slideDown();
         } else if (!value) {
             $(element).slideUp();
         }

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/knockout_bindings.ko.js.diff.txt
@@ -93,7 +93,7 @@
                  };
                  return clickAction;
              };
-@@ -638,7 +644,7 @@
+@@ -642,7 +648,7 @@
              options.sanitize = false;
          }
          if (options.title || options.content) { // don't show empty popovers
@@ -102,7 +102,7 @@
          }
      },
  };
-@@ -710,5 +716,3 @@
+@@ -714,5 +720,3 @@
          });
      },
  };


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
There was a bug where elements that use data-binding `slideVisible` show the sliding animation upon page load or element creation. 

This is done in multiple areas such as on the roles & permission modal and app case list configuration. However, it is most evident for collapsed repeat groups. It manifested in two ways:
1. Upon opening a form, collapsable but open groups would have their header already visible but then its body "pops open" to be visible 
2. When creating a new group via repeat group, the header would appear first, and then the group's body content would "pop open" seemingly lagging behind.

This PR changes the behavior such that on initial page load or element creation, the element is instantly visible and does not show the animation. 


Old:

https://github.com/user-attachments/assets/b8c722ca-bb91-46fb-83bc-9716fe291b20


New:

https://github.com/user-attachments/assets/53ce2908-97b6-4703-8742-bc99b66274ae


This does not affect the original intention of the animation to (i'm guessing) visually highly a new item is available. This is because these elements already exist on the DOM, but just have their visibility toggled. 

https://github.com/user-attachments/assets/6a55c250-f0a3-496c-8b71-6b8a67c47b60


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[USH-6271 ](https://dimagi.atlassian.net/browse/USH-6271)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
no FF

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
locally tested and tested on staging with BHA test app.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
no QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
