### PR TITLE
Update Dimagi address

### DIFF
--- a/corehq/apps/accounting/templates/accounting/email/autopay_card_removed.html
+++ b/corehq/apps/accounting/templates/accounting/email/autopay_card_removed.html
@@ -21,7 +21,7 @@
     www.commcarehq.org
   </p>
   <p>
-    Statement From: CommCare and the corporation Dimagi, Inc. 585 Massachusetts Ave, Ste 3, Cambridge, MA 02139 USA
+    Statement From: CommCare and the corporation Dimagi, Inc. 245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
   </p>
 
 {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/bulk_payment_receipt.html
+++ b/corehq/apps/accounting/templates/accounting/email/bulk_payment_receipt.html
@@ -55,6 +55,6 @@
   {% blocktrans %}
     Email From:<br />
     CommCare and the corporation Dimagi, Inc.<br />
-    585 Massachusetts Ave, Ste 3, Cambridge, MA 02139 USA
+    245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
   {% endblocktrans %}
 </p>

--- a/corehq/apps/accounting/templates/accounting/email/bulk_payment_receipt.txt
+++ b/corehq/apps/accounting/templates/accounting/email/bulk_payment_receipt.txt
@@ -26,5 +26,5 @@ www.commcarehq.org
 
 Email From:
 CommCare and the corporation Dimagi, Inc.
-585 Massachusetts Ave, Ste 3, Cambridge, MA 02139 USA
+245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
 {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/credit_receipt.html
+++ b/corehq/apps/accounting/templates/accounting/email/credit_receipt.html
@@ -35,6 +35,6 @@
   {% blocktrans %}
     Email From:<br />
     CommCare and the corporation Dimagi, Inc.<br />
-    585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+    245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
   {% endblocktrans %}
 </p>

--- a/corehq/apps/accounting/templates/accounting/email/credit_receipt.txt
+++ b/corehq/apps/accounting/templates/accounting/email/credit_receipt.txt
@@ -21,5 +21,5 @@ www.commcarehq.org
 {% blocktrans %}
 Email From:
 CommCare and the corporation Dimagi, Inc.
-585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
 {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/customer_invoice.txt
+++ b/corehq/apps/accounting/templates/accounting/email/customer_invoice.txt
@@ -92,5 +92,5 @@ www.commcarehq.org
 
 Statement From:
 CommCare and the corporation Dimagi, Inc.
-585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
 {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/invoice.txt
+++ b/corehq/apps/accounting/templates/accounting/email/invoice.txt
@@ -93,5 +93,5 @@ www.commcarehq.org
 
 Statement From:
 CommCare and the corporation Dimagi, Inc.
-585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
 {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/invoice_autopay_setup.html
+++ b/corehq/apps/accounting/templates/accounting/email/invoice_autopay_setup.html
@@ -54,6 +54,6 @@
   {% blocktrans %}
     Email From:<br />
     CommCare and the corporation Dimagi, Inc.<br />
-    585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+    245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
   {% endblocktrans %}
 </p>

--- a/corehq/apps/accounting/templates/accounting/email/invoice_autopayment.html
+++ b/corehq/apps/accounting/templates/accounting/email/invoice_autopayment.html
@@ -98,6 +98,6 @@
   {% blocktrans %}
     Statement From:
     CommCare and the corporation Dimagi, Inc.
-    585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+    245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
   {% endblocktrans %}
 </p>

--- a/corehq/apps/accounting/templates/accounting/email/invoice_autopayment.txt
+++ b/corehq/apps/accounting/templates/accounting/email/invoice_autopayment.txt
@@ -31,5 +31,5 @@
 {% blocktrans %}
     Statement From:
     CommCare and the corporation Dimagi, Inc.
-    585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+    245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
 {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/invoice_receipt.html
+++ b/corehq/apps/accounting/templates/accounting/email/invoice_receipt.html
@@ -56,6 +56,6 @@
   {% blocktrans %}
     Email From:<br />
     CommCare and the corporation Dimagi, Inc.<br />
-    585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+    245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
   {% endblocktrans %}
 </p>

--- a/corehq/apps/accounting/templates/accounting/email/invoice_receipt.txt
+++ b/corehq/apps/accounting/templates/accounting/email/invoice_receipt.txt
@@ -29,5 +29,5 @@ www.commcarehq.org
 
 Email From:
 CommCare and the corporation Dimagi, Inc.
-585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
 {% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/wire_invoice.html
+++ b/corehq/apps/accounting/templates/accounting/email/wire_invoice.html
@@ -100,6 +100,6 @@
   {% blocktrans %}
     Statement From:
     CommCare and the corporation Dimagi, Inc.
-    585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+    245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
   {% endblocktrans %}
 </p>

--- a/corehq/apps/accounting/templates/accounting/email/wire_invoice.txt
+++ b/corehq/apps/accounting/templates/accounting/email/wire_invoice.txt
@@ -35,5 +35,5 @@ www.commcarehq.org
 
 Statement From:
 CommCare and the corporation Dimagi, Inc.
-585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA
+245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
 {% endblocktrans %}

--- a/corehq/apps/accounting/tests/generator.py
+++ b/corehq/apps/accounting/tests/generator.py
@@ -105,10 +105,10 @@ def arbitrary_contact_info(account, web_user_creator):
         email_list=[web_user_creator],
         phone_number="+15555555",
         company_name="Company Name",
-        first_line="585 Mass Ave",
+        first_line="245 Main Street",
         city="Cambridge",
         state_province_region="MA",
-        postal_code="02139",
+        postal_code="02142",
         country="US",
     )
 

--- a/corehq/apps/registration/templates/registration/email/base_templates/_base.html
+++ b/corehq/apps/registration/templates/registration/email/base_templates/_base.html
@@ -140,8 +140,8 @@
 
         <p>
           Dimagi, Inc.
-          585 Massachusetts Ave, Ste 4,
-          Cambridge, MA 02139 United States
+          245 Main Street, 2nd Floor,
+          Cambridge, MA 02142 United States
         </p>
 
       </div>{#  /footer-content #}

--- a/corehq/apps/registration/templates/registration/email/confirm_account.txt
+++ b/corehq/apps/registration/templates/registration/email/confirm_account.txt
@@ -15,8 +15,8 @@ Cheers,
 The CommCare Team
 
 Dimagi, Inc.
-585 Massachusetts Ave, Suite 4
-Cambridge,  MA 02139 United States
+245 Main Street, 2nd Floor
+Cambridge,  MA 02142 United States
 
 You received this message because we received a New User request
 www.commcarehq.org with your email address.

--- a/corehq/apps/registration/templates/registration/email/confirm_account_reminder.txt
+++ b/corehq/apps/registration/templates/registration/email/confirm_account_reminder.txt
@@ -16,8 +16,8 @@ Cheers,
 The CommCare Team
 
 Dimagi, Inc.
-585 Massachusetts Ave, Suite 4
-Cambridge,  MA 02139 United States
+245 Main Street, 2nd Floor
+Cambridge,  MA 02142 United States
 
 You received this message because we received a New User request
 www.commcarehq.org with your email address.

--- a/corehq/apps/registration/templates/registration/email/mobile_signup_reminder.txt
+++ b/corehq/apps/registration/templates/registration/email/mobile_signup_reminder.txt
@@ -8,8 +8,8 @@ Cheers,
 The CommCare Team
 
 Dimagi, Inc.
-585 Massachusetts Ave, Suite 4
-Cambridge, MA 02139 United States
+245 Main Street, 2nd Floor
+Cambridge, MA 02142 United States
 
 You received this message because we received a reminder request from
 www.commcarehq.org with your email address.

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -173,8 +173,8 @@ class BulkAppTranslationTestBase(SimpleTestCase, TestXmlMixin):
          (("employee", (("1", "cory", "m"),
                         ("2", "christian", "m"),
                         ("3", "amelia", "f"))),
-          ("building", (("1", "dimagi", "585 mass ave."),
-                        ("2", "old dimagi", "529 main st."))))
+          ("building", (("1", "dimagi", "245 main st."),
+                        ("2", "old dimagi", "585 mass ave."))))
         """
         if not expected_messages:
             expected_messages = ["App Translations Updated!"]

--- a/corehq/ex-submodules/couchexport/export.py
+++ b/corehq/ex-submodules/couchexport/export.py
@@ -64,8 +64,8 @@ def export_raw(headers, data, file, format=Format.XLS_2007,
      (("employee", (("1", "cory", "m"),
                     ("2", "christian", "m"),
                     ("3", "amelia", "f"))),
-      ("building", (("1", "dimagi", "585 mass ave."),
-                    ("2", "old dimagi", "529 main st."))))
+      ("building", (("1", "dimagi", "245 main st."),
+                    ("2", "old dimagi", "585 mass ave."))))
 
     """
     context = export_raw_to_writer(headers=headers, data=data, file=file, format=format,

--- a/corehq/motech/openmrs/tests/test_finders.py
+++ b/corehq/motech/openmrs/tests/test_finders.py
@@ -258,7 +258,7 @@ class WeightedPropertyPatientFinderTests(SimpleTestCase):
         case = CaseMock({
             'first_name': 'Mahapajapati',
             'last_name': 'Gotami',
-            'address_1': '585 Massachusetts Ave',
+            'address_1': '245 Main Street',
             'address_2': 'Cambridge',
             'dob': '1983-01-01T00:00:00.000+0200',
         })


### PR DESCRIPTION
## Product Description
Mostly applies in emails; anywhere the address is used it has been updated.

## Technical Summary
Relates to https://dimagi.atlassian.net/browse/SAAS-18564
Just updates the text of our address, plus anywhere it's used as a default or example in test data.

## Safety Assurance

### Safety story
Just text changes, nothing risky here.

### Automated test coverage
No, I don't imagine so.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
