### PR TITLE
Increase expiration time for mobile worker email invites to 24 hours

### DIFF
--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1615,7 +1615,7 @@ class CommCareUserConfirmAccountViewByEmailView(CommCareUserConfirmAccountView):
 
     @property
     def _expiration_time_in_hours(self):
-        return 1
+        return 24
 
 
 @location_safe


### PR DESCRIPTION
## Product Description
Mobile worker email invites will expire after 24 hours, rather than 1 hour.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18588

## Safety Assurance

### Safety story
Code-wise, this just changes a single number. In terms of what is affected, it should be reasonable to increase expiration time for _invite emails_ somewhat, particularly since this change is very limited in scope (i.e. we're not changing the length of time allowed for password reset links, which would have a greater security implication).

### Automated test coverage
We don't test for a particular expiration length, but we do see that the time being expired works correctly in `TestMobileWorkerConfirmAccountView::test_invite_expired_message`.

### QA Plan
Not planned.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
