### PR TITLE
Add safeguard when fetching autopay eligible invoices

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2376,6 +2376,7 @@ class Invoice(InvoiceBase):
         """ Invoices that can be auto paid on date_due """
         invoices = cls.objects.select_related('subscription__account').filter(
             is_hidden=False,
+            date_paid__isnull=True,
             subscription__account__auto_pay_user__isnull=False,
         )
         # we use Ellipsis because date due can actually be None
@@ -2498,6 +2499,7 @@ class CustomerInvoice(InvoiceBase):
         invoices = cls.objects.select_related('account').filter(
             date_due=date_due,
             is_hidden=False,
+            date_paid__isnull=True,
             account__auto_pay_user__isnull=False
         )
         return invoices

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -411,7 +411,7 @@ class AutoPayInvoicePaymentHandler(object):
             try:
                 payment_record = PaymentRecord.create_record(payment_method, transaction_id, amount)
             except IntegrityError:
-                log_accounting_error("[Autopay] Attempt to double charge invoice {}".format(invoice.id))
+                log_accounting_error(f"[Autopay] Invoice was double charged {invoice.id}")
             else:
                 invoice.pay_invoice(payment_record)
                 invoice.subscription.account.last_payment_method = LastPayment.CC_AUTO

--- a/corehq/apps/accounting/tests/test_autopay_with_api.py
+++ b/corehq/apps/accounting/tests/test_autopay_with_api.py
@@ -19,7 +19,6 @@ from corehq.apps.accounting.payment_handlers import (
 )
 from corehq.apps.accounting.tests import generator
 from corehq.apps.accounting.tests.test_invoicing import BaseInvoiceTestCase
-from django.db import transaction
 from unittest import SkipTest
 from django.conf import settings
 from unittest.mock import patch
@@ -134,9 +133,7 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         invoice.balance = balance
         invoice.save()
         # Run autopay again to test no double charge
-        with transaction.atomic(), self.assertLogs(level='ERROR') as log_cm:
-            self._run_autopay()
-            self.assertIn("[BILLING] [Autopay] Attempt to double charge invoice", "\n".join(log_cm.output))
+        self._run_autopay()
         self.assertEqual(len(PaymentRecord.objects.all()), 1)
         self.assertEqual(len(mail.outbox), self.original_outbox_length + 1)
 


### PR DESCRIPTION
## Technical Summary
this PR adds `date_paid__isnull=True` to the filter in `autopay_invoices` to ensure we never double-charge someone who might have manually paid an invoice prior to the invoice being due.

## Safety Assurance

### Safety story
safe change, makes the code safer.

### Automated test coverage
yes

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
