### PR TITLE
Avoid rendering HTML tags in user-defined case list display text

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/config_modal.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/config_modal.html
@@ -14,7 +14,7 @@
             data-index="<%= index %>"
             <%= columnVisibility[index] ? 'checked' : '' %> >
           <label class="form-check-label" for="column-checkbox-<%= index %>">
-            <%= columnName %>
+            <%- columnName %>
           </label>
         </div>
       <% } }); %>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/detail.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/detail.html
@@ -8,7 +8,7 @@
         <tr>
           <% _.each(headers, function(header, index) { %>
           <% if (!(styles[index].widthHint === 0)) { %>
-          <th class="module-case-list-header"> <%= header %></th>
+          <th class="module-case-list-header"> <%- header %></th>
           <% } %>
           <% }); %>
         </tr>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/search_controls.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/search_controls.html
@@ -42,7 +42,7 @@
       >
         <a>
           <span class="d-flex justify-content-between align-items-center">
-            <%= sortOption.header %> <% if (sortOption.sortOrder) { %>
+            <%- sortOption.header %> <% if (sortOption.sortOrder) { %>
             <i
               class="fa fa-arrow-<%= sortOption.sortOrder === 'V' ? 'down' : 'up' %> ms-2"
             ></i>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/table_container.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/table_container.html
@@ -20,11 +20,11 @@
           class="module-case-list-header header-clickable formplayer-request"
           data-id="<%- index %>"
         >
-          <%= header %>
+          <%- header %>
         </th>
         <% } else { %>
         <th class="module-case-list-header" data-id="<%- index %>">
-          <%= header %>
+          <%- header %>
         </th>
         <% } %> <% } %> <% }); %>
       </tr>


### PR DESCRIPTION
## Product Description
Previously, a customer may have been able to use html tags for text formatting in "display text" fields in case lists and case details in web apps. This does not appear to have been an intended feature nor was it documented. Now, they will not be able to do so. In practice, this change should be invisible.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18554

## Safety Assurance

### Safety story
This change should improve safety by reducing opportunities for XSS, as noted in the ticket. Tested locally and on staging to see the intended effect, though I could not find the combination of app settings that would display the `case_list/detail.html` template, which appears to be used to display a case list within a case detail tab.

### Automated test coverage
Not likely.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
