### PR TITLE
Validation for Connect Messaging

### DIFF
--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -2074,8 +2074,30 @@ class ScheduleForm(Form):
         return [
             crispy.Field(
                 'recipient_types',
-                data_bind="selectedOptions: recipient_types",
+                data_bind=(
+                    "selectedOptions: recipient_types, "
+                    f"enable: content() !== '{self.CONTENT_CONNECT_MESSAGE}' && "
+                    f"content() !== '{self.CONTENT_CONNECT_SURVEY}'"
+                ),
                 style="width: 100%;"
+            ),
+            crispy.Div(
+                crispy.HTML(
+                    """
+                        <p class="help-block alert alert-info">
+                        <i class="fa fa-info-circle"></i>
+                            %s
+                        </p>
+                    """
+                    % _(
+                        """
+                            Connect Messages can only be sent to users who have a PersonalID account.
+                        """
+                    )),
+                data_bind=(
+                    f"visible: content() === '{self.CONTENT_CONNECT_MESSAGE}' || "
+                    f"content() === '{self.CONTENT_CONNECT_SURVEY}'"
+                )
             ),
             crispy.Div(
                 crispy.HTML(

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -2081,6 +2081,18 @@ class ScheduleForm(Form):
                 ),
                 style="width: 100%;"
             ),
+            # Hidden fields to submit recipient_types values when the visible field is disabled.
+            crispy.Div(
+                crispy.HTML(
+                    '<!-- ko foreach: recipient_types -->'
+                    f'<input type="hidden" name="{self.prefix}-recipient_types" data-bind="value: $data" />'
+                    '<!-- /ko -->'
+                ),
+                data_bind=(
+                    f"if: content() === '{self.CONTENT_CONNECT_MESSAGE}' || "
+                    f"content() === '{self.CONTENT_CONNECT_SURVEY}'"
+                )
+            ),
             crispy.Div(
                 crispy.HTML(
                     """

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
@@ -275,6 +275,8 @@ var CreateScheduleViewModel = function (initialValues, select2UserRecipients,
         if (newValue === 'connect_message' || newValue === 'connect_survey') {
             self.recipient_types(['CommCareUser']);
             $('#id_schedule-recipient_types').val(['CommCareUser']).trigger('change');
+            self.user_recipients.value('');
+            $('#id_schedule-user_recipients').val(null).trigger('change');
         }
     });
 

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
@@ -271,6 +271,13 @@ var CreateScheduleViewModel = function (initialValues, select2UserRecipients,
 
     self.send_frequency.subscribe(self.setRepeatOptionText);
 
+    self.content.subscribe(function (newValue) {
+        if (newValue === 'connect_message' || newValue === 'connect_survey') {
+            self.recipient_types(['CommCareUser']);
+            $('#id_schedule-recipient_types').val(['CommCareUser']).trigger('change');
+        }
+    });
+
     self.usesCustomEventDefinitions = ko.computed(function () {
         return self.send_frequency() === 'custom_daily' || self.send_frequency() === 'custom_immediate';
     });

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
@@ -193,9 +193,10 @@ var CreateScheduleViewModel = function (initialValues, select2UserRecipients,
     self.occurrences = ko.observable(initialValues.occurrences);
     self.recipient_types = ko.observableArray(initialValues.recipient_types || []);
     $('#id_schedule-recipient_types').select2();
+    self.content = ko.observable(initialValues.content);
 
     self.user_recipients = new recipientsSelect2Handler(select2UserRecipients,
-        initialValues.user_recipients, 'schedule-user_recipients');
+        initialValues.user_recipients, 'schedule-user_recipients', self);
     self.user_recipients.init();
 
     self.user_group_recipients = new recipientsSelect2Handler(select2UserGroupRecipients,
@@ -223,7 +224,6 @@ var CreateScheduleViewModel = function (initialValues, select2UserRecipients,
 
     self.is_trial_project = initialValues.is_trial_project;
     self.displayed_email_trial_message = false;
-    self.content = ko.observable(initialValues.content);
     self.standalone_content_form = new ContentViewModel(initialValues.standalone_content_form);
     self.custom_events = ko.observableArray();
     self.visit_scheduler_app_and_form_unique_id = new formSelect2Handler(currentVisitSchedulerForm,
@@ -520,7 +520,7 @@ var CreateScheduleViewModel = function (initialValues, select2UserRecipients,
 };
 
 var baseSelect2Handler = select2Handler.baseSelect2Handler,
-    recipientsSelect2Handler = function (initialObjectList, initialCommaSeparatedList, field) {
+    recipientsSelect2Handler = function (initialObjectList, initialCommaSeparatedList, field, viewModel) {
         /*
          * initialObjectList is a list of {id: ..., text: ...} objects representing the initial value
          *
@@ -534,6 +534,14 @@ var baseSelect2Handler = select2Handler.baseSelect2Handler,
 
         self.getHandlerSlug = function () {
             return 'scheduling_select2_helper';
+        };
+
+        self.getExtraData = function () {
+            let data = {};
+            if (viewModel && viewModel.content) {
+                data['content'] = viewModel.content();
+            }
+            return data;
         };
 
         self.getInitialData = function () {


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
When a user selects either "Connect Messaging" or "Connect Survey" for broadcasts or conditional alerts, the UI will now enforce only being able to select "Users" as the recipient type:
![enforce-users](https://github.com/user-attachments/assets/745a9214-62cb-47a4-8e43-4adc710e73c2)

Additionally, the list of available recipients will be filtered to only show users that have an active PersonalID account:
![only-personalid-users](https://github.com/user-attachments/assets/9b556470-92f1-40be-92c2-664f53aa23c0)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/CCCT-1589).

This PR adds extra validation for Connect messaging by only allowing users to set recipients that make sense for Connect messaging. This can help prevent weird configurations where settings are selected that are incompatible with Connect messaging.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`COMMCARE_CONNECT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- QA completed.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests exist for the actual scheduling/messaging logic, however no tests for the forms.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
QA has been completed. Ticket available [here](https://dimagi.atlassian.net/browse/QA-8148).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
