### PR TITLE
Client Variables for Credential Issuing

### DIFF
--- a/corehq/apps/users/credentials_issuing.py
+++ b/corehq/apps/users/credentials_issuing.py
@@ -144,7 +144,7 @@ def submit_credentials(credentials_to_submit, cred_id_groups):
         json={
             'credentials': credentials_to_submit
         },
-        auth=(settings.CONNECTID_CLIENT_ID, settings.CONNECTID_SECRET_KEY),
+        auth=(settings.CONNECTID_CREDENTIALS_CLIENT_ID, settings.CONNECTID_CREDENTIALS_CLIENT_SECRET),
     )
     response.raise_for_status()
     mark_credentials_as_issued(response, cred_id_groups)

--- a/settings.py
+++ b/settings.py
@@ -1165,6 +1165,8 @@ CONNECTID_SECRET_KEY = ''
 CONNECTID_CHANNEL_URL = 'http://localhost:8080/messaging/create_channel/'
 CONNECTID_MESSAGE_URL = 'http://localhost:8080/messaging/send_fcm/'
 CONNECTID_CREDENTIALS_URL = 'http://localhost:8080/users/add_credential/'
+CONNECTID_CREDENTIALS_CLIENT_ID = ''
+CONNECTID_CREDENTIALS_CLIENT_SECRET = ''
 
 MAX_MOBILE_UCR_LIMIT = 300  # used in corehq.apps.cloudcare.util.should_restrict_web_apps_usage
 MAX_MOBILE_UCR_SIZE = 100000  # max number of rows allowed when syncing a mobile UCR


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/CCCT-1727).
Link to related CC Cloud PR [here](https://github.com/dimagi/commcare-cloud/pull/6694).

This PR adds new client ID and secret credentials which will be used for submitting worker credentials to PersonalID. This change is being done as part of introducing tighter security in how we limit what scope a particular client secret has.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Simply adds new variables with the blast radius being limited to the credentials issuing PersonalID feature.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests exist for the task using the new client ID/secret.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations
When reverting this PR the related CC Cloud PR will also need to be reverted.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
