### PR TITLE
Release/Disable Feature Flags

### DIFF
--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -166,15 +166,18 @@
     </div>
   {% endif %}
 
-  <div class="alert alert-info" role="alert">
-    <strong>Toggle Status:</strong> {{ toggle.status }}
+    <div
+      class="alert {% if toggle.status == 'active' %} alert-info {% else %} alert-warning {% endif %}"
+      role="alert"
+    >
+      Toggle Status: <strong>{{ toggle.status }}</strong>
     <button
       class="btn btn-primary pull-right"
       data-toggle="modal"
       data-target="#change-toggle-status"
       {% if not user.is_staff %}disabled{% endif %}
     >
-      Change
+      See More / Edit
     </button>
   </div>
 
@@ -190,6 +193,22 @@
         <form class="form" action="{% url 'toggle_status' toggle.slug %}" method="POST">
           {% csrf_token %}
           <div class="modal-body">
+            <p>
+              This is a utility to allow us to release or remove feature flags
+              without a code deploy, and with a much easier way to walk back the
+              change. This makes the code changes a lower risk cleanup step that
+              won't affect any users.
+            </p>
+
+            <p>
+              The default state for a feature flag is "active" - where it can be
+              turned on or off for individual users or domains. If we are to
+              remove a feature flag, you can first set it to "disabled" here,
+              which will behave the same as removing everything from the list.
+              Likewise to release a feature flag, set it to "released," and it
+              will behave as if you've enabled the flag for all projects and
+              users.
+            </p>
             {% for status_option in status_options %}
             <div class="radio">
               <label>
@@ -244,12 +263,22 @@
           <h5>
             <i class="fa fa-info-circle"></i> {% trans "Why can't I edit?" %}
           </h5>
-          <p>
-            {% blocktrans %}
-              You do not have permission to modify this flag. Please contact
-              support if any changes are needed.
-            {% endblocktrans %}
-          </p>
+          {% if toggle.status == 'active' %}
+            <p>
+              {% blocktrans %}
+                You do not have permission to modify this flag. Please contact
+                support if any changes are needed.
+              {% endblocktrans %}
+            </p>
+          {% else %}
+            <p>
+              {% blocktrans with status=toggle.status %}
+                This toggle is currently {{ status }} and will soon be removed.
+                This applies to all users and domains, so the individually
+                toggled items are irrelevant.
+              {% endblocktrans %}
+            </p>
+          {% endif %}
         </div>
       {% endif %}
       <table class="table table-condensed" id="feature-flag-items">

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -166,6 +166,54 @@
     </div>
   {% endif %}
 
+  <div class="alert alert-info" role="alert">
+    <strong>Toggle Status:</strong> {{ toggle.status }}
+    <button
+      class="btn btn-primary pull-right"
+      data-toggle="modal"
+      data-target="#change-toggle-status"
+      {% if not user.is_staff %}disabled{% endif %}
+    >
+      Change
+    </button>
+  </div>
+
+  <div class="modal fade" id="change-toggle-status" tabindex="-1" role="dialog" aria-labelledby="change-toggle-status-label">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h4 class="modal-title" id="change-toggle-status-label">Change feature flag status</h4>
+        </div>
+        <form class="form" action="{% url 'toggle_status' toggle.slug %}" method="POST">
+          {% csrf_token %}
+          <div class="modal-body">
+            {% for status_option in status_options %}
+            <div class="radio">
+              <label>
+                <input
+                  type="radio"
+                  name="toggle_status"
+                  value="{{ status_option }}"
+                  {% if status_option == toggle.status %}checked{% endif %}
+                >
+                {{ status_option }}
+              </label>
+            </div>
+            {% endfor %}
+          </div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-danger">
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
   <hr />
   <div id="toggle_editing_ko">
     {% if can_edit_toggle %}

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -166,20 +166,22 @@
     </div>
   {% endif %}
 
+  {% if not is_random %}
     <div
       class="alert {% if toggle.status == 'active' %} alert-info {% else %} alert-warning {% endif %}"
       role="alert"
     >
       Toggle Status: <strong>{{ toggle.status }}</strong>
