### PR TITLE
Decrease heartbeat threshold from 60 to 15 minutes

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -625,7 +625,7 @@ CELERY_HEARTBEAT_THRESHOLDS = {
     "reminder_case_update_queue": 15 * 60,
     "reminder_queue": 15 * 60,
     "reminder_rule_queue": 15 * 60,
-    "repeat_record_queue": 60 * 60,
+    "repeat_record_queue": 15 * 60,
     "saved_exports_queue": 6 * 60 * 60,
     "send_report_throttled": 6 * 60 * 60,
     "sms_queue": 5 * 60,


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18524

Changes the heartbeat threshold for the repeat record queue from 60 minutes to 15 minutes. This is in line with our expectations around the repeat record queue being available/not having slow tasks that clog the entire queue. This will result in an HQ downtime alert if exceeded.

We've had issues with workers on this queue especially dying, and given it usually is an issue, we should increase the threshold so that HQ reports as down if this threshold is exceeded. I've setup a datadog alert as well, but realistically when these workers die, it becomes a problem so we should have a more aggressive threshold.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Very safe change. Will just result in a HQ is down alert if this threshold is hit.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