-    <button
-      class="btn btn-primary pull-right"
-      data-toggle="modal"
-      data-target="#change-toggle-status"
-      {% if not user.is_staff %}disabled{% endif %}
-    >
-      See More / Edit
-    </button>
-  </div>
+      <button
+        class="btn btn-primary pull-right"
+        data-toggle="modal"
+        data-target="#change-toggle-status"
+        {% if not user.is_staff %}disabled{% endif %}
+      >
+        See More / Edit
+      </button>
+    </div>
+  {% endif %}
 
   <div class="modal fade" id="change-toggle-status" tabindex="-1" role="dialog" aria-labelledby="change-toggle-status-label">
     <div class="modal-dialog" role="document">

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -176,12 +176,11 @@
         class="btn btn-primary pull-right"
         data-toggle="modal"
         data-target="#change-toggle-status"
-        {% if not user.is_staff %}disabled{% endif %}
       >
-        See More / Edit
+        See More {% if user.is_staff %}/ Edit{% endif %}
       </button>
     </div>
-  {% endif %}
+    {% endif %}
 
   <div class="modal fade" id="change-toggle-status" tabindex="-1" role="dialog" aria-labelledby="change-toggle-status-label">
     <div class="modal-dialog" role="document">
@@ -207,9 +206,9 @@
               turned on or off for individual users or domains. If we are to
               remove a feature flag, you can first set it to "disabled" here,
               which will behave the same as removing everything from the list.
-              Likewise to release a feature flag, set it to "released," and it
-              will behave as if you've enabled the flag for all projects and
-              users.
+              Likewise to make a feature flag generally available (GA), set it
+              to "released," and it will behave as if you've enabled the flag
+              for all projects and users.
             </p>
             {% for status_option in status_options %}
             <div class="radio">
@@ -226,7 +225,11 @@
             {% endfor %}
           </div>
           <div class="modal-footer">
-            <button type="submit" class="btn btn-danger">
+            <button
+              type="submit"
+              class="btn btn-danger"
+              {% if not user.is_staff %}disabled{% endif %}
+            >
               Save
             </button>
           </div>

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -168,12 +168,12 @@
 
   {% if not is_random %}
     <div
-      class="alert {% if toggle.status == 'active' %} alert-info {% else %} alert-warning {% endif %}"
+      class="alert d-flex justify-content-between {% if toggle.status == 'active' %} alert-info {% else %} alert-warning {% endif %}"
       role="alert"
     >
-      Toggle Status: <strong>{{ toggle.status }}</strong>
+      <div>Toggle Status: <strong>{{ toggle.status }}</strong></div>
       <button
-        class="btn btn-primary pull-right"
+        class="btn btn-default"
         data-toggle="modal"
         data-target="#change-toggle-status"
       >
@@ -218,6 +218,7 @@
                   name="toggle_status"
                   value="{{ status_option }}"
                   {% if status_option == toggle.status %}checked{% endif %}
+                  {% if not user.is_staff %}disabled{% endif %}
                 >
                 {{ status_option }}
               </label>
@@ -225,6 +226,9 @@
             {% endfor %}
           </div>
           <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">
+              Close
+            </button>
             <button
               type="submit"
               class="btn btn-danger"
@@ -278,9 +282,9 @@
           {% else %}
             <p>
               {% blocktrans with status=toggle.status %}
-                This toggle is currently {{ status }} and will soon be removed.
-                This applies to all users and domains, so the individually
-                toggled items are irrelevant.
+                This feature is {{ status }} for all users and domains, so the
+                individually toggled items are irrelevant. The toggle will soon
+                be removed.
               {% endblocktrans %}
             </p>
           {% endif %}

--- a/corehq/apps/toggle_ui/urls.py
+++ b/corehq/apps/toggle_ui/urls.py
@@ -3,13 +3,15 @@ from django.urls import re_path as url
 from corehq.apps.toggle_ui.views import (
     ToggleEditView,
     ToggleListView,
-    set_toggle,
     export_toggles,
+    set_toggle,
+    toggle_status,
 )
 
 urlpatterns = [
     url(r'^$', ToggleListView.as_view(), name=ToggleListView.urlname),
     url(r'^export_toggles/$', export_toggles, name='export_toggles'),
     url(r'^edit/(?P<toggle>[\w_-]+)/$', ToggleEditView.as_view(), name=ToggleEditView.urlname),
+    url(r'^edit_status/(?P<toggle_slug>[\w_-]+)/$', toggle_status, name='toggle_status'),
     url(r'^set_toggle/(?P<toggle_slug>[\w_-]+)/$', set_toggle, name='set_toggle'),
 ]

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -432,6 +432,9 @@ def toggle_status(request, toggle_slug):
     toggle = Toggle.get(toggle_slug)
     toggle.status = status
     toggle.save()
+    for entry in toggle.enabled_users:
+        namespace, entry = parse_toggle(entry)
+        clear_toggle_cache_by_namespace(namespace, entry)
     return HttpResponseRedirect(reverse(ToggleEditView.urlname, args=[toggle_slug]))
 
 

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -174,7 +174,7 @@ class ToggleEditView(BasePageView):
         context = {
             'static_toggle': self.static_toggle,
             'toggle': toggle,
-            'can_edit_toggle': self.can_edit_toggle,
+            'can_edit_toggle': self.can_edit_toggle and toggle.status == ToggleStatus.ACTIVE,
             'namespaces': namespaces,
             'usage_info': self.usage_info,
             'server_environment': settings.SERVER_ENVIRONMENT,

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -4,7 +4,7 @@ from collections import Counter, defaultdict
 
 from django.conf import settings
 from django.contrib import messages
-from django.http import JsonResponse
+from django.http import HttpResponseRedirect, JsonResponse
 from django.http.response import Http404, HttpResponseForbidden
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
@@ -39,7 +39,7 @@ from corehq.toggles import (
     toggles_enabled_for_email_domain,
     toggles_enabled_for_user,
 )
-from corehq.toggles.models import Toggle
+from corehq.toggles.models import Toggle, ToggleStatus
 from corehq.toggles.shortcuts import (
     can_user_edit_tag,
     get_editable_toggle_tags_for_user,
@@ -181,7 +181,8 @@ class ToggleEditView(BasePageView):
             'is_random': self.is_random_editable,
             'is_random_editable': self.is_random_editable,
             'is_feature_release': self.is_feature_release,
-            'allows_items': all(n in ALL_NAMESPACES for n in namespaces)
+            'allows_items': all(n in ALL_NAMESPACES for n in namespaces),
+            'status_options': map(str, ToggleStatus),
         }
         if self.usage_info:
             context['last_used'] = _get_usage_info(toggle)
@@ -416,6 +417,22 @@ def set_toggle(request, toggle_slug):
     _set_toggle(request.user.username, static_toggle, item, namespace, enabled)
 
     return JsonResponse({'success': True})
+
+
+@require_superuser_or_contractor
+@require_POST
+def toggle_status(request, toggle_slug):
+    if not request.user.is_staff:
+        return HttpResponseForbidden("Only Django admin users can do that")
+
+    status = request.POST['toggle_status']
+    if status not in ToggleStatus:
+        raise Exception('Invalid toggle status')
+
+    toggle = Toggle.get(toggle_slug)
+    toggle.status = status
+    toggle.save()
+    return HttpResponseRedirect(reverse(ToggleEditView.urlname, args=[toggle_slug]))
 
 
 @require_superuser_or_contractor

--- a/corehq/toggles/models.py
+++ b/corehq/toggles/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import StrEnum
 
 from couchdbkit import ResourceNotFound
 
@@ -11,6 +12,12 @@ from corehq.util.quickcache import quickcache
 TOGGLE_ID_PREFIX = 'hqFeatureToggle'
 
 
+class ToggleStatus(StrEnum):
+    ACTIVE = 'active'  # default state, controlled per-item
+    RELEASED = 'released'  # always enabled, ignores individual items
+    DISABLED = 'disabled'  # always disabled, ignores individual items
+
+
 class Toggle(Document):
     """
     A very simple implementation of a feature toggle. Just a list of items
@@ -19,6 +26,7 @@ class Toggle(Document):
     slug = StringProperty()
     enabled_users = ListProperty()
     last_modified = DateTimeProperty()
+    status = StringProperty(choices=list(map(str, ToggleStatus)), default=ToggleStatus.ACTIVE)
 
     class Meta(object):
         app_label = 'toggle'

--- a/corehq/toggles/shortcuts.py
+++ b/corehq/toggles/shortcuts.py
@@ -1,7 +1,7 @@
 from couchdbkit import ResourceNotFound
 from django.conf import settings
 
-from .models import Toggle
+from .models import Toggle, ToggleStatus
 
 
 def toggle_enabled(slug, item, namespace=None):
@@ -15,7 +15,13 @@ def toggle_enabled(slug, item, namespace=None):
     item = namespaced_item(item, namespace)
     if not settings.UNIT_TESTING or getattr(settings, 'DB_ENABLED', True):
         toggle = Toggle.cached_get(slug)
-        return item in toggle.enabled_users if toggle else False
+        if not toggle:
+            return False
+        if toggle.status == ToggleStatus.RELEASED:
+            return True
+        if toggle.status == ToggleStatus.DISABLED:
+            return False
+        return item in toggle.enabled_users
 
 
 def set_toggle(slug, item, enabled, namespace=None):


### PR DESCRIPTION
## Product Description
This is a feature available only to users with Django admin access (`is_staff`) that's intended to improve the process of removing feature flags.  Here's the intended workflow:

* Tech team begins investigating whether a feature flag can be released or removed
* Once it's considered safe to do, they go to the feature flag page and change the status from "active" to either "released" (turned on for everybody) or "disabled" (turned off for everybody), which will take effect immediately for all domains.
* Monitor for any unanticipated user impacts
* Once everything is stable, a developer can remove the now-dead code whenever convenient.

By giving dynamic control over feature flag removal, we can effect the change at any time, without being tied to a deploy cycle, and it gives us the ability to easily walk back the change in an emergency.

Another goal here is to separate the process into two pieces - the user-facing change and code cleanup.  In my experience, the more daunting part of removing a feature flag is understanding the user impact and doing the comms necessary to safely remove or release the functionality.  This is often done at least in part by someone who is not a developer.

After that step has been completed, removing the flag entirely becomes a much easier, safer operation without user-facing changes.  A `FEATURE_FLAG.enabled()` check can be replaced with `True` for released flags, and `False` for disabled flags, and the developer can focus on cleaning up the resulting code state, knowing that it already behaves that way on Dimagi environments.

<img width="2378" height="694" alt="image" src="https://github.com/user-attachments/assets/bd0319af-2305-4de6-bb47-e90e806d36d6" />

<img width="2408" height="802" alt="image" src="https://github.com/user-attachments/assets/63c455d1-1bb7-456d-8024-a065f12e7611" />

<img width="2361" height="880" alt="image" src="https://github.com/user-attachments/assets/a0a0f4e6-8ee9-4a1c-a826-94b35f8c6e16" />


## Technical Summary
https://dimagi.atlassian.net/browse/USH-6160

I also toyed with the idea of piggybacking on the `DynamicallyPredictablyRandomToggle` functionality, as you could set that to 100% to release a flag.  However, to remove a flag, you'd have to set it to 0% AND delete all entries from the list of what's enabled, which is harder to roll back if there's a problem.  Plus that added a lot of new stuff to flags that didn't have it already (the logic depends on what combinations of namespaces you have available, whether this is enabled for the environment, whether `enabled` is called with an explicit `namespace`).  It felt like the wrong direction to enable randomness for flags when we're trying to reduce/remove them.  This wasn't much work, and it seemed a lot clearer.

## Feature Flag


## Safety Assurance
This is now live on staging, will still be shopping around a bit before we call this safe to merge.

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
